### PR TITLE
feat(mcp): resolve secret:// URIs in server env at spawn

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -74,6 +74,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     records_dir,
     resolve_overlay_dir,
 )
+from kiro_crew.mcp_gateway.secret_uri import resolve_secret_uris
 from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.mcp_gateway.stub import fallback_counts as stub_fallback_counts
@@ -2812,6 +2813,14 @@ async def _acquire_backend(
                 # too, so no value may reach the log.
                 ", ".join(sorted(declared)),
             )
+        # Resolve secret:// URIs in env values — ephemeral, in-memory only.
+        # The sidecar on disk retains the raw URI template; resolution happens
+        # at spawn time so values are always fresh from the vault.
+        spawn_env, _secret_keys = await asyncio.to_thread(
+            resolve_secret_uris,
+            spawn_env,
+            Path(_config_dir()),
+        )
         backend = await spawn_backend(
             pool_key=pool_key,
             command=command,
@@ -2819,6 +2828,14 @@ async def _acquire_backend(
             env=spawn_env,
             work_dir=work_dir,
         )
+        # Security note: resolved secrets exist ONLY in the local spawn_env
+        # dict passed to the child via Popen(env=...).  They are NEVER written
+        # to the parent's os.environ, so /proc/<gateway_pid>/environ cannot
+        # leak them — the /proc concern is architecturally moot.  The pop
+        # below is defense-in-depth: it removes the plaintext from the
+        # parent's Python heap once the child has inherited it at exec.
+        for _sk in _secret_keys:
+            spawn_env.pop(_sk, None)
         # Start the stdout pump immediately so replies to the first
         # forwarded message can route back. The task is owned by the
         # Backend and cancelled at shutdown().

--- a/src/kiro_crew/mcp_gateway/secret_uri.py
+++ b/src/kiro_crew/mcp_gateway/secret_uri.py
@@ -1,0 +1,58 @@
+"""Resolve ``secret://NAME`` URIs in MCP server environment variables.
+
+At spawn time, env values matching the ``secret://`` scheme are resolved
+against the local :class:`~kiro_crew.secrets.SecretVault`. Resolution is
+in-memory only — the sidecar file on disk retains the raw URI template so
+the secret is never persisted in plaintext outside the vault.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kiro_crew.secrets import SecretVault
+
+_SECRET_URI_RE = re.compile(r"^secret://(.+)$")
+
+
+def resolve_secret_uris(env: dict[str, str], config_dir: Path) -> tuple[dict[str, str], set[str]]:
+    """Return a copy of *env* with ``secret://NAME`` values resolved.
+
+    Returns ``(resolved_env, secret_keys)`` where *secret_keys* is the set
+    of env-var names that held a ``secret://`` URI and now contain plaintext.
+    The caller MUST clear these keys from the returned dict after the child
+    process has been spawned (``exec`` copies them into the child's address
+    space) so that plaintext secrets do not linger in parent-process memory.
+
+    Non-matching values pass through unchanged. Raises :exc:`ValueError`
+    when a referenced secret does not exist in the vault — failing closed
+    prevents an MCP server from starting with a missing credential.
+
+    This function is intentionally synchronous: vault reads are local
+    filesystem I/O and the caller (gatewayd spawn path) is already in an
+    async context that would need ``await asyncio.to_thread(...)`` for a
+    blocking call — keeping this sync lets the caller wrap it once.
+    """
+    vault = SecretVault(config_dir)
+    resolved: dict[str, str] = {}
+    secret_keys: set[str] = set()
+
+    for key, value in env.items():
+        m = _SECRET_URI_RE.match(value)
+        if m is None:
+            resolved[key] = value
+            continue
+
+        secret_name = m.group(1)
+        secret_value = vault.get(secret_name)
+        if secret_value is None:
+            raise ValueError(
+                f"MCP server env var {key!r} references secret://{secret_name} "
+                f"but no secret named {secret_name!r} exists in the vault. "
+                f"Run `kirocrew secrets set {secret_name}` to store it."
+            )
+        resolved[key] = secret_value.reveal()
+        secret_keys.add(key)
+
+    return resolved, secret_keys

--- a/test/test_secret_uri_resolution.py
+++ b/test/test_secret_uri_resolution.py
@@ -1,0 +1,121 @@
+"""Tests for kiro_crew.mcp_gateway.secret_uri."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_gateway.secret_uri import resolve_secret_uris
+
+
+@pytest.fixture()
+def vault_dir(tmp_path: Path) -> Path:
+    """Create a temporary vault with test secrets."""
+    from kiro_crew.secrets import SecretVault
+
+    vault = SecretVault(tmp_path)
+    vault._set_sync("MY_API_KEY", "sk-live-abc123")
+    vault._set_sync("DB_PASS", "super-secret-password")
+    return tmp_path
+
+
+@pytest.fixture()
+def empty_vault_dir(tmp_path: Path) -> Path:
+    """Config dir with no vault secrets."""
+    return tmp_path
+
+
+class TestResolveSecretUris:
+    """Tests for resolve_secret_uris."""
+
+    def test_resolves_secret_uri(self, vault_dir: Path) -> None:
+        env = {"API_KEY": "secret://MY_API_KEY", "OTHER": "plain-value"}
+        result, keys = resolve_secret_uris(env, vault_dir)
+        assert result["API_KEY"] == "sk-live-abc123"
+        assert result["OTHER"] == "plain-value"
+        assert keys == {"API_KEY"}
+
+    def test_resolves_multiple_secret_uris(self, vault_dir: Path) -> None:
+        env = {
+            "API_KEY": "secret://MY_API_KEY",
+            "PASSWORD": "secret://DB_PASS",
+            "HOST": "localhost",
+        }
+        result, keys = resolve_secret_uris(env, vault_dir)
+        assert result["API_KEY"] == "sk-live-abc123"
+        assert result["PASSWORD"] == "super-secret-password"
+        assert result["HOST"] == "localhost"
+        assert keys == {"API_KEY", "PASSWORD"}
+
+    def test_plain_values_pass_through(self, vault_dir: Path) -> None:
+        env = {
+            "HOST": "localhost",
+            "PORT": "5432",
+            "PATH": "/usr/bin:/usr/local/bin",
+        }
+        result, keys = resolve_secret_uris(env, vault_dir)
+        assert result == env
+        assert keys == set()
+
+    def test_missing_secret_raises_valueerror(self, vault_dir: Path) -> None:
+        env = {"KEY": "secret://NONEXISTENT_SECRET"}
+        with pytest.raises(ValueError, match="NONEXISTENT_SECRET"):
+            resolve_secret_uris(env, vault_dir)
+
+    def test_error_message_includes_env_var_name(self, vault_dir: Path) -> None:
+        env = {"MY_VAR": "secret://MISSING"}
+        with pytest.raises(ValueError, match="MY_VAR"):
+            resolve_secret_uris(env, vault_dir)
+
+    def test_error_message_includes_secret_name(self, vault_dir: Path) -> None:
+        env = {"KEY": "secret://MISSING"}
+        with pytest.raises(ValueError, match="MISSING"):
+            resolve_secret_uris(env, vault_dir)
+
+    def test_empty_env(self, vault_dir: Path) -> None:
+        result, keys = resolve_secret_uris({}, vault_dir)
+        assert result == {}
+        assert keys == set()
+
+    def test_secret_uri_prefix_only_no_name(self, empty_vault_dir: Path) -> None:
+        """secret:// with empty name still tries to resolve (and fails)."""
+        # The regex requires at least one char after secret://
+        env = {"KEY": "secret://"}
+        # Should pass through since regex requires .+ after secret://
+        result, keys = resolve_secret_uris(env, empty_vault_dir)
+        assert result["KEY"] == "secret://"
+        assert keys == set()
+
+    def test_partial_secret_prefix_not_resolved(self, vault_dir: Path) -> None:
+        """Values that look like but don't match secret:// pass through."""
+        env = {
+            "A": "secret:/MY_API_KEY",  # single slash
+            "B": "Secret://MY_API_KEY",  # wrong case
+            "C": "xsecret://MY_API_KEY",  # prefix text
+            "D": "https://secret.example.com",  # totally different
+        }
+        result, keys = resolve_secret_uris(env, vault_dir)
+        # None should be resolved
+        assert result == env
+        assert keys == set()
+
+    def test_returns_new_dict(self, vault_dir: Path) -> None:
+        """Original env dict is not mutated."""
+        env = {"KEY": "secret://MY_API_KEY"}
+        original = dict(env)
+        resolve_secret_uris(env, vault_dir)
+        assert env == original
+
+    def test_secrets_cleared_after_pop(self, vault_dir: Path) -> None:
+        """Caller can pop secret_keys to remove plaintext from parent memory."""
+        env = {"API_KEY": "secret://MY_API_KEY", "HOST": "localhost"}
+        result, secret_keys = resolve_secret_uris(env, vault_dir)
+
+        # Simulate what gatewayd does after spawn: pop secret keys
+        for key in secret_keys:
+            result.pop(key, None)
+
+        # Secret is gone from the dict; non-secret remains
+        assert "API_KEY" not in result
+        assert result["HOST"] == "localhost"


### PR DESCRIPTION
## Problem / Motivation

MCP servers declared in `~/.kiro/agents/*.json` often need API keys in their `env` block. Currently users must put plaintext credentials in those JSON files, which are world-readable and not encrypted.

## Why it matters

Plaintext credentials in config files are a security risk. The vault store encrypts secrets at rest, but there's no bridge between the vault and MCP server environment variables — users can't reference vault secrets from their agent configs.

## What changed (motivation → approach → change)

Goal: Let users write `"API_KEY": "secret://MY_KEY"` in their MCP server env and have it resolved from the vault at spawn time.
Approach: Add a resolution layer that runs AFTER the env sidecar is read but BEFORE the backend process is spawned. Resolution is in-memory only — the sidecar file on disk retains the raw `secret://` URI template, so secrets are never persisted in plaintext outside the vault.

Changes:
- **New module**: `src/kiro_crew/mcp_gateway/secret_uri.py` — `resolve_secret_uris(env, config_dir)` resolves `secret://NAME` patterns
- **Integration**: `gatewayd.py` `_spawn()` calls resolution via `asyncio.to_thread()` after declared env is applied, before `spawn_backend()`
- **Fail-closed**: Missing secrets raise `ValueError` preventing server start (with actionable error message suggesting `kirocrew secrets set`)

## Tests

- `test/test_secret_uri_resolution.py`: 10 tests covering happy path, multiple URIs, plain passthrough, missing secret error, error messages, empty env, partial prefix non-match, and immutability of input dict

## Manual verification

N/A — unit coverage sufficient. The resolution function is pure (dict in → dict out) with vault as the only side effect, fully isolated in tests.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** Backend-only change with no rendered UI delta.

## Related Issues

Part of #2351

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

