### PR TITLE
fix(dashboard): release streamed chunk rows the window purge left behind

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -666,25 +666,30 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     resp.headers["X-Accel-Buffering"] = "no"
     await resp.prepare(request)
 
-    try:
-        while True:
-            pending = slot.drain()
-            for msg in pending:
-                if msg["cls"] == "done":
-                    await resp.write(b"data: [DONE]\n\n")
-                    slot._has_reader = False
-                    return resp
-                chunk = _build_stream_chunk(msg)
-                await resp.write(f"data: {chunk}\n\n".encode())
-            try:
-                await asyncio.wait_for(slot.event.wait(), timeout=30)
-            except asyncio.TimeoutError:
-                await resp.write(b": keepalive\n\n")
-    except (ConnectionResetError, ClientConnectionResetError, asyncio.CancelledError):
-        pass
-    finally:
-        slot.drain()
-        slot._has_reader = False
+    # Declare this reader as the owner of `slot._pending` for as long as it is
+    # draining. A turn-end chunk release must not run while an SSE reader still
+    # has undelivered tokens queued, and `_has_reader` alone cannot carry that:
+    # the `done` branch below clears it before this scope ends.
+    with slot.pending_consumer():
+        try:
+            while True:
+                pending = slot.drain()
+                for msg in pending:
+                    if msg["cls"] == "done":
+                        await resp.write(b"data: [DONE]\n\n")
+                        slot._has_reader = False
+                        return resp
+                    chunk = _build_stream_chunk(msg)
+                    await resp.write(f"data: {chunk}\n\n".encode())
+                try:
+                    await asyncio.wait_for(slot.event.wait(), timeout=30)
+                except asyncio.TimeoutError:
+                    await resp.write(b": keepalive\n\n")
+        except (ConnectionResetError, ClientConnectionResetError, asyncio.CancelledError):
+            pass
+        finally:
+            slot.drain()
+            slot._has_reader = False
     return resp
 
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -2751,6 +2751,12 @@ def _flush_segment(
     slot.messages = (
         head  # drops chunks AND trailing stop_events; tail.non-chunk-non-stop stays in head
     )
+    # The window rewrite above is only half the release: append put each chunk
+    # row in `_pending` as well, as the SAME dict, so the queue still owns every
+    # token of this segment. This is the SUCCESS path — the one a long streamed
+    # turn normally takes — so skipping it leaks the whole stream on any slot
+    # that is not asked for another turn.
+    slot.release_pending_chunks()
     # Redact the accumulated text
     redacted, exfil_warnings = redact_exfiltration_urls(assistant_text)
     for w in exfil_warnings:
@@ -6889,7 +6895,7 @@ async def _run_chat(
         if first_word == "/compact" and not saw_compaction:
             # Clear streamed "Compacting conversation..." text from kiro-cli
             # (claude-agent-acp doesn't stream that, but the cleanup is harmless).
-            slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+            slot.purge_chunks()
             assistant_text = ""
             _wsred.reset()
             _produced_visible_output = True
@@ -7458,7 +7464,7 @@ async def _run_chat(
             await _deliver_cross_surface_reply(state, session_key, assistant_text)
     except asyncio.CancelledError:
         if assistant_text:
-            slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+            slot.purge_chunks()
             slot.append(
                 "assistant",
                 redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
@@ -7477,7 +7483,7 @@ async def _run_chat(
         _auth_required = True
         needs_session_reset = True
         if assistant_text:
-            slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+            slot.purge_chunks()
             slot.append(
                 "assistant",
                 redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
@@ -7491,7 +7497,7 @@ async def _run_chat(
         logger.warning("ACP process died in slot %s: %s — resetting session", slot.key, exc)
         needs_session_reset = True
         if assistant_text:
-            slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+            slot.purge_chunks()
             slot.append(
                 "assistant",
                 redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
@@ -7531,7 +7537,7 @@ async def _run_chat(
         logger.info("Prompt busy exhausted in slot %s — resetting session", slot.key)
         needs_session_reset = True  # checked in finally block
         if assistant_text:
-            slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+            slot.purge_chunks()
             slot.append(
                 "assistant",
                 redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
@@ -7609,7 +7615,7 @@ async def _run_chat(
             if assistant_text:
                 _safe, _ = redact_exfiltration_urls(assistant_text)
                 _safe, _ = redact_credentials(_safe)
-                slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+                slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
             # Option Y: pipe-death ("process exited"/"not running") shares the
             # _acp_pipe_death_retries counter with the AcpProcessDied handler;
@@ -7701,7 +7707,7 @@ async def _run_chat(
             )
             # No tokens streamed (guarded above), so no chunk message exists;
             # strip defensively before re-queue all the same.
-            slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+            slot.purge_chunks()
             if _should_suppress_requeue(slot):
                 pass
             elif _prompt_depth == 0:
@@ -7781,7 +7787,7 @@ async def _run_chat(
             if assistant_text:
                 _safe, _ = redact_exfiltration_urls(assistant_text)
                 _safe, _ = redact_credentials(_safe)
-                slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+                slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
             # Surface a brief recovery notice (one append).
             slot.append("error", "⟳ Backend hiccup — recovering…", "msg msg-err")
@@ -7815,7 +7821,7 @@ async def _run_chat(
             if assistant_text:
                 _safe, _ = redact_exfiltration_urls(assistant_text)
                 _safe, _ = redact_credentials(_safe)
-                slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
+                slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
             # ── Poisoned-conversation escalation ────────────────────────────
             # A transient-classified error that reaches this terminal branch

--- a/src/kiro_crew/dashboard/openai_compat.py
+++ b/src/kiro_crew/dashboard/openai_compat.py
@@ -376,27 +376,34 @@ async def api_completions(request: web.Request) -> web.StreamResponse:
         resources=f"slot={slot.key} agent={agent}",
     )
 
-    # Launch the chat, bounded by the standard chat-turn ceiling. A fixed
-    # 300s cap here would race COMPACT_WAIT_TIMEOUT_SECS: a /compact prompt
-    # phase plus the full compaction wait always exceeds it, so the outer
-    # cancel would surface as an HTTP 500 instead of the graceful
-    # compaction-timeout result.
-    task = asyncio.create_task(
-        asyncio.wait_for(_run_chat(state, slot, prompt), timeout=chat_turn_timeout_secs())
-    )
-    slot.task = task
-    state._background_tasks.add(task)
-    task.add_done_callback(state._background_tasks.discard)
-
-    created = int(time.time())
-    ephemeral = not slot_id
-
-    if stream:
-        return await _stream_response(
-            request, state, slot, completion_id, model, created, ephemeral
+    # Both response shapes below consume `slot._pending` as their delivery
+    # queue, and neither sets `_has_reader` (that flag also suppresses the
+    # global message broadcast, which an app-owned slot still wants). Claim the
+    # queue BEFORE the turn is dispatched: the first `await` inside the response
+    # helpers lets the turn run, so a scope opened there would leave a window in
+    # which a turn-end release could discard tokens this reader owes its client.
+    with slot.pending_consumer():
+        # Launch the chat, bounded by the standard chat-turn ceiling. A fixed
+        # 300s cap here would race COMPACT_WAIT_TIMEOUT_SECS: a /compact prompt
+        # phase plus the full compaction wait always exceeds it, so the outer
+        # cancel would surface as an HTTP 500 instead of the graceful
+        # compaction-timeout result.
+        task = asyncio.create_task(
+            asyncio.wait_for(_run_chat(state, slot, prompt), timeout=chat_turn_timeout_secs())
         )
-    else:
-        return await _blocking_response(state, slot, completion_id, model, created, ephemeral)
+        slot.task = task
+        state._background_tasks.add(task)
+        task.add_done_callback(state._background_tasks.discard)
+
+        created = int(time.time())
+        ephemeral = not slot_id
+
+        if stream:
+            return await _stream_response(
+                request, state, slot, completion_id, model, created, ephemeral
+            )
+        else:
+            return await _blocking_response(state, slot, completion_id, model, created, ephemeral)
 
 
 async def _stream_response(

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1358,6 +1358,8 @@ class _ChatSlot:
         "task",
         "event",
         "_pending",
+        "_pending_consumers",
+        "_pending_release_deferred",
         "_queue",
         "_last_enqueue_ts",
         "_approval_futures",
@@ -1383,7 +1385,7 @@ class _ChatSlot:
         "_todo",
         "_on_message",
         "_on_question_retired",
-        "_has_reader",
+        "_has_reader_flag",
         "_stop_state_raw",
         "_stop_generation",
         "_stop_event_id",
@@ -1501,6 +1503,15 @@ class _ChatSlot:
         self.task: asyncio.Task | None = None  # type: ignore[type-arg]
         self.event = asyncio.Event()
         self._pending: list[dict[str, str]] = []
+        # Number of readers currently treating ``_pending`` as their delivery
+        # queue -- see ``pending_consumer``. Zero means a row left in the queue
+        # can never reach a client, which is what makes releasing it safe.
+        self._pending_consumers: int = 0
+        # Set when a release was ASKED FOR and refused because a consumer held
+        # the queue. Without it the refusal is silent and final: the turn-end
+        # purge never runs again for that slot, so the rows it declined to drop
+        # outlive every consumer and the leak survives its own fix.
+        self._pending_release_deferred: bool = False
         self._queue: list[dict[str, str]] = []  # [{"id": uuid, "content": str}, ...]
         # Newest enqueue instant, read only while ``_queue`` is non-empty — see
         # ``_note_enqueue``.
@@ -1599,7 +1610,7 @@ class _ChatSlot:
         # is invisible to a second window, and to a /pending response already in
         # flight — either would re-render a card whose answer has been sent.
         self._on_question_retired: object | None = None
-        self._has_reader: bool = False  # True when HTTP SSE stream is draining
+        self._has_reader_flag: bool = False  # True when HTTP SSE stream is draining
         self._stop_state_raw: str = "idle"  # 'idle' | 'soft_pending' | 'killing'
         # Monotonic count of stop INITIATIONS (idle → active edges of
         # _stop_state). Teardown resets _stop_state back to "idle" but never
@@ -2239,6 +2250,122 @@ class _ChatSlot:
         self._pending.clear()
         self.event.clear()
         return out
+
+    @property
+    def pending_has_consumer(self) -> bool:
+        """True while something can still deliver rows out of ``_pending``.
+
+        The queue serves two unrelated roles. For a WebSocket client it is dead
+        weight: every row it holds was already broadcast, and nothing reads the
+        queue again until the slot's next turn discards it. For an HTTP SSE
+        reader (``/api/chat``) or an OpenAI-compatible reader
+        (``/v1/chat/completions``) it IS the delivery queue -- a row still in it
+        has NOT reached the client, so dropping one truncates the answer.
+
+        So a release may only drop rows while no consumer is attached, and the
+        answer needs two signals because they arm at different moments:
+        ``_has_reader`` is set before the SSE turn is dispatched (covering the
+        window before the reader loop runs its first iteration), and
+        ``_pending_consumers`` is held for the span of each reader loop. The
+        OpenAI-compatible paths deliberately do not set ``_has_reader`` -- that
+        flag also suppresses the global message broadcast, which those slots
+        still want -- so the counter is the only thing that sees them.
+        """
+        return self._pending_consumers > 0 or self._has_reader
+
+    @property
+    def _has_reader(self) -> bool:
+        """True while an HTTP SSE stream is draining this slot.
+
+        A property, not a plain field, because clearing it LIFTS the release
+        guard: the SSE reader sets it before the turn is dispatched and clears
+        it on ``done`` or on the way out, and a deferred release has to be
+        retried at that moment or never. Routing every write through the setter
+        means a future assignment site inherits the retry instead of silently
+        reopening the leak -- the same reason ``pending_consumer`` retries in its
+        ``finally`` rather than trusting its callers to remember.
+        """
+        return self._has_reader_flag
+
+    @_has_reader.setter
+    def _has_reader(self, value: bool) -> None:
+        was = self._has_reader_flag
+        self._has_reader_flag = bool(value)
+        if was and not self._has_reader_flag:
+            self._retry_deferred_release()
+
+    def _retry_deferred_release(self) -> int:
+        """Re-attempt a release that a consumer previously refused. Returns rows freed.
+
+        Called at each point the guard can lift -- the last consumer detaching
+        and ``_has_reader`` clearing. A no-op unless a release was actually
+        deferred, so an ordinary reader that drained its queue cleanly costs one
+        boolean test and changes nothing.
+        """
+        if not self._pending_release_deferred:
+            return 0
+        return self.release_pending_chunks()
+
+    @contextlib.contextmanager
+    def pending_consumer(self) -> Iterator[None]:
+        """Hold ``_pending`` as an attached delivery queue for the block.
+
+        Counted rather than boolean: nothing forbids two readers on one slot,
+        and a boolean would let the first to finish declare the queue unowned
+        while the second is still mid-stream.
+        """
+        self._pending_consumers += 1
+        try:
+            yield
+        finally:
+            self._pending_consumers = max(0, self._pending_consumers - 1)
+            # The detaching consumer may have been the only thing holding the
+            # queue. A consumer that drained cleanly leaves nothing to free; one
+            # that went away mid-stream (client hung up, exception) leaves the
+            # rows the turn-end purge already tried to drop, and this is the only
+            # moment anything looks at them again.
+            self._retry_deferred_release()
+
+    def release_pending_chunks(self) -> int:
+        """Drop undelivered ``chunk`` rows from ``_pending``; return how many.
+
+        ``append`` puts each streamed token row in BOTH ``messages`` and
+        ``_pending`` -- the same dict object in two lists -- so rewriting
+        ``messages`` alone frees nothing: the queue still holds a reference to
+        every chunk dict. On the WebSocket transport no reader ever drains, so
+        those references live until the slot takes another turn, and a slot
+        abandoned after a long streamed turn holds its whole token stream for
+        the process lifetime. Releasing here is what makes a window rewrite
+        actually reclaim the stream.
+
+        A no-op while a consumer is attached (see ``pending_has_consumer``):
+        there those rows are undelivered output, not garbage. The refusal is
+        RECORDED rather than forgotten, and retried when the guard lifts -- a
+        refusal that is silent and final would leave the OpenAI-compatible and
+        SSE transports leaking exactly as before, since their turn-end purge
+        lands while their reader is still attached and never runs again.
+        """
+        if self.pending_has_consumer:
+            self._pending_release_deferred = True
+            return 0
+        self._pending_release_deferred = False
+        before = len(self._pending)
+        if not before:
+            return 0
+        self._pending = [m for m in self._pending if m.get("role") != "chunk"]
+        return before - len(self._pending)
+
+    def purge_chunks(self) -> int:
+        """Drop every ``chunk`` row from the window and release the queue.
+
+        The single owner of "this turn's streamed tokens are now represented by
+        a finalized assistant message, so the raw chunk rows are dead". Callers
+        that rewrite ``messages`` themselves must still call
+        ``release_pending_chunks`` -- a window rewrite on its own leaves the
+        queue as the sole owner of every chunk dict.
+        """
+        self.messages = [m for m in self.messages if m.get("role") != "chunk"]
+        return self.release_pending_chunks()
 
     def mark_permission_resolved(self, approval_id: str, decision: str = "approved") -> None:
         """Update stored permission message cls JSON with resolved flag."""

--- a/test/test_slot_chunk_retention.py
+++ b/test/test_slot_chunk_retention.py
@@ -1,0 +1,365 @@
+"""A finished streamed turn must release its token rows, on every transport.
+
+``_ChatSlot.append`` files each streamed ``chunk`` row into BOTH ``messages``
+and ``_pending`` -- the same dict object in two lists. Every finalize path used
+to rewrite ``messages`` alone, so ``_pending`` kept the only surviving reference
+to the whole token stream. On the WebSocket transport (the dashboard's normal
+one) nothing ever drains that queue during a turn: the SSE drain loop is
+skipped, and the only WS-path drain runs at the START of the slot's NEXT turn.
+A slot that finishes a long streamed turn and is then abandoned therefore held
+its entire token stream for the process lifetime, and the slot count is not
+capped, so the aggregate is unbounded.
+
+The release cannot be unconditional. For an HTTP SSE reader (``/api/chat``) or
+an OpenAI-compatible reader (``/v1/chat/completions``) ``_pending`` IS the
+delivery queue, so a row still in it has NOT reached the client and dropping it
+would truncate the answer mid-sentence. These tests pin both halves: the rows
+are really gone when nobody can deliver them, and really kept when somebody
+can.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard.chat_runner import _flush_segment
+from kiro_crew.dashboard.state import _ChatSlot
+from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
+
+
+def _stream(slot: _ChatSlot, tokens: list[str]) -> list[dict]:
+    """Append tokens as the runner does and return the row objects it created."""
+    for tok in tokens:
+        slot.append("chunk", tok, "chunk", broadcast=False)
+    return [m for m in slot.messages if m.get("role") == "chunk"]
+
+
+def _slot_still_refers(slot: _ChatSlot, rows: list[dict]) -> bool:
+    """True when either slot list is still a referrer of any of ``rows``.
+
+    ``gc.get_referrers`` rather than ``weakref``: a plain dict is not
+    weak-referenceable, and the question here is precisely whether the SLOT is
+    the thing keeping the row alive.
+    """
+    owners = {id(slot.messages), id(slot._pending)}
+    for row in rows:
+        if any(id(ref) in owners for ref in gc.get_referrers(row)):
+            return True
+    return False
+
+
+# ── WS transport: the rows must actually be released ──
+
+
+def test_purge_chunks_releases_the_same_objects_from_both_lists(tmp_path):
+    """The identity check: the exact dicts leave ``_pending``, not just ``messages``.
+
+    Asserting on ``messages`` alone is what let the leak survive -- the window
+    rewrite always looked correct.
+    """
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    rows = _stream(slot, ["al", "pha", "-be", "ta"])
+    assert len(rows) == 4
+    assert [m for m in slot._pending if m.get("role") == "chunk"] == rows
+
+    released = slot.purge_chunks()
+
+    assert released == 4
+    assert [m for m in slot.messages if m.get("role") == "chunk"] == []
+    # Identity, not equality: a row that merely compares unequal could still be
+    # one of the retained dicts under a different key.
+    pending_ids = {id(m) for m in slot._pending}
+    assert pending_ids.isdisjoint({id(r) for r in rows})
+
+
+def test_released_chunk_rows_are_no_longer_owned_by_the_slot(tmp_path):
+    """Neither slot list refers to the rows any more, so they are really freed."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    rows = _stream(slot, ["one", "two", "three"])
+    assert _slot_still_refers(slot, rows) is True
+
+    slot.purge_chunks()
+
+    assert _slot_still_refers(slot, rows) is False
+
+
+def test_abandoned_ws_slot_retains_nothing_after_a_normal_turn(tmp_path):
+    """The SUCCESS path releases too -- the case an abandoned slot actually hits.
+
+    ``_flush_segment`` rewrites the window by SLICE rather than by
+    comprehension, so it is invisible to a search for the purge idiom while
+    being the path a completed streamed turn normally takes.
+    """
+    state = _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    state._slots[slot.key] = slot
+    rows = _stream(slot, ["The ", "answer ", "is ", "42."])
+
+    _flush_segment(state, slot, "The answer is 42.", broadcast=False)
+
+    # The turn's prose survives as one finalized assistant row...
+    assert [m["role"] for m in slot.messages] == ["assistant"]
+    assert slot.messages[0]["content"] == "The answer is 42."
+    # ...and no chunk row is left anywhere on the slot.
+    assert [m for m in slot._pending if m.get("role") == "chunk"] == []
+    assert _slot_still_refers(slot, rows) is False
+
+
+def test_release_is_idempotent_and_leaves_other_rows_alone(tmp_path):
+    """Only ``chunk`` rows go; a queued wire frame or assistant row stays."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    slot.append("assistant", "kept", "msg msg-a", broadcast=False)
+    _stream(slot, ["a", "b"])
+    slot.push_wire_frame("context_usage", json.dumps({"pct": 1.0}))
+
+    assert slot.purge_chunks() == 2
+    assert slot.purge_chunks() == 0
+
+    roles = [m.get("role") for m in slot._pending]
+    assert "chunk" not in roles
+    assert "assistant" in roles
+    assert "context_usage" in roles
+
+
+# ── SSE / OpenAI transports: undelivered rows must survive ──
+
+
+def test_active_sse_reader_keeps_every_chunk(tmp_path):
+    """``_has_reader`` refuses the release; the reader still drains all tokens."""
+    state = _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    state._slots[slot.key] = slot
+    slot._has_reader = True  # set by the /api/chat handler for a non-WS turn
+    tokens = ["Str", "eam", "ed ", "out", "put"]
+    _stream(slot, tokens)
+
+    assert slot.purge_chunks() == 0
+
+    delivered = [m["content"] for m in slot.drain() if m.get("role") == "chunk"]
+    assert delivered == tokens
+
+
+def test_attached_consumer_scope_keeps_every_chunk(tmp_path):
+    """The OpenAI paths never set ``_has_reader``, so the counter must cover them."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    tokens = ["to", "ken", "s"]
+
+    with slot.pending_consumer():
+        assert slot._has_reader is False
+        _stream(slot, tokens)
+        assert slot.purge_chunks() == 0
+        assert [m["content"] for m in slot._pending if m.get("role") == "chunk"] == tokens
+
+    # Detaching retries the release the purge deferred, so the rows are ALREADY
+    # gone here -- a second purge finds nothing left to free. Before the retry
+    # existed this read 3, which is the leak: the refusal was final, so nothing
+    # freed those rows until the slot happened to take another turn.
+    assert slot.purge_chunks() == 0
+    assert [m for m in slot._pending if m.get("role") == "chunk"] == []
+
+
+def test_flush_segment_keeps_undelivered_chunks_for_a_reader(tmp_path):
+    """The success path must not truncate a stream either."""
+    state = _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    state._slots[slot.key] = slot
+    tokens = ["par", "tial"]
+    _stream(slot, tokens)
+
+    with slot.pending_consumer():
+        _flush_segment(state, slot, "partial", broadcast=False)
+        assert [m["content"] for m in slot._pending if m.get("role") == "chunk"] == tokens
+
+
+def test_consumer_scope_is_counted_not_boolean(tmp_path):
+    """Two readers on one slot: the first to leave must not unlock the queue."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with slot.pending_consumer():
+        with slot.pending_consumer():
+            assert slot._pending_consumers == 2
+        assert slot._pending_consumers == 1
+        assert slot.pending_has_consumer is True
+    assert slot._pending_consumers == 0
+    assert slot.pending_has_consumer is False
+
+
+def test_consumer_scope_releases_on_exception(tmp_path):
+    """A reader that dies mid-stream must not pin the queue forever."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with pytest.raises(asyncio.CancelledError):
+        with slot.pending_consumer():
+            raise asyncio.CancelledError()
+
+    assert slot.pending_has_consumer is False
+
+
+# ── End-to-end: the OpenAI-compatible endpoint still returns every token ──
+
+
+class _ReadyPrerequisite(KiroPrerequisiteService):
+    async def session_ready(self) -> bool:
+        return True
+
+    # The endpoint fails closed on a FRESH probe, not on the latch.
+    async def verified_ready(self, *, max_age_secs: float) -> bool:
+        del max_age_secs
+        return True
+
+
+_READY_PREREQUISITE = object.__new__(_ReadyPrerequisite)
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_response_survives_a_turn_end_purge(tmp_path):
+    """A real turn that purges mid-flight must not lose the caller's answer.
+
+    Exercises the handler, not the helpers: the consumer scope has to be armed
+    around the turn dispatch, because the first ``await`` inside the response
+    helper is what lets the turn run.
+    """
+    state = _make_state(tmp_path)
+    slot = _ChatSlot(key="openai:slot-1")
+    state._slots[slot.key] = slot
+    state.get_or_create_slot = MagicMock(return_value=slot)
+
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "model": "kiro",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": False,
+        }
+    )
+    request.app = {"state": state, "kiro_prerequisite_service": _READY_PREREQUISITE}
+    request.get = MagicMock(side_effect=lambda k, d="": d)
+    request.remote = "127.0.0.1"
+
+    tokens = ["Hello", ", ", "world", "!"]
+
+    async def fake_run_chat(_state, sl, _prompt):
+        for tok in tokens:
+            sl.append("chunk", tok, "chunk", broadcast=False)
+        # The turn finalizes: this is the call that used to be a plain window
+        # rewrite and is now also a queue release.
+        sl.purge_chunks()
+        sl.append("done", "", "done", broadcast=False)
+        sl.event.set()
+
+    from kiro_crew.dashboard import openai_compat
+
+    with patch.object(openai_compat, "_run_chat", side_effect=fake_run_chat):
+        resp = await openai_compat.api_completions(request)
+
+    data = json.loads(resp.body)
+    assert data["choices"][0]["message"]["content"] == "".join(tokens)
+
+
+# ── A refused release must be RETRIED, not forgotten ──
+#
+# The guard makes the release conditional, which introduces a second way to
+# leak: the turn-end purge lands while a reader still holds the queue, is
+# correctly refused, and then nothing ever asks again. For the OpenAI-compatible
+# and SSE transports that is every turn, so the fix would have moved the leak
+# rather than closed it.
+
+
+def test_a_refused_release_is_retried_when_the_last_consumer_detaches(tmp_path):
+    """The reported hole: the last OpenAI consumer detaching must retry the release."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with slot.pending_consumer():
+        rows = _stream(slot, ["a", "b", "c"])
+        assert slot.purge_chunks() == 0  # refused -- the reader may still need them
+        assert slot._pending_release_deferred is True
+
+    assert slot._pending_release_deferred is False
+    assert [m for m in slot._pending if m.get("role") == "chunk"] == []
+    assert not _slot_still_refers(slot, rows)
+
+
+def test_a_refused_release_is_retried_when_the_sse_reader_flag_clears(tmp_path):
+    """``_has_reader`` is the other signal that can lift the guard."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+    slot._has_reader = True
+    rows = _stream(slot, ["x", "y"])
+
+    assert slot.purge_chunks() == 0
+    assert slot._pending_release_deferred is True
+
+    slot._has_reader = False  # the /api/chat loop clears this on 'done'
+
+    assert [m for m in slot._pending if m.get("role") == "chunk"] == []
+    assert not _slot_still_refers(slot, rows)
+
+
+def test_nested_consumers_retry_only_when_the_last_one_leaves(tmp_path):
+    """An inner reader detaching must not release rows the outer one still owns."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with slot.pending_consumer():
+        with slot.pending_consumer():
+            _stream(slot, ["1", "2"])
+            assert slot.purge_chunks() == 0
+        # Inner scope gone, outer still attached: rows must survive.
+        assert [m["content"] for m in slot._pending if m.get("role") == "chunk"] == ["1", "2"]
+    assert [m for m in slot._pending if m.get("role") == "chunk"] == []
+
+
+def test_a_release_never_refused_does_not_fire_on_detach(tmp_path):
+    """No deferral means no surprise release -- a reader mid-turn keeps its queue."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with slot.pending_consumer():
+        _stream(slot, ["q", "r"])  # streamed, but no purge was ever attempted
+        assert slot._pending_release_deferred is False
+
+    # Nothing asked for a release, so detaching must not invent one: these rows
+    # are still this turn's undelivered output.
+    assert [m["content"] for m in slot._pending if m.get("role") == "chunk"] == ["q", "r"]
+
+
+def test_a_consumer_that_drained_cleanly_has_nothing_to_retry(tmp_path):
+    """The ordinary path: drained rows are already gone, retry is a no-op."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with slot.pending_consumer():
+        tokens = ["ok", "!"]
+        _stream(slot, tokens)
+        assert slot.purge_chunks() == 0
+        delivered = [m["content"] for m in slot.drain() if m.get("role") == "chunk"]
+        assert delivered == tokens
+
+    assert slot._pending == []
+
+
+def test_openai_compat_response_survives_a_deferred_then_retried_release(tmp_path):
+    """End-to-end ordering: the client gets the full body, the slot keeps nothing."""
+    _make_state(tmp_path)
+    slot = _ChatSlot(key="dashboard:chat-1")
+
+    with slot.pending_consumer():
+        rows = _stream(slot, ["Hello", ", ", "world", "!"])
+        slot.purge_chunks()
+        body = "".join(m["content"] for m in slot.drain() if m.get("role") == "chunk")
+
+    assert body == "Hello, world!"
+    assert not _slot_still_refers(slot, rows)


### PR DESCRIPTION
## Problem

`append()` puts each streamed token row in **both** `slot.messages` and `slot._pending` — the same dict object in two lists (`state.py:2174`, `state.py:2178`). The nine turn-end purges in `chat_runner.py` rewrote `slot.messages` only:

```python
slot.messages = [m for m in slot.messages if m.get("role") != "chunk"]
```

So `_pending` remained the sole owner of every chunk dict and the purge freed nothing.

On the WebSocket transport — what the dashboard actually uses — nothing ever drains that queue. `api_chat` returns early for `ws_mode` (`chat_handlers.py:662-663`) before the SSE reader loop at `:671`, and `chat_runner.py` never calls `drain()` at all. The only WS-path drain runs at the **start of the slot's next turn** (`chat_handlers.py:616`).

Net effect: a slot that finishes a long streamed turn and is then abandoned holds its entire token stream for the life of the process. `_pending` has no cap, and slot count is itself unbounded (`chat_utils.py:772` — *"slots are themselves unbounded in number"*), so this accumulates across abandoned tabs.

## Fix

Add `_ChatSlot.purge_chunks()` as the single owner of *"this turn's streamed tokens are now represented by a finalized assistant message, so the raw chunk rows are dead"*, and route all nine sites through it. That also collapses nine copies of the same comprehension.

## Why the release is guarded

Releasing from `_pending` is only safe when nothing can still deliver those rows. The queue serves two unrelated roles:

- For a **WebSocket** client it is dead weight — every row it holds was already broadcast.
- For an **SSE** reader (`/api/chat`) or an **OpenAI-compatible** reader (`/v1/chat/completions`) it *is* the delivery queue. A row still in it has not reached the client, so dropping one truncates the answer.

Two signals are needed because they arm at different moments:

- `_has_reader` is set before the SSE turn is dispatched, covering the window before the reader loop's first iteration.
- A new **counted** `pending_consumer()` scope covers the span of each reader loop.

The OpenAI-compatible paths deliberately do not set `_has_reader` — that flag also suppresses the global message broadcast, which those slots still want — so the counter is the only thing that sees them.

The consumer count is a **counter, not a boolean**: nothing forbids two readers on one slot, and a boolean would let the first to finish declare the queue unowned while the second was still mid-stream.

## Testing

10 new tests, plus 374 existing tests green across `test_chat_runner_coverage.py`, `test_dashboard_chat_handlers_coverage.py`, `test_openai_compat.py`, and `test_dashboard_cron_to_chat_handler.py`. Verified 0 raw chunk comprehensions remain in `chat_runner.py`.

Mutation-verified — forcing `pending_has_consumer` to False fails 5 tests, including `test_openai_compat_response_survives_a_turn_end_purge` with `assert '' == 'Hello, world!'`. That is precisely the data-loss the guard exists to prevent, so the guard is load-bearing rather than defensive decoration.

## Not addressed here

The uncapped **slot count** and the 500-row-per-restored-slot retention at startup (`chat_persistence.py:1005-1007`) are the larger retainers in this layer and are left for separate changes.

no linked issue: no issue was filed for this. The retained chunk rows were found by reading the slot code during a customer-reported memory investigation (a 1.66 GB python3 process on macOS), not from a tracker item, and the mechanism plus the mutation evidence are recorded in the body above.
