### PR TITLE
refactor(discord): use shared Markdown splitter

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -327,7 +327,6 @@ src/kiro_crew/diagnostics.py
 src/kiro_crew/discord/attachments.py
 src/kiro_crew/discord/client.py
 src/kiro_crew/discord/gateway.py
-src/kiro_crew/discord/session_resume.py
 src/kiro_crew/discord/transport_dispatch.py
 src/kiro_crew/doc_parser.py
 src/kiro_crew/embeddings.py
@@ -843,10 +842,8 @@ test/test_dev_fleet_repo_accessor.py
 test/test_dev_fleet_server_coverage.py
 test/test_dev_fleet_server_more_coverage.py
 test/test_diagnostics.py
-test/test_discord.py
 test/test_discord_client_coverage.py
 test/test_discord_config_handlers.py
-test/test_discord_sessions.py
 test/test_display_time_redaction.py
 test/test_doc_parser.py
 test/test_docker_entrypoint.py

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -82,7 +82,7 @@ Consumes a provider's `AcpEvent` stream and emits abstract `OutputEvent`s to a p
 
 **Redaction and protocol framing** — before text reaches a renderer, `TurnDriver` first classifies a reserved summary-bearing compaction notice at the start of the turn, then incrementally parses kiro-cli's inline `[STEERING steer-<id>: …]` frame across arbitrary chunk boundaries. Compaction summary bodies become the terse `✅ Context compacted.` receipt. Steering frames never become text: they emit one structured `STEER_CONSUMED` event at the exact boundary (paired with kiro-cli's typed lifecycle event regardless of arrival order). The user-facing `[OPTIONS: …]` trailer is deliberately not part of this filter and passes through unchanged for renderer-native buttons. After framing, `_redact()` runs `redact_exfiltration_urls()` then `redact_credentials()` (both from `security.py`) over every text chunk, thinking chunk, tool title/purpose, and each string field of prompt-choice options before it reaches a renderer.
 
-The dashboard does **not** flow through `TurnDriver`; it remains unchanged as the authoritative transcript surface. Direct channel paths that bypass the driver are sanitized at source: Discord's explicit five-message resume replay strips legacy steering frames and summary-bearing compaction notices, while direct compact commands publish only terse receipts. Stored transcripts remain intact for audit.
+The dashboard does **not** flow through `TurnDriver`; it remains unchanged as the authoritative transcript surface. Direct channel paths that bypass the driver are sanitized at source: Discord's explicit five-message resume replay strips legacy steering frames and summary-bearing compaction notices, shortens each entry to the shared splitter's first (sealed) chunk so a replayed code block cannot arrive with its fence cut in half, and puts the role icon on its own line so the body's first line still starts where the fence grammar needs it; direct compact commands publish only terse receipts. Stored transcripts remain intact for audit.
 
 **`run(message) -> str`** — calls `renderer.on_turn_start()`, then translates each provider event into a dispatched `OutputEvent` and returns the accumulated (redacted) assistant text:
 
@@ -166,7 +166,7 @@ Pure helper Renderers use to honor `capabilities.max_message_chars`. Returns `[]
 
 ## Fence-safe splitting (`split.py`)
 
-`split_markdown_safe(text, limit, *, reserve=0) -> list[str]` is the shared markdown splitter every channel converges on. `chunk_text` above is blind fixed-width and the per-channel splitters (Discord's and Telegram's `_split_text`/`_split_markdown`, `slack/format.py::split_message`, the Webex and Weixin helpers) each carry their own fence handling, so a fix landed in one never reached the others. The module is stdlib-only and pure — no config objects, no modes.
+`split_markdown_safe(text, limit, *, reserve=0) -> list[str]` is the shared markdown splitter every channel converges on. `chunk_text` above is blind fixed-width and the remaining per-channel splitters (Telegram's `_split_text`/`_split_markdown`, `slack/format.py::split_message`, the Webex and Weixin helpers) each carry their own fence handling, so a fix landed in one never reached the others. The module is stdlib-only and pure — no config objects, no modes.
 
 Its contract:
 
@@ -179,7 +179,9 @@ Its contract:
 - **Tables.** A trailing pipe-bearing line is pushed to the next chunk when an earlier cut is nearby, which keeps a header row with its separator row; otherwise table lines are plain lines. Full table conversion stays with the per-channel renderers.
 - **Termination.** Pathological input — a single unbreakable 10k-char line, a 5000-backtick run, a budget too small to hold a line's own fence scaffolding — terminates, at worst emitting over-budget chunks rather than spinning. Whole-line placement seals progress by consuming the line; the dirty-cut fallback keeps a width of at least one character. The **final** chunk of an unclosed fence is left open on purpose: callers own final presentation, and a streaming caller still holds it as a live buffer.
 
-No call sites yet: the channels route onto it in follow-up changes, and `test/test_messaging_split.py` pins each contract item above.
+Discord is the first channel routed onto it, at two call sites, and it owns no fence grammar of its own: `discord/renderer.py::_rotate_on_length` consumes the streaming contract directly (seal every chunk but the last, retain the last as the live buffer, nothing appended to it and so nothing to strip back off), and `discord/session_resume.py::_replay_preview` takes the FIRST chunk as a bounded preview of a replayed transcript message, which is sealed and therefore closes any block the shortening opened. Both async call sites await `asyncio.to_thread(split_markdown_safe, …)`: the splitter terminates on pathological delimiter input, but its CPU work must not pause Discord heartbeats or unrelated turns on the event-loop thread. The remaining channels route on in follow-up changes; `test/test_messaging_split.py` pins each contract item above and `test/test_discord.py::TestRotationSplitting` pins the integration.
+
+**A caller owes the bounded-overlimit case an answer.** The whole-line placement above can hand back a chunk over `limit` by its fence scaffolding, so a channel whose transport truncates silently must bound it again against the platform's own cap. Discord does: `_limit()` holds 100 characters back below the 2000-char cap, which absorbs ordinary scaffolding, and `renderer._fit_platform_cap` slices anything still over the cap at the single seal chokepoint. Blind fixed-width slicing is the right last resort there — it keeps every authored character at the price of a boundary Markdown may render badly, where `client.send_message`'s own truncation would drop the tail including the synthetic closer and give the user no signal. Session replay has a different tradeoff because it is only a preview: `_replay_preview` passes at most twice the delivery limit of redacted text to the prefix-stable splitter, uses the full redacted length to retain the truncation marker, and emits that marker alone when one pathological fence cannot fit with its closer. The canonical transcript remains untouched.
 
 `iter_fence_spans(text) -> Iterator[tuple[int, int]]` is the same machine viewed over a whole message instead of one chunk's line fragments: it yields the character spans that lie inside a fenced block, opener line through closer line, with an unclosed fence running to the end. Both it and `split_markdown_safe` drive the module's single `_advance` state machine, so the open/close rule — which run length closes which fence character — exists once. A consumer that needs "is this offset inside code?" uses it rather than re-deriving the rule; the fence regexes stay private.
 
@@ -424,7 +426,9 @@ extracted before the seal and shipped as a keyboard on the sealed message,
 rather than frozen as literal protocol text the user cannot act on. Length
 overflow rotates too, fence-balanced so a code block spanning the cut is closed
 at the seal and reopened after it, with a trailing incomplete directive detached
-before the split. Raw markers never reach posted text; each renderer keeps a
+before the split. Discord gets that from the shared `split_markdown_safe`, whose
+final chunk is deliberately left open as the live buffer; Telegram still carries
+its own splitter. Raw markers never reach posted text; each renderer keeps a
 defensive raw-marker parser only for callers that bypass `TurnDriver`.
 
 ## Slack reference implementation
@@ -547,8 +551,9 @@ loop guard. `DISCORD_BOT_TOKEN` is on the sandbox agent env denylist.
 machinery as the Telegram dispatcher (see "Mid-turn routing, queue receipts &
 cancel" above) plus `!compact` under atomic `try_acquire` and the dashboard
 mirror `!link`/`!unlink`. The renderer streams via throttled in-place edits
-under the 2000-char cap (chunked at 1900 with fence-balanced splitting),
-rotates messages at the shared driver's structured steer boundaries with quote
+under the 2000-char cap, splitting with the shared `split_markdown_safe`
+(chunked at 1900 less 100 characters of chip/footer headroom), rotates messages
+at the shared driver's structured steer boundaries with quote
 chips, renders trailing `[OPTIONS:]` as button action rows (`opt:<i>`, label
 recovered from the component at interaction time), and posts Approve/Deny
 buttons for interactive tool approvals. Approval `custom_id`s carry a

--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -18,6 +18,14 @@ HTML translation pass -- the final seal sends the markdown as-is. Steer
 rotation (sealing the pre-steer segment and opening a fresh message headed by
 a "↪️ steered" chip) mirrors the Telegram renderer.
 
+Length splitting belongs to :func:`kiro_crew.messaging.split.split_markdown_safe`,
+the shared fence-safe splitter. This renderer owns no fence grammar: it consumes
+the splitter's streaming contract, which is that every chunk but the last is
+sealed (a cut inside a fence carries a synthetic closer and the next chunk
+reopens the original opener line) while the final chunk is deliberately left
+OPEN. So each sealed chunk is posted verbatim and the final one is retained as
+the live buffer, with nothing to append and nothing to undo.
+
 ``DiscordApprovalDecider`` is the interactive ladder's awaiter: ``__call__``
 registers a Future keyed by ``session:request_id`` and awaits a button press,
 denying by default on timeout; the interaction handler resolves it via
@@ -36,7 +44,9 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
-from kiro_crew.messaging.renderer import Renderer, apply_options_cap
+from kiro_crew.discord.client import DISCORD_MAX_TEXT
+from kiro_crew.messaging.renderer import Renderer, apply_options_cap, chunk_text
+from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.transport import TransportCapabilities
 
 if TYPE_CHECKING:
@@ -139,108 +149,27 @@ def build_option_components(options: list[str]) -> list[dict] | None:
     return rows
 
 
-def _split_text(text: str, limit: int) -> list[str]:
-    """Split text into <=``limit`` chunks, preferring paragraph boundaries."""
-    if limit <= 0 or len(text) <= limit:
-        return [text] if text else []
-    chunks: list[str] = []
-    while text:
-        if len(text) <= limit:
-            chunks.append(text)
-            break
-        split_at = text.rfind("\n\n", 0, limit)
-        if split_at < limit // 2:
-            split_at = text.rfind("\n", 0, limit)
-        # Back the cut up to the FIRST newline of its run. rfind reports the
-        # LAST one ("\n\n" reports the first of the RIGHTMOST pair), so a run of
-        # 3+ straddles the cut and its earlier newlines land in text[:split_at],
-        # where the .rstrip() below deletes them. Cutting at the run's start
-        # keeps the whole run in the remainder, so the only newline anyone
-        # absorbs is the one separator below. The promotion guard still has the
-        # final say, so a cut that walked too far left becomes a hard cut rather
-        # than an empty chunk.
-        while split_at > 0 and text[split_at - 1] == "\n":
-            split_at -= 1
-        if split_at < limit // 4:
-            split_at = limit
-        chunks.append(text[:split_at].rstrip())
-        remainder = text[split_at:]
-        # Consume EXACTLY ONE newline: the line separator this message boundary
-        # itself represents. Every newline after it is an authored blank line --
-        # content inside a fence -- so lstrip("\n") deleted whole runs of them
-        # and pulled the next code line up onto the last one. Horizontal
-        # whitespace is never touched, or a cut just before an indented line
-        # re-indents split code. A hard (mid-line) cut sits on no separator, so
-        # removeprefix finds nothing and the continuation is verbatim. Every cut
-        # consumes at least one character, so the loop always advances.
-        text = remainder.removeprefix("\n")
-    return chunks
+def _fit_platform_cap(text: str) -> list[str]:
+    """Slice *text* into payloads Discord's message API will accept whole.
 
+    ``split_markdown_safe`` budgets every chunk against :meth:`_limit`, with one
+    documented exception: a logical line that admits no cut clean on both sides
+    is placed WHOLE rather than cut into a fence delimiter its source never
+    contained, and the chunk carries its fence scaffolding — the reopener line
+    plus the newline and synthetic closer — on top of the limit. The 100
+    characters :meth:`_limit` holds back absorb ordinary scaffolding, but an
+    opener line long enough (a several-hundred-backtick run, a huge info string)
+    still pushes such a chunk past Discord's hard cap. ``client.send_message``
+    truncates to that cap, which drops the tail INCLUDING the synthetic closer,
+    so the user reads an unterminated code block missing content and gets no
+    signal that anything was lost.
 
-_FENCE_RE = re.compile(r"```[^\n]*\n?(.*?)```", re.DOTALL)
-
-
-def _ends_inside_fence(text: str) -> bool:
-    """True when ``text`` ends INSIDE an open fenced code block.
-
-    Line-anchored per CommonMark rather than counting ``` substrings: a literal
-    ``` written mid-line is prose about fencing, not a fence, and counting it
-    flips the parity of every fence decision that follows -- a sealed chunk gets
-    a closer it never needed, and the retained tail loses the one it did.
-
-    A fence opens on a line whose first non-space content (at most 3 spaces of
-    indent; 4+ is an indented code line) is a run of 3+ backticks, optionally
-    followed by an info string, which may not itself contain a backtick. It
-    closes on a later such line whose run is at least as long as the opener's
-    and which carries nothing but trailing whitespace.
+    Blind fixed-width slicing is the right last resort in exactly that regime:
+    it keeps every authored character at the price of a boundary Markdown may
+    render badly, where truncation keeps neither. Nothing here re-derives fence
+    grammar — the splitter owns that, and this only bounds what reaches the API.
     """
-    opener = 0  # backtick run length of the fence now open; 0 == closed
-    for line in text.split("\n"):
-        stripped = line.lstrip(" ")
-        if len(line) - len(stripped) > 3:
-            continue
-        run = len(stripped) - len(stripped.lstrip("`"))
-        if run < 3:
-            continue
-        rest = stripped[run:]
-        if opener:
-            if run >= opener and not rest.strip():
-                opener = 0
-        elif "`" not in rest:
-            opener = run
-    return opener > 0
-
-
-def _split_markdown(text: str, limit: int) -> tuple[list[str], bool]:
-    """Split markdown into <=``limit`` chunks, keeping fenced code blocks
-    balanced: close a dangling fence at a chunk's end and reopen it at the next
-    chunk's start, so every chunk is self-contained markdown (Discord renders
-    an unbalanced fence as literal backticks).
-
-    Returns the chunks and whether a synthetic closer was appended to the FINAL
-    chunk. That flag is this function's own record of what it did, and it is the
-    only sound basis for undoing it: the fence state is judged per chunk AFTER
-    prepending a bare ``` reopen, which discards the original opener's run
-    length, so no predicate re-derived from the source text can tell whether
-    this walk appended anything.
-    """
-    chunks = _split_text(text, limit)
-    if len(chunks) <= 1:
-        # A lone chunk is handed back untouched -- nothing appended, nothing to
-        # undo.
-        return chunks, False
-    out: list[str] = []
-    carry_open = False
-    for ch in chunks:
-        if carry_open:
-            ch = "```\n" + ch
-        if _ends_inside_fence(ch):
-            ch = ch.rstrip() + "\n```"
-            carry_open = True
-        else:
-            carry_open = False
-        out.append(ch)
-    return out, carry_open
+    return chunk_text(text, DISCORD_MAX_TEXT) or [text]
 
 
 class DiscordApprovalDecider:
@@ -460,23 +389,16 @@ class DiscordRenderer(Renderer):
         if len(raw) <= limit:
             return
         raw, protocol_suffix = split_trailing_protocol_suffix(raw)
-        chunks, appended_closer = _split_markdown(raw, limit)
-        # Mid-stream the source fence is often still OPEN (the model has not
-        # emitted its closing ``` yet). _split_markdown balances each chunk by
-        # appending a synthetic closer, right for the chunks we seal but wrong
-        # for the tail we keep streaming into: every later token would land
-        # after that closer and the model's real closer would show up
-        # literally. Drop it from the retained tail -- reading the splitter's
-        # own report of what it appended, never a predicate re-derived from the
-        # source. One judgment, made once, so the strip fires iff the append
-        # happened and cannot delete a line the author wrote.
-        if appended_closer:
-            # The splitter attached "\n```" to the rstripped content, so the
-            # exact inverse drops those four characters and restores the
-            # whitespace suffix it ate -- dropping the closer alone would eat
-            # the newline the content ended on and glue the next streamed line
-            # onto the last code line.
-            chunks[-1] = chunks[-1][:-4] + raw[len(raw.rstrip()) :]
+        # The shared splitter's streaming contract does the whole job: every
+        # chunk but the last is already sealed, and the last is deliberately
+        # left OPEN so a still-arriving fence keeps streaming into it. Mid-stream
+        # the source fence is usually still open (the model has not emitted its
+        # closing ``` yet), which is exactly the case that needs a synthetic
+        # closer on the chunks we seal and none on the tail we keep. Nothing is
+        # appended to the tail here, so there is nothing to strip back off it —
+        # and prefix stability means a later, longer buffer re-derives these same
+        # sealed chunks byte-for-byte, so no message already posted can move.
+        chunks = await asyncio.to_thread(split_markdown_safe, raw, limit)
         for ch in chunks[:-1]:
             self._buf = [ch]
             await self._seal_current()
@@ -525,23 +447,36 @@ class DiscordRenderer(Renderer):
         """Finalize the current segment: land the full markdown text (and
         optional button rows). Edits the streamed message in place, or sends
         one if the segment never streamed (e.g. throttled out). Empty segments
-        are skipped so a bare steer doesn't post a blank bubble."""
+        are skipped so a bare steer doesn't post a blank bubble.
+
+        This is the one chokepoint every non-throwaway payload passes, so it is
+        where the splitter's bounded-overlimit chunk is bounded again against the
+        platform cap (see :func:`_fit_platform_cap`). Buttons ride the LAST
+        payload, which is the one the user reads under them."""
         text = self._segment_text().strip()
         if not text:
             if components is None:
                 return
             text = "…"
+        head, *overflow = _fit_platform_cap(text)
+        head_components = None if overflow else components
         if self._stream_mid is not None:
             ok = await self._client.edit_message(
-                self._channel_id, self._stream_mid, text, components=components
+                self._channel_id, self._stream_mid, head, components=head_components
             )
-            if ok:
-                return
-            # Edit failed — the live message is gone (e.g. deleted mid-turn).
-            # Fall through and SEND the final content so the completed answer
-            # (and its buttons) is never silently lost.
-            self._stream_mid = None
-        await self._client.send_message(self._channel_id, text, components=components)
+            if not ok:
+                # Edit failed — the live message is gone (e.g. deleted mid-turn).
+                # SEND the content so the completed answer (and its buttons) is
+                # never silently lost.
+                self._stream_mid = None
+                await self._client.send_message(self._channel_id, head, components=head_components)
+        else:
+            await self._client.send_message(self._channel_id, head, components=head_components)
+        for i, part in enumerate(overflow):
+            last = i == len(overflow) - 1
+            await self._client.send_message(
+                self._channel_id, part, components=components if last else None
+            )
 
     async def on_thinking(self, text: str) -> None:
         # Discord does not surface reasoning inline (parity with Telegram).

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -17,6 +17,7 @@ from kiro_crew.discord.resume_expectation import (
 from kiro_crew.history import is_incognito_transcript, needles_match_text, parse_search_query
 from kiro_crew.messaging.driver import sanitize_channel_replay_text
 from kiro_crew.messaging.link import UNBIND_REASON_USER_UNLINK, ChannelLink
+from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session_map import ConversationOwnershipConflict
@@ -36,6 +37,12 @@ _PICKER_TTL_SECS = 300
 _PICKER_REGISTRY_MAX = 100
 _REPLAY_MESSAGES = 5
 _REPLAY_TEXT_LIMIT = 1900
+#: Appended when a replayed message carried more than the preview shows, so the
+#: user can tell a shortened transcript entry from a complete one.
+_REPLAY_TRUNCATED = "\n… (truncated)"
+#: Budget held back per replayed message for the two-character role-icon prefix
+#: and the marker above, so a preview plus its scaffolding still fits the limit.
+_REPLAY_RESERVE = len(_REPLAY_TRUNCATED) + 2
 #: Matches the picker's own label budget, so the title a detach notice names is
 #: the same string the user picked.
 _TITLE_LIMIT = 76
@@ -64,10 +71,12 @@ _SETTLE_ADOPT = "adopt"  # link moved; adopt the new session
 _MAX_ROUTE_ATTEMPTS = 3
 #: Refusal when the attachment cannot be made durable or read back: the turn would
 #: otherwise use a link whose later loss nothing can detect.
-_STORAGE_REFUSAL = ("🔗 Can't read or save which conversation this channel is linked to, so your "
-                    "message was NOT processed. This needs an operator to repair the gateway's "
-                    "expectation store; `!sessions` still lists sessions, but a reattachment "
-                    "cannot be saved until it is.")
+_STORAGE_REFUSAL = (
+    "🔗 Can't read or save which conversation this channel is linked to, so your "
+    "message was NOT processed. This needs an operator to repair the gateway's "
+    "expectation store; `!sessions` still lists sessions, but a reattachment "
+    "cannot be saved until it is."
+)
 
 
 class ResumeReleaseError(RuntimeError):
@@ -100,14 +109,65 @@ class _SessionPicker:
     choices: tuple[_SessionChoice, ...]
 
 
-def _safe_discord_text(text: str, max_chars: int) -> str:
-    """Redact full text, suppress Discord mentions, then truncate."""
+def _redact_discord_text(text: str) -> str:
+    """Redact credentials and exfiltration URLs, then defuse Discord mentions.
+
+    Mention defusing lengthens the text, so it runs before any budgeting: a
+    caller measuring the pre-defused string would under-count the payload.
+    """
     clean, _ = redact_exfiltration_urls(text or "")
     clean, _ = redact_credentials(clean)
-    clean = clean.replace("@", "@\u200b")
+    return clean.replace("@", "@\u200b")
+
+
+def _safe_discord_text(text: str, max_chars: int) -> str:
+    """Redact full text, suppress Discord mentions, then truncate.
+
+    For a short label (a session title, an error string). A Markdown BODY goes
+    through :func:`_replay_preview` instead, which shortens without cutting a
+    fenced code block in half.
+    """
+    clean = _redact_discord_text(text)
     if len(clean) <= max_chars:
         return clean
     return clean[: max_chars - 1] + "…"
+
+
+async def _replay_preview(text: str, limit: int, *, reserve: int) -> str:
+    """A fence-safe preview of *text*, marked when it left content behind.
+
+    The replay is a bounded context preview, so a long transcript message is
+    still shortened — but a blind character slice can land inside a fenced code
+    block, and Discord then renders everything after it as literal backticks
+    instead of code. Taking the shared splitter's FIRST chunk shortens at a
+    boundary the fence grammar accepts: every chunk but the last is sealed, so
+    that chunk closes any block the cut opened and stands on its own.
+
+    The splitter is prefix-stable, so only a bounded prefix is needed to derive
+    its first sealed chunk. The bounded split still runs off the asyncio thread:
+    pathological delimiter input is finite but CPU-intensive, and transcript
+    replay must not pause unrelated Discord traffic while deriving a preview.
+
+    ``reserve`` is the caller's own scaffolding — the role icon, and the marker
+    below — held out of the splitter's budget so the assembled message still fits
+    ``limit``. A pathological opener can need more fence scaffolding than that
+    budget can hold. In that case the marker is safer than a blind API truncation
+    that would expose an unterminated fence.
+    """
+    redacted = _redact_discord_text(text)
+    probe = redacted[: max(1, limit) * 2]
+    probe_left_content = len(probe) < len(redacted)
+    chunks = await asyncio.to_thread(split_markdown_safe, probe, limit, reserve=reserve)
+    if not chunks:
+        return ""
+
+    first = chunks[0]
+    prefix_reserve = max(0, reserve - len(_REPLAY_TRUNCATED))
+    if len(chunks) == 1 and not probe_left_content:
+        return first if len(first) <= limit - prefix_reserve else _REPLAY_TRUNCATED
+    if len(first) > limit - reserve:
+        return _REPLAY_TRUNCATED
+    return first + _REPLAY_TRUNCATED
 
 
 def _history_dashboard_key(raw_key: object) -> str | None:
@@ -142,11 +202,16 @@ def _picker_components(nonce: str, choices: tuple[_SessionChoice, ...]) -> list[
     return rows
 
 
-def _storage_refused(channel_id: str, why: str,
-                     observed: "InboundResolution | None" = None) -> "RoutingDecision":
+def _storage_refused(
+    channel_id: str, why: str, observed: "InboundResolution | None" = None
+) -> "RoutingDecision":
     """Log and refuse: routing on an unreadable store attaches the turn to a binding whose later loss nothing can detect."""
-    logger.warning("discord resume: %s at channel %s; refusing rather than routing "
-                   "undetectably", why, channel_id, exc_info=True)
+    logger.warning(
+        "discord resume: %s at channel %s; refusing rather than routing " "undetectably",
+        why,
+        channel_id,
+        exc_info=True,
+    )
     return RoutingDecision(refusal=_STORAGE_REFUSAL, settle=_SETTLE_NOTHING, observed=observed)
 
 
@@ -226,25 +291,40 @@ class DiscordSessionResume:
                 # binding revives on restart, splitting the conversation history.
                 try:
                     expected = await self._expectations.get(channel_id)
-                    owner = seen.key or next(iter(self.sessions.find_mirror_sessions(
-                        self.link_for(channel_id), inbound_only=True)), None)
+                    owner = seen.key or next(
+                        iter(
+                            self.sessions.find_mirror_sessions(
+                                self.link_for(channel_id), inbound_only=True
+                            )
+                        ),
+                        None,
+                    )
                     if owner and (expected is None or expected.retired):
-                        await self._expectations.record(channel_id, owner, await self._title_of(owner))
+                        await self._expectations.record(
+                            channel_id, owner, await self._title_of(owner)
+                        )
                 except ExpectationStoreError as exc:
                     raise ResumeReleaseError("release evidence write failed") from exc
                 # Free every co-located occupant so unlink cannot leave an ambiguous owner.
                 cleared = self.sessions.clear_mirror_links_at(
-                    self.link_for(channel_id), reason=UNBIND_REASON_USER_UNLINK)
+                    self.link_for(channel_id), reason=UNBIND_REASON_USER_UNLINK
+                )
             # A retry must land a failed in-memory removal before record retirement.
             try:
                 await self.sessions.aflush()
             except Exception as exc:
-                logger.warning("discord resume: binding release was not durable for channel %s",
-                               channel_id, exc_info=True)
+                logger.warning(
+                    "discord resume: binding release was not durable for channel %s",
+                    channel_id,
+                    exc_info=True,
+                )
                 raise ResumeReleaseError("session-map flush failed") from exc
             if releasing:
-                logger.info("discord: released resumed session %s (cleared bindings: %s)",
-                            seen.key or "(ambiguous)", ", ".join(cleared) or "none")
+                logger.info(
+                    "discord: released resumed session %s (cleared bindings: %s)",
+                    seen.key or "(ambiguous)",
+                    ", ".join(cleared) or "none",
+                )
                 self._push_slots()
             try:
                 # Retire on the version CAS alone: an owner racing the flush is a NEW
@@ -257,7 +337,10 @@ class DiscordSessionResume:
             except ExpectationStoreError:
                 logger.warning(
                     "discord resume: could not retire the released record at channel %s; "
-                    "one stale detach notice may follow", channel_id, exc_info=True)
+                    "one stale detach notice may follow",
+                    channel_id,
+                    exc_info=True,
+                )
         return seen.key or (cleared[0] if cleared else None)
 
     async def route(self, channel_id: str) -> RoutingDecision:
@@ -273,11 +356,15 @@ class DiscordSessionResume:
                 return _storage_refused(channel_id, "cannot read the store")
             resolution = self.resolve_inbound(channel_id)
             if resolution.ambiguous:
-                return RoutingDecision(refusal=(
+                return RoutingDecision(
+                    refusal=(
                         "🔗 Ambiguous link: this conversation is claimed by more than "
                         "one session, so it cannot be resumed and your message was NOT "
-                        "processed. Run `!unlink` to release them, then `!sessions` to " "reattach."
-                    ), settle=_SETTLE_NOTHING, observed=resolution,
+                        "processed. Run `!unlink` to release them, then `!sessions` to "
+                        "reattach."
+                    ),
+                    settle=_SETTLE_NOTHING,
+                    observed=resolution,
                 )
             if resolution.key is None:
                 if expected is None or expected.retired:
@@ -293,7 +380,7 @@ class DiscordSessionResume:
                     described=expected,
                     observed=resolution,
                 )
-            if (expected is not None and not expected.retired and expected.key == resolution.key):
+            if expected is not None and not expected.retired and expected.key == resolution.key:
                 return RoutingDecision(resumed_key=resolution.key)
 
             title = await self._title_of(resolution.key)
@@ -350,8 +437,8 @@ class DiscordSessionResume:
                 await self.sessions.aflush()
             except Exception:
                 logger.warning(
-                    "discord resume: detach durability failed at %s",
-                    channel_id, exc_info=True)
+                    "discord resume: detach durability failed at %s", channel_id, exc_info=True
+                )
                 return
         try:
             if decision.settle == _SETTLE_CLEAR:
@@ -367,7 +454,9 @@ class DiscordSessionResume:
             # Unsettled, so the same refusal is owed again.
             logger.warning(
                 "discord resume: could not settle the notice at channel %s; the "
-                "next message will be refused again", channel_id, exc_info=True,
+                "next message will be refused again",
+                channel_id,
+                exc_info=True,
             )
 
     def _display(self, expected: ResumeExpectation) -> str:
@@ -434,9 +523,9 @@ class DiscordSessionResume:
                 fallback_needles, fallback_phrase, fallback_floor = parse_search_query(
                     normalized_query
                 )
-                fallback_multi = [
-                    n.text for n in fallback_needles if n.required
-                ] != [fallback_phrase]
+                fallback_multi = [n.text for n in fallback_needles if n.required] != [
+                    fallback_phrase
+                ]
                 if not rows and fallback_multi:
                     # search_sessions matches multi-word queries needle-wise (all
                     # required needles must appear, in the title or the content),
@@ -538,7 +627,9 @@ class DiscordSessionResume:
             )
         else:
             if total_choices > _PICKER_LIMIT:
-                summary = f"Showing {_PICKER_LIMIT} of {total_choices} most recent dashboard sessions."
+                summary = (
+                    f"Showing {_PICKER_LIMIT} of {total_choices} most recent dashboard sessions."
+                )
             else:
                 summary = (
                     f"Showing {total_choices} most recent dashboard session"
@@ -667,7 +758,8 @@ class DiscordSessionResume:
             except ExpectationStoreError:
                 logger.warning(
                     "discord resume: the pick of %s did not take effect",
-                    choice.key, exc_info=True,
+                    choice.key,
+                    exc_info=True,
                 )
                 await client.edit_message(
                     interaction.channel_id,
@@ -800,11 +892,17 @@ class DiscordSessionResume:
             raw_content = str(message.get("content") or "")
             if role == "assistant":
                 raw_content = sanitize_channel_replay_text(raw_content)
-            content = _safe_discord_text(raw_content, _REPLAY_TEXT_LIMIT)
+            content = await _replay_preview(
+                raw_content, _REPLAY_TEXT_LIMIT, reserve=_REPLAY_RESERVE
+            )
             if role not in {"user", "assistant"} or not content:
                 continue
             icon = "🧑" if role == "user" else "🤖"
             try:
-                await client.send_message(channel_id, f"{icon} {content}")
+                # The icon gets its OWN line: on the body's first line it would
+                # sit in front of a fence opener, which must start the line, so a
+                # replayed code block would render as literal backticks however
+                # carefully the body was split.
+                await client.send_message(channel_id, f"{icon}\n{content}")
             except Exception:
                 logger.debug("discord resume: context replay failed", exc_info=True)

--- a/src/kiro_crew/messaging/split.py
+++ b/src/kiro_crew/messaging/split.py
@@ -1,9 +1,10 @@
 """Fence-safe markdown splitting, shared by every messaging channel.
 
-Six splitters grew independently — Discord and Telegram each carry a
+Six splitters grew independently — Telegram carries a
 ``_split_text``/``_split_markdown`` pair, ``messaging/renderer.py`` chunks blind
 fixed-width, and Slack, Webex and Weixin have their own — so a fix landed in one
-never reached the others. This module is the single engine they converge on.
+never reached the others. This module is the single engine they converge on, and
+Discord is the first channel on it.
 
 Three properties make it safe for the shared path:
 

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -29,6 +29,7 @@ from kiro_crew.discord.client import (
     _INTENT_GUILD_MESSAGES,
     _INTENT_MESSAGE_CONTENT,
     DISCORD_CHUNK_LIMIT,
+    DISCORD_MAX_TEXT,
     DiscordClient,
     DiscordInbound,
     DiscordInteraction,
@@ -41,10 +42,7 @@ from kiro_crew.discord.commands import (
 from kiro_crew.discord.renderer import (
     DiscordApprovalDecider,
     DiscordRenderer,
-    _ends_inside_fence,
     _extract_options,
-    _split_markdown,
-    _split_text,
     _strip_steering,
     build_option_components,
 )
@@ -64,6 +62,7 @@ from kiro_crew.messaging.link import (
     legacy_dashboard_mirror_key,
 )
 from kiro_crew.messaging.queue_receipt import receipt_text as _receipt_text
+from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import _opt_out_key
 from kiro_crew.session_map import ConversationOwnershipConflict
@@ -133,9 +132,7 @@ class FakeClient:
     async def create_dm_channel(self, user_id: str) -> str:
         return f"dm-{user_id}"
 
-    async def create_thread_from_message(
-        self, channel_id: str, message_id: str, name: str
-    ) -> str:
+    async def create_thread_from_message(self, channel_id: str, message_id: str, name: str) -> str:
         thread_id = f"thread-{message_id}"
         self.created_threads.append((channel_id, message_id, name))
         self.thread_channels.add(thread_id)
@@ -530,164 +527,343 @@ _FENCE_SHAPES = [
 ]
 
 
-class TestSplitText:
-    def test_short_text_single_chunk(self) -> None:
-        assert _split_text("hello", 100) == ["hello"]
+class TestRotationSplitting:
+    """The regression corpus, repointed onto the shared splitter.
 
-    def test_empty_text(self) -> None:
-        assert _split_text("", 100) == []
+    Discord owns no splitter: ``_rotate_on_length`` consumes
+    ``split_markdown_safe``, so every shape below is that module's behavior as a
+    Discord user reads it. The module's own contracts -- fence grammar, budget,
+    prefix stability, lossless reassembly -- are pinned in
+    ``test_messaging_split.py`` and are deliberately not restated here. These
+    tests pin the INTEGRATION: which chunks the renderer seals, which one it
+    keeps live, and that it adds and removes nothing on the way.
+    """
 
-    def test_splits_at_paragraph_boundary(self) -> None:
-        text = "para one\n\npara two\n\npara three"
-        chunks = _split_text(text, 20)
-        assert all(len(c) <= 20 for c in chunks)
-        assert "".join(c.replace("\n", "") for c in chunks)  # nothing lost
+    def _renderer(
+        self, monkeypatch: pytest.MonkeyPatch, limit: int
+    ) -> tuple[DiscordRenderer, FakeClient]:
+        cli = FakeClient()
+        r = DiscordRenderer(cli, "chan1", DISCORD_CAPABILITIES, session_key="sk")  # type: ignore[arg-type]
+        monkeypatch.setattr(r, "_limit", lambda: limit)
+        # A live frame is throttled and re-rendered by design, so it carries no
+        # stability promise and would interleave with the sealed frames. Holding
+        # it back leaves ``cli.sent`` as exactly the sealed chunks, in order,
+        # which is the channel every assertion below reads.
+        monkeypatch.setattr("kiro_crew.discord.renderer._EDIT_THROTTLE_S", 1e9)
+        return r, cli
 
-    def test_split_markdown_balances_fences(self) -> None:
-        code = "```py\n" + ("x = 1\n" * 50) + "```"
-        chunks, appended = _split_markdown(code, 120)
-        assert len(chunks) > 1
-        for ch in chunks:
-            assert ch.count("```") % 2 == 0  # every chunk self-contained
-        # The source's own closer lands in the final chunk, so nothing was
-        # invented there.
-        assert appended is False
+    async def _rotate(
+        self, monkeypatch: pytest.MonkeyPatch, src: str, limit: int
+    ) -> tuple[list[str], str]:
+        """The sealed frames and the retained live buffer for *src* at *limit*."""
+        r, cli = self._renderer(monkeypatch, limit)
+        r._buf = [src]
+        await r._rotate_on_length()
+        return [t for t, _ in cli.sent], "".join(r._buf)
 
-    def test_split_markdown_reports_its_own_synthetic_closer(self) -> None:
-        # The flag is the splitter's record of what it appended to the FINAL
-        # chunk -- the only sound basis for the rotation's strip, since the
-        # per-chunk walk runs after a bare ``` reopen has already discarded the
-        # original opener's run length.
-        open_fence = "```py\n" + ("x = 1\n" * 50)
-        chunks, appended = _split_markdown(open_fence, 120)
-        assert len(chunks) > 1
-        assert appended is True
-        assert chunks[-1].endswith("\n```")
-        # A lone chunk is handed back untouched, so the flag alone expresses the
-        # "nothing to undo" case -- no len(chunks) guard is needed at the strip.
-        for text in ["```py\nx = 1\n", "type ``` here", "", "plain prose"]:
-            lone, lone_appended = _split_markdown(text, 1900)
-            assert len(lone) <= 1
-            assert lone_appended is False
-            assert lone == _split_text(text, 1900)
+    @pytest.mark.asyncio
+    async def test_pathological_splitter_work_is_offloaded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.discord import renderer as renderer_module
 
-    def test_inline_backticks_are_not_a_fence(self) -> None:
-        # A ``` written MID-LINE is prose about fencing, not a fence. Counting
-        # ``` substrings calls this "open" and flips every later fence decision.
-        assert not _ends_inside_fence("Type ``` to open a block.")
-        assert not _ends_inside_fence("Prose\nsay ``` here\nmore prose")
-        # ...and it must not mask a fence that really is open.
-        assert _ends_inside_fence("Type ``` first.\n\n```py\nx = 1\n")
+        r, _ = self._renderer(monkeypatch, 100)
+        source = "`" * 5_000
+        r._buf = [source]
+        offloads: list[tuple[Any, tuple[Any, ...], dict[str, Any]]] = []
 
-    def test_fence_state_walk_follows_commonmark(self) -> None:
-        assert _ends_inside_fence("```py\nx = 1\n")
-        assert not _ends_inside_fence("```py\nx = 1\n```")
-        assert not _ends_inside_fence("```py\nx = 1\n```\ntrailing prose")
-        # Up to 3 spaces of indent still opens; 4+ is an indented code line.
-        assert _ends_inside_fence("   ```\nx\n")
-        assert not _ends_inside_fence("    ```\nx\n")
-        # A closer may be LONGER than its opener but never shorter, and carries
-        # nothing after it -- an info string is legal only on the opener.
-        assert not _ends_inside_fence("```\nx\n`````")
-        assert _ends_inside_fence("`````\nx\n```")
-        assert _ends_inside_fence("```\nx\n``` not a closer")
-        # An info string containing a backtick is inline code, not a fence.
-        assert not _ends_inside_fence("```a`b\nx\n")
+        def _capture(text: str, limit: int) -> list[str]:
+            return [text]
 
-    def test_continuation_preserves_leading_indentation(self) -> None:
-        # A cut landing just before an INDENTED line must not re-indent it: only
-        # newlines are stripped at the boundary, never horizontal whitespace.
-        text = "a" * 30 + "\n" + "    indented = 1\n" + "b" * 30
-        chunks = _split_text(text, 40)
-        assert len(chunks) > 1
-        assert chunks[1].startswith("    indented = 1")
+        async def _offload(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+            offloads.append((func, args, kwargs))
+            return func(*args, **kwargs)
 
-    def test_newline_only_remainder_keeps_blank_code_lines(self) -> None:
-        # Blank lines are CONTENT inside a fenced block. A boundary that leaves a
-        # remainder of nothing but newlines must not drop them, or the blank code
-        # lines vanish and every later code line shifts up one row.
-        text = "```py\n" + "x = 1\n" * 299 + "\n\n"
-        chunks = _split_text(text, 1800)
-        # The tail is its own chunk -- it neither vanished nor re-entered the
-        # loop unchanged. Its first newline terminates the last code line, so it
-        # is the separator this boundary represents and only it is absorbed; the
-        # two authored blank lines are what remain.
-        assert chunks[-1] == "\n\n"
-        # Exact accounting, replacing a raw total-newline count: that count came
-        # out equal only because the absorbed separator was being counted as
-        # content, which is one blank line more than the source has. Rejoining on
-        # the separator each cut consumed reproduces the source verbatim, so no
-        # newline is lost and none is invented.
-        assert "\n".join(chunks) == text
+        monkeypatch.setattr(renderer_module, "split_markdown_safe", _capture)
+        monkeypatch.setattr(renderer_module.asyncio, "to_thread", _offload)
 
-    def test_all_newline_text_terminates(self) -> None:
-        # A zero-width cut on an all-newline tail must not re-enter the loop
-        # unchanged. Watchdogged so a regression fails instead of hanging.
-        done: list[list[str]] = []
-        t = threading.Thread(target=lambda: done.append(_split_text("\n\n", 1)), daemon=True)
-        t.start()
-        t.join(5.0)
-        assert done, "_split_text did not terminate on an all-newline tail"
+        await r._rotate_on_length()
 
-    def test_blank_code_lines_straddling_a_cut_survive(self) -> None:
-        # A blank line FOLLOWED BY CONTENT is an authored code line, not the
-        # boundary separator. The cut lands on the run, so lstrip("\n") deleted
-        # every newline in it at once and the next code line shifted up two rows.
-        text = "```py\nx = 1\n\n\ny = 2\ny = 3\n"
-        chunks = _split_text(text, 20)
-        assert len(chunks) == 2
-        assert chunks[0] == "```py\nx = 1"
-        # BOTH authored blank lines lead the continuation.
-        assert chunks[1] == "\n\ny = 2\ny = 3\n"
-        # Exactly one newline -- the separator this boundary itself represents --
-        # was absorbed, so rejoining on it reproduces the source verbatim.
-        assert "\n".join(chunks) == text
+        assert offloads == [(_capture, (source, 100), {})]
 
-    def test_prose_paragraph_gap_survives_a_cut(self) -> None:
-        # The prose twin: the blank line of a paragraph gap is equally authored.
-        text = "para one\n\npara two\n\npara three"
-        chunks = _split_text(text, 20)
-        assert chunks == ["para one\n\npara two", "\npara three"]
-        assert "\n".join(chunks) == text
+    @pytest.mark.asyncio
+    async def test_a_segment_under_the_cap_is_not_rotated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert await self._rotate(monkeypatch, "hello", 100) == ([], "hello")
+        assert await self._rotate(monkeypatch, "", 100) == ([], "")
 
-    def test_continuation_gains_no_leading_blank_line(self) -> None:
-        # The opposite failure mode of the widened preservation: where the source
-        # had a single separator and no blank line, the continuation must render
-        # exactly as it does today -- content first, no invented gap.
-        text = "a" * 30 + "\n" + "b" * 30
-        assert _split_text(text, 40) == ["a" * 30, "b" * 30]
+    @pytest.mark.asyncio
+    async def test_a_lone_chunk_is_handed_back_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Nothing appended and nothing to undo, including for the shapes the
+        # deleted tail-closer strip used to have to reason about.
+        for text in ["```py\nx = 1\n", "type ``` here", "plain prose"]:
+            assert await self._rotate(monkeypatch, text, 1900) == ([], text)
 
-    def test_swept_cut_absorbs_at_most_one_newline(self) -> None:
-        """Whitespace-fidelity oracle over the same corpus as the strip sweep.
+    @pytest.mark.asyncio
+    async def test_a_paragraph_boundary_is_preferred(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sealed, tail = await self._rotate(monkeypatch, "para one\n\npara two\n\npara three", 20)
+        assert sealed == ["para one"]  # cut at the paragraph break, blank line trimmed
+        assert tail == "para two\n\npara three"
 
-        That sweep asserts only that non-whitespace survives, so it is blind to
-        blank lines -- exactly the class ``lstrip("\\n")`` deleted. Every chunk is
-        a verbatim slice of the source, so walking the slices in order exposes
-        what the splitter dropped at each cut: it must be whitespace only, and it
-        must be at most the single line separator the message boundary itself
-        represents. That bounds newline-run loss inside fences and in prose alike
-        at oracle strength, and it fails on ``lstrip("\\n")``, which drops the
-        whole run.
+    @pytest.mark.asyncio
+    async def test_every_sealed_frame_closes_its_own_fence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sealed, tail = await self._rotate(monkeypatch, "```py\n" + "x = 1\n" * 50 + "```", 120)
+        assert len(sealed) > 1
+        for frame in sealed:
+            # Self-contained: the language tag is carried into every
+            # continuation and a matching closer ends it.
+            assert frame.startswith("```py\n"), frame[:12]
+            assert frame.endswith("\n```"), frame[-8:]
+            assert frame.count("```") % 2 == 0
+        assert tail.endswith("```")  # the source's own closer, not an invented one
+
+    @pytest.mark.asyncio
+    async def test_the_retained_tail_is_left_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The final chunk keeps a still-arriving fence OPEN, by contract.
+
+        This is what replaced a whole append-then-strip protocol. The private
+        splitter sealed every chunk including the last and reported, through a
+        returned flag, that it had done so; the rotation then undid it on the
+        retained tail. The shared splitter never seals the final chunk, so there
+        is no flag to read and nothing to strip -- and no way for an append and
+        a strip to disagree, which is what every defect in that cluster was.
         """
-        cuts = 0
+        src = "```py\n" + "x = 1\n" * 50  # the model's closing ``` has not arrived
+        sealed, tail = await self._rotate(monkeypatch, src, 120)
+        assert len(sealed) > 1
+        for frame in sealed:
+            assert frame.endswith("\n```")
+        assert tail.startswith("```py\n")  # the authored opener, not a bare ```
+        assert not tail.rstrip().endswith("```")
+        assert src.endswith(tail[len("```py\n") :])  # the tail IS the source's own tail
+
+    @pytest.mark.asyncio
+    async def test_fence_grammar_seams_survive_a_rotation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only a real fence line opens a block, and its run length is kept.
+
+        A ``` counted as a substring reads prose about fencing as code and
+        inverts every later decision; a closer shorter than its opener closes
+        nothing. Each row is (opener line, the tail's reopener, the closer a
+        sealed frame carries) -- an empty reopener means the source opened no
+        fence at all, so no frame may carry a closer either.
+        """
+        code = "x = 1\n" * 60
+        for opener, reopen, closer in [
+            ("```py\n", "```py\n", "\n```"),
+            ("````md\n", "````md\n", "\n````"),
+            ("`````\n", "`````\n", "\n`````"),
+            ("   ```py\n", "   ```py\n", "\n```"),  # <=3 spaces of indent still opens
+            ("    ```py\n", "", ""),  # 4+ is an indented code line
+            ("```a`b\n", "", ""),  # a backtick in the info string is inline code
+            ("You type ``` inline.\n", "", ""),  # mid-line, so it opens nothing
+        ]:
+            sealed, tail = await self._rotate(monkeypatch, opener + code, 120)
+            where = repr(opener)
+            assert len(sealed) > 1, where
+            assert tail.startswith(reopen), (where, tail[:14])
+            for frame in sealed:
+                assert frame.endswith(closer or "x = 1"), (where, frame[-10:])
+
+    @pytest.mark.asyncio
+    async def test_an_authored_inner_fence_line_survives_a_rotation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 4-backtick block documenting 3-backtick ones keeps its own ``` lines.
+
+        Per CommonMark the inner bare ``` closes nothing, so the source fence is
+        still open at the cut and every continuation reopens the 4-backtick one.
+        A per-chunk walk run after a BARE ``` reopen loses the opener's run
+        length, reads the authored inner closer as closing the block, and the
+        strip that followed then deleted the author's own line.
+        """
+        src = "````markdown\n" + "Nest a block:\n\n```py\nx = 1\n```\n\n" * 90
+        sealed, tail = await self._rotate(monkeypatch, src, 1800)
+        assert len(sealed) >= 1
+        assert tail.startswith("````markdown\n")
+        assert src.endswith(tail[len("````markdown\n") :])  # a suffix, not a shortened copy
+        authored = src.count("\n```\n")
+        assert sum(f.count("\n```\n") for f in sealed) + tail.count("\n```\n") >= authored
+
+    @pytest.mark.asyncio
+    async def test_indentation_inside_a_fence_reaches_the_user_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stripping leading whitespace silently re-indents split code. Inside a
+        # fence the reopener heads every continuation, so an indented code line
+        # never starts a frame and survives the renderer's own strip too.
+        src = "```py\n" + "    indented = 1\n" * 40
+        sealed, tail = await self._rotate(monkeypatch, src, 200)
+        assert len(sealed) > 1
+        for frame in sealed + [tail]:
+            for line in frame.split("\n"):
+                if "indented" in line:
+                    assert line == "    indented = 1", repr(line)
+
+    @pytest.mark.asyncio
+    async def test_blank_code_lines_survive_a_rotation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Blank lines are CONTENT inside a fence, and no cut absorbs a run.
+
+        ``lstrip("\\n")`` on a boundary remainder deleted whole runs of them and
+        pulled the next code line up a row. The shared splitter absorbs no line
+        separator at all, so the run reaches the retained tail intact.
+        """
+        # A remainder of nothing but newlines.
+        _, tail = await self._rotate(monkeypatch, "```py\n" + "x = 1\n" * 299 + "\n\n", 1800)
+        assert tail.endswith("\n\n\n")
+        # The same run straddling the cut, with more code AFTER it.
+        src = "```py\n" + "x = 1\n" * 6 + "\n\n" + "y = 2\n" * 6
+        sealed, tail = await self._rotate(monkeypatch, src, 60)
+        assert len(sealed) >= 1
+        joined = "".join(sealed) + tail
+        assert "x = 1y = 2" not in joined  # no code line shifted up onto another
+        assert "\n\n" in joined  # the blank code lines are still there
+
+    @pytest.mark.asyncio
+    async def test_a_continuation_gains_no_leading_blank_line(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The opposite failure mode of preserving a run: where the source had a
+        # single separator and no blank line, the continuation must start with
+        # content and no invented gap.
+        sealed, tail = await self._rotate(monkeypatch, "a" * 30 + "\n" + "b" * 30, 40)
+        assert sealed == ["a" * 30]
+        assert tail == "b" * 30
+
+    @pytest.mark.timeout(30)
+    @pytest.mark.asyncio
+    async def test_a_rotation_terminates_on_pathological_input(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Input no cut fits cleanly must finish rather than spin.
+
+        An all-newline tail, a 5000-backtick run, and a budget too small to hold
+        a fence's own scaffolding are the three shapes with no clean cut
+        anywhere. Chunks legitimately go over budget in the last of them; what
+        matters is that the call returns and makes progress.
+        """
+        for src, limit in [
+            ("\n\n", 1),
+            ("`" * 5000, 100),
+            ("```a-very-long-info-string-indeed\n" + "code\n" * 20, 12),
+        ]:
+            sealed, tail = await self._rotate(monkeypatch, src, limit)
+            assert sealed or tail, repr(src[:14])
+
+    @pytest.mark.asyncio
+    async def test_an_overlimit_chunk_never_reaches_the_api_whole(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The splitter's one documented budget exception, bounded again here.
+
+        A logical line that admits no cut clean on both sides is placed WHOLE
+        and its chunk carries the fence scaffolding on top of the limit. The 100
+        characters ``_limit`` holds back absorb ordinary scaffolding, but an
+        opener this long does not fit in them, so the chunk passes Discord's
+        hard cap -- where ``send_message`` truncates and drops the tail
+        INCLUDING the synthetic closer, leaving an unterminated code block
+        missing content and no signal that anything went.
+        """
+        opener = "`" * 260  # scaffolding wider than _limit's headroom
+        line = "x" + "`" * 1699  # content: not a bare run, and no cut is clean
+        src = opener + "\n" + line + "\n" + "tail\n" * 40
+        limit = 1800  # DISCORD_CAPABILITIES' own _limit()
+        assert any(len(c) > DISCORD_MAX_TEXT for c in split_markdown_safe(src, limit))
+
+        sealed, tail = await self._rotate(monkeypatch, src, limit)
+        assert sealed
+        for frame in sealed:
+            assert len(frame) <= DISCORD_MAX_TEXT, len(frame)
+        # Sliced, not truncated: every authored character still reaches the user.
+        it = iter("".join(("".join(sealed) + tail).split()))
+        assert all(c in it for c in "".join(src.split()))
+
+        # The same guard covers the final seal, which is the other payload the
+        # API sees whole.
+        r, cli = self._renderer(monkeypatch, limit)
+        await r.on_text_chunk(src)
+        await r.on_done()
+        for text, _ in cli.sent:
+            assert len(text) <= DISCORD_MAX_TEXT, len(text)
+        for _mid, text, _components in cli.edits:
+            assert len(text) <= DISCORD_MAX_TEXT, len(text)
+
+    @pytest.mark.asyncio
+    async def test_streaming_a_source_seals_what_splitting_it_whole_would(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Prefix stability, end to end: incremental == one-shot.
+
+        Splitting is greedy left-to-right, so re-splitting a longer prefix of
+        the same stream reproduces every chunk but the last byte-for-byte. That
+        is what lets this renderer POST a sealed chunk and keep only the final
+        one live -- Discord has no affordance for un-posting a message, so a cut
+        that moved once more text arrived would be unrecoverable. Streaming the
+        source in slices must therefore land exactly the messages one shot does.
+        """
+        src = _FENCE_SHAPES[3]  # a 4-backtick block full of inner 3-backtick ones
+        limit = 200
+        r, cli = self._renderer(monkeypatch, limit)
+        posted: list[str] = []
+        for start in range(0, len(src), 37):
+            await r.on_text_chunk(src[start : start + 37])
+            grown = [t for t, _ in cli.sent]
+            assert grown[: len(posted)] == posted, "a message already posted moved"
+            posted = grown
+        whole = split_markdown_safe(src, limit)
+        assert posted == [_strip_steering(c) for c in whole[:-1]]
+        assert "".join(r._buf) == whole[-1]
+
+    @pytest.mark.asyncio
+    async def test_the_renderer_seals_the_splitter_chunks_unmodified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Swept oracle: a rotation IS the splitter's output, verbatim.
+
+        The renderer used to carry its own splitter and then undo part of it, and
+        every defect in that cluster was the append and the strip disagreeing on
+        one shape. There is nothing left to disagree about, and this pins that:
+        each chunk but the last is sealed exactly once, in order, and the last is
+        retained as the live buffer byte-for-byte. The only transform in the
+        identity is ``_strip_steering``, the renderer's pre-existing normalizer
+        (which also collapses runs of 3+ newlines, so THAT is the visible
+        blank-line cap, not the splitter's) -- any re-added append or strip fails
+        it, whatever shape motivated it.
+
+        Shapes cover what a per-chunk fence walk cannot recover from the source:
+        3/4/5-backtick openers, authored inner bare ``` lines, literal backticks
+        in prose, 4-space-indented lookalikes, info strings, and blank-line runs.
+        """
+        rotated = frames = 0
         for src in _FENCE_SHAPES:
+            assert src and "[OPTIONS" not in src and "[STEERING" not in src  # no detach
             for limit in list(range(40, 201, 7)) + [1900]:
-                chunks = _split_text(src, limit)
-                cuts += len(chunks) - 1
-                pos = 0
-                for ch in chunks:
-                    where = f"shape={src[:14]!r} limit={limit}"
-                    at = src.find(ch, pos)
-                    assert at >= 0, f"chunk is not a source slice: {where}"
-                    gap = src[pos:at]
-                    assert not gap.strip(), f"authored text dropped at a cut: {where}"
-                    assert gap.count("\n") <= 1, (
-                        f"cut absorbed {gap.count(chr(10))} newlines, "
-                        f"blank lines deleted: {where}"
-                    )
-                    pos = at + len(ch)
-                assert not src[pos:].strip(), f"authored tail dropped: {src[:14]!r}"
-        assert cuts > 300, cuts  # the sweep is not vacuous
+                chunks = split_markdown_safe(src, limit)
+                sealed, tail = await self._rotate(monkeypatch, src, limit)
+                where = f"shape={src[:14]!r} limit={limit}"
+                rotated += len(chunks) > 1
+                frames += len(sealed)
+                assert tail == chunks[-1], f"live buffer is not the final chunk: {where}"
+                assert sealed == [
+                    _strip_steering(c) for c in chunks[:-1]
+                ], f"sealed frames are not the splitter's own chunks: {where}"
+                # Nothing authored is dropped: every non-whitespace source
+                # character still appears, in order, across the frames plus the
+                # tail. Synthetic backticks only ever ADD.
+                it = iter("".join(("".join(sealed) + tail).split()))
+                assert all(
+                    c in it for c in "".join(src.split())
+                ), f"authored characters deleted: {where}"
+        # The sweep must not go vacuous.
+        assert rotated > 300 and frames > 1000, (rotated, frames)
 
 
 class TestOptionComponents:
@@ -879,9 +1055,7 @@ class TestGatewayAttachmentNormalization:
         assert dest.read_bytes() == b"firstsecond"
         assert all(operation_threads.values())
         assert all(
-            thread != loop_thread
-            for threads in operation_threads.values()
-            for thread in threads
+            thread != loop_thread for threads in operation_threads.values() for thread in threads
         )
 
     @pytest.mark.asyncio
@@ -894,9 +1068,7 @@ class TestGatewayAttachmentNormalization:
             "https://media.discordapp.net:444/file.png",
         ],
     )
-    async def test_download_refuses_non_discord_origin(
-        self, tmp_path: Any, url: str
-    ) -> None:
+    async def test_download_refuses_non_discord_origin(self, tmp_path: Any, url: str) -> None:
         client = DiscordClient(token="test")
         with pytest.raises(ValueError, match="Discord attachment URL"):
             await client.download_attachment(url, str(tmp_path / "out"))
@@ -918,12 +1090,8 @@ class TestDiscordAttachmentAdapter:
             transcribed.append(path)
             return "spoken words"
 
-        monkeypatch.setattr(
-            "kiro_crew.transcribe.is_available", lambda: True
-        )
-        monkeypatch.setattr(
-            "kiro_crew.transcribe.transcribe_audio", _transcribe
-        )
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", lambda: True)
+        monkeypatch.setattr("kiro_crew.transcribe.transcribe_audio", _transcribe)
 
         result = await process_discord_attachments(
             client,  # type: ignore[arg-type]
@@ -955,9 +1123,7 @@ class TestDiscordAttachmentAdapter:
             observed.append(threading.get_ident())
             return False
 
-        monkeypatch.setattr(
-            "kiro_crew.transcribe.is_available", _available
-        )
+        monkeypatch.setattr("kiro_crew.transcribe.is_available", _available)
         result = await process_discord_attachments(
             client,  # type: ignore[arg-type]
             [
@@ -971,9 +1137,7 @@ class TestDiscordAttachmentAdapter:
         )
 
         assert observed and loop_thread not in observed
-        assert result.rejections == [
-            "[Audio attachment — transcription is unavailable]"
-        ]
+        assert result.rejections == ["[Audio attachment — transcription is unavailable]"]
         cleanup(result.temp_paths)
 
 
@@ -1361,9 +1525,7 @@ class TestRenderer:
         # internal steer acknowledgment follows it and arrives across chunks,
         # with the combined buffer well past Discord's message cap.
         await r.on_text_chunk(
-            ("x" * 3800)
-            + "\n\n[OPTIONS: Alpha | Bravo | Charlie]"
-            + "\n\n[STEERING steer-7e6a4a0d"
+            ("x" * 3800) + "\n\n[OPTIONS: Alpha | Bravo | Charlie]" + "\n\n[STEERING steer-7e6a4a0d"
         )
         await r.on_text_chunk("94314d2db: acknowledged]")
         await r.on_done()
@@ -1456,18 +1618,19 @@ class TestRenderer:
         # sealed side keeps the code, and the blank lines belong to the tail.
         await r.on_text_chunk("```py\n" + "x = 1\n" * 6 + "\n\n" + "y = 2\n" * 6)
         sealed = cli.sent[0][0]
-        assert sealed.endswith("x = 1\n```")  # code sealed, synthetic closer on
-        # The retained tail reopens the fence and still carries BOTH blank lines.
-        assert "".join(r._buf) == "```\n" + "\n\n" + "y = 2\n" * 6
+        assert sealed.endswith("```")  # code sealed, synthetic closer on
+        # The retained tail reopens the fence with the AUTHORED opener (language
+        # tag and all, where a bare ``` reopen would have lost it).
+        assert "".join(r._buf).startswith("```py\n")
         await r.on_text_chunk("```")
         await r.on_done()
         # The blank code line survived to what the user reads and the later code
         # did not shift up. Only ONE blank line is asserted here: _strip_steering
         # collapses every run of 3+ newlines to 2 on EVERY render, so the visible
-        # cap is that normalizer's (pre-existing, and the same before this cut
-        # changed), not the splitter's.
-        assert "\n\ny = 2" in cli.final_text()
-        assert "x = 1\ny = 2" not in cli.final_text()
+        # cap is that normalizer's, not the splitter's.
+        visible = "".join([t for t, _ in cli.sent] + [t for _, t, _c in cli.edits])
+        assert "\n\n" in visible
+        assert "x = 1y = 2" not in visible
 
     @pytest.mark.asyncio
     async def test_rotation_ignores_inline_backticks_in_prose(self) -> None:
@@ -1494,18 +1657,18 @@ class TestRenderer:
         assert "Final sentence, outside any code block." in cli.final_text()
 
     @pytest.mark.asyncio
-    async def test_rotation_strips_closer_when_inline_backticks_hide_open_fence(self) -> None:
+    async def test_rotation_keeps_the_tail_open_behind_inline_backticks(self) -> None:
         r, cli = self._renderer()
         await r.on_turn_start()
         # The mirror miscount: one literal ``` in the prose plus a genuinely
-        # OPEN fence makes the substring count even, so the strip never fires
-        # and the retained tail is sealed shut around a live code block.
+        # OPEN fence makes a ``` SUBSTRING count even, so a parity-based
+        # splitter seals the retained tail shut around a live code block.
         await r.on_text_chunk(
             "You type ``` to open a block, like this:\n\n```py\n" + "x = 1\n" * 400
         )
         buf = "".join(r._buf)
-        assert buf.startswith("```")  # continuation reopens the live fence
-        assert not buf.rstrip().endswith("```")  # synthetic closer dropped
+        assert buf.startswith("```py\n")  # continuation reopens the live fence
+        assert not buf.rstrip().endswith("```")  # and it is left OPEN
         await r.on_text_chunk("y = 2\n```")
         await r.on_done()
         final = cli.final_text()
@@ -1519,8 +1682,8 @@ class TestRenderer:
         # Prose about fencing ends with a literal ``` and is itself UNDER the
         # cap -- only the long [OPTIONS:] trailer pushes the buffer over it. The
         # trailer is detached before splitting, so the splitter hands back a
-        # lone chunk and reports no synthetic closer (appended_closer False).
-        # The strip therefore never fires and the author's backticks survive.
+        # lone chunk, which is the final chunk and therefore untouched: the
+        # author's backticks survive.
         body = ("To fence a block in Discord, open the line with " * 36) + "type ```"
         assert len(body) < r._limit()
         trailer = "\n\n[OPTIONS: " + ("Yes " * 20) + " | " + ("No " * 20) + "]"
@@ -1538,84 +1701,29 @@ class TestRenderer:
         # ``` closes nothing (a closer must be at least as long as its opener),
         # so the source fence is still open at the cut.
         #
-        # The splitter judges each chunk AFTER prepending a bare ``` reopen,
-        # which throws away the 4-backtick opener's run length: to the walk the
-        # tail's fence is a 3-backtick one that the authored inner ``` CLOSES,
-        # so it appends no synthetic closer. Any predicate re-derived from the
-        # source disagrees -- it still sees the 4-backtick fence open -- and the
-        # strip then deletes the author's own ``` line from the retained buffer.
+        # A per-chunk fence walk run AFTER prepending a bare ``` reopen throws
+        # away the 4-backtick opener's run length: to that walk the tail's fence
+        # is a 3-backtick one the authored inner ``` CLOSES. The shared splitter
+        # carries the opener verbatim instead, so the reopen is the real fence
+        # and the author's own ``` line is never mistaken for scaffolding.
         src = "````markdown\n" + "Nest a block:\n\n```py\nx = 1\n```\n\n" * 90
         assert len(src) > r._limit()
         await r.on_text_chunk(src)
         buf = "".join(r._buf)
         assert len(buf) < len(src)  # the rotation really fired
+        assert buf.startswith("````markdown\n")  # run length and info string kept
         # The author's inner closer is the last thing they wrote; it must still
         # be there, with the blank line that followed it.
         assert buf.endswith("```\n\n")
         # Stronger: the retained tail IS the source's own tail (modulo the
         # continuation reopen) -- not a shortened copy of it.
-        assert src.endswith(buf[4:] if buf.startswith("```\n") else buf)
+        assert src.endswith(buf[len("````markdown\n") :])
         # It survives all the way to what the user reads.
         await r.on_text_chunk("Done.\n````")
         await r.on_done()
         frames = [t for t, _ in cli.sent] + [t for _, t, _c in cli.edits]
         authored = src.count("\n```\n")
         assert sum(f.count("\n```\n") for f in frames) >= authored
-
-    @pytest.mark.asyncio
-    async def test_rotation_strip_matches_the_splitter_in_both_directions(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Swept oracle: the strip fires iff the splitter appended.
-
-        Two directions, both pinned. (a) Nothing the author wrote is ever
-        deleted -- the retained tail stays a suffix of the source and every
-        non-whitespace source character survives across the frames. (b) A
-        synthetic closer never survives into the retained tail, or the live
-        code block is sealed shut and every later token renders outside it.
-
-        Shapes cover the information the per-chunk walk cannot see from the
-        source: 3/4/5-backtick openers, authored inner bare ``` lines, literal
-        backticks in prose, 4-space-indented lookalikes, and info strings.
-        """
-        rotated = appends = 0
-        for src in _FENCE_SHAPES:
-            assert src and "[OPTIONS" not in src and "[STEERING" not in src  # no detach
-            for limit in list(range(40, 201, 7)) + [1900]:
-                chunks, appended = _split_markdown(src, limit)
-                rotated += len(chunks) > 1
-                appends += appended
-                r, cli = self._renderer()
-                monkeypatch.setattr(r, "_limit", lambda limit=limit: limit)
-                r._buf = [src]
-                await r._rotate_on_length()
-                tail = "".join(r._buf)
-                where = f"shape={src[:14]!r} limit={limit}"
-                # (b) the strip fired exactly when the splitter appended…
-                if appended:
-                    assert tail != chunks[-1], f"synthetic closer retained: {where}"
-                # …and never otherwise.
-                else:
-                    assert tail == chunks[-1], f"untouched tail was modified: {where}"
-                # (a) the retained tail is the source's own tail, modulo the
-                # bare ``` reopen a continuation chunk carries. This one does
-                # not consult the flag, so it holds the strip to the source even
-                # if the splitter's report were wrong.
-                assert src.endswith(tail[4:] if tail.startswith("```\n") else tail), (
-                    f"retained tail is not a source suffix: {where}"
-                )
-                # (a) nothing authored was dropped anywhere: every
-                # non-whitespace source character still appears, in order,
-                # across the sealed frames plus the retained tail. Synthetic
-                # backticks only ever ADD.
-                seen = "".join(t for t, _ in cli.sent) + tail
-                it = iter("".join(seen.split()))
-                assert all(c in it for c in "".join(src.split())), (
-                    f"authored characters deleted: {where}"
-                )
-        # The sweep must not go vacuous: most cases really rotate, and a large
-        # share really do get a synthetic closer on the final chunk.
-        assert rotated > 300 and appends > 100, (rotated, appends)
 
     @pytest.mark.asyncio
     async def test_tool_footer_transient(self) -> None:
@@ -1825,9 +1933,7 @@ class TestDispatcher:
         assert "!sessions [query]" in cli.sent[-1][0]
 
     @pytest.mark.asyncio
-    async def test_typing_indicator_starts_before_the_session_cold_start(
-        self, monkeypatch
-    ) -> None:
+    async def test_typing_indicator_starts_before_the_session_cold_start(self, monkeypatch) -> None:
         """TTFT guard: the typing loop must be STARTED before the ACP cold start.
 
         ``sessions.get_or_create`` can spend seconds spawning and handshaking an
@@ -1866,9 +1972,9 @@ class TestDispatcher:
 
         assert "typing_started" in order, "typing was never started"
         assert "cold_start" in order, "session was never acquired"
-        assert order.index("typing_started") < order.index("cold_start"), (
-            f"typing must start before the cold start, got {order}"
-        )
+        assert order.index("typing_started") < order.index(
+            "cold_start"
+        ), f"typing must start before the cold start, got {order}"
 
     @pytest.mark.asyncio
     async def test_normal_turn_streams_and_releases(self) -> None:
@@ -2107,10 +2213,7 @@ class TestDispatcher:
         def _batch(prefix: str) -> list[dict[str, Any]]:
             batch: list[dict[str, Any]] = []
             for i in range(10):
-                url = (
-                    "https://cdn.discordapp.com/attachments/c/m/"
-                    f"{prefix}-{i}.png"
-                )
+                url = "https://cdn.discordapp.com/attachments/c/m/" f"{prefix}-{i}.png"
                 cli.attachment_bodies[url] = _PNG
                 batch.append(
                     {
@@ -2132,9 +2235,7 @@ class TestDispatcher:
 
         await d._drain_queue(d._session_key("u1"), "u1", "c1")
 
-        assert cli.attachment_downloads == [
-            item["url"] for item in [*first, *second]
-        ]
+        assert cli.attachment_downloads == [item["url"] for item in [*first, *second]]
         assert sess.queued == []
         assert len(d.ctx_builder.messages) == 2
         assert d.ctx_builder.messages[0].splitlines()[0] == "first batch"
@@ -2323,9 +2424,9 @@ class TestDispatcher:
         self._occupy_ambiguously(sess)
         await d.handle_message(self._msg("!link"))
         assert any("`!unlink`" in t for t, _ in cli.sent)
-        assert sess.mirror_opt_outs == {_opt_out_key(d._session_key("u1"))}, (
-            "a refused link must not withdraw the refusal"
-        )
+        assert sess.mirror_opt_outs == {
+            _opt_out_key(d._session_key("u1"))
+        }, "a refused link must not withdraw the refusal"
 
     @pytest.mark.asyncio
     async def test_an_ambiguous_conversation_is_answered_but_not_processed(self) -> None:
@@ -2339,9 +2440,9 @@ class TestDispatcher:
         self._occupy_ambiguously(sess)
         await d.handle_message(self._msg("hello world"))
         assert "Ambiguous link" in (cli.final_text() or "")
-        assert "Answer: hello world" not in (cli.final_text() or ""), (
-            "the message was processed while routing was denied"
-        )
+        assert "Answer: hello world" not in (
+            cli.final_text() or ""
+        ), "the message was processed while routing was denied"
         assert d._session_key("u1") not in sess.mirror_links
 
     @pytest.mark.asyncio

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -10,8 +10,8 @@ from typing import Any
 import pytest
 
 from kiro_crew.config.paths import config_dir
-from kiro_crew.discord import resume_expectation
-from kiro_crew.discord.client import DiscordInteraction
+from kiro_crew.discord import resume_expectation, session_resume
+from kiro_crew.discord.client import DISCORD_CHUNK_LIMIT, DiscordInteraction
 from kiro_crew.discord.commands import parse_command, parse_command_argument
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
 from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
@@ -279,7 +279,7 @@ class _ConversationLog:
             raw_key = str(row.get("key") or "")
             canonical = raw_key
             while canonical.startswith("dashboard_"):
-                canonical = canonical[len("dashboard_"):]
+                canonical = canonical[len("dashboard_") :]
             canonical = f"dashboard:{canonical}" if canonical else raw_key
             body = " ".join(
                 str(msg.get("content") or "")
@@ -821,6 +821,7 @@ async def test_resume_evidence_is_durable_before_the_success_banner(banner_lands
             if not banner_lands:
                 return False
         return await real_edit(channel_id, message_id, text, components=components)
+
     client.edit_message = _crash_boundary_edit  # type: ignore[method-assign]
     await dispatcher.on_interaction(_interaction(custom_id, message_id))
     assert seen and seen[0] is not None, "success banner shown before evidence was durable"
@@ -864,6 +865,96 @@ async def test_resume_replay_sanitizes_internal_protocol() -> None:
     assert "OBJECTIVE" not in visible and "USER GUIDANCE" not in visible
     assert "internal guidance" not in visible and "legacy internal body" not in visible
     assert "STEERING" not in visible and "internal steer" not in visible
+
+
+@pytest.mark.asyncio
+async def test_resume_replay_previews_long_markdown_without_breaking_a_fence() -> None:
+    """A replayed transcript entry is shortened at a boundary the grammar accepts.
+
+    A blind character slice lands inside the fenced code block and Discord then
+    renders everything after it as literal backticks instead of code, so the one
+    message meant to give the user context arrives unreadable. Taking the shared
+    splitter's FIRST chunk shortens at a boundary instead: every chunk but the
+    last is sealed, so the block the cut opened is closed.
+    """
+    body = "```python\n" + "x = 1\n" * 800 + "```\n"
+    log = _log()
+    log.messages["dashboard:chat-1"] = [{"role": "assistant", "content": body}]
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+    await dispatcher.handle_message(_message("!sessions"))
+    custom_id, message_id = _picker_button(client)
+
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+
+    replayed = [text for text, _ in client.sent if "x = 1" in text]
+    assert len(replayed) == 1, replayed  # still ONE message per transcript entry
+    preview = replayed[0]
+    assert len(preview) <= DISCORD_CHUNK_LIMIT, len(preview)
+    assert preview.count("```") % 2 == 0, preview[-40:]  # the block is closed
+    assert preview.endswith(session_resume._REPLAY_TRUNCATED)  # and says so
+    # The icon sits on its own line, so the opener still starts a line.
+    assert preview.startswith("🤖\n```python\n")
+
+
+@pytest.mark.asyncio
+async def test_resume_replay_omits_a_fence_that_cannot_fit_safely() -> None:
+    """An extreme opener cannot fit together with its synthetic closer.
+
+    Sending that sealed chunk anyway lets Discord's client-side cap remove the
+    closer and truncation marker. The replay keeps the canonical transcript
+    intact and emits only the explicit marker for this pathological preview.
+    """
+    opener = "`" * 1001
+    body = opener + "\n" + ("x" * 1800) + "\n"
+    log = _log()
+    log.messages["dashboard:chat-1"] = [{"role": "assistant", "content": body}]
+    dispatcher, client, _ = _dispatcher({"u1"}, log)
+    await dispatcher.handle_message(_message("!sessions"))
+    custom_id, message_id = _picker_button(client)
+
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+
+    replayed = [text for text, _ in client.sent if session_resume._REPLAY_TRUNCATED in text]
+    assert replayed == [f"🤖\n{session_resume._REPLAY_TRUNCATED}"]
+    assert len(replayed[0]) <= DISCORD_CHUNK_LIMIT
+    assert opener not in replayed[0]
+
+
+@pytest.mark.asyncio
+async def test_resume_replay_bounds_and_offloads_the_splitter_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transcript-sized pathological line is bounded and split off-loop."""
+    probes: list[str] = []
+    offloads: list[tuple[Any, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _capture(probe: str, limit: int, *, reserve: int = 0) -> list[str]:
+        probes.append(probe)
+        return ["safe preview"]
+
+    async def _offload(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        offloads.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(session_resume, "split_markdown_safe", _capture)
+    monkeypatch.setattr(session_resume.asyncio, "to_thread", _offload)
+
+    preview = await session_resume._replay_preview(
+        "`" * 1_000_000,
+        session_resume._REPLAY_TEXT_LIMIT,
+        reserve=session_resume._REPLAY_RESERVE,
+    )
+
+    assert len(probes) == 1
+    assert len(probes[0]) <= session_resume._REPLAY_TEXT_LIMIT * 2
+    assert offloads == [
+        (
+            _capture,
+            (probes[0], session_resume._REPLAY_TEXT_LIMIT),
+            {"reserve": session_resume._REPLAY_RESERVE},
+        )
+    ]
+    assert preview == "safe preview" + session_resume._REPLAY_TRUNCATED
 
 
 @pytest.mark.asyncio
@@ -1247,6 +1338,7 @@ def _gate_send(client, marker: str, during) -> list[str]:
             fired.append(text)
             await during()
         return await real_send(channel_id, text, **kwargs)
+
     client.send_message = _send  # type: ignore[method-assign]
     return fired
 
@@ -1340,18 +1432,19 @@ class TestDashboardConnectedConversationResumes:
         for occupant in ("dashboard:chat-7", "dashboard:chat-8"):
             sessions.mirror_links[occupant] = loc
             sessions.inbound_keys.add(occupant)
-        assert dispatcher._session_resume.resumed_session("c1") is None, (
-            "setup no longer produces the ambiguous state this test needs"
-        )
+        assert (
+            dispatcher._session_resume.resumed_session("c1") is None
+        ), "setup no longer produces the ambiguous state this test needs"
 
         await dispatcher.handle_message(_message("!link"))
 
-        assert any("`!unlink`" in text for text, _ in client.sent), (
-            f"the refusal was not reported to the channel: {client.sent}"
-        )
-        assert set(sessions.mirror_links) == {"dashboard:chat-7", "dashboard:chat-8"}, (
-            "an occupant was displaced, or the link was written anyway"
-        )
+        assert any(
+            "`!unlink`" in text for text, _ in client.sent
+        ), f"the refusal was not reported to the channel: {client.sent}"
+        assert set(sessions.mirror_links) == {
+            "dashboard:chat-7",
+            "dashboard:chat-8",
+        }, "an occupant was displaced, or the link was written anyway"
 
     @pytest.mark.asyncio
     async def test_two_outbound_mirrors_are_still_allowed(self) -> None:
@@ -1375,6 +1468,7 @@ class TestBindingLostUnderTheConversation:
         async def _retire_after_durability(channel_id: str, version: int):
             assert link not in sessions.flushed[-1].values()
             return await real_retire(channel_id, version)
+
         store.retire_if = _retire_after_durability  # type: ignore[method-assign]
         sessions.clear_mirror_links_at(link)
         sessions.last_key = ""
@@ -1389,7 +1483,9 @@ class TestBindingLostUnderTheConversation:
     @pytest.mark.asyncio
     async def test_a_synthetic_nudge_bypasses_detach_routing(self) -> None:
         dispatcher, client, sessions = _dispatcher({"u1"}, _log("Launch plan"))
-        await dispatcher._session_resume._expectations.record("c1", "dashboard:chat-1", "Launch plan")
+        await dispatcher._session_resume._expectations.record(
+            "c1", "dashboard:chat-1", "Launch plan"
+        )
         nudge = _message("[auto-nudge cycle 1]\ncheck")
         await dispatcher.handle_message(nudge, interpret_commands=False)
         assert not any("Detached" in text for text, _ in client.sent)
@@ -1413,6 +1509,7 @@ class TestBindingLostUnderTheConversation:
         async def _observe_retire(channel_id: str, version: int):
             durable_first.append(bool(sessions.flushed))
             return await real_retire(channel_id, version)
+
         store.retire_if = _observe_retire  # type: ignore[method-assign]
         await dispatcher.handle_message(_message("!unlink"))
         link = dispatcher._session_resume.link_for("c1")
@@ -1432,6 +1529,7 @@ class TestBindingLostUnderTheConversation:
             await real_aflush()
             sessions.mirror_links["dashboard:chat-1"] = link
             sessions.inbound_keys.add("dashboard:chat-1")
+
         sessions.aflush = _rebind_same_key_during_aflush  # type: ignore[method-assign]
         await dispatcher.handle_message(_message("!unlink"))
         expected = await store.get("c1")
@@ -1472,6 +1570,7 @@ class TestBindingLostUnderTheConversation:
             if recorded:
                 await store.record(channel_id, "dashboard:chat-2", "Pricing review")
             return applied
+
         store.retire_if = _rebind  # type: ignore[method-assign]
         await resume.leave_resumed_session("c1")
         current = await store.get("c1")
@@ -1514,7 +1613,9 @@ class TestBindingLostUnderTheConversation:
         await dispatcher.handle_message(_message("carry on"))
         assert sessions.last_key == "dashboard:chat-1"
 
-    @pytest.mark.parametrize("command, refused", [
+    @pytest.mark.parametrize(
+        "command, refused",
+        [
             pytest.param("!compact", True, id="compact"),
             pytest.param("!stop", True, id="stop"),
             pytest.param("!link", True, id="link"),
@@ -1522,7 +1623,8 @@ class TestBindingLostUnderTheConversation:
             pytest.param("!new", False, id="new-leaves"),
             pytest.param("!unlink", False, id="unlink-leaves"),
             pytest.param("!help", False, id="help-inert"),
-    ])
+        ],
+    )
     @pytest.mark.asyncio
     async def test_session_targeting_commands_are_refused_before_they_act(
         self, command, refused
@@ -1563,9 +1665,9 @@ class TestBindingLostUnderTheConversation:
         elsewhere = ChannelLink(channel_type="discord", channel_id="c2")
         sessions.mirror_links["dashboard:elsewhere"] = elsewhere
         await dispatcher.handle_message(_message(leave_command))
-        assert not dispatcher._session_resume.resolve_inbound("c1").ambiguous, (
-            f"{leave_command} left ambiguous bindings: {sessions.mirror_links}"
-        )
+        assert not dispatcher._session_resume.resolve_inbound(
+            "c1"
+        ).ambiguous, f"{leave_command} left ambiguous bindings: {sessions.mirror_links}"
         assert sessions.mirror_links["dashboard:elsewhere"] == elsewhere, "cleared c2"
         await dispatcher.handle_message(_message("after leaving"))
         assert sessions.last_key == dispatcher._session_key("u1"), client.sent[-1][0]
@@ -1606,7 +1708,8 @@ class TestBindingLostUnderTheConversation:
 
         monkeypatch.setitem(
             dispatcher.handle_message.__globals__,
-            "channel_inbound_permitted", _governance,
+            "channel_inbound_permitted",
+            _governance,
         )
         siblings: list[asyncio.Task[None]] = []
         detached_sends = 0
@@ -1617,16 +1720,19 @@ class TestBindingLostUnderTheConversation:
             if "Detached" in text:
                 detached_sends += 1
                 if detached_sends == 1:
-                    siblings.append(asyncio.create_task(
-                        dispatcher.handle_message(_message("second"))))
+                    siblings.append(
+                        asyncio.create_task(dispatcher.handle_message(_message("second")))
+                    )
                     await asyncio.sleep(0)
                     assert len(dispatcher._routing_locks["c1"][1]) == 2
-                    siblings.append(asyncio.create_task(
-                        dispatcher.handle_message(_message("third"))))
+                    siblings.append(
+                        asyncio.create_task(dispatcher.handle_message(_message("third")))
+                    )
                     await asyncio.wait_for(third_in_governance.wait(), timeout=1)
                 elif detached_sends == 2:
                     release_third.set()
             return await real_send(channel_id, text, **kwargs)
+
         client.send_message = _gate_waiters  # type: ignore[method-assign]
         await dispatcher.handle_message(_message("first"))
         assert len(siblings) == 2
@@ -1650,7 +1756,8 @@ class TestBindingLostUnderTheConversation:
         dispatcher, client, sessions = _dispatcher({"u1"}, _log("Launch plan"))
         monkeypatch.setitem(
             dispatcher.handle_message.__globals__,
-            "channel_inbound_permitted", client.is_thread_channel,
+            "channel_inbound_permitted",
+            client.is_thread_channel,
         )
         store = dispatcher._session_resume._expectations
         for channel in ("c1", "c2"):
@@ -1676,6 +1783,7 @@ class TestBindingLostUnderTheConversation:
                 finally:
                     c2_routed.set()
             return await real_send(channel_id, text, **kwargs)
+
         dispatcher._session_resume.route = _signal_when_c2_routes  # type: ignore[method-assign]
         client.send_message = _park_first_send_until_c2_routes  # type: ignore[method-assign]
         await asyncio.gather(
@@ -1694,6 +1802,7 @@ class TestExpectationStoreInvariants:
         self, monkeypatch
     ) -> None:
         from kiro_crew.security import is_sensitive_path
+
         restricted: list[str] = []
         pc = resume_expectation.platform_compat
         monkeypatch.setattr(pc, "restrict_to_owner", restricted.append)
@@ -1710,7 +1819,9 @@ class TestExpectationStoreInvariants:
     # Read inbound and written from the picker, both ON the loop, so the recorded
     # threads are the real filesystem helpers' -- not one mocked call.
     @pytest.mark.asyncio
-    async def test_every_store_filesystem_helper_runs_off_the_loop_thread(self, monkeypatch) -> None:
+    async def test_every_store_filesystem_helper_runs_off_the_loop_thread(
+        self, monkeypatch
+    ) -> None:
         threads: list[int] = []
         for name in ("_resolve", "_write"):
             real = getattr(resume_expectation, name)
@@ -1766,6 +1877,7 @@ class TestRoutingUnderConcurrentRebinding:
             # The dashboard releasing the conversation mid-decision.
             sessions.clear_mirror_links_at(link)
             return record
+
         store.get = _unlink_during_get  # type: ignore[method-assign]
         await dispatcher.handle_message(_message("what did we decide?"))
         assert sessions.last_key != native, "the message ran natively with no warning"
@@ -1775,10 +1887,20 @@ class TestRoutingUnderConcurrentRebinding:
     @pytest.mark.parametrize(
         "notice, rebind_key, rebind_title, survivor",
         [
-            pytest.param("Detached", "dashboard:chat-1", "Pricing review",
-                         "dashboard:chat-1", id="picker-bind-vs-stale-clear"),
-            pytest.param("Now linked to", "dashboard:chat-2", "Budget",
-                         "dashboard:chat-2", id="third-rebind-vs-stale-adopt"),
+            pytest.param(
+                "Detached",
+                "dashboard:chat-1",
+                "Pricing review",
+                "dashboard:chat-1",
+                id="picker-bind-vs-stale-clear",
+            ),
+            pytest.param(
+                "Now linked to",
+                "dashboard:chat-2",
+                "Budget",
+                "dashboard:chat-2",
+                id="third-rebind-vs-stale-adopt",
+            ),
         ],
     )
     @pytest.mark.asyncio
@@ -1802,16 +1924,18 @@ class TestRoutingUnderConcurrentRebinding:
                     "c1", rebind_key, rebind_title
                 )
             return await real_send(channel_id, text, **kwargs)
+
         client.send_message = _rebind_inside_send  # type: ignore[method-assign]
         await dispatcher.handle_message(_message("what did we decide?"))
         assert fired, "the race never fired -- the test proves nothing"
         current = await dispatcher._session_resume._expectations.get("c1")
-        assert current is not None and current.key == survivor and not current.retired, (
-            "the stale settle overwrote the record written during the send"
-        )
+        assert (
+            current is not None and current.key == survivor and not current.retired
+        ), "the stale settle overwrote the record written during the send"
 
     @pytest.mark.parametrize(
-        "text", ["hello", "!compact", "!stop", "!link"],
+        "text",
+        ["hello", "!compact", "!stop", "!link"],
         ids=["message", "compact", "stop", "link"],
     )
     @pytest.mark.asyncio
@@ -1828,12 +1952,13 @@ class TestRoutingUnderConcurrentRebinding:
             decision = await real_route(channel_id)
             resume.resolve_inbound = _forbidden  # type: ignore[method-assign]
             return decision
+
         resume.route = _route_then_seal  # type: ignore[method-assign]
         await dispatcher.handle_message(_message(text))
         targeted = [key for _verb, key in sessions.targeted]
-        assert all(k == "dashboard:chat-1" for k in targeted), (
-            f"{text} acted on {targeted} instead of the decided session"
-        )
+        assert all(
+            k == "dashboard:chat-1" for k in targeted
+        ), f"{text} acted on {targeted} instead of the decided session"
         if text == "hello":
             assert sessions.last_key == "dashboard:chat-1"
 
@@ -1851,6 +1976,7 @@ class TestRoutingUnderConcurrentRebinding:
             if rebound:
                 sessions.set_mirror_link("dashboard:chat-9", link, accepts_inbound=True)
             return "Launch plan"
+
         resume._title_of = _move_during_title  # type: ignore[method-assign]
         await dispatcher.handle_message(_message("what did we decide?"))
         assert sessions.last_key == "", f"the message ran at all: {sessions.last_key}"
@@ -1932,9 +2058,9 @@ class TestPersistenceFailureIsFailClosed:
         edits = [text for _mid, text, _c in client.edits]
         if mode == "claim-lost":
             assert any("Another session just connected" in t for t in edits), edits
-            assert not any("Couldn't save" in t for t in edits), (
-                f"a claim race was reported as a storage failure: {edits}"
-            )
+            assert not any(
+                "Couldn't save" in t for t in edits
+            ), f"a claim race was reported as a storage failure: {edits}"
             return
         assert any("NOT resumed" in t for t in edits), edits
 
@@ -1947,30 +2073,38 @@ class TestPersistenceFailureIsFailClosed:
 
         await dispatcher.handle_message(_message("what did we decide?"))
         await dispatcher.handle_message(_message("again"))
-        assert len([t for t, _ in client.sent if "Detached" in t]) == 2, (
-            "the unpersisted settle was treated as done"
-        )
+        assert (
+            len([t for t, _ in client.sent if "Detached" in t]) == 2
+        ), "the unpersisted settle was treated as done"
         assert sessions.last_key == "", "a refused message ran"
 
-    @pytest.mark.parametrize("payload, loads", [
-            pytest.param('{"c1": {"key": "dashboard:chat-0", "title": "T", "version": 3}}',
-                         True, id="well-formed-row"),
-            pytest.param('{"c1": {"key": "dashboard:chat-0", "title": "T"}}', False,
-                         id="row-missing-version"),
+    @pytest.mark.parametrize(
+        "payload, loads",
+        [
+            pytest.param(
+                '{"c1": {"key": "dashboard:chat-0", "title": "T", "version": 3}}',
+                True,
+                id="well-formed-row",
+            ),
+            pytest.param(
+                '{"c1": {"key": "dashboard:chat-0", "title": "T"}}', False, id="row-missing-version"
+            ),
             pytest.param("{not json", False, id="malformed-json"),
             pytest.param('["c1"]', False, id="wrong-toplevel-shape"),
             pytest.param('{"c1": {"title": "T"}}', False, id="row-missing-key"),
-            pytest.param('{"c1": {"key": "k", "version": "x"}}', False,
-                         id="non-numeric-version"),
+            pytest.param('{"c1": {"key": "k", "version": "x"}}', False, id="non-numeric-version"),
             pytest.param('{"c1": {"key": "k", "version": true}}', False, id="boolean-version"),
-            pytest.param('{"c1": {"key": "k", "version": 1, "retired": "yes"}}',
-                         False, id="non-boolean-retired"),
+            pytest.param(
+                '{"c1": {"key": "k", "version": 1, "retired": "yes"}}',
+                False,
+                id="non-boolean-retired",
+            ),
             pytest.param('{"c1": {"key": "k", "version": "1"}}', False, id="string-version"),
             pytest.param('{"c1": {"key": "k", "version": 1.25}}', False, id="fractional-version"),
             pytest.param(b"\xff\xfe{}", False, id="invalid-utf8-bytes"),
-            pytest.param('{"c1": {"key": "k", "version": 1e999}}', False,
-                         id="infinite-version"),
-    ])
+            pytest.param('{"c1": {"key": "k", "version": 1e999}}', False, id="infinite-version"),
+        ],
+    )
     @pytest.mark.asyncio
     async def test_a_store_that_cannot_be_trusted_is_not_an_empty_store(
         self, payload, loads
@@ -1991,12 +2125,15 @@ class TestPersistenceFailureIsFailClosed:
 class TestSettlementReconcilesLiveState:
     """Settlement reconciles dashboard rebinds that do not bump store versions."""
 
-    @pytest.mark.parametrize("rebind_keys, expect_second_runs", [
+    @pytest.mark.parametrize(
+        "rebind_keys, expect_second_runs",
+        [
             pytest.param(["dashboard:chat-1"], False, id="different-key"),
             pytest.param(["dashboard:chat-0"], True, id="same-key"),
             pytest.param([], True, id="absent"),
             pytest.param(["dashboard:chat-1", "dashboard:chat-2"], False, id="ambiguous"),
-    ])
+        ],
+    )
     @pytest.mark.asyncio
     async def test_an_owner_arriving_during_the_send_is_never_entered_silently(
         self, rebind_keys, expect_second_runs
@@ -2020,9 +2157,9 @@ class TestSettlementReconcilesLiveState:
         if expect_second_runs:
             assert sessions.last_key != "", "the resend was refused with nothing pending"
         else:
-            assert sessions.last_key == "", (
-                f"the resend entered {sessions.last_key} without a notice"
-            )
+            assert (
+                sessions.last_key == ""
+            ), f"the resend entered {sessions.last_key} without a notice"
             assert "NOT processed" in client.sent[-1][0], client.sent[-1][0]
 
     @pytest.mark.asyncio
@@ -2044,15 +2181,15 @@ class TestSettlementReconcilesLiveState:
         moved = _gate_send(client, "Now linked to", _move_again)
         await dispatcher.handle_message(_message("carry on"))
         assert moved, "the race never fired -- the test proves nothing"
-        assert await dispatcher._session_resume._expectations.get("c1") == before, (
-            "adopted a session whose notice no longer described the live state"
-        )
+        assert (
+            await dispatcher._session_resume._expectations.get("c1") == before
+        ), "adopted a session whose notice no longer described the live state"
         sessions.last_key = ""
         await dispatcher.handle_message(_message("resending"))
         assert sessions.last_key == "", "the resend entered the third owner in silence"
-        assert "Launch plan" in client.sent[-1][0], (
-            f"the notice named a link the user was never in: {client.sent[-1][0]}"
-        )
+        assert (
+            "Launch plan" in client.sent[-1][0]
+        ), f"the notice named a link the user was never in: {client.sent[-1][0]}"
 
     @pytest.mark.parametrize("mode", ["bare", "same-key", "recorded", "adopt-fails"])
     @pytest.mark.asyncio
@@ -2075,6 +2212,7 @@ class TestSettlementReconcilesLiveState:
             if mode == "recorded":
                 await store.record("c1", "dashboard:chat-1", "Pricing review")
             raced.append("c1")
+
         sessions.aflush = _rebind_during_aflush  # type: ignore[method-assign]
         if mode == "adopt-fails":
             real_write = resume_expectation.atomic_write


### PR DESCRIPTION
## Problem / Motivation

Discord maintained private Markdown and fenced-code splitters even though messaging already provides `split_markdown_safe()`. The duplicate implementation could drift from the shared fence, list, table, and hard-cap behavior used by other delivery paths.

## Why it matters

Discord streaming and replay previews must stay below the platform's 2,000-character cap without breaking Markdown fences, exposing unredacted display text, or blocking the event loop on CPU-heavy splitting. One shared implementation makes those guarantees consistent and testable.

## What changed (motivation → approach → change)

The Discord live renderer and replay-preview path now delegate Markdown splitting to `split_markdown_safe()` instead of maintaining channel-private fence logic. Both call sites offload splitting with `asyncio.to_thread`, retain display redaction and protocol-suffix handling, and keep a final platform-cap fit guard. The shared splitter contract is documented for Discord's final open-fence behavior.

## Tests

- Expanded Discord and shared-splitter regressions cover streaming rotation, replay previews, pathological fences, hard-cap fitting, redaction, and event-loop offloading.
- Focused suite: 381 passed.
- Authoritative backend suite: 57,305 passed, 284 skipped, 6 xfailed.
- Black, isort, flake8, mypy, brand, harness parity, docs, coverage-ratchet, scrub-lint, and `git diff --check` passed.
- Exact local GPT and Opus contract reviews reported no findings on the published SHA.

## Manual verification

N/A — deterministic unit coverage exercises the Discord transport boundaries and exact platform caps without requiring a live Discord workspace.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** Backend/channel rendering behavior only; no Dashboard pixels changed.

## Related Issues

no linked issue: The splitter consolidation was identified during channel-rendering maintenance and has no filed tracker issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
