### PR TITLE
fix(sidebar): freeze digit-jump order while the modifier is held

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -2565,6 +2565,22 @@ function ChatSidebar({
     () => (flatView && folders.length > 0 ? flatSlots : filteredSlots).map(s => s.key),
     [flatView, folders.length, flatSlots, filteredSlots],
   )
+  // Freeze the shortcut order while the jump modifier is held. Under a
+  // last-activity sort, background agent events (touchSlotActivity recency
+  // bumps) re-sort the list at any moment; without the freeze, the digits
+  // reassign between the user aiming at a badge and pressing it, so the press
+  // lands on whatever row REPLACED the one they read. Frozen, the badge map
+  // and the published store order both derive from the same held snapshot:
+  // badges travel with their rows if the visual order shifts mid-hold, and
+  // the digit picks the session the user saw. Render-time ref write is the
+  // same derived-state pattern ChatPage uses for filteredSlotsRef; the
+  // `.length` guard re-arms the freeze if the modifier was held before the
+  // first slots frame arrived.
+  const digitModifierHeld = useDigitModifierHeld()
+  const heldOrderRef = useRef<string[] | null>(null)
+  if (!digitModifierHeld) heldOrderRef.current = null
+  else heldOrderRef.current ??= (shortcutOrderKeys.length ? shortcutOrderKeys : null)
+  const effectiveOrderKeys = heldOrderRef.current ?? shortcutOrderKeys
   // Publish to the store for useKeyboardShortcuts (which reads at keypress
   // time). Diff-guarded so slot-detail churn that doesn't reorder rows never
   // dispatches. Deliberately not cleared on unmount: a last-known display
@@ -2572,21 +2588,35 @@ function ChatSidebar({
   // collapsed.
   const lastPublishedOrderRef = useRef('')
   useEffect(() => {
-    const joined = shortcutOrderKeys.join('\n')
+    const joined = effectiveOrderKeys.join('\n')
     if (joined === lastPublishedOrderRef.current) return
     lastPublishedOrderRef.current = joined
-    dispatch(setSidebarOrder(shortcutOrderKeys))
-  }, [shortcutOrderKeys, dispatch])
+    dispatch(setSidebarOrder(effectiveOrderKeys))
+  }, [effectiveOrderKeys, dispatch])
 
   // First nine sessions in shortcut order → their digit, shown as row badges
   // while the jump modifier is held (Ctrl on Mac in Ctrl+digit mode, Alt
   // elsewhere — mirrors the Digit1..9 chords).
-  const digitModifierHeld = useDigitModifierHeld()
   const shortcutDigitByKey = useMemo(() => {
+    // Compact the frozen order exactly like the jump handler's
+    // orderSlotsBySidebar does — drop keys whose session no longer exists —
+    // BEFORE assigning digits. If a session closes mid-hold, the handler's
+    // digit N targets the Nth surviving frozen key; numbering the raw frozen
+    // list instead would leave a row visibly badged "3" that digit 2 picks —
+    // the exact badge/target drift this feature exists to prevent. The
+    // `slots` prop is the existence basis (mirrors the handler's store
+    // lookup), not the display list, so a mid-hold visibility change cannot
+    // desynchronize the two consumers either.
+    const live = new Set(slots.map(s => s.key))
     const m = new Map<string, number>()
-    shortcutOrderKeys.slice(0, 9).forEach((k, i) => m.set(k, i + 1))
+    let digit = 1
+    for (const k of effectiveOrderKeys) {
+      if (digit > 9) break
+      if (!live.has(k)) continue
+      m.set(k, digit++)
+    }
     return m
-  }, [shortcutOrderKeys])
+  }, [effectiveOrderKeys, slots])
 
   // Folder rows for the filter menu: every folder in tree order, each with the
   // count of flat-lane sessions filed directly in it, and whether an unchecked

--- a/website/src/test/ChatSidebar.digitBadges.test.tsx
+++ b/website/src/test/ChatSidebar.digitBadges.test.tsx
@@ -97,21 +97,22 @@ function renderSidebar(slots: any[] = SLOTS, folders: ChatFolder[] = []) {
   })
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
   qc.setQueryData(['chat-folders'], folders)
-  const utils = render(
+  const tree = (s: any[]) => (
     <QueryClientProvider client={qc}>
       <Provider store={store}>
         <ThemeProvider>
           <MemoryRouter>
             <ChatSidebar
-              slots={slots} activeSlot={null} unreadSlots={[]}
+              slots={s} activeSlot={null} unreadSlots={[]}
               history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
             />
           </MemoryRouter>
         </ThemeProvider>
       </Provider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   )
-  return { store, ...utils }
+  const utils = render(tree(slots))
+  return { store, rerenderWith: (s: any[]) => utils.rerender(tree(s)), ...utils }
 }
 
 beforeEach(() => localStorage.clear())
@@ -155,5 +156,54 @@ describe('chat sidebar — held-modifier digit badges', () => {
     const { getAllByTestId } = renderSidebar(many)
     act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
     expect(getAllByTestId('digit-jump-badge')).toHaveLength(9)
+  })
+
+  it('freezes digits and the published order while held: a background recency bump neither renumbers badges nor moves the jump targets until release', () => {
+    const { store, rerenderWith, getAllByTestId } = renderSidebar()
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-newest', 'k-middle', 'k-oldest'])
+
+    // Mid-hold, agent activity bumps the oldest session to the top of the
+    // date-desc sort (touchSlotActivity semantics: last-activity changes).
+    rerenderWith([
+      { key: 'k-oldest', title: 'Oldest', messages: 1, running: false, modified: 4000 },
+      { key: 'k-middle', title: 'Middle', messages: 1, running: false, modified: 2000 },
+      { key: 'k-newest', title: 'Newest', messages: 1, running: false, modified: 3000 },
+    ])
+
+    // Frozen: each digit stays glued to the session the user aimed at (badges
+    // travel with their rows), and the store order the jump handler reads is
+    // unchanged — pressing 1 still picks k-newest.
+    const byRow = getAllByTestId('digit-jump-badge').map(b => [b.closest('[data-session-row]')?.getAttribute('data-session-row'), b.textContent])
+    expect(byRow).toContainEqual(['k-newest', '1'])
+    expect(byRow).toContainEqual(['k-middle', '2'])
+    expect(byRow).toContainEqual(['k-oldest', '3'])
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-newest', 'k-middle', 'k-oldest'])
+
+    // Release: the deferred reorder publishes.
+    act(() => { fireEvent.keyUp(window, { altKey: false }) })
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-oldest', 'k-newest', 'k-middle'])
+  })
+
+  it('renumbers badges compactly when a session closes mid-hold, matching the jump handler compaction', () => {
+    const { store, rerenderWith, getAllByTestId } = renderSidebar()
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+
+    // Mid-hold, the middle session closes. The jump handler compacts the
+    // frozen order (digit 2 now targets k-oldest), so the badges must
+    // renumber the same way — a stale "3" on k-oldest would be picked by
+    // digit 2, the exact badge/target drift the freeze exists to prevent.
+    rerenderWith([
+      { key: 'k-oldest', title: 'Oldest', messages: 1, running: false, modified: 1000 },
+      { key: 'k-newest', title: 'Newest', messages: 1, running: false, modified: 3000 },
+    ])
+
+    const byRow = getAllByTestId('digit-jump-badge').map(b => [b.closest('[data-session-row]')?.getAttribute('data-session-row'), b.textContent])
+    expect(byRow).toHaveLength(2)
+    expect(byRow).toContainEqual(['k-newest', '1'])
+    expect(byRow).toContainEqual(['k-oldest', '2'])
+    // The published frozen order is untouched — the handler compacts at
+    // keypress time from the same live-slot basis the badge map now uses.
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-newest', 'k-middle', 'k-oldest'])
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #4727. Under `date-desc` sort, background agent activity (`touchSlotActivity` recency bumps from streaming/subagents/crons) re-sorts the sidebar continuously. The digit badges and the published `dashboard.sidebarOrder` reassigned on every re-sort, so between *aiming* at a badge and *pressing* its digit the mapping could silently move — the press landed on whatever row replaced the one the user read.

While the jump modifier is held, the badge map and the published order now derive from a snapshot taken at hold start. Badges are keyed to sessions, so a mid-hold visual reshuffle moves badges *with* their rows instead of renumbering them, and the keypress handler (which reads the store at keypress time) picks exactly the session the user saw. Releasing the modifier publishes the deferred reorder.

## Testing

- New regression test: mid-hold recency bump neither renumbers badges nor changes the published order; release publishes the new order. Mutation-proven (fails on pre-fix code).
- `tsc` clean; 94 tests green across the badge, shortcut, and arrow-nav suites on this exact tree.

## Notes

- No handler changes — the freeze lives entirely in ChatSidebar's publish path.
- The `.length` guard re-arms the freeze if the modifier was held before the first slots frame.

no linked issue: defect found during live-gateway verification of already-merged #4727; fixed directly in this follow-up, no issue was filed.
