### PR TITLE
fix(messaging): always close the transport's aiohttp session on shutdown

### DIFF
--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -600,13 +600,25 @@ class DiscordClient:
         rather than as a shutdown.
         """
         self._closed = True
-        self._stop_heartbeat()
-        if self._ws is not None and not self._ws.closed:
-            try:
-                await self._ws.close()
-            except Exception:
-                pass
+        # The session close is the LAST thing this method must do and the one
+        # thing it must not skip, so it lives in a `finally`. Every step above it
+        # can raise: `task.cancel()` on a task that ALREADY died with an error
+        # is a no-op, and the following `await self._task` then re-raises that
+        # error -- `except asyncio.CancelledError` does not catch it. A shutdown
+        # while this coroutine is itself being cancelled does the same, since
+        # `CancelledError` is a `BaseException`.
+        #
+        # Leaking the `ClientSession` leaves its connector and open sockets
+        # behind for the process lifetime (aiohttp reports it as "Unclosed
+        # client session" at GC), and `self._session` stays non-None, so a
+        # later close finds a session it believes is already handled.
         try:
+            self._stop_heartbeat()
+            if self._ws is not None and not self._ws.closed:
+                try:
+                    await self._ws.close()
+                except Exception:
+                    pass
             if self._task:
                 self._task.cancel()
                 try:
@@ -616,17 +628,22 @@ class DiscordClient:
                 finally:
                     self._task = None
         finally:
-            # Snapshot first: a cancelled handler's done-callback mutates the set.
-            handlers = list(self._handler_tasks)
-            for handler in handlers:
-                handler.cancel()
-            if handlers:
-                # return_exceptions so one handler raising during unwind cannot
-                # abandon the others or skip the session close below.
-                await asyncio.gather(*handlers, return_exceptions=True)
-            if self._session and not self._session.closed:
-                await self._session.close()
-                self._session = None
+            # The drain below awaits, so a cancellation landing DURING it would
+            # exit this finally before the session close -- the nested finally
+            # keeps the close unconditional either way.
+            try:
+                # Snapshot first: a cancelled handler's done-callback mutates the set.
+                handlers = list(self._handler_tasks)
+                for handler in handlers:
+                    handler.cancel()
+                if handlers:
+                    # return_exceptions so one handler raising during unwind cannot
+                    # abandon the others or skip the session close below.
+                    await asyncio.gather(*handlers, return_exceptions=True)
+            finally:
+                if self._session and not self._session.closed:
+                    await self._session.close()
+                    self._session = None
 
     def set_message_handler(self, on_message: Callable[[DiscordInbound], Awaitable[None]]) -> None:
         """Set/replace the inbound-message handler after construction.

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -722,8 +722,10 @@ class TelegramClient:
         # handler it spawns races SessionManager._closing and may be refused,
         # exactly as a plain message arriving at shutdown already is today. It
         # costs nothing, sometimes wins, and drains the buffer either way.
-        self._flush_all_albums()
+        # Session close in a `finally` -- see DiscordClient.close() for why the
+        # steps above it can raise and what leaking the session costs.
         try:
+            self._flush_all_albums()
             if self._task:
                 self._task.cancel()
                 try:

--- a/src/kiro_crew/webex/client.py
+++ b/src/kiro_crew/webex/client.py
@@ -367,6 +367,8 @@ class WebexClient:
     async def close(self) -> None:
         """Gracefully shut down."""
         self._closed = True
+        # Session close in a `finally` -- see DiscordClient.close() for why the
+        # steps above it can raise and what leaking the session costs.
         try:
             if self._task:
                 self._task.cancel()
@@ -377,14 +379,19 @@ class WebexClient:
                 finally:
                     self._task = None
         finally:
-            if self._handler_tasks:
-                for t in list(self._handler_tasks):
-                    t.cancel()
-                await asyncio.gather(*self._handler_tasks, return_exceptions=True)
-                self._handler_tasks.clear()
-            if self._session and not self._session.closed:
-                await self._session.close()
-                self._session = None
+            # The drain below awaits, so a cancellation landing DURING it would
+            # exit this finally before the session close -- the nested finally
+            # keeps the close unconditional either way.
+            try:
+                if self._handler_tasks:
+                    for t in list(self._handler_tasks):
+                        t.cancel()
+                    await asyncio.gather(*self._handler_tasks, return_exceptions=True)
+                    self._handler_tasks.clear()
+            finally:
+                if self._session and not self._session.closed:
+                    await self._session.close()
+                    self._session = None
 
     def set_message_handler(self, on_message: Callable[[WebexInbound], Awaitable[None]]) -> None:
         """Set/replace the inbound-message handler after construction.

--- a/src/kiro_crew/wecom/client.py
+++ b/src/kiro_crew/wecom/client.py
@@ -246,12 +246,17 @@ class WeComClient:
         invariant; ``TeamsClient.close`` owns the same one.
         """
         self._closed = True
-        if self._ws and not self._ws.closed:
-            try:
-                await self._ws.close()
-            except Exception:
-                pass
+        # Session close in a `finally` -- see DiscordClient.close() for why the
+        # steps above it can raise and what leaking the session costs.
         try:
+            if self._ws and not self._ws.closed:
+                # Guarded like DiscordClient.close(): closing a websocket whose
+                # transport is already broken raises, and this one is on the way out
+                # either way.
+                try:
+                    await self._ws.close()
+                except Exception:
+                    pass
             if self._task:
                 self._task.cancel()
                 try:
@@ -264,14 +269,20 @@ class WeComClient:
             # Fail any push still waiting on an ACK: the socket is going away, so the
             # answer is "not delivered", and leaving the future pending would hang the
             # caller until its timeout for no reason.
-            for waiter in list(self._pending_acks.values()):
-                if not waiter.done():
-                    waiter.set_result(-1)
-            self._pending_acks.clear()
-            await self._drain_handler_tasks()
-            if self._session and not self._session.closed:
-                await self._session.close()
-                self._session = None
+            #
+            # The drain below awaits, so a cancellation landing DURING it would
+            # exit this finally before the session close -- the nested finally
+            # keeps the close unconditional either way.
+            try:
+                for waiter in list(self._pending_acks.values()):
+                    if not waiter.done():
+                        waiter.set_result(-1)
+                self._pending_acks.clear()
+                await self._drain_handler_tasks()
+            finally:
+                if self._session and not self._session.closed:
+                    await self._session.close()
+                    self._session = None
 
     async def _drain_handler_tasks(self) -> None:
         """Cancel and await the in-flight turn tasks.

--- a/test/test_transport_close_session_leak.py
+++ b/test/test_transport_close_session_leak.py
@@ -1,0 +1,204 @@
+"""A transport client's ``close()`` must always close its aiohttp session.
+
+Each of the four long-lived messaging clients (Discord, Telegram, WeCom, Webex)
+owns one ``aiohttp.ClientSession`` and one background task, and each ``close()``
+cancels the task, awaits it, and then closes the session.
+
+``task.cancel()`` on a task that has ALREADY finished with an exception is a
+no-op, and the following ``await self._task`` re-raises that exception --
+``except asyncio.CancelledError`` does not catch it. The reconnect/polling loops
+do not catch every exception type, so this is reachable: one unexpected error in
+the loop, then a shutdown, and the session close was skipped. A ``CancelledError``
+arriving while ``close()`` itself is being awaited did the same, since it is a
+``BaseException``.
+
+The cost is a leaked connector with its open sockets for the process lifetime
+(aiohttp surfaces it as "Unclosed client session" at GC) and a ``self._session``
+left non-None, so nothing retries.
+
+These tests drive each real ``close()`` with a task that died with an error, and
+assert the session was closed anyway and the exception still propagated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _FakeSession:
+    """Just enough ClientSession for close(): a `closed` flag and `close()`."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.closed = True
+
+
+async def _task_that_died(exc: BaseException) -> asyncio.Task:
+    """A task already finished with *exc* — cancel() on it is a no-op."""
+
+    async def _boom() -> None:
+        raise exc
+
+    task = asyncio.ensure_future(_boom())
+    with pytest.raises(type(exc)):
+        await task
+    return task
+
+
+def _discord():
+    from kiro_crew.discord.client import DiscordClient
+
+    return DiscordClient(token="t", on_message=AsyncMock())
+
+
+def _telegram():
+    from kiro_crew.telegram.client import TelegramClient
+
+    return TelegramClient(token="t", on_message=AsyncMock())
+
+
+def _wecom():
+    from kiro_crew.wecom.client import WeComClient
+
+    return WeComClient(bot_id="b", secret="s", ws_url="wss://fake", on_message=AsyncMock())
+
+
+def _webex():
+    from kiro_crew.webex.client import WebexClient
+
+    return WebexClient(token="t", on_message=AsyncMock())
+
+
+_CLIENTS = [
+    pytest.param(_discord, id="discord"),
+    pytest.param(_telegram, id="telegram"),
+    pytest.param(_wecom, id="wecom"),
+    pytest.param(_webex, id="webex"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("build", _CLIENTS)
+async def test_close_closes_session_when_the_task_died_with_an_error(build) -> None:
+    client = build()
+    session = _FakeSession()
+    client._session = session  # type: ignore[assignment]
+    client._task = await _task_that_died(RuntimeError("loop blew up"))
+
+    with pytest.raises(RuntimeError):
+        await client.close()
+
+    assert session.close_calls == 1, (
+        "close() skipped the session close because awaiting the dead task "
+        "re-raised; the connector and its sockets leak for the process lifetime"
+    )
+    assert client._session is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("build", _CLIENTS)
+async def test_close_closes_session_when_the_task_was_cancelled(build) -> None:
+    """The already-handled arm: a genuinely cancelled task must still close."""
+    client = build()
+    session = _FakeSession()
+    client._session = session  # type: ignore[assignment]
+
+    async def _sleep_forever() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.ensure_future(_sleep_forever())
+    await asyncio.sleep(0)
+    client._task = task
+
+    await client.close()
+
+    assert session.close_calls == 1
+    assert client._session is None
+
+
+@pytest.mark.asyncio
+async def test_wecom_close_survives_a_websocket_that_refuses_to_close() -> None:
+    """WeCom awaited `_ws.close()` unguarded, unlike DiscordClient.close().
+
+    A websocket whose transport is already broken raises there, which took the
+    session close down with it.
+    """
+    client = _wecom()
+    session = _FakeSession()
+    client._session = session  # type: ignore[assignment]
+
+    class _BadWS:
+        closed = False
+
+        async def close(self) -> None:
+            raise OSError("transport gone")
+
+    client._ws = _BadWS()  # type: ignore[assignment]
+
+    await client.close()
+
+    assert session.close_calls == 1
+    assert client._session is None
+
+
+_DRAINING_CLIENTS = [
+    pytest.param(_discord, id="discord"),
+    pytest.param(_wecom, id="wecom"),
+    pytest.param(_webex, id="webex"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("build", _DRAINING_CLIENTS)
+async def test_close_closes_session_when_cancelled_while_draining_handlers(build) -> None:
+    """Cancelling ``close()`` while it awaits the handler drain must still close.
+
+    These three clients drain in-flight handler tasks INSIDE the ``finally``,
+    above the session close. That drain awaits, so a ``CancelledError`` landing
+    there would exit ``close()`` with the session -- the exact leak this module
+    exists to prevent -- still open, unless the close is nested in its own
+    ``finally``. (Telegram is not parametrised here: its session close is the
+    first awaited statement in its ``finally``.)
+    """
+    client = build()
+    session = _FakeSession()
+    client._session = session  # type: ignore[assignment]
+
+    swallowed_once = False
+
+    async def _stubborn_handler() -> None:
+        nonlocal swallowed_once
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            if not swallowed_once:
+                swallowed_once = True
+                # Swallow the drain's cancel once so close() stays parked in
+                # its gather until the cancellation lands on close() itself.
+                await asyncio.sleep(3600)
+            raise
+
+    handler = asyncio.ensure_future(_stubborn_handler())
+    await asyncio.sleep(0)
+    client._handler_tasks.add(handler)
+
+    close_task = asyncio.ensure_future(client.close())
+    # Let close() run into the drain's gather before cancelling it.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert session.close_calls == 1, (
+        "cancelling close() while it drained handler tasks skipped the "
+        "session close; the connector and its sockets leak"
+    )
+    assert client._session is None


### PR DESCRIPTION
Fixes #4627

## Problem / Motivation

`DiscordClient`, `TelegramClient`, `WeComClient` and `WebexClient` each own one
`aiohttp.ClientSession` and one background task. When this PR was written, every
`close()` had the same sequential shape (`main` has since independently adopted a
partial try/finally in these methods; the rebase notes below cover how the two
were reconciled):

```python
if self._task:
    self._task.cancel()
    try:
        await self._task
    except asyncio.CancelledError:
        pass
    self._task = None
if self._session and not self._session.closed:
    await self._session.close()
    self._session = None
```

`task.cancel()` on a task that has **already finished with an exception** is a
no-op, and the following `await self._task` re-raises that exception.
`except asyncio.CancelledError` does not catch it, so the session close is never
reached.

That is reachable, not theoretical: the reconnect/polling loops do not catch
every exception type. `WeComClient._run_loop` handles `aiohttp.ClientError`,
`asyncio.TimeoutError`, `OSError` and `asyncio.CancelledError`; anything else
escapes and kills the task. The transport then shuts down — gateway stop, config
change, reconnect teardown — `close()` runs, and the session is skipped. A
`CancelledError` delivered while `close()` is itself being awaited does the same,
`CancelledError` being a `BaseException`.

## Why it matters

The `ClientSession`'s connector and its open sockets are held for the process
lifetime; aiohttp surfaces this as `Unclosed client session` / `Unclosed
connector` at GC. `self._session` is also left non-None, so a later `close()`
sees a session it believes was already handled — nothing ever retries.

`WeComClient` has a second, earlier exit onto the same leak:

```python
if self._ws and not self._ws.closed:
    await self._ws.close()
```

`DiscordClient.close()` has wrapped the equivalent call in
`try/except Exception: pass` all along, because closing a websocket whose
transport is already broken raises. `WeComClient` does not.

## What changed (motivation → approach → change)

Each session close moves into a `finally`. The exception still propagates —
nothing is swallowed, only the cleanup is made unconditional. This is the same
shape `AcpRuntime.terminate_session` already uses for its own local cleanup, and
for the same stated reason.

`WeComClient`'s websocket close is guarded to match its Discord sibling.

The full rationale comment lives once, in `DiscordClient.close()`; the other
three point at it rather than repeating twelve lines four times.

**Rebase reconciliation (2026-08-26):** `main` independently landed a partial
try/finally in these methods, with the in-flight handler-task drain inside the
`finally`. The rebase keeps main's structure and this PR's delta on top, plus one
completion required to preserve this PR's guarantee: the drain *awaits*, so a
`CancelledError` landing during it would exit the `finally` before the session
close ran. Discord, Webex and WeCom now nest the drain in its own `try` whose
`finally` closes the session. Telegram needs no nesting — its session close is
the first awaited statement in its `finally`.

No behaviour change on the happy path or on the already-handled cancelled-task
path.

## Tests

New `test/test_transport_close_session_leak.py` (12 tests), parametrised over the
**real** clients (constructed directly, with a fake session object standing in
for `ClientSession`):

- task died with a `RuntimeError` → session closed, `self._session is None`, and
  the `RuntimeError` still propagates (all four clients)
- task genuinely cancelled (the arm that already worked) → session closed (all four)
- WeCom with a websocket whose `close()` raises `OSError` → session closed
- `close()` cancelled while draining handler tasks → session still closed,
  `CancelledError` still propagates (Discord/WeCom/Webex — the three whose
  `finally` awaits a drain above the close)

```
pytest test/test_transport_close_session_leak.py
```

| | result |
|---|---|
| source guards reverted, tests kept (red-before) | **3 failed** (cancelled-mid-drain arm) |
| with this change | **12 passed** |

(The original pre-rebase red-before was 5 failed / 4 passed against then-main
`7cd987ee3`; main has since adopted part of the fix, so the surviving red arm is
the cancellation-during-drain one.)

Full backend suite on this branch: 69,995 passed; the 83 failures are this
host's known pre-existing environment set (file-explorer, AF_UNIX-path,
design-tweak), zero transport-related, reproducing identically on pristine
`origin/main`.

## Manual verification

Not applicable — reproducing this by hand means killing a live transport's
polling loop with an unhandled exception and then watching for aiohttp's
`Unclosed client session` at interpreter shutdown. The tests drive each real
`close()` with exactly that precondition and assert on the session object.
