### PR TITLE
fix: harden the DMG rebuild against the Spotlight eject race

### DIFF
--- a/packaging/signing/README.md
+++ b/packaging/signing/README.md
@@ -27,6 +27,14 @@ trigger macOS Gatekeeper warnings).
   DMG layout template with the signed/stapled app, then shrinks and recompresses
   the image before the DMG signing and notarization stages.
 
+  The mounted-volume phase races Spotlight and XProtect, which start reading
+  the freshly-copied app and can hold the volume against ejection ("Resource
+  busy") — the same transient class electron-builder retries on. The script
+  layers its defenses: `-nobrowse` keeps the volume out of Finder, and the
+  eject gets bounded retries with a synced force fallback. hdiutil calls run without `-quiet`, because
+  that flag suppresses stderr too and previously reduced failures of this
+  script to bare exit codes.
+
   The branded background is a **volume-bound alias recorded inside `.DS_Store`**,
   which is why the image is reused rather than rebuilt from a folder: recreating
   it drops the layout. The script fingerprints the template's `.DS_Store` before

--- a/packaging/signing/build-dmg.sh
+++ b/packaging/signing/build-dmg.sh
@@ -31,14 +31,47 @@ read_write_image="$scratch_dir/layout-rw.dmg"
 mounted=0
 cleanup() {
   if [ "$mounted" -eq 1 ]; then
-    hdiutil detach "$mount_dir" -force -quiet >/dev/null 2>&1 || true
+    hdiutil detach "$mount_dir" -force >/dev/null 2>&1 || true
   fi
   rm -rf -- "$scratch_dir"
 }
 trap cleanup EXIT
 
+# Spotlight (mds) and XProtect race this script: the moment the app bundle
+# lands on the mounted volume they start reading it, and a volume with open
+# files refuses to eject ("Resource busy"). Whether the eject wins is purely
+# load-dependent -- the step has failed nightly runs on exactly this race.
+# Ejecting on a multitasking OS is inherently cooperative, so the mitigation
+# is layered rather than absolute: keep the volume out of Finder (-nobrowse
+# at both attach sites) and give the eject bounded retries with a force
+# fallback. electron-builder classifies hdiutil's "Resource busy" as
+# transient-retry for the same reason.
+detach_mount() {
+  # Flush first so a force-detach on the final attempt cannot lose writes.
+  # Force is acceptable here because every write we issued has completed and
+  # synced, and the resize/convert/verification stages that follow re-read the
+  # image and fail loudly on a damaged filesystem.
+  sync
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if hdiutil detach "$mount_dir"; then
+      mounted=0
+      return 0
+    fi
+    echo "WARN: detach of $mount_dir failed (attempt ${attempt}/5); retrying" >&2
+    sleep $((attempt * 3))
+  done
+  echo "WARN: detach still busy after 5 attempts; forcing" >&2
+  hdiutil detach "$mount_dir" -force
+  mounted=0
+}
+
 mkdir -p "$mount_dir" "$(dirname "$output_path")"
-hdiutil convert "$template_path" -format UDRW -o "$read_write_image" -quiet
+# hdiutil's -quiet is NOT used anywhere on this path: unlike most tools' quiet
+# flags it closes stderr as well as stdout, which turned three nightly failures
+# of this script into zero-diagnostic exits. Progress spew goes to stdout, so
+# redirecting stdout alone keeps the log clean while errors still surface.
+hdiutil convert "$template_path" -format UDRW -o "$read_write_image" >/dev/null
 
 # Code signatures and staple tickets make the final app slightly larger than
 # its unsigned template. Add 256 MiB of temporary workspace, then shrink the
@@ -65,10 +98,10 @@ expanded_sectors=$((current_sectors + 524288))
 if [ "$expanded_sectors" -gt "$maximum_sectors" ]; then
   expanded_sectors="$maximum_sectors"
 fi
-hdiutil resize -sectors "$expanded_sectors" "$read_write_image" -quiet
+hdiutil resize -sectors "$expanded_sectors" "$read_write_image" >/dev/null
 
-hdiutil attach -readwrite -noverify -noautoopen \
-  -mountpoint "$mount_dir" "$read_write_image" -quiet
+hdiutil attach -readwrite -noverify -noautoopen -nobrowse \
+  -mountpoint "$mount_dir" "$read_write_image" >/dev/null
 mounted=1
 
 # The background is a volume-bound alias recorded INSIDE .DS_Store, so that file
@@ -97,10 +130,9 @@ fi
 rm -rf -- "${template_apps[0]}"
 /usr/bin/ditto "$app_path" "$mount_dir/$(basename "$app_path")"
 
-hdiutil detach "$mount_dir" -quiet
-mounted=0
-hdiutil resize -size min "$read_write_image" -quiet
-hdiutil convert "$read_write_image" -format UDZO -o "$output_path" -ov -quiet
+detach_mount
+hdiutil resize -size min "$read_write_image" >/dev/null
+hdiutil convert "$read_write_image" -format UDZO -o "$output_path" -ov >/dev/null
 
 # The whole point of reusing the template is that Finder's background survives as
 # a volume-bound alias in .DS_Store. That survival is not guaranteed by anything
@@ -116,8 +148,8 @@ hdiutil convert "$read_write_image" -format UDZO -o "$output_path" -ov -quiet
 # available on a runner re-renders the window, so the definitive check is the
 # first real signing run -- see README.md, which also names the plan-B that
 # removes this question entirely.
-hdiutil attach -readonly -noverify -noautoopen \
-  -mountpoint "$mount_dir" "$output_path" -quiet
+hdiutil attach -readonly -noverify -noautoopen -nobrowse \
+  -mountpoint "$mount_dir" "$output_path" >/dev/null
 mounted=1
 missing=()
 [ -f "$mount_dir/.DS_Store" ] || missing+=(".DS_Store (Finder icon placement)")
@@ -137,6 +169,5 @@ if [ "$final_layout_digest" != "$template_layout_digest" ]; then
   echo "       shipping .DS_Store: $final_layout_digest" >&2
   exit 1
 fi
-hdiutil detach "$mount_dir" -quiet
-mounted=0
+detach_mount
 echo "Branded layout verified on $output_path (layout record $template_layout_digest)"


### PR DESCRIPTION
## Summary

`build-dmg.sh`'s bare `hdiutil detach` loses a race against Spotlight/XProtect and has failed 3 of the step's first 8 nightly executions with zero diagnostics. This PR keeps the volume out of Finder (`-nobrowse`), gives the eject bounded retries with a synced `-force` fallback, and removes `-quiet` from the main path so any future failure reaches the log.

no linked issue: root cause was diagnosed live from tonight's nightly failure (run 32403923585); fix is small and time-sensitive for the next scheduled nightly.

## Root cause

The DMG-rebuild flow introduced in #4298 mounts the branded layout template, swaps in the stapled app, and ejects. The moment the app lands on the volume, Spotlight (mds) and XProtect start reading it; a volume with open files refuses to eject (`Resource busy`). Whether the eject wins is load-dependent:

| Execution | Outcome | Step duration |
|---|---|---|
| Nightly 2026-08-18 23:29 (first after #4298) | FAIL | ~2.5 min |
| 3 nightlies 08-19 → 08-20 06:07 | pass | ~60 s |
| Nightly run 32403923585 (08-20 18:34) | FAIL | 2 m 17 s |
| Same run, re-run of failed job | FAIL | 2 m 31 s |
| Repro on the same inputs, `-quiet` stripped (run 32421924592) | pass, but the eject alone stalled **90 s** | 126 s |

Every failure produced zero output because hdiutil's `-quiet` — unlike most tools' quiet flags — closes **stderr as well as stdout**, leaving only the exit code. The post-job cleanup's "Terminate orphan process: diskimages-help" was the only trace.

This is a known transient class: electron-builder wraps every hdiutil call in a retry helper and documents exit code 16 as "Resource busy — wait and retry often works".

## Changes

- `hdiutil attach` (both sites): add `-nobrowse` so the volume never registers with Finder, removing the Finder/QuickLook reader from the race.
- `detach_mount()`: `sync`, then up to 5 detach attempts with linear backoff, then `-force` as last resort. Force cannot lose writes here: all writes have completed and synced, and the resize/convert/digest-verification stages that follow re-read the image and fail loudly on damage.
- Drop `-quiet` from every main-path hdiutil call; progress goes to stdout (redirected to /dev/null), errors keep flowing to stderr. The cleanup-trap detach stays silenced — best-effort by design.
- An earlier revision also switched off per-volume Spotlight indexing via `mdutil -i off`; verification showed both the plain and `sudo -n` paths are refused on GitHub macOS runners, so the layer was removed as dead code rather than shipped with a misleading per-run WARN.
- `packaging/signing/README.md`: document the race and the layered mitigation in the same commit.

## Verification

Hardened script run on `macos-15` against the **exact inputs of the failing nightly** (run 32403923585's `unsigned-build-darwin-universal` artifact): run 32424676620 — exit 0 in 34 s, detach succeeded first try, and the `.DS_Store` layout-digest assertion passed (`c25d6f71…`), proving the branded layout still round-trips. Throwaway verify branch/workflow deleted after use; this PR ships only the script + README.

Not verifiable pre-merge: the race itself is load-dependent, so "5 retries always suffice" cannot be proven — the `-force` fallback and the now-visible stderr are the backstops.
