### PR TITLE
feat(session-pulse): trigger only after 10 real turns and 10 sessions

### DIFF
--- a/src/kiro_crew/dashboard/handlers/feedback.py
+++ b/src/kiro_crew/dashboard/handlers/feedback.py
@@ -54,6 +54,10 @@ from kiro_crew import beacon
 from kiro_crew import sel as _sel_mod
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.handlers._shared import read_bounded_json
+from kiro_crew.dashboard.session_pulse_counter import (
+    NEW_USER_SESSION_THRESHOLD,
+    get_user_session_count,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -350,6 +354,13 @@ async def api_feedback_eligible(request: web.Request) -> web.Response:
     # Egress consent gate: an opted-out install must not even reach Aperture.
     # Off the event loop (config I/O + SEL audit record).
     if not await asyncio.to_thread(_telemetry_permitted, "feedback_eligible"):
+        return web.json_response({"eligible": False})
+
+    # New-user window: never surface the survey until this install has started
+    # at least NEW_USER_SESSION_THRESHOLD genuine user chats. The count is kept
+    # durably server-side (session_pulse_counter), so a fresh install fails
+    # closed here. Off the event loop: it reads a small state file.
+    if await asyncio.to_thread(get_user_session_count) < NEW_USER_SESSION_THRESHOLD:
         return web.json_response({"eligible": False})
 
     # Off the event loop: install_id() may create/permission the id file.

--- a/src/kiro_crew/dashboard/session_pulse_counter.py
+++ b/src/kiro_crew/dashboard/session_pulse_counter.py
@@ -1,0 +1,87 @@
+"""Durable per-install count of genuine user-initiated chat sessions.
+
+Gates the session-pulse survey's "new user" window: the survey must not appear
+until this install has started at least ``NEW_USER_SESSION_THRESHOLD`` genuine
+user chats (``SlotOrigin.USER``). Counting only user-origin sessions -- not
+cron, app, system, or restored-untagged slots -- keeps the gate a measure of
+real human engagement, matching the only surface the survey ever shows on.
+
+The count is persisted next to the other dashboard state files via
+``config_dir()`` so it honors ``KIROCREW_HOME`` and survives restarts. The
+in-memory ``_slot_counter`` in state.py cannot serve this: it resets to 0 on
+every gateway boot and only reseeds past currently-live slots, so it is not a
+lifetime count.
+
+Both functions are best-effort and never raise into their callers: a survey
+timing gate must not be able to break session creation or the eligibility
+check. On any read/write trouble they log and fall back (read -> 0, which keeps
+a new-ish install gated shut rather than surfacing the survey on bad data).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from kiro_crew.config.loader import config_dir
+
+logger = logging.getLogger(__name__)
+
+_FILE = "session_pulse_sessions.json"
+_KEY = "user_sessions"
+
+# Minimum genuine user-initiated chats before the survey may appear. A person
+# below this is treated as a new user and never surveyed -- their rating would
+# reflect a first impression, not real use.
+NEW_USER_SESSION_THRESHOLD = 10
+
+
+def _path() -> Path:
+    return config_dir() / _FILE
+
+
+def get_user_session_count() -> int:
+    """Best-effort read of the durable user-session count (0 if unset/unreadable)."""
+    try:
+        data = json.loads(_path().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        logger.warning("session-pulse session count unreadable; treating as 0", exc_info=True)
+        return 0
+    # Valid but non-object JSON (e.g. ``null``, ``5``, ``[]``) parses fine yet has
+    # no ``.get`` -- guard it here so a hand-edited or truncated-then-valid file
+    # can never raise into the session-creation path that calls this.
+    if not isinstance(data, dict):
+        return 0
+    val = data.get(_KEY, 0)
+    return val if isinstance(val, int) and val >= 0 else 0
+
+
+def increment_user_session_count() -> int:
+    """Increment the durable count by one and return the new value.
+
+    Atomic write (temp file + ``os.replace``) so a crash mid-write cannot
+    corrupt the file. On write failure this logs and returns the pre-increment
+    value rather than raising into the session-creation path.
+    """
+    current = get_user_session_count()
+    new_val = current + 1
+    path = _path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{_FILE}.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({_KEY: new_val}, fh)
+            os.replace(tmp, path)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+    except Exception:
+        logger.warning("failed to persist session-pulse session count", exc_info=True)
+        return current
+    return new_val

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -31,6 +31,7 @@ from kiro_crew.constants import (
     SUBAGENT_COMPLETION_PREFIX,
 )
 from kiro_crew.dashboard.chat_compaction_notice import deliver_channel_compaction_notice
+from kiro_crew.dashboard.session_pulse_counter import increment_user_session_count
 from kiro_crew.dashboard.side_state import SideState
 from kiro_crew.dashboard.system_notices import is_system_notice
 from kiro_crew.history import latest_transcript_ts, monotonic_transcript_ts
@@ -4864,6 +4865,12 @@ class DashboardState:
                     f"Slot {name!r} already exists with memory_mode={existing.memory_mode!r}"
                 )
             return existing
+        # A brand-new chat arrives with no name and is auto-minted here; restore
+        # and rehydrate always pass the persisted key as ``name`` (and
+        # get-existing returns above). Only the mint path is a genuine new
+        # user-initiated chat, so only it may count toward the survey's session
+        # window -- otherwise every restart re-counts each restored user slot.
+        minted_new = not name
         if not name:
             self._slot_counter += 1
             ts = int(time.time())
@@ -4906,6 +4913,15 @@ class DashboardState:
         # SlotOrigin.USER), so a caller that forgets to declare loses
         # visibility instead of leaking — the direction this has to fail in.
         slot._origin = origin or (SlotOrigin.APP if app else "")
+        if minted_new and slot._origin == SlotOrigin.USER:
+            # Count only genuine, newly-minted user chats toward the survey's
+            # "new user" window (session_pulse_counter). `minted_new` excludes
+            # restore/rehydrate (which passes the persisted key as name) and
+            # get-existing, so a restart never re-counts already-seen sessions;
+            # only the request layer ever supplies origin=USER. Best-effort:
+            # the helper swallows its own I/O errors and never raises into
+            # slot creation.
+            increment_user_session_count()
         if memory_mode and memory_mode != "persistent":
             self._restricted_keys.add(f"dashboard:{name}")
         if ephemeral:

--- a/test/test_feedback.py
+++ b/test/test_feedback.py
@@ -95,6 +95,11 @@ def _allow(monkeypatch: pytest.MonkeyPatch, identity: str = _TEST_IDENTITY) -> N
     exercises the Aperture path rather than the consent gate."""
     monkeypatch.setattr(feedback, "_telemetry_permitted", lambda *a, **k: True)
     monkeypatch.setattr(feedback, "_survey_identity", lambda: identity)
+    # Established user: past the new-user session window, so route tests reach
+    # the Aperture path rather than being short-circuited by the window gate.
+    monkeypatch.setattr(
+        feedback, "get_user_session_count", lambda: feedback.NEW_USER_SESSION_THRESHOLD
+    )
 
 
 def _deny_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -221,6 +226,57 @@ class TestConsentGate:
         resp = await feedback.api_feedback_submit(_dashboard_req("POST", "/api/feedback/submit"))
         assert resp.status == 403
         assert json.loads(resp.body) == {"code": "telemetry_disabled"}
+
+
+class TestNewUserSessionWindow:
+    """The survey stays hidden until the install has >= NEW_USER_SESSION_THRESHOLD
+    genuine user sessions, and that gate short-circuits before Aperture."""
+
+    def _req(self) -> web.Request:
+        return _dashboard_req("GET", "/api/feedback/eligible")
+
+    @pytest.mark.asyncio
+    async def test_under_threshold_not_eligible_even_if_aperture_would_say_yes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _allow(monkeypatch)
+        # One short of the window.
+        monkeypatch.setattr(
+            feedback, "get_user_session_count", lambda: feedback.NEW_USER_SESSION_THRESHOLD - 1
+        )
+        # Aperture WOULD return eligible; if the gate is working we never reach it.
+        _install_fake_session(monkeypatch, _FakeResp(200, json_body={"prompt": "x"}))
+        resp = await feedback.api_feedback_eligible(self._req())
+        assert resp.status == 200
+        assert json.loads(resp.body) == {"eligible": False}
+
+    @pytest.mark.asyncio
+    async def test_at_threshold_reaches_aperture(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _allow(monkeypatch)
+        monkeypatch.setattr(
+            feedback, "get_user_session_count", lambda: feedback.NEW_USER_SESSION_THRESHOLD
+        )
+        _install_fake_session(monkeypatch, _FakeResp(200, json_body={"prompt": "x"}))
+        resp = await feedback.api_feedback_eligible(self._req())
+        assert resp.status == 200
+        assert json.loads(resp.body) == {"eligible": True}
+
+    @pytest.mark.asyncio
+    async def test_past_window_but_server_dedup_not_due_stays_not_eligible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The session+cooldown combo at the server layer: the new-user window is
+        # cleared (count == threshold), but Aperture's own per-user dedup says
+        # "not due yet" (null body) -- the server-side analog of the 30-day
+        # cooldown. Clearing the session window must NOT override it; both gates
+        # are independent, so the survey stays not-eligible. (The browser's
+        # 30-day localStorage cooldown is a separate client gate, proven in
+        # SessionPulseSurveyCard.test.tsx; the backend never sees it.)
+        _allow(monkeypatch)  # session count == NEW_USER_SESSION_THRESHOLD
+        _install_fake_session(monkeypatch, _FakeResp(200, json_body=None))
+        resp = await feedback.api_feedback_eligible(self._req())
+        assert resp.status == 200
+        assert json.loads(resp.body) == {"eligible": False}
 
 
 class TestCustomerResponses:

--- a/test/test_session_pulse_counter.py
+++ b/test/test_session_pulse_counter.py
@@ -1,0 +1,66 @@
+"""Tests for the durable session-pulse session counter (session_pulse_counter).
+
+Covers the count that gates the survey's "new user" window: default 0 when
+unset, atomic increment + persistence, monotonic sequential increments, and
+fail-safe handling of a missing/corrupt file (treated as 0, never raising).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.dashboard import session_pulse_counter as spc
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    # Point the counter's config_dir at a throwaway dir so tests never touch the
+    # real ~/.kiro/crew state.
+    monkeypatch.setattr(spc, "config_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def test_get_returns_zero_when_file_absent() -> None:
+    assert spc.get_user_session_count() == 0
+
+
+def test_increment_creates_file_and_returns_one(_isolated_home) -> None:
+    assert spc.increment_user_session_count() == 1
+    # Persisted to disk under config_dir.
+    path = _isolated_home / "session_pulse_sessions.json"
+    assert path.exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == {"user_sessions": 1}
+
+
+def test_sequential_increments_are_monotonic() -> None:
+    assert [spc.increment_user_session_count() for _ in range(3)] == [1, 2, 3]
+    assert spc.get_user_session_count() == 3
+
+
+def test_corrupt_file_is_treated_as_zero(_isolated_home) -> None:
+    (_isolated_home / "session_pulse_sessions.json").write_text("{not json", encoding="utf-8")
+    assert spc.get_user_session_count() == 0
+    # A corrupt file must not wedge the counter forever: the next increment
+    # overwrites it with a clean value.
+    assert spc.increment_user_session_count() == 1
+
+
+def test_negative_or_wrong_type_value_is_treated_as_zero(_isolated_home) -> None:
+    path = _isolated_home / "session_pulse_sessions.json"
+    path.write_text(json.dumps({"user_sessions": -5}), encoding="utf-8")
+    assert spc.get_user_session_count() == 0
+    path.write_text(json.dumps({"user_sessions": "10"}), encoding="utf-8")
+    assert spc.get_user_session_count() == 0
+
+
+@pytest.mark.parametrize("raw", ["null", "5", '"x"', "[1, 2]", "true"])
+def test_valid_non_object_json_is_treated_as_zero_not_a_crash(_isolated_home, raw) -> None:
+    # A valid JSON file that is not an object has no ``.get`` -- it must NOT
+    # raise (this runs inside session creation), just read as 0. Regression for
+    # the GPT blocking finding "valid non-object JSON crashes session creation".
+    (_isolated_home / "session_pulse_sessions.json").write_text(raw, encoding="utf-8")
+    assert spc.get_user_session_count() == 0
+    # And the counter still recovers cleanly on the next increment.
+    assert spc.increment_user_session_count() == 1

--- a/test/test_session_pulse_session_count.py
+++ b/test/test_session_pulse_session_count.py
@@ -1,0 +1,86 @@
+"""The survey "new user" counter increments only on genuine user chats.
+
+``DashboardState.get_or_create_slot`` is the sole place a brand-new slot is
+minted. This asserts the durable session-pulse counter goes up by one only when
+the new slot's origin is ``SlotOrigin.USER`` (a person starting a dashboard
+chat), and stays put for cron / app / system / untagged origins and for
+get_or_create calls that return an EXISTING slot.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from chat_test_helpers import _make_ready_kiro_prerequisite
+
+from kiro_crew.dashboard import session_pulse_counter as spc
+from kiro_crew.dashboard.state import DashboardState, SlotOrigin
+from kiro_crew.history import ConversationLog
+
+
+@pytest.fixture(autouse=True)
+def _isolated_counter(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    counter_dir = tmp_path / "home"
+    counter_dir.mkdir()
+    # Both the counter module and state resolve config_dir(); point both at a
+    # throwaway dir so the counter file and any open-slots snapshot stay local.
+    monkeypatch.setattr(spc, "config_dir", lambda: counter_dir)
+    import kiro_crew.dashboard.state as state_mod
+
+    monkeypatch.setattr(state_mod, "config_dir", lambda: counter_dir, raising=False)
+    return counter_dir
+
+
+def _make_state(tmp_path) -> DashboardState:
+    sessions = MagicMock(count=0)
+    sessions.remove = AsyncMock()
+    sessions.recycle_background = AsyncMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    state = DashboardState(
+        sessions=sessions,
+        crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=ConversationLog(base_dir=tmp_path / "log"),
+    )
+    state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+    return state
+
+
+def test_user_origin_new_chat_increments(tmp_path) -> None:
+    state = _make_state(tmp_path)
+    assert spc.get_user_session_count() == 0
+    state.get_or_create_slot(origin=SlotOrigin.USER)
+    assert spc.get_user_session_count() == 1
+    state.get_or_create_slot(origin=SlotOrigin.USER)
+    assert spc.get_user_session_count() == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"origin": SlotOrigin.CRON},
+        {"origin": SlotOrigin.SYSTEM},
+        {"app": "some-app"},  # resolves to APP origin
+        {},  # untagged (origin="")
+    ],
+)
+def test_non_user_origins_do_not_increment(tmp_path, kwargs) -> None:
+    state = _make_state(tmp_path)
+    state.get_or_create_slot(**kwargs)
+    assert spc.get_user_session_count() == 0
+
+
+def test_restore_shape_named_user_slot_does_not_increment(tmp_path) -> None:
+    # Restore/rehydrate calls get_or_create_slot with the persisted key as
+    # `name` and origin=USER. That must NOT count -- otherwise every gateway
+    # restart re-counts each restored user session. Regression for the GPT
+    # blocking finding "restoring sessions corrupts the durable session count".
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot(name="chat-9-1786589233", origin=SlotOrigin.USER)
+    assert spc.get_user_session_count() == 0
+    # Returning the now-existing slot also does not count.
+    again = state.get_or_create_slot(name="chat-9-1786589233", origin=SlotOrigin.USER)
+    assert again is slot
+    assert spc.get_user_session_count() == 0

--- a/website/src/components/SessionPulseSurveyCard.tsx
+++ b/website/src/components/SessionPulseSurveyCard.tsx
@@ -52,8 +52,10 @@ const CONFIRMATION_DISPLAY_MS = 3000
 // whichever check is stricter wins.
 const COOLDOWN_KEY = 'kirocrew_survey_last_shown'
 const COOLDOWN_DAYS = 30
-// Minimum live (post-baseline) assistant turns before the survey is eligible.
-const MIN_LIVE_TURNS = 3
+// Minimum live (post-baseline) completed back-and-forth turns before the survey
+// is eligible. A "turn" here is one user message answered by an assistant reply
+// (counted in ChatPage as completedTurnCount), not a raw assistant message.
+const MIN_LIVE_TURNS = 10
 
 function localCooldownElapsed(): boolean {
   const lastShown = safeGetItem(COOLDOWN_KEY)
@@ -145,14 +147,15 @@ export default function SessionPulseSurveyCard({
   const [submitError, setSubmitError] = useState(false)
   // Baseline captured once per session mount (this component remounts on
   // session switch via `key={activeSlot}`). turnCount includes every
-  // assistant turn already loaded from history, so without a baseline,
-  // reopening any session with >=3 prior turns would pop the survey on every
-  // visit — merely re-reading old messages, not a fresh interaction. Only
-  // turns completed live past this baseline count toward eligibility.
+  // completed turn already loaded from history, so without a baseline,
+  // reopening any session with prior turns past the threshold would pop the
+  // survey on every visit — merely re-reading old messages, not a fresh
+  // interaction. Only turns completed live past this baseline count toward
+  // eligibility.
   const [baselineTurnCount] = useState(turnCount)
   const liveTurnCount = turnCount - baselineTurnCount
-  // Without this guard, crossing the turn-3 threshold re-fires the query on
-  // every subsequent turn (4th, 5th, ...) as long as the card stays hidden —
+  // Without this guard, crossing the turn threshold re-fires the query on
+  // every subsequent turn as long as the card stays hidden —
   // each one re-hitting /api/feedback/eligible for an answer that cannot
   // change mid-session. `enabled` covers that (React Query only fetches once
   // while the gate stays true and the result is cached), so no separate

--- a/website/src/lib/completedTurns.test.ts
+++ b/website/src/lib/completedTurns.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { countCompletedTurns, type TurnCountMessage } from './completedTurns'
+
+const user = (): TurnCountMessage => ({ role: 'user' })
+const asst = (): TurnCountMessage => ({ role: 'assistant' })
+const notice = (kind: 'compaction' | 'session_reload'): TurnCountMessage => ({ role: 'assistant', kind })
+
+describe('countCompletedTurns', () => {
+  it('collapses a multi-assistant-message turn into a single back-and-forth', () => {
+    // One user message answered by a tool step + the reply + a follow-up card.
+    // The old tally (count every assistant message) returned 3 here, which is
+    // exactly why the survey fired a turn or two early.
+    expect(countCompletedTurns([user(), asst(), asst(), asst()])).toBe(1)
+  })
+
+  it('counts exactly 10 at the survey threshold, even with extra assistant messages and a notice', () => {
+    // MIN_LIVE_TURNS in SessionPulseSurveyCard is 10, so this transcript is the
+    // real boundary: the card must NOT show until this returns 10.
+    const msgs: TurnCountMessage[] = []
+    for (let i = 0; i < 10; i++) {
+      msgs.push(user())
+      msgs.push(asst()) // the reply
+      if (i % 2 === 0) msgs.push(asst()) // some turns emit an extra assistant message
+      if (i === 4) msgs.push(notice('compaction')) // a mid-stream status notice
+    }
+    // The old buggy rule (every assistant-role message) would count well over 10...
+    expect(msgs.filter((m) => m.role === 'assistant').length).toBeGreaterThan(10)
+    // ...but real completed back-and-forths is exactly 10.
+    expect(countCompletedTurns(msgs)).toBe(10)
+  })
+
+  it('returns 9 (below the 10 threshold) for 9 completed exchanges', () => {
+    const msgs: TurnCountMessage[] = []
+    for (let i = 0; i < 9; i++) {
+      msgs.push(user(), asst())
+    }
+    expect(countCompletedTurns(msgs)).toBe(9)
+  })
+
+  it('ignores system notices and an unanswered trailing user message', () => {
+    const msgs = [
+      notice('session_reload'), // status line before any real turn
+      user(),
+      asst(), // 1 real exchange
+      user(), // sent, no reply yet
+    ]
+    expect(countCompletedTurns(msgs)).toBe(1)
+  })
+
+  it('does not count assistant messages with no preceding user message', () => {
+    expect(countCompletedTurns([asst(), asst(), user(), asst()])).toBe(1)
+  })
+
+  it('reads the notice kind from meta.kind as well as the top-level kind', () => {
+    const metaNotice: TurnCountMessage = { role: 'assistant', meta: { kind: 'compaction' } }
+    expect(countCompletedTurns([user(), metaNotice, asst()])).toBe(1)
+  })
+})

--- a/website/src/lib/completedTurns.ts
+++ b/website/src/lib/completedTurns.ts
@@ -1,0 +1,40 @@
+import { isSystemNoticeKind } from './systemNotice'
+
+/**
+ * Minimal message shape this counter needs. `ChatMessage` satisfies it
+ * structurally, so callers pass their real message array unchanged while tests
+ * can build tiny literals without every ChatMessage field.
+ */
+export interface TurnCountMessage {
+  role: string
+  kind?: string
+  meta?: { kind?: unknown } | null
+}
+
+/**
+ * Count COMPLETED back-and-forths: one user message answered by an assistant
+ * reply. A single exchange can emit several assistant-role messages (the reply
+ * plus a tool step, a stage separator, or a follow-up card), so a plain
+ * assistant-message tally over-counts and trips the survey threshold sooner
+ * than the user perceives one "turn".
+ *
+ * The walk counts only the FIRST assistant reply after each user message
+ * (`awaitingReply` flips false once counted and only a new user message re-arms
+ * it), so any run of assistant messages inside one turn collapses to exactly 1.
+ * Assistant-role system notices (compaction, session_reload) are skipped
+ * entirely so a status line never stands in for a real turn.
+ */
+export function countCompletedTurns(messages: readonly TurnCountMessage[]): number {
+  let count = 0
+  let awaitingReply = false
+  for (const m of messages) {
+    if (isSystemNoticeKind(m.kind ?? (m.meta?.kind as string | undefined))) continue
+    if (m.role === 'user') {
+      awaitingReply = true
+    } else if (m.role === 'assistant' && awaitingReply) {
+      count += 1
+      awaitingReply = false
+    }
+  }
+  return count
+}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -99,7 +99,7 @@ import SessionGridView from '../components/SessionGridView'
 import { anchorForSlot, loadLayout, sessionSlots } from '../hooks/splitLayoutStore'
 import { modelSupportsEffort } from '../lib/effort'
 import { isEmbeddedPane } from '../lib/embedded'
-import { isSystemNoticeKind } from '../lib/systemNotice'
+import { countCompletedTurns } from '../lib/completedTurns'
 import { displayModel, pinIsWithheld } from '../lib/model'
 import FollowUpCard from '../components/FollowUpCard'
 import FolderSuggestionCard from './chat/FolderSuggestionCard'
@@ -870,19 +870,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const messagesRef = useRef(messages)
   messagesRef.current = messages
   const kiroCrewVersion = useAppSelector(s => s.dashboard.status?.version) || ''
-  const assistantTurnCount = useMemo(
-    () =>
-      messages.filter(
-        m =>
-          m.role === 'assistant' &&
-          // Skip ALL assistant-role system notices (compaction, session_reload,
-          // and any future kind), not just compaction — otherwise a reload
-          // notice or stage separator counts as a completed assistant turn and
-          // can trip the survey's 3-turn threshold with no real interaction.
-          !isSystemNoticeKind(m.kind ?? (m.meta?.kind as string | undefined)),
-      ).length,
-    [messages],
-  )
+  // Count COMPLETED back-and-forths (one user message answered by an assistant
+  // reply), not raw assistant-role messages — see countCompletedTurns for why a
+  // plain assistant-message tally over-counts. Extracted to a pure helper so the
+  // counting rule is unit-tested directly (completedTurns.test.ts).
+  const completedTurnCount = useMemo(() => countCompletedTurns(messages), [messages])
   const knowledgeFetch = useKnowledgeFetch(activeSlot)
   const knowledgeFetchRef = useRef(knowledgeFetch)
   knowledgeFetchRef.current = knowledgeFetch
@@ -6804,7 +6796,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                     key={activeSlot}
                     sessionId={activeSlot}
                     kiroCrewVersion={kiroCrewVersion}
-                    turnCount={assistantTurnCount}
+                    turnCount={completedTurnCount}
                     slotOrigin={currentSlot?.origin}
                     onLayoutChange={handleSurveyLayoutChange}
                   />

--- a/website/src/test/SessionPulseSurveyCard.test.tsx
+++ b/website/src/test/SessionPulseSurveyCard.test.tsx
@@ -58,9 +58,9 @@ function renderCard(onLayoutChange = vi.fn()) {
   return { ...utils, rerenderWithTurnCount, onLayoutChange }
 }
 
-/** Crosses the turn-3 eligibility threshold and waits for the card to show. */
+/** Crosses the 10-turn eligibility threshold and waits for the card to show. */
 async function showCard(rerenderWithTurnCount: (n: number) => void) {
-  rerenderWithTurnCount(3)
+  rerenderWithTurnCount(10)
   await waitFor(() => {
     expect(screen.getByText(RATING_QUESTION)).toBeInTheDocument()
   })
@@ -119,9 +119,30 @@ describe('SessionPulseSurveyCard (collapsed disclosure)', () => {
 
     // A later turn arriving must not re-trigger the reopen-loop bug this
     // redesign sits on top of.
-    rerenderWithTurnCount(4)
+    rerenderWithTurnCount(11)
     await new Promise((r) => setTimeout(r, 50))
     expect(screen.queryByText(RATING_QUESTION)).not.toBeInTheDocument()
+  })
+
+  it('does NOT re-show within 30 days of a prior show, even past the turn threshold', async () => {
+    // Simulate a browser that already saw the survey in a prior build: a fresh
+    // cooldown stamp is present. Even with eligibility true (beforeEach) and
+    // the turn gate crossed, the 30-day cooldown must keep the card hidden --
+    // this is what stops anyone who already answered from being re-surveyed.
+    const { rerenderWithTurnCount } = renderCard()
+    localStorage.setItem('kirocrew_survey_last_shown', new Date().toISOString())
+    rerenderWithTurnCount(10)
+    await new Promise((r) => setTimeout(r, 100))
+    expect(screen.queryByText(RATING_QUESTION)).not.toBeInTheDocument()
+  })
+
+  it('shows again once the 30-day cooldown has elapsed', async () => {
+    // The flip side: a stamp older than 30 days no longer blocks, so the pulse
+    // remains periodic rather than one-and-done.
+    const { rerenderWithTurnCount } = renderCard()
+    const thirtyOneDaysAgoMs = Date.now() - 31 * 24 * 60 * 60 * 1000
+    localStorage.setItem('kirocrew_survey_last_shown', new Date(thirtyOneDaysAgoMs).toISOString())
+    await showCard(rerenderWithTurnCount)
   })
 
   it('submitting collapses to a one-line thank-you row (not the full form) and auto-hides', async () => {
@@ -208,7 +229,7 @@ describe('SessionPulseSurveyCard (origin-based surface gate)', () => {
     ['system', 'a gateway-internal session'],
     [undefined, 'an untagged / still-loading session'],
   ])(
-    'never shows for origin=%s (%s), even on a chat-<n>-<ts> key past turn 3',
+    'never shows for origin=%s (%s), even on a chat-<n>-<ts> key past turn 10',
     async (origin) => {
       // Deliberately uses the ORDINARY chat-key shape: the gate is the slot
       // ORIGIN, not the key. A non-user origin must be excluded even when the
@@ -219,7 +240,7 @@ describe('SessionPulseSurveyCard (origin-based surface gate)', () => {
         'chat-1-1786589233',
         origin as string | undefined,
       )
-      rerenderWithTurnCount(3)
+      rerenderWithTurnCount(10)
       // Give any (incorrectly) enabled query a chance to resolve and the show
       // effect a chance to fire, so this isn't just "we didn't wait long enough".
       await new Promise((r) => setTimeout(r, 100))
@@ -260,9 +281,9 @@ describe('SessionPulseSurveyCard (cooldown re-checked at show time)', () => {
       </QueryClientProvider>
     )
 
-    // First mount: cross turn 3 so the card shows and writes the cooldown stamp.
+    // First mount: cross turn 10 so the card shows and writes the cooldown stamp.
     const first = render(tree(0))
-    first.rerender(tree(3))
+    first.rerender(tree(10))
     await waitFor(() => {
       expect(screen.getByText(RATING_QUESTION)).toBeInTheDocument()
     })
@@ -272,7 +293,7 @@ describe('SessionPulseSurveyCard (cooldown re-checked at show time)', () => {
     // cached `true`, `handled` has reset, but the 30-day cooldown is now active.
     first.unmount()
     const second = render(tree(0))
-    second.rerender(tree(3))
+    second.rerender(tree(10))
 
     // The card must stay closed: the show effect re-checks the cooldown via
     // eligibilityGate, so a stale cached `true` can no longer reopen it and
@@ -386,7 +407,7 @@ describe('SessionPulseSurveyCard (eligibility fails closed)', () => {
       http.post('/api/feedback/submit', () => HttpResponse.json({ ok: true })),
     )
     const { rerenderWithTurnCount } = renderCard()
-    rerenderWithTurnCount(3)
+    rerenderWithTurnCount(10)
     // Give the (now failing) eligibility query time to resolve so this isn't
     // just "we didn't wait long enough".
     await new Promise((r) => setTimeout(r, 100))
@@ -399,8 +420,49 @@ describe('SessionPulseSurveyCard (eligibility fails closed)', () => {
       http.post('/api/feedback/submit', () => HttpResponse.json({ ok: true })),
     )
     const { rerenderWithTurnCount } = renderCard()
-    rerenderWithTurnCount(3)
+    rerenderWithTurnCount(10)
     await new Promise((r) => setTimeout(r, 100))
     expect(screen.queryByText(RATING_QUESTION)).not.toBeInTheDocument()
+  })
+})
+
+describe('SessionPulseSurveyCard (turn baseline / reopened chat)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    server.use(
+      http.get('/api/feedback/eligible', () => HttpResponse.json({ eligible: true })),
+      http.post('/api/feedback/submit', () => HttpResponse.json({ ok: true })),
+    )
+  })
+
+  it('ignores an old chat\u2019s prior history: needs 10 NEW back-and-forths past the mount baseline', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const tree = (turnCount: number) => (
+      <QueryClientProvider client={qc}>
+        <SessionPulseSurveyCard
+          sessionId="chat-9-1786950000"
+          kiroCrewVersion="1.0.0"
+          turnCount={turnCount}
+          slotOrigin="user"
+        />
+      </QueryClientProvider>
+    )
+
+    // Reopen a chat that already has 40 back-and-forths of history: the card
+    // captures 40 as its baseline at mount, so those prior turns must NOT count.
+    const { rerender } = render(tree(40))
+
+    // 9 NEW back-and-forths (turnCount 49) is still one short of the live
+    // threshold -- the survey stays hidden even though the absolute count (49)
+    // is far past 10.
+    rerender(tree(49))
+    await new Promise((r) => setTimeout(r, 100))
+    expect(screen.queryByText(RATING_QUESTION)).not.toBeInTheDocument()
+
+    // The 10th NEW back-and-forth (turnCount 50) crosses the live threshold.
+    rerender(tree(50))
+    await waitFor(() => {
+      expect(screen.getByText(RATING_QUESTION)).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The session-pulse survey (re-introduced in #4341) prompts too early in a user's experience. It could appear after as few as ~2 perceived exchanges in a brand-new user's very first session, before they've used KiroCrew enough to have a meaningful opinion. Reviewers/PMs flagged this: an early prompt yields a first-impression rating, not a read on real use.

Two root causes:
- The in-session turn counter tallied every assistant-role message, so a single exchange that emitted a reply plus a tool step / stage line / follow-up card counted as 2–3 "turns".
- There was no "new user" floor at all — the survey could show to someone in their very first session.

## Why it matters

The session pulse is our broad, always-on health signal for KiroCrew. If it's dominated by first-impression ratings from brand-new users, the signal is noisier and less representative of genuine, established use. Asking later and only of users with real history makes the metric cleaner and reduces prompt fatigue for newcomers.

## What changed (motivation → approach → change)

Symptom (survey fires too early) → two causes (over-counted turns; no new-user floor) → two scoped gates, both of which only *further restrict* when the survey may show:

1. **Count real back-and-forths, threshold 3 → 10.** Replaced the raw assistant-message tally with a completed user→assistant exchange count (a run of assistant messages after a user message collapses to 1), extracted to a pure `countCompletedTurns()` helper, and raised `MIN_LIVE_TURNS` from 3 to 10.
2. **New-user window: ≥10 genuine sessions.** Added a durable, per-install counter incremented only when a genuine user chat is created (`SlotOrigin.USER`; cron/app/system/restored-untagged excluded). `/api/feedback/eligible` now returns not-eligible until the install has ≥10 sessions, failing closed and short-circuiting before Aperture.

The 30-day cooldown and the origin/consent/redaction gates are unchanged. Anyone already surveyed is not re-surveyed (their cooldown is untouched). The per-install counter starts fresh on deploy (no historical count exists), so existing installs re-earn the survey over their next ~10 sessions — an intentional, one-time effect.

## Tests

- **Frontend (27 vitest):** `countCompletedTurns` at the 10 boundary and multi-message-turn collapse; card shows only at 10 live turns; the 30-day cooldown blocks a re-show and expires correctly; a reopened old chat with prior history still needs 10 fresh exchanges (baseline).
- **Backend (pytest):** the durable counter (persistence, corrupt/missing-file safety, non-negative-int handling); the increment fires only on `SlotOrigin.USER` (not cron/app/system/untagged) and never double-counts an existing slot; `/api/feedback/eligible` is not-eligible below the window and short-circuits before Aperture, is eligible at the window, and stays not-eligible when the window is cleared but Aperture's own dedup says not-due.

## Manual verification

N/A — unit coverage is sufficient. The survey card renders and submits unchanged (this PR only alters the conditions for showing it), and both new gates are deterministic and unit-tested on both layers. A live end-to-end trigger now requires an install with ≥10 sessions plus 10 fresh exchanges plus a forced-eligible response, which the unit tests reproduce precisely.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** Timing-only change. The survey card's appearance, copy, layout, and submit flow are unchanged — this PR only alters *when* the card is allowed to appear (turn count and session-count gates). No rendered pixel changes.

## Related Issues

no linked issue: follow-up tuning to the survey shipped in #4341; no separate tracked issue was filed.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
