### PR TITLE
fix(acp): destroy the shared-subagent handle even if cancel is interrupted

### DIFF
--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -189,17 +189,23 @@ class AcpSessionProvider(LLMProvider):
             # prompt on that sessionId with "already in progress". So cancel the
             # session's turn first (best-effort, bounded so an unresponsive
             # runtime can't turn shutdown into a hang), then destroy the handle.
-            if self._handle.is_turn_active:
-                try:
-                    await asyncio.wait_for(self._handle.cancel(), timeout=5.0)
-                except Exception:
-                    logger.debug(
-                        "AcpSessionProvider.shutdown: session cancel failed", exc_info=True
-                    )
             try:
-                await self._handle.destroy()
-            except Exception:
-                logger.debug("AcpSessionProvider.shutdown: destroy failed", exc_info=True)
+                if self._handle.is_turn_active:
+                    try:
+                        await asyncio.wait_for(self._handle.cancel(), timeout=5.0)
+                    except Exception:
+                        logger.debug(
+                            "AcpSessionProvider.shutdown: session cancel failed", exc_info=True
+                        )
+            finally:
+                # destroy() must still run even if a CancelledError (a BaseException,
+                # not caught above) interrupts the cancel wait — it's the only RSS
+                # reclaim available on this shared-runtime path and it deletes the
+                # session transcript below. Cancellation still propagates after.
+                try:
+                    await self._handle.destroy()
+                except Exception:
+                    logger.debug("AcpSessionProvider.shutdown: destroy failed", exc_info=True)
             # destroy() deletes the shared-subagent session transcript
             # (~/.kiro/sessions/cli/{sid}.json+.jsonl); no separate cleanup call
             # needed. cleanup_session() below remains for the LLMProvider API.

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -190,6 +191,22 @@ class TestAcpSessionProviderLifecycle:
         provider = AcpSessionProvider(handle, runtime, owns_runtime=False)
 
         await provider.shutdown()
+        handle.destroy.assert_awaited_once()
+        runtime.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_destroys_handle_even_if_cancel_is_interrupted(self):
+        # asyncio.CancelledError is a BaseException, so it is not caught by the
+        # `except Exception` around the cancel wait. destroy() must still run
+        # (it's the only RSS reclaim on this shared-runtime path, and it deletes
+        # the session transcript) before the cancellation propagates.
+        handle = _make_handle(is_turn_active=True)
+        handle.cancel = AsyncMock(side_effect=asyncio.CancelledError())
+        runtime = _make_runtime()
+        provider = AcpSessionProvider(handle, runtime, owns_runtime=False)
+
+        with pytest.raises(asyncio.CancelledError):
+            await provider.shutdown()
         handle.destroy.assert_awaited_once()
         runtime.kill.assert_not_called()
 


### PR DESCRIPTION
## Problem / Motivation

`AcpSessionProvider.shutdown()`'s session-sharing (shared-runtime subagent) arm cancels an in-flight turn and *then* destroys the handle, sequentially, with `destroy()` sitting after the cancel rather than in a `finally`. `asyncio.CancelledError` is a `BaseException`, so it is not caught by the `except Exception` wrapping the cancel wait — when a `CancelledError` interrupts `await asyncio.wait_for(self._handle.cancel(), timeout=5.0)`, `destroy()` is never reached.

## Why it matters

This cancellation has a production source: the dashboard restart path wraps `provider.shutdown()` in `asyncio.wait_for(..., timeout=_SHUTDOWN_TIMEOUT_SECS)` and `asyncio.gather()`s several of these together — a timeout, or a cancelled sibling in the gather, delivers a `CancelledError` into `shutdown()` at whatever await it happens to be sitting on. When that lands mid-cancel, `destroy()` is skipped, which loses two things this branch is explicitly responsible for: the `terminate_session` RSS reclaim (the only cleanup available here without killing the runtime the subagent shares with co-tenant sessions), and the session transcript unlink (`~/.kiro/sessions/cli/{sid}.json+.jsonl`) — nothing else deletes it. No caller retries; every caller drops the provider immediately after `shutdown()` returns or raises.

## What changed (motivation → approach → change)

Symptom → root cause → fix:
- Symptom: a shared-subagent session can leak its runtime slot and transcript file when shutdown is cancelled mid-flight.
- Root cause: `destroy()` runs after the cancel `try/except Exception`, not in a `finally`, so a `CancelledError` (uncaught by `except Exception`) skips it entirely.
- Fix: wrap the `is_turn_active` cancel branch in `try/finally`, moving `destroy()` (with its existing `except Exception` swallow-and-log) into the `finally`. Ordinary-exception behavior is unchanged (still swallowed, logged at debug); a `CancelledError` still propagates after `destroy()` runs, matching the documented `close_all()` convention (`docs/system-specs/modules/session.md`: "A cancel that fires mid-drain ... propagates ... so the caller's hard deadline stays honest"). `AcpSessionHandle.destroy()` itself is untouched — this is purely a shutdown-flow-control fix in `session_provider.py`.

## Tests

Added `test_shutdown_destroys_handle_even_if_cancel_is_interrupted` in `test/test_acp_session_provider.py::TestAcpSessionProviderLifecycle`: `handle.cancel()` raises `asyncio.CancelledError`, and the test asserts `shutdown()` still re-raises it (propagation preserved) *and* `handle.destroy()` was awaited before it did.

`python -m pytest test/test_acp_session_provider.py -q` — 91 passed. `black`/`isort`/`flake8`/`mypy` clean on the touched files.

## Manual verification

N/A — unit coverage sufficient; this is a pure control-flow fix around mocked async calls, fully exercised by the async unit tests above.

## Related Issues

Fixes #4694.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec documents this shutdown method's internal sequencing at this granularity
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)