### PR TITLE
fix: damp ineffective auto-compactions with the failure cooldown (#4687)

### DIFF
--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -396,6 +396,16 @@ def _compact_result_wait_secs(elapsed: float) -> float:
 # broken /compact does not fire on every subsequent turn.
 _COMPACT_FAILURE_COOLDOWN_SECS = 60.0
 
+# A compaction that completes but frees less than this many percentage points
+# of the context window made no meaningful progress: the next turn-end check
+# would re-trigger immediately and each attempt costs a real model-generated
+# summarization. Such an INEFFECTIVE compaction keeps (rather than clears) the
+# failure cooldown above, damping the retry loop. Measured as a drop in
+# ``context_usage_pct()`` across the attempt — a drop, not "still above the
+# threshold", because a legitimately good compaction of a very long turn can
+# land above ``autocompact_pct`` while still having freed real headroom.
+_COMPACT_MIN_EFFECT_PCT_POINTS = 5.0
+
 
 class _CompactCallback(Protocol):
     async def __call__(self, key: str, pct: float, *, success: bool) -> None: ...  # noqa: E704
@@ -892,6 +902,11 @@ class SessionManager:
         # cold-start).
         self._recycling: dict[str, "_Session"] = {}
         self._compact_cooldown_until: dict[str, float] = {}
+        # Compactions whose effect could not be measured at completion time
+        # (post-compaction stats reset to unknown, or telemetry not refreshed
+        # yet): key -> the pct that triggered the attempt. Settled by the
+        # first CONFIRMED reading in check_context_usage.
+        self._compact_pending_verdict: dict[str, float] = {}
         # Per-session channel conversation to send unattended output to (the
         # auto-compact notice). In-memory on purpose: see set_origin_link.
         self._origin_links: dict[str, ChannelLink] = {}
@@ -3113,6 +3128,7 @@ class SessionManager:
             # The new process is a fresh start — drop any stale failure
             # cooldown so it isn't inherited.
             self._compact_cooldown_until.pop(key, None)
+            self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         if session:
             # Capture PID and child tree before shutdown clears them
@@ -3211,6 +3227,15 @@ class SessionManager:
         if session:
             session.prompt_count += 1
 
+        # Settle a deferred compaction verdict on the first CONFIRMED reading
+        # after the attempt (see _settle_compact_cooldown). Runs BEFORE the
+        # trigger decision below so an ineffective compaction's cooldown
+        # suppresses the immediate re-trigger in this very call.
+        baseline = self._compact_pending_verdict.get(key)
+        if baseline is not None and not _context_pct_is_unknown(provider):
+            del self._compact_pending_verdict[key]
+            self._judge_compact_effect(key, baseline, pct)
+
         # CC per_session handles its own compaction natively — skip KiroCrew's
         _is_cc_persistent = (
             ClaudeCodeProvider is not None
@@ -3300,8 +3325,8 @@ class SessionManager:
 
         - ``_compacting`` set: dedup concurrent triggers; an in-flight
           compaction blocks new triggers until it completes.
-        - ``_compact_cooldown_until``: after a failed compact, suppress
-          re-triggers until the cooldown elapses.
+        - ``_compact_cooldown_until``: after a failed OR ineffective compact,
+          suppress re-triggers until the cooldown elapses.
 
         The actual work runs in a fire-and-forget task so the caller's
         response path is never blocked.
@@ -3311,9 +3336,10 @@ class SessionManager:
             return
         cooldown_until = self._compact_cooldown_until.get(key, 0.0)
         if cooldown_until > time.monotonic():
-            # Last compact failed. Skip until the cooldown elapses so a broken
-            # /compact does not fire on every subsequent turn. Log at INFO —
-            # the original failure was already logged at exception level.
+            # Last compact failed or made no progress. Skip until the cooldown
+            # elapses so a broken or ineffective /compact does not fire on
+            # every subsequent turn. Log at INFO — the original outcome was
+            # already logged at exception/warning level.
             logger.info(
                 "Session %s compaction skipped — cooldown active for %.0fs more",
                 key,
@@ -3374,8 +3400,9 @@ class SessionManager:
                     )
                     await self._fire_compact_callback(key, pct, success=False)
                     return
-                # Success: clear any prior cooldown so subsequent triggers work.
-                self._compact_cooldown_until.pop(key, None)
+                # Completed: decide the cooldown from the measured effect —
+                # an ineffective compaction keeps it, an effective one clears it.
+                self._settle_compact_cooldown(key, claude_session.provider, pct)
                 logger.info("Compacted session %s (context overflow)", key)
                 await self._fire_compact_callback(key, pct, success=True)
                 return
@@ -3453,7 +3480,9 @@ class SessionManager:
 
         Returns:
         - ``"ok"``: compaction completed; session (and its process) survives.
-          The success callback has been fired and the cooldown cleared.
+          The success callback has been fired and the cooldown settled from
+          the measured effect (cleared when effective, armed when
+          ineffective, deferred when not yet measurable).
         - ``"busy"``: the turn semaphore could not be acquired within
           ``COMPACT_WAIT_TIMEOUT_SECS`` — a turn is still running. Nothing was
           attempted; the caller must NOT recycle (no mid-turn kill).
@@ -3544,10 +3573,84 @@ class SessionManager:
             return "recycled"
         finally:
             session.semaphore.release()
-        self._compact_cooldown_until.pop(key, None)
+        self._settle_compact_cooldown(key, session.provider, pct)
         logger.info("Compacted session %s in place (context overflow)", key)
         await self._fire_compact_callback(key, pct, success=True)
         return "ok"
+
+    def _settle_compact_cooldown(self, key: str, provider: LLMProvider, pct_before: float) -> None:
+        """Set, clear, or defer the failure cooldown from a compaction's effect.
+
+        Re-reads ``context_usage_pct()`` and compares it with *pct_before* (the
+        reading that triggered the attempt). A completed compaction that freed
+        less than ``_COMPACT_MIN_EFFECT_PCT_POINTS`` is INEFFECTIVE: without a
+        cooldown the next turn-end ``check_context_usage`` re-triggers at once
+        and every "successful" attempt pays another model-generated
+        summarization. Reusing the failure cooldown (rather than a second
+        constant or counter) keeps one damping mechanism for both outcomes.
+
+        The verdict is only made on a reading that demonstrably describes the
+        compacted conversation. Two normal paths cannot provide one here:
+
+        - kiro-cli, terminal status observed MID-TURN: the stream handler ran
+          ``reset_after_compaction`` (pct 0.0, flagged unknown) and no
+          post-compaction metadata drain has run yet — the reading is unknown.
+        - a backend whose stats were never reset by the compaction: the
+          reading still shows the PRE-compaction value, so a fully successful
+          compaction would compute a zero drop and be damped by mistake.
+
+        Both defer: the trigger pct is stashed in ``_compact_pending_verdict``
+        and ``check_context_usage`` settles it at the first CONFIRMED reading
+        (that reading includes the following turn's own growth, so a very
+        large turn can under-measure the drop and arm one spurious cooldown —
+        bounded at ``_COMPACT_FAILURE_COOLDOWN_SECS``). Any cooldown already
+        running is left to expire on its own while a verdict is pending.
+
+        The compaction callback still fires ``success=True`` for an
+        ineffective attempt: the compaction genuinely completed and rewrote
+        the conversation, so skill-context reinjection (gated on success in
+        ``_fire_compact_callback``) must run, and the failure notice
+        ("will retry after cooldown — run /compact manually") would
+        misdescribe an attempt that ran to completion. The warning below
+        carries the ineffectiveness signal.
+        """
+        pct_after = provider.context_usage_pct()
+        unknown = _context_pct_is_unknown(provider)
+        if unknown or pct_after >= pct_before:
+            self._compact_pending_verdict[key] = pct_before
+            logger.info(
+                "Session %s compaction effect not measurable yet "
+                "(%.1f%% -> %.1f%%%s) — verdict deferred to the next confirmed reading",
+                key,
+                pct_before,
+                pct_after,
+                ", unconfirmed" if unknown else "",
+            )
+            return
+        self._compact_pending_verdict.pop(key, None)
+        self._judge_compact_effect(key, pct_before, pct_after)
+
+    def _judge_compact_effect(self, key: str, pct_before: float, pct_after: float) -> None:
+        """Arm the cooldown on an ineffective measured drop; clear it otherwise.
+
+        The test is the measured drop, not "still above the threshold": a
+        legitimately good compaction of a very long turn can land above
+        ``autocompact_pct`` while still having freed real headroom, and what
+        the cooldown damps is the no-progress case.
+        """
+        if pct_before - pct_after < _COMPACT_MIN_EFFECT_PCT_POINTS:
+            self._compact_cooldown_until[key] = time.monotonic() + _COMPACT_FAILURE_COOLDOWN_SECS
+            logger.warning(
+                "Session %s compaction ineffective — context %.1f%% -> %.1f%% "
+                "(freed %.1f < %.1f points); cooldown applied",
+                key,
+                pct_before,
+                pct_after,
+                pct_before - pct_after,
+                _COMPACT_MIN_EFFECT_PCT_POINTS,
+            )
+            return
+        self._compact_cooldown_until.pop(key, None)
 
     async def _fire_compact_callback(self, key: str, pct: float, *, success: bool) -> None:
         """Invoke ``_on_compacted`` if registered, swallowing exceptions."""
@@ -3597,6 +3700,7 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
+            self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         if session:
             await session.provider.shutdown()
@@ -3629,6 +3733,7 @@ class SessionManager:
                 return False
             del self._sessions[key]
             self._compact_cooldown_until.pop(key, None)
+            self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         await session.provider.shutdown()
         await self.release_subagent_runtime(key)
@@ -3645,6 +3750,7 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
+            self._compact_pending_verdict.pop(key, None)
         try:
             if session:
                 await session.provider.shutdown()
@@ -3672,6 +3778,7 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
+            self._compact_pending_verdict.pop(key, None)
         try:
             if session:
                 await session.provider.shutdown()
@@ -3909,6 +4016,7 @@ class SessionManager:
             sessions = dict(self._sessions)
             self._sessions.clear()
             self._compact_cooldown_until.clear()
+            self._compact_pending_verdict.clear()
 
         # Bound concurrent shutdowns: each provider.shutdown() -> _kill_process()
         # enqueues 2-3 subprocess_executor tasks (child scan, record capture,

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -3505,10 +3505,12 @@ class TestCooldownPruning:
         await mgr.get_or_create("k1")
         mgr.release("k1")
         mgr._compact_cooldown_until["k1"] = time.monotonic() + 60.0
+        mgr._compact_pending_verdict["k1"] = 92.0
 
         await mgr.remove("k1")
 
         assert "k1" not in mgr._compact_cooldown_until
+        assert "k1" not in mgr._compact_pending_verdict
         await mgr.close_all()
 
     @pytest.mark.asyncio
@@ -3517,10 +3519,12 @@ class TestCooldownPruning:
         await mgr.get_or_create("k1")
         mgr.release("k1")
         mgr._compact_cooldown_until["k1"] = time.monotonic() + 60.0
+        mgr._compact_pending_verdict["k1"] = 92.0
 
         await mgr.destroy("k1")
 
         assert "k1" not in mgr._compact_cooldown_until
+        assert "k1" not in mgr._compact_pending_verdict
         await mgr.close_all()
 
     @pytest.mark.asyncio
@@ -3529,10 +3533,12 @@ class TestCooldownPruning:
         await mgr.get_or_create("k1")
         mgr.release("k1")
         mgr._compact_cooldown_until["k1"] = time.monotonic() + 60.0
+        mgr._compact_pending_verdict["k1"] = 92.0
 
         await mgr.reset("k1")
 
         assert "k1" not in mgr._compact_cooldown_until
+        assert "k1" not in mgr._compact_pending_verdict
         await mgr.close_all()
 
     @pytest.mark.asyncio
@@ -3542,10 +3548,12 @@ class TestCooldownPruning:
         mgr.release("k1")
         mgr._compact_cooldown_until["k1"] = time.monotonic() + 60.0
         mgr._compact_cooldown_until["k2"] = time.monotonic() + 60.0
+        mgr._compact_pending_verdict["k1"] = 92.0
 
         await mgr.close_all()
 
         assert mgr._compact_cooldown_until == {}
+        assert mgr._compact_pending_verdict == {}
 
 
 class TestCloseAllPersistence:
@@ -4244,4 +4252,262 @@ class TestLoadRecoveryHistoryReplay:
         await mgr.get_or_create("thread1")
         sess = next(iter(mgr._sessions.values()))
         assert sess.provider_switch_replay is False
+        await mgr.close_all()
+
+
+class TestIneffectiveCompactionCooldown:
+    """A compaction that completes but frees no meaningful headroom keeps the
+    failure cooldown instead of clearing it — otherwise every "successful"
+    no-progress attempt re-triggers on the next turn end and each retry pays
+    another model-generated summarization (#4687)."""
+
+    @staticmethod
+    def _inplace_factory(pct_after: float):
+        """kiro-cli-style provider whose /compact completes and whose
+        post-compaction ``context_usage_pct()`` reads *pct_after*."""
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            m = AsyncMock()
+            m.start = AsyncMock()
+            m.shutdown = AsyncMock()
+            m.context_usage_pct = lambda: pct_after
+
+            async def _stream(_cmd):
+                return
+                yield  # pragma: no cover — make this an async generator
+
+            m.stream_command = MagicMock(side_effect=_stream)
+            m.wait_for_compaction = AsyncMock(return_value={"type": "completed"})
+            return m
+
+        return factory
+
+    # ── (a) effective compaction clears the cooldown ──
+
+    @pytest.mark.asyncio
+    async def test_inplace_effective_clears_cooldown(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=self._inplace_factory(pct_after=40.0))
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        mgr._compact_cooldown_until["dashboard:chat-1"] = time.monotonic() + 999
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_claude_effective_clears_cooldown(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+        provider.compact = AsyncMock()
+        provider.context_usage_pct = lambda: 40.0
+        mgr._compact_cooldown_until["k1"] = time.monotonic() + 999
+
+        with patch("kiro_crew.session._is_claude_backend", return_value=True):
+            await mgr._compact_session("k1", 92.0)
+
+        assert "k1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_unknown_post_compaction_pct_defers_verdict(self, cfg):
+        """kiro-cli's mid-turn terminal status resets the stats to 0.0/unknown
+        before any post-compaction metadata lands. An unknown reading must not
+        be judged (a 0.0 would read as a huge drop and mask #4687 entirely);
+        the verdict is deferred to the first confirmed reading."""
+        mgr = SessionManager(cfg, provider_factory=self._inplace_factory(pct_after=0.0))
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        provider.context_usage_unknown = lambda: True
+        mgr._compact_cooldown_until["dashboard:chat-1"] = time.monotonic() + 999
+
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        # No verdict yet: the running cooldown is left to expire on its own
+        # and the trigger pct is stashed for the next confirmed reading.
+        assert "dashboard:chat-1" in mgr._compact_cooldown_until
+        assert mgr._compact_pending_verdict["dashboard:chat-1"] == 92.0
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_deferred_verdict_effective_clears_cooldown(self, cfg):
+        """First confirmed reading shows a real drop: the deferred verdict is
+        effective and the cooldown clears."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        mgr._compact_pending_verdict["dashboard:chat-1"] = 92.0
+        mgr._compact_cooldown_until["dashboard:chat-1"] = time.monotonic() + 999
+        provider.context_usage_pct = lambda: 40.0
+
+        mgr.check_context_usage("dashboard:chat-1", provider)
+
+        assert "dashboard:chat-1" not in mgr._compact_pending_verdict
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_deferred_verdict_ineffective_arms_cooldown_and_suppresses_trigger(
+        self, cfg, caplog
+    ):
+        """First confirmed reading is still within the no-progress band: the
+        deferred verdict arms the cooldown BEFORE the same call's trigger
+        decision, so the immediate re-trigger is suppressed."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        mgr._compact_pending_verdict["dashboard:chat-1"] = 92.0
+        provider.context_usage_pct = lambda: 91.0  # >= autocompact_pct (90)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session"):
+            mgr.check_context_usage("dashboard:chat-1", provider)
+
+        assert "dashboard:chat-1" not in mgr._compact_pending_verdict
+        assert mgr._compact_cooldown_until.get("dashboard:chat-1", 0.0) > time.monotonic()
+        assert any("ineffective" in r.message for r in caplog.records)
+        # The 91% reading is above the trigger threshold, but the just-armed
+        # cooldown suppressed the re-trigger: no compaction task started.
+        assert "dashboard:chat-1" not in mgr._compacting
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_deferred_verdict_waits_for_confirmed_reading(self, cfg):
+        """An unknown reading does not consume the pending verdict."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        mgr._compact_pending_verdict["dashboard:chat-1"] = 92.0
+        provider.context_usage_pct = lambda: 0.0
+        provider.context_usage_unknown = lambda: True
+
+        mgr.check_context_usage("dashboard:chat-1", provider)
+
+        assert mgr._compact_pending_verdict["dashboard:chat-1"] == 92.0
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_claude_stale_reading_defers_instead_of_damping_success(self, cfg):
+        """The claude branch can return from compact() before any telemetry
+        refresh, so the re-read still shows the PRE-compaction value. Judging
+        that stale reading would arm the cooldown on a compaction that in
+        fact succeeded — it must defer instead, and the next confirmed
+        reading (showing the real drop) must clear cleanly."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+        provider.compact = AsyncMock()
+        provider.context_usage_pct = lambda: 92.0  # unchanged: stats never reset
+
+        with patch("kiro_crew.session._is_claude_backend", return_value=True):
+            await mgr._compact_session("k1", 92.0)
+
+        # Deferred, not damped: a successful compaction must not be punished.
+        assert "k1" not in mgr._compact_cooldown_until
+        assert mgr._compact_pending_verdict["k1"] == 92.0
+        # Next turn's confirmed reading shows the real drop — verdict clears.
+        provider.context_usage_pct = lambda: 40.0
+        mgr.check_context_usage("k1", provider)
+        assert "k1" not in mgr._compact_pending_verdict
+        assert "k1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    # ── (b) effective but still above the trigger threshold is NOT ineffective ──
+
+    @pytest.mark.asyncio
+    async def test_inplace_effective_above_threshold_not_damped(self, cfg):
+        """A good compaction of a very long turn can land above
+        ``autocompact_pct`` while still having freed real headroom. The
+        ineffective test is the measured drop, not the absolute level."""
+        mgr = SessionManager(cfg, provider_factory=self._inplace_factory(pct_after=92.0))
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        assert 92.0 >= cfg.session.autocompact_pct  # still above the trigger
+
+        await mgr._compact_session("dashboard:chat-1", 99.0)
+
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
+        await mgr.close_all()
+
+    # ── (c) ineffective compaction arms the cooldown and suppresses the next trigger ──
+
+    @pytest.mark.asyncio
+    async def test_inplace_ineffective_sets_cooldown_and_suppresses_retrigger(self, cfg, caplog):
+        mgr = SessionManager(cfg, provider_factory=self._inplace_factory(pct_after=91.0))
+        provider, _, _ = await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session"):
+            await mgr._compact_session("dashboard:chat-1", 92.0)
+
+        assert mgr._compact_cooldown_until.get("dashboard:chat-1", 0.0) > time.monotonic()
+        assert any("ineffective" in r.message for r in caplog.records)
+        # The compaction DID complete and rewrote the conversation: the
+        # callback stays success=True (reinjection must run; the failure
+        # notice would misdescribe a completed attempt).
+        cb.assert_awaited_once_with("dashboard:chat-1", 92.0, success=True)
+        # The immediate next trigger is suppressed by the cooldown.
+        mgr._trigger_compaction("dashboard:chat-1", "context 92%", 92.0)
+        assert "dashboard:chat-1" not in mgr._compacting
+        provider.stream_command.assert_called_once()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_claude_ineffective_sets_cooldown(self, cfg, caplog):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider, _, _ = await mgr.get_or_create("k1")
+        mgr.release("k1")
+        provider.compact = AsyncMock()
+        provider.context_usage_pct = lambda: 91.0
+        cb = AsyncMock()
+        mgr.set_compact_callback(cb)
+
+        with (
+            patch("kiro_crew.session._is_claude_backend", return_value=True),
+            caplog.at_level(logging.WARNING, logger="kiro_crew.session"),
+        ):
+            await mgr._compact_session("k1", 92.0)
+
+        assert mgr._compact_cooldown_until.get("k1", 0.0) > time.monotonic()
+        assert any("ineffective" in r.message for r in caplog.records)
+        cb.assert_awaited_once_with("k1", 92.0, success=True)
+        assert mgr.has_session("k1")  # in place: the session survives
+        await mgr.close_all()
+
+    # ── (d) repeated ineffective compactions and the circuit breaker ──
+
+    @pytest.mark.asyncio
+    async def test_repeated_ineffective_keeps_damping_until_breaker_resets(self, cfg):
+        """Each ineffective attempt re-arms the one existing cooldown (no
+        second counter), so nothing masks the repetition from the existing
+        circuit breaker: when the stuck session's turns keep failing,
+        ``record_failure`` trips at ``_CIRCUIT_BREAKER_THRESHOLD`` and the
+        forced reset clears the cooldown along with the session."""
+        from kiro_crew.session import _CIRCUIT_BREAKER_THRESHOLD
+
+        mgr = SessionManager(cfg, provider_factory=self._inplace_factory(pct_after=91.0))
+        await mgr.get_or_create("dashboard:chat-1")
+        mgr.release("dashboard:chat-1")
+
+        # Two ineffective attempts (the second simulating a post-cooldown
+        # retry) each re-arm the same cooldown.
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+        first = mgr._compact_cooldown_until["dashboard:chat-1"]
+        await mgr._compact_session("dashboard:chat-1", 92.0)
+        assert mgr._compact_cooldown_until["dashboard:chat-1"] >= first
+
+        # The session is still stuck at high context, so its turns fail; the
+        # existing breaker observes that repetition and force-resets.
+        tripped = False
+        for _ in range(_CIRCUIT_BREAKER_THRESHOLD):
+            tripped = await mgr.record_failure("dashboard:chat-1")
+        assert tripped
+        assert not mgr.has_session("dashboard:chat-1")
+        # The forced reset clears the cooldown too — the fresh session starts
+        # with no inherited damping.
+        assert "dashboard:chat-1" not in mgr._compact_cooldown_until
         await mgr.close_all()


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Auto-compaction treats the arrival of a terminal compaction status event as success and never checks whether context usage actually went down. The failure cooldown covers only *failed* compactions: a compaction that completes but frees little or nothing pops the cooldown, the next turn-end `check_context_usage` still sees the session at or above `autocompact_pct`, and another real model-generated summarization fires. Nothing damps the loop because every attempt looks successful.

## Why it matters

Each ineffective attempt costs real credits and latency — one model-generated summarization per turn for as long as the session sits above the threshold. Long agentic sessions with one dominating tool result are exactly the sessions that hit this, and they pay repeatedly for compactions that achieve nothing.

## What changed (motivation → approach → change)

Symptom: repeated summarizations on sessions stuck above the threshold. Root cause: the two success paths (`_compact_session`'s claude branch and `_compact_in_place`'s `"ok"` path) decide the cooldown from the status event alone, never from measured effect.

The change makes "completed but freed no meaningful headroom" a distinct outcome, decided at those two places:

- A new module constant `_COMPACT_MIN_EFFECT_PCT_POINTS = 5.0` (next to `_COMPACT_FAILURE_COOLDOWN_SECS`) defines ineffective as *freed less than 5 percentage points*. A drop test rather than "still above the threshold" on purpose: a legitimately good compaction of a very long turn can land above `autocompact_pct` while still having freed real headroom, and what the cooldown damps is the *no progress* case. 5 points sits below one typical turn's growth, so a smaller drop cannot prevent the immediate re-trigger anyway.
- `_settle_compact_cooldown` re-reads `context_usage_pct()` after a terminal-successful compaction and compares it with the trigger reading. A confirmed measured drop is judged immediately: `>= 5` points clears the cooldown (as today), `< 5` points **keeps the existing failure cooldown** — no second cooldown constant, no second counter — and logs both readings at warning.
- **The verdict is only made on a reading that describes the compacted conversation.** Two normal paths cannot provide one at completion time: kiro-cli's mid-turn terminal status resets stats to 0.0/unknown before any metadata drain (a naive re-read would compute a huge drop and classify *every* compaction effective, leaving the bug in place), and a backend that returns before any telemetry refresh still shows the pre-compaction value (a naive re-read would compute a zero drop and *punish a successful compaction*). Both defer: the trigger pct is stashed in `_compact_pending_verdict` and settled by `check_context_usage` at the first confirmed reading (via the existing `_context_pct_is_unknown` probe), *before* that same call's trigger decision — so an ineffective compaction's immediate re-trigger is still suppressed.
- Callback decision (all callers read): an ineffective compaction still fires `_fire_compact_callback(..., success=True)`. The compaction genuinely completed and rewrote the conversation, so skill-context reinjection (gated on success) must run, and `success=False` would post the dashboard/channel "Auto-compact failed — run `/compact` manually" notice for an attempt that ran to completion. The warning log carries the ineffectiveness signal; surfacing a distinct user-visible notice would change the notice contract and is out of scope here.
- The existing circuit breaker (`_CIRCUIT_BREAKER_THRESHOLD`) is deliberately reused rather than duplicated: repeated ineffective attempts keep re-arming the one cooldown, and the breaker's forced `reset()` clears it along with the session.
- `_compact_pending_verdict` is cleaned at the same lifecycle points as `_compact_cooldown_until` (reset / remove / remove_if_unclaimed / delete / discard / close_all), and the pruning tests now pin that parity.

Out of scope (unchanged by design): trigger thresholds and defaults, and the task runner's own verify-and-reset behaviour in `task_executor.py` — routing it through `SessionManager` is #4686.

## Tests

New `TestIneffectiveCompactionCooldown` in `test/test_session.py` (11 tests):

- effective compaction clears the cooldown — in-place and claude branches (spec a)
- effective-but-still-above-threshold is NOT treated as ineffective (spec b)
- ineffective compaction arms the cooldown, logs at warning, keeps `success=True`, and the immediate next `_trigger_compaction` is suppressed — in-place and claude (spec c)
- repeated ineffective attempts re-arm the one cooldown and the existing circuit breaker's forced reset clears it (spec d)
- unknown post-compaction reading defers the verdict (locks the kiro mid-turn path — fails on the naive always-effective shape)
- stale unchanged reading defers instead of damping a successful compaction (locks the claude path — fails on the naive zero-drop shape)
- deferred verdicts settle at the first confirmed reading: effective clears, ineffective arms before the same call's trigger decision, unknown readings don't consume the pending verdict

`TestCooldownPruning` extended to pin `_compact_pending_verdict` lifecycle parity.

Local gates: `isort` / `flake8` / `mypy` (1003 files) all clean; full backend suite 58,677 passed (12 failures pre-existing on clean `origin/main` in this environment — artifact-source allowed-roots and xdist host-budget assertions specific to the `/tmp` checkout location and host shape, verified by re-running the identical set on an unmodified checkout).

## Manual verification

N/A — unit coverage sufficient: both compaction paths, both deferral legs, the trigger-suppression ordering, and the breaker interaction are all exercised directly against `SessionManager` with provider doubles.

## Related Issues

Closes #4687

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — cooldown semantics live in `session.py` docstrings, updated in place; `docs/system-specs/modules/session.md` does not document the cooldown
- [x] No secrets, credentials, or internal references in the diff
