### PR TITLE
fix(deploy): retry the pending-store replacement on Windows

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -313,7 +313,6 @@ src/kiro_crew/deploy/__init__.py
 src/kiro_crew/deploy/engine.py
 src/kiro_crew/deploy/handlers.py
 src/kiro_crew/deploy/iam.py
-src/kiro_crew/deploy/pending.py
 src/kiro_crew/deploy/pricing.py
 src/kiro_crew/deploy/profiles.py
 src/kiro_crew/deploy/render.py

--- a/src/kiro_crew/deploy/pending.py
+++ b/src/kiro_crew/deploy/pending.py
@@ -6,6 +6,7 @@ via the dashboard UI (Artifact Deploy page) by a cookie-authenticated human.
 Storage: ``~/.kiro/crew/deploy/pending-deploys.json`` — same atomic-write
 pattern as profiles.py registry.
 """
+
 from __future__ import annotations
 
 import contextlib
@@ -18,6 +19,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.paths import config_dir
 from kiro_crew.platform_compat import file_lock
 
@@ -55,7 +57,21 @@ def _save_raw(entries: list[dict[str, Any]]) -> None:
         tmp.flush()
         os.fsync(tmp.fileno())
         tmp.close()
-        os.replace(tmp.name, str(p))
+        # `replace_with_retry`, not a bare `os.replace`: on Windows the rename
+        # raises `PermissionError` while any other handle is open on either
+        # path -- an indexer, an AV scanner, or a concurrent reader of this
+        # store -- and that transient is the only thing standing between a
+        # fully-durable write (fsync'd temp, above) and the entry landing.
+        # Every writer here funnels through this one call, so a faulted rename
+        # aborts whichever of add/claim/remove was in flight: a preview that
+        # cannot record its pending confirmation, a human confirm whose atomic
+        # claim cannot be persisted, or a dismiss that does not take.
+        #
+        # The retry only helps where it is allowed to sleep, and it is: the
+        # dashboard drives every one of these through `asyncio.to_thread`
+        # (`deploy/handlers.py`), so the helper's off-the-event-loop gate leaves
+        # it enabled on that path.
+        replace_with_retry(tmp.name, p)
     except BaseException:
         tmp.close()
         with contextlib.suppress(OSError):

--- a/test/test_deploy_pending_replace_retry.py
+++ b/test/test_deploy_pending_replace_retry.py
@@ -1,0 +1,144 @@
+"""The pending-deploy store's atomic replace must survive Windows contention.
+
+``deploy/pending.py::_save_raw`` does the whole durable-write dance —
+``NamedTemporaryFile`` in the destination's directory, ``flush``, ``fsync``,
+close, then an atomic rename — and finishes on a bare ``os.replace``. On Windows
+that rename raises ``PermissionError`` while any other handle is open on either
+path (an indexer, an AV scanner, a concurrent reader), which is the transient
+window ``atomic_write.replace_with_retry`` exists to absorb.
+
+All three public writers funnel through ``_save_raw`` under the same
+cross-process ``file_lock``: ``add_pending`` (a preview asking for
+confirmation), ``claim_pending`` (the human confirm) and ``remove_pending``
+(dismiss). One faulted rename aborts whichever of those was in flight.
+
+The retry is only useful where it is allowed to sleep, and it is: every
+dashboard caller runs the store through ``asyncio.to_thread`` — six
+``add_pending``, one ``claim_pending``, one ``remove_pending`` in
+``deploy/handlers.py`` — so ``replace_with_retry``'s off-the-event-loop gate
+leaves the retry enabled on the path that matters.
+
+These drive ``add_pending`` because the three writers share the one rename;
+duplicating the same scenario per public function would pin nothing extra.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from windows_sim import replace_sharing_violation
+
+from kiro_crew import atomic_write as aw
+from kiro_crew import platform_compat
+from kiro_crew.deploy import pending
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """Keep the bounded retry loop instant; attempt COUNT is what these pin."""
+    monkeypatch.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0)
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    path = tmp_path / "deploy" / "pending-deploys.json"
+    monkeypatch.setattr(pending, "_store_path", lambda: path)
+    return path
+
+
+@pytest.fixture
+def _windows(monkeypatch):
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+
+def _params(site: str = "site-1"):
+    return {
+        "site_id": site,
+        "artifact_slug": "deck",
+        "local_dir": "/tmp/x",
+        "profile": "default",
+        "region": "us-east-1",
+    }
+
+
+def test_a_contended_rename_retries_and_the_entry_is_persisted(store, _windows):
+    """One faulted rename, then one that succeeds: the confirmation survives."""
+    with replace_sharing_violation(match="pending-deploys.json", times=1) as state:
+        entry = pending.add_pending(_params())
+
+    assert entry["id"]
+    stored = json.loads(store.read_text(encoding="utf-8"))
+    assert [e["id"] for e in stored] == [entry["id"]]
+    assert state["n"] == 2, (
+        "the simulator must have FAULTED the store's own rename -- n < 2 means "
+        "the retry was never on the production path"
+    )
+
+
+def test_a_permanently_contended_rename_still_fails_and_leaves_the_store_intact(store, _windows):
+    """Bounded, not infinite — and a failed write must not damage what is there."""
+    pending.add_pending(_params("site-first"))
+    before = store.read_text(encoding="utf-8")
+
+    with replace_sharing_violation(match="pending-deploys.json", times=10_000) as state:
+        with pytest.raises(PermissionError):
+            pending.add_pending(_params("site-second"))
+
+    assert state["n"] == aw._REPLACE_MAX_ATTEMPTS, "the retry must be bounded"
+    assert store.read_text(encoding="utf-8") == before, "the previous store was damaged"
+    assert sorted(p.name for p in store.parent.glob("*.tmp")) == [], (
+        "the temp file was left behind; _save_raw's BaseException cleanup must "
+        "still run when the retry gives up"
+    )
+
+
+def test_posix_permission_errors_are_not_slept_over(store, monkeypatch):
+    """On POSIX the OS permits replacing an open file, so a PermissionError is a
+    REAL access fault. This is the non-vacuity proof for the platform gate: the
+    same simulator settings recover in the first test and must not here."""
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+
+    with replace_sharing_violation(match="pending-deploys.json", times=1) as state:
+        with pytest.raises(PermissionError):
+            pending.add_pending(_params())
+
+    assert state["n"] == 1, "it must not have tried a second time"
+
+
+@pytest.mark.skipif(
+    not platform_compat.IS_WINDOWS,
+    reason="POSIX permits replacing a file that another handle holds open",
+)
+def test_a_real_windows_reader_no_longer_defeats_the_pending_write(store, monkeypatch):
+    """No simulator: a real open handle on the destination, on a real Windows
+    host. The only test here that evidences the OS behaviour itself.
+
+    Deterministic without wall-clock: the handle is released from inside the
+    retry's own backoff, so attempt 1 fails against a genuinely locked file and
+    attempt 2 succeeds against a genuinely free one.
+    """
+    first = pending.add_pending(_params("site-first"))
+
+    handle = open(store, "rb")  # e.g. an indexer or a concurrent reader
+    releases = {"n": 0}
+
+    class _ReleaseOnBackoff:
+        """Stands in for the ``time`` module inside ``atomic_write`` only."""
+
+        @staticmethod
+        def sleep(_seconds):
+            releases["n"] += 1
+            if not handle.closed:
+                handle.close()
+
+    monkeypatch.setattr(aw, "time", _ReleaseOnBackoff)
+    try:
+        second = pending.add_pending(_params("site-second"))
+    finally:
+        if not handle.closed:
+            handle.close()
+
+    stored = json.loads(store.read_text(encoding="utf-8"))
+    assert [e["id"] for e in stored] == [first["id"], second["id"]]
+    assert releases["n"] == 1, "exactly one backoff, i.e. the first rename really failed"


### PR DESCRIPTION
Fixes #4701

## Problem / Motivation

`deploy/pending.py::_save_raw` already does the whole durable-write dance — a
`NamedTemporaryFile` in the destination's own directory, `flush`, `fsync`,
close — and then finishes on a **bare** `os.replace`.

On Windows that rename raises `PermissionError` while any other handle is open
on either path: an indexer, an AV scanner, or a concurrent reader of the store.
`atomic_write.replace_with_retry` is the shared helper that exists to absorb
that transient window, and the same family has already been closed twice
(#4548, #4638).

All three public writers funnel through this one call under the same
cross-process `file_lock`, so a faulted rename aborts whichever operation was in
flight:

| writer | user-facing effect |
|---|---|
| `add_pending` | a preview that cannot record its pending confirmation — the tool/API call reports a failure the user cannot act on |
| `claim_pending` | Confirm was pressed, but the atomic claim rewrite cannot be persisted, so the confirm path breaks |
| `remove_pending` | a dismiss that does not take |

**This is not data loss and the PR does not claim it is.** The replace is
atomic, so the previous store is left byte-identical and the existing
`except BaseException` arm removes the temp file. What the missing retry costs
is that an otherwise-valid workflow fails on a transient the repo already knows
how to ride out.

## Why it matters

The pending-deploy store is part of the human approval path for publishing. A
transient Windows file-sharing collision can currently abort an otherwise-valid
preview, confirm, or dismiss, even though the store it was writing is left
intact and the contention is normally short-lived.

That makes the failure user-visible and unnecessarily platform-specific. The
repository already carries a bounded Windows retry primitive for exactly this
final atomic-replace window, and the dashboard paths run the store off the event
loop, so the retry can actually apply here rather than degrading to a single
attempt.

## Why the helper actually applies here

`replace_with_retry` deliberately degrades to a single attempt on an event-loop
thread, which makes some candidate call sites pointless to convert. Not this
one — every dashboard caller runs the store off the loop
(`deploy/handlers.py`):

```python
entry   = await asyncio.to_thread(claim_pending, entry_id)
          await asyncio.to_thread(add_pending, entry)      # x6
removed = await asyncio.to_thread(remove_pending, entry_id)
```

so the worker has no loop of its own and the retry is live on the path that
matters. I checked this before writing the fix rather than assuming it.

The MCP `deploy_artifact` tool calls `add_pending` synchronously; that handler
is a plain `def` and I did not establish which thread its dispatcher runs it on.
If it does run on a loop thread it simply keeps today's single-attempt
behaviour — no regression either way.

## What changed (motivation → approach → change)

One call site:

```python
os.replace(tmp.name, str(p))   ->   replace_with_retry(tmp.name, p)
```

`_save_raw` keeps its own tempfile, `flush`, `fsync` and `BaseException`
cleanup. Nothing is rerouted through `atomic_write()`, no lock / JSON / fsync
semantics move, and no caller is touched. If the retry exhausts its budget the
`PermissionError` still propagates and the existing cleanup arm still unlinks
the temp file — pinned by a test.

## Tests

New `test/test_deploy_pending_replace_retry.py`. They drive the real
`add_pending`; the three writers share the one rename, so duplicating the
scenario per public function would pin nothing extra.

| test | what it pins |
|---|---|
| `test_a_contended_rename_retries_and_the_entry_is_persisted` | one faulted rename then one that succeeds — entry durable, `state["n"] == 2` |
| `test_a_permanently_contended_rename_still_fails_and_leaves_the_store_intact` | bounded attempts, `PermissionError` propagates, previous store byte-identical, no `.tmp` left |
| `test_posix_permission_errors_are_not_slept_over` | platform gate — one attempt only, no retry |
| `test_a_real_windows_reader_no_longer_defeats_the_pending_write` | **no simulator**: a real `open(store, "rb")` handle on a real Windows host |

The simulator tests assert `state["n"]`, not merely that the write succeeded.
#4638 showed a test that only wraps a call in `replace_sharing_violation` can
pass vacuously without ever faulting the production rename, so the fault has to
be *observed*.

The real-OS test is deterministic without wall-clock: the handle is released
from inside the retry's own backoff, so attempt 1 fails against a genuinely
locked file and attempt 2 succeeds against a genuinely free one, and it asserts
exactly one backoff occurred.

```
pytest test/test_deploy_pending_replace_retry.py
```

| | result |
|---|---|
| against `origin/main` (`69b60c3b6`) | **3 failed, 1 passed** — the first fails with an uncaught `PermissionError`, which is the defect itself |
| with this change | **4 passed** |

Wider suite on this branch:

```
pytest test/ -k "pending or deploy"
→ 876 passed, 98 skipped, 16 failed, 4 errors
```

The 16 failures and 4 errors are **identical, name for name**, to a run of the
same selection on pristine `origin/main` (872 passed there; the +4 are the new
tests). They are the box's `WinError 1314` symlink-privilege class plus some
CloudFormation template assertions, none of them related to this change.

`flake8`, `isort --check-only` and `mypy` on the changed module are clean.

### One declared rider

`.github/black-baseline.txt` loses one line: `src/kiro_crew/deploy/pending.py`.

Black's only complaint about that file on `main` is a missing blank line after
the module docstring. This change adds it, so the file becomes black-clean, and
the gate's graduation half — which is not diff-scoped — then requires the entry
to be pruned. The removal is `scripts/check_black_formatting.py
--update-baseline`, which only ever deletes lines; it deleted exactly one. It
cannot be moved to another PR without leaving this one red. With it, the gate
reports `black gate passed`.

## Manual verification

The real-OS test above is the manual verification, automated: a real reader
handle on a real Windows host, driven through the real `add_pending`. Not
exercised: a live AV scanner or Search Indexer holding the file — the held
handle reproduces the same OS refusal deterministically, which is the standard
#4548 / #4638 set.
