### PR TITLE
fix: show external app registries in the store when the catalog is online

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -661,6 +661,17 @@ catalog's OFFLINE SNAPSHOT, not a peer source: a reachable catalog means the
 store renders the published document's list, display copy, AND installable
 inventory; an unreachable one degrades the listing to the seed.
 
+User-configured external registries (`config.registries`) are a separate,
+always-present source: both `list_registry` and `list_catalog_apps` merge them
+through one shared site, `_append_external_registry_apps`, so the online and
+offline paths enrich, probe (`detectInstalled`), and trust-stamp external rows
+identically and cannot drift. A catalog/seed/builtin row wins a `name`
+collision; the catalog path reserves every catalog name (snapshotted before the
+`git`-installability filter) plus every seed name, so an external row can only
+ADD a name no catalog or seed row claims and can never shadow a name install
+resolves by. External rows keep their `provenance: "external"`/`verified: false`
+stamp.
+
 The catalog is trusted only as far as TLS, so its power is bounded by
 pin-or-refuse rather than by withholding coordinates.
 `official_catalog.inventory()` materialises each `git`-source entry as an
@@ -704,7 +715,8 @@ A name is a filesystem path on install, so `inventory()` and
 
 Writers: `apps/official_catalog.py` (`list_catalog_rows`, `inventory`,
 `fetch_inventory_entries`, `inventory_for_install`), `apps/registry.py`
-(`list_catalog_apps`, `_resolve_registry_row`, `_git_fetch_commit`),
+(`list_catalog_apps`, `_resolve_registry_row`, `_git_fetch_commit`,
+`_append_external_registry_apps`, `_detect_installed_probe`),
 `apps/routes.py` (`handle_registry`).
 
 ## 15. A registry's credential posture follows its index's change control

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -2422,6 +2422,100 @@ async def refresh_registries(repo: str | None = None) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+async def _detect_installed_probe(
+    entries: list[dict[str, Any]],
+    installed_map: dict[str, dict[str, Any]],
+) -> set[str]:
+    """Run each entry's ``detectInstalled`` probe; return the names that report installed.
+
+    Names already known to the app manager (present in *installed_map*) are
+    skipped, as are names whose execution policy denies the probe. A probe
+    timeout or ``OSError`` is swallowed and treated as not-installed. Shared by
+    ``list_registry`` (offline path) and ``_append_external_registry_apps``
+    (online path) so both probe identically -- an app installed OUTSIDE the app
+    manager reads installed on either path.
+    """
+    detected: set[str] = set()
+    for entry in entries:
+        name = entry.get("name", "")
+        if name in installed_map:
+            continue  # already known, skip detection
+        detect_cmd = entry.get("detectInstalled", "")
+        if not detect_cmd:
+            continue
+        denied = app_execution_denied(name, action="registry_detect_installed", caller="registry")
+        if denied:
+            logger.debug("Skipping registry detectInstalled for %s: %s", name, denied)
+            continue
+        try:
+
+            base_cmd = ["/bin/sh", "-c", detect_cmd]
+            sandboxed_cmd, _cleanup = wrap_argv(base_cmd, mode="strict")
+            sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
+            proc = await create_subprocess_limited(
+                *sandboxed_cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            )
+            await _communicate_with_timeout(proc, timeout=5)
+            if proc.returncode == 0:
+                detected.add(name)
+                logger.info("Detected external install: %s", name)
+        except (asyncio.TimeoutError, OSError):
+            pass  # detection failed, treat as not installed
+    return detected
+
+
+async def _append_external_registry_apps(
+    rows: list[dict[str, Any]],
+    reserved_names: set[Any],
+    installed_map: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """Append user-configured external-registry apps to *rows*; return ``(rows, detected)``.
+
+    The SINGLE site where external registries merge into a store listing, called
+    by both ``list_registry`` (offline fallback) and ``list_catalog_apps`` (online
+    catalog path) so the two paths cannot drift. External rows:
+
+    - load via ``_load_external_registries`` (each server-tagged ``_registry``);
+    - deduplicate by ``name`` against *reserved_names* AND each other, so a
+      catalog/seed/builtin row always wins a collision and an external row only
+      ADDS a name no reserved source claims (mirrors ``list_registry``'s original
+      ``seen_names`` precedence). The caller reserves EVERY name the catalog and
+      seed declare -- including a catalog ``git`` name it filtered out as
+      not-yet-installable -- so an external row can never shadow a name install
+      resolves by, which would point install-by-name at the wrong repository;
+    - resolve display copy from the app's own ``app.json`` via ``_resolve_manifest``
+      (the per-app fetch external rows pay today; catalog/seed rows do not pay it);
+    - are probed with ``detectInstalled`` via ``_detect_installed_probe``.
+
+    ``_index_author`` is deliberately NOT snapshotted here: every external row
+    carries ``_registry``, so ``_apply_trust_fields`` takes its external branch,
+    which drops ``_index_author`` and never derives the verified mark from it.
+    """
+    external = await _load_external_registries()
+    seen = set(reserved_names)
+    kept: list[dict[str, Any]] = []
+    for entry in external:
+        name = entry.get("name")
+        if name in seen:
+            continue
+        seen.add(name)
+        kept.append(entry)
+    if not kept:
+        return rows, set()
+    resolved = await asyncio.gather(
+        *[_resolve_manifest(e) for e in kept],
+        return_exceptions=True,
+    )
+    kept = [r if isinstance(r, dict) else kept[i] for i, r in enumerate(resolved)]
+    detected = await _detect_installed_probe(kept, installed_map)
+    rows.extend(kept)
+    return rows, detected
+
+
 async def list_registry() -> list[dict[str, Any]]:
     """Return all registry apps with display info and install status.
 
@@ -2491,14 +2585,6 @@ async def list_registry() -> list[dict[str, Any]]:
         logger.warning("no official catalog inventory this listing", exc_info=True)
 
     # Load external registries from config, deduplicating against core and each other
-    external_entries = await _load_external_registries()
-    seen_names = {e.get("name") for e in entries}
-    for e in external_entries:
-        name = e.get("name")
-        if name not in seen_names:
-            seen_names.add(name)
-            entries.append(e)
-
     installed = await asyncio.to_thread(list_installed_apps)
     installed_map = {a["name"]: a for a in installed}
     # Snapshot the INDEX-declared author before the manifest merge below
@@ -2507,7 +2593,10 @@ async def list_registry() -> list[dict[str, Any]]:
     # the bundled/edition index is trusted content, the fetched manifest is
     # the app author's — a repo publishing ``"author": "kirocrew"`` in its
     # app.json must not mint the badge. Unconditional assignment also
-    # neutralizes an index that pre-seeds the key itself.
+    # neutralizes an index that pre-seeds the key itself. External rows are
+    # appended AFTER this by ``_append_external_registry_apps`` and always carry
+    # ``_registry``, so ``_apply_trust_fields`` drops ``_index_author`` for them
+    # and never reads it — which is why the helper does not snapshot it.
     for entry in entries:
         entry["_index_author"] = entry.get("author")
 
@@ -2525,37 +2614,15 @@ async def list_registry() -> list[dict[str, Any]]:
     )
     entries = [r if isinstance(r, dict) else entries[i] for i, r in enumerate(resolved)]
 
-    # Run detectInstalled commands for apps not already in installed_map
-    detected: set[str] = set()
-    for entry in entries:
-        name = entry.get("name", "")
-        if name in installed_map:
-            continue  # already known, skip detection
-        detect_cmd = entry.get("detectInstalled", "")
-        if not detect_cmd:
-            continue
-        denied = app_execution_denied(name, action="registry_detect_installed", caller="registry")
-        if denied:
-            logger.debug("Skipping registry detectInstalled for %s: %s", name, denied)
-            continue
-        try:
-
-            base_cmd = ["/bin/sh", "-c", detect_cmd]
-            sandboxed_cmd, _cleanup = wrap_argv(base_cmd, mode="strict")
-            sandboxed_cmd = cgroup_scope_argv(sandboxed_cmd)  # cgroup DoS ceiling
-            proc = await create_subprocess_limited(
-                *sandboxed_cmd,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-                start_new_session=platform_compat.IS_POSIX,
-                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
-            )
-            await _communicate_with_timeout(proc, timeout=5)
-            if proc.returncode == 0:
-                detected.add(name)
-                logger.info("Detected external install: %s", name)
-        except (asyncio.TimeoutError, OSError):
-            pass  # detection failed, treat as not installed
+    # Probe the seed/catalog rows, then append external registries at the single
+    # shared merge site. Reserving every seed/catalog name means an external row
+    # can only ADD a name none of them claim — the precedence the inline dedup
+    # here used to enforce.
+    detected = await _detect_installed_probe(entries, installed_map)
+    entries, external_detected = await _append_external_registry_apps(
+        entries, {e.get("name") for e in entries}, installed_map
+    )
+    detected |= external_detected
 
     # Overlay the official catalog's curated fields LAST among the content
     # sources, so they win over a fetched manifest -- that is what curation
@@ -2611,6 +2678,17 @@ async def list_catalog_apps() -> list[dict[str, Any]]:
     installable. ``verified`` stays ``False`` for non-builtin rows until the
     catalog signature is checked, so this path never mints the first-party badge
     from a document trusted only as far as TLS.
+
+    User-configured external registries (``config.registries``) are appended here
+    too, through the same ``_append_external_registry_apps`` merge site
+    ``list_registry`` uses, so they surface whether or not the catalog is
+    reachable and are enriched, probed, and trust-stamped identically on both
+    paths. A catalog/seed/builtin row WINS a name collision — external rows only
+    ADD apps no catalog or seed name claims — and only external rows pay the
+    per-app manifest fetch. The reserved names include EVERY catalog row name,
+    snapshotted before the ``git``-installability filter below drops a
+    not-yet-installable ``git`` row, so an external row can never shadow a name
+    install resolves by (which would point install-by-name at the wrong repo).
     """
     # Off the event loop: the first call after a cache expiry does network I/O.
     rows = await asyncio.to_thread(official_catalog.list_catalog_rows)
@@ -2618,14 +2696,21 @@ async def list_catalog_apps() -> list[dict[str, Any]]:
         return []
     installable = await asyncio.to_thread(_load_registry_file)
     installable_names = {e.get("name") for e in installable if isinstance(e, dict)}
+    # Reserve every catalog name BEFORE the git filter, plus every seed name, so
+    # an external row can never shadow a catalog/seed name — including a catalog
+    # `git` row filtered out here for not being installable yet, whose name
+    # install still resolves by.
+    reserved_names: set[Any] = {row.get("name") for row in rows} | installable_names
     rows = [
         row
         for row in rows
         if row.get("source", {}).get("type") != "git" or row.get("name") in installable_names
     ]
+
     installed = await asyncio.to_thread(list_installed_apps)
     installed_map = {a["name"]: a for a in installed}
-    return _apply_trust_fields(_enrich_with_install_status(rows, installed_map))
+    rows, detected = await _append_external_registry_apps(rows, reserved_names, installed_map)
+    return _apply_trust_fields(_enrich_with_install_status(rows, installed_map, detected))
 
 
 def get_server_platform() -> dict[str, str]:

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1383,6 +1383,144 @@ class TestApplyTrustFields:
         assert "featured" not in rows["ext-app"]
         # The internal snapshot key never leaks into the API payload.
         assert all("_index_author" not in r for r in rows.values())
+
+
+# ---------------------------------------------------------------------------
+# External registries must surface on the ONLINE catalog path.
+#
+# Regression: handle_registry prefers list_catalog_apps when the published
+# catalog is reachable and only falls back to list_registry (the sole path that
+# merged external registries) when the catalog is empty. So a configured
+# external app was silently dropped from the store the moment the catalog came
+# online. list_catalog_apps now appends external-registry rows itself.
+# ---------------------------------------------------------------------------
+class TestCatalogAppsIncludesExternalRegistries:
+    @pytest.mark.asyncio
+    async def test_external_registry_app_appears_when_catalog_is_online(self, monkeypatch):
+        """With a NON-EMPTY catalog (so the catalog path is taken), a configured
+        external app still shows up — tagged external, not-installed — and a
+        same-named catalog row wins the dedup."""
+        # Catalog is reachable and non-empty: this forces the list_catalog_apps
+        # path rather than the offline list_registry fallback.
+        catalog_rows = [
+            {"name": "catalog-app", "displayName": "Catalog App"},
+            # Collision: the catalog also lists a name an external registry uses.
+            {"name": "shared-app", "displayName": "Official Shared App"},
+        ]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        # Seed only matters for the git-row installable filter; keep it empty.
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        external_rows = [
+            {"name": "labs-app", "repo": "x", "_registry": "labs"},
+            # Same name as a catalog row — the catalog row must win.
+            {"name": "shared-app", "repo": "y", "_registry": "labs"},
+        ]
+
+        async def _fake_external():
+            return external_rows
+
+        async def _fake_resolve(entry):
+            # Manifests already present in the index fixture; return as-is.
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+
+        # The external-only app is present, tagged external, and not installed.
+        assert "labs-app" in rows
+        assert rows["labs-app"]["_registry"] == "labs"
+        assert rows["labs-app"]["provenance"] == "external"
+        assert rows["labs-app"]["verified"] is False
+        assert rows["labs-app"]["installed"] is False
+        # The collision resolves to the catalog row (official), not the external one.
+        assert rows["shared-app"]["displayName"] == "Official Shared App"
+        assert rows["shared-app"]["provenance"] != "external"
+        # The plain catalog app is untouched.
+        assert "catalog-app" in rows
+        # The internal snapshot key never leaks into the API payload.
+        assert all("_index_author" not in r for r in rows.values())
+
+    @pytest.mark.asyncio
+    async def test_detect_installed_only_external_app_reads_installed_on_catalog_path(
+        self, monkeypatch
+    ):
+        """Install-status PARITY with the offline path: an external app known ONLY
+        via its detectInstalled probe (absent from installed_map) must read
+        installed=True on the ONLINE catalog path too, because that path now runs
+        the same probe and passes the resulting `detected` into enrichment."""
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "list_catalog_rows",
+            lambda: [{"name": "catalog-app", "displayName": "Catalog App"}],
+        )
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        async def _fake_external():
+            return [
+                {
+                    "name": "detect-app",
+                    "repo": "z",
+                    "_registry": "labs",
+                    "detectInstalled": "true",
+                }
+            ]
+
+        async def _fake_resolve(entry):
+            return entry
+
+        # Stand in for the real subprocess probe: report installed the same way
+        # _detect_installed_probe would for a returncode-0 command.
+        async def _fake_probe(entries, installed_map):
+            return {e["name"] for e in entries if e.get("detectInstalled")}
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+        monkeypatch.setattr(registry, "_detect_installed_probe", _fake_probe)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        assert rows["detect-app"]["installed"] is True
+
+    @pytest.mark.asyncio
+    async def test_external_row_cannot_shadow_filtered_catalog_git_name(self, monkeypatch):
+        """GPT BLOCK regression: a catalog `git` row dropped by the installability
+        filter must still RESERVE its name, so an external row with the same name
+        is deduped away and can never become the row install-by-name resolves."""
+        catalog_rows = [
+            {"name": "keep-app", "displayName": "Keep App"},
+            # git source, and NOT in the seed installable set below -> filtered out.
+            {"name": "filtered-git", "source": {"type": "git"}},
+        ]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        async def _fake_external():
+            # External registry tries to claim the filtered-out catalog name.
+            return [{"name": "filtered-git", "repo": "evil", "_registry": "labs"}]
+
+        async def _fake_resolve(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        # The catalog git row was filtered out AND the external row was reserved
+        # away, so the name is absent entirely -- crucially it never appears as an
+        # EXTERNAL row pointing at the "evil" repo.
+        assert rows.get("filtered-git", {}).get("provenance") != "external"
+        assert "filtered-git" not in rows
+
+
 # ---------------------------------------------------------------------------
 # Git-install build step: the interpreter, and where the build runs.
 #


### PR DESCRIPTION
<!-- no-visual-delta --> Backend-only change to the store's registry-listing logic; no UI/component/layout change, so no screenshots.

## Problem / Motivation

User-configured **external app registries** (`config.registries`, each `{name, repo, branch}`) never appear in the dashboard App Store when the official published catalog is reachable. The source row shows 0 apps and the app is unsearchable. External registries only work when the machine is offline.

## Why it matters

Adding an external registry is the supported way to distribute third-party apps outside the official catalog. Because almost every online machine can reach the catalog, external registries were effectively broken for their entire intended audience — configured correctly, cached correctly, and still invisible.

## What changed (motivation → approach → change)

- **Symptom:** external-registry apps missing from the store whenever the catalog is online.
- **Root cause:** `handle_registry` (`GET /api/apps/registry`) does `apps = await list_catalog_apps(); if not apps: apps = await list_registry()`. `list_catalog_apps()` builds rows only from the official catalog + the bundled seed and **never** calls `_load_external_registries()`. `list_registry()` is the only path that merges external registries, and it runs solely as the offline fallback. So when the catalog is online, external rows are dropped before they can be listed.
- **Change:** `list_catalog_apps()` now appends external-registry rows on the catalog path, routing them through the exact helper chain `list_registry` already uses — `_load_external_registries()` → `_resolve_manifest()` → `_enrich_with_install_status()` → `_apply_trust_fields()` — so trust stamping (`provenance: "external"`, `verified: false`) and install status are computed identically and never hand-rolled. Dedup is by app `name` mirroring `list_registry`'s `seen_names` precedence: a catalog/seed/builtin row **wins** a collision, and external rows only ADD apps the catalog lacks. Offline behavior, the catalog no-clone optimization (only external rows pay the manifest fetch they already pay today), and every trust/SSRF/blob-proxy guard are unchanged.

## Tests

- `test/test_apps_registry.py::TestCatalogAppsIncludesExternalRegistries::test_external_registry_app_appears_when_catalog_is_online` — stubs `official_catalog.list_catalog_rows` to return a **non-empty** list (forcing the catalog path), configures an external registry, and asserts the external-only app appears with its `_registry` tag, `provenance == "external"`, `verified is False`, and `installed is False`. It also asserts a same-named catalog row **wins** the dedup (keeps the official `displayName`/provenance) and that `_index_author` never leaks into the payload.
- **Mutation-verified:** reverting the production change turns the test RED (`assert 'labs-app' in ...` fails); restoring turns it GREEN. Full `test_apps_registry.py` passes (75 tests).

## Manual verification

N/A — unit coverage exercises the catalog-online branch, dedup precedence, and trust stamping directly; the change is pure listing logic with no external service dependency at test time.

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (docs/system-specs/modules/app-kit-platform.md §14)
- [x] No secrets, credentials, or internal references in the diff
