### PR TITLE
fix: suppress standalone ack in cancelled-turn restore block (#4765)

### DIFF
--- a/docs/architecture/design-notes/soft-stop.md
+++ b/docs/architecture/design-notes/soft-stop.md
@@ -281,8 +281,10 @@ between, caps each at 2000 characters, and renders:
 
 ```
 [PREVIOUS TURN WAS CANCELLED BY THE USER — context restore]
-The following user request was interrupted mid-response. Acknowledge it only if
-the current request refers to it.
+The following user request was interrupted mid-response. Do not emit any
+standalone acknowledgment of the cancellation. Use this restored context
+silently and respond only to the current user request, referencing the
+interrupted work only when the current request depends on it.
 
 Cancelled user request:
 <user text>

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1205,7 +1205,10 @@ def build_cancelled_turn_preamble(
     lines = [
         "[PREVIOUS TURN WAS CANCELLED BY THE USER — context restore]",
         "The following user request was interrupted mid-response. "
-        "Acknowledge it only if the current request refers to it.",
+        "Do not emit any standalone acknowledgment of the cancellation. "
+        "Use this restored context silently and respond only to the current "
+        "user request, referencing the interrupted work only when the "
+        "current request depends on it.",
         "",
         f"Cancelled user request:\n{user_text}",
     ]

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -2567,6 +2567,48 @@ class TestStopEventContextInjection:
         assert result == ""
 
 
+class TestCancelledTurnPreambleInstruction:
+    """The restore block must not invite a standalone cancellation ack.
+
+    The model reads the cancelled-turn preamble verbatim; an instruction that
+    permits acknowledging the cancellation makes it emit a synthetic
+    "Response was interrupted" message styled like a real response. The
+    wording must forbid any standalone acknowledgment, and the bracket
+    markers must stay byte-identical because context_blocks.py parses them.
+    """
+
+    def test_preamble_forbids_standalone_acknowledgment(self, tmp_path):
+        import json
+
+        from kiro_crew.context import build_cancelled_turn_preamble
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("sess1", "user", "please refactor the parser")
+        log.append("sess1", "assistant", "Starting on the parser")
+        log.append("sess1", "system", json.dumps({
+            "kind": "stop_event",
+            "id": "stop-abc",
+            "state": "stopped",
+            "outcome": "soft",
+        }))
+
+        result = build_cancelled_turn_preamble(log, "sess1")
+        # Markers parsed by context_blocks.py stay byte-identical.
+        assert result.startswith(
+            "[PREVIOUS TURN WAS CANCELLED BY THE USER \u2014 context restore]"
+        )
+        assert result.endswith("[END PREVIOUS TURN]")
+        # The instruction forbids a standalone acknowledgment and directs
+        # the model to the current request instead.
+        assert "Do not emit any standalone acknowledgment" in result
+        assert "respond only to the current user request" in result
+        # No wording that invites acknowledging the cancellation.
+        assert "Acknowledge it" not in result
+        # Restored context is still carried.
+        assert "please refactor the parser" in result
+        assert "Starting on the parser" in result
+
+
 class TestAutoSkillHelpers:
     """Module-level helpers for auto-skill eligibility."""
 


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

When a streaming turn is cancelled (explicit stop, or a new message sent while a tool call is in flight), the next turn's prompt is prepended with the cancelled-turn restore block built by `build_cancelled_turn_preamble` in `src/kiro_crew/context.py`. The block's instruction — "Acknowledge it only if the current request refers to it" — leads the model to emit a short synthetic acknowledgment such as "Response was interrupted by the user", rendered with exactly the same styling as a real assistant response. Users who rapid-fire messages while a tool call is running see multiple stacked synthetic acknowledgments they cannot distinguish from genuine output.

## Why it matters

The synthetic acknowledgments look like real agent responses, so users read them as the agent's answer to their message. In the rapid-message trigger pattern each cancel+restore cycle produces another one, stacking several confusing "interrupted" messages in a row. This erodes trust in what is real output and what is recovery machinery.

## What changed (motivation → approach → change)

Symptom: grey "Response was interrupted by the user" messages indistinguishable from real responses. Root cause: the restore-block instruction invites an acknowledgment ("Acknowledge it only if..."). The issue lays out two options; Option A (tell the model to produce no standalone acknowledgment) is cheaper, avoids the extra model output entirely, and needs no frontend styling change — so the acknowledgment never renders at all, rather than rendering differently.

- `src/kiro_crew/context.py` — the restore-block instruction now tells the model NOT to emit any standalone acknowledgment of the cancellation: use the restored context silently, respond only to the current user request, and reference the interrupted work only when the current request depends on it. Both parser markers (`[PREVIOUS TURN WAS CANCELLED BY THE USER — context restore]` and `[END PREVIOUS TURN]`, matched by `context_blocks.py`'s marker regex) are byte-identical — only the instruction sentence inside the block changed.
- `docs/architecture/design-notes/soft-stop.md` — the rendered-block example updated in the same commit to match the code it documents.

## Tests

- `test/test_history.py::TestCancelledTurnPreambleInstruction::test_preamble_forbids_standalone_acknowledgment` (new) — locks in: (a) both bracket markers stay byte-identical so `context_blocks.py` keeps recognizing the block, (b) the instruction forbids a standalone acknowledgment and directs the model to the current request, (c) no wording that invites acknowledging the cancellation remains, (d) the restored user/assistant context is still carried. A future edit that reintroduces the acknowledgment invitation fails this test.
- `test/metrics/test_context_blocks.py` — existing marker-recognition pin passes unchanged (the marker lines are untouched).

## Manual verification

N/A — unit coverage sufficient: the change is a prompt-wording change inside a pure string-building function; the test asserts the exact rendered block, and the model-behavior effect (no synthetic acknowledgment) follows from the instruction text that the test pins.

## Related Issues

Closes #4765

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend prompt-wording change only; no frontend file touched and no rendered pixel changes (the fix removes a synthetic message rather than styling one).
