### PR TITLE
fix(desktop): refuse to launch a half-extracted bundled backend

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -313,6 +313,10 @@ same way). Key details:
   relative dylib references (genuinely portable, no system Python dependency).
 - **Entry point** is `bin/kirocrew` — a shell script that execs
   `bin/python3.12 -s -m kiro_crew "$@"`.
+- **Stdlib probes verified** — `stdlib_probe_gate` fails the build if any package
+  the launcher's readiness check probes is missing from the pruned tree, so a
+  drifted probe list breaks the build instead of every user's launch (see
+  [How the app finds and launches the backend](#how-the-app-finds-and-launches-the-backend)).
 - **Self-containment verified** — the build script runs
   `PYTHONNOUSERSITE=1 bin/python3.12 -m kiro_crew --version` to catch any
   missing dependency before packaging.
@@ -329,6 +333,79 @@ forward to a remote gateway—is reused. Otherwise the shell locates the backend
 binary via [`find-bin.js`](../../website/electron/find-bin.js), spawns it as
 `kirocrew gateway --no-open`, polls `/api/status`, and loads the dashboard once
 it is healthy.
+
+Before spawning a **bundled** backend the shell checks that the bundle's Python
+stdlib is fully on disk
+([`bundle-integrity.js`](../../website/electron/bundle-integrity.js)). The
+Windows NSIS installer extracts `backend-dist/` incrementally and launches the
+app as it finishes (`runAfterFinish`), so a launch inside that window finds
+`python.exe` present while late-alphabet stdlib packages are not — the
+interpreter then dies on `from urllib.parse import …` reached through
+`pathlib`, which reads as a corrupt install rather than an unfinished one. The
+check probes stdlib packages spread across the alphabet — via each one's
+`__init__.py`, since an extractor creates a directory before filling it and a
+top-level `.py` file lands with the early batch — and, when any are missing,
+reports "still being installed" through the normal gateway-failure dialog, whose
+**Retry** succeeds once extraction completes. It stays silent for the legacy
+flat layout, which carries no interpreter tree to verify.
+
+That pre-spawn check cannot be complete, and does not pretend to be: extraction
+order *within* a package is not the app's to control, so `import zoneinfo` can
+still fail moments after `zoneinfo/__init__.py` appears. A second, sound check
+backstops it. The two are not redundant — the pre-spawn probe is **preventive but
+unsound**, the backstop **sound but after-the-fact**, and each covers what the
+other cannot. Refusing before `spawn()` keeps a doomed interpreter from running
+module-scope work against the live data home (it creates the home and
+`.local_secret`, and writes bytecode caches) and from failing in messier ways than
+a clean `ModuleNotFoundError` while extraction is still writing underneath it;
+the backstop can only ever explain a crash that already happened.
+
+When a spawn dies on a **stdlib** import, the launch log is read and the failure
+reclassified as an unfinished install. Two traceback forms are matched, because a
+half-written package does not report the obvious one:
+
+- `ModuleNotFoundError: No module named 'urllib'` — the package (or, for a dotted
+  name, a submodule of a package that did land) is absent.
+- `ImportError: cannot import name '_tzpath' from partially initialized module
+  'zoneinfo'` — the package's `__init__.py` arrived before its siblings. This is
+  what CPython actually raises in that case, verified against the shipped
+  interpreter, and it is precisely the state the pre-spawn probe cannot see.
+
+Three conditions keep it from excusing anything else. Judgement is by the
+**top-level package name**, which must be in the stdlib set, so a missing
+third-party or first-party module (a genuine packaging defect) is never relabelled.
+Only a **bundled** backend qualifies — a user's own install or a `PATH` `kirocrew`
+failing on a stdlib import is a broken environment, and "wait for the installer"
+would be misleading advice there. And only the **current launch attempt** is read:
+the log is append-only across launches, so the text is sliced from the last spawn
+marker (`SPAWN_MARKER`, owned by `bundle-integrity.js` and logged by `main.js` so
+writer and reader cannot drift). Without that, an older traceback could relabel
+this attempt's unrelated failure — a `SIGKILL`, or a bound port whose real remedy
+is force-stop rather than a bare Retry — and show a reassuring dialog over a live
+fault. When the marker has scrolled out of the tail, attribution is unknowable and
+the check declines.
+
+**Why not an installer-written completion sentinel?** It looks like the obviously
+sounder mechanism — the installer knows exactly when extraction finished, and
+`installer.nsh` could write a marker from `customInstall`. It is rejected because
+`nsis.perMachine` is `false` and updates run the new version's installer **over the
+existing install directory**: after the first update the tree carries a sentinel
+written by the *previous* installer, which cannot be told apart from a valid one
+while a newer build is still extracting. That is precisely the reported failure (an
+update, not a fresh install), so a naive sentinel would assert "complete" during the
+exact race it was added to close. A sound version must be version-scoped, rewritten
+atomically per install, and compared against the running app's own version. It would
+also be Windows-only — the DMG and the Linux packages have no `customInstall` — so
+it is an addition on top of the probe, never a replacement for it.
+
+The build enforces the other direction: **`stdlib_probe_gate`** runs after
+pruning in both backend build paths and **fails the build** if any probed package
+is absent from the tree just built. A probe list that drifts from the shipped
+stdlib (a Python bump turning a package back into a module, a rename, or a new
+prune) would otherwise refuse *every* launch of a healthy app — a permanent
+failure worse than the transient one the gate prevents. Like `resolver_gate` it
+needs `node`, and logs a visible SKIP rather than failing when none is on PATH,
+so a `node`-less build environment still produces a bundle (unvalidated).
 
 The gateway-hosted dashboard then checks both prerequisites needed by the ACP
 provider:

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -313,6 +313,9 @@ LAUNCH
     rm -rf lib/python3.12/test lib/python3.12/idlelib lib/python3.12/tkinter \
            lib/python3.12/turtledemo lib/python3.12/ensurepip lib/python3.12/lib2to3 2>/dev/null || true )
 
+  # After pruning, so it validates what actually ships.
+  stdlib_probe_gate "$out"
+
   echo "    $(basename "$out") size: $(du -sh "$out" 2>/dev/null | cut -f1)"
 }
 
@@ -364,7 +367,42 @@ build_backend_windows() {
     find Lib/site-packages -type d \( -name tests -o -name test \) -prune -exec rm -rf {} + 2>/dev/null || true
     rm -rf Lib/test Lib/idlelib Lib/tkinter Lib/turtledemo Lib/ensurepip Lib/lib2to3 2>/dev/null || true )
 
+  # After pruning, so it validates what actually ships.
+  stdlib_probe_gate "$out"
+
   echo "    $(basename "$out") size: $(du -sh "$out" 2>/dev/null | cut -f1)"
+}
+
+# Stdlib-probe agreement gate: every package bundle-integrity.js probes must be
+# present, as an importable package, in the tree we just built. That module
+# refuses to spawn a backend whose stdlib looks incomplete, so a name it probes
+# that this bundle does not ship (a Python bump turning a package back into a
+# module, a rename, or a new prune above) would refuse EVERY launch of a healthy
+# app — a permanent failure strictly worse than the transient one it prevents.
+# Failing the build here converts that into a build error the developer sees.
+#   $1 = built backend tree
+stdlib_probe_gate() {
+  local out="$1"
+  if ! command -v node >/dev/null 2>&1; then
+    log "node unavailable — SKIPPING stdlib-probe gate for $(basename "$out")"
+    return 0
+  fi
+  log "Verifying bundle-integrity.js stdlib probes resolve ($(basename "$out"))…"
+  node -e '
+    const fs=require("fs"), path=require("path");
+    const { findMissingBundleParts, REQUIRED_STDLIB_PARTS } =
+      require(path.join(process.argv[1], "bundle-integrity"));
+    const out = process.argv[2];
+    const missing = findMissingBundleParts(fs, path, out);
+    if (missing.length) {
+      console.error(`ERROR: bundle-integrity.js probes ${REQUIRED_STDLIB_PARTS.length} stdlib `
+        + `packages; this bundle is missing: ${missing.join(", ")}`);
+      console.error("       The launcher would refuse to start this bundle on every launch.");
+      console.error("       Fix the prune step, or update REQUIRED_STDLIB_PARTS in");
+      console.error("       website/electron/bundle-integrity.js to match the shipped stdlib.");
+      process.exit(1);
+    }
+  ' "$ELECTRON_DIR" "$out" || exit 1
 }
 
 # Resolver-agreement gate: the Electron launcher (find-bin.js) must locate the

--- a/website/electron/bundle-integrity.js
+++ b/website/electron/bundle-integrity.js
@@ -1,0 +1,312 @@
+"use strict";
+//
+// Detects a bundled backend tree whose Python stdlib is only PARTLY on disk, so
+// the launcher can say "the install is still finishing" instead of exec'ing a
+// half-extracted interpreter and surfacing a raw ModuleNotFoundError.
+//
+// Why this is a real state and not paranoia: the Windows NSIS installer (and an
+// auto-update swap) extracts `resources/backend-dist/` incrementally, roughly in
+// directory order, while the app is already launchable — `runAfterFinish` starts
+// the app as the installer finishes. Launch inside that window and `python.exe`
+// plus the top-level stdlib FILES are present while late-alphabet PACKAGE dirs
+// are not. `pathlib.py` then imports cleanly and dies on `from urllib.parse
+// import quote_from_bytes`, which reads to a user as a corrupt install and to a
+// bug report as an inexplicable missing-stdlib crash.
+//
+// Pure and injectable (no electron, no real fs) so it is unit-testable.
+
+// Stdlib packages the gateway's own import chain needs, spread across the
+// alphabet so a partial extraction is caught wherever it stopped.
+//
+// Probed via each package's `__init__.py`, not the directory: an extractor
+// creates a directory before writing its contents, so an empty `Lib/zoneinfo/`
+// would satisfy a directory check while `import zoneinfo` still fails. The
+// `__init__.py` is also the exact file Python needs to treat the directory as a
+// package, so its presence is the same question the interpreter will ask.
+// Probing a package rather than a top-level module stays essential: a truncated
+// extraction leaves top-level .py files in place long before the late package
+// dirs land, so probing `pathlib.py` would report a broken bundle as healthy.
+//
+// The tail matters as much as the middle. Extraction proceeds roughly in
+// directory order, so the last names are the likeliest to be missing when a
+// launch races it, and `zipfile`/`zoneinfo` sort after everything else while
+// still being module-scope imports on the gateway's chain (cron, cli_setup,
+// portability). Stopping the list at `urllib` — the package the observed failure
+// hit — would leave exactly the most-likely-missing dirs unchecked.
+const REQUIRED_STDLIB_PARTS = [
+  "asyncio",
+  "collections",
+  "concurrent",
+  "ctypes",
+  "email",
+  "encodings",
+  "http",
+  "importlib",
+  "json",
+  "logging",
+  "multiprocessing",
+  "re",
+  "sqlite3",
+  "urllib",
+  "xml",
+  "xmlrpc",
+  "zipfile",
+  "zoneinfo",
+];
+
+/**
+ * Locate the stdlib root inside a bundled backend tree, across both layouts the
+ * builder emits: Windows PBS puts it at `Lib/`, POSIX PBS at
+ * `lib/python3.<minor>/`. The POSIX minor version is discovered by scanning
+ * rather than hardcoded, so a Python bump does not silently turn this gate off.
+ *
+ * The POSIX layout is probed FIRST, and that order is load-bearing on a
+ * case-insensitive filesystem (macOS APFS by default). There, `Lib` and `lib`
+ * name the same directory, so a `Lib/` probe against a POSIX tree succeeds and
+ * yields the dir holding `python3.<minor>/` — not the stdlib — which would make
+ * every required part look missing and refuse a perfectly good launch. The POSIX
+ * branch self-validates by requiring a `python3.<minor>` child, so on Windows
+ * (where the same case-insensitive match sends it into the real `Lib/`) it finds
+ * no such child and correctly falls through.
+ *
+ * @param {{existsSync: Function, readdirSync: Function}} fs
+ * @param {typeof import("path")} path
+ * @param {string} backendRoot  the `…/backend-dist/kirocrew-backend` directory
+ * @returns {string|null} absolute stdlib dir, or null if none is present yet
+ */
+function resolveStdlibDir(fs, path, backendRoot) {
+  const root = backendRoot || "";
+  const posixLib = path.join(root, "lib");
+  if (fs.existsSync(posixLib)) {
+    let entries = [];
+    try { entries = fs.readdirSync(posixLib); } catch { entries = []; }
+    // Sort so the choice is deterministic if a tree ever carries two minors.
+    const pyDir = entries.filter((e) => /^python3\.\d+$/.test(e)).sort()[0];
+    if (pyDir) {
+      const resolved = path.join(posixLib, pyDir);
+      if (fs.existsSync(resolved)) return resolved;
+    }
+  }
+  const winLib = path.join(root, "Lib");
+  return fs.existsSync(winLib) ? winLib : null;
+}
+
+/**
+ * True if `backendRoot` holds an actual Python interpreter, i.e. the tree this
+ * gate understands. The legacy flat PyInstaller layout carries a single frozen
+ * executable and NO stdlib directory, so probing it for `Lib/` would report a
+ * healthy bundle as incomplete; requiring an interpreter keeps the gate scoped
+ * to the python-build-standalone trees the current builder emits.
+ *
+ * @param {{existsSync: Function, readdirSync: Function}} fs
+ * @param {typeof import("path")} path
+ * @param {string} backendRoot
+ * @returns {boolean}
+ */
+function hasBundledInterpreter(fs, path, backendRoot) {
+  const root = backendRoot || "";
+  if (fs.existsSync(path.join(root, "python.exe"))) return true;
+  const posixBin = path.join(root, "bin");
+  if (!fs.existsSync(posixBin)) return false;
+  let entries;
+  try { entries = fs.readdirSync(posixBin); } catch { return false; }
+  return entries.some((e) => /^python3(\.\d+)?$/.test(e));
+}
+
+/**
+ * Which required stdlib parts are absent from a bundled backend tree.
+ *
+ * Returns [] for a tree that carries no bundled interpreter at all (the legacy
+ * flat layout, or a path that is not a backend tree) — this gate only speaks
+ * about interpreter trees, and must never block a launch it does not understand.
+ *
+ * @param {{existsSync: Function, readdirSync: Function}} fs
+ * @param {typeof import("path")} path
+ * @param {string} backendRoot  the `…/backend-dist/kirocrew-backend` directory
+ * @returns {string[]} missing part names ([] = complete or not applicable).
+ *   `["Lib"]` means the stdlib root itself is not there yet, i.e. extraction has
+ *   barely begun.
+ */
+function findMissingBundleParts(fs, path, backendRoot) {
+  if (!hasBundledInterpreter(fs, path, backendRoot)) return [];
+  const stdlib = resolveStdlibDir(fs, path, backendRoot);
+  if (!stdlib) return ["Lib"];
+  return REQUIRED_STDLIB_PARTS.filter(
+    (rel) => !fs.existsSync(path.join(stdlib, ...rel.split("/"), "__init__.py"))
+  );
+}
+
+/**
+ * User-facing one-liner for a bundle that is not fully on disk. Frames it as an
+ * unfinished install (retry is the fix) rather than a corrupt one (reinstall) —
+ * waiting for extraction to finish genuinely resolves it.
+ *
+ * Reports a COUNT rather than the package names: the names are Python stdlib
+ * internals a reader cannot act on, and the refusal is already logged with the
+ * full list for a bug report. The count conveys the one actionable thing — how
+ * much is still arriving.
+ *
+ * @param {string[]} missing  from findMissingBundleParts
+ * @returns {string}
+ */
+function describeIncompleteBundle(missing) {
+  const count = Array.isArray(missing) ? missing.length : 0;
+  const detail = count === 1 ? "1 component is" : `${count || "Some"} components are`;
+  // The reinstall advice carries an explicit time anchor. Extraction can run for
+  // minutes, so an unqualified "if this persists" reads as satisfied by two Retry
+  // clicks twenty seconds apart — steering the user into the very reinstall this
+  // message exists to prevent.
+  return `Kiro Crew's bundled Python runtime is still being installed — ${detail} `
+    + "not on disk yet. This can take a few minutes. Wait, then retry. If it is "
+    + "still failing after five minutes, restart the app; if that does not help, "
+    + "reinstall it.";
+}
+
+// The line main.js logs immediately before each spawn. It delimits one launch
+// attempt's child output in the append-only log, so the crash matcher can read
+// THIS attempt rather than an earlier one. Owned here and imported by main.js so
+// the writer and the reader cannot drift apart.
+const SPAWN_MARKER = "---- spawning gateway; child stdout+stderr follows ----";
+
+// Top-level stdlib names whose absence means "extraction is unfinished" rather
+// than "this build is broken". Kept to modules the gateway's own import chain
+// reaches, so an unrelated ModuleNotFoundError is never excused.
+//
+// Drift here is bounded and fails SAFE, unlike REQUIRED_STDLIB_PARTS: a name that
+// should be listed and is not merely means that crash is reported as an ordinary
+// failure (the status quo), never that a healthy launch is refused. Which is why
+// this set is not gated at build time — a build gate would have to assert absence
+// of nothing. Names compiled INTO the interpreter (`sys.builtin_module_names`,
+// e.g. zlib) are deliberately excluded: they cannot be missing from an extraction,
+// so listing them would only misdescribe what this set is for.
+const STDLIB_MODULE_NAMES = new Set([
+  ...REQUIRED_STDLIB_PARTS,
+  "base64", "configparser", "contextlib", "dataclasses", "datetime", "enum",
+  "functools", "gzip", "hashlib", "hmac", "inspect", "io", "ipaddress",
+  "pathlib", "platform", "queue", "random", "secrets", "selectors", "shlex",
+  "shutil", "signal", "socket", "ssl", "string", "struct", "subprocess",
+  "tempfile", "textwrap", "threading", "traceback", "types", "typing", "uuid",
+  "warnings", "weakref",
+]);
+
+/**
+ * True if a launch-log tail shows the interpreter dying on a missing stdlib
+ * module — the signature of a bundle that was still being written when it ran.
+ *
+ * This is the BACKSTOP that makes the pre-spawn check's incompleteness
+ * survivable, and it is sound where a filesystem probe cannot be. Extraction
+ * order is not ours to control: within a package `__init__.py` is written before
+ * its siblings, so `import zoneinfo` can still fail a moment after
+ * `zoneinfo/__init__.py` appears. Enumerating each package's private modules
+ * would not converge (every CPython release may add one) and would couple the
+ * launcher to internals — the exact drift that turns this guard into a permanent
+ * refusal. Reading the actual failure asks the only question that settles it:
+ * the interpreter itself reported which module it could not find.
+ *
+ * Deliberately narrow in two ways. The module must belong to the stdlib set, so a
+ * missing THIRD-PARTY or first-party dependency (a genuine packaging defect, e.g.
+ * `aiohttp` or `kiro_crew.foo`) is never excused as "still installing". And only
+ * the CURRENT launch attempt is read: the log is append-only across launches, so
+ * a traceback from an earlier attempt must not relabel this attempt's unrelated
+ * failure (a SIGKILL, a bound port) as an unfinished install, which would show a
+ * reassuring dialog over a real fault and leave Retry looping. `SPAWN_MARKER` is
+ * the line `main.js` writes immediately before each spawn, so the text after its
+ * last occurrence is exactly this attempt's child output.
+ *
+ * @param {string} text  launch-log tail
+ * @returns {boolean}
+ */
+function isIncompleteBundleCrash(text) {
+  // Only this attempt's output. An absent marker yields "", which matches nothing
+  // below, so the ordinary failure path reports it rather than this one guessing.
+  const s = currentAttemptLog(text);
+  if (!s) return false;
+  const missing = /ModuleNotFoundError: No module named ['"]([^'"]+)['"]/.exec(s);
+  if (missing) {
+    const name = missing[1];
+    // A dotted name is a SUBMODULE of a package that is itself present. Where the
+    // package is stdlib, that is still the extraction race (the package landed,
+    // its submodule had not), so judge it by its top-level package.
+    return STDLIB_MODULE_NAMES.has(name.split(".")[0]);
+  }
+  // A package whose __init__.py landed before its siblings does NOT raise
+  // ModuleNotFoundError: CPython reports the half-initialized package instead,
+  // e.g. `from . import _tzpath` inside a freshly-written zoneinfo/__init__.py
+  // gives "ImportError: cannot import name '_tzpath' from partially initialized
+  // module 'zoneinfo'". Verified against the shipped interpreter. Match that
+  // form too, or the case the pre-spawn probe cannot see stays uncovered.
+  const partial = /ImportError: cannot import name .+ from partially initialized module ['"]([^'"]+)['"]/.exec(s);
+  if (partial) return STDLIB_MODULE_NAMES.has(partial[1].split(".")[0]);
+  return false;
+}
+
+/**
+ * The portion of a launch-log tail belonging to the CURRENT launch attempt, i.e.
+ * the text after the last `SPAWN_MARKER`. Returns "" when the marker is absent,
+ * because the boundary has scrolled off and nothing in the tail can be attributed
+ * to this attempt.
+ *
+ * Callers should derive EVERY log-sniffed signal from this, not from the raw tail:
+ * the log is append-only across launches, so an older line (a bound port, a
+ * traceback) otherwise gets read as describing the current failure.
+ *
+ * @param {string} text  launch-log tail
+ * @returns {string}
+ */
+function currentAttemptLog(text) {
+  if (!text) return "";
+  const full = String(text);
+  const at = full.lastIndexOf(SPAWN_MARKER);
+  return at === -1 ? "" : full.slice(at);
+}
+
+/**
+ * Whether a spawn failure should be RE-labelled as an unfinished install based
+ * on the launch log. Pure, so the precedence rules are tested directly rather
+ * than inferred from the dialog.
+ *
+ * @param {object} o
+ * @param {boolean} o.failedToStart  the wait rejected with kind === 'failed'
+ * @param {{incompleteBundle?: boolean}|null} [o.failure]  the failure record
+ * @param {string} [o.logTail]      launch-log tail
+ * @param {boolean} [o.portInUseInLog]  a bound port reported by THIS attempt
+ *   (derive it from `currentAttemptLog`, not the raw tail, or a stale port line
+ *   suppresses a genuine current stdlib crash)
+ * @param {boolean} [o.bundled]     the spawned binary was our bundled backend
+ * @returns {boolean}
+ */
+function shouldReclassifyAsInstalling({
+  failedToStart,
+  failure = null,
+  logTail = "",
+  portInUseInLog = false,
+  bundled = false,
+} = {}) {
+  if (!failedToStart || !failure) return false;
+  // Already labelled by the pre-spawn refusal — nothing to re-derive.
+  if (failure.incompleteBundle) return false;
+  // Only OUR bundled interpreter can be half-extracted. A user's own install or
+  // a PATH `kirocrew` failing on a stdlib import is a broken environment, not an
+  // unfinished download, and telling that user to "wait for the installer" would
+  // be actively misleading. Taken from the caller, which knows which binary it
+  // chose, rather than re-parsed out of the log.
+  if (!bundled) return false;
+  // A bound port is the actionable story: it needs force-stop, not a bare retry,
+  // and the append-only log may carry a stdlib traceback from an earlier launch.
+  if (portInUseInLog) return false;
+  return isIncompleteBundleCrash(logTail);
+}
+
+// Exported surface = what production actually calls: main.js uses the three
+// launcher entry points, build-desktop.sh's gate uses findMissingBundleParts and
+// REQUIRED_STDLIB_PARTS. `resolveStdlibDir` / `hasBundledInterpreter` /
+// `isIncompleteBundleCrash` stay internal — they are steps of those, and tests
+// reach them through the public functions rather than pinning private shapes.
+module.exports = {
+  REQUIRED_STDLIB_PARTS,
+  SPAWN_MARKER,
+  currentAttemptLog,
+  findMissingBundleParts,
+  describeIncompleteBundle,
+  shouldReclassifyAsInstalling,
+};

--- a/website/electron/gateway-wait.js
+++ b/website/electron/gateway-wait.js
@@ -96,6 +96,11 @@ function describeGatewayFailure(failure) {
       + "not to start one on this machine. Start the gateway you connect to (or "
       + "the connection that reaches it) and retry, or start one here.";
   }
+  // An incomplete bundle is not a launch failure — the installer is still writing
+  // the backend. That message already explains the state and names Retry, so pass
+  // it through bare; prefixing "could not be launched" would open with failure
+  // vocabulary under a title saying the install is still finishing.
+  if (failure.incompleteBundle && failure.error) return failure.error;
   if (failure.error) return `The gateway could not be launched: ${failure.error}`;
   if (failure.signal === "SIGKILL") {
     return "The gateway was killed on launch (SIGKILL). On macOS this usually "

--- a/website/electron/local-gateway.js
+++ b/website/electron/local-gateway.js
@@ -50,12 +50,17 @@ function setLocalGatewayEnabled(store, enabled) {
  * use" line left by an earlier run would otherwise classify a silent port as a
  * conflict and offer to force-stop a holder that does not exist.
  *
+ * The incomplete-bundle case is likewise not a crash: the spawn was refused
+ * because the installer is still writing the backend, so a plain retry resolves
+ * it and "failed to start" would send the user hunting a defect that is not there.
+ *
  * @param {object} o
  * @param {boolean} o.failedToStart      the wait rejected with kind === 'failed'
- * @param {{disabled?: boolean}|null} [o.failure]  the failure record it carried
+ * @param {{disabled?: boolean, incompleteBundle?: boolean}|null} [o.failure]
+ *   the failure record it carried
  * @param {boolean} [o.isOwnPort]        this window points at our own gateway port
  * @param {boolean} [o.portInUseInLog]   the launch log tail reports a bound port
- * @returns {"client-only"|"port-conflict"|"failed"|"unreachable"}
+ * @returns {"client-only"|"installing"|"port-conflict"|"failed"|"unreachable"}
  */
 function classifyStartFailure({
   failedToStart,
@@ -64,6 +69,7 @@ function classifyStartFailure({
   portInUseInLog = false,
 } = {}) {
   if (failedToStart && failure && failure.disabled) return "client-only";
+  if (failedToStart && failure && failure.incompleteBundle) return "installing";
   if (failedToStart && isOwnPort && portInUseInLog) return "port-conflict";
   if (failedToStart) return "failed";
   return "unreachable";

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -7,6 +7,13 @@ const path = require("path");
 const http = require("http");
 
 const { findKirocrewBin } = require("./find-bin");
+const {
+  findMissingBundleParts,
+  describeIncompleteBundle,
+  shouldReclassifyAsInstalling,
+  currentAttemptLog,
+  SPAWN_MARKER,
+} = require("./bundle-integrity");
 const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
@@ -207,6 +214,10 @@ const LINUX_FRAME_DECISION = IS_LINUX
   : null;
 const LINUX_FRAMELESS = !!(LINUX_FRAME_DECISION && LINUX_FRAME_DECISION.frameless);
 const DEFAULT_THEME_ACCENT = "#8E48FF";
+// Loading-screen status for a refused spawn on a bundle that is still being
+// written. Deliberately not "Gateway failed": nothing failed, so the line must
+// not contradict the dialog that follows.
+const INSTALLING_STATUS = "Finishing installation…";
 const THEME_ACCENT_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
 function currentThemeAccent() {
@@ -801,6 +812,36 @@ function spawnGateway(resolve) {
         let execState = "executable";
         try { fs.accessSync(bin, fs.constants.X_OK); } catch (e) { execState = `NOT-EXECUTABLE(${e.code})`; }
         glog(`no gateway on :${PORT} — spawning bundled backend: bin=${bin} bundled=${bundled} ${execState}`);
+
+        // Refuse to exec a bundled interpreter whose stdlib is only partly on
+        // disk. The installer extracts backend-dist/ incrementally and starts the
+        // app as it finishes (runAfterFinish), so a launch inside that window
+        // finds python.exe present but late-alphabet stdlib packages missing --
+        // the interpreter then dies on `from urllib.parse import ...` from inside
+        // pathlib, which reads as a corrupt install rather than an unfinished one.
+        //
+        // This is PREVENTIVE and unsound; the launch-log backstop in the failure
+        // handler is sound but after-the-fact. They cover different halves, so
+        // neither replaces the other: refusing before spawn() keeps a doomed
+        // interpreter from running module-scope work against the user's live data
+        // home (it creates the home and .local_secret, and writes bytecode caches)
+        // and from failing in messier ways than ModuleNotFoundError while
+        // extraction is still writing underneath it -- the backstop only ever
+        // explains a crash that already happened.
+        if (bundled) {
+          const backendRoot = path.resolve(path.dirname(bin), "..");
+          const missingParts = findMissingBundleParts(fs, path, backendRoot);
+          if (missingParts.length) {
+            const errMsg = describeIncompleteBundle(missingParts);
+            glog(`spawn REFUSED: incomplete bundle at ${backendRoot} — missing: ${missingParts.join(", ")}`);
+            gatewayStartFailure = { error: errMsg, incompleteBundle: true, bundled: true };
+            // Neutral status: nothing failed, the install has not finished.
+            sendStatus(INSTALLING_STATUS);
+            resolve(false);
+            return;
+          }
+        }
+
         sendStatus("Starting gateway…");
 
         // Linux AppImage only: this process is about to exec the backend with no
@@ -843,7 +884,7 @@ function spawnGateway(resolve) {
         // "killed: 9" on a recipient's machine.
         let childOut = "ignore";
         try { childOut = fs.openSync(gatewayLogPath(), "a"); } catch (e) { glog(`WARN could not open child log fd: ${e.message}`); }
-        glog("---- spawning gateway; child stdout+stderr follows ----");
+        glog(SPAWN_MARKER);
         gatewayStartFailure = null; // re-arm for this spawn attempt
 
         // Bind handlers to THIS child via a captured reference, not the
@@ -868,14 +909,24 @@ function spawnGateway(resolve) {
             spawnBin = pyExe;
             spawnArgs = ["-s", "-m", "kiro_crew", ...spawnArgs];
           } else {
-            // Bundled layout is present but python.exe is missing/corrupted.
-            // Surface this as a clear error instead of letting spawn() hang or
-            // emit a cryptic ENOENT for the .cmd shim.
-            const errMsg = `Bundled Python interpreter not found at ${pyExe}. `
-              + `The installation may be corrupted — reinstall the app.`;
-            glog(`spawn ERROR: ${errMsg}`);
-            gatewayStartFailure = { error: errMsg };
-            sendStatus(`Gateway failed: ${errMsg}`);
+            // The .cmd shim is here but python.exe is not. That is the same
+            // extraction race as the incomplete-stdlib case above, caught one
+            // wave earlier — bin/ lands before the interpreter — so it gets the
+            // same "still installing, retry" framing.
+            //
+            // A mid-extraction tree and a permanently truncated one are
+            // indistinguishable at this instant, so this deliberately reads the
+            // ambiguity as transient. Mid-extraction is the common state (every
+            // install and update passes through it) and the costs are asymmetric:
+            // guessing "installing" wrongly costs a retry, after which the copy's
+            // "if this persists, reinstall" gives the right instruction anyway,
+            // while guessing "corrupted" wrongly sends the user to reinstall a
+            // bundle that needed a few more seconds — the harm this whole path
+            // exists to prevent, and not undoable once done.
+            const errMsg = describeIncompleteBundle([]);
+            glog(`spawn REFUSED: bundled interpreter absent at ${pyExe} — install likely still extracting`);
+            gatewayStartFailure = { error: errMsg, incompleteBundle: true, bundled: true };
+            sendStatus(INSTALLING_STATUS);
             resolve(false);
             return;
           }
@@ -918,7 +969,7 @@ function spawnGateway(resolve) {
           // ENOENT = bin not found on disk; EACCES = present but not executable.
           glog(`spawn ERROR code=${err.code || "?"} msg=${err.message}`);
           if (gatewayProcess !== child) return; // stale child we already replaced
-          gatewayStartFailure = { error: err.message };
+          gatewayStartFailure = { error: err.message, bundled };
           sendStatus(`Gateway failed: ${err.message}`);
           resolve(false);
         });
@@ -937,7 +988,7 @@ function spawnGateway(resolve) {
           // user-initiated Retry clears it so a re-probe can genuinely succeed.
           // Guard: preserve the root cause from the 'error' handler if it fired
           // first (Node fires both 'error' then 'exit' on spawn failure).
-          if (!gatewayStartFailure) gatewayStartFailure = { code, signal };
+          if (!gatewayStartFailure) gatewayStartFailure = { code, signal, bundled };
           gatewayProcess = null;
         });
         resolve(true);
@@ -2745,9 +2796,36 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
     // Nothing was spawned in the client-only case, so it is classified before
     // the port-conflict probe — see classifyStartFailure for why the log tail
     // cannot be trusted to mean "a holder exists right now".
-    const failureKind = classifyStartFailure({
+    // The pre-spawn check cannot be complete: extraction order within a package
+    // is not ours to control, so a spawn can still die on a stdlib import that
+    // was a moment away from existing. The interpreter's own traceback settles
+    // what no filesystem probe could, so a missing-stdlib crash is reclassified
+    // here as an unfinished install rather than reported as a defect.
+    //
+    // Requires the tail to be free of a bound-port report. The launch log is
+    // append-only across launches, so a stdlib traceback left by an EARLIER run
+    // would otherwise relabel today's "address already in use" exit as
+    // "installing" and hide the force-stop path — the port holder is still
+    // there, so Retry alone would loop. When both signals appear, the port
+    // conflict is the actionable one. This guard applies only to the log-sniffed
+    // path; a pre-spawn refusal sets `incompleteBundle` explicitly and keeps
+    // outranking a stale port line, since nothing was spawned in that case.
+    const failureRecord = shouldReclassifyAsInstalling({
       failedToStart,
       failure: err.failure,
+      logTail,
+      // Scoped to THIS attempt, like the crash match itself: a bound-port line
+      // left by an earlier launch must not suppress a genuine current stdlib
+      // crash. The port-conflict branch below keeps using the whole tail, since
+      // its own guard is about not offering force-stop for a port nothing holds.
+      portInUseInLog: isPortInUse(currentAttemptLog(logTail)),
+      bundled: !!(err.failure && err.failure.bundled),
+    })
+      ? { ...err.failure, incompleteBundle: true }
+      : err.failure;
+    const failureKind = classifyStartFailure({
+      failedToStart,
+      failure: failureRecord,
       isOwnPort: backendUrl === BACKEND_URL,
       portInUseInLog: isPortInUse(logTail),
     });
@@ -2755,7 +2833,15 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
     const portConflict = failureKind === "port-conflict";
 
     let title, message;
-    if (localGatewayOff) {
+    if (failureKind === "installing") {
+      // The bundled backend is still being written to disk, so the honest
+      // framing is "not ready yet" and Retry is the whole remedy. Use the
+      // unfinished-install copy rather than err.message: on the reclassified
+      // path err.message is the interpreter's own exit report, which is what
+      // this branch exists to stop showing as the headline.
+      title = "Kiro Crew — installation still finishing";
+      message = err.failure?.incompleteBundle ? err.message : describeIncompleteBundle([]);
+    } else if (localGatewayOff) {
       // Nothing failed here — the app was told not to start a gateway and the
       // port is silent. "Failed to start" would send the user hunting a crash.
       title = `Kiro Crew — no gateway on port ${PORT}`;

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -138,6 +138,7 @@
       "instance-guard.js",
       "context-menu.js",
       "find-bin.js",
+      "bundle-integrity.js",
       "data-home.js",
       "auto-update.js",
       "update-logger.js",

--- a/website/electron/test/bundle-integrity.test.js
+++ b/website/electron/test/bundle-integrity.test.js
@@ -1,0 +1,492 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const {
+  REQUIRED_STDLIB_PARTS,
+  SPAWN_MARKER,
+  currentAttemptLog,
+  findMissingBundleParts,
+  describeIncompleteBundle,
+  shouldReclassifyAsInstalling,
+} = require("../bundle-integrity");
+
+// resolveStdlibDir / hasBundledInterpreter / isIncompleteBundleCrash are internal
+// steps of the exported functions, so they are exercised through them:
+//   - layout + interpreter detection -> findMissingBundleParts
+//   - crash matching -> shouldReclassifyAsInstalling (failedToStart + a log tail)
+const missingFor = (fs, root) => findMissingBundleParts(fs, path, root);
+// The matcher reads only the CURRENT launch attempt, so a tail must carry the
+// spawn marker; `bundled` is what main.js observed about the binary it chose.
+const crashIsInstalling = (childOutput) =>
+  shouldReclassifyAsInstalling({
+    failedToStart: true,
+    failure: { code: 1, bundled: true },
+    logTail: `${SPAWN_MARKER}
+${childOutput}`,
+    bundled: true,
+  });
+
+const ROOT = "/mock/backend-dist/kirocrew-backend";
+const WIN_PY = path.join(ROOT, "python.exe");
+
+// A fully-extracted package: the dir AND the __init__.py that makes it
+// importable. The gate probes the latter, since an extractor creates the
+// directory before filling it.
+const pkgPaths = (stdlib, rel) => [
+  path.join(stdlib, ...rel.split("/")),
+  path.join(stdlib, ...rel.split("/"), "__init__.py"),
+];
+const allPkgPaths = (stdlib, parts = REQUIRED_STDLIB_PARTS) =>
+  parts.flatMap((rel) => pkgPaths(stdlib, rel));
+
+// Fake fs over an explicit set of existing paths. Only existsSync + readdirSync
+// are used by the module, so the fakes stay this small.
+function fakeFs(existing, dirs = {}) {
+  const set = new Set(existing);
+  return {
+    existsSync: (p) => set.has(p),
+    readdirSync: (p) => {
+      if (!dirs[p]) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return dirs[p];
+    },
+  };
+}
+
+// Fake fs that resolves paths case-INSENSITIVELY, modelling macOS APFS (and
+// NTFS). Required to cover the layout probes: a case-sensitive Set cannot
+// express "Lib and lib are the same directory", which is exactly the condition
+// that made a Lib-first probe resolve a POSIX tree to the wrong directory.
+function fakeFsCaseInsensitive(existing, dirs = {}) {
+  const lower = new Set(existing.map((p) => p.toLowerCase()));
+  const lowerDirs = new Map(Object.entries(dirs).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    existsSync: (p) => lower.has(String(p).toLowerCase()),
+    readdirSync: (p) => {
+      const hit = lowerDirs.get(String(p).toLowerCase());
+      if (!hit) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return hit;
+    },
+  };
+}
+
+/** Every path a COMPLETE Windows-layout bundle would carry. */
+function completeWindows(root = ROOT) {
+  const lib = path.join(root, "Lib");
+  return [path.join(root, "python.exe"), lib, ...allPkgPaths(lib)];
+}
+
+// Interpreter detection, observed through the public function: a tree WITH an
+// interpreter but no stdlib is judged (reports the stdlib root); a tree without
+// one is not this gate's business and must stay silent.
+describe("interpreter detection", () => {
+  it("judges a Windows tree (python.exe at the root)", () => {
+    assert.deepStrictEqual(missingFor(fakeFs([WIN_PY]), ROOT), ["Lib"]);
+  });
+
+  it("judges a POSIX tree (bin/python3.12)", () => {
+    const bin = path.join(ROOT, "bin");
+    const fs = fakeFs([bin], { [bin]: ["python3.12", "kirocrew"] });
+    assert.deepStrictEqual(missingFor(fs, ROOT), ["Lib"]);
+  });
+
+  it("stays silent on the legacy flat layout (frozen exe, no interpreter tree)", () => {
+    const flat = path.join(ROOT, "kirocrew-backend");
+    assert.deepStrictEqual(missingFor(fakeFs([flat]), ROOT), []);
+  });
+
+  it("stays silent on a bin/ dir holding no python3 binary", () => {
+    const bin = path.join(ROOT, "bin");
+    const fs = fakeFs([bin], { [bin]: ["kirocrew"] });
+    assert.deepStrictEqual(missingFor(fs, ROOT), []);
+  });
+});
+
+// Layout resolution, observed through the public function. A tree whose stdlib
+// root is found but empty reports every part; one whose root cannot be found at
+// all reports ["Lib"]. That difference is what makes these assertions meaningful.
+describe("stdlib layout resolution", () => {
+  const ALL = REQUIRED_STDLIB_PARTS.length;
+
+  it("finds the Windows layout (Lib/)", () => {
+    const fs = fakeFs([WIN_PY, path.join(ROOT, "Lib")]);
+    assert.equal(missingFor(fs, ROOT).length, ALL, "found Lib/, so every part is judged missing");
+  });
+
+  it("finds the POSIX layout by scanning for a python3.* dir", () => {
+    const lib = path.join(ROOT, "lib");
+    const py = path.join(lib, "python3.12");
+    const bin = path.join(ROOT, "bin");
+    const fs = fakeFs([bin, lib, py], { [lib]: ["python3.12", "pkgconfig"], [bin]: ["python3.12"] });
+    assert.equal(missingFor(fs, ROOT).length, ALL);
+  });
+
+  it("reports the stdlib root itself when no layout is present", () => {
+    assert.deepStrictEqual(missingFor(fakeFs([WIN_PY]), ROOT), ["Lib"]);
+  });
+
+  it("reports the stdlib root when lib/ holds no python3.* dir", () => {
+    const lib = path.join(ROOT, "lib");
+    const fs = fakeFs([WIN_PY, lib], { [lib]: ["pkgconfig"] });
+    assert.deepStrictEqual(missingFor(fs, ROOT), ["Lib"]);
+  });
+
+  // On a case-insensitive volume (macOS APFS by default) `Lib` resolves to the
+  // POSIX tree's real `lib`, whose children are `python3.<minor>/` and
+  // `pkgconfig/` -- NOT stdlib packages. Resolving there would report every part
+  // missing and refuse a valid bundle, so the POSIX layout must win.
+  it("reports a complete POSIX bundle as complete on a case-insensitive volume", () => {
+    const lib = path.join(ROOT, "lib");
+    const py = path.join(lib, "python3.12");
+    const bin = path.join(ROOT, "bin");
+    const fs = fakeFsCaseInsensitive(
+      [bin, lib, py, ...allPkgPaths(py)],
+      { [lib]: ["python3.12", "pkgconfig"], [bin]: ["python3.12", "kirocrew"] }
+    );
+    assert.deepStrictEqual(missingFor(fs, ROOT), []);
+  });
+
+  // The mirror case: on Windows `lib` case-matches the real `Lib`, which holds
+  // stdlib packages and no python3.<minor> child, so the POSIX probe must decline
+  // and fall through to Lib/.
+  it("reports a complete Windows bundle as complete on a case-insensitive volume", () => {
+    const lib = path.join(ROOT, "Lib");
+    const fs = fakeFsCaseInsensitive(
+      [WIN_PY, lib, ...allPkgPaths(lib)],
+      { [lib]: REQUIRED_STDLIB_PARTS.slice() }
+    );
+    assert.deepStrictEqual(missingFor(fs, ROOT), []);
+  });
+});
+
+describe("findMissingBundleParts", () => {
+  it("reports nothing for a fully extracted Windows bundle", () => {
+    const fs = fakeFs(completeWindows());
+    assert.deepStrictEqual(findMissingBundleParts(fs, path, ROOT), []);
+  });
+
+  it("reports nothing for a fully extracted POSIX bundle", () => {
+    const lib = path.join(ROOT, "lib");
+    const py = path.join(lib, "python3.12");
+    const bin = path.join(ROOT, "bin");
+    const existing = [bin, lib, py, ...allPkgPaths(py)];
+    const fs = fakeFs(existing, { [lib]: ["python3.12"], [bin]: ["python3.12", "kirocrew"] });
+    assert.deepStrictEqual(findMissingBundleParts(fs, path, ROOT), []);
+  });
+
+  // The gate must stay silent on trees it does not model, or it would refuse a
+  // launch that would actually have worked.
+  it("reports nothing for the legacy flat layout (no interpreter tree to check)", () => {
+    const flat = path.join(ROOT, "kirocrew-backend");
+    assert.deepStrictEqual(findMissingBundleParts(fakeFs([flat]), path, ROOT), []);
+  });
+
+  // The regression this module exists for: an install/update interrupted
+  // mid-extraction leaves the stdlib populated only up to some alphabetical
+  // point. `urllib` sorts late, so it is typically absent while `http`/`json`
+  // are already present -- and `pathlib.py` (a top-level FILE, extracted with
+  // the early batch) imports fine and then dies on `from urllib.parse import`.
+  it("reports the late-alphabet packages a half-extracted bundle is missing", () => {
+    const lib = path.join(ROOT, "Lib");
+    const present = REQUIRED_STDLIB_PARTS.filter((rel) => rel < "q");
+    const fs = fakeFs([WIN_PY, lib, ...allPkgPaths(lib, present)]);
+    const missing = findMissingBundleParts(fs, path, ROOT);
+    assert.ok(missing.includes("urllib"), `expected urllib among ${missing.join(", ")}`);
+    assert.ok(!missing.includes("json"), "json was extracted and must not be reported");
+  });
+
+  // Extraction proceeds roughly in directory order, so the tail is where a
+  // racing launch most often lands. A bundle that got as far as Lib/xml is still
+  // missing zipfile/zoneinfo, both module-scope imports on the gateway's chain --
+  // passing it would let the spawn die on the same raw ModuleNotFoundError.
+  it("catches a bundle whose extraction stopped just past xml", () => {
+    const lib = path.join(ROOT, "Lib");
+    const present = REQUIRED_STDLIB_PARTS.filter((rel) => rel <= "xml");
+    const fs = fakeFs([WIN_PY, lib, ...allPkgPaths(lib, present)]);
+    const missing = findMissingBundleParts(fs, path, ROOT);
+    assert.ok(missing.includes("zoneinfo"), `expected zoneinfo among ${missing.join(", ")}`);
+    assert.ok(missing.includes("zipfile"), `expected zipfile among ${missing.join(", ")}`);
+    assert.ok(!missing.includes("urllib"), "urllib was extracted and must not be reported");
+  });
+
+  // An extractor creates a directory before writing its contents, so the final
+  // package is routinely present-but-empty mid-extraction. A directory-existence
+  // check would pass that bundle and let the spawn die on the very import the
+  // gate exists to prevent, so the probe must look for the __init__.py.
+  it("catches a package whose directory exists but is still empty", () => {
+    const lib = path.join(ROOT, "Lib");
+    const others = REQUIRED_STDLIB_PARTS.filter((rel) => rel !== "zoneinfo");
+    const fs = fakeFs([
+      WIN_PY,
+      lib,
+      ...allPkgPaths(lib, others),
+      path.join(lib, "zoneinfo"), // dir created, __init__.py not yet written
+    ]);
+    assert.deepStrictEqual(findMissingBundleParts(fs, path, ROOT), ["zoneinfo"]);
+  });
+
+  it("reports the stdlib root itself when extraction has not reached it", () => {
+    assert.deepStrictEqual(findMissingBundleParts(fakeFs([WIN_PY]), path, ROOT), ["Lib"]);
+  });
+
+  it("reports a single missing package by name", () => {
+    const lib = path.join(ROOT, "Lib");
+    const urllibPaths = new Set(pkgPaths(lib, "urllib"));
+    const existing = completeWindows().filter((p) => !urllibPaths.has(p));
+    assert.deepStrictEqual(findMissingBundleParts(fakeFs(existing), path, ROOT), ["urllib"]);
+  });
+
+  it("stays silent on an empty/missing backend root rather than throwing", () => {
+    assert.deepStrictEqual(findMissingBundleParts(fakeFs([]), path, ""), []);
+  });
+});
+
+describe("crash matching (via shouldReclassifyAsInstalling)", () => {
+  // The exact traceback this whole change exists to explain.
+  const REAL_LOG = [
+    "Traceback (most recent call last):",
+    '  File "...\\Lib\\site-packages\\kiro_crew\\platform_compat.py", line 29, in <module>',
+    "    from pathlib import Path",
+    '  File "...\\Lib\\pathlib.py", line 20, in <module>',
+    "    from urllib.parse import quote_from_bytes as urlquote_from_bytes",
+    "ModuleNotFoundError: No module named 'urllib'",
+  ].join("\n");
+
+  it("recognizes the reported urllib crash", () => {
+    assert.equal(crashIsInstalling(REAL_LOG), true);
+  });
+
+  // The gap GPT identified: within a package, __init__.py is written before its
+  // siblings, so the pre-spawn probe can pass while `import zoneinfo` still
+  // fails. No filesystem probe closes that; the traceback does.
+  it("recognizes a crash on a package whose __init__.py had already landed", () => {
+    assert.equal(
+      crashIsInstalling("ModuleNotFoundError: No module named 'zoneinfo'"),
+      true
+    );
+  });
+
+  it("accepts double-quoted module names", () => {
+    assert.equal(crashIsInstalling('ModuleNotFoundError: No module named "encodings"'), true);
+  });
+
+  // Must NOT excuse a genuine packaging defect as "still installing", or a real
+  // missing dependency ships looking like a transient condition.
+  it("does not excuse a missing third-party dependency", () => {
+    assert.equal(crashIsInstalling("ModuleNotFoundError: No module named 'aiohttp'"), false);
+  });
+
+  it("does not excuse a missing first-party module", () => {
+    assert.equal(crashIsInstalling("ModuleNotFoundError: No module named 'kiro_crew'"), false);
+  });
+
+  // A dotted stdlib name means the package landed but a submodule had not —
+  // still the extraction race, so it is judged by its top-level package.
+  it("recognizes a missing stdlib SUBMODULE", () => {
+    assert.equal(
+      crashIsInstalling("ModuleNotFoundError: No module named 'urllib.parse'"),
+      true
+    );
+  });
+
+  it("still refuses a dotted NON-stdlib name", () => {
+    assert.equal(
+      crashIsInstalling("ModuleNotFoundError: No module named 'kiro_crew.acp'"),
+      false
+    );
+  });
+
+  // The form a half-written package actually raises. Verified against the shipped
+  // interpreter: copying only zoneinfo/__init__.py and importing ZoneInfo gives
+  // this, NOT ModuleNotFoundError — so matching only the latter would leave the
+  // one case the pre-spawn probe cannot see uncovered.
+  it("recognizes a partially initialized stdlib package", () => {
+    assert.equal(
+      crashIsInstalling(
+        "ImportError: cannot import name '_tzpath' from partially initialized module "
+        + "'zoneinfo' (most likely due to a circular import) (C:\\...\\zoneinfo\\__init__.py)"
+      ),
+      true
+    );
+  });
+
+  it("does not excuse a partially initialized NON-stdlib package", () => {
+    assert.equal(
+      crashIsInstalling(
+        "ImportError: cannot import name 'x' from partially initialized module 'kiro_crew'"
+      ),
+      false
+    );
+  });
+
+  it("ignores unrelated failures and empty logs", () => {
+    assert.equal(crashIsInstalling("OSError: [Errno 98] address already in use"), false);
+    assert.equal(crashIsInstalling(""), false);
+    assert.equal(crashIsInstalling(undefined), false);
+  });
+});
+
+describe("shouldReclassifyAsInstalling", () => {
+  const STDLIB_CRASH = `${SPAWN_MARKER}
+ModuleNotFoundError: No module named 'urllib'`;
+  const base = {
+    failedToStart: true,
+    failure: { code: 1, bundled: true },
+    logTail: STDLIB_CRASH,
+    bundled: true,
+  };
+
+  it("relabels a missing-stdlib crash", () => {
+    assert.equal(shouldReclassifyAsInstalling(base), true);
+  });
+
+  // The launch log is append-only across launches, so a stdlib traceback from an
+  // EARLIER run must not relabel today's bound-port exit: the holder is still
+  // there, so Retry alone loops and the force-stop path would be hidden.
+  it("defers to a bound port, which needs force-stop rather than a bare retry", () => {
+    assert.equal(
+      shouldReclassifyAsInstalling({
+        ...base,
+        logTail: `${STDLIB_CRASH}\nOSError: [Errno 98] address already in use`,
+        portInUseInLog: true,
+      }),
+      false
+    );
+  });
+
+  // GPT advisory: isPortInUse scanned the WHOLE tail, so a bound-port line left by
+  // an earlier launch suppressed a genuine current stdlib crash. Both signals must
+  // come from the same attempt slice.
+  it("is not suppressed by a bound-port line from a PREVIOUS attempt", () => {
+    const raw = [
+      SPAWN_MARKER,
+      "OSError: [Errno 98] address already in use",
+      "gateway child exited code=1 signal=null",
+      SPAWN_MARKER,
+      "ModuleNotFoundError: No module named 'urllib'",
+    ].join("\n");
+    // Scoped the way main.js does it.
+    const scoped = currentAttemptLog(raw);
+    assert.ok(!/address already in use/.test(scoped), "stale port line must be out of scope");
+    assert.equal(
+      shouldReclassifyAsInstalling({
+        ...base,
+        logTail: raw,
+        portInUseInLog: /address already in use/.test(scoped),
+      }),
+      true
+    );
+  });
+
+  it("does not re-derive a label the pre-spawn refusal already set", () => {
+    assert.equal(
+      shouldReclassifyAsInstalling({ ...base, failure: { incompleteBundle: true } }),
+      false
+    );
+  });
+
+  it("stays out of the way of a timeout or a non-failure", () => {
+    assert.equal(shouldReclassifyAsInstalling({ ...base, failedToStart: false }), false);
+    assert.equal(shouldReclassifyAsInstalling({ ...base, failure: null }), false);
+    assert.equal(shouldReclassifyAsInstalling(), false);
+  });
+
+  it("leaves an unrelated crash alone", () => {
+    assert.equal(
+      shouldReclassifyAsInstalling({
+        ...base,
+        logTail: `${SPAWN_MARKER}
+ModuleNotFoundError: No module named 'aiohttp'`,
+      }),
+      false
+    );
+  });
+
+  // Only OUR bundled interpreter can be half-extracted. A user's own install
+  // failing this way is a broken environment, and "wait for the installer to
+  // finish" would be actively misleading advice.
+  it("refuses to excuse a NON-bundled backend", () => {
+    assert.equal(shouldReclassifyAsInstalling({ ...base, bundled: false }), false);
+  });
+
+  // The log is append-only across launches. A traceback from an EARLIER attempt
+  // must not relabel this attempt's unrelated failure (a SIGKILL, say) as an
+  // unfinished install -- that would show a reassuring dialog over a real fault.
+  it("ignores a stdlib traceback from a previous launch attempt", () => {
+    const staleThenNew = [
+      SPAWN_MARKER,
+      "ModuleNotFoundError: No module named 'urllib'",
+      "gateway child exited code=1 signal=null",
+      SPAWN_MARKER,
+      "Fatal Python error: Segmentation fault",
+    ].join("\n");
+    assert.equal(shouldReclassifyAsInstalling({ ...base, logTail: staleThenNew }), false);
+  });
+
+  it("still relabels when the CURRENT attempt is the one that hit a stdlib crash", () => {
+    const staleThenStdlib = [
+      SPAWN_MARKER,
+      "Fatal Python error: Segmentation fault",
+      SPAWN_MARKER,
+      "ModuleNotFoundError: No module named 'zoneinfo'",
+    ].join("\n");
+    assert.equal(shouldReclassifyAsInstalling({ ...base, logTail: staleThenStdlib }), true);
+  });
+
+  // Without the boundary the tail may span two attempts, so attribution is
+  // unknowable -- decline rather than guess.
+  it("declines when the attempt boundary has scrolled out of the tail", () => {
+    assert.equal(
+      shouldReclassifyAsInstalling({
+        ...base,
+        logTail: "ModuleNotFoundError: No module named 'urllib'",
+      }),
+      false
+    );
+  });
+});
+
+describe("describeIncompleteBundle", () => {
+  it("frames the state as an unfinished install and names retry as the fix", () => {
+    const msg = describeIncompleteBundle(["urllib", "zoneinfo"]);
+    assert.match(msg, /still being installed/i);
+    assert.match(msg, /retry/i);
+  });
+
+  // Stdlib package names are internals the reader cannot act on, and they are
+  // already in the launch log; the dialog carries the count instead.
+  it("reports a count rather than leaking stdlib package names", () => {
+    const msg = describeIncompleteBundle(["urllib", "zoneinfo"]);
+    assert.match(msg, /2 components/);
+    assert.ok(!/urllib|zoneinfo/.test(msg), `message leaked package names: ${msg}`);
+  });
+
+  // Extraction can run for minutes, so an unqualified "if this persists" is
+  // satisfied by two Retry clicks twenty seconds apart -- which would steer the
+  // user into the reinstall this message exists to prevent.
+  it("anchors the reinstall advice to a duration rather than bare persistence", () => {
+    const msg = describeIncompleteBundle(["urllib"]);
+    assert.match(msg, /take a few minutes/i);
+    assert.match(msg, /after five minutes/i);
+    // "persists" with no time qualifier is what made the advice premature.
+    assert.ok(!/persists after restarting/i.test(msg), `unanchored advice: ${msg}`);
+  });
+
+  it("uses singular wording for exactly one missing component", () => {
+    assert.match(describeIncompleteBundle(["zoneinfo"]), /1 component is/);
+  });
+
+  it("stays short even when the whole stdlib is missing", () => {
+    const msg = describeIncompleteBundle(REQUIRED_STDLIB_PARTS.concat(["Lib"]));
+    assert.ok(msg.length < 400, `message too long (${msg.length} chars)`);
+  });
+
+  // Used verbatim for the missing-interpreter case, where the caller has no part
+  // list to hand over: the copy must still read as an unfinished install rather
+  // than naming a count it does not know.
+  it("reads correctly with no parts, for the missing-interpreter case", () => {
+    const msg = describeIncompleteBundle([]);
+    assert.match(msg, /still being installed/i);
+    assert.match(msg, /Some components are/);
+    assert.ok(!/\b0 components?\b/.test(msg), `message claimed a zero count: ${msg}`);
+  });
+});

--- a/website/electron/test/gateway-wait.test.js
+++ b/website/electron/test/gateway-wait.test.js
@@ -91,6 +91,18 @@ test("waitForGateway aborts when the window is gone", async () => {
 
 // ── describeGatewayFailure ──
 
+// An incomplete bundle is not a launch failure: the installer is still writing
+// the backend. Prefixing "could not be launched" would open with failure
+// vocabulary under a title that says the install is still finishing.
+test("describeGatewayFailure: an incomplete bundle passes its message through bare", () => {
+  const msg = "Kiro Crew's bundled Python runtime is still being installed — retry.";
+  assert.strictEqual(describeGatewayFailure({ error: msg, incompleteBundle: true }), msg);
+});
+
+test("describeGatewayFailure: an ordinary spawn error keeps the launch-failure prefix", () => {
+  assert.match(describeGatewayFailure({ error: "EACCES" }), /could not be launched/);
+});
+
 test("describeGatewayFailure: exit code", () => {
   assert.match(describeGatewayFailure({ code: 1, signal: null }), /code 1/);
 });

--- a/website/electron/test/local-gateway.test.js
+++ b/website/electron/test/local-gateway.test.js
@@ -78,6 +78,39 @@ test("classifyStartFailure: client-only OUTRANKS a stale port-in-use log line", 
   );
 });
 
+test("classifyStartFailure: a refused incomplete bundle is 'installing', not a crash", () => {
+  assert.equal(
+    classifyStartFailure({ failedToStart: true, failure: { incompleteBundle: true } }),
+    "installing",
+  );
+});
+
+test("classifyStartFailure: installing OUTRANKS a stale port-in-use log line", () => {
+  // Nothing was spawned, so a bound-port line left by an earlier run must not
+  // offer to force-stop a holder that this refusal says nothing about.
+  assert.equal(
+    classifyStartFailure({
+      failedToStart: true,
+      failure: { incompleteBundle: true },
+      isOwnPort: true,
+      portInUseInLog: true,
+    }),
+    "installing",
+  );
+});
+
+test("classifyStartFailure: client-only outranks an incomplete bundle", () => {
+  // Both can hold at once on a client-only install that also has a partial
+  // bundle; the user turned the local gateway off, so that is the real story.
+  assert.equal(
+    classifyStartFailure({
+      failedToStart: true,
+      failure: { disabled: true, incompleteBundle: true },
+    }),
+    "client-only",
+  );
+});
+
 test("classifyStartFailure: a real port conflict still wins when nothing is disabled", () => {
   assert.equal(
     classifyStartFailure({ failedToStart: true, isOwnPort: true, portInUseInLog: true }),


### PR DESCRIPTION
## Problem

Launching the Windows desktop app right after an update fails: the gateway never starts, and the launch log shows

```
File "...\backend-dist\kirocrew-backend\Lib\site-packages\kiro_crew\platform_compat.py", line 29
    from pathlib import Path
File "...\backend-dist\kirocrew-backend\Lib\pathlib.py", line 20
    from urllib.parse import quote_from_bytes as urlquote_from_bytes
ModuleNotFoundError: No module named 'urllib'
```

The app retries, fails identically, and the user is left with a dead gateway and a traceback that reads as a corrupt install. Trying again minutes later works, which makes it look nondeterministic.

## Why it matters

This is a **hard launch failure on the happy path** — update the app, open it, nothing works. The reported cause (`urllib` missing from the Python stdlib) is so implausible that it sends anyone debugging it toward the wrong conclusion: reinstall, or a broken build. The actual condition is transient and self-healing, but nothing in the UI says so, so a user reinstalls to fix something that would have fixed itself.

## Fix (symptoms → root cause → change)

**Symptom.** `ModuleNotFoundError: No module named 'urllib'` from a bundled interpreter, only right after an install/update.

**Root cause.** The NSIS installer extracts `resources/backend-dist/` incrementally and launches the app as it finishes (`runAfterFinish`), so the app can start while extraction is still running. Directory mtimes from the failing install show extraction proceeding in roughly alphabetical waves — `asyncio`…`pydoc_data` completing at `00:13:43`, then `site-packages`…`zoneinfo` at `00:21:26`–`00:21:47`. **Both failed spawn attempts (`00:20:39`, `00:21:02`) fall inside that gap**, when extraction had only reached `pydoc_data`. `urllib` sorts after `pydoc_data`, so its directory did not exist yet.

Two details confirm it rather than merely fitting it:
- The error names `urllib`, **not** `urllib.parse` — the *package* was absent, not a file inside it.
- `pathlib.py` is a top-level *file*, extracted with the early batch, so it imported fine and only died on its `urllib` dependency.

`main.js` gated on `python.exe` existing but never checked the stdlib, so it exec'd a half-extracted interpreter.

**Change.** Verify the bundle's stdlib is on disk before spawning a bundled backend (`website/electron/bundle-integrity.js`, pure + injectable). Notes on the shape:

- **Probes each package's `__init__.py`, not the directory.** An extractor creates a directory before writing into it, so an empty `Lib/zoneinfo/` would satisfy a directory check while `import zoneinfo` still fails. `__init__.py` is uniform across all probed names and is the exact file Python needs to treat the directory as a package, so the gate asks the same question the interpreter will. Probing a *package* rather than a top-level module stays essential: a truncated extraction leaves top-level `.py` files in place long before the late package dirs land, so probing `pathlib.py` would report a broken bundle as healthy.
- **Coverage runs through the tail** (`xmlrpc`, `zipfile`, `zoneinfo`). Extraction proceeds roughly in directory order, so those sort last and are the likeliest to be missing when a launch races the installer; all three are module-scope imports on the gateway's chain (`cron`, `cli_setup`, `portability`).
- **POSIX layout is probed first, and that order is load-bearing.** On a case-insensitive volume (macOS APFS by default) `Lib` resolves to a POSIX tree's real `lib`, whose children are `python3.<minor>/` and `pkgconfig/` — not stdlib packages. A `Lib`-first probe would report every part missing and **refuse every valid macOS bundle**. The POSIX branch self-validates by requiring a `python3.<minor>` child, so on Windows it declines and falls through to `Lib/`.
- **Cannot refuse a launch it does not model.** Gated on `bundled`, and further on a tree actually carrying an interpreter (`python.exe` or `bin/python3.*`), so the legacy flat PyInstaller layout (no stdlib dir) and user/PATH installs are never touched.
- **The same race one wave earlier gets the same treatment.** `bin/` lands before `python.exe`, so a launch landing there hit `main.js`'s "the installation may be corrupted — reinstall the app" — the exact misdiagnosis this change exists to remove. It now reports the unfinished-install state and routes to Retry. A genuinely corrupt bundle is served correctly too: the copy names reinstalling as the fallback if it persists.
- **Two layers, neither redundant.** The pre-spawn probe is **preventive but unsound** — extraction order *within* a package is not the app's to control — and a **sound but after-the-fact** backstop covers what it cannot see: when a spawn dies on a stdlib import, the launch log is read and the failure reclassified as an unfinished install. Two traceback forms are matched, because a half-written package does not raise the obvious one: `ModuleNotFoundError: No module named 'urllib'` (absent package, or a submodule of one that did land), and `ImportError: cannot import name '_tzpath' from partially initialized module 'zoneinfo'` — what CPython actually raises when a package's `__init__.py` arrives before its siblings, **verified against the shipped interpreter**, and exactly the state the probe cannot detect. Judgement is by top-level package name, which must be in the stdlib set, so a missing third-party or first-party module (a real packaging defect) is never excused. Three conditions keep it narrow: the top-level package must be in the stdlib set; the backend must be **ours** (a user install failing on a stdlib import is a broken environment, not an unfinished download); and only the **current launch attempt** is read — the log is append-only, so the text is sliced from the last spawn marker, and a missing marker makes the check decline rather than guess. Without that scoping an older traceback would relabel this attempt's unrelated failure (a `SIGKILL`, or a bound port whose real remedy is force-stop) and show a reassuring dialog over a live fault. Refusing before `spawn()` still matters independently: it keeps a doomed interpreter from running module-scope work against the live data home (it creates the home and `.local_secret`, and writes bytecode caches).
- **A stale probe list is the guard's own worst failure mode** — it would refuse every launch of a healthy app, *permanently*, which is worse than the transient crash it prevents. So the **build now gates on it**: a new `stdlib_probe_gate` in `build-desktop.sh` imports this module and runs it against the tree just built, in **both** backend build paths, **after** pruning (so it validates what actually ships). A probed package the bundle does not carry **fails the build** with the remedy named, instead of shipping an app that refuses to start. Like the existing `resolver_gate` it needs `node`, and logs a visible SKIP rather than failing when none is on PATH.
- **The refusal is not a crash, so it does not borrow crash framing.** The failure record carries `incompleteBundle`, `classifyStartFailure` maps it to a new `"installing"` kind alongside the existing `"client-only"` precedent, and the dialog reads "installation still finishing" with **Retry** as the remedy. The message reports a component *count*, not stdlib package names — those are internals a reader cannot act on, and the full list is already in the launch log for a bug report.

**Manifest change:** `website/electron/package.json` gains one entry in electron-builder's `build.files` (the new module). **No dependency added, removed, or bumped**; `package-lock.json` is untouched. `test/packaging.test.js` already fails if a local `require()` in `main.js` is missing from that list, so the entry is gated.

## Tests

43 cases across `test/bundle-integrity.test.js` and `test/local-gateway.test.js`:

| Area | Locks in |
|---|---|
| Layout resolution | POSIX `lib/python3.*`, Windows `Lib/`, minor discovered by scanning, `null` when neither is present |
| Case-insensitive volumes | A POSIX tree resolves to `lib/python3.*` even when `Lib` case-matches, and the Windows mirror still resolves to `Lib/` — uses a case-**insensitive** fs fake, which a case-sensitive one cannot express |
| Interpreter detection | `python.exe`, `bin/python3.*`; false for the legacy flat layout and a `bin/` with no python |
| Half-extracted bundles | The observed `urllib` failure (asserts `json` *not* reported), a stop just past `xml` (asserts `zipfile`/`zoneinfo`), and a package whose **directory exists but is empty** (fails against a directory-only probe) |
| Never-false-refuse | Complete Windows + POSIX bundles report nothing; legacy flat layout and an empty root stay silent |
| Message | Unfinished-install framing, retry named, count reported, names *not* leaked, singular/plural, bounded length, and no "0 components" for the missing-interpreter case |
| Failure classification | `"installing"` kind, and its precedence against `client-only` and a stale port-in-use log line |
| Crash backstop | Both traceback forms reclassify; a missing stdlib submodule counts, third-party/first-party names do not; a non-bundled backend, a bound-port log, a traceback from a PREVIOUS attempt, and a missing attempt boundary are all declined |

## Manual verification

Verified against the **real installed bundle** on this machine (`KiroCrew Nightly`), the tree that produced the failure:

- Complete bundle → `[]`. This was the critical check: a false positive would block every launch.
- Replaying extraction state at `00:20:39` → catches `["re","sqlite3","urllib","xml","xmlrpc","zipfile","zoneinfo"]`; a stop past `xml` → `["xmlrpc","zipfile","zoneinfo"]`.
- Withholding only `Lib/zoneinfo/__init__.py` → `["zoneinfo"]` (this passed before the `__init__.py` change).
- All 18 probed `__init__.py` files present in the real bundle, and none of the probed packages appear in the builder's prune step.
- On a real case-insensitive volume, a synthetic POSIX tree resolves to `lib/python3.12`; pre-fix it resolved to `Lib` and reported every part missing.
- `isIncompleteBundleCrash` run against the **actual `gateway-launch.log`** from the failing install → `true`, so the report that opened this PR now lands on the honest dialog.
- `stdlib_probe_gate` exercised both ways: passes on the real bundle, fails with the remedy message on a synthetic tree missing one probed package, and SKIPs cleanly with no `node` on PATH.

Gates: electron `node --test` → **1086 pass, 0 fail**; `npx tsc -b` clean; `jscpd` clean; `docs_lint.py` clean; brand gate clean; `bash -n packaging/build-desktop.sh` clean.

Not covered locally: an end-to-end NSIS install timed to hit the race live — it is a timing window during extraction. The extraction states are reproduced against the real bundle instead.

## Screenshots

N/A — no dashboard UI change. The new path reuses the existing gateway-failure dialog with a distinct title and message.

---

no linked issue: found and diagnosed directly from a failing Windows nightly launch log on this machine; no existing issue covers it (searched for urllib / ModuleNotFoundError / installer-race reports).
