### PR TITLE
feat: capture socket enrichment in loop-stall crash dumps

### DIFF
--- a/src/kiro_crew/dashboard/loop_watchdog.py
+++ b/src/kiro_crew/dashboard/loop_watchdog.py
@@ -67,6 +67,8 @@ import time
 import typing
 from collections.abc import Callable
 
+from kiro_crew.dashboard.stall_enrichment import collect_stall_enrichment
+
 logger = logging.getLogger("kiro_crew.dashboard.loop_watchdog")
 
 
@@ -161,6 +163,20 @@ class LoopStallWatchdog:
             Defaults to :func:`_default_arm_later`.
         cancel_later: Cancels the armed timer, injectable for tests.  Defaults
             to :func:`_default_cancel_later`.
+        enrich_after: Seconds of heartbeat silence before the daemon thread
+            emits stall enrichment (stall UTC timestamp + this process's
+            established TCP sockets with rx/tx queue depths) to the logger at
+            WARNING.  Must sit below ``exit_after`` so the capture lands
+            *before* the armed timer's dump-then-exit — with the 5s poll
+            cadence, 15s triggers on the 15–20s tick, ahead of the 25s exit.
+            Never written into ``dump_file``: that file is the boot-time
+            crash sentinel (line-count classified), so an append would make a
+            recovered stall read as a fatal crash on the next startup.  Both
+            production stalls to date froze the loop inside websocket frame
+            parsing; this records *which* socket without needing a repro.
+        enrich: Enrichment collector ``silence_secs -> lines``, injectable for
+            tests.  Defaults to
+            :func:`kiro_crew.dashboard.stall_enrichment.collect_stall_enrichment`.
         log: Logger, injectable for tests.
     """
 
@@ -175,6 +191,8 @@ class LoopStallWatchdog:
         arm_later: Callable[[float], None] | None = None,
         cancel_later: Callable[[], None] | None = None,
         dump_file: "typing.IO[str] | typing.Any | None" = None,
+        enrich_after: float = 15.0,
+        enrich: "Callable[[float], list[str]] | None" = None,
         log: logging.Logger | None = None,
     ) -> None:
         self._stall_after = stall_after
@@ -185,6 +203,9 @@ class LoopStallWatchdog:
         self._dump = dump or (lambda: _default_dump(dump_file))
         self._arm_later = arm_later or (lambda t: _default_arm_later(t, dump_file))
         self._cancel_later = cancel_later or _default_cancel_later
+        self._enrich_after = enrich_after
+        self._enrich = enrich or collect_stall_enrichment
+        self._enriched = False
         self._log = log or logger
         self._last_beat = now()
         self._dumped = False
@@ -219,8 +240,34 @@ class LoopStallWatchdog:
 
         Pure and synchronous so tests can step it with a fake clock.  Emits at
         most one dump per stall episode and re-arms when the loop recovers.
+
+        Stages by silence duration (defaults): **enrichment** at
+        ``enrich_after`` (15s) — stall timestamp + socket table emitted to the
+        logger at WARNING while the armed 25s dump-then-exit timer is still
+        pending — then the **soft dump** at ``stall_after`` (30s), reachable
+        only when the armed timer is off/failed.
+
+        Enrichment deliberately never touches ``dump_file``: that file is the
+        boot-time crash sentinel (``crash_dump_store._is_header_only`` counts
+        lines), so a watchdog-side append would make a *recovered* 15–25s
+        stall read as a fatal crash on the next startup.  Only faulthandler
+        writes stacks into it.  The journal WARNING survives both outcomes —
+        the process lives to keep logging on recovery, and journald has
+        already persisted the line when ``_exit`` fires on a fatal stall.
         """
         silence = self._now() - self._last_beat
+        if silence >= self._enrich_after and not self._enriched:
+            self._enriched = True
+            try:
+                lines = self._enrich(silence)
+            except Exception:  # pragma: no cover - collector already degrades; belt & braces
+                self._log.exception("loop watchdog stall enrichment failed")
+                lines = ["=== STALL ENRICHMENT FAILED (collector raised) ==="]
+            self._log.warning(
+                "event loop silent %.1fs — stall enrichment captured:\n%s",
+                silence,
+                "\n".join(lines),
+            )
         if silence >= self._stall_after:
             if not self._dumped:
                 self._dumped = True
@@ -236,12 +283,22 @@ class LoopStallWatchdog:
                     self._log.exception("loop watchdog stack dump failed")
                 return True
             return False
-        # Healthy / recovered.
+        if silence >= self._enrich_after:
+            # Mid-episode: enriched but below the soft-dump threshold.  Keep the
+            # episode flags so neither capture repeats within one stall.
+            return False
+        # Healthy / recovered — silence is back below the first threshold.
         if self._dumped:
             self._log.warning(
                 "event loop recovered after stall (last beat %.1fs ago)", silence
             )
+        if self._enriched and not self._dumped:
+            self._log.warning(
+                "event loop recovered after stall enrichment (last beat %.1fs ago)",
+                silence,
+            )
         self._dumped = False
+        self._enriched = False
         return False
 
     def _run(self) -> None:
@@ -272,11 +329,22 @@ class LoopStallWatchdog:
             target=self._run, name="loop-stall-watchdog", daemon=True
         )
         self._thread.start()
+        if self._exit_after is not None and self._enrich_after >= self._exit_after:
+            # Not fatal — enrichment just never lands before the exit.  Flag it
+            # so a tuned exit budget doesn't silently disable the capture.
+            self._log.warning(
+                "loop watchdog enrich_after (%.0fs) >= exit_after (%.0fs); "
+                "stall enrichment will not be captured before dump-then-exit",
+                self._enrich_after,
+                self._exit_after,
+            )
         self._log.info(
-            "loop stall watchdog armed (stall_after=%.0fs, poll=%.0fs, exit_after=%s)",
+            "loop stall watchdog armed (stall_after=%.0fs, poll=%.0fs, exit_after=%s, "
+            "enrich_after=%.0fs)",
             self._stall_after,
             self._poll_interval,
             f"{self._exit_after:.0f}s" if self._exit_after is not None else "off",
+            self._enrich_after,
         )
 
     def stop(self, timeout: float | None = 2.0) -> None:

--- a/src/kiro_crew/dashboard/stall_enrichment.py
+++ b/src/kiro_crew/dashboard/stall_enrichment.py
@@ -1,0 +1,136 @@
+"""Stall-time enrichment — record WHAT the wedged loop was attached to.
+
+A faulthandler loop-stall dump answers *where the code is stuck* but not
+*which connection it was servicing* or *when the stall actually happened*
+(the dump file is named for gateway **boot** time, not stall time, because
+faulthandler needs a stable fd for the process lifetime).
+
+Both production loop-stall dumps to date (2026-08-14 and 2026-08-20) froze
+the main thread inside ``websockets`` frame parsing on an outbound TLS
+socket — and the dump alone could not say which socket, nor whether its
+receive queue was backed up.  This module closes that gap: the watchdog's
+daemon thread (which keeps running while the loop thread is wedged) calls
+:func:`collect_stall_enrichment` once a stall crosses the enrichment
+threshold and emits the result to the logger at WARNING.
+
+The capture is deliberately **not** written into the ``loopstall-*.txt``
+crash-dump file: that file doubles as the boot-time crash *sentinel*
+(``crash_dump_store._is_header_only`` classifies a prior session as
+crashed by line count alone), so any watchdog-side append would make a
+recovered 15–25s stall read as a fatal crash on the next startup —
+false "work in flight was lost" notifications, cautious boot, and an
+unreapable file aging real stall evidence out of rotation.  The journal
+WARNING carries the capture for both recovered stalls (the process lives
+to keep logging) and fatal ones (journald has already persisted it when
+``_exit`` fires).
+
+Captured per enrichment:
+
+* an explicit UTC **stall timestamp** and the observed heartbeat silence —
+  the crash-dump filename carries boot time, so the log line is what
+  records the real stall time;
+* every ESTABLISHED non-loopback TCP connection owned by this process,
+  with local/remote endpoints and the kernel ``tx_queue``/``rx_queue``
+  byte counts (a large ``rx_queue`` at stall time is direct evidence of an
+  inbound flood on that socket).
+
+Implementation is Linux-``/proc`` based (no subprocesses, no psutil — the
+gateway venv does not ship psutil, and spawning a subprocess from a
+watchdog thread in a sick process is riskier than reading procfs).  Socket
+inodes come from the existing :func:`kiro_crew.acp.liveness.socket_inodes`
+rather than a second spelling of that walk.  On non-Linux platforms or any
+parse failure it degrades to a short note; it must never raise into the
+watchdog.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import struct
+import sys
+import time
+from pathlib import Path
+
+from kiro_crew.acp.liveness import socket_inodes
+
+__all__ = ["collect_stall_enrichment"]
+
+# /proc/net/tcp{,6} socket-state code for ESTABLISHED.
+_TCP_ESTABLISHED = "01"
+
+
+def _decode_proc_addr(hex_addr: str, hex_port: str) -> tuple[str, int]:
+    """Decode a ``/proc/net/tcp{,6}`` address pair into ``(ip, port)``.
+
+    IPv4 addresses are one little-endian 32-bit word rendered as 8 hex
+    chars (``127.0.0.1`` → ``"0100007F"``); IPv6 are four such words (32
+    hex chars).  Ports are plain big-endian hex.
+    """
+    port = int(hex_port, 16)
+    if len(hex_addr) == 8:
+        packed = struct.pack("<I", int(hex_addr, 16))
+        return str(ipaddress.IPv4Address(packed)), port
+    words = [struct.pack("<I", int(hex_addr[i : i + 8], 16)) for i in range(0, 32, 8)]
+    return str(ipaddress.IPv6Address(b"".join(words))), port
+
+
+def _established_lines(proc_file: str, inodes: set[str]) -> list[str]:
+    """One line per ESTABLISHED non-loopback connection of ours in *proc_file*."""
+    lines: list[str] = []
+    try:
+        rows = Path(proc_file).read_text().splitlines()[1:]
+    except OSError:
+        return lines
+    for row in rows:
+        cols = row.split()
+        # sl local remote st tx:rx timers retrnsmt uid timeout inode ...
+        if len(cols) < 10 or cols[3] != _TCP_ESTABLISHED or cols[9] not in inodes:
+            continue
+        try:
+            lip, lport = _decode_proc_addr(*cols[1].split(":"))
+            rip, rport = _decode_proc_addr(*cols[2].split(":"))
+            if ipaddress.ip_address(rip).is_loopback:
+                continue
+            tx_hex, rx_hex = cols[4].split(":")
+            lines.append(
+                f"ESTAB {lip}:{lport} -> {rip}:{rport} "
+                f"rx_queue={int(rx_hex, 16)}B tx_queue={int(tx_hex, 16)}B "
+                f"inode={cols[9]}"
+            )
+        except (ValueError, OSError):
+            continue  # malformed row; skip rather than lose the whole capture
+    return lines
+
+
+def collect_stall_enrichment(silence_secs: float) -> list[str]:
+    """Return crash-dump enrichment lines for a loop stall in progress.
+
+    Called from the watchdog's daemon thread while the event loop is wedged;
+    must be cheap, allocation-light, and must never raise (the watchdog also
+    guards the call, but degrade gracefully here too).
+    """
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    header = (
+        f"=== STALL ENRICHMENT @ {stamp} — loop silent {silence_secs:.1f}s; "
+        "captured by watchdog daemon thread before dump-then-exit ==="
+    )
+    lines = [header]
+    if not sys.platform.startswith("linux"):
+        lines.append("(socket capture unavailable: non-Linux platform)")
+        return lines
+    try:
+        inodes = socket_inodes("/proc", os.getpid())
+        socket_lines = _established_lines("/proc/net/tcp", inodes)
+        socket_lines += _established_lines("/proc/net/tcp6", inodes)
+        if socket_lines:
+            lines.extend(socket_lines)
+            lines.append(
+                f"({len(socket_lines)} established non-loopback TCP connection(s); "
+                "a large rx_queue marks an inbound flood on that socket)"
+            )
+        else:
+            lines.append("(no established non-loopback TCP connections)")
+    except Exception as exc:  # noqa: BLE001 — enrichment must never hurt the watchdog
+        lines.append(f"(socket capture failed: {exc!r})")
+    return lines

--- a/test/test_loop_watchdog.py
+++ b/test/test_loop_watchdog.py
@@ -234,3 +234,168 @@ def test_start_stop_thread_lifecycle() -> None:
     assert wd.is_running() is True
     wd.stop()
     assert wd.is_running() is False
+
+
+# ---------------------------------------------------------------------------
+# Stall enrichment stage (journal-only capture; dump file is a crash sentinel
+# that only faulthandler may write into — see crash_dump_store._is_header_only)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDumpFile:
+    """DumpFile stand-in proving the watchdog NEVER writes into the sentinel."""
+
+    def __init__(self) -> None:
+        self.written: list[str] = []
+        self.flushes = 0
+
+    def write(self, data: str) -> int:
+        self.written.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+
+class _RecordingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def _make_enrich(enrich_after: float = 15.0, stall_after: float = 30.0):
+    """Fixture for the enrichment stage: fake clock, sentinel-guard dump file,
+    recording collector + logger; armed timer disabled so nothing touches real
+    faulthandler."""
+    clock = _Clock()
+    dump_file = _FakeDumpFile()
+    calls: list[float] = []
+    handler = _RecordingHandler()
+    log = logging.Logger("test.loop_watchdog.enrich")
+    log.addHandler(handler)
+
+    def collector(silence: float) -> list[str]:
+        calls.append(silence)
+        return [f"=== STALL ENRICHMENT (test) silence={silence:.1f}s ==="]
+
+    wd = LoopStallWatchdog(
+        stall_after=stall_after,
+        exit_after=None,
+        poll_interval=5.0,
+        now=clock,
+        dump=lambda: None,
+        arm_later=lambda _t: None,
+        cancel_later=lambda: None,
+        dump_file=dump_file,
+        enrich_after=enrich_after,
+        enrich=collector,
+        log=log,
+    )
+    return wd, clock, dump_file, calls, handler
+
+
+def test_enrichment_fires_once_per_episode_at_threshold() -> None:
+    wd, clock, dump_file, calls, handler = _make_enrich()
+
+    clock.advance(10.0)  # below enrich_after
+    wd.check()
+    assert calls == []
+
+    clock.advance(6.0)  # silence 16s >= 15s
+    wd.check()
+    assert len(calls) == 1
+    assert calls[0] >= 15.0
+    assert any("STALL ENRICHMENT" in m for m in handler.messages)
+
+    clock.advance(5.0)  # still the same episode — no second capture
+    wd.check()
+    assert len(calls) == 1
+
+
+def test_recoverable_stall_leaves_dump_file_untouched() -> None:
+    # THE sentinel-integrity regression (PR #4678 review finding): a 15-25s
+    # stall that recovers must leave loopstall-*.txt byte-identical, or the
+    # next boot misclassifies the session as crashed (_is_header_only counts
+    # lines) — false "work lost" notification, cautious boot, unreapable file.
+    wd, clock, dump_file, calls, handler = _make_enrich()
+
+    clock.advance(16.0)  # cross enrich_after
+    wd.check()
+    assert len(calls) == 1
+
+    wd.beat()  # loop recovers before exit_after would have fired
+    wd.check()
+    assert any("recovered after stall enrichment" in m for m in handler.messages)
+
+    clock.advance(16.0)  # a second, distinct stall episode re-enriches
+    wd.check()
+    assert len(calls) == 2
+
+    # The invariant under test: zero writes into the crash sentinel, ever.
+    assert dump_file.written == []
+    assert dump_file.flushes == 0
+
+
+def test_enrichment_collector_failure_is_contained() -> None:
+    clock = _Clock()
+    dump_file = _FakeDumpFile()
+    handler = _RecordingHandler()
+    log = logging.Logger("test.loop_watchdog.enrich")
+    log.addHandler(handler)
+
+    def broken(_silence: float) -> list[str]:
+        raise RuntimeError("collector exploded")
+
+    wd = LoopStallWatchdog(
+        stall_after=30.0,
+        exit_after=None,
+        poll_interval=5.0,
+        now=clock,
+        dump=lambda: None,
+        arm_later=lambda _t: None,
+        cancel_later=lambda: None,
+        dump_file=dump_file,
+        enrich_after=15.0,
+        enrich=broken,
+        log=log,
+    )
+    clock.advance(16.0)
+    wd.check()  # must not raise
+    assert any("ENRICHMENT FAILED" in m for m in handler.messages)
+    assert dump_file.written == []  # failure marker goes to the log, never the sentinel
+
+
+def test_enrichment_without_dump_file_only_logs() -> None:
+    clock = _Clock()
+    calls: list[float] = []
+    wd = LoopStallWatchdog(
+        stall_after=30.0,
+        exit_after=None,
+        poll_interval=5.0,
+        now=clock,
+        dump=lambda: None,
+        arm_later=lambda _t: None,
+        cancel_later=lambda: None,
+        dump_file=None,
+        enrich_after=15.0,
+        enrich=lambda s: (calls.append(s) or ["line"]),
+        log=logging.getLogger("test.loop_watchdog.enrich"),
+    )
+    clock.advance(16.0)
+    wd.check()  # must not raise despite no file target
+    assert len(calls) == 1
+
+
+def test_enrichment_precedes_soft_dump_threshold() -> None:
+    # One episode crossing both thresholds: enrichment at 15s, soft dump at 30s.
+    wd, clock, dump_file, calls, handler = _make_enrich()
+    clock.advance(16.0)
+    assert wd.check() is False  # enriched, not yet soft-dumped
+    assert len(calls) == 1
+    clock.advance(15.0)  # silence 31s
+    assert wd.check() is True  # soft dump fires; enrichment still once
+    assert len(calls) == 1
+    assert dump_file.written == []  # even a full episode writes nothing itself

--- a/test/test_stall_enrichment.py
+++ b/test/test_stall_enrichment.py
@@ -1,0 +1,75 @@
+"""Tests for stall-time enrichment (/proc TCP capture for loop-stall dumps).
+
+The /proc parsers are exercised against crafted rows (deterministic, no real
+sockets needed); the collector gets one live smoke test on Linux where it runs
+against the real ``/proc`` of the test process.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from kiro_crew.dashboard.stall_enrichment import (
+    _decode_proc_addr,
+    _established_lines,
+    collect_stall_enrichment,
+)
+
+
+def test_decode_proc_addr_ipv4() -> None:
+    # /proc renders IPv4 as one little-endian 32-bit word: 127.0.0.1 -> 0100007F.
+    assert _decode_proc_addr("0100007F", "1F90") == ("127.0.0.1", 8080)
+    # 52.40.255.127 -> bytes 34 28 FF 7F read LE -> 0x7FFF2834.
+    assert _decode_proc_addr("7FFF2834", "01BB") == ("52.40.255.127", 443)
+
+
+def test_decode_proc_addr_ipv6_loopback() -> None:
+    # ::1 in /proc/net/tcp6 is four LE words: 00000000 x3 then 01000000.
+    ip, port = _decode_proc_addr("00000000000000000000000001000000", "0050")
+    assert ip == "::1"
+    assert port == 80
+
+
+def test_established_lines_filters_and_parses(tmp_path) -> None:
+    proc = tmp_path / "tcp"
+    rows = [
+        "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+        # ESTABLISHED but loopback remote -> excluded.
+        "   0: 0100007F:1F90 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1000        0 111 1 0 20 4 30 10 -1",
+        # ESTABLISHED, external, our inode -> included; rx_queue 0x1FC30 = 130096.
+        "   1: 0A0A0A0A:E88E 7FFF2834:01BB 01 00000000:0001FC30 00:00000000 00000000  1000        0 222 1 0 20 4 30 10 -1",
+        # LISTEN (st=0A), external -> excluded.
+        "   2: 0A0A0A0A:1F40 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 333 1 0 20 4 30 10 -1",
+        # ESTABLISHED, external, NOT our inode -> excluded.
+        "   3: 0A0A0A0A:E890 7FFF2834:01BB 01 00000000:00000000 00:00000000 00000000  1000        0 444 1 0 20 4 30 10 -1",
+    ]
+    proc.write_text("\n".join(rows) + "\n")
+
+    lines = _established_lines(str(proc), inodes={"111", "222", "333"})
+
+    assert len(lines) == 1
+    (line,) = lines
+    assert "10.10.10.10:59534 -> 52.40.255.127:443" in line
+    assert "rx_queue=130096B" in line
+    assert "tx_queue=0B" in line
+    assert "inode=222" in line
+
+
+def test_established_lines_missing_file_is_empty() -> None:
+    assert _established_lines("/proc/definitely/not/here", inodes={"1"}) == []
+
+
+def test_collect_smoke_on_linux() -> None:
+    lines = collect_stall_enrichment(12.5)
+    assert "STALL ENRICHMENT" in lines[0]
+    assert "12.5s" in lines[0]
+    assert len(lines) >= 2  # header plus at least one capture/degradation line
+    if sys.platform.startswith("linux"):
+        # Real /proc walk must not degrade to the failure line.
+        assert not lines[1].startswith("(socket capture failed")
+
+
+def test_collect_never_raises_even_if_silence_weird() -> None:
+    # Degenerate inputs must not blow up the watchdog thread.
+    assert collect_stall_enrichment(0.0)
+    assert collect_stall_enrichment(1e9)


### PR DESCRIPTION
## Problem / Motivation

When the gateway's event loop stalls, the loop-stall watchdog captures a `faulthandler` all-threads dump and exits. The dump answers *where the code is stuck*, but two production stalls (2026-08-14 and 2026-08-20, the latter killing the gateway across a scheduled cron fire window) showed it cannot answer two follow-up questions that decide the investigation:

- **Which connection was the loop servicing?** Both dumps froze the main thread at the byte-identical stack — inside `websockets` frame parsing on an outbound TLS socket (`frames.py parse` → `asyncio/connection.py data_received` → `sslproto` → selector loop) — but the dump cannot name the socket or show whether its receive queue was backed up.
- **When did the stall actually happen?** The dump file is named for gateway **boot** time (faulthandler needs a stable fd for the process lifetime, so the file is pre-opened at startup), which reads as misleading metadata during incident review.

#1572 is an earlier example of the same investigative dead end: repeated watchdog trips, root cause unknown.

## Why it matters

A loop stall takes down the whole gateway — every agent turn, scheduled cron fire, and messaging channel on it — and today each occurrence ends at "the loop was wedged in websocket parsing, cause unknown." Without socket identity and queue depths at stall time, operators cannot distinguish an inbound flood on one connection from GIL starvation or a slow callback, so the underlying bug survives to stall the gateway again.

## What changed (motivation → approach → change)

Goal: capture the missing context at stall time, without making the watchdog itself risky in a sick process.

Approach: the watchdog's daemon thread keeps running while the loop thread is wedged (CPython releases the GIL around blocking syscalls), and its 5s poll cadence gives it a window between stall onset and the 25s dump-then-exit timer. That is the safe place to enrich — off the wedged loop, before the process dies. The capture reads Linux `/proc` directly (no subprocess spawn from a watchdog thread in a sick process; no `psutil`, which is not a runtime dependency) and degrades to a one-line note on non-Linux or any parse failure. An out-of-process sampler was rejected for the same reasons the existing design already documents (portability, privileges).

Change:

- New `stall_enrichment.py`: decodes `/proc/net/tcp{,6}` for this process's ESTABLISHED non-loopback connections — local/remote endpoints plus kernel `rx_queue`/`tx_queue` byte counts (a large `rx_queue` at stall time is direct evidence of an inbound flood on that socket) — under an explicit stall UTC timestamp header. Socket inodes come from the existing `acp.liveness.socket_inodes` (review feedback: no second spelling of that `/proc` walk). Never raises.
- `loop_watchdog.py`: new enrichment stage at `enrich_after` (default 15s of heartbeat silence; invariant `enrich_after < exit_after < stall_after` = 15s < 25s < 30s) emits those lines to the logger at WARNING — and deliberately **never** into `loopstall-*.txt` (review feedback): that file is the boot-time crash sentinel (`crash_dump_store._is_header_only` classifies by line count alone), so a watchdog-side append would make a *recovered* 15–25s stall read as a fatal crash on the next startup — false "work in flight was lost" notification, cautious boot, and an unreapable file aging real stall evidence out of rotation. Only faulthandler writes into the sentinel. The journal WARNING survives both outcomes: the process lives to keep logging on recovery, and journald has already persisted the line when `_exit` fires on a fatal stall. `start()` warns if a tuned `exit_after` would silently disable the capture, and reports `enrich_after` in the arming log line.
- Bug fix surfaced by the new tests: in `check()`, silence *between* two thresholds fell through to the "healthy / recovered" branch and reset the per-episode flag — with the new enrichment stage that would have re-fired the capture on every 5s poll tick. An explicit mid-episode band now keeps episode flags until silence drops back below the first threshold.

No behavior change to the existing two-layer design (25s dump-then-exit, 30s soft dump); enrichment is an additive earlier stage on the daemon thread.

## Tests

`python -m pytest test/test_loop_watchdog.py test/test_stall_enrichment.py` — **24 passed** (13 pre-existing, 11 new), Python 3.12.

New watchdog tests (existing injected-clock pattern; sentinel-guard fake dump file, recording collector and logger, armed timer disabled):

- fires exactly once per stall episode at the threshold (not below it, not again mid-episode);
- a recoverable stall (enrich → recover) leaves the dump file **byte-untouched** — the sentinel-integrity regression from review — and a second stall re-enriches;
- a raising collector is contained; the failure marker goes to the log, never the sentinel;
- `dump_file=None` (dashboard-only processes) is safe;
- enrichment precedes the soft-dump threshold within a single episode (locks in the mid-episode band fix), with zero sentinel writes across the full episode.

New enrichment tests:

- `/proc` address decoding for IPv4 and IPv6 little-endian word forms;
- row filtering against crafted `/proc/net/tcp` content: keeps only ESTABLISHED + own-inode + non-loopback, parses hex queue-depths (`rx_queue=130096B`);
- missing procfile returns empty rather than raising;
- live-`/proc` smoke test on Linux; degenerate silence values never raise.

## Manual verification

Verified the capture path end to end on a live Linux gateway host: the `/proc` walk of the running gateway process resolves its single outbound TLS connection (the Slack Socket Mode edge) with correct endpoints and queue depths — the exact artifact the two production dumps were missing. Non-Linux degradation covered by unit test; not exercised on a real macOS/Windows host.

## Related Issues

Related context (not fixed by this PR): #1572 (repeated loop-stall trips, root cause unknown — this PR adds the missing evidence for that class of investigation).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat: capture socket enrichment in loop-stall crash dumps`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — module/class docstrings document the new stage, its timing invariant, and the sentinel rationale
- [x] No secrets, credentials, or internal references in the diff
