### PR TITLE
fix(acp): reset the client even when the kill fails on shutdown

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3460,8 +3460,28 @@ class AcpClient:
 
     async def shutdown(self) -> None:
         """Gracefully stop the ACP process."""
-        await self._kill_process(force=True)
-        self._reset_state()  # untracks all PIDs (root + children)
+        # `_reset_state` in a `finally`, because `_kill_process` can leave
+        # through several doors: it awaits four `run_in_executor` calls (child
+        # scan, record capture, escaped-child sweep) that are not individually
+        # guarded, `subprocess_executor()` refuses new work once the loop is
+        # tearing down, and `asyncio.CancelledError` is a `BaseException` --
+        # shutdown being exactly when cancellation arrives.
+        #
+        # Nothing retries. Every caller treats this as terminal and drops the
+        # client immediately afterwards (`AcpWorker` and `_shutdown_quietly`
+        # both `except Exception: log` and then set their reference to None), so
+        # a skipped reset is permanent: the pipes stay open, the sandbox temp
+        # files stay on disk, and for the claude backend
+        # `.claude/settings.local.json` -- written to hold `bypassPermissions`
+        # for the session -- survives the process it belonged to.
+        #
+        # Running it after a failed kill is safe by construction: `_reset_state`
+        # untracks only PIDs it confirms dead and deliberately RETAINS tracking
+        # for survivors so the orphan sweep still reaps them.
+        try:
+            await self._kill_process(force=True)
+        finally:
+            self._reset_state()  # untracks all PIDs (root + children)
 
     # ── JSON-RPC Transport ──
 

--- a/test/test_acp_client_shutdown_reset.py
+++ b/test/test_acp_client_shutdown_reset.py
@@ -1,0 +1,89 @@
+"""``AcpClient.shutdown()`` must reset its state even when the kill fails.
+
+``shutdown`` awaited ``_kill_process(force=True)`` and then called
+``_reset_state()`` sequentially, so any exception out of the kill skipped the
+reset entirely.
+
+``_kill_process`` has several exits: four ``run_in_executor`` awaits (child
+scan, record capture, escaped-child sweep) that are not individually guarded,
+``subprocess_executor()`` refusing new work once the loop is tearing down, and
+``asyncio.CancelledError`` -- a ``BaseException`` -- arriving mid-await, which
+is precisely what a shutdown produces.
+
+Nothing retries. Every caller treats ``shutdown`` as terminal and drops the
+client right after: ``AcpWorker`` (``knowledge/llm_pool.py``) and
+``_shutdown_quietly`` (``connections/mint.py``) both ``except Exception``, log,
+and set their reference to ``None``. So a skipped reset is permanent.
+
+The effect asserted here is the one with a security shape: for the claude
+backend ``_reset_state`` deletes ``.claude/settings.local.json``, which exists
+only to carry ``bypassPermissions`` for the live session. These tests use a real
+work directory and a real file rather than asserting a mock was called.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kiro_crew.acp.client import ACP_BACKEND_CLAUDE, AcpClient
+
+
+def _claude_client(tmp_path):
+    """A client whose reset has one plainly observable effect on disk."""
+    client = AcpClient(work_dir=tmp_path)
+    # `_is_claude` is a read-only property over the backend seam.
+    client._acp_backend = ACP_BACKEND_CLAUDE
+    settings = tmp_path / ".claude" / "settings.local.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text('{"permissions": "bypassPermissions"}', encoding="utf-8")
+    # No live child: the reset's PID bookkeeping is not what these pin.
+    client._process = None
+    client._pid = None
+    client._child_pids = {}
+    return client, settings
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_kill_still_resets_the_client(tmp_path):
+    """Cancellation is the shutdown case, and it must not skip the reset."""
+    client, settings = _claude_client(tmp_path)
+    client._kill_process = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.shutdown()
+
+    assert not settings.exists(), (
+        "settings.local.json outlived the session it granted bypassPermissions "
+        "for; no caller retries shutdown, so nothing else removes it"
+    )
+    assert client._session_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_failing_kill_still_resets_the_client(tmp_path):
+    """The executor refusing work during teardown looks like this."""
+    client, settings = _claude_client(tmp_path)
+    client._kill_process = AsyncMock(
+        side_effect=RuntimeError("cannot schedule new futures after shutdown")
+    )
+
+    with pytest.raises(RuntimeError):
+        await client.shutdown()
+
+    assert not settings.exists()
+    assert client._session_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_clean_shutdown_still_resets(tmp_path):
+    """Control: the path that already worked must keep working."""
+    client, settings = _claude_client(tmp_path)
+    client._kill_process = AsyncMock()
+
+    await client.shutdown()
+
+    assert not settings.exists()
+    assert client._session_id is None


### PR DESCRIPTION
Fixes #4642

## Problem / Motivation

```python
async def shutdown(self) -> None:
    """Gracefully stop the ACP process."""
    await self._kill_process(force=True)
    self._reset_state()  # untracks all PIDs (root + children)
```

Sequential, so any exception out of `_kill_process` skips `_reset_state`
entirely.

It can escape. `_kill_process` awaits four `run_in_executor` calls — the
child-PID scan, the child-record capture, and two `_kill_escaped_children`
sweeps — none of them individually guarded; `subprocess_executor()` refuses new
work once the loop is tearing down; and `asyncio.CancelledError` is a
`BaseException` arriving mid-await, which is exactly what a shutdown produces.

## Why it matters

Nothing retries. Every caller treats `shutdown()` as terminal and drops the
client immediately after:

| Caller | Shape |
|---|---|
| `knowledge/llm_pool.py:291`, `:376` | `try: await self._client.shutdown()` → `except Exception: logger.debug(...)` → `self._client = None` |
| `connections/mint.py:493` (`_shutdown_quietly`) | wrapped in `except Exception`, never called again |
| `providers/acp.py:1189` | plain forward |

So a skipped reset is permanent, and `_reset_state` is not bookkeeping-only. It
leaves behind the process's stdin/stdout/stderr pipes, the macOS seatbelt
sandbox temp files, an uncancelled stderr reader task, confirmed-dead PIDs still
recorded in the orphan-tracking files, and — for the claude backend —
`.claude/settings.local.json`, which the code's own comment describes as
*"Remove settings.local.json so bypassPermissions doesn't persist after crash"*,
surviving the session it was written for.

## What changed (motivation → approach → change)

The reset moves into a `finally`. The exception still propagates — nothing is
swallowed, only the cleanup is made unconditional.

**Running the reset after a failed kill is safe by construction, and that is not
an assumption I am making.** `_reset_state` untracks only PIDs it confirms dead
via `_pid_gone_or_unmanaged`, and deliberately *retains* tracking for survivors
so the periodic orphan sweep and `cleanup_orphaned_sessions()` still reap them —
its own comment calls untracking a survivor "the memory-leak this guards
against". A kill that failed halfway therefore leaves the tracking files in
exactly the state those sweeps expect.

This is the same shape as `AcpRuntime.terminate_session`, which already
unregisters its queue in a `finally` for the same stated `BaseException` reason.

## Tests

New `test/test_acp_client_shutdown_reset.py`:

- `_kill_process` raises `CancelledError` → `settings.local.json` is gone,
  `_session_id` is cleared, `CancelledError` still propagates
- `_kill_process` raises `RuntimeError("cannot schedule new futures after
  shutdown")` → same
- clean shutdown → control, the path that already worked

They use a real `work_dir` and a real `settings.local.json` and assert on the
file, rather than asserting `_reset_state` was called.

```
pytest test/test_acp_client_shutdown_reset.py
```

| | result |
|---|---|
| against `origin/main` (`55ea3ac1d`), pristine worktree | **2 failed, 1 passed** |
| with this change | **3 passed** |

The one that passes either way is the control.

Wider relevant suite on this branch:

```
pytest test/ -k "acp or llm_pool or worker_pool or mint"
→ 1472 passed, 23 skipped, 9 failed
```

All 9 failures are `OSError [WinError 1314]` — creating a symlink needs a
privilege this box does not hold — in `test_acp_liveness.py` and
`test_connections_mint.py`. Running those two files against pristine
`origin/main` gives the same `9 failed, 106 passed`. (A collection error in
`test/test_bench_download_fd.py`, `KeyError: 'file'`, is likewise pre-existing
and unrelated.)

`flake8` clean; the baselined black gate passes with both files in scope.

## Manual verification

Not applicable — reproducing this by hand means cancelling a shutdown mid-kill
on a live claude-backend session and then looking for
`.claude/settings.local.json`. The tests drive the same production method with
that precondition and assert on the same file.