### PR TITLE
fix(config): drive session.pool_size default from one constant

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -619,7 +619,7 @@ class SessionConfig:
     timeout_secs: int = 3600       # 60 min idle timeout (DEFAULT_SESSION_TIMEOUT)
     empty_response_auto_continue: bool = True  # after TWO consecutive empty model responses, auto-send ONE synthetic "continue" nudge on the same live session (transcript-visible notice; bounded to once per user message; the config gate fails OPEN to the default so a config-load hiccup cannot disable self-healing). See session.md "Empty-response recovery ladder".
     autocompact_pct: float = 70.0  # context usage % at which auto-compaction triggers (DEFAULT_AUTOCOMPACT_PCT). Load-time clamped to [5.0, 90.0] (one constant pair shared with the dashboard write gate)
-    pool_size: int = 2             # pre-warmed kiro-cli processes kept ready for instant session start; 0 disables. Load-time clamped to [0, 10]
+    pool_size: int = 0             # pre-warmed kiro-cli processes kept ready for instant session start; 0 (the default) disables. Single source of truth: DEFAULT_POOL_SIZE, read by both the field default and load()'s file-parse fallback. Load-time clamped to [0, 10]
     watchdog_rss_max_mb: int = 0   # recycle a session when its process tree RSS exceeds this many MiB; 0 disables (default). Busy sessions (turn in flight) are never recycled.
 
 @dataclass

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -243,6 +243,20 @@ DEFAULT_AUTOCOMPACT_PCT = 70.0
 # unreachable and the early signal disappears for whoever did not change the
 # default. Kept here rather than in either consumer so the two cannot drift.
 CONTEXT_WARN_MARGIN_PCT = 20.0
+# session.pool_size — warm pool OFF by default. Each pooled slot is a full
+# kiro-cli process plus the MCP stdio servers its agent spec spawns (~109 MB per
+# backend), and a non-zero value is also reserved out of the memory term that
+# sizes the subagent cap (subagent.compute_max_subagents), so the cost is paid on
+# every host whether or not the pool is ever claimed. Cold start is instead
+# hidden by session.eager_spawn, which is on by default and pre-creates a slot's
+# session behind user think-time.
+#
+# Read by BOTH the SessionConfig field default and load()'s file-parse fallback,
+# because those are two independent paths to the same value: a home with no
+# config.json takes the field default, and a config.json that omits the key takes
+# the parse fallback. A literal in either place lets the two disagree, which is
+# invisible on disk — this constant is the only place the value is written.
+DEFAULT_POOL_SIZE = 0
 DEFAULT_MAX_PARALLEL_STEPS = (
     0  # 0 = auto: derive from agent.subagent_auto_max via compute_max_subagents
 )
@@ -1838,7 +1852,7 @@ class SessionConfig:
         ),
     )
     pool_size: int = field(
-        default=0,
+        default=DEFAULT_POOL_SIZE,
         metadata=_meta(
             "Warm Pool Size",
             "Number of pre-spawned kiro-cli processes kept ready for instant session start. 0 disables.",
@@ -6532,7 +6546,12 @@ class KiroCrewConfig:
                     lo=AUTOCOMPACT_PCT_MIN,
                     hi=AUTOCOMPACT_PCT_MAX,
                 ),
-                pool_size=_safe_int(session_data.get("pool_size", 2), 2, 0, POOL_SIZE_MAX),
+                pool_size=_safe_int(
+                    session_data.get("pool_size", DEFAULT_POOL_SIZE),
+                    DEFAULT_POOL_SIZE,
+                    0,
+                    POOL_SIZE_MAX,
+                ),
                 pool_agent=str(session_data.get("pool_agent", "")),
                 pool_ttl_secs=_safe_int(session_data.get("pool_ttl_secs", 1800), 1800),
                 eager_spawn=bool(session_data.get("eager_spawn", True)),

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -6,10 +6,12 @@ for property-based testing.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
 import platform
+import re
 import tempfile
 import unittest.mock
 from pathlib import Path
@@ -88,6 +90,25 @@ def _load_from_dict(data: object) -> KiroCrewConfig:
             return KiroCrewConfig.load()
     finally:
         tmp.unlink(missing_ok=True)
+
+
+def _load_absent_config() -> KiroCrewConfig:
+    """Load with NEITHER config.json nor config.local.json present.
+
+    This is the only path that reaches the dataclass field defaults, so it is
+    what a default must be compared against.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        missing = Path(d) / "config.json"
+        missing_local = Path(d) / "config.local.json"
+        with unittest.mock.patch(
+            "kiro_crew.config.loader.config_path",
+            return_value=missing,
+        ), unittest.mock.patch(
+            "kiro_crew.config.loader.config_local_path",
+            return_value=missing_local,
+        ):
+            return KiroCrewConfig.load()
 
 
 def _load_from_raw_string(content: str) -> KiroCrewConfig:
@@ -2978,6 +2999,68 @@ class TestAutocompactPctLoadClamp:
         assert (AUTOCOMPACT_PCT_MIN, AUTOCOMPACT_PCT_MAX) == (5.0, 90.0)
 
 
+class TestPoolSizeDefaultSingleSource:
+    """``session.pool_size`` has TWO independent paths to its default and they
+    must not be able to disagree.
+
+    A home with no ``config.json`` at all constructs ``SessionConfig()`` and
+    takes the dataclass field default; a home WITH a ``config.json`` that omits
+    the key reaches ``load()``'s file-parse fallback instead. An install that has
+    run setup is always the second case, so a literal at the parse site decides
+    the real default for essentially every host while the field default decides
+    what the schema, the docs, and a never-set-up home report. The disagreement
+    is invisible on disk: nothing serializes the difference, and each pooled slot
+    it silently buys is a kiro-cli process plus that agent's MCP stdio servers.
+    """
+
+    def test_field_default_reads_the_shared_constant(self) -> None:
+        assert loader_module.DEFAULT_POOL_SIZE == 0
+        assert (
+            SessionConfig.__dataclass_fields__["pool_size"].default
+            == loader_module.DEFAULT_POOL_SIZE
+        )
+        assert SessionConfig().pool_size == loader_module.DEFAULT_POOL_SIZE
+
+        # A dataclass default is bound at class creation, so no runtime
+        # assertion can tell a literal that happens to equal the constant from
+        # the constant itself. Read the declaration to close that gap: a literal
+        # here is exactly how the two spellings come apart.
+        decl = re.search(
+            r"pool_size:\s*int\s*=\s*field\(\s*default=([^,\s]+)\s*,",
+            inspect.getsource(SessionConfig),
+        )
+        assert decl is not None, "SessionConfig.pool_size field declaration not found"
+        assert decl.group(1) == "DEFAULT_POOL_SIZE"
+
+    def test_omitted_key_and_absent_file_agree(self) -> None:
+        """The behavioural invariant, stated without naming a value: whether a
+        config file omits ``pool_size``, omits the whole ``session`` block, or
+        does not exist, all three land on the same warm-pool size."""
+        omits_key = _load_from_dict({"session": {"timeout_secs": 1800}}).session.pool_size
+        omits_section = _load_from_dict({"agent": {"provider": "acp"}}).session.pool_size
+        no_file = _load_absent_config().session.pool_size
+
+        assert omits_key == omits_section == no_file == loader_module.DEFAULT_POOL_SIZE
+
+    def test_parse_fallback_holds_no_literal_of_its_own(self) -> None:
+        """Repoint the constant and the file-parse path must follow it.
+
+        This is what makes the constant the ONLY definition rather than merely
+        one that happens to agree today: with a literal at the parse site, the
+        loaded value ignores the repoint and this fails.
+        """
+        with unittest.mock.patch.object(loader_module, "DEFAULT_POOL_SIZE", 7):
+            assert _load_from_dict({"session": {}}).session.pool_size == 7
+            # The same fallback catches an unparseable value, so it must be
+            # sourced from the constant there too.
+            assert _load_from_dict({"session": {"pool_size": "two"}}).session.pool_size == 7
+
+    def test_explicit_value_still_wins_over_the_default(self) -> None:
+        """The reconciliation must not swallow a configured pool."""
+        assert _load_from_dict({"session": {"pool_size": 2}}).session.pool_size == 2
+        assert _load_from_dict({"session": {"pool_size": 0}}).session.pool_size == 0
+
+
 class TestConfigWriteProtection:
     """config.json / config.local.json are WRITE-protected (reads allowed)."""
 
@@ -3658,8 +3741,10 @@ class TestMalformedConfigNeverBricksLoad:
 
     def test_non_numeric_int_field_falls_back(self) -> None:
         # Pre-fix: ValueError: invalid literal for int() with base 10: 'two'.
+        # The fallback is the field's own default, read from the one constant
+        # that defines it rather than restated here.
         cfg = _load_from_dict({"session": {"pool_size": "two"}})
-        assert cfg.session.pool_size == 2
+        assert cfg.session.pool_size == loader_module.DEFAULT_POOL_SIZE
 
     def test_non_numeric_float_field_falls_back(self) -> None:
         cfg = _load_from_dict({"agent": {"subagent_cost_gb": "lots"}})


### PR DESCRIPTION
## Behaviour change, stated up front

This makes `session.pool_size` default to **0 (warm pool off)** on the paths that consult a default. Installs that currently pick up the accidental `2` lose two pre-warmed `kiro-cli` processes, which makes the first turn of a session cold. See "Why 0" and "Who is actually affected" below — the real blast radius is narrower than it first looks.

## Problem

The default disagreed across three places:

| Location | Value |
|---|---|
| `SessionConfig` field default (`config/loader.py`) | `0` |
| `load()` file-parse fallback (`loader.py:6207`) | `2` |
| `docs/system-specs/modules/config.md:667` | `2` |

`load()` is the path every real install takes, so a `config.json` that simply **omits** the key silently got a 2-process warm pool while reading the dataclass predicted zero. The two literals could drift because nothing tied them together.

This is not cosmetic. Each pooled slot is a full `kiro-cli` process plus the MCP stdio servers its agent spec spawns (~109 MB per backend, `agent.py:647`), and a non-zero `pool_size` is *also* reserved out of the memory term that sizes the subagent cap (`subagent.compute_max_subagents`) — so the cost is paid on every host whether or not the pool is ever claimed.

## Fix

One `DEFAULT_POOL_SIZE = 0` constant, read by **both** the field default and `load()`'s file-parse fallback, with the docs corrected to match. Those are two independent routes to the same value (no config file → field default; config file omitting the key → parse fallback), and a literal in either lets them disagree invisibly.

## Why 0 rather than 2

- It is what the dataclass and the field's own comment already claimed.
- Cold start is already hidden by `session.eager_spawn`, which is **on by default** and pre-creates a slot's session behind user think-time — so the warm pool is largely redundant with a mechanism that costs no idle processes.
- A default that reserves memory from the subagent cap on every host, claimed or not, is a poor default to arrive at by accident.

If maintainers prefer `2`, the correct change is the mirror image — set the constant to 2 and fix the dataclass and comment — and the single-constant structure here makes that a one-line change.

## Who is actually affected

Narrower than it appears, and worth knowing before weighing the latency cost. Per #4389, `to_dict` serializes the session block with `asdict`, so **every** `save()` writes all session keys explicitly — including `pool_size`. Any install that has ever saved config (dashboard settings PATCH, `kirocrew config set`, `agent add`, app install, onboarding import) already has its loaded value persisted to disk, and `load()` prefers a persisted value over any default.

So this reaches new installs and configs that omit the key. It does **not** reach installs that already persisted `pool_size: 2` — those keep their warm pool until someone edits the file. That also means the drift has already been baked into on-disk configs on hosts that loaded via the fallback and then saved. Migrating a persisted value is the product call #4389 exists to make and is deliberately not made here.

Related: #4389 (open) covers this class of default-does-not-reach-existing-installs problem; this PR fixes the drift, not the migration, so #4389 stays open.

## Testing

302 tests pass in `test_config_loader.py`, including new tests pinning that a config file omitting `pool_size` and no config file at all produce the **same** value, and that the constant is the only definition of it.

no linked issue: #4389 is cited as related context and must stay OPEN - it tracks whether a persisted config value should be migrated on existing installs, which this PR deliberately does not decide. This PR fixes only the default drift, so closing #4389 on merge would be wrong.
