### PR TITLE
fix: clamp session.autocompact_pct on load to the dashboard range (#4734)

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -663,7 +663,7 @@ class AgentConfig:
 class SessionConfig:
     timeout_secs: int = 3600       # 60 min idle timeout (DEFAULT_SESSION_TIMEOUT)
     empty_response_auto_continue: bool = True  # after TWO consecutive empty model responses, auto-send ONE synthetic "continue" nudge on the same live session (transcript-visible notice; bounded to once per user message; the config gate fails OPEN to the default so a config-load hiccup cannot disable self-healing). See session.md "Empty-response recovery ladder".
-    autocompact_pct: float = 90.0  # context usage % at which auto-compaction triggers (5-90)
+    autocompact_pct: float = 90.0  # context usage % at which auto-compaction triggers. Load-time clamped to [5.0, 90.0] (one constant pair shared with the dashboard write gate)
     pool_size: int = 2             # pre-warmed kiro-cli processes kept ready for instant session start; 0 disables. Load-time clamped to [0, 10]
     watchdog_rss_max_mb: int = 0   # recycle a session when its process tree RSS exceeds this many MiB; 0 disables (default). Busy sessions (turn in flight) are never recycled.
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3667,6 +3667,20 @@ LOOP_STALL_EXIT_AFTER_MAX = 300
 # constant to avoid a config→subagent import cycle).
 MAX_SUBAGENTS_FIXED_FLOOR = 3
 
+# session.autocompact_pct — context-usage percentage at which the backend
+# autocompactor fires. SINGLE SOURCE OF TRUTH for the documented 5-90 range:
+# the dashboard config API (``dashboard/handlers/core.py``) validates writes
+# against these same constants, and the load read clamps a hand-edited
+# config.json value into them, so the two ranges cannot drift as separate
+# literals. The autocompactor is the backstop that keeps a session's context
+# window from overflowing — above the ceiling the trigger
+# (``pct >= autocompact_pct``) never fires before the window overflows, and
+# at/below zero it fires on every turn. Floats are outside the int-only
+# ``_SECURITY_BOUNDED_FIELDS`` sweep, so the clamp lives on the ``_safe_float``
+# read instead.
+AUTOCOMPACT_PCT_MIN = 5.0
+AUTOCOMPACT_PCT_MAX = 90.0
+
 # (section, key, min, max) for each bounded field clamped at load time. The
 # mins match the runtime floors: subagent_auto_max has a floor of 3
 # (``subagent._LEGACY_DEFAULT_MAX`` — the auto-size minimum), so a value < 3 is
@@ -6203,7 +6217,12 @@ class KiroCrewConfig:
                 empty_response_auto_continue=bool(
                     session_data.get("empty_response_auto_continue", True)
                 ),
-                autocompact_pct=_safe_float(session_data.get("autocompact_pct", 90.0), 90.0),
+                autocompact_pct=_safe_float(
+                    session_data.get("autocompact_pct", 90.0),
+                    90.0,
+                    lo=AUTOCOMPACT_PCT_MIN,
+                    hi=AUTOCOMPACT_PCT_MAX,
+                ),
                 pool_size=_safe_int(session_data.get("pool_size", 2), 2, 0, POOL_SIZE_MAX),
                 pool_agent=str(session_data.get("pool_agent", "")),
                 pool_ttl_secs=_safe_int(session_data.get("pool_ttl_secs", 1800), 1800),

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -29,6 +29,8 @@ from kiro_crew.computer_use.types import MAX_TREE_NODES_LIMIT as _CU_MAX_TREE_NO
 from kiro_crew.computer_use.types import MIN_SCREENSHOT_MAX_PX as _CU_MIN_SCREENSHOT_MAX_PX
 from kiro_crew.config.loader import (
     _VALID_STT_PROVIDERS,
+    AUTOCOMPACT_PCT_MAX,
+    AUTOCOMPACT_PCT_MIN,
     MAX_SUBAGENTS_FIXED_FLOOR,
     SUBAGENT_AUTO_MAX_CEILING,
     SUBAGENT_MAX_TURNS_CEILING,
@@ -1636,7 +1638,13 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     "agent.completion_keep_chars": {"type": "int", "min": 0, "max": RESULT_FILE_MAX_BYTES},
     "agent.soft_stop_budget_secs": {"type": "float", "min": 0.5, "max": 60.0},
     "session.timeout_secs": {"type": "int", "min": 0, "max": 86400},
-    "session.autocompact_pct": {"type": "float", "min": 5.0, "max": 90.0},
+    # Range shared with the load-time clamp in config/loader.py — one constant
+    # pair, so the write gate and the load path cannot drift (issue #4734).
+    "session.autocompact_pct": {
+        "type": "float",
+        "min": AUTOCOMPACT_PCT_MIN,
+        "max": AUTOCOMPACT_PCT_MAX,
+    },
     "session.pool_size": {"type": "int", "min": 0, "max": 10},
     "session.pool_agent": {"type": "str", "values_fn": _agent_values},
     "session.pool_ttl_secs": {"type": "int", "min": 0, "max": 7200},

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -2923,6 +2923,56 @@ class TestSecurityBoundClamping:
             _log_config_clamp_event("agent.subagent_auto_max", 200, 64, 1, 64)
 
 
+class TestAutocompactPctLoadClamp:
+    """session.autocompact_pct clamps into the documented 5-90 range at load
+    time (issue #4734).
+
+    The dashboard config API rejected out-of-range writes but a hand-edited
+    config.json loaded verbatim: at 500 the autocompactor trigger
+    (``pct >= autocompact_pct``) can never fire, silently disabling the
+    context-window backstop, and at 0 or below it fires on every turn.
+    """
+
+    def test_above_range_clamped_to_max(self) -> None:
+        from kiro_crew.config.loader import AUTOCOMPACT_PCT_MAX
+
+        cfg = _load_from_dict({"session": {"autocompact_pct": 500}})
+        assert cfg.session.autocompact_pct == AUTOCOMPACT_PCT_MAX == 90.0
+
+    def test_negative_clamped_to_min(self) -> None:
+        from kiro_crew.config.loader import AUTOCOMPACT_PCT_MIN
+
+        cfg = _load_from_dict({"session": {"autocompact_pct": -10}})
+        assert cfg.session.autocompact_pct == AUTOCOMPACT_PCT_MIN == 5.0
+
+    def test_zero_clamped_to_min(self) -> None:
+        """0 would fire auto-compaction on every turn; clamped UP to the floor."""
+        cfg = _load_from_dict({"session": {"autocompact_pct": 0}})
+        assert cfg.session.autocompact_pct == 5.0
+
+    def test_in_range_value_preserved(self) -> None:
+        cfg = _load_from_dict({"session": {"autocompact_pct": 75.5}})
+        assert cfg.session.autocompact_pct == 75.5
+
+    def test_default_when_omitted(self) -> None:
+        cfg = _load_from_dict({})
+        assert cfg.session.autocompact_pct == 90.0
+
+    def test_load_range_and_dashboard_validator_share_one_constant(self) -> None:
+        """Drift guard: the dashboard write-gate bounds for
+        ``session.autocompact_pct`` must BE the loader's clamp constants — the
+        same objects, not two sets of literals that can drift apart (the drift
+        is exactly how the load path lost the range in the first place)."""
+        from kiro_crew.config.loader import AUTOCOMPACT_PCT_MAX, AUTOCOMPACT_PCT_MIN
+        from kiro_crew.dashboard.handlers.core import _EDITABLE_CONFIG
+
+        spec = _EDITABLE_CONFIG["session.autocompact_pct"]
+        assert spec["type"] == "float"
+        assert spec["min"] is AUTOCOMPACT_PCT_MIN
+        assert spec["max"] is AUTOCOMPACT_PCT_MAX
+        assert (AUTOCOMPACT_PCT_MIN, AUTOCOMPACT_PCT_MAX) == (5.0, 90.0)
+
+
 class TestConfigWriteProtection:
     """config.json / config.local.json are WRITE-protected (reads allowed)."""
 


### PR DESCRIPTION
## What is the problem?

`session.autocompact_pct` is loaded from config.json without bounds. The load read in `src/kiro_crew/config/loader.py` called `_safe_float(session_data.get("autocompact_pct", 90.0), 90.0)` with no `lo`/`hi`, while the dashboard save path (`src/kiro_crew/dashboard/handlers/core.py`) enforces `{"type": "float", "min": 5.0, "max": 90.0}`. The documented 5.0-90.0 range was therefore enforced only on dashboard edits: a hand-edited `autocompact_pct: 500` (or a negative/zero value) loaded as-is. The range also lived as two independent literal pairs that could drift.

## Why this issue matters to the user

The autocompactor is the backend backstop that keeps a session's context window from overflowing. With an out-of-range value on disk the failure is silent in both directions: at 500 the trigger `pct >= autocompact_pct` can never fire, so the backstop is disabled and long sessions run into context overflow; at 0 it fires on every turn. Same defect class as the merged #4688 per-transport threshold fix: validity was a property of whichever write path remembered to clamp, not of the load path.

## How our fix solves it

Chain from symptom to root cause: the out-of-range value survives because the load path never states the range; the range can drift because it exists as two literal pairs.

- `src/kiro_crew/config/loader.py`: adds `AUTOCOMPACT_PCT_MIN = 5.0` / `AUTOCOMPACT_PCT_MAX = 90.0` as the single source of truth beside the other load-time bound constants, and passes them as `lo`/`hi` to the existing `_safe_float` at the load read. `_safe_float` already handles NaN/Inf/bool/non-numeric by falling back to the default, so the clamp composes with the existing coercion. The clamp is silent by design, matching the coercion-site precedent for behavior knobs (`_threshold_pct`); the SEL-logged `_SECURITY_BOUNDED_FIELDS` sweep is int-only and covers resource-consumption ceilings, which this is not - the constant's comment records that reasoning.
- `src/kiro_crew/dashboard/handlers/core.py`: the `_EDITABLE_CONFIG` entry for `session.autocompact_pct` now references those same constants instead of its own literals, so the write gate and the load path cannot drift.
- `docs/system-specs/modules/config.md`: the field's spec line now documents the load-time clamp, matching the sibling clamped fields.
- `SessionConfig` is constructed from disk data at exactly one site (verified by sweep), so the single clamped read covers every consumer (`session.py`, `task_executor.py`, `cli_chat.py` all read the loaded dataclass).

Deliberately NOT in scope: the #4689 transport-ladder design question, and any other float knob - this PR is the one-field mechanical clamp the issue asks for.

## What tests we did

- New `TestAutocompactPctLoadClamp` in `test/test_config_loader.py`: 500 clamps to 90.0, -10 clamps to 5.0, 0 clamps to 5.0 (would otherwise fire every turn), in-range 75.5 preserved, omitted key defaults to 90.0, and a drift guard asserting the dashboard validator's `min`/`max` ARE the loader constants (object identity, not equality - two equal literals fail it).
- Mutation-verified both directions: removing `lo`/`hi` from the load read fails the three clamp tests (500.0 != 90.0 etc.); reverting the validator entry to literals fails the drift guard (`assert 5.0 is 5.0` on distinct objects).
- Full backend suite: 58654 passed, 14 failed - all 14 reproduced identically on an unmodified origin/main checkout on the same host (path/home/cpu-count environment failures), zero introduced by this change.
- Gates: isort, flake8, mypy (1003 files clean), black baseline gate (diff-scoped, clean), brand-name gate.

## Any other suggestions on the work

`_SECURITY_BOUNDED_FIELDS` being int-only means float knobs each carry their clamp at the coercion site; if a third float knob grows a range, generalizing the sweep to floats (with its WARNING+SEL logging) would be the structural home. Not needed for this one-field fix.

Closes #4734
