### PR TITLE
fix(file-explorer): accept proxy signatures for paths that are not requote-stable

### DIFF
--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -831,22 +831,37 @@ class FileExplorerHandler(BaseHTTPRequestHandler):
         logger.info("%s - %s", self.address_string(), fmt % args)
 
     # ----- routing -----
-    def _authorized_or_health(self, method: str) -> bool:
+    def _authorized_or_health(self, method: str, body: bytes = b"") -> bool:
         """Verify the gateway's X-KiroCrew-Proxy HMAC before dispatch (CWE-306).
 
         The health endpoint stays unauthenticated because the gateway's own
         liveness probe (apps/backend.py) hits the backend directly, unsigned.
         A read-only GET carries no body, so the signed body hash is sha256(b"").
+
+        The signature is accepted over either of two request-target forms:
+
+        1. The raw wire bytes (``self.path``) — the historical behavior.
+        2. The DECODED path+query. The gateway signs the decoded target
+           (aiohttp's ``match_info`` / ``request.query_string``), then sends a
+           plain-str URL that yarl re-encodes — so the wire bytes differ from
+           the signed form whenever the decoded text is not requote-stable.
+           A space is the common case: signed as ``' '`` but sent as ``'+'``,
+           so every request for a path like ``~/My Documents`` failed
+           verification and the UI showed a silently empty tree. Every
+           aiohttp-based app backend verifies the decoded form; this mirrors
+           them.
         """
         route = urllib.parse.urlparse(self.path).path.rstrip("/")
         if route in ("", "/health", "/api", "/api/health"):
             return True
-        if verify_proxy_request(
-            self.headers.get("X-KiroCrew-Proxy", ""),
-            method=method,
-            target=self.path,
-            body=b"",
-        ):
+        header = self.headers.get("X-KiroCrew-Proxy", "")
+        if verify_proxy_request(header, method=method, target=self.path, body=body):
+            return True
+        split = urllib.parse.urlsplit(self.path)
+        decoded = urllib.parse.unquote(split.path)
+        if split.query:
+            decoded += "?" + urllib.parse.unquote_plus(split.query)
+        if verify_proxy_request(header, method=method, target=decoded, body=body):
             return True
         _sel_audit("proxy_auth_failed", self.path, outcome="denied")
         self._json(401, {"error": "unauthorized"})

--- a/test/test_file_explorer_proxy_auth.py
+++ b/test/test_file_explorer_proxy_auth.py
@@ -1,0 +1,70 @@
+"""Proxy-signature verification for the file-explorer backend.
+
+Regression coverage for request targets that are not requote-stable: the
+gateway signs the DECODED target (aiohttp's ``match_info`` /
+``request.query_string``), then sends a plain-str URL that yarl re-encodes,
+so the wire bytes differ from the signed form whenever the decoded text does
+not survive a requote round-trip.  A space is the everyday case — signed as
+``' '`` but sent as ``'+'`` — which made every request for a path like
+``~/My Documents`` fail HMAC verification and the Files tree render silently
+empty.
+"""
+
+import hashlib
+import hmac
+import time
+
+from kiro_crew.apps.builtins.file_explorer import server
+
+SECRET = "test-proxy-secret"
+
+
+def _sign(secret: str, method: str, target: str, body: bytes = b"") -> str:
+    ts = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    msg = f"{ts}:{method}:{target}:{body_hash}"
+    sig = hmac.new(secret.encode(), msg.encode(), hashlib.sha256).hexdigest()
+    return f"{ts}:{sig}"
+
+
+def _auth(wire_path: str, header: str, method: str = "GET", body: bytes = b"") -> bool:
+    handler = server.FileExplorerHandler.__new__(server.FileExplorerHandler)
+    handler.path = wire_path
+    handler.headers = {"X-KiroCrew-Proxy": header}
+    handler._json = lambda code, payload: None
+    return handler._authorized_or_health(method, body=body)
+
+
+class TestProxyAuthRequoteStability:
+    def test_raw_wire_target_accepted(self, monkeypatch):
+        """Historical behavior: a signature over the exact wire bytes passes."""
+        monkeypatch.setenv("KIROCREW_PROXY_SECRET", SECRET)
+        wire = "/api/read?path=%2Fhome%2Fuser%2Ffile.txt"
+        assert _auth(wire, _sign(SECRET, "GET", wire)) is True
+
+    def test_decoded_target_with_space_accepted(self, monkeypatch):
+        """The fix: a signature over the DECODED target must also pass, or
+        every space-path request 401s and the tree renders empty."""
+        monkeypatch.setenv("KIROCREW_PROXY_SECRET", SECRET)
+        wire = "/api/read?path=%2Fhome%2Fuser%2FMy+Documents%2Fnotes.md"
+        decoded = "/api/read?path=/home/user/My Documents/notes.md"
+        assert _auth(wire, _sign(SECRET, "GET", decoded)) is True
+
+    def test_wrong_signature_rejected(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_PROXY_SECRET", SECRET)
+        wire = "/api/read?path=%2Fhome%2Fuser%2Ffile.txt"
+        assert _auth(wire, _sign("wrong-secret", "GET", wire)) is False
+
+    def test_body_participates_in_the_signature(self, monkeypatch):
+        """The optional body parameter binds the payload: the same header must
+        not verify over different bytes."""
+        monkeypatch.setenv("KIROCREW_PROXY_SECRET", SECRET)
+        wire = "/api/read?path=%2Fhome%2Fuser%2Ffile.txt"
+        body = b"payload"
+        header = _sign(SECRET, "POST", wire, body)
+        assert _auth(wire, header, method="POST", body=body) is True
+        assert _auth(wire, header, method="POST", body=b"tampered") is False
+
+    def test_health_stays_unauthenticated(self):
+        """The gateway's own liveness probe hits /health unsigned."""
+        assert _auth("/health", "") is True


### PR DESCRIPTION
## Problem / Motivation

The Files app shows a silently empty tree for any folder whose path contains a space — e.g. `~/My Documents` or `~/internal work`. The backend rejects every request for such paths with a 401 the UI swallows, so the app just looks broken with no error shown.

## Why it matters

Space-containing folder names are everywhere on real machines (macOS especially), so affected users experience the app as "shows no files at all" for exactly the folders they care about — with no clue why. The failure is invisible: no error surfaces in the UI or the browser console beyond a swallowed 401.

## What changed (motivation → approach → change)

Observed symptom: folder listings for space paths return 401 while sibling paths without spaces work.

Root cause: the gateway signs the DECODED request target (aiohttp's `match_info` / `request.query_string`), then sends a plain-str URL that yarl re-encodes — so the wire bytes differ from the signed form whenever the decoded text does not survive a requote round-trip. A space is the everyday case: signed as `' '`, sent as `'+'`. The file-explorer backend verified only the raw wire bytes, so verification failed for every such request.

Change: `_authorized_or_health` verifies the raw wire target first (unchanged behavior, zero risk to currently-working paths), then falls back to the decoded form — the same contract every aiohttp-based app backend in this repo already uses; the file-explorer backend was the one deviating. The handler also gains an optional `body` parameter so future non-GET routes can sign over their payload.

## Tests

New `test/test_file_explorer_proxy_auth.py`:
- `test_decoded_target_with_space_accepted` — the regression: **fails against the pre-fix handler and passes with this change** (verified by running it against `upstream/main`'s server.py: 5 failed → 5 passed).
- `test_raw_wire_target_accepted` — pins that the historical raw-bytes form still verifies.
- `test_wrong_signature_rejected` — wrong key never passes either form.
- `test_body_participates_in_the_signature` — a signature over one body must not verify over different bytes.
- `test_health_stays_unauthenticated` — the gateway's unsigned liveness probe keeps working.

Full existing file-explorer suite passes (75 tests). isort / flake8 / mypy clean on the touched files.

## Manual verification

Reproduced and verified end-to-end against a locally booted backend with signed requests: pre-fix, a listing of a real space path returns 401; post-fix it returns the folder's entries. Also verified in a production install where the same symptom was originally diagnosed.

## Related Issues

Discovered while preparing #4648; this fix is standalone and #4650 stacks on it.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior fix with no doc surface
- [x] No secrets, credentials, or internal references in the diff
