### PR TITLE
docs: correct the session-summary scope claim

### DIFF
--- a/docs/system-specs/modules/session-summary.md
+++ b/docs/system-specs/modules/session-summary.md
@@ -400,12 +400,57 @@ prevent the gateway from starting.
 
 ## Scope in this release
 
-Dashboard sessions only. The generator hangs off the dashboard turn-end hub, so
-Slack, cron, webhook and task-runner turns do not produce summaries. Reaching
-them means threading the flag through the same four call sites
-`skills.auto_create_from_sessions` uses (`cli.py`, `cli_server.py`,
-`dashboard/server.py`, `slack/gateway.py`). This is a deliberate cut, not an
-oversight.
+**The boundary is the turn loop, not the surface.** `_should_summarize` contains
+no check on where a message came from — it gates on `enabled`, an in-flight pass,
+incognito mode, liveness, a clean `end_turn`, the turn count and the cadence, and
+nothing else. Coverage is decided instead by *where the generator is called from*:
+the automatic pass has exactly one dispatch site, `_finish_queue_cycle` at the
+tail of a `_ChatSlot` turn in `dashboard/chat_runner.py`, plus the explicit
+on-demand route in `dashboard/chat_handlers.py`. Only a turn that ran through
+`_run_chat` on a slot reaches the automatic pass — and reaching it is not the same
+as producing a summary, because the gates above still apply. The on-demand route
+is the one path that produces a summary with no turn at all.
+
+So the excluded set is every surface that owns its own turn loop, and it is wider
+than "not the dashboard":
+
+| Surface | Where its turn is driven instead |
+|---|---|
+| Slack | `slack/handler.py` (native ACP loop) or `messaging/driver.py` (`TurnDriver`) |
+| Discord, Telegram, Teams, Webex, WeCom, WeChat | `messaging/driver.py` (`TurnDriver`), one shared loop |
+| Task runner | `task_executor.py`, streaming an ACP client directly |
+| Cron wake | `slack/gateway.py`; the result is *appended* into a `cron-<id>` slot by `dashboard/cron_inject.py` — a bare append with no turn lifecycle |
+| Agent webhooks | `dashboard/handlers/hooks.py` |
+| Workflow phase calls | `workflows/agent_exec.py` |
+| Subagents | `subagent.py` — never a `_ChatSlot` at all, so a `.intents` sidecar is not reachable |
+| `kirocrew chat` | `cli_chat.py`, straight onto the provider |
+
+Two corollaries the "dashboard only" shorthand gets wrong in both directions.
+The OpenAI-compatible endpoint (`dashboard/openai_compat.py`) calls `_run_chat` on
+a real slot, so it **does** summarize — a single-shot ephemeral request still
+stops at `min_user_turns`, but a caller reusing an `id` does not. And the
+initiator is not the boundary: a Slack thread explicitly linked to a slot, an
+auto-nudge cycle **on a dashboard slot** (a nudge on a channel key uses a separate
+fire path and does not), a cron delivering with `session="origin"`, a workflow's
+post-run auto-turn, and the task runner's review handoff to chat all cross into
+`_run_chat`, and so reach the automatic pass on the dashboard session they drive —
+never on themselves, and still subject to every gate above.
+
+Excluding the channels is deliberate, and enforced rather than incidental:
+`DashboardState` refuses to index a channel-born session's self-referential
+`slack_thread_ts`, because binding it would make inbound Slack resolve to a
+"linked" slot and silently change the execution engine and approval semantics of
+all Slack traffic.
+
+Widening coverage is therefore not a matter of threading the config flag to more
+call sites — the flag is already global, and every excluded surface skips the
+generator by never reaching its dispatch site. It needs either a turn-end dispatch
+in each surface's own loop, or one shared post-turn boundary that all of them
+cross. Note also that reaching the dispatch site is not sufficient: an auto-nudge
+cycle does reach it, but a nudge row is persisted under role `nudge` and
+`extract_turns` reads only `user` and `assistant`, so a nudge cycle never advances
+`count_user_turns`. A nudge-only session therefore stays below `min_user_turns`
+until a person types.
 
 No governance capability scope. Nothing enforces one, and a scope is a data-only
 addition later; if one is ever added it must be registered inline in


### PR DESCRIPTION
## Problem / Motivation

`docs/system-specs/modules/session-summary.md`'s "Scope in this release" section
described session-summary coverage as a property of the **originating surface**,
and pointed readers at a remediation that does not correspond to the code:

> Dashboard sessions only. The generator hangs off the dashboard turn-end hub, so
> Slack, cron, webhook and task-runner turns do not produce summaries. Reaching
> them means threading the flag through the same four call sites
> `skills.auto_create_from_sessions` uses (`cli.py`, `cli_server.py`,
> `dashboard/server.py`, `slack/gateway.py`). This is a deliberate cut, not an
> oversight.

Three things are wrong with that paragraph, and one is right but under-evidenced.

- **`skills.auto_create_from_sessions` is a config `bool`, not a function**
  (`config/loader.py`, the `SkillsConfig` block), so "the call sites it uses" is a
  category error. The four filenames are real, but they are constructor-wiring
  sites that pass `auto_skills_enabled=` into one shared `HistoryConsolidator`.
- **The analogy inverts what the code does.** Auto-skill creation rides on history
  consolidation, and `maybe_consolidate` is *already* called from the chat runner,
  the Slack handler, the Slack transport dispatch and the task runner. Nothing was
  ever threaded per-surface to widen it, so it is the opposite of a template for
  widening summary coverage.
- **"Dashboard sessions only" is wrong in both directions.** The
  OpenAI-compatible endpoint calls `_run_chat` on a real slot and *does*
  summarize; and several non-dashboard *initiators* bridge into `_run_chat` and
  produce a summary of the dashboard session they drive.
- **"A deliberate cut, not an oversight" is correct**, but the doc offered no
  evidence for it. There is stronger evidence available: `DashboardState`
  actively refuses to index a channel-born session's self-referential
  `slack_thread_ts`, on the recorded grounds that binding it would change the
  execution engine and approval semantics of all Slack traffic.

## Why it matters

A spec doc is where a reader goes to find out what the system does, so a
confident wrong scope claim keeps being believed. This one already propagated: a
downstream design method inherited a false "coverage gap" from this paragraph and
carried it as a blocker, which is work spent on a gap that does not exist.

The remediation sentence is the more expensive half. A reader who wants to widen
coverage is sent to look for call sites of something that is not callable, using
as their model a mechanism that needed no such threading — so the paragraph costs
them time and then leaves them with the wrong plan.

## What changed (motivation → approach → change)

**Motivation.** The paragraph answers "which turns summarize?" with the wrong
predicate. Coverage is not a property of the surface a message arrived on.

**Root cause of the wrong claim.** `_should_summarize` contains no surface check
at all — it gates on `enabled`, an in-flight pass, incognito mode, liveness, a
clean `end_turn`, the turn count and the cadence. Coverage is decided entirely by
*where the generator is called from*, and the automatic pass has exactly one
dispatch site: `_finish_queue_cycle`, at the tail of a `_ChatSlot` turn. The
old text described a consequence of that arrangement as if it were a rule the
code enforced, which is why it could be wrong in both directions at once.

**Change.** The section is rewritten to state the real boundary and its
consequences:

1. The boundary is the turn loop, not the surface — with the gate list, the one
   automatic dispatch site, and the explicit on-demand route that is the only path
   producing a summary with no turn at all.
2. A table of the surfaces that own their own turn loop and are therefore excluded
   — wider than "not the dashboard": Slack plus six other channels, the task
   runner, cron wakes, agent webhooks, workflow phase calls, subagents, and
   `kirocrew chat`, each naming where its turn is driven instead.
3. The two corollaries the old shorthand got backwards: the OpenAI-compat endpoint
   summarizes, and the initiator is not the boundary (five bridges into
   `_run_chat` named).
4. The deliberate-exclusion claim, now grounded in the `slack_thread_ts` guard.
5. The remediation sentence replaced with the real options: a turn-end dispatch in
   each surface's own loop, or one shared post-turn boundary all of them cross.
6. A closing note that reaching the dispatch site is not sufficient — a nudge row
   is persisted under role `nudge` and `extract_turns` reads only `user` and
   `assistant`, so a nudge cycle never advances `count_user_turns`.

Prose-only. No behaviour change, and no code file is touched.

## Tests

**None added, and none apply.** This diff changes one markdown file and no
importable code, so there is no behaviour for a test to lock in. Prose accuracy is
not something the suite can assert.

What did run, and what each actually checks:

- `scripts/docs-lint.sh` (+ its `--test` self-check) — passes; index/link
  integrity across 215 markdown files, which is what catches a docs change that
  orphans a reference.
- `scripts/check_brand_name.py`, `check_changelog_history.py`,
  `check_focus_cue.py`, `check_harness_parity.py` — all run diff-scoped against
  the merge base, all pass.
- `scripts/scrub-lint.sh --no-history`, `scripts/verify_vendor_manifest.py`,
  `scripts/check_per_file_coverage.py --test` — pass.
- `scripts/check_black_formatting.py` — passes (nothing in scope unformatted
  outside the baseline).

Deliberately deferred to CI, with the reason: `pytest`, `isort`, `flake8`, `mypy`
— `src/kiro_crew/` and `test/` are byte-identical to `origin/main` on this branch,
so any verdict they produce describes main rather than this PR. Likewise the
frontend and template lanes (`npm build`, `tsc -b`, `eslint`, `i18n:check`,
`i18n:render`, `vitest`, `cfn-lint`) — no `website/` or YAML file is touched.

## Manual verification

Every factual claim in the new section was traced against the code rather than
inferred, because the paragraph being replaced was itself an untraced inference.

Verified directly: the gate list in `_should_summarize`; that
`generate_session_summary` has exactly two callers (the automatic
`_finish_queue_cycle` dispatch and the forced on-demand route); each
surface-to-file mapping in the exclusion table; that `openai_compat` calls
`_run_chat` on a real slot; that `cron_inject` is a bare `slot.append` with no turn
lifecycle; that `_fire_dashboard_nudge` reaches `_run_chat` while
`_fire_slack_nudge` / `_fire_discord_nudge` are separate paths; that the nudge row
is appended under role `nudge` and `_READ_ROLES` is `{"user", "assistant"}`; and
that the `slack_thread_ts` self-reference guard exists.

Also checked: no sibling spec restates a stale "dashboard-only" summary scope, so
this commit leaves no companion doc inconsistent.

**Not verified, and stated plainly:** no surface was executed end to end to
*observe* a summary being written or not written. The exclusions are established
from the call graph — each surface's turn loop provably never reaches the one
dispatch site — not from a runtime experiment. Claims about panel rendering are
out of scope here; this section describes generation only.

The base moved twice during preparation. After the final rebase the two moved
files that this section cites (`dashboard/state.py`, `slack/gateway.py`) were
re-checked: both changed only in the update-capability surface, and all four cited
claims still hold at the new base.

## Related Issues

no linked issue: this corrects a wrong paragraph found while auditing the module,
and nothing was filed for it beforehand.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — no new tests; docs-only, see Tests
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — this PR *is* the documentation update
- [x] No secrets, credentials, or internal references in the diff
