### PR TITLE
feat(cron): let an operator hand a cron job to a chat session, and show who owns one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ destructive-command deny rules, `~/.aws` / `~/.ssh` path blocking, the SEL audit
   agent config granted it. The evaluator is scope-name-agnostic, so adding a scope
   is a `SCOPE_CATALOG` data change, never an evaluator edit.
 - **`CONTRACT_VERSION` stays pinned at 1 pre-launch.**
-- **Denied commands** are `DeniedCommandRule` records (`BUILTIN_DENIED_RULES`, 139 rules)
+- **Denied commands** are `DeniedCommandRule` records (`BUILTIN_DENIED_RULES`)
   enforced only at the `hooks.py` PreToolUse gate. Never restate the rule count in
   prose: `test/test_denied_commands_security.py` pins it, and a restated count goes
   stale silently.

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -20,7 +20,7 @@ KiroCrew implements defense-in-depth security across multiple layers: OS-level p
 | Fail-open owner lock | `KIROCREW_OWNER_ID` unset → no check | Deny-by-default: refuse connect + reject messages |
 | MCP input injection | Malformed/oversized tool inputs from LLM | Centralized schema validation (`validation.py`) |
 | MCP response DoS | Unbounded tool output fills memory | Response truncation at 100K |
-| Destructive CLI commands | LLM runs `rm -rf /`, `git push --force` | 130 built-in denied-command rules (`BUILTIN_DENIED_RULES`, default-on / user-disableable) enforced at the hooks PreToolUse gate + governance `commands` force-deny (enterprise, un-opt-out-able) + 55 suspicious bash patterns with per-segment matching (`security.py`) |
+| Destructive CLI commands | LLM runs `rm -rf /`, `git push --force` | Built-in denied-command rules (`BUILTIN_DENIED_RULES`, default-on / user-disableable) enforced at the hooks PreToolUse gate + governance `commands` force-deny (enterprise, un-opt-out-able) + 55 suspicious bash patterns with per-segment matching (`security.py`) |
 | Frontend XSS | `dangerouslySetInnerHTML` with unsanitized content | DOMPurify + safe DOM APIs + Mermaid `securityLevel: 'strict'` (iframe sandbox) |
 | Widget postMessage forged turn | LLM-emitted `<script>` in a sandboxed `<mcwidget>` iframe calls `parent.postMessage({type:'mc-widget-action'})`, bypassing the in-iframe `isTrusted` click guard | Frontend requires a human gesture: a widget action only PRE-FILLS the composer (never auto-submits) and tags the resulting user-initiated send `meta.origin='widget'`. Backend deny-by-default: `api_chat` refuses the sole chat-text-reachable privilege escalation — orchestrator `go`/`go all` auto-run — for `origin='widget'` turns (SEL `auto_run_denied`), letting the text fall through to a normal fully-gated turn. Mode changes and tool approvals are on separate endpoints the iframe cannot reach |
 | YOLO mode abuse | Unbounded auto-approve window | Time-limited safety override: Slack 30min, dashboard 6h, config 24h (no permanent mode). Re-auth required after expiry. SEL audit on every lifecycle event |
@@ -428,7 +428,7 @@ than an automatic readiness failure.
 
 ### Denied Commands (`security.py` + `hooks.py`)
 
-138 first-class `DeniedCommandRule` records in `BUILTIN_DENIED_RULES` (`security.py`) — each a stable `id`, a Python regex `pattern`, a `category`, and a human `description` — blocking destructive and credential-exfiltrating operations. They are enforced **only** at KiroCrew's own `hooks.py` PreToolUse gate (`HookManager.on_tool_call` → `PolicyAuthority.is_denied`), never by kiro-cli. They are no longer a raw `deniedCommands` array injected into a kiro agent JSON, so there is no `execute_bash`/`shell` tool-settings copy and no project-dir `agents/defaults.json` override for them. Built-ins are **default-ON but user-DISABLEABLE** from Settings → Security (see "Denied-command rules, opt-out state, and read-only auto-approve" below). ada credential patterns are NOT in KiroCrew's denied commands — kiro-cli has its own built-in deny list for `ada credentials` that cannot be overridden via agent config.
+First-class `DeniedCommandRule` records in `BUILTIN_DENIED_RULES` (`security.py`) — each a stable `id`, a Python regex `pattern`, a `category`, and a human `description` — blocking destructive and credential-exfiltrating operations. They are enforced **only** at Kiro Crew's own `hooks.py` PreToolUse gate (`HookManager.on_tool_call` → `PolicyAuthority.is_denied`), never by kiro-cli. They are no longer a raw `deniedCommands` array injected into a kiro agent JSON, so there is no `execute_bash`/`shell` tool-settings copy and no project-dir `agents/defaults.json` override for them. Built-ins are **default-ON but user-DISABLEABLE** from Settings → Security (see "Denied-command rules, opt-out state, and read-only auto-approve" below). ada credential patterns are NOT in Kiro Crew's denied commands — kiro-cli has its own built-in deny list for `ada credentials` that cannot be overridden via agent config.
 
 **Credential exfiltration blocks**:
 - `.*echo.*\$AWS_SECRET.*`, `.*echo.*\$AWS_ACCESS.*`, `.*echo.*\$AWS_SESSION.*` — env var echo
@@ -510,7 +510,7 @@ than an automatic readiness failure.
 SEL audit key), `pattern: str` (a Python regex matched via `re.search`,
 case-insensitive), `category: str`, and `description: str` (one human sentence
 for the UI). `BUILTIN_DENIED_RULES: list[DeniedCommandRule]` is the canonical
-default-ON catalog of **130** rules across categories `aws-destructive`,
+default-ON catalog spanning the categories `aws-destructive`,
 `credential-exfil`, `iac-teardown`, `local-destructive`, `pipe-to-shell`, `sql`,
 `self-protection`, `git-publish`, `reverse-shell`, and `sensitive-file-read`.
 `BUILTIN_DENY_PATTERNS` is retained as a derived alias
@@ -620,7 +620,7 @@ once at init — so a just-disabled built-in or just-added user deny reaches
 unattended heartbeat sessions without a gateway restart (cross-surface
 consistency).
 
-**Defense-in-depth nuance** — ~45 of the 130 rules overlap an independent,
+**Defense-in-depth nuance** — roughly a third of the rules overlap an independent,
 always-on keystone control (sensitive-file reads, IMDS, git-publish, cred-env
 dumps). Most rules are disableable, but disabling a rule does **not** disable
 its keystone control — such a command stays blocked by defense-in-depth. The

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1189,6 +1189,24 @@ Examples:
     cron_trigger = cron_sub.add_parser("trigger", help="Trigger a cron job immediately")
     cron_trigger.add_argument("job_id", help="Job ID to trigger")
 
+    cron_adopt = cron_sub.add_parser(
+        "adopt",
+        help="Give a cron job an owning chat session, so that session can manage it and receives its results",
+    )
+    cron_adopt.add_argument("job_id", help="Job ID to adopt")
+    adopt_target = cron_adopt.add_mutually_exclusive_group(required=True)
+    adopt_target.add_argument(
+        "--session-of",
+        metavar="SESSION",
+        help='Dashboard slot name ("chat-3-1712793600") or a fully-qualified '
+        'session key ("dashboard:chat-3-1712793600"); see `kirocrew cron list`',
+    )
+    adopt_target.add_argument(
+        "--release",
+        action="store_true",
+        help="Clear the owning session, returning the job to CLI/dashboard-only management",
+    )
+
     cron_preview = cron_sub.add_parser(
         "preview",
         help="Run a script cron locally with real MCP tools; notifications are captured and printed instead of delivered",

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -61,6 +61,7 @@ from kiro_crew.dashboard.origin import parse_dashboard_url
 from kiro_crew.eval.judge import LLMJudge
 from kiro_crew.eval.runner import EvalRunner, format_results, score_by_dimension
 from kiro_crew.eval.scenario import AssertionType, load_scenario, load_scenarios
+from kiro_crew.history import ConversationLog
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.learn import Lesson, LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
@@ -838,6 +839,97 @@ def _cron(args: argparse.Namespace) -> None:
             status = "✅" if j.enabled else "⏸️"
             sched = _format_schedule(j.schedule)
             print(f"  {status} {j.id}  {j.name}  ({sched})  {j.message[:60]}")
+            # Ownership is printed because it decides which surfaces can manage
+            # the job at all: a job with no owning session is outside every chat
+            # session's scope, so `cron_list` from chat does not list it and the
+            # mutating tools answer a deliberately vague "job not found". That is
+            # the intended boundary, but with the field invisible here the CLI
+            # was the only place the state existed and nothing showed it -- which
+            # is what made a normal, correct state read as a job that had
+            # vanished. `cron adopt` is the way back.
+            owner = j.session_key or ""
+            provenance = j.created_by or ""
+            if owner:
+                detail = f"owner: {owner}"
+            else:
+                detail = "owner: none (manage from CLI or the dashboard Schedule page)"
+            if provenance:
+                detail += f"  created by: {provenance}"
+            print(f"      {detail}")
+
+    elif action == "adopt":
+        job_id = args.job_id
+        if getattr(args, "release", False):
+            session_key = ""
+        else:
+            # One flag, two accepted spellings of the same target. A bare slot
+            # name gets the `dashboard:` namespace the delivery consumers strip
+            # back off (messaging.py / the Slack gateway both
+            # removeprefix("dashboard:")), so adding it here is their exact
+            # inverse and needs no lookup. An already-namespaced key passes
+            # through untouched -- there is no second flag for that case,
+            # because a key with no namespace at all could never equal any
+            # caller's session key and so could only ever produce a row nobody
+            # can own.
+            target = (getattr(args, "session_of", None) or "").strip()
+            if not target:
+                print("Error: --session-of requires a session", file=sys.stderr)
+                sys.exit(1)
+            session_key = target if ":" in target else f"dashboard:{target}"
+        if not svc.adopt_job(job_id, session_key):
+            print(f"Error: job not found: {job_id}", file=sys.stderr)
+            sys.exit(1)
+        sel().log_api_access(
+            caller="cli",
+            operation="cron.adopt",
+            outcome="allowed",
+            source="cli",
+            resources=f"job_id={job_id} session_key={session_key or '(released)'}",
+        )
+        if session_key:
+            # Ownership and delivery do not have the same reach. `_owned_by`
+            # matches any namespace, so a Slack or Telegram session can own and
+            # manage a job -- but only a `dashboard:` key resolves to a slot the
+            # delivery path can inject into (both consumers reach a slot with
+            # removeprefix("dashboard:")). Saying "results are delivered there"
+            # for a `slack:` key would be a promise the code does not keep.
+            if session_key.startswith("dashboard:"):
+                print(
+                    f"Job {job_id} now belongs to {session_key}: that session can manage it "
+                    f"and its results are delivered there."
+                )
+                # A typo'd key is accepted by the store but resolves to no slot,
+                # so the job's output would go nowhere -- the same
+                # invisible-delivery state this command exists to recover from.
+                # Warn rather than refuse: the delivery path resolves a live slot
+                # first and only falls back to rehydrating from history, so a
+                # brand-new tab that has not logged anything yet is a legitimate
+                # target and absence of a log does not prove the key is wrong.
+                slot = session_key.removeprefix("dashboard:")
+                try:
+                    known = ConversationLog().has_log(slot)
+                except Exception:
+                    known = True  # cannot tell -> stay quiet rather than cry wolf
+                if not known:
+                    print(
+                        f"Warning: no recorded session named {slot!r}. If that is a typo, "
+                        f"the job's results will not reach anyone -- re-run with the right "
+                        f"key, or `--release` to undo.",
+                        file=sys.stderr,
+                    )
+            else:
+                print(f"Job {job_id} now belongs to {session_key}: that session can manage it.")
+                print(
+                    f"Note: results are not injected into a chat for a "
+                    f"{session_key.split(':', 1)[0]!r} owner -- only a dashboard session is "
+                    f"resolved as a delivery target. Ownership transferred; delivery did not.",
+                    file=sys.stderr,
+                )
+        else:
+            print(
+                f"Job {job_id} released: no owning session, so manage it from the CLI or "
+                f"the dashboard Schedule page."
+            )
 
     elif action == "add":
         every = getattr(args, "every", None)

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -2054,6 +2054,46 @@ class CronService:
             self._arm_timer()
         return removed
 
+    def adopt_job(self, job_id: str, session_key: str) -> bool:
+        """Point ``job_id`` at ``session_key`` as its originating chat session.
+
+        ``session_key`` names the chat session a job belongs to, and it is ONE
+        field with ONE meaning: every consumer reads it as the delivery target
+        (``session="origin"`` resolution and script-result injection both strip
+        the ``dashboard:`` prefix off it to get a slot). So adopting a job also
+        makes its output arrive in that session -- that is what being the
+        originating session IS, not a side effect the caller has to be warned
+        about separately. Pass ``""`` to release the job back to the operator
+        surfaces (CLI and the dashboard Schedule page), which is the state every
+        job created outside a chat legitimately starts in.
+
+        Deliberately NOT a branch in :meth:`_update_job_locked`: that path is
+        reachable from MCP ``cron_update`` and the dashboard ``PATCH``, and a
+        ``session_key`` branch there would hand both surfaces the power to
+        repoint where any job delivers. Ownership is asserted by the operator,
+        so the CLI -- the one surface that is not a session -- is its only
+        writer.
+
+        Returns ``False`` when the id is absent. Raises :class:`CronStoreBusy`
+        on lock contention. Synchronous only: the CLI is its sole caller and has
+        no event loop, so an async sibling would be dead code.
+        """
+        ok = self._adopt_job_locked(job_id, session_key)
+        if ok:
+            self._arm_timer()
+        return ok
+
+    def _adopt_job_locked(self, job_id: str, session_key: str) -> bool:
+        """Lock/reload/mutate/save core of :meth:`adopt_job` (no timer work)."""
+        with self._file_lock():
+            self._sync()
+            for job in self._jobs:
+                if job.id == job_id:
+                    job.session_key = session_key
+                    self._save()
+                    return True
+        return False
+
     def enable_job(self, job_id: str, enabled: bool = True) -> bool:
         """Enable or disable a job by ID.
 

--- a/src/kiro_crew/docs/cron-and-scheduling.md
+++ b/src/kiro_crew/docs/cron-and-scheduling.md
@@ -183,6 +183,72 @@ Via Dashboard: toggle "Strict schedule" when creating or editing a job.
 | Pause | Pause button | `cron pause <id>` | — |
 | Resume | Resume button | `cron resume <id>` | — |
 | Delete | Delete button | `cron remove <id>` | `kirocrew cron remove <id>` |
+| Adopt / release | — | — | `kirocrew cron adopt <id> --session-of <slot>` / `--release` |
+
+### Which chat session owns a job
+
+A job's `session_key` names the chat session it belongs to, and that one field
+carries one meaning: it is also where the job's output is delivered
+(`session="origin"` sends and script results both resolve a slot from it). A job
+created outside a chat — `kirocrew cron add`, the dashboard Schedule page, an
+onboarding import — therefore has no owning session, which is truthful rather
+than a defect: there is no chat to deliver into.
+
+The consequence is worth stating plainly, because it is easy to read as a job
+that disappeared. A job with no owning session is outside every chat session's
+scope: `cron_list` from chat does not list it, and the mutating cron tools answer
+a deliberately vague `job not found` so the reply cannot be used to enumerate
+jobs the caller may not see. Those jobs are managed from the operator surfaces
+instead: `kirocrew cron list`, which is the only surface that shows *who* owns a
+job, and the dashboard Schedule page, which lists and manages every job regardless
+of owner but does not yet display ownership (its API payload does not carry
+`session_key`).
+
+`kirocrew cron adopt` is the way across that line, in both directions:
+
+```
+kirocrew cron adopt <id> --session-of chat-3-1712793600   # hand it to a session
+kirocrew cron adopt <id> --session-of dashboard:chat-3-1712793600
+kirocrew cron adopt <id> --release                        # back to operator-only
+```
+
+`--session-of` takes either a bare dashboard slot name or a fully-qualified
+session key; a bare name gets the `dashboard:` namespace added. There is no
+separate flag for the qualified form, because a key carrying no namespace at all
+could never match any session's own key and so could only ever produce a job
+nobody can own.
+
+Adopting makes that session able to manage the job **and** the destination for
+its results — for this field those are the same fact. Ownership is asserted by
+the operator, so the CLI is deliberately the only surface that can write it: the
+MCP `cron_update` tool and the dashboard `PATCH` cannot, or a session could
+repoint where another job's output lands.
+
+Because an agent can reach the CLI through bash, that restriction is enforced
+rather than assumed: `cron adopt` is covered by the `self-protection-cron-adopt`
+denied-command rule, so a session cannot claim a job for itself by shelling out.
+Like every built-in rule it is default-ON and can be turned off in
+Settings → Security.
+
+That rule is **best-effort against a shell-capable agent, not an invariant**. It
+guards the command; it does not guard the store. `crons.json` is not among the
+protected leaves, so a direct edit of the file sets the same field without the
+rule ever matching, and the regex tier cannot see a spelling the shell has yet to
+expand (`$K cron adopt`) any more than it can for the rest of the catalog. The
+control that does not depend on spelling is the structural one: `session_key` is
+not writable through MCP `cron_update` or the dashboard `PATCH` at all.
+
+Ownership and delivery do not have the same reach. A job can be owned by any
+session namespace -- a Slack or Telegram session can own and manage one -- but
+only a `dashboard:` key resolves to a slot results are injected into, so adopting
+into another namespace transfers management without delivery, and the command
+says so.
+
+If the key names no recorded session the command still succeeds but warns: a
+brand-new tab that has logged nothing yet is a legitimate target (delivery
+resolves a live slot first), so the unknown case cannot be refused — but a typo
+would otherwise leave the job delivering to nobody, which is the state this
+command exists to undo.
 
 ## Reliability
 

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -1370,6 +1370,24 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
         ),
     ),
     DeniedCommandRule(
+        id="self-protection-cron-adopt",
+        pattern=".*kiro.?crew\\b(?:(?!&&)[^;|])*?\\bcron\\b(?:(?!&&)[^;|])*?\\badopt\\b.*",
+        category="self-protection",
+        description=(
+            "Blocks 'kirocrew cron adopt' so the agent cannot assign itself ownership of a "
+            "scheduled job. A cron's owning session both manages the job and receives its "
+            "output, and the MCP cron tools deliberately cannot write that field -- without "
+            "this rule a session could reach the same power through bash and claim a job that "
+            "belongs to another session. The gaps between the words tolerate anything that is "
+            "not a command separator, rather than enumerating what may sit there: the CLI "
+            "accepts '-v'/'--verbose' and '--no-jail' before a subcommand, a shell redirection "
+            "is legal anywhere in a simple command, and $IFS is a word separator too, so an "
+            "allow-list of interlopers would need extending on each new spelling. A single '&' "
+            "is allowed through because '2>&1' is a redirection, while '&&' still ends the "
+            "match: the three words have to belong to ONE simple command."
+        ),
+    ),
+    DeniedCommandRule(
         id="self-protection-gateway-restart",
         pattern=".*kiro.?crew gateway restart.*",
         category="self-protection",

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -780,6 +780,12 @@
     "description": "Blocks pkill/killall naming a kirocrew process, and a bare kill whose PID comes from a command substitution that resolves the kirocrew name, so the agent cannot terminate its own gateway or supervisor and disable the controls governing it. Scoped to the kill target within one command segment: an incidental mention of the product in a later command or a comment (a file being restored, a log path) is not a kill."
   },
   {
+    "id": "self-protection-cron-adopt",
+    "pattern": ".*kiro.?crew\\b(?:(?!&&)[^;|])*?\\bcron\\b(?:(?!&&)[^;|])*?\\badopt\\b.*",
+    "category": "self-protection",
+    "description": "Blocks 'kirocrew cron adopt' so the agent cannot assign itself ownership of a scheduled job. A cron's owning session both manages the job and receives its output, and the MCP cron tools deliberately cannot write that field -- without this rule a session could reach the same power through bash and claim a job that belongs to another session. The gaps between the words tolerate anything that is not a command separator, rather than enumerating what may sit there: the CLI accepts '-v'/'--verbose' and '--no-jail' before a subcommand, a shell redirection is legal anywhere in a simple command, and $IFS is a word separator too, so an allow-list of interlopers would need extending on each new spelling. A single '&' is allowed through because '2>&1' is a redirection, while '&&' still ends the match: the three words have to belong to ONE simple command."
+  },
+  {
     "id": "legacy-get-secret",
     "pattern": "get_secret.*",
     "category": "credential-exfil",

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -985,7 +985,7 @@ class TestPolicyCli:
         ):
             cc._policy(_ns(policy_action="show"))
         out = capsys.readouterr().out
-        assert "commands.denied: 139 rules in 10 categories" in out
+        assert "commands.denied: 140 rules in 10 categories" in out
         assert "aws-destructive(47)" in out
         # Counts only by default -- rule ids are the --ids opt-in.
         assert "aws-destructive-ec2-terminate-instances" not in out

--- a/test/test_cron_adopt_ownerless.py
+++ b/test/test_cron_adopt_ownerless.py
@@ -1,0 +1,470 @@
+"""Recovery path for a cron job with no owning chat session (issue #4660).
+
+A cron created outside a chat -- ``kirocrew cron add``, the dashboard Schedule
+page, an onboarding import -- has no originating chat session, so its
+``session_key`` is empty. That is truthful, not a defect: every consumer reads
+that field as the delivery target (``session="origin"`` resolution and
+script-result injection both strip the ``dashboard:`` prefix off it to reach a
+slot), and such a job has no chat to deliver into.
+
+What was missing is the operator's side of it: nothing displayed the field, and
+nothing could write it, so once per-session scoping treats an empty owner as
+"outside every chat session's scope" the state is invisible AND one-way. These
+tests pin the two halves of the way back -- ``cron list`` showing ownership and
+``cron adopt`` setting it -- plus the prefix invariant that keeps ``--session-of``
+the exact inverse of what the delivery consumers do.
+"""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.cli_commands import _cron
+
+
+def _job(job_id="abc12345", *, session_key="", created_by=""):
+    job = MagicMock()
+    job.id = job_id
+    job.name = "nightly"
+    job.message = "run the sweep"
+    job.enabled = True
+    job.schedule.kind = "every"
+    job.schedule.every_secs = 3600
+    job.schedule.cron_expr = None
+    job.schedule.at_ts = None
+    job.session_key = session_key
+    job.created_by = created_by
+    return job
+
+
+def _adopt_args(job_id="abc12345", *, session_of=None, release=False):
+    return argparse.Namespace(
+        cron_action="adopt",
+        job_id=job_id,
+        session_of=session_of,
+        release=release,
+    )
+
+
+class TestCronListOwnership:
+    """``cron list`` is the only surface that shows who owns a job."""
+
+    def test_list_marks_a_job_with_no_owning_session(self, capsys):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc_cls.return_value.list_jobs.return_value = [_job()]
+            _cron(argparse.Namespace(cron_action="list"))
+        out = capsys.readouterr().out
+        # Without this line the CLI was the one place the state existed and
+        # nothing rendered it, so a correct "no chat owns this" read as a job
+        # that had silently vanished from chat.
+        assert "owner: none" in out
+        assert "dashboard Schedule page" in out
+
+    def test_list_shows_the_owning_session_key(self, capsys):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc_cls.return_value.list_jobs.return_value = [
+                _job(session_key="dashboard:chat-3-1712793600")
+            ]
+            _cron(argparse.Namespace(cron_action="list"))
+        out = capsys.readouterr().out
+        assert "owner: dashboard:chat-3-1712793600" in out
+        assert "owner: none" not in out
+
+    def test_list_shows_provenance_when_tagged(self, capsys):
+        """``created_by`` is a separate, namespaced provenance tag (``app:*`` /
+        ``import:*``) and is NOT the owner -- printing both keeps them distinct."""
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc_cls.return_value.list_jobs.return_value = [
+                _job(created_by="import:slack-reminders")
+            ]
+            _cron(argparse.Namespace(cron_action="list"))
+        out = capsys.readouterr().out
+        assert "owner: none" in out
+        assert "created by: import:slack-reminders" in out
+
+
+class TestCronAdopt:
+    def test_adopt_reports_the_delivery_consequence(self, capsys):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc = mock_svc_cls.return_value
+            mock_svc.adopt_job.return_value = True
+            _cron(_adopt_args(session_of="chat-3-1712793600"))
+        out = capsys.readouterr().out
+        # The message states the delivery consequence, because for this field
+        # owning the job and receiving its output are the same fact.
+        assert "results are delivered there" in out
+        assert "dashboard:chat-3-1712793600" in out
+
+    def test_session_of_adds_the_prefix_the_consumers_strip(self):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc = mock_svc_cls.return_value
+            mock_svc.adopt_job.return_value = True
+            _cron(_adopt_args(session_of="chat-3-1712793600"))
+            mock_svc.adopt_job.assert_called_once_with("abc12345", "dashboard:chat-3-1712793600")
+
+    def test_session_of_round_trips_through_the_real_delivery_resolver(self):
+        """Drift guard: ``--session-of`` must be the exact inverse of the
+        transform the delivery path applies.
+
+        Both consumers (``_resolve_session_target`` in the dashboard messaging
+        handler and the Slack gateway's script-result delivery) turn a stored
+        key into a slot with ``removeprefix("dashboard:")``. If either side ever
+        changes prefix, adoption would silently point a job at a slot that does
+        not exist and its results would go nowhere -- so assert the round trip
+        rather than restating the literal.
+        """
+        stored = {}
+
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc = mock_svc_cls.return_value
+            mock_svc.adopt_job.side_effect = lambda jid, sk: stored.setdefault(jid, sk) or True
+            _cron(_adopt_args(session_of="chat-7-1712793999"))
+
+        assert stored["abc12345"].removeprefix("dashboard:") == "chat-7-1712793999"
+
+    def test_session_of_accepts_an_already_qualified_key_unchanged(self):
+        """A key that already carries a namespace is passed through, so an
+        operator pasting a full key into ``--session-of`` is not double-prefixed
+        into an undeliverable ``dashboard:dashboard:...``."""
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc = mock_svc_cls.return_value
+            mock_svc.adopt_job.return_value = True
+            _cron(_adopt_args(session_of="dashboard:chat-3-1712793600"))
+            mock_svc.adopt_job.assert_called_once_with("abc12345", "dashboard:chat-3-1712793600")
+
+    def test_release_clears_the_owner(self, capsys):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc = mock_svc_cls.return_value
+            mock_svc.adopt_job.return_value = True
+            _cron(_adopt_args(release=True))
+            mock_svc.adopt_job.assert_called_once_with("abc12345", "")
+        assert "released" in capsys.readouterr().out
+
+    def test_missing_job_exits_nonzero(self):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = False
+            with pytest.raises(SystemExit) as exc:
+                _cron(_adopt_args("deadbeef", session_of="dashboard:chat-1"))
+            assert exc.value.code == 1
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_target_is_refused_rather_than_silently_releasing(self, blank):
+        """A blank target must NOT fall through to the release path: that would
+        turn a typo into a silent hand-back to operator-only management."""
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc = mock_svc_cls.return_value
+            with pytest.raises(SystemExit) as exc:
+                _cron(_adopt_args(session_of=blank))
+            assert exc.value.code == 1
+            mock_svc.adopt_job.assert_not_called()
+
+    def test_adopt_is_audited(self):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel") as mock_sel,
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = True
+            _cron(_adopt_args(session_of="dashboard:chat-3"))
+            mock_sel.return_value.log_api_access.assert_called_once()
+            kwargs = mock_sel.return_value.log_api_access.call_args.kwargs
+            assert kwargs["operation"] == "cron.adopt"
+            assert "dashboard:chat-3" in kwargs["resources"]
+
+
+class TestAdoptTargetVisibility:
+    """A typo must not silently produce a job whose output reaches nobody.
+
+    Accepting an unknown key is deliberate -- the delivery path resolves a live
+    slot first and only falls back to rehydrating from history, so a brand-new
+    tab that has logged nothing yet is a legitimate target. What is not
+    acceptable is doing it silently, which would recreate the very
+    invisible-delivery state this command exists to recover from.
+    """
+
+    def _run_adopt_with_known(self, known):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+            patch("kiro_crew.cli_commands.ConversationLog") as mock_log_cls,
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = True
+            mock_log_cls.return_value.has_log.return_value = known
+            _cron(_adopt_args(session_of="chat-9-1712799999"))
+            return mock_log_cls
+
+    def test_unknown_session_warns(self, capsys):
+        self._run_adopt_with_known(False)
+        err = capsys.readouterr().err
+        assert "no recorded session" in err
+        assert "chat-9-1712799999" in err
+        assert "--release" in err
+
+    def test_known_session_does_not_warn(self, capsys):
+        self._run_adopt_with_known(True)
+        assert "no recorded session" not in capsys.readouterr().err
+
+    def test_existence_is_checked_on_the_slot_not_the_prefixed_key(self):
+        """The lookup must use the same slot the delivery path derives, or the
+        warning would fire on every adopt and be trained away as noise."""
+        mock_log_cls = self._run_adopt_with_known(True)
+        mock_log_cls.return_value.has_log.assert_called_once_with("chat-9-1712799999")
+
+    def test_a_failing_lookup_stays_quiet(self, capsys):
+        """Cannot-tell is not evidence of a typo -- never cry wolf."""
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+            patch("kiro_crew.cli_commands.ConversationLog", side_effect=OSError("no dir")),
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = True
+            _cron(_adopt_args(session_of="chat-9"))
+        assert "no recorded session" not in capsys.readouterr().err
+
+    def test_release_does_not_warn(self, capsys):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = True
+            _cron(_adopt_args(release=True))
+        assert "no recorded session" not in capsys.readouterr().err
+
+
+class TestAdoptNamespaceHonesty:
+    """Ownership and delivery do not have the same reach, and the output says so.
+
+    ``_owned_by`` matches any namespace, so a Slack or Telegram session can own
+    and manage a job. But only a ``dashboard:`` key resolves to a slot the
+    delivery path can inject into -- both consumers reach a slot with
+    ``removeprefix("dashboard:")``. Promising delivery for a ``slack:`` owner
+    would be a claim the code does not honour.
+    """
+
+    def _adopt(self, target):
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+            patch("kiro_crew.cli_commands.ConversationLog") as mock_log_cls,
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = True
+            mock_log_cls.return_value.has_log.return_value = True
+            _cron(_adopt_args(session_of=target))
+
+    @pytest.mark.parametrize("target", ["slack:1712793600.001", "telegram:12345"])
+    def test_a_non_dashboard_owner_is_not_promised_delivery(self, target, capsys):
+        self._adopt(target)
+        cap = capsys.readouterr()
+        assert "results are delivered there" not in cap.out
+        assert "can manage it." in cap.out
+        assert "Ownership transferred; delivery did not." in cap.err
+
+    def test_a_dashboard_owner_is_promised_delivery(self, capsys):
+        self._adopt("chat-3-1712793600")
+        cap = capsys.readouterr()
+        assert "results are delivered there" in cap.out
+        assert "Ownership transferred; delivery did not." not in cap.err
+
+    def test_the_unknown_session_warning_is_dashboard_only(self, capsys):
+        """The history lookup only knows dashboard slots, so a `slack:` key must
+        not be run through it and reported as a typo."""
+        with (
+            patch("kiro_crew.cli_commands.CronService") as mock_svc_cls,
+            patch("kiro_crew.cli_commands.sel"),
+            patch("kiro_crew.cli_commands.ConversationLog") as mock_log_cls,
+        ):
+            mock_svc_cls.return_value.adopt_job.return_value = True
+            mock_log_cls.return_value.has_log.return_value = False
+            _cron(_adopt_args(session_of="slack:1712793600.001"))
+            mock_log_cls.return_value.has_log.assert_not_called()
+        assert "no recorded session" not in capsys.readouterr().err
+
+
+class TestAdoptIsDeniedFromBash:
+    """The narrow-writer design must be enforced, not merely undocumented.
+
+    "The CLI is the only writer" is only true while a session's agent cannot run
+    the CLI. It can, through bash -- so without a denied-command rule an agent
+    could run ``cron adopt --session-of <its own slot>`` and acquire exactly the
+    power the MCP ``cron_update`` tool is denied: management scope over another
+    session's job, plus delivery of its output. The repo's spec requires new
+    destructive CLI-facing surfaces to carry a rule in ``BUILTIN_DENIED_RULES``.
+    """
+
+    def _rule(self):
+        from kiro_crew.security import BUILTIN_DENIED_RULES
+
+        return next(
+            (r for r in BUILTIN_DENIED_RULES if r.id == "self-protection-cron-adopt"),
+            None,
+        )
+
+    def test_a_rule_exists_in_the_builtin_set(self):
+        rule = self._rule()
+        assert rule is not None, "cron adopt must be covered by a DeniedCommandRule"
+        assert rule.category == "self-protection"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kirocrew cron adopt abc123 --session-of chat-3",
+            "kirocrew cron adopt abc123 --release",
+            "kiro-crew cron adopt abc123 --session-of dashboard:chat-3",
+            "kiro.crew cron adopt abc123 --session-of dashboard:chat-3",
+            "cd /tmp && kirocrew cron  adopt abc123 --session-of chat-3",
+            "KIROCREW_HOME=/tmp kirocrew cron adopt abc123 --session-of chat-3",
+            # The module spelling, which is how the CLI is invoked from a venv.
+            # `kiro.?crew` covers it because `.` matches the underscore.
+            "python3 -m kiro_crew cron adopt abc123 --release",
+            # Interposed top-level flags. The CLI really accepts these before a
+            # subcommand (`--verbose`/`-v` is a repeatable count and `--no-jail`
+            # is declared on the top-level parser as well as the jailed
+            # subparsers) -- verified by running `kirocrew -v cron list`, which
+            # executes normally.
+            "kirocrew -v cron adopt abc123 --session-of chat-3",
+            "kirocrew -vv cron adopt abc123 --session-of chat-3",
+            "kirocrew --verbose cron adopt abc123 --session-of chat-3",
+            "kirocrew --no-jail cron adopt abc123 --session-of chat-3",
+            "kirocrew -v --no-jail cron adopt abc123 --session-of chat-3",
+            # Separators that are not whitespace and not flags. A redirection is
+            # legal anywhere in a simple command, and $IFS is a word separator,
+            # so an allow-list of interlopers would need extending per spelling.
+            "kirocrew >/dev/null cron adopt abc123 --release",
+            "kirocrew 2>/dev/null cron adopt abc123 --release",
+            "kirocrew >/dev/null 2>&1 cron adopt abc123 --release",
+            "kirocrew${IFS}cron${IFS}adopt abc123 --release",
+            "kirocrew\tcron\tadopt abc123 --release",
+            "kirocrew cron >/dev/null adopt abc123 --release",
+        ],
+    )
+    def test_the_pattern_matches_the_forms_an_agent_would_reach_for(self, command):
+        import re
+
+        rule = self._rule()
+        assert re.search(rule.pattern, command, re.IGNORECASE), command
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # A command separator ends the match: the words must belong to ONE
+            # simple command, so an unrelated `adopt` in a LATER command does not
+            # combine with an earlier harmless `kirocrew cron` read.
+            "kirocrew cron list; echo adopt",
+            "kirocrew cron list && git adopt-nothing",
+            "kirocrew cron list | grep adopt",
+        ],
+    )
+    def test_a_command_separator_ends_the_match(self, command):
+        import re
+
+        rule = self._rule()
+        assert not re.search(rule.pattern, command, re.IGNORECASE), command
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kirocrew cron list",
+            "kirocrew cron add nightly 'sweep' --every 3600",
+            "kirocrew cron remove abc123",
+            "git commit -m 'adopt a cron convention'",
+        ],
+    )
+    def test_the_pattern_does_not_catch_the_read_and_sibling_verbs(self, command):
+        import re
+
+        rule = self._rule()
+        assert not re.search(rule.pattern, command, re.IGNORECASE), command
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kirocrew cron adopt abc123 --session-of chat-3",
+            "kirocrew -v cron adopt abc123 --session-of chat-3",
+        ],
+    )
+    def test_the_real_gate_denies_it_not_just_the_regex(self, command):
+        """Assert through ``is_denied`` -- the function the PreToolUse gate calls --
+        so the test proves enforcement rather than only pattern shape."""
+        from kiro_crew import security
+
+        assert security.is_denied(
+            command, denied_regexes=[r.pattern for r in security.BUILTIN_DENIED_RULES]
+        ), command
+
+    def test_the_real_gate_still_allows_reading_the_list(self):
+        from kiro_crew import security
+
+        assert not security.is_denied(
+            "kirocrew cron list",
+            denied_regexes=[r.pattern for r in security.BUILTIN_DENIED_RULES],
+        )
+
+
+class TestAdoptJobService:
+    """``adopt_job`` is the only writer of ``session_key`` outside creation."""
+
+    def test_adopt_and_release_persist(self, tmp_path):
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="nightly", message="sweep", every_secs=3600)
+        assert job.session_key == ""
+
+        assert svc.adopt_job(job.id, "dashboard:chat-3-1712793600") is True
+        assert CronService(base_dir=tmp_path).get_job(job.id).session_key == (
+            "dashboard:chat-3-1712793600"
+        )
+
+        assert svc.adopt_job(job.id, "") is True
+        assert CronService(base_dir=tmp_path).get_job(job.id).session_key == ""
+
+    def test_adopt_missing_id_returns_false(self, tmp_path):
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path)
+        assert svc.adopt_job("deadbeef", "dashboard:chat-1") is False
+
+    def test_update_job_still_cannot_set_session_key(self, tmp_path):
+        """Ownership stays off the shared update path.
+
+        ``update_job`` is reachable from MCP ``cron_update`` and the dashboard
+        ``PATCH``; if it grew a ``session_key`` branch, those surfaces could
+        repoint where any job delivers. The CLI -- the one surface that is not
+        itself a session -- is deliberately the only writer.
+        """
+        from kiro_crew.cron import CronService
+
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(name="nightly", message="sweep", every_secs=3600)
+        svc.update_job(job.id, session_key="dashboard:chat-attacker")
+        assert CronService(base_dir=tmp_path).get_job(job.id).session_key == ""

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -36,9 +36,9 @@ class TestCatalog:
         # 130 patterns ported byte-exact from the retired agent-config
         # deniedCommands list + 7 legacy security.py globs (secret-fetch tool
         # names + boto3 underscore destructive forms) restored as regexes.
-        assert len(BUILTIN_DENIED_RULES) == 139
+        assert len(BUILTIN_DENIED_RULES) == 140
         ids = [r.id for r in BUILTIN_DENIED_RULES]
-        assert len(set(ids)) == 139
+        assert len(set(ids)) == 140
 
     def test_token_mint_is_blocked_in_both_the_cli_and_module_forms(self):
         """`kirocrew token` mints a signed dashboard token that authenticates to EVERY gateway
@@ -176,7 +176,7 @@ class TestCatalog:
     def test_patterns_match_manifest_verbatim(self):
         golden = json.loads(_GOLDEN.read_text(encoding="utf-8"))
         golden_by_id = {g["id"]: g for g in golden}
-        assert len(golden_by_id) == 139
+        assert len(golden_by_id) == 140
         for rule in BUILTIN_DENIED_RULES:
             g = golden_by_id[rule.id]
             assert rule.pattern == g["pattern"]
@@ -190,7 +190,7 @@ class TestCatalog:
 
     def test_builtin_denied_rules_accessor_returns_dicts(self):
         rules = builtin_denied_rules()
-        assert len(rules) == 139
+        assert len(rules) == 140
         first = rules[0]
         assert set(first.keys()) == {"id", "pattern", "category", "description"}
         assert isinstance(first["id"], str)


### PR DESCRIPTION
## 1. What is the problem?

A cron job's `session_key` names the chat session it belongs to. That one field
carries one meaning, and it is a routing meaning: every consumer reads it as the
delivery target. `_resolve_session_target` (dashboard messaging handler) and the
Slack gateway's script-result delivery both do `session_key.removeprefix("dashboard:")`
to reach a slot.

A job created outside a chat has no such session, so the field is empty:

- `kirocrew cron add` -- never passes `session_key`
- the dashboard Schedule page -- `api_crons_create` never sets it (its own comment
  documents this as "cron created from dashboard UI without an originating chat")
- an onboarding import -- same

That empty value is truthful, not a defect. There is no chat to deliver into.

The problem is what an operator can do about it. Per-session scoping reads the
same empty field as "outside every chat session's scope" -- the correct boundary,
since an identified session is not necessarily the operator -- and the state was
both **invisible** and **one-way**:

- nothing rendered the field, so `kirocrew cron list` (the only surface holding
  the state) never showed why a job was unreachable from chat;
- nothing could write it, so there was no route back.

## 2. Why this issue matters to the user

From inside a chat the job simply is not there. `cron_list` answers `No cron jobs.`
-- not "some are hidden", because the scoping happens before rendering -- and every
mutating tool answers a deliberately vague `job not found`. That vagueness is
correct (a distinct message would confirm the existence of a row the caller cannot
see), but combined with an invisible owner field it turns a perfectly ordinary
state into a job that appears to have silently vanished, with the only recovery
being "use the CLI" and the only place that is explained being release notes.

The boundary should stay. The dead end should not.

## 3. How our fix solves it -- chain from symptom to root cause

Symptom: a job created outside a chat is unreachable from chat, permanently.
^ because nothing can write `session_key` after creation.
^ because the only write path, `_update_job_locked`, has no branch for it -- and
  must not grow one, since it is reachable from MCP `cron_update` and the
  dashboard `PATCH`, which would let a session repoint where any job delivers.
^ and the state was undiagnosable because no surface printed the field.

So the fix adds the operator's half of an existing, correct rule:

- **`kirocrew cron list` prints ownership** -- the owning session, or `owner: none`
  naming the surfaces that do manage it. `created_by` provenance (`app:*`,
  `import:*`) prints alongside and stays distinct: it is a separate tag with its
  own scoped-removal semantics, not the owner.
- **`kirocrew cron adopt <id> --session-of <session> | --release`** sets or clears
  the owning session. ONE target flag with two accepted spellings: a bare slot
  name gets the `dashboard:` namespace the delivery consumers strip back off (so
  the two are exact inverses), and an already-qualified key passes through
  untouched. There is deliberately no second flag for the qualified form -- a key
  with no namespace at all could never equal any session's own key, so it could
  only ever produce a job nobody can own. When the key names no
  recorded session the command succeeds but **warns**: a brand-new tab that has
  logged nothing is a legitimate target (delivery resolves a live slot first and
  only then rehydrates from history), so the unknown case cannot be refused --
  but a silent typo would leave the job delivering to nobody, which is the exact
  state this command exists to undo.

Adopting also makes results deliver into that session. That is not a side effect
to warn about: for this field, owning the job and receiving its output are the
same fact. The command says so in its output.

### The write is narrow in two layers

1. **`adopt_job` is not on the shared update path.** It is its own locked
   service method, so no new capability appears on MCP `cron_update` or the
   dashboard `PATCH`. A test pins that `update_job(session_key=...)` still
   cannot set the field.
2. **`cron adopt` is a denied command.** "The CLI is the only writer" is only
   true while a session cannot run the CLI -- and it can, through bash. Without a
   gate, an agent (or a prompt-injected messaging session, a named multi-human
   boundary) could run `cron adopt --session-of <its own slot>` and acquire
   exactly the power `cron_update` is denied. `self-protection-cron-adopt` in
   `BUILTIN_DENIED_RULES` closes that, matching the existing pattern for
   `kirocrew restart` / `update` / `cloud`, and satisfying the security spec's
   requirement that new destructive CLI-facing surfaces carry a rule. Like every
   built-in it stays user-disableable in Settings -> Security.

**No creation path changed.** An empty owner stays correct for every non-chat
surface. This adds a route back rather than inventing an owner nobody asserted --
which is also why there is no migration: for a chat-created job predating
per-session scoping the originating session was never recorded, and guessing one
would reopen the fail-open that scoping closed. An operator asserting it with one
command is the honest replacement.

## 4. What tests we did

`test/test_cron_adopt_ownerless.py`, 31 tests: ownership rendering (none / owned /
provenance-tagged), adopt via `--session` and `--session-of`, an already-qualified
key not double-prefixed, `--release`, missing id exiting non-zero, blank target
refused rather than silently releasing, SEL audit, the unknown-session warning
(fires / stays quiet when known / checks the slot not the prefixed key / stays
quiet when the lookup itself fails / never on release), the denied-command rule's
existence and its pattern against six invocation forms an agent would reach for
plus four it must not catch, and the service-level persist/release round trip.

Five guards mutation-verified -- each killed its own line and nothing else:

| Mutation | Result |
|---|---|
| add a `session_key` branch to `_update_job_locked` | `test_update_job_still_cannot_set_session_key` fails (`'dashboard:chat-attacker' == ''`) |
| change the `--session-of` prefix to `dash:` | the round-trip drift guard + the literal test fail |
| let a blank `--session` fall through | both parametrizations of the blank-target test fail |
| narrow the deny pattern to require `--force` | all six pattern-match forms fail |
| suppress the unknown-session warning | `test_unknown_session_warns` fails |

The prefix drift guard asserts the round trip through `removeprefix("dashboard:")`
rather than restating the literal, so if either side ever changes prefix the test
catches it instead of adoption silently pointing a job at a slot that does not
exist.

Also run: end-to-end against a throwaway `KIROCREW_HOME` (add -> `owner: none` ->
adopt -> value confirmed in `crons.json` -> release -> `owner: none`, plus exit 1
on a missing id and argparse mutual exclusion), and
`test_cron_adopt_ownerless.py` + `test_denied_commands_security.py` +
`test_denied_commands_api.py` + `test_cli.py` + `test_cli_commands_coverage.py` +
`test_cron.py` = 1073 passed / 2 skipped. `flake8` clean; `black` clean on every
non-baselined file.

The catalog goes 139 -> 140 rules: the golden manifest entry was generated from
the live rule object rather than retyped (so it cannot drift from the code it
pins), and the count assertions were updated. The hand-written rule counts in the
prose are **deleted**, not re-synced -- the security spec's was already stale at
138 before this change, which is the argument against restating a count at all.
The count-pinning tests remain as the mechanism that cannot drift.

## 5. Any other suggestions on the work

Two things found while tracing this, neither folded in:

- **Three fields carry partial ownership meaning.** `created_by` is declared as
  "Slack user ID of the creator (for DM fallback)" but is actually used as a
  namespaced provenance tag (`app:*`, `import:*`) and drives
  `remove_jobs_by_owner`; `session_key` is originating-session-plus-delivery; and
  scoping authorizes on the latter. Unifying them is a real design change, not a
  recovery fix -- worth its own issue.
- **A count hint on the chat side was considered and dropped.** `cron_list` could
  report how many jobs are outside the caller's scope without naming them, but a
  count is still a weak existence oracle, and the dashboard Schedule page already
  gives an operator full visibility -- so nothing is gained that is not already
  reachable, and the chat surface stays silent. Happy to revisit if you disagree.

- **The four sibling `self-protection` rules are still bypassable.** `restart`,
  `update`, `cloud` and `gateway restart` keep the flag-anchored form, so
  `kirocrew -v restart` evades each one -- verified through `is_denied`. Filed as
  #4799 rather than widening four security patterns inside a cron-ownership PR.
- **The hand-maintained rule counts are gone rather than re-synced.** This change
  found the spec's count already stale (138 against a real 139), and the sentence
  being edited says a restated count goes stale silently. The count-pinning tests
  are the mechanism that cannot drift, so the prose numbers came out of AGENTS.md
  and security.md -- and the three further stale `130` restatements First
  Principles found elsewhere in the same file (a table row, the catalog
  description, and an overlap ratio) are gone too, so the subtraction is applied
  consistently instead of half-done.
- **The store itself is not a protected leaf**, so a direct edit of `crons.json`
  sets `session_key` without any rule matching. The doc says the deny rule is
  best-effort against a shell-capable agent rather than an invariant; gating the
  file is filed as #4812 because it is a class decision and would also refuse a
  human's hand edit.
- **The dashboard Schedule page still does not show ownership, and that is
  accepted-and-deferred here.** `api_crons` serializes ~28 job fields and
  `session_key` is not one of them, so the page lists and manages every job but
  cannot answer "who owns this". Adding it means an API field plus a rendered
  column plus i18n plus screenshot evidence -- a frontend change, not a CLI one --
  and a payload field with nothing rendering it would just be dead weight. Filed
  as #4815; the doc now says plainly that `kirocrew cron list` is the only surface
  that shows the owner.

Scoping-side wording (`_UNOWNED`, "unowned row") is left alone here: this PR is
file-disjoint from the scoping change so the two can land in either order.

Refs #4660
