### PR TITLE
fix(chat): disclose auto in the per-turn model footer

### DIFF
--- a/docs/system-specs/features/turn-stats-footer.md
+++ b/docs/system-specs/features/turn-stats-footer.md
@@ -27,13 +27,13 @@ TurnUsage on EVENT_COMPLETE  ──►  chat_runner captures _turn_elapsed_ms /
 ## Backend (`src/kiro_crew/dashboard/chat_runner.py`)
 
 - **Turn start stamp**: `_turn_t0 = time.monotonic()` is recorded immediately before the event-stream loop of each turn.
-- **Capture at `EVENT_COMPLETE`**: `_turn_elapsed_ms` prefers the provider-reported `TurnUsage.duration_ms` (claude_code fills it; kiro/acp reports 0) and falls back to local wall clock. `_turn_credits` is kiro-cli's per-turn `meteringUsage` sum; `_turn_cost_usd` is claude_code's API-reported cost.
+- **Capture at `EVENT_COMPLETE`**: `_turn_elapsed_ms` prefers the provider-reported `TurnUsage.duration_ms` (claude_code fills it; kiro/acp reports 0) and falls back to local wall clock. `_turn_credits` is kiro-cli's per-turn `meteringUsage` sum; `_turn_cost_usd` is claude_code's API-reported cost; `_turn_model` is `read_turn_model(client)` (see Model attribution).
 - **`_attach_turn_stats(slot, elapsed_ms, credits, cost_usd, turn_boundary)`**: mirrors `_flush_file_changes` — walks `slot.messages[turn_boundary:]` backwards and sets `meta["turn_stats"]` on the last assistant message. `turn_boundary` is `len(slot.messages)` captured at turn start, restricting the scan to messages appended during THIS turn — an error/refusal-only turn (no assistant message) therefore attaches nothing rather than overwriting the previous turn's stats. Runs in the `not _retrying_empty` post-turn block, *before* `_flush_file_changes` and `_save_slot_to_history`, so the meta both persists and reaches live tabs via the existing `chat_done` → `refreshSlot` re-fetch (no new WS event).
 
 ### Meta contract
 
 ```json
-"turn_stats": { "elapsed_ms": 84210, "credits": 2.5, "cost_usd": 0.0231 }
+"turn_stats": { "elapsed_ms": 84210, "credits": 2.5, "cost_usd": 0.0231, "model": "claude-sonnet-4.6" }
 ```
 
 | Field | Presence | Meaning |
@@ -41,6 +41,23 @@ TurnUsage on EVENT_COMPLETE  ──►  chat_runner captures _turn_elapsed_ms /
 | `elapsed_ms` | always (> 0) | Turn wall clock (provider duration preferred) |
 | `credits` | only when > 0 (rounded to 4 dp) | kiro per-turn credit spend |
 | `cost_usd` | only when > 0 (rounded to 6 dp) | claude_code API cost |
+| `model` | only when non-empty | What served the turn: a resolved id, or the bare `auto` |
+
+### Model attribution
+
+`read_turn_model` (`dashboard/handlers/usage.py`) answers "what served this turn" in three states, and the distinction between the last two is the point:
+
+| State | Value | When |
+|-------|-------|------|
+| Resolved | e.g. `global.anthropic.claude-opus-4-8[1m]` | A concrete id reached the provider chain (`_resolved_model_id`, else `_model`) |
+| Auto | `auto` | The session is on Auto and the backend disclosed no id for the turn |
+| Unattributable | `""` (key omitted) | No model information at all |
+
+Auto is reported as the bare sentinel rather than collapsed into the empty state because a blank footer is indistinguishable from a turn with no measurement, which reads as a broken footer rather than as "the backend chose". It is never presented as a model id.
+
+Auto's per-turn choice is not on the ACP wire — the `_kiro.dev/metadata` frame carries `contextUsagePercentage` and `meteringUsage` only, and `currentModelId` is session-scoped (`session/new` / `session/load`), which `set_model("auto")` then overwrites with the sentinel. So `auto` is the whole of what can be said truthfully; disclosing which model Auto picked requires the backend to report it per turn.
+
+`read_effective_model` remains the reader for pricing and context-window lookups, where the sentinel is not a usable key.
 
 Edge cases: no attach when `elapsed_ms <= 0` (turn never reached `EVENT_COMPLETE`); no synthetic message is fabricated and no earlier turn is touched when a turn produced no assistant message (error-only turns — enforced by `turn_boundary`). Empty-response re-queue turns skip attachment entirely (the whole post-turn block is skipped).
 
@@ -50,10 +67,12 @@ Edge cases: no attach when `elapsed_ms <= 0` (turn never reached `EVENT_COMPLETE
 - **User control**: Chat Settings includes a `Show elapsed time and credits` switch. It defaults to enabled for existing/new users, persists in `mc-chat-config`, and hides only the presentation — collection and persistence continue so re-enabling restores stats on existing messages.
 - Rendered only on messages where `showFooter` is true (the last assistant message of each completed turn) and never while streaming — so exactly one stats line per turn.
 - Always visible (unlike the hover-revealed action footer): 11px muted mono line with a clock icon, e.g. `⏱ 1m 24s · 2.50 credits`. `cost_usd` renders as `· $0.02` only when credits are absent (providers bill in one or the other).
+- **Model chip**: `model` leads the line when present, trimmed by `fmtTurnModel` (drops region/vendor routing prefixes) for width; the untrimmed id stays in the footer tooltip. The `auto` sentinel passes through the trimmer verbatim and renders as `auto`.
 - Formatting: `fmtTurnElapsed` — `3.5s` under 10 s, `42s` under a minute, `2m 34s` beyond; `fmtCredits` — 2 decimals under 10, 1 above.
 - Messages persisted before this feature simply lack the meta and render nothing.
 
 ## Tests
 
-- `test/test_turn_stats.py` — attach/omit semantics, last-assistant targeting, rounding, meta coexistence with `file_changes`.
-- `website/src/test/AssistantMessage.test.tsx` (`turn stats footer` suite) — render variants (credits / cost / elapsed-only), hidden while streaming / `showFooter=false` / missing meta, formatter contracts.
+- `test/test_turn_stats.py` — attach/omit semantics, last-assistant targeting, rounding, meta coexistence with `file_changes`, and the binding that keeps the footer on the auto-aware model reader.
+- `test/test_usage.py` (`TestReadTurnModel`) — the three attribution states.
+- `website/src/test/AssistantMessage.test.tsx` (`turn stats footer` suite) — render variants (credits / cost / elapsed-only / model / `auto`), hidden while streaming / `showFooter=false` / missing meta, formatter contracts.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -110,7 +110,7 @@ from kiro_crew.dashboard.handlers.usage import (
     persist_token_record_async,
     read_context_tokens,
     read_effective_agent,
-    read_effective_model,
+    read_turn_model,
 )
 from kiro_crew.dashboard.session_directive_apply import apply_session_directive
 from kiro_crew.dashboard.state import (
@@ -1027,11 +1027,12 @@ def _attach_turn_stats(
 
     ``elapsed_ms`` is the turn wall clock (or the provider-reported duration
     when available); ``credits`` is kiro-cli's per-turn ``meteringUsage`` sum;
-    ``cost_usd`` is claude_code's API-reported cost. ``model`` is the id the
-    backend actually served this turn (``read_effective_model``) — on the
-    ``auto`` path this is the disclosure of what auto resolved to, on a pinned
-    session it is confirmation. Zero/empty fields are omitted so the frontend
-    renders only what the provider actually reported.
+    ``cost_usd`` is claude_code's API-reported cost. ``model`` is what served
+    this turn (``read_turn_model``): a concrete id on a pinned session, or the
+    bare ``"auto"`` when the turn was handed to Auto and the backend disclosed
+    no id for it — Auto's per-turn choice is not on the ACP wire, so ``"auto"``
+    is the whole of what can be said truthfully. Zero/empty fields are omitted
+    so the frontend renders only what the provider actually reported.
 
     ``turn_boundary`` is ``len(slot.messages)`` captured at turn start: only
     messages appended DURING this turn are candidates. Without it, an
@@ -6616,12 +6617,13 @@ async def _run_chat(
                     _turn_cost_usd = float(_u.cost_usd or 0.0)
                 except (TypeError, ValueError):
                     _turn_elapsed_ms = int((time.monotonic() - _turn_t0) * 1000)
-                # Resolved model for the footer: the id the backend actually
-                # served this turn. read_effective_model prefers
-                # _resolved_model_id over _model, skips the "auto" sentinel,
-                # and never raises — an unresolved auto turn stays "" and the
-                # footer omits the field rather than guessing.
-                _turn_model = read_effective_model(client)
+                # Model attribution for the footer. read_turn_model reports the
+                # id the backend actually served, or the bare "auto" when the
+                # turn was handed to Auto and no concrete id came back — the
+                # two are different facts and a blank footer conflates them
+                # with a missing measurement. Still never guesses: an
+                # unattributable turn stays "" and the footer omits the field.
+                _turn_model = read_turn_model(client)
                 if _u.input_tokens or _u.output_tokens or _u.credits:
                     try:
                         _provider_name = cfg.agent.provider  # type: ignore[possibly-undefined]
@@ -6701,9 +6703,7 @@ async def _run_chat(
                     _ac = slot._acp_client
                     _awaiting = bool(
                         getattr(_ac, "_awaiting_permission", False)
-                        or getattr(
-                            getattr(_ac, "_handle", None), "_awaiting_permission", False
-                        )
+                        or getattr(getattr(_ac, "_handle", None), "_awaiting_permission", False)
                     )
                     emit_counter(
                         TURN_TIMEOUT_CAUSE,

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -998,6 +998,27 @@ def _source_requests_auto(source: object) -> bool:
         return False
 
 
+def read_turn_model(source: object) -> str:
+    """Return what served the turn: a resolved id, ``"auto"``, or ``""``.
+
+    :func:`read_effective_model` alone collapses two different situations into
+    ``""``: a turn whose model the provider never reported, and a turn the user
+    deliberately handed to Auto. They read identically to a consumer, so a
+    display surface that omits a blank model shows nothing for an Auto turn and
+    an absent model becomes indistinguishable from a missing measurement.
+
+    ``"auto"`` is not a model id and is never presented as one — it is the
+    honest answer to "who chose", which is all the backend discloses when
+    Auto routes a turn (the ACP per-turn metadata frame carries context and
+    metering only). Callers that need a concrete id for a pricing or window
+    lookup must keep using :func:`read_effective_model`. Never raises.
+    """
+    resolved = read_effective_model(source)
+    if resolved:
+        return resolved
+    return "auto" if _source_requests_auto(source) else ""
+
+
 def _resolve_model(model: str, model_source: object) -> str:
     """Resolve the model to record, retaining a known Auto selection.
 
@@ -1010,12 +1031,12 @@ def _resolve_model(model: str, model_source: object) -> str:
     requested = (model or "").strip().lower()
     if requested not in ("", "auto"):
         return model
-    resolved = read_effective_model(model_source) if model_source is not None else ""
+    resolved = read_turn_model(model_source) if model_source is not None else ""
     if resolved:
         return resolved
-    if requested == "auto" or _source_requests_auto(model_source):
-        return "auto"
-    return ""
+    # An explicit Auto request stands on its own: the caller named it, so it is
+    # recorded even when the provider chain no longer reports it.
+    return "auto" if requested == "auto" else ""
 
 
 def _coerce_int(value: Any) -> int:

--- a/test/test_turn_stats.py
+++ b/test/test_turn_stats.py
@@ -5,7 +5,9 @@ Covers ``chat_runner._attach_turn_stats``: the helper that mirrors
 message of a completed turn, so the dashboard footer can show the same
 end-of-turn elapsed/credits line kiro-cli prints natively.
 """
+from kiro_crew.dashboard import chat_runner
 from kiro_crew.dashboard.chat_runner import _attach_turn_stats
+from kiro_crew.dashboard.handlers import usage
 from kiro_crew.dashboard.state import _ChatSlot
 
 
@@ -13,6 +15,17 @@ def _make_slot_with_assistant_message() -> _ChatSlot:
     slot = _ChatSlot("test-turn-stats")
     slot.append("assistant", "done.", "msg msg-a", broadcast=False)
     return slot
+
+
+def test_footer_reads_the_auto_aware_model_helper():
+    """The footer must use ``read_turn_model``, not ``read_effective_model``.
+
+    Both readers exist and differ only on the Auto path: the latter reports ""
+    there, which the footer renders as nothing — indistinguishable from a turn
+    with no model information at all. Binding the footer to the wrong one is a
+    silent regression, since every pinned-model assertion still passes.
+    """
+    assert chat_runner.read_turn_model is usage.read_turn_model
 
 
 class TestAttachTurnStats:
@@ -70,15 +83,23 @@ class TestAttachTurnStats:
         assert slot.messages[-1]["meta"]["turn_stats"]["credits"] == 0.1235
 
     def test_model_included_when_resolved(self):
-        # The served model id (read_effective_model at EVENT_COMPLETE) rides
-        # along so the footer can disclose what an "auto" session ran on.
+        # The served model id (read_turn_model at EVENT_COMPLETE) rides along so
+        # the footer can confirm what a pinned session actually ran on.
         slot = _make_slot_with_assistant_message()
         _attach_turn_stats(slot, 3000, 1.0, 0.0, model="claude-sonnet-4.6")
         stats = slot.messages[-1]["meta"]["turn_stats"]
         assert stats["model"] == "claude-sonnet-4.6"
 
-    def test_model_omitted_when_unresolved(self):
-        # An unresolved auto turn yields "" — the key must be absent, not
+    def test_auto_sentinel_is_carried_like_any_other_value(self):
+        # An Auto turn arrives as the literal "auto" — not a model id, but the
+        # only true answer available, and it must reach the footer rather than
+        # being filtered back into the omitted-key case below.
+        slot = _make_slot_with_assistant_message()
+        _attach_turn_stats(slot, 3000, 1.0, 0.0, model="auto")
+        assert slot.messages[-1]["meta"]["turn_stats"]["model"] == "auto"
+
+    def test_model_omitted_when_unattributable(self):
+        # No model information at all yields "" — the key must be absent, not
         # empty, so the frontend renders nothing rather than a blank chip.
         slot = _make_slot_with_assistant_message()
         _attach_turn_stats(slot, 3000, 1.0, 0.0, model="")

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -26,6 +26,7 @@ from kiro_crew.dashboard.handlers.usage import (
     read_context_tokens,
     read_effective_agent,
     read_effective_model,
+    read_turn_model,
 )
 
 # ── _parse_sessions ─────────────────────────────────────────────────────
@@ -1126,6 +1127,42 @@ class TestReadEffectiveModel:
         node._client = node
         node._model = "claude-opus-4.8"
         assert read_effective_model(node) == "claude-opus-4.8"
+
+
+class TestReadTurnModel:
+    """read_turn_model: display attribution — concrete id, `auto`, or blank."""
+
+    def test_concrete_id_outranks_the_sentinel(self):
+        # A resolved id anywhere in the chain wins even while an outer wrapper
+        # still reports the Auto request, so a pinned turn never reads "auto".
+        handle = type("Handle", (), {"_resolved_model_id": "claude-opus-4.8"})()
+        provider = type("P", (), {"_model": "auto", "_handle": handle})()
+        assert read_turn_model(provider) == "claude-opus-4.8"
+
+    def test_auto_request_with_no_resolved_id_reports_auto(self):
+        # The case read_effective_model collapses to "": the user chose Auto and
+        # the backend disclosed no id. Reporting the choice is not guessing.
+        assert read_turn_model(_Inner("auto")) == "auto"
+        assert read_effective_model(_Inner("auto")) == ""
+
+    def test_auto_sentinel_is_matched_case_and_space_insensitively(self):
+        assert read_turn_model(_Inner("  AUTO ")) == "auto"
+
+    def test_auto_found_deeper_in_the_chain(self):
+        inner = type("Handle", (), {"_model": "auto"})()
+        assert read_turn_model(type("P", (), {"_handle": inner})()) == "auto"
+
+    def test_no_model_information_stays_blank(self):
+        # Distinct from the Auto case: nothing is known, so nothing is claimed.
+        assert read_turn_model(object()) == ""
+
+    def test_never_raises_on_a_hostile_source(self):
+        class Boom:
+            @property
+            def _model(self):
+                raise RuntimeError("no")
+
+        assert read_turn_model(Boom()) == ""
 
 
 class TestReadEffectiveAgent:

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -471,6 +471,17 @@ describe('turn stats footer (elapsed time + credits)', () => {
     expect(screen.queryByTestId('turn-model')).not.toBeInTheDocument()
   })
 
+  // An Auto turn arrives as the literal `auto`, not a model id, because Auto's
+  // per-turn choice is not disclosed on the wire. It still renders: a blank
+  // chip there is indistinguishable from a turn with no measurement at all,
+  // which is exactly the reading this chip exists to prevent.
+  it('shows the bare auto sentinel for a turn the backend routed itself', () => {
+    render(<AssistantMessage content="done" isStreaming={false} slotRunning={false} turnStats={{ elapsed_ms: 6_100, credits: 0.64, model: 'auto' }} />)
+    expect(screen.getByTestId('turn-model')).toHaveTextContent('auto')
+    const text = screen.getByTestId('turn-stats').textContent!.replace(/\s+/g, ' ').trim()
+    expect(text).toMatch(/^auto ·\s*0\.64 credits ·\s*6\.1s$/)
+  })
+
   // The tooltip is four whole-sentence catalog keys, one per combination of the
   // two optional clauses. Nothing else asserts the `title`, so without these a
   // wrong key or a dropped clause would render silently and every visible-text
@@ -525,6 +536,9 @@ describe('turn stats footer (elapsed time + credits)', () => {
     expect(fmtTurnModel('anthropic.claude-haiku-4-5')).toBe('claude-haiku-4-5')
     expect(fmtTurnModel('claude-sonnet-4.6')).toBe('claude-sonnet-4.6')
     expect(fmtTurnModel('gpt-5.6-luna')).toBe('gpt-5.6-luna')
+    // The Auto sentinel is passed through verbatim — the trimmer must not
+    // mistake it for a vendor-prefixed id and leave an empty label behind.
+    expect(fmtTurnModel('auto')).toBe('auto')
   })
 })
 


### PR DESCRIPTION
## Problem

The per-turn footer's model chip disappeared on every Auto turn — the line read `0.56 credits · 19s` with no model, while a pinned turn in the same session read `claude-opus-5 · 0.64 credits · 6.1s`. A blank there is indistinguishable from a turn that reported no measurement at all, so it reads as a broken footer rather than as "the backend chose".

Mechanically: `read_effective_model` skips the `auto` sentinel by design, and picking Auto writes that sentinel into **both** `_model` and `_resolved_model_id` (`session_handle.py:1102/1122`, `client.py:2360/2361`), clobbering the concrete `currentModelId` that `session/new` reported. Both candidates were the sentinel, so the reader returned `""` and the footer omitted the whole segment.

This also contradicted `_attach_turn_stats`'s own docstring, which claimed the `auto` path was "the disclosure of what auto resolved to" — the one path where it disclosed nothing.

Verified against live data before changing anything: five session files written minutes apart on the current build carried `turn_stats` with `elapsed_ms` + `credits` and no `model`.

## Change

`read_turn_model` splits the single blank into three distinct answers:

| State | Value | When |
|-------|-------|------|
| Resolved | e.g. `global.anthropic.claude-opus-4-8[1m]` | A concrete id reached the provider chain |
| Auto | `auto` | The session is on Auto and the backend disclosed no id |
| Unattributable | `""` (key omitted) | No model information at all |

Auto's per-turn choice is **not on the ACP wire** — the `_kiro.dev/metadata` frame carries `contextUsagePercentage` and `meteringUsage` only (`acp/_dispatch.py:148`), and `currentModelId` is session-scoped (`session/new` / `session/load`). So `auto` is the whole of what can be said truthfully. It is never presented as a model id, and `read_effective_model` remains the reader for pricing and context-window lookups where the sentinel is not a usable key.

The telemetry path (`_resolve_model`) already had an equivalent Auto fallback, so the usage row store knew a turn was Auto while the footer did not. Both now go through one reader; the pre-existing `TestModelSourceFallback::test_auto_source_fills_empty_model` covers that the refactor is behaviour-preserving.

**No frontend production change.** The existing chip renders the sentinel verbatim, so `auto` displays as-is and the tooltip becomes `… · model: auto` through the existing `turn_model` key — zero new i18n keys.

## Attribution semantics (unchanged by this PR, worth stating)

The value is read at that turn's `EVENT_COMPLETE` and frozen into the message's `meta.turn_stats`; the frontend renders the persisted meta and never recomputes. So switching the model later does not relabel an older message, which is correct — that turn really was served by what it says.

Switching mid-turn is not a quiet relabel either: the live-switch path refuses when `has_active_turn()` and falls back to a session reset, which ends the turn — and a turn that never reaches `EVENT_COMPLETE` keeps `_turn_model = ""` (`chat_runner.py:4990`), so nothing is attached. Background ops (titles, suggestions) are separate ACP sessions with their own handle, and `_wrapper_chain` visits `_runtime` last so process-level `--model` cannot outrank session state.

The honest limit: the value is *derived* from mutable session state at turn end, not *recorded* when the prompt was sent, so this rests on the no-mid-turn-switch invariant rather than on the data model.

## Not in scope

Disclosing **which** model Auto picked requires the backend to report it per turn. `_dispatch.py`'s `_log_unrecognized_metadata_fields` already logs novel metadata fields once each, so it will surface if kiro-cli starts sending one.

## Tests

- `test/test_usage.py::TestReadTurnModel` — the three attribution states, sentinel matched case/space-insensitively, found deeper in the wrapper chain, never raises on a hostile source.
- `test/test_turn_stats.py` — the sentinel is carried like any other value; plus a binding test that the footer uses `read_turn_model`, since both readers exist and differ *only* on the Auto path, so binding the wrong one is a silent regression that every pinned-model assertion still passes.
- `website/src/test/AssistantMessage.test.tsx` — an `auto` turn renders the chip and the full line; `fmtTurnModel('auto')` passes through unchanged.

**Mutation-verified both layers.** Neutering `_source_requests_auto` in the helper failed 4 tests (3 new + the pre-existing telemetry one). Adding `&& turnStats.model !== 'auto'` to the renderer failed the new frontend test. Both reverted.

Renamed `test_model_omitted_when_unresolved` → `test_model_omitted_when_unattributable`: "unresolved auto" is no longer that case.

## Docs

`docs/system-specs/features/turn-stats-footer.md` never documented the `model` field at all. Added the meta-contract row, the three-state table, and why Auto's per-turn choice is unobtainable.

## Unrelated hunk, and why it is required

`chat_runner.py` is **not** in `.github/black-baseline.txt` but was **not** black-clean on `origin/main` either (verified against pristine main: one hunk, a manual wrap black would join at `:6703`). The formatting gate is diff-scoped and requires any non-baselined file in scope to be clean, so the first PR to touch this file pays that one line. Applied by hand exactly as black asked rather than letting black rewrite the file.

## Verification

Green locally: `pytest` targeted (1475 across every module importing the touched code), `isort`, `flake8`, `mypy` (999 files), the black gate at real diff scope, `docs-lint`, `tsc -b`, `eslint`, `jscpd`, `i18n:check` with `I18N_BASE_REF`, and the full frontend suite — **22208 passed, 0 failed**.

Full backend suite: **58188 passed, 43 failed**, none of them this change. Not one of the 12 failing files references `handlers.usage`, `chat_runner`, `turn_stats`, or either reader. 7 are self-inflicted by the dev host: its glibc is too old for Pillow 12's manylinux wheels, so Pillow had to be built from source with `-C jpeg=disable` (no libjpeg headers) and `PIL.features.check('jpg')` is `False`, which is exactly what `test_acp_prompt_blocks`'s jpeg/webp mime tests assert on. The other 36 are host/tooling (playwright node bootstrap, ssh multiplexing, `ps` parsing, macOS release, GitHub workflow triage, xdist host-budget at load average 27). CI runs on a clean image and is the check that matters for these.

## Follow-up noticed, not fixed here

`chat_handlers.py:3312` asserts "The UI disables the model button while a turn runs", but no run-state `disabled` guard is apparent on the model button in `ChatPage.tsx`. It does not change behaviour (the backend `has_active_turn()` guard plus the reset path covers it), but the comment may be stale and the front line of defence is the backend, not the UI.
