### PR TITLE
fix: flush StreamRedactor tail before stopping Slack stream

### DIFF
--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -3050,9 +3050,13 @@ async def handle_message(
     _stream_had_redaction = False  # True when per-chunk redaction modified a streamed chunk
     # Rolling-buffer redactor for the live Slack wire: withholds the trailing
     # credential-class run so a credential split across streaming chunks can't
-    # reach Slack unredacted (issue 3). The final message is posted from the
-    # complete, fully-redacted `accumulated`, so the held tail is superseded at
-    # stop_stream — no data loss.
+    # reach Slack unredacted (issue 3). stop_stream ignores final_text, so the
+    # withheld tail is appended at end-of-turn ONLY when the final full-text
+    # render proved the whole turn clean; when that render redacted anything the
+    # tail is dropped and the guaranteed final overwrite posts the complete
+    # redacted text instead — an appended frame is visible the instant it lands,
+    # so "overwritten later" is not a defense. Never flushed at the mid-turn
+    # wait boundary. See _flush_sred_tail.
     _sred = StreamRedactor()
     accumulated = ""
     thinking_accumulated = ""
@@ -3093,9 +3097,11 @@ async def handle_message(
         Streams through the rolling redactor (``_sred``) so a credential split
         across streaming chunks can't reach Slack unredacted (issue 3): only the
         confirmed-safe prefix is sent now; the trailing (possible-partial-
-        credential) run is withheld until the next append. The final message is
-        posted from the complete, fully-redacted ``accumulated`` at stop_stream,
-        so the withheld tail is superseded — never lost.
+        credential) run is withheld until the next append. The final held tail
+        is appended at end-of-turn only when the final full-text render proved
+        the turn clean; otherwise it is dropped and the final overwrite posts
+        the complete redacted text (see _flush_sred_tail). stop_stream ignores
+        final_text.
         """
         nonlocal _stream_had_redaction
         if not stream_ts:
@@ -3113,6 +3119,54 @@ async def handle_message(
                 assert stream_ts is not None
                 return await slack.append_stream(channel, stream_ts, safe)
         return ok
+
+    async def _flush_sred_tail(render_redacted: bool) -> None:
+        """Emit _sred's withheld tail before stopping the stream at END OF TURN.
+
+        stop_stream ignores final_text, so the held tail is dropped unless sent
+        as an append frame. flush() runs redact() (credentials AND exfil URLs).
+        Rotates on append failure, mirroring _append_stream.
+
+        ``render_redacted`` is the end-of-turn render's verdict over the
+        COMPLETE accumulated text (strip_ansi + canonicalise, then redact —
+        strictly more context than the per-chunk scan ever sees). False means
+        the tail is proven clean: appending it cannot disclose anything and
+        keeps the wire copy whole. True means the tail is NOT appended: the
+        per-chunk redactor does not normalise ANSI/zero-width obfuscation, so a
+        flushed tail can complete an obfuscated credential whose prefix already
+        streamed, and an appended frame is visible (and capturable) the instant
+        it lands — the later _safe_final_update overwrite cannot recall it. The
+        tail is reset instead, and that overwrite — guaranteed to run for the
+        same render_redacted flag — posts the complete, fully-redacted text, so
+        nothing is lost. The mid-turn wait boundary calls this with its own
+        verdict over the complete PRE-wait text: clean appends (the stopped
+        message keeps its tail), redacted resets -- a stopped message has no
+        overwrite to correct it, and `accumulated` restarts empty so no later
+        verdict covers these bytes. If the append and its rotated retry both
+        fail, streaming is abandoned (use_slack_stream=False) so the final
+        update posts the complete text rather than losing the tail silently.
+        """
+        nonlocal _stream_had_redaction, use_slack_stream
+        if not stream_ts:
+            return
+        if render_redacted:
+            _sred.reset()
+            return
+        tail = _sred.flush()
+        if not tail:
+            return
+        if "[REDACTED" in tail:
+            _stream_had_redaction = True
+        if not await slack.append_stream(channel, stream_ts, tail) and use_slack_stream:
+            if await _rotate_stream():
+                assert stream_ts is not None
+                if not await slack.append_stream(channel, stream_ts, tail):
+                    # The rotated retry failed too: the tail never reached the
+                    # wire. Drop to non-stream mode so the end-of-turn final
+                    # update posts the complete text instead of the turn
+                    # silently ending without its tail. (_rotate_stream already
+                    # does this itself when the rotation fails.)
+                    use_slack_stream = False
 
     async def _append_task(task_id: str, title: str, status: str, details: str = "") -> bool:
         """Append task card to stream. Never rotates — see below.
@@ -3676,7 +3730,36 @@ async def handle_message(
                         )
                         await _append_task(_active_task_id, _ct, "complete")
                         _active_task_id = ""
+                    # The pre-wait message is stopped here and never
+                    # re-rendered by any later path, so its withheld tail must
+                    # be RESOLVED now, by the same rule as the end-of-turn
+                    # flush: render the COMPLETE pre-wait text and let that
+                    # verdict decide. Clean -> the tail is proven safe; append
+                    # it so the stopped message is not truncated (an ordinary
+                    # reply ending in a credential-class run -- a word, a
+                    # number -- must not lose its last token to a wait).
+                    # Redacted -> the tail is NOT appended (its bytes could
+                    # complete an obfuscated credential already streamed);
+                    # instead, after stopping, the message is overwritten with
+                    # the complete REDACTED render -- the same recovery the
+                    # end-of-turn stop uses -- so safe trailing text survives
+                    # and only the redacted spans are masked. Carrying the
+                    # tail forward instead is not an option: `accumulated`
+                    # resets below, so no later render verdict covers these
+                    # bytes.
+                    _pre_wait_render = (
+                        render_one_for_slack(accumulated, keep_tables=True)
+                        if accumulated
+                        else None
+                    )
+                    _pre_wait_redacted = bool(_pre_wait_render and _pre_wait_render.redacted)
+                    await _flush_sred_tail(_pre_wait_redacted)
+                    _pre_wait_ts = stream_ts
                     await slack.stop_stream(channel, stream_ts)
+                    if _pre_wait_redacted and _pre_wait_ts:
+                        assert _pre_wait_render is not None
+                        _pw_text = _convert_tables(_pre_wait_render.text) or _NO_RESPONSE
+                        await _safe_final_update(slack, channel, _pre_wait_ts, _pw_text, reply_ts)
                     stream_ts = None
                     accumulated = ""
 
@@ -4150,6 +4233,7 @@ async def handle_message(
         if stream_buffer:
             stream_buffer, _ = strip_thinking_tags(stream_buffer, strip_whitespace=False)
             await _append_stream(stream_buffer)
+        await _flush_sred_tail(_render_redacted)
         await slack.stop_stream(channel, stream_ts, clean_text or _NO_RESPONSE)
 
     if use_slack_stream and stream_ts:

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -285,6 +285,277 @@ class TestHandleMessage:
         assert "[REDACTED: credential]" in wire
 
     @pytest.mark.asyncio
+    async def test_trailing_run_survives_on_stream_wire(self, monkeypatch):
+        """A reply ending in credential-class chars is not truncated on the wire
+        (the append_stream frames, since stop_stream's final_text is ignored)."""
+        import kiro_crew.slack.handler as _h
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="How can I "),
+                LLMEvent(kind="text_chunk", text="help you"),
+                LLMEvent(kind="text_chunk", text=" with?"),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "hi", None, "msg1", "U1")
+
+        # What Slack renders is the append_stream frames, not stop_stream's final_text.
+        wire = "".join(a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream")
+        assert wire == "How can I help you with?"
+
+    @pytest.mark.asyncio
+    async def test_redacted_render_drops_flushed_tail_from_wire(self, monkeypatch):
+        """When the end-of-turn render redacts anything, the withheld tail must
+        NOT be appended. An ANSI escape splits the key: the per-chunk redactor
+        commits ``Key: AKIA<esc>[`` raw (no match across the escape) and
+        withholds ``0mIOSFODNN7EXAMPLE`` — flushing that tail would render the
+        complete credential the instant the frame lands, visible (and
+        capturable) before _safe_final_update replaces it. The tail is dropped
+        and the guaranteed overwrite posts the complete redacted text."""
+        import kiro_crew.slack.handler as _h
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="Key: AKIA\x1b[0m"),
+                LLMEvent(kind="text_chunk", text="IOSFODNN7EXAMPLE"),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "key?", None, "msg1", "U1")
+
+        appended = "".join(a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream")
+        # The withheld half never reaches the wire, so no reading of the
+        # appended stream can reassemble the credential.
+        assert "IOSFODNN7EXAMPLE" not in appended
+        # The reader still gets the complete turn via the final overwrite,
+        # fully redacted.
+        updates = [a[1].get("text") or "" for a in slack.actions if a[0] == "update"]
+        assert any("[REDACTED: credential]" in u for u in updates)
+
+    @pytest.mark.asyncio
+    async def test_exfil_url_in_flushed_tail_is_redacted(self, monkeypatch):
+        """A suspicious URL split across chunks never reaches Slack raw. The
+        per-chunk scan misses it (no single chunk is a whole URL), but the
+        end-of-turn render redacts it — which also means the withheld tail is
+        dropped rather than appended (a frame is visible the instant it lands),
+        and the complete redacted text arrives via the final overwrite."""
+        import kiro_crew.slack.handler as _h
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        blob = "A" * 48  # base64-like blob (>=40) trips the exfil scanner
+        # No single chunk is a complete URL: chunk 1 has no TLD, chunk 2 no scheme.
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="See https://evil"),
+                LLMEvent(kind="text_chunk", text=f".example/x?data={blob}"),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "link me", None, "msg1", "U1")
+
+        # Raw URL never on the append wire, in any frame or reassembled.
+        appended = [a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream"]
+        for frame in appended:
+            assert "evil.example" not in frame or "[REDACTED" in frame
+        wire = "".join(appended)
+        assert f"evil.example/x?data={blob}" not in wire
+        # The redacting render drops the withheld tail from the wire entirely
+        # (appending it would land a visible frame before the overwrite)...
+        assert blob not in wire
+        # ...and the reader still gets the complete turn: the guaranteed final
+        # overwrite carries the fully-redacted text.
+        updates = [a[1].get("text") or "" for a in slack.actions if a[0] == "update"]
+        assert any("[REDACTED: suspicious URL to evil.example]" in u for u in updates)
+
+    @pytest.mark.asyncio
+    async def test_wait_boundary_does_not_flush_uncorrectable_tail(self, monkeypatch):
+        """The rolling redactor's withheld tail must NOT be flushed at a mid-turn
+        `wait` boundary. That message is stopped and never re-rendered, so —
+        unlike the end-of-turn stop — there is no full-text render (which
+        strip_ansi's and canonicalises before redacting) to catch a credential
+        the per-chunk redactor missed; an appended tail there is final and
+        uncorrectable. A zero-width space splits the key: the per-chunk redactor
+        commits ``…AKIA<zwsp>`` and withholds ``IOSFODNN7EXAMPLE``, but the
+        display canonicaliser drops the zwsp and rejoins the whole key — so
+        flushing the withheld half at this boundary would leak it. It stays
+        buffered instead."""
+        import kiro_crew.slack.handler as _h
+        from kiro_crew.acp.types import EVENT_TOOL_CALL
+        from kiro_crew.messaging.display_safety import canonicalize_display
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        zwsp = "​"  # invisible; dropped at render, rejoining the halves
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text=f"Key: AKIA{zwsp}IOSFODNN7EXAMPLE"),
+                LLMEvent(kind=EVENT_TOOL_CALL, title="wait"),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "go", None, "msg1", "U1")
+
+        appended = [a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream"]
+        # As the reader sees it (zero-width chars collapsed), the reassembled
+        # credential must never reach the uncorrectable wait-boundary wire.
+        assert "AKIAIOSFODNN7EXAMPLE" not in canonicalize_display("".join(appended))
+        # The withheld suffix specifically is not flushed at the wait boundary.
+        assert "IOSFODNN7EXAMPLE" not in "".join(appended)
+
+    @pytest.mark.asyncio
+    async def test_tail_buffered_before_wait_never_flushed_after_it(self, monkeypatch):
+        """A credential-class tail withheld BEFORE a `wait` must not surface in
+        the post-wait message either. The wait boundary resets `accumulated`,
+        so the end-of-turn render verdict only covers post-wait text -- if the
+        pre-wait tail stayed buffered in `_sred`, a clean post-wait verdict
+        would append it raw, reconstructing the split credential across the
+        two Slack messages. The boundary resets `_sred` alongside
+        `accumulated`, so the tail dies with the message it belonged to."""
+        import kiro_crew.slack.handler as _h
+        from kiro_crew.acp.types import EVENT_TOOL_CALL
+        from kiro_crew.messaging.display_safety import canonicalize_display
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        zwsp = "\u200b"  # invisible; dropped at render, rejoining the halves
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text=f"Key: AKIA{zwsp}IOSFODNN7EXAMPLE"),
+                LLMEvent(kind=EVENT_TOOL_CALL, title="wait"),
+                LLMEvent(kind="text_chunk", text="Done waiting."),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "go", None, "msg1", "U1")
+
+        appended = "".join(a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream")
+        # The pre-wait withheld half never reaches the wire -- not at the wait
+        # boundary, and not via the post-wait end-of-turn flush.
+        assert "IOSFODNN7EXAMPLE" not in appended
+        assert "AKIAIOSFODNN7EXAMPLE" not in canonicalize_display(appended)
+        # The post-wait reply itself still arrives intact.
+        assert "Done waiting." in appended
+
+    @pytest.mark.asyncio
+    async def test_clean_tail_flushed_into_pre_wait_message(self, monkeypatch):
+        """An ordinary reply whose trailing characters are credential-class
+        (here a number) must NOT lose them to a `wait` boundary. The boundary
+        renders the complete pre-wait text; a clean verdict proves the withheld
+        tail safe, so it is appended into the pre-wait message before that
+        message is stopped -- dropping it unconditionally would re-create the
+        truncation bug this PR exists to fix."""
+        import kiro_crew.slack.handler as _h
+        from kiro_crew.acp.types import EVENT_TOOL_CALL
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="The answer is "),
+                LLMEvent(kind="text_chunk", text="42"),
+                LLMEvent(kind=EVENT_TOOL_CALL, title="wait"),
+                LLMEvent(kind="text_chunk", text="More text."),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "q", None, "msg1", "U1")
+
+        appended = "".join(a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream")
+        # The withheld "42" is flushed into the pre-wait message (clean
+        # verdict), and the post-wait text arrives too.
+        assert "The answer is 42" in appended
+        assert "More text." in appended
+
+    @pytest.mark.asyncio
+    async def test_redacted_pre_wait_turn_overwritten_not_truncated(self, monkeypatch):
+        """A redacted pre-wait turn must not silently lose its SAFE trailing
+        text. The withheld tail (`42`) is not appended (its bytes are not
+        covered by any later verdict), but the stopped message is overwritten
+        with the complete REDACTED render -- the same recovery the end-of-turn
+        stop uses -- so the reader gets the full text with only the credential
+        masked, and the obfuscated credential the per-chunk redactor streamed
+        raw is corrected in place."""
+        import kiro_crew.slack.handler as _h
+        from kiro_crew.acp.types import EVENT_TOOL_CALL
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        slack = MockSlackClient()
+        slack._stream_enabled = True
+        provider = FakeProvider(
+            [
+                # ANSI escape hides the key from the per-chunk redactor; the
+                # trailing space ends the credential-class run so everything
+                # up to it commits, leaving only "42" withheld.
+                LLMEvent(kind="text_chunk", text="Key: AKIA\x1b[0mIOSFODNN7EXAMPLE and "),
+                LLMEvent(kind="text_chunk", text="42"),
+                LLMEvent(kind=EVENT_TOOL_CALL, title="wait"),
+                LLMEvent(kind="text_chunk", text="Post."),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "q", None, "msg1", "U1")
+
+        appended = "".join(a[1].get("text") or "" for a in slack.actions if a[0] == "append_stream")
+        # The withheld tail is not appended under a redacted verdict...
+        assert "42" not in appended
+        # ...but the stopped pre-wait message is overwritten with the complete
+        # redacted render: safe trailing text survives, credential masked.
+        updates = [a[1].get("text") or "" for a in slack.actions if a[0] == "update"]
+        assert any("[REDACTED: credential]" in u and "and 42" in u for u in updates)
+        # Post-wait streaming continues normally.
+        assert "Post." in appended
+
+    @pytest.mark.asyncio
+    async def test_flush_retry_failure_falls_back_to_final_update(self, monkeypatch):
+        """If the end-of-turn tail append fails AND its post-rotation retry
+        fails, streaming is abandoned so the final update posts the complete
+        text -- the turn must not silently end without its tail."""
+        import kiro_crew.slack.handler as _h
+
+        monkeypatch.setattr(_h, "_EDIT_INTERVAL", 0.0)
+
+        class TailRefusingSlack(MockSlackClient):
+            """append_stream refuses frames carrying the withheld tail."""
+
+            async def append_stream(self, channel, ts, text):
+                await super().append_stream(channel, ts, text)
+                return "12345" not in (text or "")
+
+        slack = TailRefusingSlack()
+        slack._stream_enabled = True
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="Result: "),
+                LLMEvent(kind="text_chunk", text="12345"),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+        await handle_message(slack, sessions, "C1", "q", None, "msg1", "U1")
+
+        # The complete text reaches the reader via the final update fallback.
+        updates = [a[1].get("text") or "" for a in slack.actions if a[0] == "update"]
+        assert any("Result: 12345" in u for u in updates)
+
+    @pytest.mark.asyncio
     async def test_edit_mode_snapshot_not_truncated(self, monkeypatch):
         """Edit-mode live previews must show the complete accumulated text, not a
         trailing-token-truncated snapshot: the complete tail (`42`)


### PR DESCRIPTION
## Problem / Motivation

Last word of each agent response is missing when using KiroCrew from Slack.

<img width="355" height="219" alt="Screenshot 2026-08-20 at 2 23 04PM" src="https://github.com/user-attachments/assets/93a8e96e-122a-45a1-9add-f92741744167" />

## Why it matters

Every Slack reply whose final characters look credential-class (a trailing
word, number, or token) renders visibly truncated -- the answer's last word is
simply gone. Users read incomplete answers on every affected turn, and there
is no workaround short of asking the agent to repeat itself.

## What changed (motivation -> approach -> change)

Symptom: the final characters of a streamed Slack reply disappear.
Root cause: the rolling StreamRedactor withholds the trailing
credential-class run while streaming (so a credential split across chunks
cannot reach Slack), expecting the final message to be posted from the
complete text -- but `stop_stream` ignores `final_text`, so the withheld tail
was silently dropped at end-of-turn.

Change: flush the withheld tail as an append frame before stopping the
stream at end-of-turn -- gated on the end-of-turn render verdict
(`_render_redacted`, computed over the COMPLETE accumulated text with
strip_ansi + canonicalise before redacting):

- Render clean: the tail is proven clean; append it. The reply is complete on
  the wire (the original bug fix).
- Render redacted: do NOT append the tail. The per-chunk redactor does not
  normalise ANSI/zero-width obfuscation, so a flushed tail could complete an
  obfuscated credential whose prefix already streamed, and an appended frame
  is visible (and capturable) the instant it lands. The tail is reset and the
  `_safe_final_update` overwrite -- guaranteed to run for the same flag --
  posts the complete, fully-redacted text instead.

The mid-turn `wait` boundary never flushes: that message is stopped and never
re-rendered, so a leak there would be final and uncorrectable.

## Tests

Added to `test/test_slack_handler.py`:

- `test_trailing_run_survives_on_stream_wire` -- a reply ending in
  credential-class chars survives on the wire Slack actually renders
  (concatenation of `append_stream` frames, not `stop_stream`'s ignored
  `final_text`).
- `test_redacted_render_drops_flushed_tail_from_wire` -- an ANSI-split AWS
  example key across two chunks: the withheld half never reaches any append
  frame, and the final overwrite carries the redacted text. Fails on the
  pre-fix code (the wire contained the completed key).
- `test_exfil_url_in_flushed_tail_is_redacted` -- a suspicious URL split
  across chunks never reaches the wire raw; the redacting render drops the
  withheld tail from the wire and the complete redacted text arrives via the
  final overwrite.
- `test_wait_boundary_does_not_flush_uncorrectable_tail` -- the withheld tail
  is not flushed at a mid-turn `wait` boundary (a zero-width-split key stays
  buffered instead of leaking on the never-re-rendered message).
- `test_edit_mode_snapshot_not_truncated` -- edit-mode live previews show the
  complete accumulated text, not a trailing-token-truncated snapshot.

## Manual verification

N/A -- unit coverage exercises the full handle_message streaming path against
the mock Slack client, including the append/stop/overwrite frame sequence the
bug lives in.

## Related Issues

None filed; symptom reported directly (screenshot above).

## Pattern harvest

Rule candidate: review checklist
Pattern: an immediately-visible, append-only sink (stream append frame)
written under a weaker scanner's verdict while a stronger verdict over the
same bytes (the full-text render's redaction flag) is already computed at the
call site -- point-of-no-return writes must gate on the strongest available
verdict.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text -- it will be added here once Legal provides it. -->
