### PR TITLE
fix(crew-store): retry the store write when a reader holds the file open

### DIFF
--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -29,7 +29,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from kiro_crew.atomic_write import read_bytes_with_retry
+from kiro_crew.atomic_write import read_bytes_with_retry, replace_with_retry
 from kiro_crew.config.loader import KiroCrewConfig, resolve_agent_bindings
 from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
@@ -256,8 +256,8 @@ class CrewStore:
         Only ``FileNotFoundError`` means "nothing enqueued yet". Anything else
         propagates: the slot refuses to build, which surfaces as a failed
         request the user can retry once the file is dealt with. A wedged slot
-        is recoverable; an erased queue is not. Writes go through
-        ``tmp.replace()``, so a malformed payload is not a torn write of ours —
+        is recoverable; an erased queue is not. Writes go through a
+        write-tmp-then-rename, so a malformed payload is not a torn write of ours —
         it is damage from outside, and papering over it is the wrong default.
         """
         path = self.dir / name
@@ -306,7 +306,23 @@ class CrewStore:
                         return  # a newer snapshot already landed
                 tmp = self.dir / f".{name}.tmp"
                 tmp.write_text(payload, encoding="utf-8")
-                tmp.replace(self.dir / name)
+                # `replace_with_retry`, not `tmp.replace()`: this is the write half
+                # of the window #4331 fixed on the read half. On Windows the rename
+                # raises `PermissionError` while ANY other handle is open on either
+                # path -- an indexer, an AV scanner, or this store's own concurrent
+                # reader -- and the payload is lost even though the write itself was
+                # correct. `_written_seq` is advanced only after the rename returns,
+                # so a lost rename also leaves the sequence un-advanced and the next
+                # writer wins by default: the user's message is simply gone.
+                #
+                # `Path.replace` was also unreachable for the repo's own emulator on
+                # Python 3.10, where pathlib holds a captured reference to
+                # `os.replace` rather than looking it up per call -- the same reason
+                # #4331 had to move the read off `Path.read_text`.
+                #
+                # This runs in `run_in_executor` (or inline with no loop), so the
+                # helper's off-the-event-loop gate leaves the retry enabled here.
+                replace_with_retry(tmp, self.dir / name)
                 # Advance ONLY after the atomic replace succeeded — a failed
                 # write must stay retryable, not be recorded as landed. The
                 # per-name io_lock guarantees no concurrent writer for this

--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -2702,7 +2702,11 @@ class TestGatewayCrewInit:
         # GPT finding on 85f8fbe2: a failed durable write must surface, and
         # the generation must stay retryable (not recorded as landed).
         st = CrewStore("s1")
-        with patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+        # Faulted at `os.replace`, the call the store's rename actually makes
+        # since it moved onto `replace_with_retry`. A bare `OSError` is not the
+        # Windows sharing violation that helper retries, so it still propagates
+        # on the first attempt — which is what this test is about.
+        with patch("os.replace", side_effect=OSError("disk full")):
             st.add_msg("doomed")
             with pytest.raises(OSError):
                 await st.wait_writes()

--- a/test/test_crew_store_write_retry.py
+++ b/test/test_crew_store_write_retry.py
@@ -1,0 +1,149 @@
+"""The write half of the Windows sharing-violation window (issue #4331).
+
+#4331 fixed the READ half: ``CrewStore._load`` now reads through
+``read_bytes_with_retry``. Its PR called out the other half explicitly --
+*"this store's write side still calls ``tmp.replace()`` directly rather than
+``replace_with_retry``, so it remains exposed to the other half of the same
+window"* -- and left it as a separate change. This is that change.
+
+On Windows the atomic rename raises ``PermissionError`` while ANY other handle
+is open on either path: an indexer, an AV scanner, or this store's own
+concurrent reader. POSIX permits it, which is why the class only ever surfaces
+on the ``Backend Tests (Windows)`` matrix and on Windows hosts.
+
+Two kinds of test here, deliberately:
+
+* ``windows_sim.replace_sharing_violation`` drives the fault on any OS. Because
+  it patches ``os.replace`` and CPython 3.10's ``pathlib`` holds a CAPTURED
+  reference to that function, the pre-fix ``tmp.replace()`` was not reachable by
+  it at all -- so these assert the fault was OBSERVED (``state["n"]``), not just
+  that the write succeeded. Without that assertion they would pass vacuously on
+  the unfixed tree, exactly the trap #4331's own read-side test documents.
+* One test uses a REAL open handle on a REAL Windows host, no simulator, and is
+  skipped elsewhere. That is the only evidence here that the OS behaves as
+  described rather than as emulated.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+from windows_sim import replace_sharing_violation
+
+from kiro_crew import atomic_write as aw
+from kiro_crew import platform_compat
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """Keep the bounded retry loop instant; attempt COUNT is what these pin."""
+    monkeypatch.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0)
+
+
+@pytest.fixture
+def _windows(monkeypatch):
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+
+def _store(tmp_path):
+    """A CrewStore with only the write machinery, no disk-reading __init__."""
+    from kiro_crew.crew_chat import CrewStore
+
+    store = CrewStore.__new__(CrewStore)
+    store.dir = tmp_path
+    store._seq_lock = threading.Lock()
+    store._io_locks_guard = threading.Lock()
+    store._io_locks = {}
+    store._write_seq = {}
+    store._written_seq = {}
+    store._pending_writes = set()
+    return store
+
+
+class TestCrewStoreSaveSurvivesAContendedReplace:
+    def test_a_contended_write_retries_and_the_payload_lands(self, tmp_path, _windows):
+        """The product path: one faulted rename, then one that succeeds."""
+        store = _store(tmp_path)
+
+        with replace_sharing_violation(match="queue.json", times=1) as state:
+            store._save("queue.json", [{"id": "q1"}])
+
+        assert json.loads((tmp_path / "queue.json").read_text(encoding="utf-8")) == [{"id": "q1"}]
+        assert state["n"] == 2, (
+            "the simulator must have FAULTED the store's own rename -- n == 0 "
+            "means the write still goes through pathlib's captured os.replace "
+            "and the retry was never on its path"
+        )
+
+    def test_a_lost_rename_does_not_advance_the_written_sequence(self, tmp_path, _windows):
+        """A permanently contended file must raise AND stay retryable.
+
+        ``_written_seq`` is what makes newest-wins work; advancing it for a
+        rename that never landed would record a lost write as durable and let
+        the next snapshot skip itself as stale.
+        """
+        store = _store(tmp_path)
+
+        with replace_sharing_violation(match="queue.json", times=10_000) as state:
+            with pytest.raises(PermissionError):
+                store._save("queue.json", [{"id": "q1"}])
+
+        assert state["n"] == aw._REPLACE_MAX_ATTEMPTS, "the retry must be bounded"
+        assert store._written_seq.get("queue.json", 0) == 0
+        assert not (tmp_path / "queue.json").exists()
+
+    def test_posix_permission_errors_are_not_slept_over(self, tmp_path, monkeypatch):
+        """On POSIX the OS permits replacing an open file, so a
+        ``PermissionError`` is a REAL access fault — retrying delays an honest
+        failure. This is the non-vacuity proof for the platform gate: the same
+        simulator settings recover in the first test and must not here."""
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        store = _store(tmp_path)
+
+        with replace_sharing_violation(match="queue.json", times=1) as state:
+            with pytest.raises(PermissionError):
+                store._save("queue.json", [{"id": "q1"}])
+
+        assert state["n"] == 1, "it must not have tried a second time"
+
+
+@pytest.mark.skipif(
+    not platform_compat.IS_WINDOWS,
+    reason="POSIX permits replacing a file that another handle holds open",
+)
+def test_a_real_windows_reader_no_longer_defeats_the_store_write(tmp_path, monkeypatch):
+    """No simulator: a real open handle on the destination, on a real Windows
+    host. This is the only test here that evidences the OS behaviour itself.
+
+    Deterministic without wall-clock: the handle is released from inside the
+    retry's own backoff, so attempt 1 fails against a genuinely locked file and
+    attempt 2 succeeds against a genuinely free one.
+    """
+    store = _store(tmp_path)
+    target = tmp_path / "queue.json"
+    target.write_text(json.dumps([{"id": "old"}]), encoding="utf-8")
+
+    handle = open(target, "rb")
+    releases = {"n": 0}
+
+    class _ReleaseOnBackoff:
+        """Stands in for the ``time`` module inside ``atomic_write`` only."""
+
+        @staticmethod
+        def sleep(_seconds):
+            releases["n"] += 1
+            if not handle.closed:
+                handle.close()
+
+    monkeypatch.setattr(aw, "time", _ReleaseOnBackoff)
+    try:
+        store._save("queue.json", [{"id": "new"}])
+    finally:
+        if not handle.closed:
+            handle.close()
+
+    assert json.loads(target.read_text(encoding="utf-8")) == [{"id": "new"}]
+    assert releases["n"] == 1, "exactly one backoff, i.e. the first rename really failed"
+    assert store._written_seq["queue.json"] == 1


### PR DESCRIPTION
Fixes #4637

The write half of the Windows sharing-violation window whose read half #4331
closed. [#4539](https://github.com/kirodotdev/KiroCrew/pull/4539) named this and
left it out on purpose:

> Noted but **not** changed: this store's write side still calls `tmp.replace()`
> directly rather than `replace_with_retry`, so it remains exposed to the other
> half of the same window. That is a separate change with its own blast radius,
> and this issue is the read.

## Problem / Motivation

`CrewStore._save`'s worker renames with `tmp.replace(self.dir / name)`. On
Windows that raises `PermissionError` while **any** other handle is open on
either path. #4331 established the concurrent reader exists by construction —
the builder's own comment reads *"Two concurrent first messages both miss the
cache above and both build a store"* — and an indexer or AV scanner on the fresh
temp file is enough on its own.

Measured on Windows 11, no KiroCrew code involved, one ordinary
`open(dst, "rb")` handle held on the destination:

```
Path.replace  (current code): PermissionError -> WinError 5
os.replace                  : PermissionError -> WinError 5
```

## Why it matters

`_written_seq` is advanced only *after* the rename returns, and the code says
why:

```python
tmp.replace(self.dir / name)
# Advance ONLY after the atomic replace succeeded — a failed
# write must stay retryable, not be recorded as landed.
```

That is correct, and it is exactly what makes the loss silent: the generation
stays un-advanced, the durable file keeps its previous contents, and the
enqueued message is absent from the store that exists to survive a restart. The
write is offloaded to an executor, so unless a caller awaits `wait_writes()` the
`PermissionError` surfaces only as a future nobody reads.

There is a structural half too. CPython 3.10's `pathlib` holds a **captured**
reference to `os.replace` rather than looking it up per call, so `tmp.replace()`
cannot be faulted by `windows_sim.replace_sharing_violation` at all — the same
reason #4331 had to move its read off `Path.read_text`. The store's write was
invisible to the repo's own Windows emulator on the 3.10 matrix.

## What changed (motivation → approach → change)

One call site: the rename goes through `atomic_write.replace_with_retry`, the
helper `read_bytes_with_retry` was built as the twin of.

**Nothing about the helper changes** — same bounded budget, same shared
`_REPLACE_MAX_ATTEMPTS` / `_REPLACE_BACKOFF_SECONDS`, same Windows-only gate,
same off-the-event-loop gate. `_save`'s writer runs in `run_in_executor` (or
inline when there is no running loop), so the retry applies where it matters,
exactly as it does for the read.

The `_load` docstring's passing reference to `tmp.replace()` is reworded to name
the pattern rather than the call, so it stays true.

No behaviour change on POSIX, where the OS permits the replace.

## Tests

New `test/test_crew_store_write_retry.py`, mirroring the read side's file:

| Test | Behavior locked in |
|---|---|
| `test_a_contended_write_retries_and_the_payload_lands` | One faulted rename, then one that succeeds — asserted on the emulator's own count |
| `test_a_lost_rename_does_not_advance_the_written_sequence` | A permanently contended file raises, stays retryable, and leaves no store file |
| `test_posix_permission_errors_are_not_slept_over` | On POSIX it must not try a second time |
| `test_a_real_windows_reader_no_longer_defeats_the_store_write` | **No simulator**: a real open handle on a real Windows host |

The simulator tests assert `state["n"]`, not merely that the write succeeded.
Because `replace_sharing_violation` patches `os.replace` and 3.10's pathlib
bypasses it, a test that only wrapped the old call would pass on the unfixed
tree while proving nothing — the same trap #4331's read-side test documents.
Asserting the fault was *observed* is what makes them non-vacuous.

The real-OS test is deterministic without wall-clock: the handle is released
from inside the retry's own backoff, so attempt 1 fails against a genuinely
locked file and attempt 2 succeeds against a genuinely free one, and it asserts
exactly one backoff occurred.

```
pytest test/test_crew_store_write_retry.py
```

| | result |
|---|---|
| against `origin/main` (`55ea3ac1d`), pristine worktree | **4 failed** |
| with this change | **4 passed** |

On `origin/main` the three simulator tests fail with `n == 0` / `DID NOT RAISE`
(the pathlib capture above), and the real-OS test fails with an uncaught
`PermissionError [WinError 5]` — which is the production bug itself.

Relevant suite on this branch:

```
pytest test/test_crew_chat.py test/test_crew_store_read_retry.py \
       test/test_crew_store_write_retry.py test/test_atomic_write_retry.py
→ 178 passed, 0 failed
```

`flake8` clean; the baselined black gate passes with these three files in scope.

### One existing test adjusted

`test_crew_chat.py::TestGatewayCrewInit::test_wait_writes_propagates_failure`
faulted `pathlib.Path.replace` — the spelling this PR moves off. It now faults
`os.replace`, the call the rename actually makes and the layer a real disk error
comes from. A bare `OSError` is not the sharing violation the helper retries, so
it still propagates on the first attempt and every assertion is unchanged. It is
red on `origin/main` for the same pathlib-capture reason, so it is a second
red-before rather than a weakened test.

## Manual verification

The `WinError 5` measurement above was run directly against `Path.replace` and
`os.replace` with a held handle on this Windows box; it is what established the
mechanism before any code changed. The real-OS test exercises the same
precondition through `CrewStore._save`. Not exercised: two live gateway requests
racing for one slot on a real install — the emulator and the held handle
reproduce the same OS fault deterministically, which is the standard #4539 set.