### PR TITLE
docs(readme): add Windows desktop installer links and update download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/kirodotdev/KiroCrew/releases"><img src="https://img.shields.io/badge/Download-macOS%20%7C%20Linux-2f6feb?style=flat-square" alt="Download Kiro Crew for macOS or Linux"></a>
+  <a href="https://github.com/kirodotdev/KiroCrew/releases"><img src="https://img.shields.io/badge/Download-macOS%20%7C%20Linux%20%7C%20Windows-2f6feb?style=flat-square" alt="Download Kiro Crew for macOS, Linux, or Windows"></a>
   <a href="docs/README.md"><img src="https://img.shields.io/badge/Documentation-1f6feb?style=flat-square" alt="Read the documentation"></a>
   <a href="docs/guides/install.md"><img src="https://img.shields.io/badge/Install%20guide-macOS%20%7C%20Linux%20%7C%20Windows-6e7781?style=flat-square" alt="Install guide for macOS, Linux, and Windows"></a>
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/Contributing-238636?style=flat-square" alt="Contributing guide"></a>


### PR DESCRIPTION
## Problem / Motivation

The main `README.md` previously indicated that Windows had no desktop build available (`- **Windows**: no desktop build yet, so run the Gateway from a source install`), and the download badge at the top omitted Windows (`Download - macOS | Linux`).

Following the addition and validation of the Windows desktop packaging workflows (`build-windows.yml`, `publish-windows.yml`), the Authenticode-signed NSIS desktop installer (`KiroCrew-Setup.exe`) is actively published to the distribution CDN on the `insider` and `nightly` channels.

## Why it matters

Windows users reading the README were guided exclusively toward running from source even though official signed desktop installer packages are actively available for download.

## What changed

- Updated the download badge in `README.md` to `Download - macOS | Linux | Windows`.
- Updated the "App downloads" section in `README.md` to include direct download links for the Windows desktop installer on the **Insider** and **Nightly** channels alongside macOS and Linux.

## Tests

- Verified markdown formatting and links.

## Manual verification

- Verified URL targets match the standard CDN pattern (`https://download.crew.kiro.dev/desktop/<channel>/latest/KiroCrew-Setup.exe`).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** documentation / link update in README.md.

## Related Issues

None.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


---
**Update (Kiro Crew drive-to-green, operator: iamwhatever):** after rebasing onto current `main`, the "App downloads" Windows-links hunk was superseded (main already carries a more complete Windows bullet), so the live diff is **badge-only**: `Download-macOS | Linux` → `Download-macOS | Linux | Windows` with matching alt text, one hunk +1/-1 in `README.md`. Original contribution by @md-abusayeed.
