### PR TITLE
fix(acp): destroy the session handle even when provider shutdown is cancelled

### DIFF
--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -189,17 +189,35 @@ class AcpSessionProvider(LLMProvider):
             # prompt on that sessionId with "already in progress". So cancel the
             # session's turn first (best-effort, bounded so an unresponsive
             # runtime can't turn shutdown into a hang), then destroy the handle.
-            if self._handle.is_turn_active:
-                try:
-                    await asyncio.wait_for(self._handle.cancel(), timeout=5.0)
-                except Exception:
-                    logger.debug(
-                        "AcpSessionProvider.shutdown: session cancel failed", exc_info=True
-                    )
+            # The destroy is in a `finally` because the cancel above can be
+            # left through a door `except Exception` does not cover:
+            # `asyncio.CancelledError` is a `BaseException`. That is not a
+            # theoretical exit — the session-restart path runs
+            # `asyncio.wait_for(p.shutdown(), timeout=_SHUTDOWN_TIMEOUT_SECS)`
+            # inside an `asyncio.gather`, so both a shutdown that outruns the
+            # budget and a cancelled restart task deliver a cancellation into
+            # this coroutine, at whatever await it is sitting on.
+            #
+            # Sequentially, that skipped the destroy entirely — and the destroy
+            # is where this arm's two invariants live: `terminate_session`
+            # evicts the session from the SHARED kiro-cli process (it is the
+            # only RSS reclaim on a runtime nothing here is allowed to kill),
+            # and the transcript unlink is the only thing that removes
+            # `~/.kiro/sessions/cli/{sid}.json(+.jsonl)`, as the comment below
+            # says. Nothing retries: every caller drops the provider afterwards.
             try:
-                await self._handle.destroy()
-            except Exception:
-                logger.debug("AcpSessionProvider.shutdown: destroy failed", exc_info=True)
+                if self._handle.is_turn_active:
+                    try:
+                        await asyncio.wait_for(self._handle.cancel(), timeout=5.0)
+                    except Exception:
+                        logger.debug(
+                            "AcpSessionProvider.shutdown: session cancel failed", exc_info=True
+                        )
+            finally:
+                try:
+                    await self._handle.destroy()
+                except Exception:
+                    logger.debug("AcpSessionProvider.shutdown: destroy failed", exc_info=True)
             # destroy() deletes the shared-subagent session transcript
             # (~/.kiro/sessions/cli/{sid}.json+.jsonl); no separate cleanup call
             # needed. cleanup_session() below remains for the LLMProvider API.

--- a/test/test_acp_session_provider_shutdown.py
+++ b/test/test_acp_session_provider_shutdown.py
@@ -1,0 +1,129 @@
+"""``AcpSessionProvider.shutdown()`` must destroy the handle even when cancelled.
+
+The shared-subagent arm cancels the in-flight turn and *then* destroys the
+handle, sequentially:
+
+```python
+if self._handle.is_turn_active:
+    try:
+        await asyncio.wait_for(self._handle.cancel(), timeout=5.0)
+    except Exception:
+        logger.debug(...)
+try:
+    await self._handle.destroy()
+```
+
+``asyncio.CancelledError`` is a ``BaseException``, so it walks straight past
+``except Exception`` and the destroy never runs. This is not hypothetical: the
+session-restart path calls ``asyncio.wait_for(p.shutdown(), timeout=10)`` and
+gathers those calls, so a timeout or a cancelled restart task delivers exactly
+that cancellation into this coroutine.
+
+``destroy()`` is where two documented invariants live — ``terminate_session``
+evicts the session from the SHARED kiro-cli process, and the transcript unlink
+is the only thing that removes ``~/.kiro/sessions/cli/{sid}.json(+.jsonl)``
+("no separate cleanup call needed", per this method's own comment).
+
+These drive the real provider with a real ``AcpSessionHandle`` and real
+transcript files, and assert on the files rather than on a mock call. The only
+seam is ``cancel()``, which is made suspendable so the cancellation lands where
+production would deliver it. Event-driven; no sleeps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.session_provider import AcpSessionProvider
+
+
+def _handle_with_transcript(tmp_path, sid: str = "sid-provider"):
+    """A real AcpSessionHandle carrying a real transcript, mid-turn."""
+    from kiro_crew.acp.session_handle import AcpSessionHandle
+
+    handle = AcpSessionHandle.__new__(AcpSessionHandle)
+    handle._session_id = sid
+    handle.keep_transcript = False
+    runtime = MagicMock()
+    runtime.is_alive.return_value = True
+    runtime.terminate_session = AsyncMock()
+    handle._runtime = runtime
+    # Real state behind the real `is_turn_active` property: a turn is running.
+    handle._turn_done = asyncio.Event()
+    handle._cancelled = False
+
+    sessions = tmp_path / "sessions" / "cli"
+    sessions.mkdir(parents=True)
+    files = [sessions / f"{sid}.json", sessions / f"{sid}.jsonl"]
+    for f in files:
+        f.write_text("{}", encoding="utf-8")
+    return handle, runtime, sessions, files
+
+
+@pytest.mark.asyncio
+async def test_shutdown_destroys_the_handle_when_cancelled_mid_cancel(tmp_path, monkeypatch):
+    """Cancel the shutdown while it is suspended in `handle.cancel()`."""
+    handle, runtime, sessions, files = _handle_with_transcript(tmp_path)
+    entered = asyncio.Event()
+
+    async def _suspended_cancel() -> None:
+        entered.set()
+        await asyncio.Event().wait()  # never completes; the task is cancelled here
+
+    handle.cancel = _suspended_cancel
+    provider = AcpSessionProvider(handle, runtime, owns_runtime=False)
+
+    monkeypatch.setattr("kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions)
+
+    task = asyncio.ensure_future(provider.shutdown())
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert [f for f in files if f.exists()] == [], (
+        "shutdown() exited without destroying the handle, so this subagent's "
+        "transcript is stranded — nothing else deletes it"
+    )
+    runtime.terminate_session.assert_awaited_once_with("sid-provider")
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_that_merely_times_out_still_destroys(tmp_path, monkeypatch):
+    """Control: the already-handled arm. `wait_for`'s TimeoutError is an
+    ordinary Exception, so it was and stays swallowed, and destroy still runs."""
+    handle, runtime, sessions, files = _handle_with_transcript(tmp_path, sid="sid-timeout")
+
+    async def _slow_cancel() -> None:
+        await asyncio.Event().wait()
+
+    handle.cancel = _slow_cancel
+    provider = AcpSessionProvider(handle, runtime, owns_runtime=False)
+    monkeypatch.setattr("kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions)
+    monkeypatch.setattr(
+        "kiro_crew.acp.session_provider.asyncio.wait_for",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    await provider.shutdown()
+
+    assert [f for f in files if f.exists()] == []
+    runtime.terminate_session.assert_awaited_once_with("sid-timeout")
+
+
+@pytest.mark.asyncio
+async def test_an_idle_session_still_destroys(tmp_path, monkeypatch):
+    """Control: with no turn running, `cancel()` is skipped entirely."""
+    handle, runtime, sessions, files = _handle_with_transcript(tmp_path, sid="sid-idle")
+    handle._turn_done.set()  # no active turn
+    handle.cancel = AsyncMock()
+    provider = AcpSessionProvider(handle, runtime, owns_runtime=False)
+    monkeypatch.setattr("kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions)
+
+    await provider.shutdown()
+
+    handle.cancel.assert_not_awaited()
+    assert [f for f in files if f.exists()] == []


### PR DESCRIPTION
Fixes #4694

## Problem / Motivation

`AcpSessionProvider.shutdown()`'s shared-subagent arm cancels the in-flight turn
and *then* destroys the handle, sequentially:

```python
if self._handle.is_turn_active:
    try:
        await asyncio.wait_for(self._handle.cancel(), timeout=5.0)
    except Exception:
        logger.debug(...)
try:
    await self._handle.destroy()
```

`asyncio.CancelledError` is a `BaseException`, so it walks past `except
Exception`, and because the destroy sits *after* the cancel rather than in a
`finally`, teardown exits without destroying the handle at all.

That exit has a production source. `dashboard/handlers/sessions.py`'s restart
path runs `asyncio.wait_for(p.shutdown(), timeout=_SHUTDOWN_TIMEOUT_SECS)`
inside an `asyncio.gather`; `wait_for` cancels the inner coroutine when the
budget expires, and a cancelled restart task cancels every gathered call. Either
way the cancellation lands inside `shutdown()`.

## Why it matters

The destroy carries this arm's two invariants, and the surrounding code states
both:

- **`terminate_session`** is the only RSS reclaim available here. This branch is
  explicitly forbidden to kill the runtime — *"the runtime is SHARED with
  co-tenant sessions (parent + sibling subagents), so we must NOT kill it"* — so
  without the terminate the finished subagent session stays resident in the
  multiplexed kiro-cli process for its whole lifetime.
- **the transcript unlink** is the only thing that removes
  `~/.kiro/sessions/cli/{sid}.json(+.jsonl)`. The comment three lines below the
  destroy says so: *"no separate cleanup call needed"*.

Nothing retries — every caller drops the provider immediately afterwards.

### Not a duplicate of #4620

Different defect in the same family. #4620 is about cleanup skipped *inside*
`AcpSessionHandle.destroy()` once entered; this is about `destroy()` never being
entered. This PR is written against, and verified on, current `main`
(`69b60c3b6`) and does not depend on #4620 landing.

## What changed (motivation → approach → change)

The destroy moves into a `finally`. Deliberately nothing else:

- an ordinary exception from the cancel is still swallowed and logged at debug,
  unchanged;
- the `CancelledError` still propagates — no `shield`, no change to the
  cancellation contract;
- `AcpSessionHandle.destroy()` is untouched;
- no generic cleanup helper, no sweep of the other ACP teardown paths.

There is no `self._handle = None` after the destroy in this method, so the
cancellation path leaves no stale-handle question to answer, and I have not
invented one.

## Tests

New `test/test_acp_session_provider_shutdown.py`. It drives the real
`AcpSessionProvider` with a real `AcpSessionHandle` and real transcript files on
disk, and asserts on the files — not on `destroy.assert_called_once()`. The only
seam is `cancel()`, made suspendable so the cancellation is delivered exactly
where production delivers it. `is_turn_active` is exercised through the real
property, driven by real state (`_turn_done`, `_cancelled`, a live runtime).
Event-driven; no sleeps.

| test | what it pins |
|---|---|
| `test_shutdown_destroys_the_handle_when_cancelled_mid_cancel` | the defect: cancel the shutdown while suspended in `handle.cancel()` → transcript gone, `terminate_session` awaited, `CancelledError` still propagates |
| `test_a_cancel_that_merely_times_out_still_destroys` | control — `wait_for`'s `TimeoutError` is an ordinary `Exception`, was and stays swallowed |
| `test_an_idle_session_still_destroys` | control — with no active turn, `cancel()` is skipped entirely |

```
pytest test/test_acp_session_provider_shutdown.py
```

| | result |
|---|---|
| against `origin/main` (`69b60c3b6`), unfixed | **1 failed, 2 passed** — *"shutdown() exited without destroying the handle, so this subagent's transcript is stranded"* |
| with this change | **3 passed** |

The two controls pass either way by design: they exist to pin the arms that
already worked against a regression from this change.

Relevant suite on this branch:

```
pytest test/test_acp_session_provider.py test/test_acp_session_provider_shutdown.py \
       test/test_subagent_continuable.py test/test_session_sharing.py \
       test/test_acp_runtime.py test/test_session_coverage.py
→ 488 passed, 1 skipped, 0 failed
```

`flake8`, `isort --check-only`, `scripts/check_black_formatting.py` and `mypy`
on the changed module are all clean.

## Manual verification

Not applicable — reproducing this by hand means cancelling a live subagent
teardown at the exact await inside `handle.cancel()` and then counting files in
`~/.kiro/sessions/cli/`. The test delivers that cancellation deterministically
through the real production method and measures the same files.