### PR TITLE
fix(doctor): surface kiro-cli auto-update installer residue in temp

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -11,6 +11,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import textwrap
 import urllib.error
 import urllib.request
@@ -1099,6 +1100,114 @@ def _doctor_memory_pressure(issues: list[str]) -> None:
     print("               Fix: add swap, enable systemd-oomd, or install earlyoom.")
 
 
+# ── kiro-cli installer residue ────────────────────────────────────────────────
+# kiro-cli runs its auto-update check on STARTUP — the ``app.disableAutoupdates``
+# setting is documented as "Disable automatic updates on startup" — and Crew
+# spawns a FRESH kiro-cli per session (``AcpRuntime`` is constructed per session
+# in ``providers/acp.py`` and ``session.py``, and again per Code Review Sage
+# worker). So that check runs once per process START, not once per host per
+# release.
+#
+# On Windows the running executable cannot be replaced, so the downloaded
+# installer can never be applied while a Crew ACP child holds the binary — and
+# the "update pending" state is not cleared after an upgrade either
+# (kirodotdev/Kiro#9825). Nothing in that loop is self-limiting: one installer is
+# left behind per process start. A reporting user cleared ~80 GB of them.
+#
+# Crew cannot fix the updater, and must NOT disable updates on the user's behalf:
+# ``app.disableAutoupdates`` is a per-user setting shared with their own
+# interactive CLI, so setting it silently would suppress their security updates.
+# What Crew can do is stop the residue being invisible, since it is Crew's
+# per-session spawning that turns a stale flag into tens of gigabytes.
+# Upstream fix requested in kirodotdev/Kiro#10970.
+_CLI_INSTALLER_GLOB = "kiro-installer*"
+
+# One file can be a download still in flight; two or more is residue, because a
+# failed apply leaves the file behind and the next process start fetches another.
+_CLI_INSTALLER_RESIDUE_MIN = 2
+
+# The temp dir is shared with every other process on the host and can hold a very
+# large number of entries, so a diagnostic must not walk it unbounded.
+# Non-recursive by design: the installer lands at the top level.
+_CLI_INSTALLER_SCAN_CAP = 512
+
+
+def _scan_cli_installer_residue(temp_dir: Path) -> tuple[int, int]:
+    """Return ``(count, total_bytes)`` for leftover kiro-cli installers in *temp_dir*.
+
+    Bounded and non-raising: the scan stops at :data:`_CLI_INSTALLER_SCAN_CAP`
+    matches, and an entry that vanishes mid-scan — another process cleaning up,
+    or the updater itself — is skipped rather than aborting the whole doctor run.
+    An unreadable temp dir reports "nothing found" for the same reason.
+    """
+    count = 0
+    total = 0
+    try:
+        for entry in temp_dir.glob(_CLI_INSTALLER_GLOB):
+            try:
+                if not entry.is_file():
+                    continue
+                total += entry.stat().st_size
+            except OSError:
+                # Raced with a delete, or unreadable: one bad entry must not
+                # abort a diagnostic.
+                continue
+            count += 1
+            if count >= _CLI_INSTALLER_SCAN_CAP:
+                break
+    except OSError:
+        return (0, 0)
+    return (count, total)
+
+
+def _doctor_cli_installer_residue(issues: list[str]) -> None:
+    """Report leftover kiro-cli auto-update installers piling up in the temp dir.
+
+    Silent on a healthy host — the common case, and every case on a platform that
+    can replace a running binary — so a normal doctor run gains no noise. This
+    speaks only when residue is actually present, which is why it is not gated on
+    ``platform.system() == "Windows"``: the gate is the evidence on disk, so the
+    check still fires if this failure mode ever appears on another platform.
+    """
+    # gettempdir() itself probes candidate directories and raises when none is
+    # usable, so it must be inside the guard too: a host with a full or
+    # unwritable temp volume is exactly the host most in need of the rest of the
+    # doctor run, and must not get a traceback instead of it.
+    try:
+        temp_dir = Path(tempfile.gettempdir())
+    except OSError:
+        return
+    count, total = _scan_cli_installer_residue(temp_dir)
+    if count < _CLI_INSTALLER_RESIDUE_MIN:
+        return
+
+    # Capped scans undercount, so say so rather than printing a precise-looking
+    # number that is actually a floor. This applies to the SIZE as well: the scan
+    # stopped summing at the cap, so the total is a floor exactly as the count is,
+    # and rendering it as exact next to a "512+" count would contradict itself.
+    capped = count >= _CLI_INSTALLER_SCAN_CAP
+    count_label = f"{count}+" if capped else str(count)
+    if total >= 1073741824:
+        size_label = f"{total / 1073741824:.2f} GiB"
+    else:
+        size_label = f"{total / 1048576:.1f} MiB"
+    if capped:
+        size_label = f"≥ {size_label}"
+
+    print("\nkiro-cli installer residue")
+    print(f"  files:       ⚠️  {count_label} in {temp_dir}")
+    print(f"  reclaimable: {size_label}")
+    print("               Auto-update downloads that could not be applied while")
+    print("               kiro-cli was running, and are not cleaned up. Crew starts")
+    print("               a kiro-cli per session, so one accumulates per start.")
+    print(f"               Fix: delete {_CLI_INSTALLER_GLOB} from {temp_dir}, then stop")
+    print("               the gateway and run `kiro-cli update` deliberately.")
+    print("               To stop the downloads: `kiro-cli settings")
+    print("               app.disableAutoupdates true` — note this is per-user, so it")
+    print("               also pauses updates for your own interactive kiro-cli.")
+    issues.append("kiro-cli installer residue in temp")
+
+
 def _doctor_model_url_reachable(issues: list[str]) -> None:
     """Light HTTPS-reachability probe of the resolved embedding-model URL.
 
@@ -1492,6 +1601,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── Memory pressure preparedness (swap / userspace OOM killer) ──
     _doctor_memory_pressure(issues)
+
+    # ── kiro-cli installer residue (silent unless residue is on disk) ──
+    _doctor_cli_installer_residue(issues)
 
     # ── MCP Tools ──
     print("\nMCP Tools")

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -1007,3 +1007,156 @@ class TestSourceCheckout:
         # the environment.
         monkeypatch.setattr(cli_doctor, "_WINDOWS_GIT_DIRS", ("Z:\\nonexistent\\Git\\cmd",))
         assert cli_doctor._windows_git_bin() is None
+
+
+class TestCliInstallerResidue:
+    """Detection of leftover kiro-cli auto-update installers in the temp dir.
+
+    kiro-cli checks for updates on every process start, and Crew spawns a fresh
+    kiro-cli per session. On Windows the running binary cannot be replaced, so
+    each check leaves an installer behind that is never cleaned up (upstream
+    kirodotdev/Kiro#10970). These guard the doctor surface that makes the
+    resulting disk usage visible.
+    """
+
+    def _installer(self, directory: Path, name: str, size: int = 1024) -> Path:
+        path = directory / name
+        path.write_bytes(b"\0" * size)
+        return path
+
+    def test_scan_counts_matching_files_and_sums_bytes(self, tmp_path: Path) -> None:
+        self._installer(tmp_path, "kiro-installer-2.14.0.msi", size=2048)
+        self._installer(tmp_path, "kiro-installer-2.15.0.msi", size=1024)
+        assert cli_doctor._scan_cli_installer_residue(tmp_path) == (2, 3072)
+
+    def test_scan_ignores_unrelated_files(self, tmp_path: Path) -> None:
+        # Must not sweep in every temp file that happens to mention kiro.
+        self._installer(tmp_path, "kiro-installer-2.14.0.msi")
+        self._installer(tmp_path, "kiro-log.txt")
+        self._installer(tmp_path, "some-other-installer.msi")
+        count, _ = cli_doctor._scan_cli_installer_residue(tmp_path)
+        assert count == 1
+
+    def test_scan_ignores_directories(self, tmp_path: Path) -> None:
+        # A directory whose name matches must not be counted as a reclaimable
+        # file, nor make stat() sizes meaningless.
+        (tmp_path / "kiro-installer-dir").mkdir()
+        assert cli_doctor._scan_cli_installer_residue(tmp_path) == (0, 0)
+
+    def test_scan_is_non_recursive(self, tmp_path: Path) -> None:
+        # The installer lands at the top level; descending would make the scan
+        # unbounded over a shared temp dir.
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        self._installer(nested, "kiro-installer-2.14.0.msi")
+        assert cli_doctor._scan_cli_installer_residue(tmp_path) == (0, 0)
+
+    def test_scan_returns_zero_for_missing_dir(self, tmp_path: Path) -> None:
+        # Note: glob() on a missing directory yields nothing rather than
+        # raising, so this pins the missing-dir OUTCOME, not the OSError
+        # handler — that branch is covered by the unreadable-dir test below.
+        assert cli_doctor._scan_cli_installer_residue(tmp_path / "gone") == (0, 0)
+
+    def test_scan_returns_zero_for_unreadable_dir(self, tmp_path: Path, monkeypatch) -> None:
+        # A temp dir the process cannot list (permissions, or a racing rmtree)
+        # must degrade to "nothing found" rather than crashing the doctor run.
+        def boom(self: Path, _pattern: str):  # type: ignore[no-untyped-def]
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "glob", boom)
+        assert cli_doctor._scan_cli_installer_residue(tmp_path) == (0, 0)
+
+    def test_scan_skips_entry_that_races_a_delete(self, tmp_path: Path, monkeypatch) -> None:
+        # The updater (or a cleanup script) can remove a file mid-scan; one
+        # unreadable entry must not abort the diagnostic.
+        self._installer(tmp_path, "kiro-installer-a.msi", size=512)
+        self._installer(tmp_path, "kiro-installer-b.msi", size=512)
+        real_stat = Path.stat
+
+        def flaky_stat(self: Path, *a, **kw):  # type: ignore[no-untyped-def]
+            if self.name == "kiro-installer-a.msi":
+                raise OSError("vanished")
+            return real_stat(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "stat", flaky_stat)
+        assert cli_doctor._scan_cli_installer_residue(tmp_path) == (1, 512)
+
+    def test_scan_stops_at_cap(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(cli_doctor, "_CLI_INSTALLER_SCAN_CAP", 3)
+        for i in range(6):
+            self._installer(tmp_path, f"kiro-installer-{i}.msi", size=10)
+        count, _ = cli_doctor._scan_cli_installer_residue(tmp_path)
+        assert count == 3
+
+    def test_single_file_is_silent(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        # One file can be a download still in flight — not residue.
+        self._installer(tmp_path, "kiro-installer-2.14.0.msi")
+        monkeypatch.setattr(cli_doctor.tempfile, "gettempdir", lambda: str(tmp_path))
+        issues: list[str] = []
+        cli_doctor._doctor_cli_installer_residue(issues)
+        assert issues == []
+        assert capsys.readouterr().out == ""
+
+    def test_clean_host_is_silent(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cli_doctor.tempfile, "gettempdir", lambda: str(tmp_path))
+        issues: list[str] = []
+        cli_doctor._doctor_cli_installer_residue(issues)
+        assert issues == []
+        assert capsys.readouterr().out == ""
+
+    def test_residue_is_reported_and_recorded(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        self._installer(tmp_path, "kiro-installer-2.14.0.msi", size=1048576)
+        self._installer(tmp_path, "kiro-installer-2.15.0.msi", size=1048576)
+        monkeypatch.setattr(cli_doctor.tempfile, "gettempdir", lambda: str(tmp_path))
+        issues: list[str] = []
+        cli_doctor._doctor_cli_installer_residue(issues)
+        out = capsys.readouterr().out
+        assert "kiro-cli installer residue" in out
+        assert "2 in" in out
+        assert "2.0 MiB" in out
+        # The remedy must name the setting AND its cost, so a user is not talked
+        # into silently disabling their own security updates.
+        assert "app.disableAutoupdates true" in out
+        assert "per-user" in out
+        assert issues == ["kiro-cli installer residue in temp"]
+
+    def test_unusable_temp_volume_does_not_crash_doctor(self, monkeypatch, capsys) -> None:
+        # gettempdir() raises when no candidate temp dir is usable. A diagnostic
+        # must degrade to silence rather than abort the whole doctor run with a
+        # traceback on exactly the host that most needs the rest of it.
+        def boom() -> str:
+            raise FileNotFoundError("No usable temporary directory found")
+
+        monkeypatch.setattr(cli_doctor.tempfile, "gettempdir", boom)
+        issues: list[str] = []
+        cli_doctor._doctor_cli_installer_residue(issues)
+        assert issues == []
+        assert capsys.readouterr().out == ""
+
+    def test_large_total_renders_gib(self, monkeypatch, capsys) -> None:
+        # Formatting only: writing gigabytes to disk in a test is not acceptable.
+        monkeypatch.setattr(
+            cli_doctor, "_scan_cli_installer_residue", lambda _d: (700, 80 * 1073741824)
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_cli_installer_residue(issues)
+        out = capsys.readouterr().out
+        assert "80.00 GiB" in out
+        # 700 is past the cap, so BOTH the count and the size are floors: the scan
+        # stopped summing at the cap, so an exact-looking size would contradict
+        # the "700+" beside it.
+        assert "700+" in out
+        assert "≥ 80.00 GiB" in out
+
+    def test_uncapped_size_is_not_marked_as_a_floor(self, monkeypatch, capsys) -> None:
+        # Below the cap the scan saw everything, so the figure is exact and must
+        # NOT be hedged -- otherwise every host reads as approximate.
+        monkeypatch.setattr(
+            cli_doctor, "_scan_cli_installer_residue", lambda _d: (4, 4 * 1048576)
+        )
+        issues: list[str] = []
+        cli_doctor._doctor_cli_installer_residue(issues)
+        out = capsys.readouterr().out
+        assert "4.0 MiB" in out
+        assert "≥" not in out
+        assert "4+" not in out


### PR DESCRIPTION
## Problem

`kirocrew doctor` is blind to a disk-exhaustion mode that Crew's own architecture amplifies. A user reported deleting **~80 GB** of `kiro-installer*.msi` from their Windows temp folder.

Three things line up:

1. **The update check is per-process, on startup.** `app.disableAutoupdates` is documented as "Disable automatic updates **on startup**", so every new kiro-cli process checks.
2. **Crew spawns a fresh kiro-cli per session.** `AcpRuntime` is constructed per session at `src/kiro_crew/providers/acp.py:700`, `src/kiro_crew/session.py:1240` and `:1323`, and again per Code Review Sage worker at `src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py:360`. (The warm pool in this repo is for MCP gateway backends, not kiro-cli.) So the check runs per process **start**, not per host per release.
3. **On Windows the download can never be applied** — the running executable cannot be replaced — and it is not cleaned up. The pending-update state is never cleared after upgrade either (kirodotdev/Kiro#9825), so the loop does not self-resolve.

Crew's spawn env (`src/kiro_crew/acp/runtime.py:970-1023`) is an `os.environ` copy plus Crew's injections; nothing suppresses the check and `disableAutoupdates` appears nowhere in this codebase. This is the default for every Windows Crew install, and it **re-arms on every new kiro-cli release**, so a manual cleanup does not hold.

## What this changes

A doctor check that makes the residue visible, since it is Crew's per-session spawning that turns a stale upstream flag into tens of gigabytes.

```
kiro-cli installer residue
  files:       ⚠️  6 in /tmp/...
  reclaimable: 720.0 MiB
               Auto-update downloads that could not be applied while
               kiro-cli was running, and are not cleaned up. Crew starts
               a kiro-cli per session, so one accumulates per start.
               Fix: delete kiro-installer* from /tmp/..., then stop
               the gateway and run `kiro-cli update` deliberately.
               To stop the downloads: `kiro-cli settings
               app.disableAutoupdates true` — note this is per-user, so it
               also pauses updates for your own interactive kiro-cli.
```

Design decisions worth reviewing:

- **Silent when clean.** A healthy run gains no output at all, matching `_doctor_kas`'s silent-when-not-selected shape.
- **Gated on evidence, not platform.** Deliberately *not* `platform.system() == "Windows"` — the gate is the residue on disk, so the check still fires if this mode ever appears elsewhere. (Verified this Linux host has zero, consistent with Linux replacing a running binary fine.)
- **Threshold of 2.** One file can be a download still in flight; two or more is residue, because a failed apply leaves the file and the next start fetches another.
- **Bounded and non-raising.** A shared temp dir can hold very many entries, so the scan is non-recursive and caps at 512 matches; a capped count renders as `512+` rather than as an exact-looking figure. An entry that vanishes mid-scan is skipped, and an unlistable temp dir degrades to "nothing found" — a diagnostic must never abort the run.
- **The remedy names its cost.** The message states the setting is per-user and also pauses the user's interactive CLI, so nobody disables their own security updates unaware. A test asserts both the setting *and* the "per-user" caveat are printed.

## What this deliberately does NOT do

Set `app.disableAutoupdates` for the user. It is a per-user setting in `~/.kiro/settings/cli.json` shared with their interactive kiro-cli, so setting it silently would suppress their security updates — a security-posture decision that is not Crew's to make unilaterally. There is no documented CLI-scoped equivalent of the IDE's `UpdateMode=none` managed policy, and I could not verify any env-var override (`strings` on the binary returns mangled fragments and cannot even find the key the CLI itself prints, so that is inconclusive rather than a negative).

The scoped suppression lever is therefore requested **upstream** in kirodotdev/Kiro#10970, along with the real fix: don't fetch an installer that cannot be applied, clean up on failed apply, and stop writing a uniquely-named file per attempt. Building a Crew-side config knob that writes a file Crew does not own would become dead weight the moment upstream ships a scoped flag.

## Testing

12 new tests in `test/test_cli_doctor.py` (`TestCliInstallerResidue`). All 9 mutations killed via a revert-verify harness with a vacuity guard that refuses a non-unique or missing anchor:

| Mutation | Test that fails |
|---|---|
| threshold 2 → 1 | `test_single_file_is_silent` |
| drop `is_file()` guard | `test_scan_ignores_directories` |
| `glob` → `rglob` | `test_scan_is_non_recursive` |
| per-entry `OSError` → re-raise | `test_scan_skips_entry_that_races_a_delete` |
| remove scan cap | `test_scan_stops_at_cap` |
| outer `OSError` → re-raise | `test_scan_returns_zero_for_unreadable_dir` |
| drop `issues.append` | `test_residue_is_reported_and_recorded` |
| disable GiB scaling | `test_large_total_renders_gib` |
| drop the `+` floor marker | `test_large_total_renders_gib` |

One test initially passed for the wrong reason and was corrected rather than left green: `test_scan_returns_zero_for_missing_dir` did not exercise the `OSError` handler at all, because `glob()` on a missing directory yields nothing instead of raising. Coverage showed the branch uncovered, so a real unreadable-dir test was added and the original retitled to pin the outcome it actually verifies.

Gates: 91 tests in the two doctor suites pass; 636 pass across the six other suites that touch `cli_doctor`; `isort`, `flake8`, and the diff-scoped `black` gate all clean (re-run *after* committing, since it scopes on `origin/main...HEAD` and reports "0 changed files" on an uncommitted tree). `mypy` has one pre-existing faiss overload error in `vector_memory.py`, reproduced against that file alone and unrelated to this change. Every line of the added region is covered. No frontend changes.

Closes #4697
