### PR TITLE
fix: unify transport context-threshold coercion and clamping (#4688)

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -393,6 +393,41 @@ def _safe_nonnegative_int(value: object, default: int) -> int:
     return result if result >= 0 else default
 
 
+def _clamp_pct(value: int) -> int:
+    """Clamp an integer context-threshold percentage to 1..100.
+
+    The single statement of the range: the floor is 1, not 0, because a 0%
+    threshold means "always over" and would fire the notice/compaction on
+    every turn.
+    """
+    return max(1, min(100, value))
+
+
+def _threshold_pct(raw: object, default: int) -> int:
+    """Coerce a transport context-threshold percentage and clamp it to 1..100.
+
+    The single coercion for every ``soft_threshold_pct`` / ``hard_threshold_pct``
+    read, so a hand-edited config can never load an out-of-range threshold on
+    any channel.
+    """
+    return _clamp_pct(_safe_int(raw, default))
+
+
+def _normalize_threshold_pair(soft: int, hard: int) -> tuple[int, int]:
+    """Normalize a soft/hard context-threshold pair to a valid ordering.
+
+    Clamp both to the shared range and pull the soft threshold down to the
+    hard one when it exceeds it, so a misconfig (e.g. hard=50, soft=95) can't
+    make the soft nudge unreachable — the transports check ``pct >= hard``
+    first.
+    """
+    soft = _clamp_pct(soft)
+    hard = _clamp_pct(hard)
+    if soft > hard:
+        soft = hard
+    return soft, hard
+
+
 def _safe_bool(value: object, default: bool) -> bool:
     """Return *value* only when it is a real bool, else *default*."""
     return value if isinstance(value, bool) else default
@@ -4879,13 +4914,13 @@ class WeComConfig:
     )
 
     def __post_init__(self) -> None:
-        # Clamp thresholds to [0, 100] and guarantee soft <= hard so a misconfig
-        # (e.g. hard=50, soft=95, or an out-of-range value) can't make the soft
-        # nudge unreachable -- _maybe_notice checks ``pct >= hard`` first.
-        self.soft_threshold_pct = max(0, min(100, self.soft_threshold_pct))
-        self.hard_threshold_pct = max(0, min(100, self.hard_threshold_pct))
-        if self.soft_threshold_pct > self.hard_threshold_pct:
-            self.soft_threshold_pct = self.hard_threshold_pct
+        # Shared normalization: clamp both thresholds and guarantee soft <= hard
+        # so a misconfig (e.g. hard=50, soft=95, or an out-of-range value) can't
+        # make the soft nudge unreachable -- _maybe_notice checks ``pct >= hard``
+        # first.
+        self.soft_threshold_pct, self.hard_threshold_pct = _normalize_threshold_pair(
+            self.soft_threshold_pct, self.hard_threshold_pct
+        )
 
 
 def _coerce_int_ids(raw: object) -> list[int]:
@@ -4978,9 +5013,7 @@ def _parse_telegram_accounts(raw: object) -> dict[str, "TelegramAccountConfig"]:
             allowed_user_ids=_coerce_int_ids(acct_data.get("allowed_user_ids")),
             allow_forum=_safe_bool(acct_data.get("allow_forum"), False),
             allowed_forum_chat_ids=_coerce_int_ids(acct_data.get("allowed_forum_chat_ids")),
-            soft_threshold_pct=max(
-                1, min(100, _coerce_int(acct_data.get("soft_threshold_pct"), 80))
-            ),
+            soft_threshold_pct=_threshold_pct(acct_data.get("soft_threshold_pct"), 80),
         )
     return out
 
@@ -5258,6 +5291,11 @@ class TelegramConfig:
         ),
     )
 
+    def __post_init__(self) -> None:
+        # Telegram carries only the soft nudge threshold; the hard-compaction
+        # backstop is the backend autocompactor (session.autocompact_pct).
+        self.soft_threshold_pct = _clamp_pct(self.soft_threshold_pct)
+
 
 @dataclass
 class WeixinConfig:
@@ -5352,6 +5390,14 @@ class WeixinConfig:
         ),
     )
 
+    def __post_init__(self) -> None:
+        # Shared normalization: clamp both thresholds and guarantee soft <= hard
+        # so a misconfig can't make the soft nudge unreachable -- _maybe_notice
+        # checks ``pct >= hard`` first. Mirrors WeComConfig.
+        self.soft_threshold_pct, self.hard_threshold_pct = _normalize_threshold_pair(
+            self.soft_threshold_pct, self.hard_threshold_pct
+        )
+
 
 @dataclass
 class DiscordConfig:
@@ -5430,6 +5476,11 @@ class DiscordConfig:
         ),
     )
 
+    def __post_init__(self) -> None:
+        # Discord carries only the soft nudge threshold; the hard-compaction
+        # backstop is the backend autocompactor (session.autocompact_pct).
+        self.soft_threshold_pct = _clamp_pct(self.soft_threshold_pct)
+
 
 @dataclass
 class WebexConfig:
@@ -5493,13 +5544,12 @@ class WebexConfig:
     )
 
     def __post_init__(self) -> None:
-        # Clamp thresholds to [0, 100] and guarantee soft <= hard so a misconfig
-        # can't make the soft nudge unreachable -- _maybe_notice checks
-        # ``pct >= hard`` first. Mirrors WeComConfig.
-        self.soft_threshold_pct = max(0, min(100, self.soft_threshold_pct))
-        self.hard_threshold_pct = max(0, min(100, self.hard_threshold_pct))
-        if self.soft_threshold_pct > self.hard_threshold_pct:
-            self.soft_threshold_pct = self.hard_threshold_pct
+        # Shared normalization: clamp both thresholds and guarantee soft <= hard
+        # so a misconfig can't make the soft nudge unreachable -- _maybe_notice
+        # checks ``pct >= hard`` first. Mirrors WeComConfig.
+        self.soft_threshold_pct, self.hard_threshold_pct = _normalize_threshold_pair(
+            self.soft_threshold_pct, self.hard_threshold_pct
+        )
 
 
 @dataclass
@@ -5588,12 +5638,12 @@ class TeamsConfig:
     )
 
     def __post_init__(self) -> None:
-        # Clamp thresholds to [0, 100] and guarantee soft <= hard so a misconfig
-        # can't make the soft nudge unreachable. Mirrors WebexConfig.
-        self.soft_threshold_pct = max(0, min(100, self.soft_threshold_pct))
-        self.hard_threshold_pct = max(0, min(100, self.hard_threshold_pct))
-        if self.soft_threshold_pct > self.hard_threshold_pct:
-            self.soft_threshold_pct = self.hard_threshold_pct
+        # Shared normalization: clamp both thresholds and guarantee soft <= hard
+        # so a misconfig can't make the soft nudge unreachable. Mirrors
+        # WebexConfig.
+        self.soft_threshold_pct, self.hard_threshold_pct = _normalize_threshold_pair(
+            self.soft_threshold_pct, self.hard_threshold_pct
+        )
 
 
 @dataclass
@@ -6362,9 +6412,7 @@ class KiroCrewConfig:
                 enabled=bool(telegram_data.get("enabled", False)),
                 bot_token=str(telegram_data.get("bot_token", "")),
                 allowed_user_ids=_coerce_int_ids(telegram_data.get("allowed_user_ids")),
-                soft_threshold_pct=max(
-                    1, min(100, _coerce_int(telegram_data.get("soft_threshold_pct"), 80))
-                ),
+                soft_threshold_pct=_threshold_pct(telegram_data.get("soft_threshold_pct"), 80),
                 allow_forum=bool(telegram_data.get("allow_forum", False)),
                 allowed_forum_chat_ids=_coerce_int_ids(telegram_data.get("allowed_forum_chat_ids")),
                 accounts=_parse_telegram_accounts(telegram_data.get("accounts")),
@@ -6377,12 +6425,8 @@ class KiroCrewConfig:
                 base_url=str(weixin_data.get("base_url", "") or "https://ilinkai.weixin.qq.com"),
                 dm_policy=str(weixin_data.get("dm_policy", "allowlist") or "allowlist"),
                 allowed_user_ids=_coerce_opaque_str_ids(weixin_data.get("allowed_user_ids")),
-                soft_threshold_pct=max(
-                    1, min(100, _coerce_int(weixin_data.get("soft_threshold_pct"), 80))
-                ),
-                hard_threshold_pct=max(
-                    1, min(100, _coerce_int(weixin_data.get("hard_threshold_pct"), 95))
-                ),
+                soft_threshold_pct=_threshold_pct(weixin_data.get("soft_threshold_pct"), 80),
+                hard_threshold_pct=_threshold_pct(weixin_data.get("hard_threshold_pct"), 95),
             ),
             discord=DiscordConfig(
                 session_folder=_coerce_session_folder(discord_data.get("session_folder")),
@@ -6395,9 +6439,7 @@ class KiroCrewConfig:
                 allowed_thread_ids=_coerce_str_ids(discord_data.get("allowed_thread_ids")),
                 allowed_channel_ids=_coerce_str_ids(discord_data.get("allowed_channel_ids")),
                 auto_thread=bool(discord_data.get("auto_thread", True)),
-                soft_threshold_pct=max(
-                    1, min(100, _coerce_int(discord_data.get("soft_threshold_pct"), 80))
-                ),
+                soft_threshold_pct=_threshold_pct(discord_data.get("soft_threshold_pct"), 80),
             ),
             webex=WebexConfig(
                 session_folder=_coerce_session_folder(webex_data.get("session_folder")),
@@ -6408,8 +6450,8 @@ class KiroCrewConfig:
                     if isinstance(webex_data.get("allowed_emails", []), list)
                     else []
                 ),
-                soft_threshold_pct=_coerce_int(webex_data.get("soft_threshold_pct"), 80),
-                hard_threshold_pct=_coerce_int(webex_data.get("hard_threshold_pct"), 95),
+                soft_threshold_pct=_threshold_pct(webex_data.get("soft_threshold_pct"), 80),
+                hard_threshold_pct=_threshold_pct(webex_data.get("hard_threshold_pct"), 95),
             ),
             teams=TeamsConfig(
                 session_folder=_coerce_session_folder(teams_data.get("session_folder")),
@@ -6425,8 +6467,8 @@ class KiroCrewConfig:
                     if isinstance(teams_data.get("allowed_emails", []), list)
                     else []
                 ),
-                soft_threshold_pct=_coerce_int(teams_data.get("soft_threshold_pct"), 80),
-                hard_threshold_pct=_coerce_int(teams_data.get("hard_threshold_pct"), 95),
+                soft_threshold_pct=_threshold_pct(teams_data.get("soft_threshold_pct"), 80),
+                hard_threshold_pct=_threshold_pct(teams_data.get("hard_threshold_pct"), 95),
             ),
             slack=SlackConfig(
                 session_folder=_coerce_session_folder(slack_data.get("session_folder")),
@@ -6487,8 +6529,8 @@ class KiroCrewConfig:
                 ],
                 allow_all_users=bool(wecom_data.get("allow_all_users", False)),
                 ws_url=str(wecom_data.get("ws_url", "wss://openws.work.weixin.qq.com")),
-                soft_threshold_pct=_safe_int(wecom_data.get("soft_threshold_pct", 80), 80),
-                hard_threshold_pct=_safe_int(wecom_data.get("hard_threshold_pct", 95), 95),
+                soft_threshold_pct=_threshold_pct(wecom_data.get("soft_threshold_pct"), 80),
+                hard_threshold_pct=_threshold_pct(wecom_data.get("hard_threshold_pct"), 95),
             ),
             dashboard=DashboardConfig(
                 url=dashboard_data.get("url", ""),

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -1250,7 +1250,11 @@ class DiscordDispatcher:
     async def _maybe_notice(
         self, channel_id: str, scope_id: str, session_key: str, provider: Any
     ) -> None:
-        """Soft-threshold context warning as a SEPARATE message (not persisted)."""
+        """Soft-threshold context warning as a SEPARATE message (not persisted).
+
+        The hard-compaction backstop is the backend autocompactor
+        (``session.autocompact_pct``).
+        """
         pct = self.sessions.check_context_usage(session_key, provider)
         soft_pct = self.cfg.discord.soft_threshold_pct
         if pct >= soft_pct and not self._conv.is_awaiting(scope_id):

--- a/src/kiro_crew/docs/discord-integration.md
+++ b/src/kiro_crew/docs/discord-integration.md
@@ -95,7 +95,9 @@ DISCORD_BOT_TOKEN=<your bot token>
 }
 ```
 
-Omit `allowed_thread_ids` or leave it empty for DMs only.
+Omit `allowed_thread_ids` or leave it empty for DMs only. An optional
+`soft_threshold_pct` (default `80`, clamped to 1–100) sets the context % at
+which the bot suggests `!compact`.
 
 ### 6. Restart the gateway
 

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -1571,6 +1571,8 @@ class TelegramDispatcher:
 
         Kept out of the streamed answer buffer so it is never persisted into the
         assistant turn and replayed next turn as though the assistant said it.
+        The hard-compaction backstop is the backend autocompactor
+        (``session.autocompact_pct``).
         """
         pct = self.sessions.check_context_usage(session_key, provider)
         soft_pct = self.cfg.telegram.soft_threshold_pct

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -5050,3 +5050,110 @@ class TestMigrationBackupContainment:
         # But the on-disk config is untouched, so the migration retries next load.
         assert json.loads(cfg_file.read_text(encoding="utf-8")) == json.loads(original)
         assert not (home / "config.json.bak").exists()
+
+
+# Transports carrying a soft/hard context-threshold pair, and those carrying
+# only the soft nudge (their hard backstop is the backend autocompactor).
+# A future transport that forgets _threshold_pct / _normalize_threshold_pair
+# fails these tests rather than shipping an unclamped read.
+_THRESHOLD_PAIR_TRANSPORTS = ["weixin", "webex", "teams", "wecom"]
+_THRESHOLD_SOFT_ONLY_TRANSPORTS = ["telegram", "discord"]
+
+
+class TestTransportThresholdConsistency:
+    """Every transport's context thresholds share ONE validation.
+
+    Locks in the invariant that validity is a property of the type: the loader
+    coerces every read through _threshold_pct (clamped to 1..100) and each
+    dataclass's __post_init__ normalizes its fields (pair transports also
+    enforce soft <= hard), so neither a hand-edited config nor a
+    code-constructed object can hold an out-of-range or inverted value.
+    """
+
+    @staticmethod
+    def _section(cfg, transport: str):
+        return getattr(cfg, transport)
+
+    @pytest.mark.parametrize(
+        "transport", _THRESHOLD_PAIR_TRANSPORTS + _THRESHOLD_SOFT_ONLY_TRANSPORTS
+    )
+    def test_defaults_when_missing(self, transport: str) -> None:
+        section = self._section(_load_from_dict({transport: {}}), transport)
+        assert section.soft_threshold_pct == 80
+        if transport in _THRESHOLD_PAIR_TRANSPORTS:
+            assert section.hard_threshold_pct == 95
+
+    @pytest.mark.parametrize(
+        "transport", _THRESHOLD_PAIR_TRANSPORTS + _THRESHOLD_SOFT_ONLY_TRANSPORTS
+    )
+    @pytest.mark.parametrize("raw", [-5, 0, 101, 10_000])
+    def test_out_of_range_values_are_clamped(self, transport: str, raw: int) -> None:
+        payload: dict = {"soft_threshold_pct": raw}
+        if transport in _THRESHOLD_PAIR_TRANSPORTS:
+            payload["hard_threshold_pct"] = raw
+        section = self._section(_load_from_dict({transport: payload}), transport)
+        assert 1 <= section.soft_threshold_pct <= 100
+        if transport in _THRESHOLD_PAIR_TRANSPORTS:
+            assert 1 <= section.hard_threshold_pct <= 100
+            assert section.soft_threshold_pct <= section.hard_threshold_pct
+
+    @pytest.mark.parametrize("transport", _THRESHOLD_PAIR_TRANSPORTS)
+    def test_soft_above_hard_is_corrected(self, transport: str) -> None:
+        # An inverted pair (soft=90, hard=50) would make the soft nudge
+        # unreachable -- the transports check pct >= hard first.
+        section = self._section(
+            _load_from_dict(
+                {transport: {"soft_threshold_pct": 90, "hard_threshold_pct": 50}}
+            ),
+            transport,
+        )
+        assert section.hard_threshold_pct == 50
+        assert section.soft_threshold_pct == 50
+
+    @pytest.mark.parametrize(
+        "transport", _THRESHOLD_PAIR_TRANSPORTS + _THRESHOLD_SOFT_ONLY_TRANSPORTS
+    )
+    def test_non_numeric_values_fall_back_to_defaults(self, transport: str) -> None:
+        payload: dict = {"soft_threshold_pct": "abc"}
+        if transport in _THRESHOLD_PAIR_TRANSPORTS:
+            payload["hard_threshold_pct"] = None
+        section = self._section(_load_from_dict({transport: payload}), transport)
+        assert section.soft_threshold_pct == 80
+        if transport in _THRESHOLD_PAIR_TRANSPORTS:
+            assert section.hard_threshold_pct == 95
+
+    @pytest.mark.parametrize(
+        "transport", _THRESHOLD_PAIR_TRANSPORTS + _THRESHOLD_SOFT_ONLY_TRANSPORTS
+    )
+    def test_code_constructed_object_is_normalized(self, transport: str) -> None:
+        # __post_init__ makes an object constructed in code valid too, not just
+        # one loaded from disk.
+        cls = {
+            "telegram": loader_module.TelegramConfig,
+            "weixin": loader_module.WeixinConfig,
+            "discord": loader_module.DiscordConfig,
+            "webex": loader_module.WebexConfig,
+            "teams": loader_module.TeamsConfig,
+            "wecom": loader_module.WeComConfig,
+        }[transport]
+        if transport in _THRESHOLD_PAIR_TRANSPORTS:
+            obj = cls(soft_threshold_pct=150, hard_threshold_pct=-3)
+            assert obj.hard_threshold_pct == 1
+            assert obj.soft_threshold_pct == 1
+        else:
+            obj = cls(soft_threshold_pct=150)
+            assert obj.soft_threshold_pct == 100
+
+    def test_telegram_account_soft_threshold_clamped(self) -> None:
+        # Deprecated/inert telegram.accounts entries still parse through the
+        # same coercion so a round-tripped config stays in range.
+        cfg = _load_from_dict(
+            {
+                "telegram": {
+                    "accounts": {
+                        "acct-1": {"bot_token": "123:abc", "soft_threshold_pct": 400}
+                    }
+                }
+            }
+        )
+        assert cfg.telegram.accounts["acct-1"].soft_threshold_pct == 100

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -2750,3 +2750,26 @@ def test_receipt_text_caps_displayed_items() -> None:
     out = _receipt_text(texts)
     assert out.startswith("⏳ Queued (8):")
     assert "…and 3 more" in out
+
+
+# ── context thresholds ───────────────────────────────────────────────────
+
+
+class TestContextThresholdNotices:
+    @pytest.mark.asyncio
+    async def test_soft_threshold_nudges(self) -> None:
+        d, cli, sess = _dispatcher({"u1"})
+        sess.check_context_usage = lambda key, provider: 85.0  # >= soft (80)
+
+        await d._maybe_notice("chan1", "scope1", "key", object())
+
+        assert any("!compact" in s[0] for s in cli.sent)
+
+    @pytest.mark.asyncio
+    async def test_below_soft_threshold_stays_silent(self) -> None:
+        d, cli, sess = _dispatcher({"u1"})
+        sess.check_context_usage = lambda key, provider: 10.0
+
+        await d._maybe_notice("chan1", "scope1", "key", object())
+
+        assert cli.sent == []

--- a/test/test_teams_config.py
+++ b/test/test_teams_config.py
@@ -70,9 +70,10 @@ class TestTeamsConfig:
         assert cfg.teams.hard_threshold_pct == 50
         assert cfg.teams.soft_threshold_pct == 50
 
-        # out-of-range values clamped to [0, 100]
+        # out-of-range values clamped to [1, 100] (1 floor: a 0% threshold
+        # would mean "always over")
         tc = TeamsConfig(soft_threshold_pct=-10, hard_threshold_pct=200)
-        assert tc.soft_threshold_pct == 0
+        assert tc.soft_threshold_pct == 1
         assert tc.hard_threshold_pct == 100
 
     def test_app_password_marked_sensitive(self) -> None:

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -4803,3 +4803,24 @@ class TestSetMyCommands:
         assert {"command": "model", "description": "Choose the model from a list"} in sent[0][1][
             "commands"
         ]
+
+
+# ── context thresholds ───────────────────────────────────────────────────
+
+
+class TestContextThresholdNotices:
+    def test_soft_threshold_nudges(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        sess.check_context_usage = lambda key, provider: 85.0  # >= soft (80)
+
+        asyncio.run(d._maybe_notice(7, ("direct", "7"), "key", object()))
+
+        assert any("/compact" in s[0] for s in cli.sent)
+
+    def test_below_soft_threshold_stays_silent(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        sess.check_context_usage = lambda key, provider: 10.0
+
+        asyncio.run(d._maybe_notice(7, ("direct", "7"), "key", object()))
+
+        assert cli.sent == []

--- a/test/test_wecom_client.py
+++ b/test/test_wecom_client.py
@@ -576,7 +576,7 @@ class TestConcurrentSends:
 
 
 class TestThresholdClamp:
-    """WeComConfig.__post_init__ clamps to [0,100] and enforces soft <= hard."""
+    """WeComConfig.__post_init__ clamps to [1,100] and enforces soft <= hard."""
 
     def test_soft_above_hard_is_lowered_to_hard(self) -> None:
         from kiro_crew.config.loader import WeComConfig
@@ -589,7 +589,7 @@ class TestThresholdClamp:
         from kiro_crew.config.loader import WeComConfig
 
         c = WeComConfig(soft_threshold_pct=-10, hard_threshold_pct=200)
-        assert c.soft_threshold_pct == 0
+        assert c.soft_threshold_pct == 1
         assert c.hard_threshold_pct == 100
 
 


### PR DESCRIPTION
## Problem / Motivation

Every messaging transport carries context thresholds (`soft_threshold_pct` / `hard_threshold_pct`), but `src/kiro_crew/config/loader.py` validated them three different ways (verified at `origin/main` `69b60c3b6`):

- telegram (`:6365`), weixin (`:6380-6384`), discord (`:6398`) — `max(1, min(100, _coerce_int(...)))`, clamped at the call site.
- webex (`:6411-6412`), teams (`:6428-6429`) — bare `_coerce_int(..., 80)` / `_coerce_int(..., 95)`, unclamped at the call site.
- wecom (`:6490-6491`) — a third helper, `_safe_int(...)`.

And the clamp-then-correct-`soft > hard` `__post_init__` block existed on only three dataclasses (wecom `:4885-4888`, webex `:5499-5502`, teams `:5593-5596`) — with a different range (`0..100`) than the call sites (`1..100`). Concretely reachable defects:

- A hand-edited weixin config with `soft=90, hard=50` (both in range) loaded as-is: the soft nudge became unreachable because `_maybe_notice` checks `pct >= hard` first, so the forced compaction fired before the prompt that was supposed to precede it.
- A `WeixinConfig`, `TelegramConfig`, or `DiscordConfig` constructed in code (not loaded from disk) had no validation at all.
- Whether a threshold was clamped depended on which call site remembered to wrap the read — the next transport added was one forgotten `max(1, min(100, ...))` away from shipping unclamped.

## Why it matters

An out-of-range or inverted threshold doesn't fail loudly — it silently disables the context-pressure UX (the "please /compact" nudge never fires, or fires after the point that was supposed to force action), and the affected user only sees the symptom much later as an overflowing or churning session. Validation scattered across call sites is exactly how webex/teams already drifted from telegram/weixin/discord.

## What changed (motivation → approach → change)

Root cause: validity was a property of whichever call site remembered to wrap the value, not of the type. The change makes it a property of the type, stated once:

- `_clamp_pct` — the single statement of the range, `1..100`. **Range decision:** the call sites used `1..100`, the `__post_init__` blocks used `0..100`; this PR picks `1..100` everywhere (a 0% threshold means "always over" and would fire on every turn).
- `_threshold_pct(raw, default)` = `_safe_int` + `_clamp_pct` — the single coercion for every transport threshold read. All seven reads (telegram, deprecated telegram accounts, weixin, discord, webex, teams, wecom) now go through it.
- `_normalize_threshold_pair` — the single pair rule (clamp both, pull `soft` down to `hard`), called from `__post_init__` on every pair-carrying dataclass (weixin — previously had no `__post_init__` at all — plus wecom/webex/teams, whose three hand-copied blocks it replaces). The soft-only dataclasses (telegram, discord) clamp `soft` in `__post_init__`.

**Deliberately NOT changed:** telegram and discord do not gain a `hard_threshold_pct`. Their hard backstop is the backend autocompactor (`session.autocompact_pct`, default 90), which already fires *below* the peers' transport-level 95 — `check_context_usage` schedules a background compaction at that trigger, so wiring a transport-level hard compaction above it would race the in-flight background compaction (two waiters on one terminal-status queue; the loser arms the autocompactor's failure cooldown). How the per-transport ladder should relate to `autocompact_pct` is exactly issue #4689 and is out of scope here, per the issue's own scoping. The deprecated, inert `telegram.accounts` entries likewise keep their soft-only shape (their reads still go through `_threshold_pct`). `session.autocompact_pct` and its default are untouched.

**Behaviour changes** (declared explicitly): for configs holding out-of-range values, a threshold of `0` now clamps to `1` (wecom/webex/teams previously clamped to `0..100` in `__post_init__`); an inverted weixin pair (`soft > hard`, both in range) previously loaded as-is and now corrects `soft` down to `hard`. In-range, correctly ordered configs — including all defaults — load identically to before.

## Tests

- `test/test_config_loader.py` — new table-driven `TestTransportThresholdConsistency` over all six transports (pair transports and soft-only transports): missing values fall back to documented defaults; out-of-range values (−5, 0, 101, 10000) clamp into `1..100`; a `soft > hard` pair is corrected; non-numeric values fall back; a code-constructed object is normalized by `__post_init__`; the deprecated telegram account parse clamps. A future transport that forgets the helper fails these tests rather than shipping an unclamped read.
- `test/test_telegram.py`, `test/test_discord.py` — new `TestContextThresholdNotices`: the soft nudge fires at ≥ soft and stays silent below it (locks in that these transports nudge only — no transport-level compaction).
- `test/test_teams_config.py`, `test/test_wecom_client.py` — existing clamp pins updated from the `0` floor to the `1` floor.

## Manual verification

N/A — unit coverage sufficient: the change is confined to config coercion/normalization and is fully exercised by the loader round-trip tests; full backend suite green locally (58.7k passed; the only failures are 12 pre-existing environment failures reproduced identically on a clean `origin/main` checkout on the same host).

## Related Issues

Closes #4688

Related: #4689 (transport-ladder vs `session.autocompact_pct` coordination — the missing-hard-threshold half for telegram/discord lands there, see above).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
