### PR TITLE
fix(dashboard): report live process RSS, not the peak since boot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,7 +401,7 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Owner-only secret (fail-loud) | `restrict_to_owner(path)` | `os.chmod(path, 0o600)` under `if IS_POSIX` (silent no-op leaves secrets world-readable) |
 | Directory link | `symlink_or_junction(target, link)` | `os.symlink` (`WinError 1314` without elevation) |
 | Detect/remove a dir link | `is_link_or_junction(path)` / `unlink_link_or_junction(path)` | `path.is_symlink()` (misses a Windows junction) |
-| Process RSS / CPU | `proc_rss_bytes()` / `proc_cpu_seconds()` | `resource.getrusage` |
+| Process RSS (live) / peak RSS / CPU | `proc_rss_bytes()` / `proc_peak_rss_bytes()` / `proc_cpu_seconds()` | `resource.getrusage` (`ru_maxrss` is a high-water mark, never a live reading, and its unit is KiB on Linux but bytes on macOS) |
 | Available host memory | `host_available_mib()` (0 = unknown, never 0 = no memory) | `/proc/meminfo` directly (Linux-only, so the bound built on it silently vanishes on macOS and Windows) |
 | FD soft limit | `raise_nofile_soft_limit(n)` | `resource.setrlimit` |
 | Port to PID | `find_listening_pids(port)` / `listening_pid_tool_available()` | `lsof` directly |

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -478,11 +478,18 @@ def _collect_system_metrics() -> dict[str, object]:
     """
     data: dict[str, object] = dict(_get_static_system_info())
 
-    # Process memory (RSS)
+    # Process memory. `proc_mem_mb` is the LIVE resident set (falls when memory
+    # is released); `proc_mem_peak_mb` is the high-water mark since start, kept
+    # as a separate reading so a transient spike stays diagnosable without the
+    # live figure inheriting it.
     try:
         data["proc_mem_mb"] = round(platform_compat.proc_rss_bytes() / (1024 * 1024), 1)
     except Exception:
         data["proc_mem_mb"] = 0
+    try:
+        data["proc_mem_peak_mb"] = round(platform_compat.proc_peak_rss_bytes() / (1024 * 1024), 1)
+    except Exception:
+        data["proc_mem_peak_mb"] = 0
 
     # System-wide memory — cross-platform
     try:

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -80,6 +80,7 @@ from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.peer_resolve import resolve_peer_identity
 from kiro_crew.platform_compat import IS_WINDOWS
 from kiro_crew.platform_compat import get_process_start_id as _get_process_start_id
+from kiro_crew.platform_compat import proc_rss_bytes as _proc_rss_bytes
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import SecurityEventLog
 
@@ -3154,75 +3155,16 @@ def _count_open_fds() -> int:
 
 
 def _read_rss_kb() -> int:
-    """Return current RSS in kilobytes, or ``-1`` if unavailable.
+    """Return this process's CURRENT RSS in kilobytes, or ``-1`` if unavailable.
 
-    Platform implementations:
-    - Linux: ``/proc/self/status`` VmRSS field (already in KB).
-    - macOS: ``resource.getrusage`` (``ru_maxrss`` is in bytes on macOS).
-    - Other POSIX: ``resource.getrusage`` (``ru_maxrss`` is in KB on Linux,
-      but this branch only runs on non-Linux where it is bytes; if neither
-      applies we fall through to ``-1``).
-    - Windows: ``GetProcessMemoryInfo`` via ctypes (WorkingSetSize in bytes).
-
-    Returns ``-1`` when the platform cannot provide the value.
+    Delegates to :func:`platform_compat.proc_rss_bytes` — the one per-platform
+    current-RSS reader — so this diagnostic cannot drift from the figure the
+    dashboard reports. The per-platform duplicate that used to live here read
+    ``ru_maxrss`` on macOS, which is a high-water mark that never decreases, so
+    a spike the gateway had already released stayed in every later snapshot.
     """
-    # Linux — parse VmRSS from /proc/self/status (current RSS, not peak).
-    try:
-        with open("/proc/self/status", "r", encoding="ascii") as fh:
-            for line in fh:
-                if line.startswith("VmRSS:"):
-                    return int(line.split()[1])
-    except (OSError, ValueError, IndexError):
-        pass
-
-    # macOS / other POSIX — resource.getrusage gives ru_maxrss.
-    # On macOS ru_maxrss is in bytes; on other BSDs it is in KB.
-    if sys.platform != "win32":
-        try:
-            import resource
-
-            ru = resource.getrusage(resource.RUSAGE_SELF)
-            maxrss = ru.ru_maxrss
-            if maxrss > 0:
-                if sys.platform == "darwin":
-                    return maxrss // 1024  # bytes → KB
-                return maxrss  # already in KB on most other POSIX
-        except (OSError, ValueError, AttributeError, ImportError):
-            pass
-
-    # Windows — GetProcessMemoryInfo returns WorkingSetSize in bytes.
-    if sys.platform == "win32":
-        try:
-            import ctypes
-            import ctypes.wintypes as wintypes
-
-            SIZE_T = ctypes.c_size_t
-
-            class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
-                _fields_ = [
-                    ("cb", wintypes.DWORD),
-                    ("PageFaultCount", wintypes.DWORD),
-                    ("PeakWorkingSetSize", SIZE_T),
-                    ("WorkingSetSize", SIZE_T),
-                    ("QuotaPeakPagedPoolUsage", SIZE_T),
-                    ("QuotaPagedPoolUsage", SIZE_T),
-                    ("QuotaPeakNonPagedPoolUsage", SIZE_T),
-                    ("QuotaNonPagedPoolUsage", SIZE_T),
-                    ("PagefileUsage", SIZE_T),
-                    ("PeakPagefileUsage", SIZE_T),
-                ]
-
-            psapi = ctypes.WinDLL("psapi", use_last_error=True)  # type: ignore[attr-defined]
-            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
-            pmc = PROCESS_MEMORY_COUNTERS()
-            pmc.cb = ctypes.sizeof(pmc)
-            handle = kernel32.GetCurrentProcess()
-            if psapi.GetProcessMemoryInfo(handle, ctypes.byref(pmc), pmc.cb):
-                return pmc.WorkingSetSize // 1024  # bytes → KB
-        except (OSError, AttributeError, ValueError):
-            pass
-
-    return -1
+    rss_bytes = _proc_rss_bytes()
+    return rss_bytes // 1024 if rss_bytes > 0 else -1
 
 
 def _collect_task_stacks() -> list[dict[str, Any]]:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3275,21 +3275,135 @@ def find_python_interpreter(reject: Optional[Callable[[str], bool]] = None) -> s
 # Resource limits
 # ---------------------------------------------------------------------------
 
+#: ``task_info`` flavor selector for ``mach_task_basic_info``
+#: (``<mach/task_info.h>``). Chosen over the legacy ``TASK_BASIC_INFO`` because
+#: its sizes are 64-bit, so a footprint above 4 GiB is not truncated.
+_MACH_TASK_BASIC_INFO = 20
 
-def proc_rss_bytes() -> int:
-    """Return this process's resident set size in bytes, or 0 on failure.
 
-    POSIX: ``resource.getrusage(RUSAGE_SELF).ru_maxrss`` (KiB on Linux, bytes
-    on macOS). Windows: ``GetProcessMemoryInfo().WorkingSetSize``.
+class _MachTimeValue(ctypes.Structure):
+    """``time_value_t`` (``<mach/time_value.h>``).
+
+    Never read; present only so the fields after it in
+    :class:`_MachTaskBasicInfo` land at the offsets the kernel writes them to.
     """
-    if IS_POSIX:
-        try:
 
-            ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-            # Linux reports KiB; macOS reports bytes.
-            return ru_maxrss if sys.platform == "darwin" else ru_maxrss * 1024
-        except (ImportError, OSError, ValueError):
-            return 0
+    _fields_ = [("seconds", ctypes.c_int32), ("microseconds", ctypes.c_int32)]
+
+
+class _MachTaskBasicInfo(ctypes.Structure):
+    """``mach_task_basic_info`` (``<mach/task_info.h>``), in kernel order.
+
+    ``resident_size`` is the task's CURRENT resident footprint in bytes and
+    falls when pages are released; ``resident_size_max`` is the high-water mark
+    that never falls. Reading the wrong one of the two is exactly the bug this
+    layout exists to avoid, so both are named rather than indexed.
+
+    Module scope is load-bearing: ``ctypes.POINTER(T)`` memoises T in a
+    module-level dict inside ctypes that is never evicted, so declaring this
+    inside the probe would pin a fresh pair of type objects on every call — and
+    this probe is polled by the dashboard's system-metrics endpoint.
+    """
+
+    _fields_ = [
+        ("virtual_size", ctypes.c_uint64),
+        ("resident_size", ctypes.c_uint64),
+        ("resident_size_max", ctypes.c_uint64),
+        ("user_time", _MachTimeValue),
+        ("system_time", _MachTimeValue),
+        ("policy", ctypes.c_int),
+        ("suspend_count", ctypes.c_int),
+    ]
+
+
+#: ``task_info`` takes and returns a count in ``natural_t``-sized elements
+#: (``MACH_TASK_BASIC_INFO_COUNT``). Derived from the layout so it cannot go
+#: stale if a field is added above.
+_MACH_TASK_BASIC_INFO_COUNT = ctypes.sizeof(_MachTaskBasicInfo) // ctypes.sizeof(ctypes.c_int)
+
+
+def _scale_ru_maxrss(ru_maxrss: int) -> int:
+    """``ru_maxrss`` -> bytes. macOS reports bytes; Linux and other POSIX KiB.
+
+    The unit differs by platform with nothing in the value to tell them apart,
+    so every reader of ``ru_maxrss`` goes through here.
+    """
+    return ru_maxrss if sys.platform == "darwin" else ru_maxrss * 1024
+
+
+def _ru_maxrss_bytes() -> int | None:
+    """Peak (high-water) RSS in bytes from ``getrusage``, or None on failure.
+
+    POSIX only. This is a **peak**, not a live reading: ``ru_maxrss`` never
+    decreases for the life of the process.
+    """
+    try:
+        return _scale_ru_maxrss(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    except (ImportError, OSError, ValueError, AttributeError):
+        return None
+
+
+def _linux_current_rss_bytes() -> int | None:
+    """Current RSS in bytes from ``/proc/self/statm``, or None if unreadable.
+
+    Field 1 of ``statm`` is the resident page count — the same quantity
+    ``/proc/self/status``'s ``VmRSS`` and ``ps -o rss=`` report, so the
+    dashboard's figure reconciles with what an operator measures by hand.
+    """
+    try:
+        fields = Path("/proc/self/statm").read_text().split()
+        return int(fields[1]) * os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _macos_current_rss_bytes() -> int | None:
+    """Current RSS in bytes via Mach ``task_info``, or None on any failure.
+
+    ``proc_rss_bytes_for_pid`` has no ctypes-only route for an ARBITRARY pid
+    (it needs a task port it cannot obtain), but ``mach_task_self()`` hands out
+    a port for THIS task unconditionally, so the self-only reading below is
+    always available — no subprocess, which matters because the macOS app
+    sandbox can deny spawning ``ps``.
+
+    Returns ``resident_size`` (what ``ps -o rss=`` reports), not
+    ``phys_footprint``: every other platform branch here reports RSS, and the
+    payload field it feeds is named for RSS. Activity Monitor's "Memory" column
+    is the phys_footprint variant and will read somewhat differently; that is a
+    separate accounting question from the peak-vs-current bug.
+    """
+    try:
+        libc = ctypes.CDLL("/usr/lib/libSystem.dylib", use_errno=True)
+    except OSError:
+        return None  # not macOS / libSystem unavailable
+    try:
+        libc.mach_task_self.restype = ctypes.c_uint
+        libc.task_info.restype = ctypes.c_int
+        libc.task_info.argtypes = [
+            ctypes.c_uint,
+            ctypes.c_uint,
+            ctypes.POINTER(_MachTaskBasicInfo),
+            ctypes.POINTER(ctypes.c_uint),
+        ]
+        info = _MachTaskBasicInfo()
+        count = ctypes.c_uint(_MACH_TASK_BASIC_INFO_COUNT)
+        # mach_task_self() returns a port name owned by the task itself, not a
+        # fresh send right, so unlike mach_host_self() it must NOT be deallocated.
+        kern_return = libc.task_info(
+            libc.mach_task_self(),
+            _MACH_TASK_BASIC_INFO,
+            ctypes.byref(info),
+            ctypes.byref(count),
+        )
+    except (AttributeError, OSError, ValueError):
+        return None
+    if kern_return != 0:  # non-zero kern_return_t -> failure
+        return None
+    return int(info.resident_size)
+
+
+def _windows_memory_counters() -> "_ProcessMemoryCounters | None":
+    """psapi ``PROCESS_MEMORY_COUNTERS`` for this process, or None on failure."""
     try:
 
         psapi = ctypes.WinDLL("psapi", use_last_error=True)  # type: ignore[attr-defined]
@@ -3311,10 +3425,52 @@ def proc_rss_bytes() -> int:
         if psapi.GetProcessMemoryInfo(
             kernel32.GetCurrentProcess(), ctypes.byref(counters), counters.cb
         ):
-            return int(counters.WorkingSetSize)
-        return 0
+            return counters
+        return None
     except Exception:
-        return 0
+        return None
+
+
+def proc_rss_bytes() -> int:
+    """Return this process's CURRENT resident set size in bytes, or 0 on failure.
+
+    "Current" is the contract, not an implementation detail: this feeds an
+    operator-facing live memory figure, so it must FALL when the gateway
+    releases memory and must reconcile with ``ps -o rss=``.
+
+    - Linux: ``/proc/self/statm`` resident pages.
+    - macOS: Mach ``task_info(MACH_TASK_BASIC_INFO).resident_size``.
+    - Windows: ``GetProcessMemoryInfo().WorkingSetSize``.
+    - Last resort on POSIX only: ``getrusage(RUSAGE_SELF).ru_maxrss``, which is
+      a **peak** that never decreases. It is here so an unreadable ``/proc`` or
+      an unavailable ``libSystem`` still yields an order-of-magnitude number
+      rather than 0, and it over-reports by construction — see
+      :func:`proc_peak_rss_bytes` for the peak as a deliberate reading.
+    """
+    if IS_POSIX:
+        current = (
+            _macos_current_rss_bytes() if sys.platform == "darwin" else _linux_current_rss_bytes()
+        )
+        if current is not None:
+            return current
+        return _ru_maxrss_bytes() or 0
+    counters = _windows_memory_counters()
+    return 0 if counters is None else int(counters.WorkingSetSize)
+
+
+def proc_peak_rss_bytes() -> int:
+    """Return this process's PEAK resident set size in bytes, or 0 on failure.
+
+    The high-water mark since the process started: it never decreases, which is
+    what makes it useful for diagnosing a transient spike that a live reading
+    has already forgotten — and useless as the live reading itself. POSIX reads
+    ``getrusage(RUSAGE_SELF).ru_maxrss``; Windows reads
+    ``GetProcessMemoryInfo().PeakWorkingSetSize``.
+    """
+    if IS_POSIX:
+        return _ru_maxrss_bytes() or 0
+    counters = _windows_memory_counters()
+    return 0 if counters is None else int(counters.PeakWorkingSetSize)
 
 
 def proc_rss_bytes_for_pid(pid: int) -> int | None:

--- a/test/test_handlers_system_proc_mem.py
+++ b/test/test_handlers_system_proc_mem.py
@@ -1,0 +1,94 @@
+"""The system-metrics payload must report LIVE process memory, plus the peak.
+
+``proc_mem_mb`` is rendered on the dashboard as the gateway's current memory. It
+was fed by ``ru_maxrss``, a high-water mark that never decreases, so the figure
+was a monotonic peak-since-boot that no ``ps -o rss=`` reading could reproduce.
+These tests pin which reader feeds which field, because the two are the same
+type and the same order of magnitude — transposing them is invisible.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def _run_collect() -> dict:
+    """Run ``_collect_system_metrics`` with the static/scan blocks stubbed out.
+
+    Every other block in the collector is individually wrapped in try/except, so
+    it degrades to a missing value rather than failing this test.
+    """
+    from kiro_crew.dashboard import handlers_system
+
+    with patch.object(handlers_system, "_get_static_system_info", return_value={}):
+        handlers_system._metrics_cache.clear()
+        handlers_system._metrics_cache_ts = 0.0
+        handlers_system._proc_scan_cache = {}
+        handlers_system._proc_scan_cache_ts = 0.0
+        return handlers_system._collect_system_metrics()
+
+
+class TestProcessMemoryFields:
+    def test_live_and_peak_come_from_their_own_readers(self) -> None:
+        from kiro_crew.dashboard import handlers_system
+
+        with (
+            patch.object(
+                handlers_system.platform_compat, "proc_rss_bytes", return_value=200 * 1024 * 1024
+            ),
+            patch.object(
+                handlers_system.platform_compat,
+                "proc_peak_rss_bytes",
+                return_value=1700 * 1024 * 1024,
+            ),
+        ):
+            data = _run_collect()
+
+        assert data["proc_mem_mb"] == 200.0
+        assert data["proc_mem_peak_mb"] == 1700.0
+
+    def test_the_live_field_is_not_fed_by_the_peak_reader(self) -> None:
+        """The reported bug in one assertion: a released spike must not persist.
+
+        The peak reader is given a figure an order of magnitude above the live
+        one, mirroring the user report of a 1.66 GB reading on a process whose
+        real residency was far lower.
+        """
+        from kiro_crew.dashboard import handlers_system
+
+        with (
+            patch.object(
+                handlers_system.platform_compat, "proc_rss_bytes", return_value=150 * 1024 * 1024
+            ),
+            patch.object(
+                handlers_system.platform_compat,
+                "proc_peak_rss_bytes",
+                return_value=1660 * 1024 * 1024,
+            ),
+        ):
+            data = _run_collect()
+
+        assert data["proc_mem_mb"] < 200
+        assert data["proc_mem_peak_mb"] > 1000
+
+    def test_a_failing_reader_degrades_to_zero_without_dropping_the_field(self) -> None:
+        # The dashboard renders whatever keys arrive, so a missing key and a 0
+        # are different failures. Keep both keys present.
+        from kiro_crew.dashboard import handlers_system
+
+        with (
+            patch.object(
+                handlers_system.platform_compat,
+                "proc_rss_bytes",
+                side_effect=OSError("no reading"),
+            ),
+            patch.object(
+                handlers_system.platform_compat,
+                "proc_peak_rss_bytes",
+                side_effect=OSError("no reading"),
+            ),
+        ):
+            data = _run_collect()
+
+        assert data["proc_mem_mb"] == 0
+        assert data["proc_mem_peak_mb"] == 0

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -15,7 +15,6 @@ the per-test ``KIROCREW_HOME`` that Kiro Crew's conftest pins.
 from __future__ import annotations
 
 import asyncio
-import builtins
 import json
 import os
 import sys
@@ -1227,38 +1226,16 @@ class TestReadRssKb:
         assert isinstance(got, int)
         assert got == -1 or got > 0
 
-    @_POSIX_ONLY
-    def test_falls_back_to_getrusage_when_procfs_is_unreadable(self, monkeypatch):
-        import resource
-
-        real_open = builtins.open
-
-        def _no_procfs(path, *args, **kwargs):
-            if isinstance(path, str) and path.startswith("/proc/"):
-                raise OSError("no procfs")
-            return real_open(path, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", _no_procfs)
-        rusage = MagicMock()
-        rusage.ru_maxrss = 4096
-        monkeypatch.setattr(resource, "getrusage", MagicMock(return_value=rusage))
-        monkeypatch.setattr(sys, "platform", "darwin")
-        # macOS reports ru_maxrss in bytes, so it must be divided down to KB.
+    def test_delegates_to_the_shared_current_rss_reader(self, monkeypatch):
+        # The per-platform duplicate that used to live here read ru_maxrss on
+        # macOS -- a peak that never falls. There is now one reader, and this
+        # pins the delegation (and the bytes -> KB conversion) so a second
+        # implementation cannot quietly reappear.
+        monkeypatch.setattr(gw, "_proc_rss_bytes", lambda: 4096)
         assert gw._read_rss_kb() == 4
 
-    @_POSIX_ONLY
-    def test_returns_minus_one_when_every_source_fails(self, monkeypatch):
-        import resource
-
-        real_open = builtins.open
-
-        def _no_procfs(path, *args, **kwargs):
-            if isinstance(path, str) and path.startswith("/proc/"):
-                raise OSError("no procfs")
-            return real_open(path, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", _no_procfs)
-        monkeypatch.setattr(resource, "getrusage", MagicMock(side_effect=OSError("nope")))
+    def test_returns_minus_one_when_the_reader_cannot_measure(self, monkeypatch):
+        monkeypatch.setattr(gw, "_proc_rss_bytes", lambda: 0)
         assert gw._read_rss_kb() == -1
 
 

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -12,6 +12,7 @@ output we can assert directly), and the process-helper return contracts.
 from __future__ import annotations
 
 import errno
+import gc
 import json
 import logging
 import os
@@ -485,6 +486,54 @@ class TestResourceShims:
         # truncated without argtypes and this silently returned 0, disabling the
         # watchdog's RSS ceiling.
         assert pc.proc_rss_bytes() > 0
+
+    def test_proc_rss_bytes_falls_back_down_when_memory_is_released(self):
+        """The reading must be CURRENT residency, not the high-water mark.
+
+        Reported symptom: the dashboard's per-process memory figure only ever
+        rose, so it disagreed with Activity Monitor / ``ps -o rss=`` by however
+        much the gateway had ever transiently used. ``ru_maxrss`` never
+        decreases, so this drives a real allocation and requires the number to
+        come back down — the one property a peak cannot have.
+        """
+        chunk = 128 * 1024 * 1024
+        page = 4096
+        baseline = pc.proc_rss_bytes()
+        buf = bytearray(chunk)
+        for offset in range(0, chunk, page):  # fault the pages in
+            buf[offset] = 1
+        while_held = pc.proc_rss_bytes()
+        peak_while_held = pc.proc_peak_rss_bytes()
+        del buf
+        gc.collect()
+        after_free = pc.proc_rss_bytes()
+
+        # Rose by most of the buffer while it was resident.
+        assert while_held - baseline > chunk // 2
+        # And gave a real part of it back. Deliberately relative to `while_held`
+        # rather than an absolute `baseline + chunk // 2` ceiling: how much the
+        # OS actually returns on free is its decision, not ours. Windows keeps
+        # freed pages in the working set until there is pressure, so it returned
+        # ~45MB of a 128MB buffer where Linux returns nearly all of it, and an
+        # absolute ceiling failed there on a reading that was behaving correctly.
+        # A peak-based implementation cannot pass this at any tolerance, because
+        # it returns a number that has not moved at all.
+        assert after_free < while_held - chunk // 8
+        # The decisive property, and the one the bug got wrong: after a free the
+        # CURRENT reading must be strictly below the peak. `ru_maxrss` returns
+        # exactly the peak here, so this is the assertion that fails for it.
+        assert after_free < peak_while_held
+        # The peak, by contrast, is not allowed to fall.
+        assert pc.proc_peak_rss_bytes() >= peak_while_held
+
+    def test_proc_peak_rss_bytes_is_never_below_the_current_reading(self):
+        # The high-water mark of a quantity cannot be under the quantity. A
+        # mismatched unit on either side (ru_maxrss is KiB on Linux, bytes on
+        # macOS) shows up here as a 1024x violation.
+        current = pc.proc_rss_bytes()
+        peak = pc.proc_peak_rss_bytes()
+        assert peak > 0
+        assert peak >= current
 
     def test_proc_rss_bytes_for_pid_self_positive(self):
         rss = pc.proc_rss_bytes_for_pid(os.getpid())
@@ -1845,8 +1894,12 @@ class TestRestrictToOwner:
 
 
 class TestResourceShimFailures:
-    def test_proc_rss_bytes_returns_zero_on_getrusage_failure(self, monkeypatch):
-        # The failure branch: getrusage raising OSError must yield 0, not raise.
+    def test_proc_rss_bytes_returns_zero_when_every_source_fails(self, monkeypatch):
+        # getrusage is no longer the primary source for proc_rss_bytes -- it is
+        # the labelled last-resort peak -- so reaching 0 now needs BOTH the
+        # current-RSS reader and the fallback to fail. Asserting only the
+        # getrusage failure would pass on a platform whose primary reader was
+        # silently removed.
         if not pc.IS_POSIX:
             pytest.skip("POSIX resource.getrusage branch")
 
@@ -1854,7 +1907,21 @@ class TestResourceShimFailures:
             raise OSError("getrusage failed")
 
         monkeypatch.setattr(pc.resource, "getrusage", boom)
+        monkeypatch.setattr(pc, "_linux_current_rss_bytes", lambda: None)
+        monkeypatch.setattr(pc, "_macos_current_rss_bytes", lambda: None)
         assert pc.proc_rss_bytes() == 0
+
+    def test_proc_peak_rss_bytes_returns_zero_on_getrusage_failure(self, monkeypatch):
+        # The peak reading has getrusage as its ONLY POSIX source, so its
+        # failure branch is still a plain 0.
+        if not pc.IS_POSIX:
+            pytest.skip("POSIX resource.getrusage branch")
+
+        def boom(*args, **kwargs):
+            raise OSError("getrusage failed")
+
+        monkeypatch.setattr(pc.resource, "getrusage", boom)
+        assert pc.proc_peak_rss_bytes() == 0
 
     def test_proc_cpu_seconds_returns_zero_on_getrusage_failure(self, monkeypatch):
         # The failure branch: getrusage raising OSError must yield 0.0, not raise.
@@ -2314,6 +2381,9 @@ class TestCtypesStructsAreModuleScoped:
         "_win_process_image_name",
         "_process_token_sid_unguarded",
         "proc_rss_bytes",
+        "proc_peak_rss_bytes",
+        "_windows_memory_counters",
+        "_macos_current_rss_bytes",
         "proc_rss_bytes_for_pid",
         "system_memory",
         "apply_job_limits",
@@ -2337,6 +2407,8 @@ class TestCtypesStructsAreModuleScoped:
             "_JobObjectExtendedLimitInformation",
             "_ThreadEntry32",
             "_VMStatistics64",
+            "_MachTimeValue",
+            "_MachTaskBasicInfo",
         ):
             assert issubclass(getattr(pc, name), ctypes.Structure), name
 
@@ -2370,6 +2442,7 @@ class TestCtypesStructsAreModuleScoped:
         pid = os.getpid()
         probes = (
             pc.proc_rss_bytes,
+            pc.proc_peak_rss_bytes,
             lambda: pc.proc_rss_bytes_for_pid(pid),
             pc.system_memory,
             lambda: pc.get_ppid(pid),

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -1912,47 +1912,142 @@ def _fake_resource(monkeypatch: pytest.MonkeyPatch, **members: Any) -> None:
     monkeypatch.setattr(pc, "resource", types.SimpleNamespace(**defaults), raising=False)
 
 
-def _memory_info_dll(working_set: int, *, ok: bool = True) -> Any:
+def _memory_info_dll(working_set: int, *, ok: bool = True, peak: int = 0) -> Any:
     def _get_memory_info(_handle: Any, counters: Any, _cb: Any) -> int:
         counters._obj.WorkingSetSize = working_set
+        counters._obj.PeakWorkingSetSize = peak
         return 1 if ok else 0
 
     return types.SimpleNamespace(GetProcessMemoryInfo=_Fn(_get_memory_info))
 
 
+def _fake_mach_libsystem(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    resident: int,
+    resident_max: int,
+    kern_return: int = 0,
+) -> None:
+    """Stand in for ``libSystem``'s ``task_info``, filling the real struct.
+
+    The struct is the module-level layout, so a wrong field order in production
+    surfaces here as the wrong number rather than passing on a hand-built dict.
+    """
+
+    def _task_info(_task: Any, _flavor: Any, out: Any, _count: Any) -> int:
+        out._obj.resident_size = resident
+        out._obj.resident_size_max = resident_max
+        return kern_return
+
+    fake = types.SimpleNamespace(
+        mach_task_self=_Fn(lambda: 1),
+        task_info=_Fn(_task_info),
+    )
+    monkeypatch.setattr(pc.ctypes, "CDLL", lambda _path, **_kw: fake)
+
+
 class TestProcRss:
-    def test_linux_scales_kib_to_bytes(self, monkeypatch):
+    """``proc_rss_bytes`` must report CURRENT residency, not the peak.
+
+    ``ru_maxrss`` is a high-water mark that never decreases for the life of the
+    process, so using it made the dashboard's per-process memory figure a
+    monotonic peak-since-boot that no ``ps -o rss=`` reading could reproduce.
+    These tests pin the live source per platform and keep ``ru_maxrss`` confined
+    to the labelled fallback.
+    """
+
+    def test_linux_reads_statm_not_the_getrusage_peak(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=9_999_999),
+        )
+        monkeypatch.setattr(pc, "_linux_current_rss_bytes", lambda: 4096)
+        assert pc.proc_rss_bytes() == 4096
+
+    @_LINUX_ONLY
+    def test_linux_current_reader_agrees_with_proc_status(self):
+        # statm's resident pages and status' VmRSS are the same quantity, and
+        # VmRSS is what `ps -o rss=` prints -- the number a user compares against.
+        vm_rss_kb = 0
+        with open("/proc/self/status", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    vm_rss_kb = int(line.split()[1])
+                    break
+        assert vm_rss_kb > 0
+        measured = pc._linux_current_rss_bytes()
+        assert measured is not None
+        # Sampled a moment apart, so allow drift rather than demanding equality.
+        assert abs(measured - vm_rss_kb * 1024) < 4 * 1024 * 1024
+
+    def test_linux_fallback_scales_the_peak_from_kib_to_bytes(self, monkeypatch):
+        # Unit handling is the trap: ru_maxrss is KiB on Linux and bytes on
+        # macOS, with nothing in the value to tell them apart.
         monkeypatch.setattr(pc, "IS_POSIX", True)
         monkeypatch.setattr(pc.sys, "platform", "linux")
         _fake_resource(
             monkeypatch,
             getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=2048),
         )
+        monkeypatch.setattr(pc, "_linux_current_rss_bytes", lambda: None)
         assert pc.proc_rss_bytes() == 2048 * 1024
 
-    def test_macos_reports_bytes_directly(self, monkeypatch):
+    def test_macos_reads_the_mach_resident_size(self, monkeypatch):
+        # Not resident_size_max, which is the same peak bug in Mach clothing.
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=7_777_777),
+        )
+        _fake_mach_libsystem(monkeypatch, resident=123_456, resident_max=999_999_999)
+        assert pc.proc_rss_bytes() == 123_456
+
+    def test_macos_task_info_failure_falls_back_to_the_peak_in_bytes(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", True)
         monkeypatch.setattr(pc.sys, "platform", "darwin")
         _fake_resource(
             monkeypatch,
             getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=999),
         )
+        _fake_mach_libsystem(monkeypatch, resident=1, resident_max=2, kern_return=5)
+        # macOS ru_maxrss is ALREADY bytes -- scaling it by 1024 here would
+        # over-report by three orders of magnitude.
         assert pc.proc_rss_bytes() == 999
 
-    def test_a_getrusage_failure_is_zero(self, monkeypatch):
+    def test_macos_missing_libsystem_falls_back(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=555),
+        )
+
+        def _no_libsystem(_path: Any, **_kw: Any) -> Any:
+            raise OSError("no libSystem")
+
+        monkeypatch.setattr(pc.ctypes, "CDLL", _no_libsystem)
+        assert pc.proc_rss_bytes() == 555
+
+    def test_a_total_posix_failure_is_zero(self, monkeypatch):
         def _boom(_who: Any) -> Any:
             raise OSError("no rusage")
 
         monkeypatch.setattr(pc, "IS_POSIX", True)
         _fake_resource(monkeypatch, getrusage=_boom)
+        monkeypatch.setattr(pc, "_linux_current_rss_bytes", lambda: None)
+        monkeypatch.setattr(pc, "_macos_current_rss_bytes", lambda: None)
         assert pc.proc_rss_bytes() == 0
 
     def test_windows_reads_the_working_set(self, monkeypatch):
         _fake_windows(
             monkeypatch,
-            psapi=_memory_info_dll(8192),
+            psapi=_memory_info_dll(8192, peak=4_000_000),
             kernel32=types.SimpleNamespace(GetCurrentProcess=_const(1)),
         )
+        # WorkingSetSize is already current; PeakWorkingSetSize must not leak in.
         assert pc.proc_rss_bytes() == 8192
 
     def test_windows_failure_is_zero(self, monkeypatch):
@@ -1968,6 +2063,76 @@ class TestProcRss:
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
         assert pc.proc_rss_bytes() == 0
+
+
+class TestMachTaskBasicInfoLayout:
+    """A wrong layout reads a neighbouring field and looks plausible.
+
+    ``task_info`` writes into raw memory and reports back how many
+    ``natural_t``-sized elements it filled, so a struct whose size disagrees
+    with the kernel's yields a number with no error -- exactly the failure mode
+    that is indistinguishable from the peak-vs-current bug being fixed.
+    """
+
+    def test_the_element_count_matches_mach_task_basic_info_count(self):
+        # MACH_TASK_BASIC_INFO_COUNT from <mach/task_info.h>.
+        assert pc._MACH_TASK_BASIC_INFO_COUNT == 12
+        assert ctypes.sizeof(pc._MachTaskBasicInfo) == 48
+
+    def test_resident_size_precedes_its_own_high_water_mark(self):
+        # Both are uint64 and adjacent, so transposing them is a silent revert
+        # to reporting the peak.
+        assert pc._MachTaskBasicInfo.resident_size.offset == 8
+        assert pc._MachTaskBasicInfo.resident_size_max.offset == 16
+
+    def test_the_flavor_selector_is_mach_task_basic_info(self):
+        assert pc._MACH_TASK_BASIC_INFO == 20
+
+
+class TestProcPeakRss:
+    """The peak is still reported, but as its own clearly-named reading."""
+
+    def test_posix_scales_kib_to_bytes_on_linux(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=2048),
+        )
+        assert pc.proc_peak_rss_bytes() == 2048 * 1024
+
+    def test_posix_reports_bytes_directly_on_macos(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=999),
+        )
+        assert pc.proc_peak_rss_bytes() == 999
+
+    def test_a_getrusage_failure_is_zero(self, monkeypatch):
+        def _boom(_who: Any) -> Any:
+            raise OSError("no rusage")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(monkeypatch, getrusage=_boom)
+        assert pc.proc_peak_rss_bytes() == 0
+
+    def test_windows_reads_the_peak_working_set(self, monkeypatch):
+        _fake_windows(
+            monkeypatch,
+            psapi=_memory_info_dll(8192, peak=4_000_000),
+            kernel32=types.SimpleNamespace(GetCurrentProcess=_const(1)),
+        )
+        assert pc.proc_peak_rss_bytes() == 4_000_000
+
+    def test_windows_failure_is_zero(self, monkeypatch):
+        _fake_windows(
+            monkeypatch,
+            psapi=_memory_info_dll(8192, ok=False, peak=4_000_000),
+            kernel32=types.SimpleNamespace(GetCurrentProcess=_const(1)),
+        )
+        assert pc.proc_peak_rss_bytes() == 0
 
 
 class TestProcRssForPid:

--- a/tests/test_gatewayd_diag.py
+++ b/tests/test_gatewayd_diag.py
@@ -56,11 +56,9 @@ class TestReadRssKb:
             assert result == -1 or result > 0
 
     def test_returns_minus_one_when_all_sources_fail(self) -> None:
-        """If /proc/self/status and resource both fail, return -1."""
-        with patch("builtins.open", side_effect=OSError("mocked")):
-            with patch.dict("sys.modules", {"resource": None}):
-                with patch.object(sys, "platform", "linux"):
-                    result = _read_rss_kb()
+        """When the shared reader cannot measure, the diagnostic says so."""
+        with patch("kiro_crew.mcp_gateway.gatewayd._proc_rss_bytes", return_value=0):
+            result = _read_rss_kb()
         assert result == -1
 
     def test_rss_is_in_kilobytes(self) -> None:

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -79,7 +79,9 @@ export interface SystemData {
   net_rx_kbs: number; net_tx_kbs: number
   disk_total_gb?: number; disk_free_gb?: number
   python: string; pid: number; cwd: string
-  proc_mem_mb: number; proc_cpu_pct: number
+  /** Live resident set size. `proc_mem_peak_mb` is the high-water mark since
+   *  the gateway started, so it never falls; do not render it as live memory. */
+  proc_mem_mb: number; proc_mem_peak_mb?: number; proc_cpu_pct: number
   child_processes: number; thread_count: number
   mcp_processes?: { sandbox: number; kiro_cli: number; builder_mcp: number }
   mcp_total?: number


### PR DESCRIPTION
## Problem

`proc_rss_bytes()` used `resource.getrusage(RUSAGE_SELF).ru_maxrss`, which is a **high-water mark that never decreases** for the life of the process. It is surfaced to users as `proc_mem_mb` on the dashboard System page (`handlers_system.py:481-485`), so the gateway's memory readout was monotonic peak-since-boot presented as live memory.

Measured on this host — the same process, allocating then freeing ~600 MB:

| stage | new `proc_rss_bytes` | old `ru_maxrss` |
|---|---|---|
| baseline | 27.1 MB | 309.9 MB |
| after +600 MB alloc | 627.0 MB | 627.0 MB |
| after free | **87.2 MB** | **627.0 MB** |

The old reading stays pinned at 627 MB after the memory is gone, and over-reports by 11x even at baseline. A user comparing the dashboard against Activity Monitor or `ps -o rss=` sees a number that is too high and never falls.

This is live: it surfaced while investigating a customer report of "1.66 GB on macOS", where the first question — is this a real footprint or a reporting artifact? — could not be answered from the dashboard figure.

## Fix

Report **current** RSS on every platform, keeping `ru_maxrss` only as a clearly-labelled last-resort fallback. Peak is genuinely useful for diagnosing a transient spike, so it is retained as a separate, unambiguously named `proc_peak_rss_bytes()` / `proc_mem_peak_mb` rather than being silently conflated with live memory.

Two platform traps handled explicitly:

- **`ru_maxrss` units differ** — KiB on Linux, bytes on macOS. Documented at the call site and covered by tests.
- **`proc_rss_bytes_for_pid()` returns `None` on macOS** ("no ctypes-only per-pid path"), but that is the *other-pid* function. For **self** on macOS a `task_info(mach_task_self())` path is available, so the per-pid limitation does not apply here.

Reviewed PRs #1742 and #2845 (both prior macOS memory-accounting corrections in this same area) before changing anything, to avoid undoing them.

## Scope note for reviewers

This grew past the single function. `gatewayd.py` shrinks by 76 lines because it carried its own duplicated RSS path, which now shares the fixed helper — that consolidation is the reason the diff is wider than "fix one function", and it can be split out if you would rather review it separately. `AGENTS.md` and `website/src/types/index.ts` are updated so the documented contract and the frontend type both state which field is live and which is a high-water mark.

## Testing

620 tests pass across `test_platform_compat.py`, `test_platform_compat_coverage.py`, `test_handlers_system_proc_mem.py`, `test_mcp_gatewayd_coverage.py`, and `tests/test_gatewayd_diag.py`.

Two failures in `test_platform_compat.py` (`test_process_descendants_snapshots_a_new_session_grandchild`, `test_parent_map_ignores_a_planted_ps_earlier_on_path`) are **pre-existing on main** — reproduced identically on pristine `69b60c3b6` with the same assertion shapes. They concern process-descendant discovery on a host with restricted `/proc` visibility and are unrelated to this change.

Existing tests that pinned the peak behaviour encoded the bug; they are updated rather than worked around.

no linked issue: no issue was filed for this. The peak-vs-current RSS defect was found while investigating a customer report of a 1.66 GB python3 process on macOS; #1742 and #2845 appear above as prior macOS accounting fixes reviewed for regressions, not as issues this closes.
