### PR TITLE
fix(dev-fleet): stop reading stale setup.cfg copies and read equality pins as interpreter floors

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py
@@ -80,9 +80,14 @@ _PROJECT = "kirocrew"
 #: makes the merged tree unimportable under this interpreter. Upper bounds and
 #: exclusions are left to pip on the next real reinstall rather than
 #: reimplemented here without a PEP 440 parser. ``~=`` is included because a
-#: compatible-release clause declares its own lower bound, and ``>`` is kept
-#: distinct from ``>=`` because it excludes the version it names.
-_PY_FLOOR = re.compile(r"(?P<op>~=|>=|>)\s*(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<micro>\d+))?")
+#: compatible-release clause declares its own lower bound, ``==`` and ``===`` are
+#: included because an equality clause pins the version it names and so declares
+#: that version as the floor, and ``>`` is kept distinct from ``>=`` because it
+#: excludes the version it names. ``===`` precedes ``==`` in the alternation so
+#: the longer operator wins; ``>=`` precedes ``>`` for the same reason.
+_PY_FLOOR = re.compile(
+    r"(?P<op>===|==|~=|>=|>)\s*(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<micro>\d+))?"
+)
 
 #: A plain PEP 508 distribution name -- letters, digits, and the separators PEP
 #: 503 normalizes. Anything else at the head of a requirement is not a name: a
@@ -240,17 +245,23 @@ def requires_python(repo: Path) -> str | None:
     build backend ignores is how this gate would silently stop firing.
 
     setup.cfg remains the fallback for a checkout with no ``[project]`` table, or
-    one that declares the field dynamic.
+    one that declares the field dynamic. A ``[project]`` table that declares the
+    field statically is the whole answer, so a table that OMITS it declares no
+    floor -- reading setup.cfg's ``python_requires`` there would enforce a copy
+    setuptools itself ignores, and a stale one can only over-refuse a revision
+    that is in fact installable. Unlike the console-script answer this needs no
+    sentinel: "no floor declared" and "the floor could not be read" both mean the
+    same thing to the caller, which is that this gate does not fire.
     """
     text = read_text(repo, "pyproject.toml")
     if text is not None:
         table = project_table(repo)
         if table is not None:
-            spec = table.get("requires-python")
-            if isinstance(spec, str) and "requires-python" not in _as_str_list(
-                table.get("dynamic")
-            ):
-                return spec.strip() or None
+            if "requires-python" not in _as_str_list(table.get("dynamic")):
+                spec = table.get("requires-python")
+                if isinstance(spec, str) and spec.strip():
+                    return spec.strip()
+                return None
         else:
             project = _section(text, "[project]")
             if "requires-python" not in _dynamic_fields(project):
@@ -299,10 +310,11 @@ def python_floor_breach(spec: str, version: tuple[int, int, int]) -> str | None:
     check and the gate has to be applied here or the merged revision becomes
     unimportable under the interpreter that has to import it.
 
-    Three spellings all declare a floor and all have to be read as one, because a
+    Four spellings all declare a floor and all have to be read as one, because a
     floor this misses is a gate that does not fire: ``>=`` names the floor
-    directly, ``~=`` (compatible release) names it as its own lower bound, and
-    ``>`` names a floor the interpreter must EXCEED rather than merely meet.
+    directly, ``~=`` (compatible release) names it as its own lower bound, ``==``
+    and ``===`` pin the version they name and so make it the floor too, and ``>``
+    names a floor the interpreter must EXCEED rather than merely meet.
     Comparison is at three components, so ``>=3.10.5`` is not truncated to the
     minor and then passed by a 3.10.0 interpreter.
     """
@@ -435,22 +447,53 @@ def _section(toml_text: str, header: str) -> str:
     return "\n".join(out)
 
 
+#: What :func:`console_script_target` returns when the authoritative declaration
+#: EXISTS and does not name the script: the entry point is REMOVED as of the
+#: merged revision. Distinct from ``None``, which means the declaration could not
+#: be read at all -- collapsing the two would let a removal pass silently, and a
+#: wrapper left dispatching to a target the revision deleted is exactly the
+#: mismatch this comparison exists to report. A truthy string that can never be a
+#: valid ``module:attr`` (it contains spaces), so the comparison in :func:`main`
+#: treats a removal like any other disagreement.
+SCRIPT_REMOVED = "removed by the merged revision"
+
+
 def console_script_target(repo: Path, script: str) -> str | None:
     """The ``module:attr`` *script* is declared to dispatch to, or ``None``.
 
     pyproject's ``[project.scripts]`` is read FIRST because that is what setuptools
     builds the wrapper from whenever ``scripts`` is not listed as dynamic; setup.cfg
     is the fallback for a checkout that still declares them there.
+
+    setup.cfg is consulted only where setuptools itself would consult it: a
+    checkout with no ``[project]`` table (pre-PEP 621 metadata), or one that
+    declares ``scripts`` dynamic. A ``[project]`` table that declares ``scripts``
+    statically is the whole answer, so a table that does not name *script* means
+    the entry point was removed rather than that it should be looked for
+    elsewhere -- reading setup.cfg's copy anyway would compare a stale
+    declaration against the installed wrapper, agree with it, and report success
+    on a script the revision deleted. That case returns
+    :data:`SCRIPT_REMOVED`.
+
+    The removal answer is only reached on the parsed path. The text fallback (3.10
+    without ``tomli``, per :func:`project_table`) cannot tell an absent
+    ``[project.scripts]`` table from an empty one, and cannot see the inline-table
+    or dotted-key spellings of the same declaration, so it would report a removal
+    for a script that is declared. It keeps the older best-effort behaviour of
+    falling through to setup.cfg instead: a missed removal there is the same gap
+    that path already has on every other question, and is preferable to refusing a
+    sync over a declaration it merely failed to read.
     """
     pyproject = read_text(repo, "pyproject.toml")
     if pyproject:
         table = project_table(repo)
         if table is not None:
-            scripts = table.get("scripts")
-            if isinstance(scripts, dict):
-                target = scripts.get(script)
+            if "scripts" not in _as_str_list(table.get("dynamic")):
+                scripts = table.get("scripts")
+                target = scripts.get(script) if isinstance(scripts, dict) else None
                 if isinstance(target, str) and target.strip():
                     return target.strip()
+                return SCRIPT_REMOVED
         else:
             scripts_text = _section(pyproject, "[project.scripts]")
             match = re.search(
@@ -598,17 +641,27 @@ def main(argv: list[str] | None = None) -> int:
             return proc.returncode
 
     # The one thing a dependency-only install cannot deliver: if the merged
-    # revision REPOINTED the console script, the wrapper on disk still dispatches
-    # to the old target and no amount of dependency installing refreshes it. The
-    # dependencies are installed by now, so this reports rather than refuses.
+    # revision REPOINTED the console script -- or dropped it -- the wrapper on
+    # disk still dispatches to the old target and no amount of dependency
+    # installing refreshes it. The dependencies are installed by now, so this
+    # reports rather than refuses.
     declared = console_script_target(repo, _SCRIPT)
     installed = installed_console_script_target(target_py, _SCRIPT)
     if declared and installed and declared != installed:
+        if declared == SCRIPT_REMOVED:
+            disagreement = (
+                f"script is no longer declared by the merged revision, while the "
+                f"installed wrapper still calls {installed}"
+            )
+        else:
+            disagreement = (
+                f"script is repointed to {declared} by the merged revision while "
+                f"the installed wrapper still calls {installed}"
+            )
         print(
             f"dep-sync: dependencies are installed, but the {_SCRIPT!r} console "
-            f"script is repointed to {declared} by the merged revision while the "
-            f"installed wrapper still calls {installed}. That wrapper cannot be "
-            "rewritten while a process is running from it: stop the gateway and run "
+            f"{disagreement}. That wrapper cannot be "
+            f"rewritten while a process is running from it: stop the gateway and run "
             f'"{target_py}" -m pip install -e "{repo}" before restarting.',
             file=sys.stderr,
         )

--- a/test/test_dev_fleet_dep_sync.py
+++ b/test/test_dev_fleet_dep_sync.py
@@ -159,6 +159,25 @@ def test_requires_python_falls_back_when_pyproject_declares_it_dynamic(repo):
     assert dep_sync.requires_python(repo) == ">=3.10"
 
 
+def test_requires_python_reads_a_static_omission_as_no_floor_at_all(repo):
+    """The same fallthrough as the console script, at the other field it owns.
+
+    A `[project]` table that declares `requires-python` statically is the whole
+    answer, so a table that omits it declares no floor. setup.cfg's copy is one
+    setuptools ignores here, and enforcing a stale copy can only over-refuse a
+    revision that is in fact installable. No sentinel is needed, unlike the
+    console-script answer: "no floor declared" and "the floor could not be read"
+    both leave this gate not firing, which is the same safe outcome.
+    """
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["dependencies"]\n',
+        encoding="utf-8",
+    )
+
+    # setup.cfg still says >=3.10; the static omission means it is not consulted.
+    assert dep_sync.requires_python(repo) is None
+
+
 def test_python_floor_breach_reports_the_highest_unmet_floor():
     assert dep_sync.python_floor_breach(">=3.10", (3, 12, 0)) is None
     assert dep_sync.python_floor_breach(">=3.13", (3, 10, 0)) == "3.13.0"
@@ -179,6 +198,17 @@ def test_python_floor_breach_reads_every_spelling_that_declares_a_floor():
     assert dep_sync.python_floor_breach(">3.10", (3, 10, 0)) == "3.10.0"
     assert dep_sync.python_floor_breach(">3.10", (3, 10, 1)) is None
     assert dep_sync.python_floor_breach(">=3.10", (3, 10, 0)) is None
+    # An equality clause pins the version it names, so that version is the floor
+    # too. `==3.12.*` is the spelling a revision uses to require one minor
+    # series; read as no floor at all, it would install on 3.10 and then fail to
+    # import. `===` is arbitrary equality and pins just as hard.
+    assert dep_sync.python_floor_breach("==3.12.*", (3, 10, 0)) == "3.12.0"
+    assert dep_sync.python_floor_breach("==3.12.*", (3, 12, 4)) is None
+    assert dep_sync.python_floor_breach("===3.10.5", (3, 10, 0)) == "3.10.5"
+    assert dep_sync.python_floor_breach("===3.10.5", (3, 10, 5)) is None
+    # `===` is read as one operator, not as `==` with a stray `=` in front, so
+    # its floor is the version it names rather than a missed match.
+    assert dep_sync._PY_FLOOR.search("===3.10.5").group("op") == "==="
 
 
 def test_dependency_authority_moved_detects_a_migration_to_pyproject(repo):
@@ -230,6 +260,58 @@ def test_console_script_target_falls_back_to_setup_cfg(repo):
     (repo / "setup.cfg").write_text(
         _SETUP_CFG + "\n\n[options.entry_points]\nconsole_scripts =\n"
         "    kirocrew = kiro_crew.old:main\n",
+        encoding="utf-8",
+    )
+
+    assert dep_sync.console_script_target(repo, "kirocrew") == "kiro_crew.old:main"
+
+
+def test_console_script_target_reports_a_removal_rather_than_reading_a_stale_copy(repo):
+    """A static `[project.scripts]` that omits the script means it was REMOVED.
+
+    Falling through to setup.cfg here is what hides the removal: this repository
+    carries the same entry point in both files, so the stale copy AGREES with the
+    installed wrapper and the comparison reports success on a script the revision
+    deleted -- the wrapper left dispatching to a target that may no longer exist.
+    """
+    (repo / "setup.cfg").write_text(
+        _SETUP_CFG + "\n\n[options.entry_points]\nconsole_scripts =\n"
+        "    kirocrew = kiro_crew.old:main\n",
+        encoding="utf-8",
+    )
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["dependencies"]\n\n'
+        '[project.scripts]\nsomething-else = "kiro_crew.other:main"\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.console_script_target(repo, "kirocrew") == dep_sync.SCRIPT_REMOVED
+
+
+def test_console_script_target_reads_no_scripts_table_as_a_removal_too(repo):
+    """No `scripts` and not dynamic is the same statement: setuptools builds none."""
+    (repo / "setup.cfg").write_text(
+        _SETUP_CFG + "\n\n[options.entry_points]\nconsole_scripts =\n"
+        "    kirocrew = kiro_crew.old:main\n",
+        encoding="utf-8",
+    )
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["dependencies"]\n',
+        encoding="utf-8",
+    )
+
+    assert dep_sync.console_script_target(repo, "kirocrew") == dep_sync.SCRIPT_REMOVED
+
+
+def test_console_script_target_still_reads_setup_cfg_when_scripts_is_dynamic(repo):
+    """A field listed as dynamic is still setup.cfg's to declare."""
+    (repo / "setup.cfg").write_text(
+        _SETUP_CFG + "\n\n[options.entry_points]\nconsole_scripts =\n"
+        "    kirocrew = kiro_crew.old:main\n",
+        encoding="utf-8",
+    )
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "kirocrew"\ndynamic = ["dependencies", "scripts"]\n',
         encoding="utf-8",
     )
 
@@ -456,6 +538,37 @@ def test_main_reports_a_repointed_console_script_after_installing(repo, capsys):
     err = capsys.readouterr().err
     assert "kiro_crew.new:main" in err
     assert "kiro_crew.old:main" in err
+    assert "No dependency was installed" not in err
+
+
+def test_main_reports_a_removed_console_script_as_a_removal(repo, capsys):
+    """A removal is a different sentence from a repoint, and must read as one.
+
+    The sentinel is a phrase, not a `module:attr`, so splicing it into the repoint
+    wording would report the script as "repointed to removed by the merged
+    revision" -- an operator cannot act on that.
+    """
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+
+    _origin_inside.repo = repo
+
+    with (
+        patch.object(dep_sync, "console_script_target", return_value=dep_sync.SCRIPT_REMOVED),
+        patch.object(
+            dep_sync, "installed_console_script_target", return_value="kiro_crew.old:main"
+        ),
+        patch.object(dep_sync.subprocess, "run", return_value=_Proc()),
+    ):
+        rc = dep_sync.main([str(repo), "py"])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no longer declared" in err
+    assert "kiro_crew.old:main" in err
+    assert "repointed to" not in err
     assert "No dependency was installed" not in err
 
 


### PR DESCRIPTION
## 1. What is the problem?

Two of the three hardening items tracked in #4549 recur in the rewritten dependency-only sync (`src/kiro_crew/apps/builtins/dev_fleet/dep_sync.py`), the path that installs dependencies instead of reinstalling the project when Windows holds a lock on the venv's `kirocrew` console script.

**The interpreter floor is not read from an equality pin.** `_PY_FLOOR` recognises `>=`, `~=` and `>`, but not `==` or `===`. A revision that requires one minor series spells that `requires-python = "==3.12.*"`; `===3.10.5` pins just as hard. Both name their version as the floor, and this gate reads neither.

**Two fields read a stale file.** `console_script_target` and `requires_python` both fall through to setup.cfg when pyproject declares the field statically but omits it -- a copy setuptools ignores once a `[project]` table exists. **A removed console script is read out of a stale file and reported as agreement.** `console_script_target` falls through to setup.cfg whenever pyproject's `[project.scripts]` does not name the script -- including when that table is present and simply omits it. This repository carries the same entry point in both files, so setup.cfg agrees with the installed wrapper and the comparison reports success.

The third item (move the comparison ahead of the pip install so every refusal precedes both writes) is moot by design in the current code: the rewrite compares AFTER installing and reports rather than refuses, which the module documents at that call site. It is not restored here.

## 2. Why this issue matters to the user

`pip install -e .` is what normally enforces `requires-python` -- pip refuses an incompatible revision rather than installing it. The dependency-only path builds nothing, so pip applies no such check and this regex is the only gate. A floor it misses is a gate that does not fire: `Pull + build` reports success, and the gateway fails to import the merged revision at its next restart, on the one platform that took this path because a normal reinstall was impossible.

The script case is the quieter of the two. The comparison exists precisely because a dependency-only install cannot refresh a locked wrapper, so an operator has to be told to stop the gateway and reinstall by hand. When a revision DELETES the entry point, the stale setup.cfg copy makes the two sides agree, the operator is told nothing, and the wrapper is left dispatching to a target the revision may have removed -- the exact failure the check was added to catch, reported as a pass.

## 3. How our fix solves it

**Equality pins are read as the floors they declare.** `_PY_FLOOR` gains `===` and `==`, with `===` first in the alternation so the longer operator wins. `python_floor_breach` needs no change: an equality pin is an inclusive floor, like `>=`. Exclusions and upper bounds stay pip's problem on the next real reinstall -- `!=3.11.*` and `<4` match no operator here, so widening the floor set does not start misreading them as floors.

**A static declaration that omits the script is an answer, not a reason to look elsewhere.** Once `scripts` is declared non-dynamically, setuptools builds the wrapper from pyproject and ignores setup.cfg's copy, so an omission means the entry point was removed as of that revision. That case now returns a `SCRIPT_REMOVED` sentinel -- distinct from `None`, which means the declaration could not be read at all and which `main` deliberately tolerates. Collapsing the two is what let a removal pass. `main` reports a removal in its own sentence ("no longer declared by the merged revision") rather than splicing the sentinel into the repoint wording, which would print "repointed to removed by the merged revision" -- something an operator cannot act on.

setup.cfg is still consulted exactly where setuptools would consult it: a checkout with no `[project]` table (pre-PEP 621 metadata), or one that declares `scripts` dynamic. Both keep their existing behaviour and both are pinned by tests.

**Stated residual:** the removal answer is reached only on the parsed path (`tomllib` on 3.11+, `tomli` when importable). The text fallback used on 3.10 without `tomli` cannot tell an absent `[project.scripts]` from an empty one, and cannot see the inline-table or dotted-key spellings of the same declaration, so giving it the same answer would refuse a sync over a declaration it merely failed to read. It keeps falling through to setup.cfg -- the same best-effort residual `project_table` already documents for every other question this module asks of pyproject.

**The same fallthrough, closed at the other field too.** First Principles review found `requires_python` (dep_sync.py:249-279) carrying the identical pattern: a `[project]` table that omits `requires-python` non-dynamically fell through to setup.cfg's `python_requires`, contradicting that function's own docstring, which says setuptools ignores that copy once a `[project]` table exists. Leaving it would make the reasoning above a claim about one call site rather than a property of the module, so it is fixed in the same commit: a static omission now answers "no floor" and setup.cfg is not consulted. No sentinel is needed there, unlike the console script -- "no floor declared" and "the floor could not be read" both leave the gate not firing, so the caller cannot act on the difference. The harm direction was the mild one (a stale floor can only over-refuse a revision that is in fact installable), which is why it was a CONCERNS rather than a block; the fix is two lines and closes the pattern at every site a grep of this module finds.

## 4. What tests we did

`test/test_dev_fleet_dep_sync.py`, 37 passed (32 before). Five new cases plus new assertions in the existing floor-spelling test:

* `==3.12.*` and `===3.10.5` refuse an interpreter below the pinned version and pass one at or above it; `_PY_FLOOR` reads `===` as one operator rather than `==` with a stray `=`.
* A present `[project.scripts]` that omits the script answers `SCRIPT_REMOVED` even though setup.cfg carries a copy.
* No `scripts` key at all, not dynamic, answers `SCRIPT_REMOVED` the same way.
* `scripts` declared dynamic still reads setup.cfg.
* A `[project]` table that omits `requires-python` non-dynamically answers `None` rather than setup.cfg's `>=3.10`.
* `main` reports a removal as a removal: the message says "no longer declared", names the installed target, and does not say "repointed to".

Each fix was mutation-verified -- reverting `_PY_FLOOR` to the pre-change alternation, deleting the `return SCRIPT_REMOVED`, deleting the `return None` in `requires_python`, and neutering the removal branch in `main` each reddened exactly the tests written for it (1, 2, 1 and 1 failures respectively) and nothing else. Probes were reverted and `git diff --stat` confirmed clean before committing.

Gates on the changed files: `black --check`, `isort --check-only`, `flake8`, `mypy` all clean. The wider dev-fleet selection ran 707 passed / 1 failed; that one, `test_trusted_bin_pins_the_resolved_target_not_the_symlink`, is a pre-existing host-environment hermeticity failure -- verified by stashing this diff and reproducing it on pristine `main` at the same SHA, where it fails identically (it asserts against a `gh` path this host resolves differently). It is untouched by this change, which edits no toolchain code.

## 5. Any other suggestions on the work

This supersedes #4562, which implemented all three items against the pre-rewrite `dep_sync.py`. #4541 was force-pushed with a wholesale rewrite that deleted the functions that PR patched, leaving it draft and conflicting; its review history is about code that no longer exists, so a fresh branch off current `main` is cleaner than a rebase. #4562's parser-first design decision is not lost -- #4541 landed it as `project_table`, which is what makes the precise removal answer possible here.

The text-scanner residual named in section 3 is the only part of #4549 left after this. It is not worth its own change on its own: closing it means making the scanner spelling-complete, which #4562's review history shows costs one round per spelling, on a path that only a 3.10 venv without `tomli` reaches.

Refs #4549
