### PR TITLE
fix: gate the git update lane on install provenance, not just the path

### DIFF
--- a/src/kiro_crew/platform/update_capability.py
+++ b/src/kiro_crew/platform/update_capability.py
@@ -27,6 +27,7 @@ import subprocess
 from dataclasses import dataclass, replace
 from typing import Any
 
+from kiro_crew._bootstrap import _source_checkout_root
 from kiro_crew.beacon import distribution
 from kiro_crew.platform_compat import trusted_system_bin
 
@@ -227,10 +228,10 @@ def is_git_worktree(root: str) -> bool:
     match would silently stop working under a non-English locale.
 
     Both paths stay ANCHORED at *root*, so ancestor capture is rejected either
-    way. What the fallback cannot do is tell this install's own checkout from an
-    unrelated repository that ``KIROCREW_PROJECT_DIR`` happens to name — neither
-    could the check it replaced, and deciding it would need a signal other than
-    the path.
+    way. What neither path can do is tell this install's own checkout from an
+    unrelated repository that ``KIROCREW_PROJECT_DIR`` happens to name — that
+    needs a signal other than the path, which is what
+    :func:`running_from_checkout` supplies on top of this probe.
     """
     if not root or "\x00" in root:
         return False
@@ -252,6 +253,42 @@ def is_git_worktree(root: str) -> bool:
         return os.path.samefile(top, root)
     except OSError:
         return os.path.realpath(top) == os.path.realpath(root)
+
+
+def running_from_checkout(root: str) -> bool:
+    """Is *root* the checkout the ``kiro_crew`` package THIS process runs from?
+
+    The signal :func:`is_git_worktree` cannot supply: that *root* is a real
+    working tree says nothing about whether the running code came from it. A
+    release install (a wheel in its own venv) whose ``KIROCREW_PROJECT_DIR``
+    resolves onto a checkout — the CWD-walking project detection does exactly
+    this when the gateway is launched from inside a clone — passes the path
+    probe while its bytes are owned by the release feed. Classifying it as a
+    git install misreports the version drift, and the apply endpoint would then
+    ``git pull`` + ``pip install -e`` that clone, silently replacing the
+    release install with whatever the clone contains.
+
+    Delegates to :func:`kiro_crew._bootstrap._source_checkout_root`, which
+    resolves where the imported package actually loads from: the repo root for
+    an editable install or a ``PYTHONPATH=src`` dev run — the layouts whose
+    bytes ``git pull`` genuinely updates — and ``None`` for anything resolving
+    through an installed tree (a wheel's ``site-packages``, including a venv
+    nested under an unrelated repository such as a dotfiles home). *root* must
+    then be that same directory: a DIFFERENT checkout is exactly the
+    misclassification this refuses.
+    """
+    if not root or "\x00" in root:
+        return False
+    checkout = _source_checkout_root()
+    if checkout is None:
+        return False
+    target = os.path.abspath(root)
+    try:
+        # Inode identity, not string equality — same reasoning as the anchor
+        # comparison in is_git_worktree.
+        return os.path.samefile(str(checkout), target)
+    except OSError:
+        return os.path.realpath(str(checkout)) == os.path.realpath(target)
 
 
 @dataclass(frozen=True)
@@ -374,7 +411,14 @@ def derive_capability(
             },
         )
 
-    if is_git_worktree(install_root):
+    if is_git_worktree(install_root) and running_from_checkout(install_root):
+        # BOTH halves are required for the git lane. The worktree probe answers
+        # "is this path a checkout"; provenance answers "is it THIS install's
+        # checkout". A release install pointed at someone's clone (the CWD-derived
+        # project dir does this) passes the first and must not take this branch:
+        # its updates come from the release feed below, and the apply endpoint
+        # would otherwise replace the install with the clone's contents.
+        #
         # can_apply is true because ``POST /api/update`` genuinely applies on a
         # checkout: git fetch + reset + rebuild + restart. It answers only
         # "can the running process apply this", which is the question an
@@ -439,4 +483,5 @@ __all__ = [
     "UpdateCapability",
     "derive_capability",
     "is_git_worktree",
+    "running_from_checkout",
 ]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -406,6 +406,10 @@ class TestUpdateFailures:
 
     def test_git_fetch_failure_exits(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
 
         def _side_effect(*args, **kwargs):
             cmd = args[0] if args else kwargs.get("args", [])
@@ -433,6 +437,10 @@ class TestUpdateFailures:
 
     def test_pip_install_failure_exits(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
 
         def _side_effect(*args, **kwargs):
             cmd = args[0] if args else kwargs.get("args", [])

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -967,6 +967,13 @@ def git_checkout(monkeypatch, tmp_path):
     # and a bare ``.git`` directory is refused by both on purpose.
     (proj / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
     monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+    # The git lane requires provenance as well as the path probe; this fixture
+    # exercises the git path with a fabricated tree the test process does not
+    # run from, so provenance is declared rather than derived.
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_capability.running_from_checkout",
+        lambda root, **kw: True,
+    )
     monkeypatch.setattr(
         "kiro_crew.platform.update_governance.resolve_remote_url",
         lambda p, remote="", branch="": "https://github.com/kirodotdev/KiroCrew.git",

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -137,18 +137,24 @@ def _sequence_procs(monkeypatch, procs: list[_FakeProc]) -> list[tuple[str, ...]
     return argv_seen
 
 
-def _git_proj(tmp_path) -> str:
+def _git_proj(monkeypatch, tmp_path) -> str:
     """A directory the capability derivation accepts as this install's checkout.
 
     ``.git/HEAD`` is written, not just ``.git/``: the derivation asks git first
     and falls back to the on-disk markers of a working tree's own root, and a
     bare ``.git`` directory satisfies neither — a fabricated one is refused on
-    purpose.
+    purpose. The git lane also requires provenance (the running package loads
+    from the tree), which a fabricated directory cannot satisfy, so it is
+    declared here rather than derived.
     """
     proj = tmp_path / "checkout"
     proj.mkdir()
     (proj / ".git").mkdir()
     (proj / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "kiro_crew.platform.update_capability.running_from_checkout",
+        lambda root, **kw: True,
+    )
     return str(proj)
 
 
@@ -219,7 +225,7 @@ class TestGitCheckoutFailurePaths:
 
     async def _run(self, monkeypatch, tmp_path, procs: list[_FakeProc]):
         argv = _sequence_procs(monkeypatch, procs)
-        await updates._check_git_checkout(_git_proj(tmp_path), _git_capability())
+        await updates._check_git_checkout(_git_proj(monkeypatch, tmp_path), _git_capability())
         return argv
 
     def _assert_failed_check(self, error: str) -> None:
@@ -581,7 +587,7 @@ class TestApplyRefusals:
         permits this host to pull from this remote -- and a blocked update must
         leave no "updating" overlay behind for the user to dismiss.
         """
-        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(monkeypatch, tmp_path))
         monkeypatch.setattr(updates, "resolve_remote_url", lambda _p: "https://example.invalid/x")
         monkeypatch.setattr(updates, "update_blocked_reason", lambda _u: "remote is not permitted")
 
@@ -597,7 +603,7 @@ class TestApplyRefusals:
 
     @pytest.mark.asyncio
     async def test_a_hung_status_check_answers_500_rather_than_hanging(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(monkeypatch, tmp_path))
         monkeypatch.setattr(updates, "resolve_remote_url", lambda _p: "")
         monkeypatch.setattr(updates, "update_blocked_reason", lambda _u: "")
         _sequence_procs(monkeypatch, [_FakeProc(time_out=True, kill_raises=True)])
@@ -611,7 +617,7 @@ class TestApplyRefusals:
 
     @pytest.mark.asyncio
     async def test_a_dirty_tree_is_refused_without_starting_the_worker(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(monkeypatch, tmp_path))
         monkeypatch.setattr(updates, "resolve_remote_url", lambda _p: "")
         monkeypatch.setattr(updates, "update_blocked_reason", lambda _u: "")
         _sequence_procs(monkeypatch, [_FakeProc(out=b" M src/kiro_crew/cli.py\n")])
@@ -625,7 +631,7 @@ class TestApplyRefusals:
 
     async def _drive_worker(self, monkeypatch, tmp_path, procs: list[_FakeProc]):
         """Accept the request, then await the background worker it scheduled."""
-        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(monkeypatch, tmp_path))
         monkeypatch.setattr(updates, "resolve_remote_url", lambda _p: "")
         monkeypatch.setattr(updates, "update_blocked_reason", lambda _u: "")
         _sequence_procs(monkeypatch, [_FakeProc(out=b"")] + procs)
@@ -664,7 +670,7 @@ class TestApplyRefusals:
         The overlay has no other way to leave the "updating" state, so a
         swallowed error strands the user on a spinner forever.
         """
-        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(monkeypatch, tmp_path))
         monkeypatch.setattr(updates, "resolve_remote_url", lambda _p: "")
         monkeypatch.setattr(updates, "update_blocked_reason", lambda _u: "")
         calls = {"n": 0}
@@ -1333,7 +1339,7 @@ class TestExternallyManagedCheck:
     async def test_an_unexpected_crash_records_an_error_rather_than_a_verdict(
         self, monkeypatch, tmp_path
     ):
-        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", _git_proj(monkeypatch, tmp_path))
 
         async def _boom(_proj: str, _capability) -> None:
             raise RuntimeError("git is not installed")

--- a/test/test_update_capability.py
+++ b/test/test_update_capability.py
@@ -19,6 +19,7 @@ from kiro_crew.platform.update_capability import (
     _git_toplevel,
     derive_capability,
     is_git_worktree,
+    running_from_checkout,
 )
 
 
@@ -255,6 +256,57 @@ class TestIsGitWorktree:
         assert is_git_worktree("--upload-pack=touch /tmp/x") is False
 
 
+class TestRunningFromCheckout:
+    """Provenance: does the RUNNING package come from the named tree?
+
+    ``is_git_worktree`` answers a path question; these answer the install
+    question layered on top of it. The probe itself is
+    ``_bootstrap._source_checkout_root`` (one probe owns "where does this
+    process's code come from"); what is tested here is the anchoring of its
+    answer to the named root.
+    """
+
+    @staticmethod
+    def _pin_checkout(monkeypatch, path):
+        monkeypatch.setattr(update_capability, "_source_checkout_root", lambda: path)
+
+    def test_the_checkout_this_process_runs_from_is_accepted(self, tmp_path, monkeypatch):
+        self._pin_checkout(monkeypatch, tmp_path)
+        assert running_from_checkout(str(tmp_path)) is True
+
+    def test_a_different_checkout_is_refused(self, tmp_path, monkeypatch):
+        # The field failure: a real Kiro Crew worktree the process does NOT run
+        # from. Same markers, wrong identity.
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        mine = tmp_path / "mine"
+        mine.mkdir()
+        self._pin_checkout(monkeypatch, mine)
+        assert running_from_checkout(str(clone)) is False
+
+    def test_a_release_install_has_no_checkout_at_all(self, tmp_path, monkeypatch):
+        # A wheel resolves inside site-packages, so the probe answers None —
+        # no root can claim provenance, whatever tree it names.
+        self._pin_checkout(monkeypatch, None)
+        assert running_from_checkout(str(tmp_path)) is False
+
+    def test_a_symlink_to_the_checkout_still_matches(self, tmp_path, monkeypatch):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+        self._pin_checkout(monkeypatch, real)
+        assert running_from_checkout(str(link)) is True
+
+    def test_empty_root_is_refused(self, tmp_path, monkeypatch):
+        self._pin_checkout(monkeypatch, tmp_path)
+        assert running_from_checkout("") is False
+
+    def test_a_nul_byte_in_the_root_is_refused_not_raised(self, tmp_path, monkeypatch):
+        self._pin_checkout(monkeypatch, tmp_path)
+        assert running_from_checkout(str(tmp_path) + "\x00") is False
+
+
 class TestDeriveCapability:
     @pytest.mark.parametrize("dist", ["dmg", "appimage"])
     def test_desktop_defers_to_its_own_updater(self, dist):
@@ -275,8 +327,11 @@ class TestDeriveCapability:
         assert capability.remediation is not None
         assert capability.remediation["kind"] == "image_pull"
 
-    def test_a_checkout_can_apply_in_process(self, tmp_path):
+    def test_a_checkout_can_apply_in_process(self, tmp_path, monkeypatch):
         _init_repo(tmp_path)
+        # The git lane needs BOTH halves; this test exercises the path half, so
+        # provenance is declared true rather than derived from this process.
+        monkeypatch.setattr(update_capability, "running_from_checkout", lambda root, **kw: True)
         capability = derive_capability(install_root=str(tmp_path), dist="source")
         assert capability.managed_by == "git"
         assert capability.can_apply is True
@@ -305,7 +360,26 @@ class TestDeriveCapability:
     def test_install_root_defaults_to_the_project_env(self, tmp_path, monkeypatch):
         _init_repo(tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(update_capability, "running_from_checkout", lambda root, **kw: True)
         assert derive_capability(dist="source").managed_by == "git"
+
+    def test_a_checkout_this_process_does_not_run_from_takes_the_feed(self, tmp_path):
+        """The defect the provenance half exists for.
+
+        A release install's CWD-derived project dir can land on somebody's clone
+        — a real working tree with nothing to do with the running code. The path
+        probe passes; provenance must refuse, or the check compares against the
+        clone's remote and the apply endpoint replaces the install with the
+        clone's contents. No stub here: this test process genuinely does not run
+        from ``tmp_path``, which is the exact shape of the field failure.
+        """
+        _init_repo(tmp_path)
+        capability = derive_capability(install_root=str(tmp_path), dist="wheel")
+        assert capability.managed_by == "kirocrew"
+        assert capability.can_apply is False
+        # The remediation is the installer for THIS install's real channel, not
+        # "kirocrew update" against the unrelated clone.
+        assert (capability.remediation or {}).get("command", "") != "kirocrew update"
 
     def test_to_dict_carries_the_whole_contract_half(self, tmp_path):
         contract = derive_capability(install_root=str(tmp_path), dist="wheel").to_dict()

--- a/test/test_update_check_install_aware.py
+++ b/test/test_update_check_install_aware.py
@@ -383,6 +383,13 @@ class TestGitCheckoutStillWorks:
     def _git_install(self, monkeypatch, tmp_path):
         _init_repo(tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        # These tests exercise the CHECK against a scripted git; the process
+        # running them does not load kiro_crew from tmp_path, so the provenance
+        # half of the git-lane gate is declared rather than derived.
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
         return tmp_path
 
     @staticmethod

--- a/test/test_update_git_guard.py
+++ b/test/test_update_git_guard.py
@@ -89,6 +89,10 @@ class TestUpdateCheckGitGuard:
         # the real git dir — update checks must still run there.
         _init_repo(tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
         called = {"n": 0}
 
         class _Proc:
@@ -108,6 +112,10 @@ class TestUpdateCheckGitGuard:
     def test_proceeds_when_dot_git_present(self, monkeypatch, tmp_path):
         _init_repo(tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
         called = {"n": 0}
 
         class _Proc:

--- a/test/test_update_progress.py
+++ b/test/test_update_progress.py
@@ -220,6 +220,10 @@ class TestUpdateEndpoints:
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
         _init_repo(tmp_path)  # must be a git checkout to reach the dirty check
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
 
         from kiro_crew.dashboard.handlers import api_update_apply
 

--- a/test/test_update_venv_detection.py
+++ b/test/test_update_venv_detection.py
@@ -272,6 +272,10 @@ class TestApiUpdateApplyVenvDispatch:
     ) -> None:
         proj = _make_pip_proj(tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
         monkeypatch.setattr("kiro_crew.env.is_toolbox_install", lambda: False)
 
         pip_called: list[bool] = []
@@ -323,6 +327,10 @@ class TestApiUpdateApplyVenvDispatch:
     ) -> None:
         proj = _make_pip_proj(tmp_path)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
         monkeypatch.setattr("kiro_crew.env.is_toolbox_install", lambda: False)
 
         restart_called: list[bool] = []

--- a/test/test_update_wheel_dispatch.py
+++ b/test/test_update_wheel_dispatch.py
@@ -34,6 +34,10 @@ class TestDetectInstallLayout:
         proj.mkdir()
         _init_repo(proj)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
 
         from kiro_crew.platform.update_layout import detect_install_layout
 
@@ -75,6 +79,10 @@ class TestDetectInstallLayout:
         proj.mkdir()
         _init_repo(proj)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
 
         from kiro_crew.platform.update_layout import detect_install_layout
 
@@ -403,6 +411,10 @@ class TestUpdateDispatch:
         proj.mkdir()
         _init_repo(proj)
         monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
 
         import kiro_crew.cli_server as cs
 


### PR DESCRIPTION
# Summary

A release install (wheel in its own venv) whose `KIROCREW_PROJECT_DIR` resolves onto a KiroCrew checkout classifies as a **git install**. The CWD-walking project detection (`cli.py::_detect_project_dir`) produces exactly this whenever the gateway is launched from inside a clone — the project markers (`skills/` + `src/kiro_crew/`) match the clone root and the env var carries it for the process's lifetime.

Observed in the field on an insider wheel install (`kirocrew-0.3.0rc11`) launched from inside a clone that happened to be on a detached HEAD:

- **Check path**: the About panel showed *"无法检查更新。: 无法从源代码仓库读取版本号。"* (`git_read_failed`) — the check ran `git rev-parse @{u}` against a clone unrelated to the running code. On a clone with an upstream it would instead have produced a confidently **wrong** verdict, comparing the insider install against the clone's remote.
- **Apply path**: with the misclassification in place, `POST /api/update` (the dashboard's Update button) would `git pull` the clone, then `pip install -e .` from it into the **running venv** — silently replacing the release install with the clone's contents and taking the user off their release channel, with no automatic way back. The dirty-tree 409 and the governance remote pin both guard the *clone*; neither guards the *install*.

## Root cause

`derive_capability()` gates the git lane on `is_git_worktree(install_root)` alone. That is a **path** question ("is this directory a working tree's own root"). The lane needs a second, independent **install** question: does the code this process is executing come from that tree? The module itself documented the gap:

> "What the fallback cannot do is tell this install's own checkout from an unrelated repository that `KIROCREW_PROJECT_DIR` happens to name — … deciding it would need a signal other than the path."

## Fix

New `running_from_checkout(root)` in `platform/update_capability.py` supplies that signal. It **delegates to the existing probe** `_bootstrap._source_checkout_root()` — the self-heal path already computes "which checkout does the running package load from" (repo root for editable installs and `PYTHONPATH=src` dev runs; `None` for anything resolving through `site-packages`, including a venv nested under an unrelated repository) — and anchors that answer to the named root with the same inode-identity comparison `is_git_worktree` uses. One probe owns the provenance answer; no second spelling to drift.

The git lane in `derive_capability()` now requires **both** halves:

```python
if is_git_worktree(install_root) and running_from_checkout(install_root):
```

- **Still git**: editable installs and `PYTHONPATH=src` dev runs — the layouts whose bytes `git pull` genuinely updates.
- **Now feed**: a release install pointed at somebody's clone falls through to the release-feed branch, which is the lane that actually owns those bytes. Its remediation is the installer command for its real channel, not `kirocrew update` against the unrelated clone.

Because every consumer (dashboard check, apply endpoint, `kirocrew update` CLI dispatch, `detect_install_layout`) already reads from this one derivation, the fix lands in all of them with a single-condition change.

## Relationship to the update-architecture RFC

`docs/request-for-change/rfc-update-architecture.md` §5 resolved the adjacent *ancestor capture* problem (`--show-toplevel` + root anchoring, since landed). That anchor cannot catch this case — here the named root **is** a genuine KiroCrew worktree root, so the equality check passes. This PR supplies the "signal other than the path" that section deferred.

## Review-lane dispositions

- **First Principles (CONCERNS)** — both subtractions applied in `54fbd7893`: `running_from_checkout` now delegates to `_bootstrap._source_checkout_root()` instead of re-deriving provenance from `kiro_crew.__file__`, and the zero-consumer `package_dir=` parameter is gone (tests pin the probe via `monkeypatch` instead).
- **GPT 5.6 (non-blocking)** — the function-local `import kiro_crew` it flagged no longer exists; the delegation import is module-scope.
- **Design (PASS)** — the convention-based `site-packages` marker heuristic it noted is also gone, subsumed by the probe's `setup.cfg` + `src/kiro_crew` root check.

## Testing

- `TestRunningFromCheckout` unit tests: the process's own checkout accepted, a *different* checkout refused (the field-failure shape), a wheel install (probe answers `None`) refused for every root, symlinked root matches by inode identity, NUL/empty-root refusal.
- `test_a_checkout_this_process_does_not_run_from_takes_the_feed` locks the field failure end-to-end with **no stubbing** — the test process genuinely does not run from `tmp_path`.
- **Mutation-verified** (re-run after the shrink): removing the `and running_from_checkout(...)` condition makes that test fail (`assert 'git' == 'kirocrew'`), so the gate has teeth.
- Existing git-lane tests across 8 files fabricate a checkout the test process does not run from — each now declares provenance true via a one-line `monkeypatch` (with a comment saying why), which is the honest statement of what those tests exercise: the path half and the downstream machinery.

## Gates

- Backend: full `pytest` — 58741 passed; 12 failures reproduce identically on clean `origin/main` on this host (artifact-source/xdist-budget environment issues, `df`/CPU-count dependent), none touch this diff. Post-shrink: all 10 touched test files re-run green (574 passed), `isort`/`flake8`/`mypy` (1004 files) clean.
- Frontend: `tsc -b` clean; `vitest` 22280 passed, 2 failures in `CliPanelCoverage.test.tsx` pass in isolation (suite-order flake) and this diff contains zero frontend files.
