### PR TITLE
chore: bump the in-code version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.3.0"
+version = "0.4.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-desktop",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
## Problem / Motivation

`0.3.0` has been promoted to stable, but `main` still stamps `0.3.0`. The
in-code version governs every **non-tag** build — nightly and local/source
installs — so tonight's nightly would be `0.3.0-nightly.<stamp>`, which sorts
*below* the `0.3.0` release that just shipped.

## Why it matters

A nightly that sorts below stable is not offered as an update to anyone tracking
nightly, and to anyone comparing versions it reads as a downgrade of the release
they already have. The bump is the documented post-stable step in
CONTRIBUTING.md → "Releasing New Versions": after each stable cut, move `main`
by 0.1 so nightlies read as previews of the *next* release.

## What changed (motivation → approach → change)

Stable now serves `0.3.0` → `main` must name the next release → bump the three
manifests CONTRIBUTING.md lists as carrying the stamp:

| File | Field |
|---|---|
| `src/kiro_crew/__init__.py` | `__version__` — the source of truth |
| `pyproject.toml` | `[project] version` — what the wheel carries |
| `website/electron/package.json` | `version` — the updater's version compare |

Plus `website/electron/package-lock.json`'s two root entries (`.version` and
`.packages[""].version`), which npm rewrites on the next install if they drift
from `package.json`. Dependency versions in that lockfile are untouched.

Kept a bare `X.Y.Z`: `nightly.yml` derives both a semver and a PEP 440 stamp
from it, and a suffixed base produces invalid versions.

`CHANGELOG.md` is deliberately not touched — the `0.4.0` section is written by
the release that ships it, not by this bump.

## Tests

No new tests. The existing contracts already cover the shape this changes, and
they pass against the bumped value: `test_release_channel.py` (channel and
prerelease derivation from a stamp), `test_config_meta_stamp.py` (the build
stamp written into config), `test_nightly_version_contract.py` (the nightly
semver/PEP 440 derivation), `test_beacon.py` (the version clamp sent in the
telemetry heartbeat) — 202 passed.

## Manual verification

N/A — unit coverage sufficient. There is no behavior here beyond the four
literals; the version stamping this feeds is itself pinned by the contract tests
above.

## Related Issues

Follows the `v0.3.0` stable promotion (post-stable step 4 in CONTRIBUTING.md →
"Cutting a release").

**Why no screenshot:** version literals in four manifests; no user-visible
surface changes.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — no new behavior)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, CONTRIBUTING.md already documents this step
- [x] No secrets, credentials, or internal references in the diff
