### PR TITLE
fix(update): follow stable by default so a promoted release stays stable

### DIFF
--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -503,6 +503,30 @@ nightly and insider stamp is a semver prerelease and would otherwise be
 invisible to its own channel). The library still refuses an equal version before
 the `allowDowngrade` branch, which is what prevents a self-reinstall loop.
 
+**Which channel a build follows is a default plus an opt-in, not a property of
+the bytes.** `channelForVersion()` classifies the version stamp and `nightly`
+stays pinned by it, but for the two production lanes `resolveChannel()` honours
+the persisted Settings → About preference and defaults to **stable** when none is
+set. It cannot read the lane out of the stamp, because stable is PROMOTED: the
+stable and insider downloads of a promoted version are the same notarized file
+carrying the same `-insider.N` stamp, so a stamp-derived channel would send every
+promoted-stable install to the insider feed. The consequences to know:
+
+- **Insider is an explicit opt-in.** Any install with no recorded preference
+  follows stable — including one installed from the insider DMG, and including an
+  insider install that predates this rule. The two downloads are identical files,
+  so nothing in them can record which page one came from, and nothing already on
+  disk distinguishes an insider install from a stable one that has been offered
+  the promoted build. Insider is reached by the switcher, once, per install.
+- **There is no way to seed that preference retroactively.** A migration would
+  have to read the channel from the version stamp, and the first build carrying
+  any such migration is itself promotion-stamped, so it would write `insider` for
+  every stable install — the defect this rule exists to remove, made permanent.
+  A future transition could use a persisted last-run version; this one cannot.
+- **The "you are running prerelease bytes" note still keys on the stamp**
+  (`stampedChannel`), not on the followed channel, because that statement is
+  about the bytes and stays literally true on a promoted stable install.
+
 The specific to Kiro Crew part is install ordering: the app supervises a bundled
 Python gateway child, so before `quitAndInstall` the client stops it gracefully
 (`POST /api/shutdown`, then SIGTERM, then SIGKILL) and disarms the liveness

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -121,20 +121,33 @@ function channelForVersion(version) {
  *   migrate the dev app onto a production channel.
  * - unstamped (dev, stamped === null) builds have no update lane; the
  *   preference cannot conjure one.
- * - production stamps (insider/stable) follow the preference when set,
- *   else their own stamp. Switching BACK can be a downgrade mid-cycle
- *   (insider 0.2.0-insider.1 -> stable 0.1.0), which is why allowDowngrade
- *   is enabled in configureUpdater.
+ * - production builds (insider/stable stamps) follow the preference when set,
+ *   and default to STABLE when it is not. Switching BACK can be a downgrade
+ *   mid-cycle (insider 0.2.0-insider.1 -> stable 0.1.0), which is why
+ *   allowDowngrade is enabled in configureUpdater.
+ *
+ * Why the unset default is stable rather than the stamp: a stable release is
+ * PROMOTED, meaning the exact notarized candidate bytes are re-pointed at the
+ * stable channel without a rebuild, so the stable download and the insider
+ * download of a promoted version are the SAME FILE and carry the same
+ * prerelease stamp (`0.3.0-insider.13`). The channel therefore cannot be a
+ * property of the bytes, and reading it out of the version string sends every
+ * promoted-stable install to the insider feed. It is a default plus an opt-in,
+ * which is what this function's own contract above already describes.
+ *
+ * `channelForVersion` deliberately keeps classifying the BYTES (it is what the
+ * About panel's "you are running prerelease bytes" note is keyed on); only the
+ * followed feed is decoupled from it here.
  *
  * @param {"nightly"|"insider"|"stable"|null} stamped - channelForVersion(version)
- * @param {"insider"|"stable"|""|null|undefined} preference - user opt-in, falsy = follow stamp
+ * @param {"insider"|"stable"|""|null|undefined} preference - user opt-in, falsy = default
  * @returns {"nightly"|"insider"|"stable"|null}
  */
 function resolveChannel(stamped, preference) {
   if (stamped === "nightly") return "nightly";
   if (stamped === null) return null;
   if (preference === "insider" || preference === "stable") return preference;
-  return stamped;
+  return "stable";
 }
 
 /**

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -107,7 +107,7 @@ const store = new Store({
     globalHotkey: null,                    // system-wide summon accelerator: null = platform default, "" = disabled, string = custom (see global-hotkey.js)
     lastNudgedVersion: "",                 // last update version announced via native notification (nudge once per version)
     themeAccent: "",                       // user's resolved theme accent hex; injected into the boot splash
-    updateChannel: "",                     // "" = follow build stamp; "insider"|"stable" = user opt-in (Settings > About)
+    updateChannel: "",                     // "" = follow the stable default; "insider"|"stable" = user opt-in (Settings > About)
     runLocalGateway: true,                 // false = act as a pure client; never start a gateway on this machine
     linuxFrameless: null,                  // Linux window chrome: true = frameless, false = native frame, null = follow the desktop environment (see linux-frame.js)
   },

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -58,11 +58,42 @@ test("resolveChannel: production stamps follow the preference when set", () => {
   assert.strictEqual(resolveChannel("insider", "stable"), "stable");
 });
 
-test("resolveChannel: no/invalid preference falls back to the stamp", () => {
+test("resolveChannel: no/invalid preference defaults to STABLE, not to the stamp", () => {
+  // A stable release is PROMOTED, not rebuilt: the stable and insider downloads
+  // of a promoted version are the same file carrying the same prerelease stamp,
+  // so the stamp cannot say which feed to follow. Insider is an explicit opt-in.
   assert.strictEqual(resolveChannel("stable", ""), "stable");
-  assert.strictEqual(resolveChannel("insider", undefined), "insider");
+  assert.strictEqual(resolveChannel("insider", undefined), "stable");
   assert.strictEqual(resolveChannel("stable", "nightly"), "stable"); // nightly is not a valid opt-in
-  assert.strictEqual(resolveChannel("insider", "bogus"), "insider");
+  assert.strictEqual(resolveChannel("insider", "bogus"), "stable");
+});
+
+test("a promoted -insider.N build with no preference follows the STABLE feed", async () => {
+  // The regression this exists for: promoting 0.3.0 publishes the insider
+  // candidate's exact bytes to stable, so every stable install would otherwise
+  // read its own version stamp and migrate itself onto the insider feed.
+  const { deps, calls } = makeDeps({ appVersion: "0.3.0-insider.13" });
+  deps.getChannelPreference = () => "";
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(calls.setFeedURL.length >= 1);
+  assert.ok(
+    calls.setFeedURL.every((o) => o.url === "https://cdn.example.dev/feed/stable/"),
+    `expected stable feed urls, got: ${calls.setFeedURL.map((o) => o.url)}`,
+  );
+  assert.strictEqual(u.getInfo().channel, "stable");
+});
+
+test("an explicit insider preference still selects insider on promoted bytes", async () => {
+  const { deps, calls } = makeDeps({ appVersion: "0.3.0-insider.13" });
+  deps.getChannelPreference = () => "insider";
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(
+    calls.setFeedURL.every((o) => o.url === "https://cdn.example.dev/feed/insider/"),
+    `expected insider feed urls, got: ${calls.setFeedURL.map((o) => o.url)}`,
+  );
+  assert.strictEqual(u.getInfo().channel, "insider");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

**The 0.3.0 promotion, as things stand, would move every stable desktop user onto the insider channel.**

A stable release is *promoted*, not rebuilt: `release.yml` resolves the recorded
candidate and re-points its exact notarized bytes at the stable channel, passing
`resolve-promotion.outputs.source_version` to every publish lane. So the stable
download and the insider download of a promoted version are **the same file**,
carrying the same `-insider.N` stamp — `desktop/stable/…` will serve an app whose
`app.getVersion()` is `0.3.0-insider.13`.

But the followed channel was derived from that stamp:

```js
// auto-update.js
function channelForVersion(version) {          // any non-nightly prerelease
  if (version.includes("-")) return "insider"; // → insider
  ...
}
function resolveChannel(stamped, preference) {
  if (preference === "insider" || preference === "stable") return preference;
  return stamped;                              // ← unset preference followed the bytes
}
```

Chain: a stable install polls stable → is offered `0.3.0-insider.13` → installs it
→ from the next poll identifies as insider → follows `feed/insider/`. A fresh
stable DMG does it on first launch. Tag `v0.4.0-insider.1` after that and people
who chose stable start receiving 0.4.0 previews.

## Why it matters

This is the **first promotion the pipeline has ever performed** — which is exactly
why three shipped releases did not surface it. `v0.2.0`'s release run
(31441740869) executed `Build Wheel` and `Build Desktop` with no
`Resolve Tested Candidate` job: it was a same-tag **rebuild**, so its stable
artifacts carried a bare `0.2.0`. The defect is structurally invisible to RC soak,
because soak validates the bytes and this only manifests when those bytes are
re-pointed at a second channel.

Unrollbackable once shipped: CDN keys are immutable and recovery is a new version.

## What changed (motivation → approach → change)

Root cause: **channel was treated as a property of the bytes, and the bytes are
byte-identical across two lanes.** It cannot be recovered from them even in
principle. So it becomes what `resolveChannel`'s own docstring already described —
a default plus an opt-in:

```diff
 function resolveChannel(stamped, preference) {
   if (stamped === "nightly") return "nightly";      // pinned, untouched
   if (stamped === null) return null;                // dev has no lane
   if (preference === "insider" || preference === "stable") return preference;
-  return stamped;
+  return "stable";
 }
```

That is the whole functional change. `channelForVersion()` is deliberately
**unchanged**: it still classifies the *bytes*, which is what the About panel's
"you are running prerelease bytes" note is keyed on (`stampedChannel`). That note
will still appear on a promoted stable install — which is true, so it stays.

## The cost, stated plainly

**An install with no recorded preference follows stable.** So an insider install
that predates this rule migrates to stable once and re-opts in through the
Settings → About switcher. Same for a fresh install from the insider DMG: the two
DMGs are identical files, so nothing in them can record which page one came from.

**This is deliberately not sweetened with a migration.** An earlier revision of
this PR carried a `channelPreferenceSeed()` that wrote the version-derived channel
into the preference for any install showing evidence of a previous run. Both
reviewers were right to block it, and it is now deleted:

- The first build carrying such a seed **is the promotion-stamped one**, so a
  stable user's first seeded launch reads `0.3.0-insider.13` → writes
  `insider` → and an explicit preference is never overwritten. It made this exact
  defect permanent for the population the PR exists to protect (First Principles).
- A *fresh* promoted install was hit too: its first run persists theme state, so
  its second launch satisfies "has prior state" and gets pinned to insider (GPT).
- The probe could only ask "has this app ever run", never "did it run before this
  build". Distinguishing those needs a persisted last-run version, which no
  existing install has ever written — so it can serve a future transition, not
  this one.

A seed that is wrong for stable upgraders is worse than no seed, so the honest
version of this change is the one-line default plus a one-click opt-in.

**One window worth knowing operationally:** between `v0.3.0-insider.13` publishing
and the bare `v0.3.0` promotion, an insider install carrying this fix polls stable
while stable is still `0.2.0`, and `allowDowngrade=true` means it will *offer* a
downgrade. Consent-first (`autoDownload=false`), so nothing installs by itself, and
the offer disappears once the promotion makes both feeds equal — but it argues for
promoting promptly after rc13 is verified rather than leaving that window open.

## Behaviour after this change

| Install | Result |
|---|---|
| Fresh stable DMG (promoted bytes) | stable → polls stable, sees its own version, no update ✅ |
| Existing stable 0.2.0 | stable → stays stable ✅ |
| Existing insider, no preference set | stable → **migrates once**, re-opts in via the switcher ⚠️ |
| Existing insider, preference set | preference wins → stays insider ✅ |
| Nightly | pinned by `resolveChannel`'s first line, untouched ✅ |
| Dev / unstamped | no lane, unchanged ✅ |

## Tests

`website/electron/test/auto-update.test.js`:

- **changed** — `resolveChannel: no/invalid preference defaults to STABLE, not to the stamp` (was `… falls back to the stamp`)
- **new** — a promoted `-insider.N` build with no preference follows the STABLE feed (the regression itself)
- **new** — an explicit insider preference still selects insider on promoted bytes

Must-not-regress, verified green: nightly pinning (`stamped nightly build points
the FEED at nightly`, `nightly build reports not switchable`), the `#709`
equal-version contract, `buildFeedBase`.

**Full Electron suite: 970 passed, 0 failed.** `docs-lint` and the brand-name gate
pass.

## Manual verification

Not performed — it needs two real signed builds and a promoted feed, which is
`ota-test.yml`'s job and cannot be reproduced locally. The change is a pure
function plus the feed url it selects, both covered above.

## Documentation

`docs/build/release.md` § "Client auto-update" gains the rule, the opt-in cost, and
why no retroactive seed is possible.

## Known follow-up (not in this PR)

UX review's CONCERNS is real and deliberately left out of a change riding into a
promotion, because it needs new user-facing strings across 12 locales: after the
promotion a default install shows version `0.3.0-insider.13`, the "thanks for
running early builds, please report it" prompt, and a switcher reading **Stable** —
three signals a reader cannot reconcile. Worth deciding at the same time whether
that prompt should key on the followed channel rather than the byte stamp, since
"early build" is no longer a true description of what a promoted stable user is
running.

## Related Issues

Required before the bare `v0.3.0` promotion tag. Needs a fresh
`v0.3.0-insider.13` candidate recorded on top.

**Why no screenshot:** update-channel resolution in the Electron main process; the
About panel's switcher reads the resolved channel and follows automatically with no
markup change.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
