### PR TITLE
fix(fork): inherit project directory from parent session

### DIFF
--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -212,7 +212,11 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     )
     new_slot.forked_from = effective_session_key(slot)
     new_slot.reasoning_effort = slot.reasoning_effort
-    # Inherit project folder so the fork appears next to its parent in the sidebar.
+    # Inherit the active project directory so the fork keeps the parent's working
+    # context (agent resolution, steering files, CWD) instead of falling back to
+    # the config/workspace default on first message.
+    new_slot.project = slot.project
+    # Inherit the sidebar folder so the fork appears next to its parent in the UI.
     new_slot.folder_id = slot.folder_id
     # Inherit tags (copied, so later edits to either slot's list stay independent).
     new_slot.tags = list(slot.tags)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -11223,6 +11223,41 @@ class TestForkSlot:
         assert new_slot.folder_id == ""
 
     @pytest.mark.asyncio
+    async def test_fork_inherits_project(self, tmp_path):
+        """Fork must carry the source slot's active project directory."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.project = str(tmp_path / "repo")
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            assert resp.status == 200
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot is not None
+        assert new_slot.project == str(tmp_path / "repo")
+
+    @pytest.mark.asyncio
+    async def test_fork_inherits_empty_project(self, tmp_path):
+        """Fork of a projectless slot stays projectless."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("src")
+        slot.append("user", "hi", "msg msg-u")
+        slot.drain()
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/chat/slots/src/fork", json={})
+            data = await resp.json()
+
+        new_slot = state._slots.get(data["key"])
+        assert new_slot.project == ""
+
+    @pytest.mark.asyncio
     async def test_fork_inherits_tags(self, tmp_path):
         """Fork must carry the source slot's assigned tag ids."""
         state = _make_state(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

When a user forks a session, the new tab loses the parent's active project directory: `slot.project` is never copied, so the fork falls back to the config/workspace default on its first message — resetting the working context (agent resolution, steering files, CWD) the user forked from. Only `folder_id` (the sidebar grouping) was inherited, and a single comment conflated the two unrelated concepts, making it look like `project` was already handled.

## Why it matters

Forking exists to branch your current working context. Losing the project directory silently reroutes the fork's agent resolution and CWD to the wrong tree — the user notices only when a command runs in the wrong checkout.

## What changed (motivation → approach → change)

Symptom: fork loses project → root cause: `chat_fork.py` copies `folder_id` but never `slot.project` → fix: copy `slot.project` onto the forked slot, and split the misleading comment into two (project directory = working context; sidebar folder = UI grouping).

- `src/kiro_crew/dashboard/chat_fork.py` — copy `slot.project`; split the comment.
- `test/test_dashboard_chat.py` — two new tests.

## Tests

- `test_fork_inherits_project` — sets a project on the source slot, forks, asserts the fork carries it.
- `test_fork_inherits_empty_project` — forks a projectless slot, asserts the fork stays projectless (no default fallback).
- Full `TestForkSlot` class: 45 passed (43 pre-existing + 2 new). isort/flake8/mypy clean.

## Manual verification

N/A — unit coverage sufficient: the change is a single field copy exercised directly by the two new tests.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff (chat_fork.py + tests); no watched frontend path touched, no rendered change.

## Related Issues

Carries forward the fix originally proposed by @psantus in #3767, rebased onto current main with the merge conflict resolved.

Fixes #3298

## Checklist

- [x] Tests added/updated
- [x] Lint/type checks pass locally
- [x] Linked issue
