### PR TITLE
fix(dashboard): accept Windows absolute paths in the file I/O schema gate

### DIFF
--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2292,21 +2292,40 @@ HOOK_UPDATE_SCHEMA = ToolSchema(
 
 # ── Tool Schemas (File I/O) ──
 
+#: Syntactic shape gate for a filesystem path arriving over the dashboard's
+#: file endpoints. It admits POSIX (``/x``, ``~/x``) *and* native Windows
+#: (``C:\x``, ``C:/x``, UNC ``\\host\share\x``) absolute paths. A prefix is
+#: still required, so a bare relative path is refused exactly as before --
+#: the endpoints that support relative input rewrite it to an absolute path
+#: via ``_resolve_project_relative`` under ``resolve=1``, ahead of this gate.
+#:
+#: One pattern rather than a ``sys.platform`` branch: a drive letter and a UNC
+#: root have no meaning on POSIX, so accepting those shapes there admits no
+#: path that was previously unreachable, and a single pattern cannot drift
+#: between platforms the way two would. This is a *syntax* gate only -- the
+#: security boundary is downstream, where ``hooks.validate_file_path``
+#: canonicalizes through ``realpath`` (resolving ``..`` and following symlinks)
+#: and refuses the resolved target via ``is_sensitive_path``.
+#:
+#: The prefix alternation is matched separately from the body so that ``:``
+#: stays confined to a drive prefix: an NTFS alternate data stream
+#: (``C:\x\file.txt:hidden``, which reads a different byte stream than the path
+#: the caller appears to name) has a ``:`` in the body and is still refused.
+#: A drive-relative path (``C:x``) is likewise refused -- it resolves against a
+#: per-drive working directory the caller cannot see.
+_FS_PATH_PATTERN = re.compile(r"^(?:[~/]|[A-Za-z]:[\\/]|\\\\)[-\w.@~/\\ ]+$")
+
 FILE_READ_SCHEMA = ToolSchema(
     tool_name="file_read",
     fields=[
-        FieldSpec(
-            "path", str, required=True, max_len=4096, pattern=re.compile(r"^[~/][-\w.@~/ ]+$")
-        ),
+        FieldSpec("path", str, required=True, max_len=4096, pattern=_FS_PATH_PATTERN),
     ],
 )
 
 FILE_WRITE_SCHEMA = ToolSchema(
     tool_name="file_write",
     fields=[
-        FieldSpec(
-            "path", str, required=True, max_len=4096, pattern=re.compile(r"^[~/][-\w.@~/ ]+$")
-        ),
+        FieldSpec("path", str, required=True, max_len=4096, pattern=_FS_PATH_PATTERN),
         FieldSpec("content", str, required=True, max_len=512000),
     ],
 )

--- a/test/test_dashboard_files_coverage.py
+++ b/test/test_dashboard_files_coverage.py
@@ -79,30 +79,15 @@ def _get_app(route: str, handler) -> web.Application:
 # ── /api/file-read ──
 
 
-# Every test below that hands a real `tmp_path` to the file-read/write/watch
-# endpoints is POSIX-only, because the PRODUCT rejects native Windows paths
-# before any branch under test is reached: FILE_READ_SCHEMA / FILE_WRITE_SCHEMA
-# in validation.py pin `path` to `^[~/][-\w.@~/ ]+$`, which admits neither the
-# `C:` drive prefix nor a backslash separator. A Windows tmp_path like
-# `C:\Users\runneradmin\AppData\Local\Temp\pytest-...` therefore 400s as
-# "invalid input" no matter what the endpoint would otherwise do.
-#
-# This is the same defect class as deploy's `_LOCAL_DIR_RE` (reported from the
-# first coverage wave): a POSIX-shaped allowlist guarding a path that reaches
-# real file I/O. Widening it is security-relevant and belongs in its own
-# reviewed change, NOT in a coverage PR -- so these classes are skipped on
-# win32 and will start covering Windows for free once the schema is fixed.
-_WINDOWS_PATH_DEFECT = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "FILE_READ/WRITE_SCHEMA reject native Windows paths (no drive letter or "
-        "backslash in the allowed pattern), so every request 400s before the "
-        "branch under test -- product defect, not a test defect"
-    ),
-)
-
-
-@_WINDOWS_PATH_DEFECT
+# Every test below hands a real `tmp_path` to the file-read/write/watch
+# endpoints, so it exercises a native Windows path on Windows and a POSIX one
+# elsewhere. That works because `_FS_PATH_PATTERN` in validation.py -- the
+# syntax gate FILE_READ_SCHEMA / FILE_WRITE_SCHEMA pin `path` to -- admits the
+# `C:` drive prefix and the backslash separator alongside the POSIX shapes.
+# Before it did, a Windows `tmp_path` like
+# `C:\Users\runneradmin\AppData\Local\Temp\pytest-...` 400'd as "invalid input"
+# ahead of every branch under test, so these three classes were skipped on
+# win32 and the endpoints had no Windows coverage at all.
 class TestFileRead:
     @staticmethod
     def _client_app() -> web.Application:
@@ -257,7 +242,6 @@ class TestFileRead:
 # ── /api/file-write ──
 
 
-@_WINDOWS_PATH_DEFECT
 class TestFileWrite:
     @staticmethod
     def _client_app() -> web.Application:
@@ -485,7 +469,6 @@ class TestFileRaw:
 # ── /api/file-watch ──
 
 
-@_WINDOWS_PATH_DEFECT
 class TestFileWatch:
     @staticmethod
     def _client_app() -> web.Application:

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -8,6 +8,8 @@ from kiro_crew.validation import (
     ARTIFACT_SAVE_SCHEMA,
     CHANNEL_ID_RE,
     CRON_ADD_SCHEMA,
+    FILE_READ_SCHEMA,
+    FILE_WRITE_SCHEMA,
     LEARN_ADD_SCHEMA,
     SEND_MESSAGE_SCHEMA,
     SET_PROJECT_SCHEMA,
@@ -1077,3 +1079,82 @@ def test_unique_items_distinguishes_bool_from_number():
             {"type": "object",
              "properties": {"x": {"type": "array", "uniqueItems": True}}},
         )
+
+
+# ── File I/O path shape (FILE_READ_SCHEMA / FILE_WRITE_SCHEMA) ──
+
+
+class TestFilePathShape:
+    """The syntax gate every dashboard file endpoint validates `path` against.
+
+    It ran POSIX-only until the dashboard file viewer was found to 400 on every
+    file on Windows: the pattern required a `~` or `/` first character and
+    allowed neither `\\` nor `:`, so a native Windows path was refused ahead of
+    the Windows-aware canonicalization below it.
+    """
+
+    @staticmethod
+    def _accepts(path: str) -> bool:
+        try:
+            validate_tool_args({"path": path}, FILE_READ_SCHEMA)
+            return True
+        except ValidationError:
+            return False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/home/user/project/notes.md",
+            "~/project/notes.md",
+            "/tmp/a file with spaces.md",
+        ],
+    )
+    def test_accepts_posix_absolute(self, path):
+        assert self._accepts(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            r"C:\Users\me\workspace\notes.md",
+            "C:/Users/me/workspace/notes.md",
+            r"c:\lower\drive\letter.md",
+            r"\\host\share\notes.md",
+            r"C:\Users\me\a file with spaces.md",
+        ],
+    )
+    def test_accepts_windows_absolute(self, path):
+        assert self._accepts(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Drive-relative: resolves against a per-drive working directory the
+            # caller cannot see, so its target is not the path it appears to name.
+            r"C:notes.md",
+            # NTFS alternate data stream: reads a different byte stream than the
+            # file the path appears to name. ':' is confined to the drive prefix
+            # precisely so this stays refused.
+            r"C:\Users\me\notes.md:hidden",
+            # A bare relative path is still refused -- the endpoints that accept
+            # relative input rewrite it to absolute via _resolve_project_relative
+            # under resolve=1, ahead of this gate.
+            "src/main.py",
+            # Shell metacharacters remain outside the allowed body class.
+            "/tmp/$evil",
+            "/tmp/a;rm -rf b",
+            "/tmp/a|b",
+            # A prefix alone names a root, not a file.
+            "/",
+            "C:\\",
+            # Newline injection into anything that later logs or splits the path.
+            "/tmp/a\nb",
+        ],
+    )
+    def test_refuses(self, path):
+        assert not self._accepts(path)
+
+    def test_write_schema_shares_the_same_gate(self):
+        # One pattern object backs both schemas, so they cannot drift apart.
+        validate_tool_args({"path": r"C:\Users\me\notes.md", "content": "x"}, FILE_WRITE_SCHEMA)
+        with pytest.raises(ValidationError):
+            validate_tool_args({"path": r"C:notes.md", "content": "x"}, FILE_WRITE_SCHEMA)

--- a/website/src/test/fileReadUrl.test.ts
+++ b/website/src/test/fileReadUrl.test.ts
@@ -34,6 +34,26 @@ describe('fileReadUrl', () => {
     expect(url).toContain('resolve=1')
     expect(url).toContain(encodeURIComponent('home/user/project/notes.md'))
   })
+
+  // A Windows path starts with neither `/` nor `~`, so the original
+  // relative-path test classified every one of them as project-relative and
+  // appended resolve=1. Inert against today's backend (its resolver passes
+  // drive and UNC shapes through untouched) but the wrong assertion to send.
+  it.each([
+    ['C:\\Users\\me\\workspace\\notes.md', 'a drive path with backslashes'],
+    ['C:/Users/me/workspace/notes.md', 'a drive path with forward slashes'],
+    ['\\\\host\\share\\notes.md', 'a UNC path'],
+  ])('treats %s as absolute (%s)', (path) => {
+    const url = fileReadUrl(path)
+    expect(url).toBe('/api/file-read?path=' + encodeURIComponent(path))
+    expect(url).not.toContain('resolve=1')
+  })
+
+  it('a drive-relative path is still relative — it has no root', () => {
+    // `C:notes.md` resolves against a per-drive working directory, so it is not
+    // absolute and the backend schema refuses it outright.
+    expect(fileReadUrl('C:notes.md')).toContain('resolve=1')
+  })
 })
 
 describe('fileDownloadUrl', () => {

--- a/website/src/utils/fileReadUrl.ts
+++ b/website/src/utils/fileReadUrl.ts
@@ -1,8 +1,18 @@
 /** Append resolve=1 for relative paths. The backend resolves such paths
  * against KIROCREW_PROJECT_DIR; absolute and ~-paths pass through unchanged. */
 function withResolve(url: string, filePath: string): string {
-  const relative = !filePath.startsWith('/') && !filePath.startsWith('~')
-  return relative ? url + '&resolve=1' : url
+  return isAbsolute(filePath) ? url : url + '&resolve=1'
+}
+
+/** Is this path already absolute, i.e. NOT to be resolved against the project dir?
+ *
+ * Covers the Windows shapes as well as the POSIX ones: a drive-qualified path
+ * (`C:\x`, `C:/x`) and a UNC path (`\\host\share\x`) are absolute, and marking
+ * them `resolve=1` mislabels them. The backend currently passes drive and UNC
+ * shapes through its resolver untouched, so the flag is inert today — but the
+ * classification is what the caller is asserting, so it should be true. */
+function isAbsolute(filePath: string): boolean {
+  return /^([~/]|[A-Za-z]:[\\/]|\\\\)/.test(filePath)
 }
 
 /** Build the /api/file-read URL, appending resolve=1 for relative paths. */


### PR DESCRIPTION
## Problem / Motivation

On Windows the dashboard file viewer shows `_Unable to read file._` for **every** file, while the sidebar file tree lists those same files correctly. Clicking any entry in the tree produces the placeholder, not content.

`FILE_READ_SCHEMA` and `FILE_WRITE_SCHEMA` in `src/kiro_crew/validation.py` pinned the `path` field to `^[~/][-\w.@~/ ]+$`. That pattern requires a `~` or `/` first character and its character class contains neither `\` nor `:`, so every native Windows absolute path failed validation and `/api/file-read` returned `400 {"error": "invalid input"}`. The frontend maps a non-404 failure to that placeholder, which is why the symptom reads as a read error rather than a rejected request. Forward slashes did not help either (`C:/...` fails the same anchor), so there was no client-side workaround.

This is not a regression -- the gate has been POSIX-only since it was introduced. Issue #3164 was a different Windows file-viewer bug (`os.O_NOFOLLOW` missing on Windows) and is already fixed.

## Why it matters

Four endpoints are affected, all of them core dashboard surfaces on Windows:

| Endpoint | What it drives |
|---|---|
| `api_file_read` | file viewer preview |
| `api_file_watch` | live-reload SSE for an open file |
| `api_file_download` | saving a file from the panel |
| `api_file_write` | editing a file from the panel |

Not affected, because they carry no schema gate: `api_file_raw`, `api_file_stream`, `api_file_sheet`, `api_file_diff`, `api_project_tree` -- which is exactly why the tree renders while the preview does not, and why the failure looks like a viewer bug rather than a validation one.

The gate also suppressed its own test coverage. `test/test_dashboard_files_coverage.py` carried a `_WINDOWS_PATH_DEFECT` skip marker whose stated reason was this defect ("will start covering Windows for free once the schema is fixed"), so 28 endpoint tests across `TestFileRead`, `TestFileWrite` and `TestFileWatch` did not execute on Windows at all.

## What changed (motivation -> approach -> change)

The layers *below* this gate were already Windows-aware, which is what makes the schema the whole defect: `hooks.validate_file_path` has an explicit `os.name == "nt"` UNC trusted-root branch, and `_resolve_project_relative` in `dashboard/handlers/files.py` deliberately passes drive-letter and UNC shapes through untouched. Windows support was implemented and unreachable.

So the change is confined to the syntax gate:

- Extract the duplicated regex into one `_FS_PATH_PATTERN` backing both schemas, so the two copies cannot drift apart -- two copies of one rule is how this class of bug survives.
- Widen it to accept drive-qualified (`C:\x`, `C:/x`) and UNC (`\\host\share\x`) roots alongside the POSIX shapes.

Two decisions worth stating, since both were deliberate:

**One pattern, not a `sys.platform` branch.** A drive letter and a UNC root have no meaning on POSIX, so accepting those shapes there admits no path that was previously unreachable, and a single pattern cannot drift between platforms the way two would. This is a *syntax* gate only -- `realpath` canonicalization (resolving `..`, following symlinks) plus `is_sensitive_path` on the resolved target remain the security boundary, and on Windows this change *activates* those checks on a path that previously never reached them.

**The prefix is matched separately from the body**, which keeps `:` confined to the drive prefix. So an NTFS alternate data stream (`C:\x\file.txt:hidden`, which reads a different byte stream than the path appears to name) and a drive-relative path (`C:x`, which resolves against a per-drive working directory the caller cannot see) are both still refused. A prefix is still *required*, so a bare relative path behaves exactly as before: the endpoints that accept relative input rewrite it to absolute via `_resolve_project_relative` under `resolve=1`, ahead of this gate.

Secondary fix: `withResolve()` in `website/src/utils/fileReadUrl.ts` classified a path as project-relative when it started with neither `/` nor `~`, so it appended `resolve=1` to every Windows path. Inert against today's backend (its resolver passes drive and UNC shapes through untouched) but the wrong assertion to send, and it would misfire if that branch ever tightened.

## Tests

Backend -- `test/test_validation.py`, new `TestFilePathShape`, driving the schemas through `validate_tool_args`:

- accepts POSIX absolute and `~`-relative paths, including one with spaces (locks in that this change takes nothing away)
- accepts `C:\x`, `C:/x`, a lower-case drive letter, `\\host\share\x`, and a drive path with spaces
- refuses the drive-relative `C:x` and the ADS `C:\x\notes.md:hidden` -- these are the two shapes the prefix/body split exists to keep out, so they are asserted rather than assumed
- refuses a bare relative path, shell metacharacters (`$`, `;`, `|`), an embedded newline, and a bare root (`/`, `C:\`)
- asserts `FILE_WRITE_SCHEMA` shares the same pattern object, so a future edit to one cannot silently spare the other

Backend -- `test/test_dashboard_files_coverage.py`: removed the three `_WINDOWS_PATH_DEFECT` markers, which turns on **28 previously-skipped endpoint tests on Windows** covering content-type-per-extension, the 512KB truncation cap and its `X-Truncated` header, `HEAD` probes, the directory-vs-missing 404 `X-Path-Kind` split, atomic write, and the watch SSE stream. The comment block above them now records why they are platform-neutral instead of why they were skipped.

Frontend -- `website/src/test/fileReadUrl.test.ts`: a table-driven case asserting a drive path (both separators) and a UNC path build a URL with no `resolve=1`, plus one asserting `C:notes.md` is still treated as relative because it has no root.

## Manual verification

`_Unable to read file._` reproduced on the live Windows gateway before the change, and the schema confirmed as the rejecting layer by feeding it the exact failing path directly:

```
pattern: ^[~/][-\w.@~/ ]+$
REJECT  C:\Users\<me>\workspace\devfleet-full-sync.ps1  -> path: invalid format
REJECT  C:/Users/<me>/workspace/devfleet-full-sync.ps1  -> path: invalid format
REJECT  \\server\share\notes.md                         -> path: invalid format
ACCEPT  /Users/<me>/notes.md
ACCEPT  ~/notes.md
```

After the change those three are accepted and the endpoint-level behaviour is covered by the 28 now-executing Windows tests, which exercise the real handlers over `aiohttp` `TestClient` with native `tmp_path` paths -- the same request shape the panel sends. Gates run on Windows: `pytest` 248 passed / 9 skipped, `flake8` clean, `isort` clean, `mypy` no errors in the changed module, `tsc -b` clean, `eslint` clean, `vitest` 9/9.

<!-- no-visual-delta -->
**Why no screenshot:** the only frontend file in the diff, `website/src/utils/fileReadUrl.ts`, is a pure URL builder with no rendered output -- it changes a query-string flag, not a pixel. The user-visible effect (the viewer rendering content instead of the placeholder) comes from the backend schema fix and is asserted at the endpoint level by the 28 Windows tests above.

## Related Issues

Fixes #4635