### PR TITLE
refactor: rename ChatPage's preview 'focus mode' to 'expand mode'

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -40,7 +40,7 @@ import OnboardingFlow from './components/OnboardingFlow'
 import AgentImportFlow from './components/AgentImportFlow'
 import PrivacyChapter from './components/PrivacyChapter'
 import { OnboardingShellHost } from './components/OnboardingChapterShell'
-import { PREVIEW_FOCUS_EVENT } from './components/WebPreviewPanel'
+import { PREVIEW_EXPAND_EVENT } from './components/WebPreviewPanel'
 import { motion, AnimatePresence } from 'framer-motion'
 import { usePersistedBool } from './hooks/usePersistedBool'
 import { isMacElectron, isWinElectron, isLinuxFramelessElectron } from './lib/electron'
@@ -1124,10 +1124,10 @@ export default function App() {
   const [navCollapsed, setNavCollapsed] = useState(() => localStorage.getItem('mc-nav') === '1')
   const navCollapsedRef = useRef(navCollapsed)
   navCollapsedRef.current = navCollapsed
-  // Preview focus (expand) mode from the Web Preview tab collapses the left nav
+  // Preview expand mode from the Web Preview tab collapses the left nav
   // as a STARTING layout, not a lock — the brand toggle keeps its standard
-  // behavior while focus mode is on, so the rail can be brought back without
-  // leaving the preview. This ref holds the pre-focus state to restore on exit,
+  // behavior while expand mode is on, so the rail can be brought back without
+  // leaving the preview. This ref holds the pre-expand state to restore on exit,
   // and is cleared the moment the user toggles the rail themselves so their
   // choice is not undone. `navCollapsed` is driven directly rather than ORed
   // with a transient flag, because an OR makes the toggle look broken.
@@ -1138,9 +1138,9 @@ export default function App() {
   // already-cleared ref and lose the restore value.
   const navAutoCollapsed = useRef<boolean | null>(null)
   useEffect(() => {
-    const onFocus = (e: Event) => {
-      const focused = !!(e as CustomEvent<{ focused?: boolean }>).detail?.focused
-      if (focused) {
+    const onPreviewExpand = (e: Event) => {
+      const expanded = !!(e as CustomEvent<{ expanded?: boolean }>).detail?.expanded
+      if (expanded) {
         if (navAutoCollapsed.current === null) navAutoCollapsed.current = navCollapsedRef.current
         setNavCollapsed(true)
         return
@@ -1149,8 +1149,8 @@ export default function App() {
       navAutoCollapsed.current = null
       if (prior !== null) setNavCollapsed(prior)
     }
-    window.addEventListener(PREVIEW_FOCUS_EVENT, onFocus)
-    return () => window.removeEventListener(PREVIEW_FOCUS_EVENT, onFocus)
+    window.addEventListener(PREVIEW_EXPAND_EVENT, onPreviewExpand)
+    return () => window.removeEventListener(PREVIEW_EXPAND_EVENT, onPreviewExpand)
   }, [])
   const isMobile = useIsMobile()
   const [sidePanelDock] = useSidePanelDock()
@@ -1809,8 +1809,8 @@ export default function App() {
   const toggleNav = () => {
     if (isMobile) { setMobileNavOpen(p => !p) }
     else {
-      // The user has taken ownership of the rail: leaving preview focus mode
-      // must not overwrite this with the pre-focus state.
+      // The user has taken ownership of the rail: leaving preview expand mode
+      // must not overwrite this with the pre-expand state.
       navAutoCollapsed.current = null
       setNavCollapsed(prev => { const next = !prev; safeSetItem('mc-nav', next ? '1' : '0'); return next })
     }

--- a/website/src/components/WebPreviewPanel.tsx
+++ b/website/src/components/WebPreviewPanel.tsx
@@ -46,13 +46,13 @@ const PREVIEW_URL_EVENT = 'kirocrew-web-preview-url'
  *  navigated) — the click-to-load counterpart of PREVIEW_URL_EVENT. */
 const PREVIEW_PENDING_EVENT = 'kirocrew-web-preview-pending'
 /**
- * Window event: enter/leave preview "focus" (expand) mode. App collapses the
+ * Window event: enter/leave the preview expand mode. App collapses the
  * left nav and ChatPage hides the session list + maximizes the side panel, so
  * the preview gets maximum room and the chat pane shrinks to its minimum. A
  * plain window event (not prop-drilling) keeps this leaf panel decoupled from
  * the two ancestors that own that layout.
  */
-export const PREVIEW_FOCUS_EVENT = 'kirocrew-preview-focus'
+export const PREVIEW_EXPAND_EVENT = 'kirocrew-preview-expand'
 /**
  * Window event: request an area screenshot into the chat input. ChatPage owns
  * the capture pipeline (getDisplayMedia in the browser / the same path routed
@@ -387,7 +387,7 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
   // browser could answer from cache, which is no reload at all for a static
   // server with no HMR. 0 = the initial mount-restored load, kept pristine.
   const [reloadKey, setReloadKey] = useState(0)
-  // Preview "focus" (expand) mode — reflected in the toggle icon; broadcast to
+  // Preview expand mode — reflected in the toggle icon; broadcast to
   // App/ChatPage which collapse the surrounding chrome.
   const [expanded, setExpanded] = useState(false)
   // Viewport preset (responsive desktop vs a fixed device size).
@@ -621,18 +621,18 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
 
   const reload = useCallback(() => setReloadKey(k => k + 1), [])
 
-  const broadcastFocus = useCallback((focused: boolean) => {
-    window.dispatchEvent(new CustomEvent(PREVIEW_FOCUS_EVENT, { detail: { focused } }))
+  const broadcastExpanded = useCallback((expanded: boolean) => {
+    window.dispatchEvent(new CustomEvent(PREVIEW_EXPAND_EVENT, { detail: { expanded } }))
   }, [])
   const toggleExpand = useCallback(() => {
-    setExpanded(v => { broadcastFocus(!v); return !v })
-  }, [broadcastFocus])
-  // Leaving the preview (tab switched away or panel/tab closed) drops focus mode
+    setExpanded(v => { broadcastExpanded(!v); return !v })
+  }, [broadcastExpanded])
+  // Leaving the preview (tab switched away or panel/tab closed) drops expand mode
   // so the chrome isn't left collapsed with the toggle out of reach.
   useEffect(() => {
-    if (!active && expanded) { setExpanded(false); broadcastFocus(false) }
-  }, [active, expanded, broadcastFocus])
-  useEffect(() => () => { broadcastFocus(false) }, [broadcastFocus])
+    if (!active && expanded) { setExpanded(false); broadcastExpanded(false) }
+  }, [active, expanded, broadcastExpanded])
+  useEffect(() => () => { broadcastExpanded(false) }, [broadcastExpanded])
 
   // What the iframe actually loads: the nav URL, varied per reload so a remount
   // is a real request. `url` itself stays pristine everywhere it's user-visible

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -137,7 +137,7 @@ import TaskProgressBar from './chat/TaskProgressBar'
 import SidePanel, { CHAT_PANE_MIN_W, sidePanelFillWidth } from './chat/SidePanel'
 import { useSidePanelDock } from '../hooks/useSidePanelDock'
 import { groupDisplayItems, applyRunningState } from './chat/groupDisplayItems'
-import { setSessionPreviewPending, normalizeUrl, PREVIEW_FOCUS_EVENT, PREVIEW_SNIP_EVENT } from '../components/WebPreviewPanel'
+import { setSessionPreviewPending, normalizeUrl, PREVIEW_EXPAND_EVENT, PREVIEW_SNIP_EVENT } from '../components/WebPreviewPanel'
 import { detectPreviewUrl, previewFeedDecision } from '../utils/detectPreviewUrl'
 import { fileLandingSlot } from '../utils/uploadRouting'
 import ChatSidebar, { SIDEBAR_MIN, SIDEBAR_MAX } from './ChatSidebar'
@@ -5097,8 +5097,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       // Always-available collapse. Only guard is no-sessions (the sidebar is
       // force-open then anyway, so there is nothing to collapse).
       if (filteredSlotsRef.current.length === 0) return
-      // Explicit user intent outranks the preview-focus auto-hide, so exiting
-      // focus mode leaves this choice alone.
+      // Explicit user intent outranks the preview-expand auto-hide, so exiting
+      // expand mode leaves this choice alone.
       sidebarAutoHidden.current = null
       setSidebarPinned(p => {
         const next = !p
@@ -6100,7 +6100,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (isMobile) setMobileSessions(false)
     return true
   }, [dispatch, isMobile, selectSource])
-  // Web Preview "focus" (expand) mode — broadcast by the Web Preview tab's
+  // Web Preview expand mode — broadcast by the Web Preview tab's
   // expand toggle. When on, hide the session list and maximize the side panel
   // (passed to SidePanel), so the preview gets max room and chat shrinks to its
   // minimum. App collapses the left nav off the same event.
@@ -6108,7 +6108,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Hiding the list drives `sidebarPinned` directly instead of overriding
   // `sidebarOpen`: an override leaves the sessions toggle visibly present but
   // inert. Driving the real state keeps that toggle working normally inside
-  // focus mode. `sidebarAutoHidden` holds the pre-focus state to restore on
+  // expand mode. `sidebarAutoHidden` holds the pre-expand state to restore on
   // exit, and is cleared once the user toggles the list themselves. Neither
   // transition persists `mc-sidebar-pinned` — only a user toggle does.
   //
@@ -6120,12 +6120,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // The mobile drawer is a separate state, so it is closed outright rather than
   // suppressed — a swipe or a tap still reopens it, which an override would not
   // allow.
-  const [previewFocused, setPreviewFocused] = useState(false)
+  const [previewExpanded, setPreviewExpanded] = useState(false)
   useEffect(() => {
-    const onFocus = (e: Event) => {
-      const focused = !!(e as CustomEvent<{ focused?: boolean }>).detail?.focused
-      setPreviewFocused(focused)
-      if (focused) {
+    const onPreviewExpand = (e: Event) => {
+      const expanded = !!(e as CustomEvent<{ expanded?: boolean }>).detail?.expanded
+      setPreviewExpanded(expanded)
+      if (expanded) {
         setMobileSessions(false)
         if (sidebarAutoHidden.current === null) sidebarAutoHidden.current = sidebarPinnedRef.current
         setSidebarPinned(false)
@@ -6135,15 +6135,15 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       sidebarAutoHidden.current = null
       if (prior !== null) setSidebarPinned(prior)
     }
-    window.addEventListener(PREVIEW_FOCUS_EVENT, onFocus)
-    return () => window.removeEventListener(PREVIEW_FOCUS_EVENT, onFocus)
+    window.addEventListener(PREVIEW_EXPAND_EVENT, onPreviewExpand)
+    return () => window.removeEventListener(PREVIEW_EXPAND_EVENT, onPreviewExpand)
   }, [])
-  // The no-sessions force-open yields to focus mode: with an empty list no
+  // The no-sessions force-open yields to expand mode: with an empty list no
   // sessions toggle is rendered, so suppressing it makes nothing inert, and the
   // preview would otherwise stay covered by a list that cannot be dismissed.
   const sidebarOpen = isMobile
     ? mobileSessions
-    : (sidebarPinned || (filteredSlots.length === 0 && !previewFocused))
+    : (sidebarPinned || (filteredSlots.length === 0 && !previewExpanded))
 
   // ── Collapsed-sidebar hover flyout ──────────────────────────────────────
   // Hovering the toggle while collapsed opens a recents list over the chat, so
@@ -6200,16 +6200,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [dispatch, defaultAgent, mode, flyout])
 
   // Force the list open when there is nothing in it, so a user with no sessions
-  // still has the surface that creates one. Skipped while focus mode owns the
+  // still has the surface that creates one. Skipped while expand mode owns the
   // hidden state: re-pinning there would fight the auto-hide and, worse, persist
   // 'true' over the user's stored preference, which the restore on exit then
   // contradicts in the live state.
   useEffect(() => {
-    if (filteredSlots.length === 0 && !sidebarPinned && !previewFocused) {
+    if (filteredSlots.length === 0 && !sidebarPinned && !previewExpanded) {
       setSidebarPinned(true)
       safeSetItem('mc-sidebar-pinned', 'true')
     }
-  }, [filteredSlots.length, sidebarPinned, previewFocused])
+  }, [filteredSlots.length, sidebarPinned, previewExpanded])
 
   // Horizontal space (px) the detail panel must keep clear so it never grows
   // past its flex row and collapses the chat pane: the open sidebar's width
@@ -6220,10 +6220,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // The panel takes its maximum only while the session list is actually hidden.
   // That maximum is measured against the header's reserve, which knows nothing
   // about the session list's width — so keeping it while the user reopens the
-  // list inside focus mode pushes the chat pane below CHAT_PANE_MIN and clips
+  // list inside expand mode pushes the chat pane below CHAT_PANE_MIN and clips
   // its content. Reverting to the normal width maths there costs the preview a
   // few hundred px in a state the user asked for by reopening the list.
-  const panelMaximized = previewFocused && !sidebarOpen
+  const panelMaximized = previewExpanded && !sidebarOpen
 
   // FILL vs BESIDE for the activity panel, decided from the width left for the
   // CHAT once the shell's hideable chrome is subtracted — the nav rail track and

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -691,7 +691,7 @@ interface ChatState {
   activityTabRequest: number
   /** Pending "reveal in sidebar" request from the session header menu, or
    *  null. State, not a window event, on purpose: the sidebar is unmounted
-   *  while the drawer is collapsed (and under preview focus / on mobile), and
+   *  while the drawer is collapsed (and under preview expand mode / on mobile), and
    *  a one-shot CustomEvent dispatched before the listener mounts is silently
    *  dropped — there is no replay. Held here, the request survives until the
    *  sidebar consumes and clears it in an effect that also runs on mount

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -968,42 +968,42 @@ describe('App routing', () => {
     localStorage.removeItem('mc-nav')
   })
 
-  it('lets the brand toggle expand the rail while preview focus mode is active', () => {
+  it('lets the brand toggle expand the rail while preview expand mode is active', () => {
     localStorage.removeItem('mc-nav')
     renderWithProviders(<App />, { route: '/chat' })
     const nav = screen.getByRole('navigation', { name: 'Main navigation' })
 
     // Entering the Web Preview's expand mode collapses the rail.
     act(() => {
-      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: true } }))
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-expand', { detail: { expanded: true } }))
     })
     expect(within(nav).getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
 
-    // The logo keeps its standard behavior inside focus mode: it expands.
+    // The logo keeps its standard behavior inside expand mode: it expands.
     fireEvent.click(within(nav).getByRole('button', { name: 'Expand sidebar' }))
     expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
 
-    // Leaving focus mode must not undo that explicit choice.
+    // Leaving expand mode must not undo that explicit choice.
     act(() => {
-      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: false } }))
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-expand', { detail: { expanded: false } }))
     })
     expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
     localStorage.removeItem('mc-nav')
   })
 
-  it('restores the pre-focus rail state when preview focus mode ends untouched', () => {
+  it('restores the pre-expand rail state when preview expand mode ends untouched', () => {
     localStorage.removeItem('mc-nav') // start expanded
     renderWithProviders(<App />, { route: '/chat' })
     const nav = screen.getByRole('navigation', { name: 'Main navigation' })
     expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
 
     act(() => {
-      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: true } }))
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-expand', { detail: { expanded: true } }))
     })
     expect(within(nav).getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
 
     act(() => {
-      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: false } }))
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-expand', { detail: { expanded: false } }))
     })
     expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
     // The auto-collapse is transient: it never writes the persisted preference.

--- a/website/src/test/ChatPage.previewExpandSessions.test.tsx
+++ b/website/src/test/ChatPage.previewExpandSessions.test.tsx
@@ -1,10 +1,10 @@
 /**
- * Preview "focus" (expand) mode must not disable the sessions toggle.
+ * Preview expand mode must not disable the sessions toggle.
  *
- * Entering focus mode (the Browser panel's expand button) hides the session
+ * Entering expand mode (the Browser panel's expand button) hides the session
  * list to give the preview room, but that is a starting layout, not a lock:
- * the sessions toggle stays mounted and keeps working, and leaving focus mode
- * restores the pre-focus state only when the user did not override it.
+ * the sessions toggle stays mounted and keeps working, and leaving expand mode
+ * restores the pre-expand state only when the user did not override it.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { StrictMode } from 'react'
@@ -87,8 +87,8 @@ globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} 
 
 import ChatPage from '../pages/ChatPage'
 
-const setFocus = (focused: boolean) => act(() => {
-  window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused } }))
+const setExpanded = (expanded: boolean) => act(() => {
+  window.dispatchEvent(new CustomEvent('kirocrew-preview-expand', { detail: { expanded } }))
 })
 
 function renderChat({ slots = 1, strict = false }: { slots?: number; strict?: boolean } = {}) {
@@ -115,37 +115,37 @@ function renderChat({ slots = 1, strict = false }: { slots?: number; strict?: bo
   return store
 }
 
-describe('ChatPage — sessions toggle inside preview focus mode', () => {
+describe('ChatPage — sessions toggle inside preview expand mode', () => {
   beforeEach(() => {
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1400 })
     localStorage.clear()
     __resetPanelTabs()
   })
 
-  it('keeps the toggle mounted and working while focus mode is active', () => {
+  it('keeps the toggle mounted and working while expand mode is active', () => {
     renderChat()
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
 
-    setFocus(true)
-    // Focus mode hides the list, but the toggle is still there to bring it back.
+    setExpanded(true)
+    // Expand mode hides the list, but the toggle is still there to bring it back.
     const toggle = screen.getByRole('button', { name: 'Show sessions sidebar' })
 
     fireEvent.click(toggle)
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
 
-    // Leaving focus mode must not undo that explicit choice.
-    setFocus(false)
+    // Leaving expand mode must not undo that explicit choice.
+    setExpanded(false)
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
   })
 
-  it('restores the pre-focus session list when focus mode ends untouched', () => {
+  it('restores the pre-expand session list when expand mode ends untouched', () => {
     renderChat()
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
 
-    setFocus(true)
+    setExpanded(true)
     expect(screen.getByRole('button', { name: 'Show sessions sidebar' })).toBeInTheDocument()
 
-    setFocus(false)
+    setExpanded(false)
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
     // The auto-hide is transient: only a user toggle writes the preference.
     expect(localStorage.getItem('mc-sidebar-pinned')).toBeNull()
@@ -158,36 +158,36 @@ describe('ChatPage — sessions toggle inside preview focus mode', () => {
     renderChat({ strict: true })
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
 
-    setFocus(true)
+    setExpanded(true)
     expect(screen.getByRole('button', { name: 'Show sessions sidebar' })).toBeInTheDocument()
 
-    setFocus(false)
+    setExpanded(false)
     expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
   })
 
-  it('keeps the hover recents flyout available while focus mode hides the list', () => {
+  it('keeps the hover recents flyout available while expand mode hides the list', () => {
     renderChat()
-    setFocus(true)
-    // aria-haspopup mirrors flyoutEligible, which focus mode no longer suppresses.
+    setExpanded(true)
+    // aria-haspopup mirrors flyoutEligible, which expand mode no longer suppresses.
     expect(screen.getByRole('button', { name: 'Show sessions sidebar' }))
       .toHaveAttribute('aria-haspopup', 'menu')
   })
 
-  it('does not let focus mode overwrite the stored preference when the list drains to empty', () => {
+  it('does not let expand mode overwrite the stored preference when the list drains to empty', () => {
     // The force-open rule persists 'true' whenever the list is empty and
-    // unpinned. Focus mode also unpins, so without the guard, draining the list
-    // to zero inside focus mode would write 'true' over a user who chose
+    // unpinned. Expand mode also unpins, so without the guard, draining the list
+    // to zero inside expand mode would write 'true' over a user who chose
     // hidden — and the restore on exit would then contradict it in the live state.
     const store = renderChat()
     fireEvent.click(screen.getByRole('button', { name: 'Hide sessions sidebar' }))
     expect(localStorage.getItem('mc-sidebar-pinned')).toBe('false')
 
-    setFocus(true)
+    setExpanded(true)
     act(() => { store.dispatch(sseSlots([])) })
     expect(localStorage.getItem('mc-sidebar-pinned')).toBe('false')
 
-    setFocus(false)
-    // Out of focus mode the empty list is the force-open rule's business again.
+    setExpanded(false)
+    // Out of expand mode the empty list is the force-open rule's business again.
     expect(localStorage.getItem('mc-sidebar-pinned')).toBe('true')
   })
 
@@ -199,7 +199,7 @@ describe('ChatPage — sessions toggle inside preview focus mode', () => {
     act(() => { store.dispatch(toggleActivity()) })
     expect(await screen.findByTestId('side-panel')).toHaveAttribute('data-expanded', 'false')
 
-    setFocus(true)
+    setExpanded(true)
     expect(screen.getByTestId('side-panel')).toHaveAttribute('data-expanded', 'true')
 
     // The session list is the only term: the nav rail is narrow enough that the
@@ -214,21 +214,21 @@ describe('ChatPage — sessions toggle inside preview focus mode', () => {
     expect(screen.queryByRole('button', { name: /sessions sidebar/ })).not.toBeInTheDocument()
   })
 
-  it('closes the list in focus mode even with an empty session list', () => {
+  it('closes the list in expand mode even with an empty session list', () => {
     // The toggle is unrendered either way here, so assert the list itself: the
     // force-open rule must not leave the preview covered by an undismissable list.
     renderChat({ slots: 0 })
     expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
 
-    setFocus(true)
+    setExpanded(true)
     expect(screen.queryByTestId('sessions-drawer')).not.toBeInTheDocument()
 
-    setFocus(false)
+    setExpanded(false)
     expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
   })
 })
 
-describe('ChatPage — mobile session drawer inside preview focus mode', () => {
+describe('ChatPage — mobile session drawer inside preview expand mode', () => {
   beforeEach(() => {
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 420 })
     localStorage.clear()
@@ -239,14 +239,14 @@ describe('ChatPage — mobile session drawer inside preview focus mode', () => {
 
   it('closes the open drawer on entry and leaves it reopenable', () => {
     // Mobile has its own state (`mobileSessions`) and no sessions toggle, so
-    // focus mode closes the drawer outright instead of suppressing it.
+    // expand mode closes the drawer outright instead of suppressing it.
     const openDrawer = () =>
       fireEvent.click(screen.getAllByRole('button', { name: 'Toggle sessions' })[0])
     renderChat()
     openDrawer()
     expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
 
-    setFocus(true)
+    setExpanded(true)
     expect(screen.queryByTestId('sessions-drawer')).not.toBeInTheDocument()
 
     // Still reachable — an override would have made this button do nothing.

--- a/website/src/test/WebPreviewPanel.test.tsx
+++ b/website/src/test/WebPreviewPanel.test.tsx
@@ -509,10 +509,10 @@ describe('WebPreviewPanel', () => {
     }
   })
 
-  it('broadcasts preview-focus true/false as the expand button toggles', () => {
+  it('broadcasts preview-expand true/false as the expand button toggles', () => {
     const seen: boolean[] = []
-    const handler = (e: Event) => seen.push(!!(e as CustomEvent<{ focused?: boolean }>).detail?.focused)
-    window.addEventListener('kirocrew-preview-focus', handler)
+    const handler = (e: Event) => seen.push(!!(e as CustomEvent<{ expanded?: boolean }>).detail?.expanded)
+    window.addEventListener('kirocrew-preview-expand', handler)
     try {
       renderWithProviders(<WebPreviewPanel sessionKey="sess-1" />)
       fireEvent.click(screen.getByLabelText('Expand preview'))
@@ -520,7 +520,7 @@ describe('WebPreviewPanel', () => {
       fireEvent.click(screen.getByLabelText('Collapse'))
       expect(seen).toContain(false)
     } finally {
-      window.removeEventListener('kirocrew-preview-focus', handler)
+      window.removeEventListener('kirocrew-preview-expand', handler)
     }
   })
 })

--- a/website/src/test/sidePanelFillWidth.test.ts
+++ b/website/src/test/sidePanelFillWidth.test.ts
@@ -95,7 +95,7 @@ describe('sidePanelEffectiveWidth', () => {
     expect(sidePanelEffectiveWidth({ ...base, width: 460, maxW: 100 })).toBe(SIDE_PANEL_MIN_W)
   })
 
-  it('takes the maximum in preview-focus (expanded) mode', () => {
+  it('takes the maximum in preview-expand mode', () => {
     expect(sidePanelEffectiveWidth({ ...base, expanded: true, maxW: 800 })).toBe(800)
     expect(sidePanelEffectiveWidth({ ...base, expanded: true, maxW: 100 })).toBe(SIDE_PANEL_MIN_W)
   })


### PR DESCRIPTION
## Problem / Motivation

The dashboard has two unrelated "focus modes". PR #4590 added the shell-chrome focus mode (`useFocusMode`, hides the top bar and nav rail behind hover). The Web Preview panel's older, unrelated concept — its expand toggle collapsing the surrounding chrome — was also named "focus mode", keyed on `PREVIEW_FOCUS_EVENT` / `'kirocrew-preview-focus'` with a `{ focused }` payload, `previewFocused` state, and "focus mode" prose across App.tsx, ChatPage.tsx, WebPreviewPanel.tsx, chatSlice.ts, and four test files.

## Why it matters

Every future reader touching either feature has to stop and disambiguate which "focus mode" an identifier, comment, or test name means — a permanent comprehension tax and a real misedit hazard (a grep for "focus mode" lands in both features).

## What changed (motivation → approach → change)

The issue designates the OLDER preview concept as the rename target. The panel's own internal state was already named `expanded` / `toggleExpand`, so "expand mode" is the consistent, unambiguous name — the rename aligns the public event surface with the naming the component already uses internally:

- `PREVIEW_FOCUS_EVENT` → `PREVIEW_EXPAND_EVENT`; event type `'kirocrew-preview-focus'` → `'kirocrew-preview-expand'`; payload `{ focused }` → `{ expanded }`. The emitter (WebPreviewPanel) and both listeners (App, ChatPage) are renamed in the same commit. The event is a same-window `CustomEvent`, never persisted and never crossing a window boundary, so there is no compatibility surface to keep.
- `broadcastFocus` → `broadcastExpanded`, `previewFocused`/`setPreviewFocused` → `previewExpanded`/`setPreviewExpanded`, handlers `onFocus` → `onPreviewExpand`.
- All "focus mode" prose in the affected comments updated ("expand mode" / "pre-expand state"), including the `chatSlice.ts` doc comment and the App.tsx rail-ownership comment.
- `ChatPage.previewFocusSessions.test.tsx` renamed to `ChatPage.previewExpandSessions.test.tsx`; its `setFocus` helper and test names renamed to match.

Pure refactor: identifier/string/prose renaming only, zero behavior change (the diff is 88 insertions / 88 deletions).

## Tests

No new tests — the existing suites are the regression net and were all renamed with the code they exercise:

- `ChatPage.previewExpandSessions.test.tsx` (13 dispatch sites): session-list hide/restore semantics of expand mode.
- `App.test.tsx`: nav-rail collapse/restore on the renamed event and payload key.
- `WebPreviewPanel.test.tsx`: the expand toggle broadcasts the renamed event with the renamed payload.
- `sidePanelFillWidth.test.ts`: panel maximization in expand mode.

All pass: `npx tsc -b` clean, `npx vitest run` 1432 test files passed.

## Manual verification

N/A — unit coverage sufficient: the rename is mechanically count-asserted (every replacement verified to hit exactly its expected occurrences), a repo-wide grep for `PREVIEW_FOCUS`, `kirocrew-preview-focus`, `previewFocused`, and `broadcastFocus` returns zero hits, and the behavior itself is locked by the existing tests above.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** pure identifier/string rename inside `.tsx` files — no rendered output changes (no user-visible strings, layout, or styling touched).

## Related Issues

Closes #4652

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no docs reference the old names
- [x] No secrets, credentials, or internal references in the diff
