### PR TITLE
fix: show external app registries in the store when the catalog is online (#4771)

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -660,10 +660,22 @@ stays `false` for a catalog `git` app until the catalog signature is checked:
 wiring signature verification into `official_catalog` is what flips that, not a
 field the catalog can assert about itself.
 
+User-configured external registries (`config.registries`) are a separate,
+always-present source: both `list_registry` and `list_catalog_apps` merge them
+through one shared site, `_append_external_registry_apps`, so the online and
+offline paths enrich, probe (`detectInstalled`), and trust-stamp external rows
+identically and cannot drift. A catalog/seed/builtin row wins a `name`
+collision; the catalog path reserves every catalog name — snapshotted before the
+`git`-installability filter, so a name the catalog declared but filtered out
+still counts — plus every seed name, so an external row can only ADD a name no
+catalog or seed row claims and can never shadow a name install resolves by.
+External rows keep their `provenance: "external"` / `verified: false` stamp.
+
 A name is a filesystem path on install, so `list_catalog_rows` drops any entry
 whose name is not kebab-case (`KEBAB_RE.fullmatch`), and the catalog fetch runs
 off the event loop (`asyncio.to_thread`) so a cache-expired request never blocks
 the gateway loop.
 
 Writers: `apps/official_catalog.py` (`list_catalog_rows`),
-`apps/registry.py` (`list_catalog_apps`), `apps/routes.py` (`handle_registry`).
+`apps/registry.py` (`list_catalog_apps`, `_append_external_registry_apps`,
+`_detect_installed_probe`), `apps/routes.py` (`handle_registry`).

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -1697,48 +1697,19 @@ async def refresh_registries(repo: str | None = None) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-async def list_registry() -> list[dict[str, Any]]:
-    """Return all registry apps with display info and install status.
+async def _detect_installed_probe(
+    entries: list[dict[str, Any]],
+    installed_map: dict[str, dict[str, Any]],
+) -> set[str]:
+    """Run each entry's ``detectInstalled`` probe; return the names that report installed.
 
-    1. Load minimal registry JSON (name, repo, branch)
-    2. Load external registries from user config
-    3. Fetch each app's app.json (cached, 24h TTL) for display info
-    4. Run detectInstalled commands for external installs
-    5. Enrich with install status from KiroCrew's app manager
-    6. Stamp server-computed trust fields (``provenance``/``verified``) and
-       strip ``featured`` from external rows — see ``_apply_trust_fields``
+    Names already known to the app manager (present in *installed_map*) are
+    skipped, as are names whose execution policy denies the probe. A probe
+    timeout or ``OSError`` is swallowed and treated as not-installed. Shared by
+    ``list_registry`` (offline path) and ``_append_external_registry_apps``
+    (online path) so both probe identically -- an app installed OUTSIDE the app
+    manager reads installed on either path.
     """
-    entries = await asyncio.to_thread(_load_registry_file)
-
-    # Load external registries from config, deduplicating against core and each other
-    external_entries = await _load_external_registries()
-    seen_names = {e.get("name") for e in entries}
-    for e in external_entries:
-        name = e.get("name")
-        if name not in seen_names:
-            seen_names.add(name)
-            entries.append(e)
-
-    installed = await asyncio.to_thread(list_installed_apps)
-    installed_map = {a["name"]: a for a in installed}
-    # Snapshot the INDEX-declared author before the manifest merge below
-    # overwrites ``author`` with the repo-fetched app.json value.
-    # ``_apply_trust_fields`` derives ``verified`` from this snapshot only:
-    # the bundled/edition index is trusted content, the fetched manifest is
-    # the app author's — a repo publishing ``"author": "kirocrew"`` in its
-    # app.json must not mint the badge. Unconditional assignment also
-    # neutralizes an index that pre-seeds the key itself.
-    for entry in entries:
-        entry["_index_author"] = entry.get("author")
-
-    # Fetch manifests in parallel for all entries
-    resolved = await asyncio.gather(
-        *[_resolve_manifest(e) for e in entries],
-        return_exceptions=True,
-    )
-    entries = [r if isinstance(r, dict) else entries[i] for i, r in enumerate(resolved)]
-
-    # Run detectInstalled commands for apps not already in installed_map
     detected: set[str] = set()
     for entry in entries:
         name = entry.get("name", "")
@@ -1769,6 +1740,102 @@ async def list_registry() -> list[dict[str, Any]]:
                 logger.info("Detected external install: %s", name)
         except (asyncio.TimeoutError, OSError):
             pass  # detection failed, treat as not installed
+    return detected
+
+
+async def _append_external_registry_apps(
+    rows: list[dict[str, Any]],
+    reserved_names: set[Any],
+    installed_map: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """Append user-configured external-registry apps to *rows*; return ``(rows, detected)``.
+
+    The SINGLE site where external registries merge into a store listing, called
+    by both ``list_registry`` (offline fallback) and ``list_catalog_apps`` (online
+    catalog path) so the two paths cannot drift. External rows:
+
+    - load via ``_load_external_registries`` (each server-tagged ``_registry``);
+    - deduplicate by ``name`` against *reserved_names* AND each other, so a
+      catalog/seed/builtin row always wins a collision and an external row only
+      ADDS a name no reserved source claims (mirrors ``list_registry``'s original
+      ``seen_names`` precedence). The caller reserves EVERY name the catalog and
+      seed declare -- including a catalog ``git`` name it filtered out as
+      not-yet-installable -- so an external row can never shadow a name install
+      resolves by, which would point install-by-name at the wrong repository;
+    - resolve display copy from the app's own ``app.json`` via ``_resolve_manifest``
+      (the per-app fetch external rows pay today; catalog/seed rows do not pay it);
+    - are probed with ``detectInstalled`` via ``_detect_installed_probe``.
+
+    ``_index_author`` is deliberately NOT snapshotted here: every external row
+    carries ``_registry``, so ``_apply_trust_fields`` takes its external branch,
+    which drops ``_index_author`` and never derives the verified mark from it.
+    """
+    external = await _load_external_registries()
+    seen = set(reserved_names)
+    kept: list[dict[str, Any]] = []
+    for entry in external:
+        name = entry.get("name")
+        if name in seen:
+            continue
+        seen.add(name)
+        kept.append(entry)
+    if not kept:
+        return rows, set()
+    resolved = await asyncio.gather(
+        *[_resolve_manifest(e) for e in kept],
+        return_exceptions=True,
+    )
+    kept = [r if isinstance(r, dict) else kept[i] for i, r in enumerate(resolved)]
+    detected = await _detect_installed_probe(kept, installed_map)
+    rows.extend(kept)
+    return rows, detected
+
+
+async def list_registry() -> list[dict[str, Any]]:
+    """Return all registry apps with display info and install status.
+
+    1. Load minimal registry JSON (name, repo, branch)
+    2. Load external registries from user config
+    3. Fetch each app's app.json (cached, 24h TTL) for display info
+    4. Run detectInstalled commands for external installs
+    5. Enrich with install status from KiroCrew's app manager
+    6. Stamp server-computed trust fields (``provenance``/``verified``) and
+       strip ``featured`` from external rows — see ``_apply_trust_fields``
+    """
+    entries = await asyncio.to_thread(_load_registry_file)
+
+    # Load external registries from config, deduplicating against core and each other
+    installed = await asyncio.to_thread(list_installed_apps)
+    installed_map = {a["name"]: a for a in installed}
+    # Snapshot the INDEX-declared author before the manifest merge below
+    # overwrites ``author`` with the repo-fetched app.json value.
+    # ``_apply_trust_fields`` derives ``verified`` from this snapshot only:
+    # the bundled/edition index is trusted content, the fetched manifest is
+    # the app author's — a repo publishing ``"author": "kirocrew"`` in its
+    # app.json must not mint the badge. Unconditional assignment also
+    # neutralizes an index that pre-seeds the key itself. External rows are
+    # appended AFTER this by ``_append_external_registry_apps`` and always carry
+    # ``_registry``, so ``_apply_trust_fields`` drops ``_index_author`` for them
+    # and never reads it — which is why the helper does not snapshot it.
+    for entry in entries:
+        entry["_index_author"] = entry.get("author")
+
+    # Fetch manifests in parallel for all entries
+    resolved = await asyncio.gather(
+        *[_resolve_manifest(e) for e in entries],
+        return_exceptions=True,
+    )
+    entries = [r if isinstance(r, dict) else entries[i] for i, r in enumerate(resolved)]
+
+    # Probe the seed/catalog rows, then append external registries at the single
+    # shared merge site. Reserving every seed/catalog name means an external row
+    # can only ADD a name none of them claim — the precedence the inline dedup
+    # here used to enforce.
+    detected = await _detect_installed_probe(entries, installed_map)
+    entries, external_detected = await _append_external_registry_apps(
+        entries, {e.get("name") for e in entries}, installed_map
+    )
+    detected |= external_detected
 
     # Overlay the official catalog's curated fields LAST among the content
     # sources, so they win over a fetched manifest -- that is what curation
@@ -1815,6 +1882,17 @@ async def list_catalog_apps() -> list[dict[str, Any]]:
     installable. ``verified`` stays ``False`` for non-builtin rows until the
     catalog signature is checked, so this path never mints the first-party badge
     from a document trusted only as far as TLS.
+
+    User-configured external registries (``config.registries``) are appended here
+    too, through the same ``_append_external_registry_apps`` merge site
+    ``list_registry`` uses, so they surface whether or not the catalog is
+    reachable and are enriched, probed, and trust-stamped identically on both
+    paths. A catalog/seed/builtin row WINS a name collision — external rows only
+    ADD apps no catalog or seed name claims — and only external rows pay the
+    per-app manifest fetch. The reserved names include EVERY catalog row name,
+    snapshotted before the ``git``-installability filter below drops a
+    not-yet-installable ``git`` row, so an external row can never shadow a name
+    install resolves by (which would point install-by-name at the wrong repo).
     """
     # Off the event loop: the first call after a cache expiry does network I/O.
     rows = await asyncio.to_thread(official_catalog.list_catalog_rows)
@@ -1822,14 +1900,21 @@ async def list_catalog_apps() -> list[dict[str, Any]]:
         return []
     installable = await asyncio.to_thread(_load_registry_file)
     installable_names = {e.get("name") for e in installable if isinstance(e, dict)}
+    # Reserve every catalog name BEFORE the git filter, plus every seed name, so
+    # an external row can never shadow a catalog/seed name — including a catalog
+    # `git` row filtered out here for not being installable yet, whose name
+    # install still resolves by.
+    reserved_names: set[Any] = {row.get("name") for row in rows} | installable_names
     rows = [
         row
         for row in rows
         if row.get("source", {}).get("type") != "git" or row.get("name") in installable_names
     ]
+
     installed = await asyncio.to_thread(list_installed_apps)
     installed_map = {a["name"]: a for a in installed}
-    return _apply_trust_fields(_enrich_with_install_status(rows, installed_map))
+    rows, detected = await _append_external_registry_apps(rows, reserved_names, installed_map)
+    return _apply_trust_fields(_enrich_with_install_status(rows, installed_map, detected))
 
 
 def get_server_platform() -> dict[str, str]:

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -1383,6 +1383,144 @@ class TestApplyTrustFields:
         assert "featured" not in rows["ext-app"]
         # The internal snapshot key never leaks into the API payload.
         assert all("_index_author" not in r for r in rows.values())
+
+
+# ---------------------------------------------------------------------------
+# External registries must surface on the ONLINE catalog path.
+#
+# Regression: handle_registry prefers list_catalog_apps when the published
+# catalog is reachable and only falls back to list_registry (the sole path that
+# merged external registries) when the catalog is empty. So a configured
+# external app was silently dropped from the store the moment the catalog came
+# online. list_catalog_apps now appends external-registry rows itself.
+# ---------------------------------------------------------------------------
+class TestCatalogAppsIncludesExternalRegistries:
+    @pytest.mark.asyncio
+    async def test_external_registry_app_appears_when_catalog_is_online(self, monkeypatch):
+        """With a NON-EMPTY catalog (so the catalog path is taken), a configured
+        external app still shows up — tagged external, not-installed — and a
+        same-named catalog row wins the dedup."""
+        # Catalog is reachable and non-empty: this forces the list_catalog_apps
+        # path rather than the offline list_registry fallback.
+        catalog_rows = [
+            {"name": "catalog-app", "displayName": "Catalog App"},
+            # Collision: the catalog also lists a name an external registry uses.
+            {"name": "shared-app", "displayName": "Official Shared App"},
+        ]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        # Seed only matters for the git-row installable filter; keep it empty.
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        external_rows = [
+            {"name": "labs-app", "repo": "x", "_registry": "labs"},
+            # Same name as a catalog row — the catalog row must win.
+            {"name": "shared-app", "repo": "y", "_registry": "labs"},
+        ]
+
+        async def _fake_external():
+            return external_rows
+
+        async def _fake_resolve(entry):
+            # Manifests already present in the index fixture; return as-is.
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+
+        # The external-only app is present, tagged external, and not installed.
+        assert "labs-app" in rows
+        assert rows["labs-app"]["_registry"] == "labs"
+        assert rows["labs-app"]["provenance"] == "external"
+        assert rows["labs-app"]["verified"] is False
+        assert rows["labs-app"]["installed"] is False
+        # The collision resolves to the catalog row (official), not the external one.
+        assert rows["shared-app"]["displayName"] == "Official Shared App"
+        assert rows["shared-app"]["provenance"] != "external"
+        # The plain catalog app is untouched.
+        assert "catalog-app" in rows
+        # The internal snapshot key never leaks into the API payload.
+        assert all("_index_author" not in r for r in rows.values())
+
+    @pytest.mark.asyncio
+    async def test_detect_installed_only_external_app_reads_installed_on_catalog_path(
+        self, monkeypatch
+    ):
+        """Install-status PARITY with the offline path: an external app known ONLY
+        via its detectInstalled probe (absent from installed_map) must read
+        installed=True on the ONLINE catalog path too, because that path now runs
+        the same probe and passes the resulting `detected` into enrichment."""
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "list_catalog_rows",
+            lambda: [{"name": "catalog-app", "displayName": "Catalog App"}],
+        )
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        async def _fake_external():
+            return [
+                {
+                    "name": "detect-app",
+                    "repo": "z",
+                    "_registry": "labs",
+                    "detectInstalled": "true",
+                }
+            ]
+
+        async def _fake_resolve(entry):
+            return entry
+
+        # Stand in for the real subprocess probe: report installed the same way
+        # _detect_installed_probe would for a returncode-0 command.
+        async def _fake_probe(entries, installed_map):
+            return {e["name"] for e in entries if e.get("detectInstalled")}
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+        monkeypatch.setattr(registry, "_detect_installed_probe", _fake_probe)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        assert rows["detect-app"]["installed"] is True
+
+    @pytest.mark.asyncio
+    async def test_external_row_cannot_shadow_filtered_catalog_git_name(self, monkeypatch):
+        """GPT BLOCK regression: a catalog `git` row dropped by the installability
+        filter must still RESERVE its name, so an external row with the same name
+        is deduped away and can never become the row install-by-name resolves."""
+        catalog_rows = [
+            {"name": "keep-app", "displayName": "Keep App"},
+            # git source, and NOT in the seed installable set below -> filtered out.
+            {"name": "filtered-git", "source": {"type": "git"}},
+        ]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        async def _fake_external():
+            # External registry tries to claim the filtered-out catalog name.
+            return [{"name": "filtered-git", "repo": "evil", "_registry": "labs"}]
+
+        async def _fake_resolve(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        # The catalog git row was filtered out AND the external row was reserved
+        # away, so the name is absent entirely -- crucially it never appears as an
+        # EXTERNAL row pointing at the "evil" repo.
+        assert rows.get("filtered-git", {}).get("provenance") != "external"
+        assert "filtered-git" not in rows
+
+
 # ---------------------------------------------------------------------------
 # Git-install build step: the interpreter, and where the build runs.
 #


### PR DESCRIPTION
## Problem / Motivation

Cherry-pick of `3bbaca5e372974361c37440493a275fc565161bc` (#4771) onto
`release/0.3.0`, so the fix ships in the **0.3.0 stable release**.

On this branch, `GET /api/apps/registry` drops every user-configured external
registry app whenever the published catalog is reachable — i.e. in the normal
online case. `handle_registry` (`apps/routes.py`) prefers the catalog path and
only falls back when it returns nothing:

```python
apps = await list_catalog_apps()
if not apps:
    apps = await list_registry()
```

and the external-registry merge (`_load_external_registries()`) existed **only**
inside `list_registry`, the offline fallback. So `config.registries` apps were
visible only while offline.

## Why it matters

Reported against the current insider build: an operator with their own registry
sees an empty source row and **cannot install any of their own apps**. For anyone
distributing third-party apps this is a total outage of that path, and it is
present in `0.3.0rc12` — verified by reading this branch, where
`_append_external_registry_apps` does not exist at all. Promoting 0.3.0 to stable
without this would ship the outage to everyone.

Users with no external registry configured are unaffected; the catalog and seed
listing are unchanged.

## What changed (motivation → approach → change)

Symptom: external rows missing online → root cause: the merge lives in the
fallback rather than in a shared site → change: both paths merge through one
function.

`_append_external_registry_apps` becomes the single site where external
registries enter a store listing, called by **both** `list_registry` (offline)
and `list_catalog_apps` (online), so the two cannot drift again. It dedupes by
`name` against reserved names — every catalog name, snapshotted *before* the
`git`-installability filter, plus every seed name — so a catalog/seed/builtin row
always wins a collision and an external row can only ADD a name, never shadow a
name install resolves by. `_detect_installed_probe` gives both paths the same
`detectInstalled` probing. External rows keep `provenance: "external"` /
`verified: false`.

## Tests

Cherry-picked verbatim: `TestCatalogAppsIncludesExternalRegistries` in
`test/test_apps_registry.py` —

- `test_external_registry_app_appears_when_catalog_is_online` — the regression itself
- `test_detect_installed_only_external_app_reads_installed_on_catalog_path` — the catalog path probes `detectInstalled` too
- `test_external_row_cannot_shadow_filtered_catalog_git_name` — a filtered-out catalog `git` name is still reserved

Full file: **77 passed** locally.

## Manual verification

N/A — unit coverage sufficient; the three tests exercise the online path that was
broken, including the shadowing guard.

## Deviation from the cherry-picked commit

One hunk was adapted rather than taken: `docs/system-specs/modules/app-kit-platform.md`.
`main`'s §14 also documents the catalog `inventory()` install path
(`inventory_for_install`, `_effective_registries`) and adds a §15 on registry
credential posture — **none of which exists on this branch**. Taking it whole
would document code 0.3.0 does not ship. This branch keeps its own catalog-trust
paragraph and gains only the paragraph describing this change, plus the two new
writers. `./scripts/docs-lint.sh` passes.

Everything else — `src/kiro_crew/apps/registry.py` and the tests — applied with
zero conflicts and is byte-identical to `main`.

## Related Issues

Cherry-pick of #4771. Required before the bare `v0.3.0` promotion tag; a new
`v0.3.0-insider.13` candidate has to be cut and recorded on top of this.

**Why no screenshot:** backend registry-resolution change; the store surface it
feeds is unchanged, it just stops omitting rows.

## Checklist

- [x] Single commit with a Conventional Commits title (original author preserved)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
