### PR TITLE
feat: make the managed-python choice sticky across installer runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ Pin an exact version:
 curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --version 0.1.0
 ```
 
+**Experimental** — run on a fully managed Python instead of the system one.
+The installer fetches a SHA-256-pinned [uv](https://docs.astral.sh/uv/) and
+provisions a self-contained CPython 3.12 into `~/.kiro/crew-python`, so the
+install never depends on (or breaks with) the system interpreter:
+
+```bash
+curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --managed-python
+```
+
+The choice is sticky: it is recorded next to the channel, so later re-runs of
+the installer — including the one `kirocrew update` performs — keep using the
+managed interpreter without the flag. Opt back out with `--system-python`.
+
 Open `http://localhost:5476` and start a conversation. The web dashboard works
 without messaging credentials. Add a messaging channel —
 [Slack](docs/guides/slack-setup.md),

--- a/cli.sh
+++ b/cli.sh
@@ -23,7 +23,9 @@
 #                                        its immutable signed CLI manifest
 #   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
 #   --managed-python                     skip the system interpreters and run on
-#                                        a uv-provisioned Python instead
+#                                        a uv-provisioned Python instead (sticky:
+#                                        later runs and updates keep the choice;
+#                                        opt out with --system-python)
 #                                        (env KIROCREW_MANAGED_PYTHON=1)
 # ──────────────────────────────────────────────────────────────────────
 set -eu
@@ -43,7 +45,10 @@ FEED_BASE="${KIROCREW_CDN_BASE:-https://updates.crew.kiro.dev}"
 ARTIFACT_BASE="${KIROCREW_CDN_BASE:-https://download.crew.kiro.dev}"
 CHANNEL="${KIROCREW_CHANNEL:-stable}"
 PIN_VERSION=""
-MANAGED_PYTHON="${KIROCREW_MANAGED_PYTHON:-0}"
+# Three states: "" = undecided (fall back to the persisted python-mode marker,
+# then to system), "1" = managed, "0" = system. An explicit env value or flag
+# always outranks the marker, so an operator can override a sticky choice.
+MANAGED_PYTHON="${KIROCREW_MANAGED_PYTHON:-}"
 
 # Pinned uv release used to provision a managed Python interpreter when the
 # system has none (or when --managed-python asks for one). uv is only ever
@@ -81,6 +86,7 @@ while [ $# -gt 0 ]; do
     --cdn) FEED_BASE="${2:?--cdn needs a value}"; ARTIFACT_BASE="$2"; shift 2 ;;
     --cdn=*) FEED_BASE="${1#*=}"; ARTIFACT_BASE="${1#*=}"; shift ;;
     --managed-python) MANAGED_PYTHON=1; shift ;;
+    --system-python) MANAGED_PYTHON=0; shift ;;
     -h|--help)
       cat <<'EOF'
 KiroCrew CLI installer (channel / wheel based).
@@ -101,7 +107,10 @@ Options / env:
                                        its immutable signed CLI manifest
   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
   --managed-python                     skip the system interpreters and run on a
-                                       uv-provisioned Python instead
+                                       uv-provisioned Python instead (sticky: later
+                                       runs and updates keep the choice)
+  --system-python                      opt back out of a recorded managed-python
+                                       choice and use the system interpreter
                                        (env KIROCREW_MANAGED_PYTHON=1)
   KIROCREW_VENV                        override the managed venv location
   KIROCREW_PYTHON_DIR                  override where uv-provisioned interpreters
@@ -293,8 +302,27 @@ _provision_python_via_uv() {
 }
 
 PY=""
+# The interpreter choice is STICKY: a completed install records its mode in
+# the data home (next to `channel`), and a later run without an explicit flag
+# or env value reuses it. Without this, every re-run of the one-liner -- most
+# importantly the one `kirocrew update` performs -- would silently flip a
+# --managed-python install back onto whatever system interpreter it finds.
+# Opt back out explicitly with --system-python (or KIROCREW_MANAGED_PYTHON=0).
+_DATA_HOME="${KIROCREW_HOME:-$HOME/.kiro/crew}"
+# The marker is agent-writable state, so the READ is guarded like the write:
+# only a plain regular file counts (a planted symlink -- e.g. to /dev/zero --
+# or a FIFO would wedge an unbounded read or spoof the mode), and the read is
+# bounded to the first bytes rather than slurping the file.
+_py_mode_file="$_DATA_HOME/python-mode"
+if [ -z "$MANAGED_PYTHON" ] && [ -f "$_py_mode_file" ] && [ ! -L "$_py_mode_file" ] \
+    && [ "$(head -c 16 "$_py_mode_file" 2>/dev/null || true)" = "managed" ]; then
+  echo "Reusing the recorded managed-python choice (override with --system-python)."
+  MANAGED_PYTHON=1
+fi
+[ -n "$MANAGED_PYTHON" ] || MANAGED_PYTHON=0
+
 if [ "$MANAGED_PYTHON" = "1" ]; then
-  echo "--managed-python: skipping system interpreters."
+  echo "managed-python: skipping system interpreters."
   _provision_python_via_uv \
     || err "could not provision a managed Python via uv. Check the network connection, or install Python >=3.10 yourself and re-run without --managed-python."
 else
@@ -558,7 +586,34 @@ fi
 
 _DATA_HOME="${KIROCREW_HOME:-$HOME/.kiro/crew}"
 mkdir -p "$_DATA_HOME"
-printf '%s\n' "$CHANNEL" > "$_DATA_HOME/channel"
+# Atomic, symlink-proof marker writes. A plain `>` redirection FOLLOWS a
+# pre-planted symlink at the destination -- the data home is agent-writable,
+# so a hostile `ln -sf ~/.bashrc .../python-mode` would turn the next install
+# run into an arbitrary-file overwrite. mktemp creates a fresh regular file
+# (O_EXCL, never a symlink); a pre-existing symlink at the destination is
+# removed first (mv would REPLACE a symlink-to-file, but would move the temp
+# file INSIDE a symlink-to-directory's target); a real directory at the
+# marker path is corrupt state and is refused loudly -- mv would otherwise
+# move the temp file inside it and every later read would silently miss the
+# marker. After those guards the destination is absent or a regular file, so
+# the rename is atomic and can never land outside the data home.
+_write_marker() {
+  _marker_dest="$_DATA_HOME/$1"
+  [ -L "$_marker_dest" ] && rm -f "$_marker_dest"
+  [ -d "$_marker_dest" ] \
+    && err "refusing to record $1: a directory occupies $_marker_dest -- remove it and re-run"
+  _marker_tmp="$(mktemp "$_DATA_HOME/.marker.XXXXXX")"
+  printf '%s\n' "$2" > "$_marker_tmp"
+  mv -f "$_marker_tmp" "$_marker_dest"
+}
+_write_marker channel "$CHANNEL"
+# Record the interpreter mode so the next run -- including the re-run that
+# `kirocrew update` performs -- keeps the same choice without the flag.
+if [ "$MANAGED_PYTHON" = "1" ]; then
+  _write_marker python-mode managed
+else
+  _write_marker python-mode system
+fi
 
 echo ""
 echo "Installed kirocrew $VER (channel: $CHANNEL)."

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -158,11 +158,14 @@ manager, no sudo, and the prebuilt interpreter runs on old-glibc distros
 (CentOS 7) whose base repos never reach 3.10. Pass `--managed-python` (or set
 `KIROCREW_MANAGED_PYTHON=1`) to always use the uv-provisioned interpreter and
 skip the system ones entirely — useful when the system Python is fragile or
-version-managed. The signed installer never pipes an unsigned third-party
-script into a shell: uv is fetched as a tarball and verified against pinned
-digests, exactly like the wheel itself. When it finishes it prints the next
-step: `kirocrew gateway` to start now, or `kirocrew service install` to run it
-as a service.
+version-managed. The choice is sticky: it is recorded in the data home
+(`python-mode`, next to `channel`), so later installer runs — including the
+re-run `kirocrew update` performs — keep it without the flag; opt back out
+with `--system-python`. The signed installer never pipes an unsigned
+third-party script into a shell: uv is fetched as a tarball and verified
+against pinned digests, exactly like the wheel itself. When it finishes it
+prints the next step: `kirocrew gateway` to start now, or `kirocrew service
+install` to run it as a service.
 
 ### b. From source (development)
 

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -458,3 +458,212 @@ def test_cli_link_removal_never_reaches_a_symlinked_venv(tmp_path: Path) -> None
     )
     # And the trailing-slash-stripped guard must still be present in cli.sh.
     assert '[ ! -L "${VENV%/}" ]' in CLI_SH.read_text()
+
+
+def test_cli_reuses_a_recorded_managed_python_choice(tmp_path: Path) -> None:
+    """A completed --managed-python install records its mode; a later run
+    WITHOUT the flag must reuse it -- most importantly the re-run that
+    `kirocrew update` performs, which passes only --channel. Without the
+    marker read, every update would silently flip a managed install back onto
+    whatever system interpreter it finds."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").write_text("managed\n")
+
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        # A perfectly usable system python that the recorded choice must skip.
+        interpreters={
+            "python3.12": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+    combined = result.stdout + result.stderr
+    assert "Reusing the recorded managed-python choice" in combined
+
+
+def test_cli_system_python_flag_overrides_the_recorded_choice(tmp_path: Path) -> None:
+    """--system-python is the opt-out: with a 'managed' marker on disk it must
+    use the system interpreter and never reach for uv."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").write_text("managed\n")
+
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        extra_args=["--system-python"],
+        interpreters={
+            "python3.12": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Reusing the recorded managed-python choice" not in combined
+    assert "Python >=3.10 is required" not in combined, combined
+    curl_marker = markers / "curl"
+    if curl_marker.exists():
+        assert "astral-sh/uv" not in curl_marker.read_text()
+
+
+def _run_marker_write_shape(data_home: Path, tmp_path: Path) -> subprocess.CompletedProcess[bytes]:
+    """Run the exact guarded marker-write shape cli.sh uses, targeting
+    ``python-mode`` with value ``managed``. Contained under tmp_path."""
+    shape = (
+        f'd="{data_home}/python-mode"; '
+        f'if [ -L "$d" ]; then rm -f "$d"; fi; '
+        f'if [ -d "$d" ]; then echo "refusing: directory" >&2; exit 1; fi; '
+        f't="$(mktemp "{data_home}/.marker.XXXXXX")"; '
+        f'printf \'%s\\n\' managed > "$t"; '
+        f'mv -f "$t" "$d"'
+    )
+    return subprocess.run(
+        ["sh", "-c", shape], check=False, capture_output=True, cwd=tmp_path
+    )
+
+
+def test_cli_marker_write_replaces_a_planted_symlink(tmp_path: Path) -> None:
+    """The channel / python-mode marker writes must be symlink-proof: the data
+    home is agent-writable, so a pre-planted `ln -sf ~/.bashrc .../python-mode`
+    would turn a plain `>` redirection into an arbitrary-file overwrite on the
+    next install run. The guarded shape removes the symlink and renames a
+    fresh regular file into place -- never writing through the link."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    victim = tmp_path / "victim-bashrc"
+    victim.write_text("precious shell profile\n")
+    (data_home / "python-mode").symlink_to(victim)
+
+    result = _run_marker_write_shape(data_home, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert victim.read_text() == "precious shell profile\n", (
+        "the marker write followed the planted symlink and overwrote the "
+        "victim file -- the guarded write shape in cli.sh has been lost"
+    )
+    marker = data_home / "python-mode"
+    assert not marker.is_symlink()
+    assert marker.read_text() == "managed\n"
+
+
+def test_cli_marker_write_survives_a_symlink_to_a_directory(tmp_path: Path) -> None:
+    """A planted symlink can also point at a DIRECTORY -- `mv` onto a
+    symlink-to-directory moves the temp file INSIDE the target instead of
+    replacing the link, silently landing the marker outside its path. The
+    symlink is removed before the rename regardless of what it points at."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    victim_dir = tmp_path / "victim-dir"
+    victim_dir.mkdir()
+    (data_home / "python-mode").symlink_to(victim_dir)
+
+    result = _run_marker_write_shape(data_home, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert list(victim_dir.iterdir()) == [], (
+        "the marker rename landed inside the symlinked directory target"
+    )
+    marker = data_home / "python-mode"
+    assert not marker.is_symlink()
+    assert marker.read_text() == "managed\n"
+
+
+def test_cli_marker_write_refuses_a_directory_target(tmp_path: Path) -> None:
+    """A real directory occupying the marker path is corrupt state: `mv` would
+    move the temp file inside it and every later read would silently miss the
+    marker (an update would quietly fall back to defaults). The write must
+    refuse loudly instead."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").mkdir()
+
+    result = _run_marker_write_shape(data_home, tmp_path)
+
+    assert result.returncode != 0
+    assert (data_home / "python-mode").is_dir()
+    assert list((data_home / "python-mode").iterdir()) == [], (
+        "the marker temp file was moved inside the directory target"
+    )
+    # And the guards must still be present in cli.sh.
+    text = CLI_SH.read_text()
+    assert "_write_marker" in text
+    assert 'mktemp "$_DATA_HOME/.marker.XXXXXX"' in text
+    assert '[ -d "$_marker_dest" ]' in text
+    assert '[ -L "$_marker_dest" ]' in text
+
+
+def test_cli_marker_read_ignores_a_planted_symlink(tmp_path: Path) -> None:
+    """The marker READ is guarded like the write: a planted symlink at
+    python-mode (e.g. to /dev/zero, which would wedge an unbounded cat, or to
+    an attacker file spoofing 'managed') must be ignored -- the run proceeds
+    on the system interpreter as if no marker existed."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    spoof = tmp_path / "spoof"
+    spoof.write_text("managed\n")
+    (data_home / "python-mode").symlink_to(spoof)
+
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={
+            "python3.12": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Reusing the recorded managed-python choice" not in combined
+    curl_marker = markers / "curl"
+    if curl_marker.exists():
+        assert "astral-sh/uv" not in curl_marker.read_text()
+    # And the read guards must still be present in cli.sh.
+    text = CLI_SH.read_text()
+    assert '[ ! -L "$_py_mode_file" ]' in text
+    assert 'head -c 16 "$_py_mode_file"' in text
+
+
+def test_cli_marker_read_never_opens_a_fifo(tmp_path: Path) -> None:
+    """A FIFO planted at python-mode would block a reader forever; the -f
+    regular-file guard must skip it without ever opening it (this test hangs
+    at the harness timeout if the guard is lost)."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    os.mkfifo(data_home / "python-mode")
+
+    result, _markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={
+            "python3.12": (
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                "  *version_info*) exit 0 ;;\n"
+                "  *--version*) echo 'Python 3.12.0' ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n"
+            ),
+        },
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Reusing the recorded managed-python choice" not in combined


### PR DESCRIPTION
## Summary

Follow-up to #4594. Two changes:

**1. The managed-python choice is now sticky.** A `--managed-python` install records its interpreter mode in the data home (`python-mode`, next to `channel`). A later installer run with no explicit flag or `KIROCREW_MANAGED_PYTHON` value reuses it — most importantly the re-run that **`kirocrew update` performs**, which composes only `--channel` (`update_layout.wheel_update_command`). Without the marker, every update silently flipped a managed install back onto whatever system interpreter it found, discarding the user's choice. A new `--system-python` flag opts back out explicitly and re-records the mode; an explicit flag or env value always outranks the marker (three-state resolution: flag/env > marker > system default).

**2. README documents the experimental install command.** The One-line install section gains the `--managed-python` one-liner with the sticky semantics spelled out; `docs/guides/install.md` updated in the same commit.

## Tests

- `test_cli_reuses_a_recorded_managed_python_choice`: with a `managed` marker on disk and a perfectly usable system python3.12 on PATH, a flag-less run must reach for the pinned uv tarball (curl marker) and print the reuse notice.
- `test_cli_system_python_flag_overrides_the_recorded_choice`: `--system-python` with the marker present must use the system interpreter and never touch uv.
- Installer suite 12/12 green; isort/flake8/mypy/docs-lint/brand gate clean; full backend suite green (11 failures verified pre-existing on clean `origin/main` on this host: `test_artifact_source`/`test_artifacts_handlers`/`test_xdist_host_budget`/`test_history_coverage`/`test_prepare_pr_prove`).

## Manual verification

Real E2E on an isolated instance (fresh HOME/KIROCREW_HOME, aarch64 Linux): `--managed-python` install writes `python-mode=managed`; a flag-less re-run prints "Reusing the recorded managed-python choice", rebuilds the venv against the PBS interpreter (pyvenv.cfg home verified), and `kirocrew --version` runs.

no linked issue: gap found while answering "does an upgrade need the flag again?" right after #4594 merged.

<!-- no-visual-delta -->
**Why no screenshot:** installer shell script, docs, and backend test only; nothing renders in the browser.
