### PR TITLE
test(embeddings): seed distinct vectors so writes survive dedupe

### DIFF
--- a/test/test_embedding_model_apply.py
+++ b/test/test_embedding_model_apply.py
@@ -1150,12 +1150,28 @@ def _store(tmp_path: Path, dim: int = 8) -> VectorMemoryStore:
     return s
 
 
+def _basis_embed(dim: int = 8):
+    """One stable vector per text, orthogonal across texts.
+
+    A text-independent constant makes every write after the first score as a
+    duplicate against the indexed vector, so a loop seeding N memories leaves
+    one row behind and the progress denominator below reads 1 instead of N.
+    """
+    slots: dict[str, int] = {}
+
+    def embed(text: str) -> list[float]:
+        slot = slots.setdefault(text, len(slots) % dim)
+        return [1.0 if i == slot else 0.0 for i in range(dim)]
+
+    return embed
+
+
 class TestBackfillProgressReporting:
     """Without a denominator the indicator can only spin."""
 
     def test_reports_total_up_front(self, tmp_path: Path) -> None:
         store = _store(tmp_path)
-        store.embed_fn = lambda t: [0.5] * 8
+        store.embed_fn = _basis_embed()
         for i in range(3):
             store.write_episodic(f"memory number {i} long enough to be stored here")
         store.db.execute("UPDATE episodic_memories SET embedding = NULL")
@@ -1170,7 +1186,7 @@ class TestBackfillProgressReporting:
 
     def test_progress_is_monotonic(self, tmp_path: Path) -> None:
         store = _store(tmp_path)
-        store.embed_fn = lambda t: [0.5] * 8
+        store.embed_fn = _basis_embed()
         for i in range(4):
             store.write_episodic(f"memory number {i} long enough to be stored here")
         store.db.execute("UPDATE episodic_memories SET embedding = NULL")

--- a/test/test_embedding_space_reconcile.py
+++ b/test/test_embedding_space_reconcile.py
@@ -30,7 +30,22 @@ def _store(tmp_path: Path, dim: int = 8) -> VectorMemoryStore:
 
 
 def _fixed_embed(dim: int = 8):
-    return lambda text: [0.5] * dim
+    """One stable vector per text, orthogonal across texts.
+
+    write_episodic rejects a write whose vector scores above the similarity
+    dedupe threshold against one already indexed, so a text-independent constant
+    collapses every memory seeded after the first into it and the row counts
+    below can never reach 2. Basis vectors keep seeded rows distinct while
+    repeating the same text still reproduces its original vector, which is what
+    the re-embed assertions rely on.
+    """
+    slots: dict[str, int] = {}
+
+    def embed(text: str) -> list[float]:
+        slot = slots.setdefault(text, len(slots) % dim)
+        return [1.0 if i == slot else 0.0 for i in range(dim)]
+
+    return embed
 
 
 def _episodic_with_vectors(store: VectorMemoryStore) -> int:


### PR DESCRIPTION
## Problem / Motivation

Four tests in the embedding reconcile and backfill suites fail whenever `faiss-cpu` is present in the environment:

```
PYTHONPATH=src python3 -m pytest test/test_embedding_space_reconcile.py test/test_embedding_model_apply.py
4 failed, 108 passed
```

```
test_embedding_space_reconcile.py::TestFirstRunWithACustomModel::test_unattributable_vectors_are_cleared_not_stamped
test_embedding_space_reconcile.py::TestModelChangeInvalidates::test_changed_model_clears_episodic_vectors
test_embedding_space_reconcile.py::TestReembedAfterInvalidation::test_backfill_re_embeds_the_cleared_rows
test_embedding_model_apply.py::TestBackfillProgressReporting::test_reports_total_up_front
```

Every failure has the same shape: the store holds fewer rows than the test seeded, so a count asserted as 2 or 3 comes back as 1.

The fixtures seed those memories through an embedding function that ignores its input:

```python
def _fixed_embed(dim: int = 8):
    return lambda text: [0.5] * dim
```

Every text therefore produces an identical vector. `write_episodic` dedupes on vector similarity (`_DEFAULT_DEDUP_THRESHOLD = 0.88` at `vector_memory.py:139`, the comparison at `:1561`), two identical vectors score 1.0, so every write after the first is discarded as a duplicate. The tests that pass are exactly the ones that seed a single memory and assert `== 1`.

## Why it matters

Two reasons.

The failures are invisible to CI. `faiss` appears nowhere in `setup.cfg`, `pyproject.toml`, or `.github/workflows/`, and the similarity dedupe at `vector_memory.py:1550` is gated on `self._faiss_index is not None`. With faiss absent the whole block is skipped, so this suite is green in CI and green for most contributors, and red only for someone who happens to have `faiss-cpu` installed. That is a confusing first run with nothing in the output pointing at the cause.

The tests also silently stop covering what they claim. `test_reports_total_up_front` exists to assert the backfill denominator is known before any work begins. Seeded with three memories but storing one, in a faiss environment it was measuring a one-row backfill, so the assertion it exists to make was weakened rather than exercised.

## What changed (motivation → approach → change)

The fixtures collided with a deliberate write-path feature, so the fix belongs in the fixtures. The dedupe on episodic writes is intentional, and the comments around `vector_memory.py:1544` describe its degradation behaviour on purpose, so relaxing it would be a behaviour decision rather than a test fix.

Both fixtures now give each distinct text its own basis vector. Distinct texts come out orthogonal (cosine 0, well under the 0.88 threshold) so seeded rows stay separate, and repeating a text returns the same vector it had before, which is what the re-embed assertions depend on. The slot is assigned by first-seen order rather than by hashing the text: hashing a handful of texts into 8 slots collides often enough to make these tests flaky.

`test_progress_is_monotonic` got the same fixture. It passed either way because it only asserts monotonicity, but it was seeding four memories and storing one, so it was not testing what it reads as testing.

No production code changes.

## Tests

Existing tests only. Both environments, on the two files the issue names:

| environment | before | after |
|---|---|---|
| with `faiss-cpu` 1.9.0 | 4 failed, 108 passed | 112 passed |
| without faiss (CI) | 112 passed | 112 passed |

Wider regression run with faiss installed, covering `test_vector_memory.py`, `test_vector_memory_coverage.py`, `test_embeddings.py`, `test_enable_embeddings_faiss.py`, `test_custom_embedding_model.py`, `test_episodic_relevance_admission.py`, `test_memory_smoke.py` and the two files above: 13 failed / 609 passed before, 9 failed / 613 passed after. The four this PR targets clear, and nothing new breaks.

Two notes on what I left alone. Of the nine remaining failures, six are the same fixture collision in `test_vector_memory.py` and `test_vector_memory_coverage.py`, which the issue does not mention; I kept this PR to the four it names, and I am happy to extend it if you would rather fix the family in one go. The other three (`TestPromotionSkipIsObservable`) are a separate faiss dimension mismatch that surfaces as `assert d == self.d` inside faiss itself, unrelated to dedupe. Whether CI should install `faiss-cpu` so any of this path is covered is a separate call and not made here.

## Manual verification

N/A for behaviour, this is a test-fixture change with no runtime surface. Gates run with the exact CI commands:

- `scripts/check_black_formatting.py` (black 26.3.1): passed, 2 files in scope
- `isort --check-only src/kiro_crew test`: passed
- `flake8 src/kiro_crew test`: passed
- `mypy src/kiro_crew/`: passed, 1003 source files

## Related Issues

Fixes #4730

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
