### PR TITLE
fix(test_prepare_pr_prove): make prove no-bytecode test residue-independent

### DIFF
--- a/test/test_prepare_pr_prove.py
+++ b/test/test_prepare_pr_prove.py
@@ -42,15 +42,25 @@ def _load_prove():
     checked-out skill tree, so a plain import would leave a ``__pycache__``
     directory in the working copy -- a persistent side effect outside any tmp
     dir, which the blocking no-test-side-effects rule forbids.
+
+    Disabling the write only covers this import. An earlier unguarded import of
+    ``prove`` elsewhere in the suite (or a stale ``.pyc`` left by a prior run)
+    would already have dropped bytecode beside the source, and this helper hands
+    back that cached module -- so we also delete any ``prove`` bytecode after
+    loading, keeping the "no bytecode in the checkout" guarantee order-independent.
     """
     sys.path.insert(0, str(Path(PROVE).parent))
     previous = sys.dont_write_bytecode
     sys.dont_write_bytecode = True
     try:
-        return importlib.import_module("prove")
+        module = importlib.import_module("prove")
     finally:
         sys.dont_write_bytecode = previous
         sys.path.pop(0)
+    cached = getattr(module, "__cached__", None)
+    if cached:
+        Path(cached).unlink(missing_ok=True)
+    return module
 
 
 def _load_reporter_plugin(tmp_path: Path):
@@ -322,8 +332,7 @@ def test_a_non_python_production_file_is_still_reverted(tmp_path: Path) -> None:
     _git(repo, "config", "user.name", "prove")
     (repo / "limits.json").write_text('{"max": 1}\n')
     (repo / "mod.py").write_text(
-        "import json\n\n\ndef limit():\n"
-        "    return json.load(open('limits.json'))['max']\n"
+        "import json\n\n\ndef limit():\n" "    return json.load(open('limits.json'))['max']\n"
     )
     (repo / "test_mod.py").write_text(
         "from mod import limit\n\n\ndef test_one():\n    assert limit() == 1\n"


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Make prove no-bytecode test residue-independent**

## Changes and rationale

### Make prove no-bytecode test residue-independent
**Problem:** test/test_prepare_pr_prove.py's _load_prove imports the prepare-pr skill's prove.py with sys.dont_write_bytecode set — but that only prevents THIS import from writing bytecode. A stale __pycache__/prove.*.pyc already beside the skill source (left by any earlier unguarded import on the host, or a prior run) is handed back as the cached module and trips the suite's no-bytecode-in-the-checkout guarantee. The failure is order- and host-residue-dependent and fires on loops that never touch the file.
**Why it matters:** A gate/CI failure in an untouched module burns attempts for unrelated work and tempts agents into forbidden out-of-owns accommodations (it already happened twice in one day).
**Tests:** `.venv/bin/python -m pytest test/test_prepare_pr_prove.py -o addopts="" -p no:cacheprovider` passes. Control: plant a stale __pycache__ beside the skill's prove.py (import it once without the guard in a scratch shell), run the suite → passes with the fix, fails without it. Clean up the planted residue. No assertion weakened; the no-bytecode guarantee keeps…
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Make prove no-bytecode test residue-independent | `test/test_prepare_pr_prove.py` |

## Commits
- [`3203dfa`](https://github.com/kirodotdev/KiroCrew/pull/4766/commits/3203dfa3c6156b51d727db7f9c0c59910bdcf148) fix(test_prepare_pr_prove): make prove no-bytecode test residue-indep…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (1 files, +12/-3)</summary>

- `test/test_prepare_pr_prove.py` (+12/-3)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->