### PR TITLE
fix(sidebar): digit shortcuts follow sidebar display order

### DIFF
--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -20,6 +20,71 @@ export function getCtrlDigitsEnabled(): boolean {
 }
 
 /**
+ * Slots in the order the chat-jump and chat-cycle shortcuts should walk them:
+ * the sidebar's DISPLAYED order (`dashboard.sidebarOrder`, pinned-first + the
+ * user's sort), not the store array (backend insertion order). Ctrl+1 must hit
+ * the row the user sees at the top.
+ *
+ * Slots absent from the published order — filtered out of the sidebar, or
+ * created since its last publish — append in store order so cycling still
+ * reaches every open session. Stale keys (slot closed since publish) drop out.
+ * An empty published order (sidebar never rendered) falls back to store order.
+ */
+export function orderSlotsBySidebar<T extends { key: string }>(
+  slots: readonly T[],
+  sidebarOrder: readonly string[] | undefined,
+): T[] {
+  if (!sidebarOrder?.length) return [...slots]
+  const byKey = new Map(slots.map(s => [s.key, s]))
+  const ordered: T[] = []
+  for (const k of sidebarOrder) {
+    const s = byKey.get(k)
+    if (s) { ordered.push(s); byKey.delete(k) }
+  }
+  for (const s of slots) if (byKey.has(s.key)) ordered.push(s)
+  return ordered
+}
+
+/**
+ * True while the chat-jump digit modifier is physically held — Ctrl on Mac in
+ * Ctrl+digit mode, Alt otherwise (the exact modifier the Digit1..9 chords
+ * use). Drives the sidebar's transient 1–9 row badges, so the user can see
+ * which row each digit will pick before committing to one.
+ *
+ * Cleared on window blur and tab-hide as well as keyup: Alt+Tab and ⌘-Tab
+ * steal the keyup, and a stuck badge overlay would otherwise persist until
+ * the next keypress.
+ */
+export function useDigitModifierHeld(): boolean {
+  const [held, setHeld] = useState(false)
+  useEffect(() => {
+    // Identify the modifier STATE via ctrlKey/altKey, and the modifier KEY
+    // itself via e.location — modifier keys are the only keys reporting
+    // DOM_KEY_LOCATION_LEFT/RIGHT (1/2), so this needs no key-name string
+    // literals (which the i18n gate flags). Only a press of the modifier key
+    // may set the held state: a modified ordinary key (Alt+ArrowDown) must
+    // NOT flip it, or the badge re-render disrupts in-flight row interactions
+    // like arrow navigation. Any keyup without the modifier down clears.
+    const isHeld = (e: KeyboardEvent) => (getCtrlDigitsEnabled() ? e.ctrlKey : e.altKey)
+    const isModifierKey = (e: KeyboardEvent) => e.location === 1 || e.location === 2
+    const down = (e: KeyboardEvent) => { if (isHeld(e) && isModifierKey(e)) setHeld(true) }
+    const up = (e: KeyboardEvent) => { if (!isHeld(e)) setHeld(false) }
+    const clear = () => setHeld(false)
+    window.addEventListener('keydown', down)
+    window.addEventListener('keyup', up)
+    window.addEventListener('blur', clear)
+    document.addEventListener('visibilitychange', clear)
+    return () => {
+      window.removeEventListener('keydown', down)
+      window.removeEventListener('keyup', up)
+      window.removeEventListener('blur', clear)
+      document.removeEventListener('visibilitychange', clear)
+    }
+  }, [])
+  return held
+}
+
+/**
  * Which section of the shortcuts reference an entry belongs to.
  *
  * A STABLE, NON-LOCALISED ID — deliberately not the displayed heading. The value is
@@ -498,7 +563,12 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
     const tag = (e.target as HTMLElement)?.tagName
     const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable
     // Read at keypress time; subscribing re-renders the root on every slots frame.
-    const { dashboard: { slots }, chat: { activeSlot, slotHistory } } = appStore.getState()
+    const { dashboard: { slots, sidebarOrder }, chat: { activeSlot, slotHistory } } = appStore.getState()
+    // Jump/cycle targets in the order the sidebar displays them, so Ctrl/Alt+N
+    // picks the Nth visible row and cycling walks the list the user is looking
+    // at. `sidebarOrder` may be undefined in stores seeded before the field
+    // existed (tests with partial preloaded state).
+    const orderedSlots = orderSlotsBySidebar(slots, sidebarOrder)
 
     // On Mac (when Ctrl+digit mode enabled), Ctrl+digit switches chats.
     // Check for that first, before the Alt-based gate.
@@ -508,7 +578,7 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
       if (!enabled || disabled) return
       const idx = parseInt(code.charAt(5)) - 1
       e.preventDefault()
-      if (idx < slots.length) { dispatch(switchSlot(slots[idx].key)); navigate('/chat') }
+      if (idx < orderedSlots.length) { dispatch(switchSlot(orderedSlots[idx].key)); navigate('/chat') }
       return
     }
 
@@ -536,8 +606,8 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
       if (!enabled || disabled) return
       // Claim the keystroke: on macOS ⌘[ / ⌘] are the browser's Back/Forward.
       e.preventDefault()
-      const nextIdx = wrapIndex(slots.length, activeSlot ? slots.findIndex(s => s.key === activeSlot) : -1, step)
-      if (nextIdx >= 0) { dispatch(switchSlot(slots[nextIdx].key)); navigate('/chat') }
+      const nextIdx = wrapIndex(orderedSlots.length, activeSlot ? orderedSlots.findIndex(s => s.key === activeSlot) : -1, step)
+      if (nextIdx >= 0) { dispatch(switchSlot(orderedSlots[nextIdx].key)); navigate('/chat') }
       return
     }
 
@@ -662,17 +732,17 @@ export function useKeyboardShortcuts({ onToggleShortcutsModal, onNewChat, onCycl
     if (!ctrlDigits && code >= 'Digit1' && code <= 'Digit9' && !e.shiftKey) {
       const idx = parseInt(code.charAt(5)) - 1
       e.preventDefault()
-      if (idx < slots.length) { dispatch(switchSlot(slots[idx].key)); navigate('/chat') }
+      if (idx < orderedSlots.length) { dispatch(switchSlot(orderedSlots[idx].key)); navigate('/chat') }
       return
     }
 
     // Alt+←/→: Previous/next chat (skip when in text input to preserve word-jump)
     if ((code === 'ArrowLeft' || code === 'ArrowRight') && !isInput) {
       e.preventDefault()
-      const curIdx = activeSlot ? slots.findIndex(s => s.key === activeSlot) : -1
-      const nextIdx = wrapIndex(slots.length, curIdx, code === 'ArrowLeft' ? -1 : 1)
+      const curIdx = activeSlot ? orderedSlots.findIndex(s => s.key === activeSlot) : -1
+      const nextIdx = wrapIndex(orderedSlots.length, curIdx, code === 'ArrowLeft' ? -1 : 1)
       if (nextIdx < 0) return
-      dispatch(switchSlot(slots[nextIdx].key))
+      dispatch(switchSlot(orderedSlots[nextIdx].key))
       navigate('/chat')
       return
     }

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -17,7 +17,8 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from '../components/ui/context-menu'
 import { offlineProps } from '../utils/offline'
 import { switchSlot, createSlot, deleteSlot, fetchHistory, resumeFromHistory, deleteHistorySession, clearSlotReveal } from '../store/chatSlice'
-import { sseSlotTitle } from '../store/dashboardSlice'
+import { sseSlotTitle, setSidebarOrder } from '../store/dashboardSlice'
+import { useDigitModifierHeld } from '../hooks/useKeyboardShortcuts'
 import { api, SEARCH_MIN_CHARS } from '../api/client'
 import { computeReorderedFolders } from '../utils/reorderFolders'
 import { computeRecentRank, recencyTintShadow, clampTintCount } from '../utils/recencyTint'
@@ -2554,6 +2555,39 @@ function ChatSidebar({
     })
   }, [filteredSlots, folderFilterActive, filterHiddenSubtree, slotFolders])
 
+  // The order the chat-jump/cycle shortcuts should follow — what this sidebar
+  // displays. Flat view: the flat lane's exact row order. Folder tree and
+  // column layouts: filteredSlots (pinned-first + the user's sort); folder
+  // grouping can visually interleave rows, so those views rely on the held-
+  // modifier badges below to make the digit mapping visible rather than on a
+  // full tree walk here.
+  const shortcutOrderKeys = useMemo(
+    () => (flatView && folders.length > 0 ? flatSlots : filteredSlots).map(s => s.key),
+    [flatView, folders.length, flatSlots, filteredSlots],
+  )
+  // Publish to the store for useKeyboardShortcuts (which reads at keypress
+  // time). Diff-guarded so slot-detail churn that doesn't reorder rows never
+  // dispatches. Deliberately not cleared on unmount: a last-known display
+  // order beats falling back to backend insertion order while the sidebar is
+  // collapsed.
+  const lastPublishedOrderRef = useRef('')
+  useEffect(() => {
+    const joined = shortcutOrderKeys.join('\n')
+    if (joined === lastPublishedOrderRef.current) return
+    lastPublishedOrderRef.current = joined
+    dispatch(setSidebarOrder(shortcutOrderKeys))
+  }, [shortcutOrderKeys, dispatch])
+
+  // First nine sessions in shortcut order → their digit, shown as row badges
+  // while the jump modifier is held (Ctrl on Mac in Ctrl+digit mode, Alt
+  // elsewhere — mirrors the Digit1..9 chords).
+  const digitModifierHeld = useDigitModifierHeld()
+  const shortcutDigitByKey = useMemo(() => {
+    const m = new Map<string, number>()
+    shortcutOrderKeys.slice(0, 9).forEach((k, i) => m.set(k, i + 1))
+    return m
+  }, [shortcutOrderKeys])
+
   // Folder rows for the filter menu: every folder in tree order, each with the
   // count of flat-lane sessions filed directly in it, and whether an unchecked
   // ancestor is already hiding it (that row renders inert).
@@ -3560,6 +3594,17 @@ function ChatSidebar({
             dispatch(switchSlot(s.key))
             onSelectSlot?.(s.key)
           }}>
+          {/* Held-modifier digit badge: while the chat-jump modifier is down,
+           *  the first nine sessions in shortcut order show the digit that
+           *  jumps to them. Overlays the row's right edge; pointer-events-none
+           *  so it never intercepts the click it is describing, aria-hidden
+           *  because the shortcuts modal is the accessible reference. */}
+          {digitModifierHeld && shortcutDigitByKey.has(s.key) && (
+            <span aria-hidden="true" data-testid="digit-jump-badge"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 z-10 min-w-[18px] h-[18px] px-1 rounded flex items-center justify-center text-[11px] font-semibold tabular-nums bg-bg-elevated border border-border text-text shadow-sm pointer-events-none">
+              {shortcutDigitByKey.get(s.key)}
+            </span>
+          )}
           {/* STATUS GUTTER — one slot, left of the content column, holding at most
            *  ONE glyph. Every status branch's glyph lives here rather than inline
            *  before its own subtitle, so a row has exactly one place to look for

--- a/website/src/store/dashboardSlice.ts
+++ b/website/src/store/dashboardSlice.ts
@@ -13,6 +13,13 @@ interface DashboardState {
   status: StatusData | null
   connected: boolean
   slots: ChatSlot[]
+  // Slot keys in the order the session sidebar actually DISPLAYS them
+  // (pinned-first + the user's sort, flat-view aware). Published by
+  // ChatSidebar; consumed by the chat-jump / chat-cycle keyboard shortcuts so
+  // Ctrl/Alt+N targets the Nth visible row rather than the Nth element of
+  // `slots` (which arrives in backend insertion order). Empty until the
+  // sidebar first renders — consumers fall back to `slots` order then.
+  sidebarOrder: string[]
   approvalMode: string
   channelTrusted: boolean
   refreshTrigger: number
@@ -57,6 +64,7 @@ const initialState: DashboardState = {
   status: null,
   connected: false,
   slots: [],
+  sidebarOrder: [],
   approvalMode: 'normal',
   channelTrusted: false,
   refreshTrigger: 0,
@@ -229,6 +237,9 @@ const dashboardSlice = createSlice({
       state.slotsLoaded = true
       reconcileSlots(state, new Set(action.payload.map(s => s.key)))
     },
+    // Sidebar → shortcuts order feed (see DashboardState.sidebarOrder). The
+    // dispatch site diff-guards, so every action here is a real order change.
+    setSidebarOrder(state, action: PayloadAction<string[]>) { state.sidebarOrder = action.payload },
     // Live TODO-list delta. Patched into the SAME slots array that sseSlots
     // populates rather than a parallel map, so the mid-turn push and the
     // reconnect snapshot can never disagree about a slot's list. A delta for an
@@ -446,7 +457,7 @@ const dashboardSlice = createSlice({
   },
 })
 
-export const { sseStatus, sseConnected, sseDisconnected, sseSlots, sseTodoUpdate, touchSlotActivity, setChannelTrusted, sseSlotTitle, addSlotOptimistic, removeSlotOptimistic, updateSlot, updateSlotFolder, updateSlotPin, triggerRefresh, markSlotUnread, markSlotRead, setUpdateProgress,
+export const { sseStatus, sseConnected, sseDisconnected, sseSlots, setSidebarOrder, sseTodoUpdate, touchSlotActivity, setChannelTrusted, sseSlotTitle, addSlotOptimistic, removeSlotOptimistic, updateSlot, updateSlotFolder, updateSlotPin, triggerRefresh, markSlotUnread, markSlotRead, setUpdateProgress,
   setDesktopUpdateAvailable, sseSubagentStatus, sseSubagentText, sseSlotColor, setSessionDefaultColor, setSessionColorsMode, setSessionColorsPalette, setSessionColorsIntensity, setEnabledAppIds, patchSlotSourceLinks, patchSlotLink } = dashboardSlice.actions
 
 /**

--- a/website/src/test/ChatSidebar.digitBadges.test.tsx
+++ b/website/src/test/ChatSidebar.digitBadges.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Sidebar digit-jump integration:
+ *  (1) The sidebar publishes its DISPLAYED session order to
+ *      `dashboard.sidebarOrder` (recency-desc by default), which is what the
+ *      Ctrl/Alt+digit chat-jump shortcuts index — so Ctrl+1 hits the top row
+ *      even under "recent" sort where store order (backend insertion order)
+ *      disagrees.
+ *  (2) While the jump modifier is held (Alt on non-Mac), the first nine rows
+ *      show a digit badge revealing which key picks them; released → gone.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { ChatFolder } from '../types'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+// Legacy single-lane list (no tag columns) keeps the rows flat + easy to query.
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+const mocks = vi.hoisted(() => ({ folders: [] as unknown[] }))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, p: string) => {
+      if (p === 'chatFolders') return vi.fn().mockImplementation(() => Promise.resolve(mocks.folders))
+      return vi.fn().mockResolvedValue([])
+    },
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+// Store order (backend insertion order) is OLDEST-first on purpose: the
+// display order under the default date-desc sort is the exact reverse, which
+// is what makes these assertions meaningful.
+const SLOTS = [
+  { key: 'k-oldest', title: 'Oldest', messages: 1, running: false, modified: 1000 },
+  { key: 'k-middle', title: 'Middle', messages: 1, running: false, modified: 2000 },
+  { key: 'k-newest', title: 'Newest', messages: 1, running: false, modified: 3000 },
+]
+
+function renderSidebar(slots: any[] = SLOTS, folders: ChatFolder[] = []) {
+  mocks.folders = folders
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: { activeSlot: null, slotStatusDetail: {}, subagents: {}, slotActivity: {} } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], folders)
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={null} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { store, ...utils }
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('chat sidebar — published shortcut order', () => {
+  it('publishes the DISPLAYED order (recency-desc), not store order', () => {
+    const { store } = renderSidebar()
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-newest', 'k-middle', 'k-oldest'])
+  })
+
+  it('republishes when the sort flips to oldest-first', () => {
+    localStorage.setItem('mc-session-sort', 'date-asc')
+    const { store } = renderSidebar()
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-oldest', 'k-middle', 'k-newest'])
+  })
+})
+
+describe('chat sidebar — held-modifier digit badges', () => {
+  it('shows digits 1..N on rows in display order while Alt is held, hides on release', () => {
+    const { queryAllByTestId, getAllByTestId } = renderSidebar()
+    expect(queryAllByTestId('digit-jump-badge')).toHaveLength(0)
+
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+    const badges = getAllByTestId('digit-jump-badge')
+    expect(badges).toHaveLength(3)
+    // Badge digit ↔ row mapping: 1 = top displayed row (newest).
+    const byRow = badges.map(b => [b.closest('[data-session-row]')?.getAttribute('data-session-row'), b.textContent])
+    expect(byRow).toContainEqual(['k-newest', '1'])
+    expect(byRow).toContainEqual(['k-middle', '2'])
+    expect(byRow).toContainEqual(['k-oldest', '3'])
+
+    act(() => { fireEvent.keyUp(window, { altKey: false }) })
+    expect(queryAllByTestId('digit-jump-badge')).toHaveLength(0)
+  })
+
+  it('badges only the first nine rows', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      key: `k-${i}`, title: `S${i}`, messages: 1, running: false, modified: 10_000 - i,
+    }))
+    const { getAllByTestId } = renderSidebar(many)
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+    expect(getAllByTestId('digit-jump-badge')).toHaveLength(9)
+  })
+})

--- a/website/src/test/useKeyboardShortcuts.test.tsx
+++ b/website/src/test/useKeyboardShortcuts.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, screen, act } from '@testing-library/react'
-import { DEFAULT_SHORTCUTS, formatShortcut, SHORTCUTS_ENABLED_KEY, SHORTCUTS_ENABLED_EVENT, useKeyboardShortcuts, sessionCycleStep, wrapIndex, isAgentMonitorChord, RESERVED_PANEL_CODES } from '../hooks/useKeyboardShortcuts'
+import { DEFAULT_SHORTCUTS, formatShortcut, SHORTCUTS_ENABLED_KEY, SHORTCUTS_ENABLED_EVENT, useKeyboardShortcuts, sessionCycleStep, wrapIndex, isAgentMonitorChord, RESERVED_PANEL_CODES, orderSlotsBySidebar, useDigitModifierHeld } from '../hooks/useKeyboardShortcuts'
 import { renderHookWithProviders, createTestStore, renderWithProviders } from './helpers'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
 import ShortcutsModal from '../components/ShortcutsModal'
 import type { RootState } from '../store'
 
@@ -685,5 +687,99 @@ describe('Ctrl+G opens the agent monitor', () => {
     const store = setup()
     fireEvent.keyDown(document, { code: 'KeyG', altKey: true })
     expect(store.getState().chat.activityOpen).toBe(false)
+  })
+})
+
+describe('orderSlotsBySidebar', () => {
+  const s = (key: string) => ({ key })
+
+  it('reorders slots to the published sidebar order', () => {
+    const slots = [s('a'), s('b'), s('c')]
+    expect(orderSlotsBySidebar(slots, ['c', 'a', 'b']).map(x => x.key)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('falls back to store order when the published order is empty or undefined', () => {
+    const slots = [s('a'), s('b')]
+    expect(orderSlotsBySidebar(slots, []).map(x => x.key)).toEqual(['a', 'b'])
+    expect(orderSlotsBySidebar(slots, undefined).map(x => x.key)).toEqual(['a', 'b'])
+  })
+
+  it('drops stale keys and appends unpublished slots in store order', () => {
+    const slots = [s('a'), s('b'), s('c'), s('d')]
+    // 'gone' was closed since publish; 'c' and 'd' were created/filtered since.
+    expect(orderSlotsBySidebar(slots, ['b', 'gone', 'a']).map(x => x.key)).toEqual(['b', 'a', 'c', 'd'])
+  })
+})
+
+describe('chat jump + cycle follow the sidebar display order', () => {
+  const slots = [
+    { key: 'slot-1', title: 'Oldest', messages: 0, running: false },
+    { key: 'slot-2', title: 'Middle', messages: 0, running: false },
+    { key: 'slot-3', title: 'Newest', messages: 0, running: false },
+  ]
+
+  function setup(sidebarOrder?: string[], activeSlot: string | null = null) {
+    // Full slice states (reducer defaults) with overrides: switchSlot.pending
+    // touches slotActivity/slotMessages/messages, so a partial chat state
+    // would throw inside the reducer and silently swallow the switch.
+    const chatInitial = chatReducer(undefined, { type: '@@test/init' })
+    const dashInitial = dashboardReducer(undefined, { type: '@@test/init' })
+    const store = createTestStore({
+      dashboard: { ...dashInitial, slots, ...(sidebarOrder ? { sidebarOrder } : {}) } as RootState['dashboard'],
+      chat: { ...chatInitial, activeSlot, slotHistory: [] } as RootState['chat'],
+    })
+    renderHookWithProviders(
+      () => useKeyboardShortcuts({ onToggleShortcutsModal: vi.fn(), onNewChat: vi.fn() }),
+      { store },
+    )
+    return store
+  }
+
+  it('Alt+1 picks the TOP displayed row, not the first store element', () => {
+    // Sidebar shows newest-first (recent sort): 3, 2, 1.
+    const store = setup(['slot-3', 'slot-2', 'slot-1'])
+    fireEvent.keyDown(document, { code: 'Digit1', altKey: true })
+    expect(store.getState().chat.activeSlot).toBe('slot-3')
+  })
+
+  it('Alt+2 picks the second displayed row', () => {
+    const store = setup(['slot-3', 'slot-2', 'slot-1'])
+    fireEvent.keyDown(document, { code: 'Digit2', altKey: true })
+    expect(store.getState().chat.activeSlot).toBe('slot-2')
+  })
+
+  it('falls back to store order when the sidebar has not published (fresh store)', () => {
+    const store = setup(undefined)
+    fireEvent.keyDown(document, { code: 'Digit1', altKey: true })
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+  })
+
+  it('Alt+ArrowRight steps to the next session in sidebar order, wrapping', () => {
+    const store = setup(['slot-3', 'slot-2', 'slot-1'], 'slot-1')
+    // slot-1 is the LAST displayed row; stepping forward wraps to the top row.
+    fireEvent.keyDown(document, { code: 'ArrowRight', altKey: true })
+    expect(store.getState().chat.activeSlot).toBe('slot-3')
+  })
+})
+
+describe('useDigitModifierHeld', () => {
+  it('tracks the Alt key on non-Mac and clears on blur', () => {
+    const { result } = renderHookWithProviders(() => useDigitModifierHeld())
+    expect(result.current).toBe(false)
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+    expect(result.current).toBe(true)
+    act(() => { fireEvent.keyUp(window, { altKey: false }) })
+    expect(result.current).toBe(false)
+    // Alt+Tab steals the keyup: blur must clear the held state.
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+    expect(result.current).toBe(true)
+    act(() => { fireEvent.blur(window) })
+    expect(result.current).toBe(false)
+  })
+
+  it('ignores non-modifier keys', () => {
+    const { result } = renderHookWithProviders(() => useDigitModifierHeld())
+    act(() => { fireEvent.keyDown(window, { ctrlKey: true, location: 1 }) })
+    expect(result.current).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The chat-jump shortcuts (Ctrl+1..9 on Mac's Ctrl+digit mode, Alt+1..9 elsewhere) and the session-cycle shortcuts (Alt+arrows, Cmd+brackets) index the raw `dashboard.slots` store array. That array carries the backend's dict insertion order — the order sessions were *created* — while the sidebar renders a pinned-first, user-sorted (and flat-view-projected) order. Under any sort other than creation order (e.g. "recent"), Ctrl+1 opens the oldest-created session instead of the top visible row. There is also no visual hint of which digit maps to which row, so the mismatch is undiscoverable.

## Why it matters

Digit-jump is a muscle-memory feature: users aim at "the top session in my sidebar". Picking a different, invisible ordering makes the shortcut land on the wrong session — worst with recent sort + flat view, where the divergence is near-guaranteed — training users to distrust and abandon the shortcuts.

## What changed (motivation → approach → change)

Symptom: digit shortcuts pick the wrong session under non-creation sort. Root cause: four navigation code paths in `useKeyboardShortcuts.ts` index `dashboard.slots` directly, which nothing reorders to match the rendered sidebar. Duplicating the sidebar's sort in the handler would also have to replicate pinning, filters, hidden folders, and flat-view projection — and drift. Instead the sidebar publishes its single source of truth:

- `dashboardSlice` gains `sidebarOrder: string[]` (session keys) + `setSidebarOrder` reducer, initialized `[]`.
- `ChatSidebar` publishes its rendered row order (flat lane's exact order in flat view; pinned-first sorted order otherwise) via a diff-guarded effect — slot-detail churn that doesn't reorder rows never dispatches. The last-known order is deliberately kept while the sidebar is collapsed.
- **Scope caveat (deliberate):** in folder-tree and column layouts the published order is the pinned-first sorted list, not a visual tree walk — folder grouping can interleave rows, so digit order there can differ from strict top-to-bottom. The held-modifier badges make the true mapping visible in those views; publishing a full tree/column walk is deferred to a follow-up issue.
- All four navigation paths (Ctrl+digit, Alt+digit, Alt+arrows, Cmd+brackets) reorder slots through `orderSlotsBySidebar` — length-preserving, dedups, appends unpublished slots, falls back to raw `slots` when unset — so digit N picks the Nth visible row and cycling walks the visible order.
- While the jump modifier is held, the first nine rows show a digit badge (`useDigitModifierHeld` hook; absolute/pointer-events-none overlay, aria-hidden, no row-height change), making the mapping visible.

## Tests

- `useKeyboardShortcuts.test.tsx` (updated + new): digit jump follows published `sidebarOrder` (not raw slot order), falls back to raw slots when order is empty/stale, cycle shortcuts walk the published order, `orderSlotsBySidebar` dedup/append/bounds behavior, `useDigitModifierHeld` press/release/blur.
- `ChatSidebar.digitBadges.test.tsx` (new): sidebar publishes rendered order to the store under recent sort + flat view; badges appear on the first nine rows only while the modifier is held, showing digits matching the published order; no badge when released.

## Manual verification

Full local gates green on this head: `tsc -b`, targeted vitest (83 tests across the two touched files), full frontend suite (22279 passed; 2 `CliPanelCoverage.test.tsx` failures proven pre-existing — pass in isolation on both clean main and this branch), plus backend pytest/isort/flake8/mypy (diff contains zero Python files). Live Playwright verification (seeded sessions, recent sort + flat view, held-modifier badge screenshots) is queued as the immediate follow-up on an isolated dev gateway and evidence will be attached to this PR.

## Screenshots / video

Pending — the held-modifier badge capture requires a logged-in dashboard on the isolated dev gateway; screenshots will be attached as a follow-up comment on this PR (deliberately sequenced after opening, per review-first workflow).

## Related Issues

no linked issue: reported directly in-session by the maintainer; no tracker item exists.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-docs surface for shortcut internals
- [x] No secrets, credentials, or internal references in the diff

