### PR TITLE
feat(dashboard): give chat folders an owner so app writes can be bounded

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -672,11 +672,60 @@ is documented here rather than hidden.
 
 The asymmetry in the last column is not an oversight. Sessions carry an owning
 app, so "yours" is a decidable question and an app is confined to its own.
-Folders carry no owner at all: one tree serves the person and every app, so
-there is no app-private folder to bound a create, rename, reparent or delete to.
-Until folders have ownership, an app is refused the tree-shaping verbs outright
-rather than handed authority nothing can scope — while keeping the two things
-that are already scoped to it, reading the tree and filing its own sessions.
+Folders now answer the same question: a folder created by an app carries it in
+`owner_app`, and an absent key reads as the person's — which is why the field
+arrived without a migration, since every folder written before it existed is the
+person's. An app may create at the top level or inside a folder it owns, and may
+rename, reparent or delete only what it owns; the top level is not a folder row
+and so has no owner to violate, which is where an app's own tree starts. A
+reparent is refused when the folder's SUBTREE holds one the caller does not own,
+because a move takes the subtree with it and would relocate the person's folder
+under cover of moving the app's. A rename, colour or collapse is not gated that
+way -- it relocates nothing. The person is never confined by any of this, and an
+app keeps what it always had: reading the whole tree, and filing its OWN sessions
+into any folder that exists.
+
+**An app cannot delete a folder at all.** Not even an empty one it owns. A delete
+relocates everything the folder contains, and those contents live in a DIFFERENT
+store from the folder -- sessions are in the slot table and the session archive,
+neither sharing a lock with it -- so "is this folder empty?" cannot be established
+atomically with the removal. Successively narrower rules each leaked through
+another seam: a session filed while the archive scan awaited, a child created while
+the lock was acquired, a session closing after the scan and writing its `folder_id`
+on the way out. Each was closable alone; the class was not, so the verb is withheld
+instead. Nothing shipped loses a capability -- no MCP tool exposes deletion and the
+only client of the route is the dashboard UI -- and an app organizes its work by
+creating, renaming and reparenting its own folders and filing its own sessions. The
+person deletes a full folder exactly as before.
+
+The policy lives in the endpoints, not in the MCP server. Only the endpoint holds
+the store lock and sees the authoritative tree, so a second copy of the rule in
+the tool layer could only drift or race. What the tool layer still decides is the
+one question the endpoint cannot: whether the caller can be placed at all, since
+an unverifiable or delegated caller has no scope to bound a write to.
+
+Moving the decision to the endpoint makes the write's IDENTITY load-bearing, so
+the gate returns the key it verified and every folder write sends that key
+unchanged. The write helpers default to `_resolve_session_key`, whose `/proc`
+ancestor walk can resolve to a different slot than `_resolve_session_key_strict`
+did; letting them re-resolve would check one identity and write under another,
+and for an app-owned session the walk landing on an ancestor makes the write
+arrive looking like the unconfined person -- which would let an app reach the
+folders the ownership rule exists to protect. `chat_folder_move_session` already
+worked this way; create and move now do too, including each intermediate folder a
+`mkdir -p` parent path creates.
+
+The same reasoning covers the OTHER way an app's write can arrive unattributable.
+An empty scope reads as the person, which is correct for a caller that never had a
+slot -- a Slack thread, a channel session, the person's own cron -- but not for a
+`dashboard:` key, which NAMES a slot: absence there means the app it would have
+been confined to is exactly what got popped, which is what a tab closing mid-call
+produces. The folder mutations therefore refuse a caller matching
+`caller_names_a_missing_slot`, the predicate that exists so a route outside the
+MCP tool set can apply the rule `_caller_app_scope` already applies inside it. It
+stays per-route rather than in the middleware on purpose: a popped slot no longer
+says whose tab it was, so refusing centrally would also refuse the person's own
+in-flight calls on every internal route at once.
 
 **Assignment is still not authorization.** Being unreferenced by default keeps a
 capability cheap and deliberate; it does not prove the user consented to reach the

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -15,7 +15,7 @@ from aiohttp import web
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.dashboard.state import DashboardState
-from kiro_crew.dashboard.token_auth import derive_caller_app
+from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot, derive_caller_app
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
@@ -269,6 +269,102 @@ def _validate_project_dir(raw: str) -> tuple[str, str | None]:
     return resolved, None
 
 
+def _refuse_unattributable_caller(
+    state: DashboardState, request: web.Request
+) -> web.Response | None:
+    """403 when the caller NAMES a dashboard slot that is gone, else None.
+
+    ``_effective_request_app`` answers ``""`` both for the person and for a
+    caller it cannot place, and the tree-shaping rules read ``""`` as the
+    person's full authority. That is sound for a caller that never had a slot --
+    a Slack thread, a channel session, the person's own cron -- but not for a
+    ``dashboard:`` key, which NAMES a slot: absence there is not "nothing to
+    confine me to", it is "the app I would have been confined to is exactly what
+    got popped". A tab closing while one of its tool calls is still in flight
+    produces precisely that, because the slot is popped synchronously without
+    draining in-flight MCP calls.
+
+    So an app-owned session going through that race would otherwise arrive here
+    with an empty scope and be handed the person's authority over the person's
+    own folders. ``mcp_dashboard._caller_app_scope`` already refuses this class
+    for its own tool set; ``caller_names_a_missing_slot`` exists so a route
+    outside that set applies the same rule, and it is deliberately NOT in the
+    middleware -- a popped slot no longer says whose tab it was, so refusing
+    there would also refuse the person's own in-flight calls on every internal
+    route at once. Each route that could not attribute a write decides for
+    itself, and a write to the shared folder tree is one of those.
+    """
+    if caller_names_a_missing_slot(
+        getattr(state, "_slots", None), request.headers.get("X-Session-Key", "")
+    ):
+        sel().log_api_access(
+            caller="unattributable",
+            operation="chat.folder_write",
+            outcome="denied",
+            source="app_isolation",
+            resources=request.path,
+            error="caller names a dashboard slot that is gone",
+        )
+        return web.json_response(
+            {
+                "error": "the calling session is gone, so this write cannot be attributed",
+                "code": "caller_unattributable",
+            },
+            status=403,
+        )
+    return None
+
+
+def _folder_owner_app(folder: dict[str, Any]) -> str:
+    """The app that owns *folder*, or ``""`` when the person owns it.
+
+    The single place the storage rule is expressed: a folder created by an app
+    carries that app in ``owner_app``, and **an absent or empty key reads as the
+    person's**. That default is what makes this a field addition rather than a
+    migration — every folder written before the field existed is the person's,
+    which is exactly what it was.
+
+    Ownership decides only the tree-shaping verbs (create-into, rename,
+    reparent, delete). Reads stay whole: an app sees the person's folders and
+    can file its OWN sessions into one (``api_chat_slot_folder``), which is the
+    case a per-app namespace would have cost.
+    """
+    return str(folder.get("owner_app") or "")
+
+
+def _subtree_holds_foreign_folder(
+    folders: list[dict[str, Any]], *, root_id: str, request_app: str
+) -> bool:
+    """True if anything under *root_id* belongs to someone other than *request_app*.
+
+    Reparenting a folder relocates everything beneath it -- that is what "the
+    folder moves with everything in it" means -- so the blast radius of a move is
+    the whole SUBTREE, not the row being written. An app moving a folder it owns
+    would otherwise relocate a folder the person nested inside it, which is the
+    same violation as editing that folder directly, reached one level down.
+
+    Used by the reparent path only. Delete asks a stricter question instead --
+    whether the folder is EMPTY -- because a delete has more kinds of content to
+    account for (sessions, and archived sessions a live scan cannot see), and
+    emptiness answers all of them without an ownership test per content type.
+
+    Scoped to the descendants and not the root: the caller's authority over the
+    root itself is a separate question, answered separately.
+
+    Uses the cycle-guarded walk so a pre-existing corrupt parent chain in
+    folders.json cannot hang the request.
+    """
+    for f in folders:
+        fid = str(f.get("id") or "")
+        if fid == root_id:
+            continue
+        if _folder_owner_app(f) == request_app:
+            continue
+        if _is_descendant(folders, ancestor_id=root_id, folder_id=fid):
+            return True
+    return False
+
+
 def _is_descendant(folders: list[dict], *, ancestor_id: str, folder_id: str) -> bool:
     """True if `folder_id` is `ancestor_id` or lies anywhere under it.
 
@@ -290,6 +386,8 @@ def _is_descendant(folders: list[dict], *, ancestor_id: str, folder_id: str) -> 
 async def api_chat_folder_create(request: web.Request) -> web.Response:
     """POST /api/chat/folders — create a project folder."""
     state: DashboardState = request.app["state"]
+    if (refusal := _refuse_unattributable_caller(state, request)) is not None:
+        return refusal
     try:
         body = await request.json()
     except Exception:
@@ -326,23 +424,52 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
     }
     if color:
         folder["color"] = color
+    # Never from the body: a caller that could name its own owner could name
+    # someone else's. Written only when an app is calling, so the person's rows
+    # keep the shape they have on disk today and "absent means the person"
+    # stays the one representation (see _folder_owner_app).
+    request_app = _effective_request_app(state, request)
+    if request_app:
+        folder["owner_app"] = request_app
 
     def _append(folders: list[dict[str, Any]]) -> tuple[bool, str]:
         # Re-check the parent under the lock. Its existence was validated before
         # the lock was taken, so a concurrent delete of that parent would
         # otherwise land this folder with a dangling parent_id — the same
         # pre-lock/post-lock gap the reparent path re-tests.
-        if parent_id and not any(f["id"] == parent_id for f in folders):
+        parent = next((f for f in folders if f["id"] == parent_id), None) if parent_id else None
+        if parent_id and parent is None:
             return False, "parent_not_found"
+        # Nesting into a folder writes to THAT folder's child list, so an app may
+        # only nest under one of its own. The top level is not a folder row and
+        # so has no owner to violate — that is where an app's own tree starts.
+        # Decided here rather than pre-lock because a reparent racing this
+        # request can change who the parent belongs to.
+        if request_app and parent is not None and _folder_owner_app(parent) != request_app:
+            return False, "forbidden_parent"
         folder["order"] = len(folders)  # recount under the lock
         folders.append(folder)
         return True, ""
 
-    if await state.mutate_folders(_append) == "parent_not_found":
+    create_err = await state.mutate_folders(_append)
+    if create_err == "parent_not_found":
         # The parent was deleted while this request waited for the lock.
         return web.json_response(
             {"error": "parent folder not found", "code": "folder_parent_not_found"},
             status=400,
+        )
+    if create_err == "forbidden_parent":
+        sel().log_api_access(
+            caller=request_app, operation="chat.folder_create",
+            outcome="denied", source="app_isolation", resources=f"parent={parent_id}",
+            error="app cannot create inside a folder it does not own",
+        )
+        return web.json_response(
+            {
+                "error": "cannot create a folder inside one this app does not own",
+                "code": "folder_not_owned",
+            },
+            status=403,
         )
     state.push_slots_update()
     source, caller = _audit_origin(request)
@@ -356,10 +483,13 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
 async def api_chat_folder_update(request: web.Request) -> web.Response:
     """PATCH /api/chat/folders/{id} — rename or reorder a folder."""
     state: DashboardState = request.app["state"]
+    if (refusal := _refuse_unattributable_caller(state, request)) is not None:
+        return refusal
     fid = request.match_info["id"]
     folder = next((f for f in state._folders if f["id"] == fid), None)
     if not folder:
         return web.json_response({"error": "not found"}, status=404)
+    request_app = _effective_request_app(state, request)
     try:
         body = await request.json()
     except Exception:
@@ -368,6 +498,10 @@ async def api_chat_folder_update(request: web.Request) -> web.Response:
     # ``folder`` — otherwise an early field (e.g. name) is persisted while a later
     # field (e.g. an invalid/cyclic parent_id) returns 400, leaving the rejected
     # request's partial mutation live for the next successful save.
+    #
+    # ``owner_app`` is deliberately absent from the fields below: ownership is
+    # stamped once at create from the authenticated caller and is not a field a
+    # request can hand over, take, or clear.
     changes: dict[str, object] = {}
     if "name" in body:
         new_name = str(body["name"]).strip()[:100]
@@ -442,11 +576,28 @@ async def api_chat_folder_update(request: web.Request) -> web.Response:
         target = next((f for f in folders if f["id"] == fid), None)
         if target is None:
             return False, "not_found"
+        # Ownership, decided here for the same reason the cycle rule is: a
+        # concurrent reparent can change who the target or the destination
+        # belongs to between validation and the write.
+        if request_app and _folder_owner_app(target) != request_app:
+            return False, "not_owned"
         if reparenting and new_parent:
             if not any(f["id"] == new_parent for f in folders):
                 return False, "parent_not_found"
             if _is_descendant(folders, ancestor_id=fid, folder_id=new_parent):
                 return False, "cycle"
+            dest = next((f for f in folders if f["id"] == new_parent), None)
+            if request_app and dest is not None and _folder_owner_app(dest) != request_app:
+                return False, "forbidden_parent"
+        if reparenting and request_app and _subtree_holds_foreign_folder(
+            folders, root_id=fid, request_app=request_app
+        ):
+            # A move takes the whole subtree with it, so a folder the person
+            # nested inside this one would be relocated by an app's write. Only
+            # the reparent is gated: a rename, a colour or a collapse changes
+            # nothing about where the descendants sit. Checked for a move to the
+            # top level too -- "" is still a move.
+            return False, "foreign_descendant"
         target.update(changes)
         if not target.get("color"):
             target.pop("color", None)
@@ -457,6 +608,27 @@ async def api_chat_folder_update(request: web.Request) -> web.Response:
         # Deleted between the validation above and acquiring the store lock.
         return web.json_response(
             {"error": "not found", "code": "folder_not_found"}, status=404
+        )
+    if err in ("not_owned", "forbidden_parent", "foreign_descendant"):
+        # Distinguished in the audit, not to the caller: one code for all three
+        # keeps the response from reporting which folder was foreign.
+        _reason = {
+            "not_owned": "app cannot change a folder it does not own",
+            "forbidden_parent": "app cannot move a folder into one it does not own",
+            "foreign_descendant": "app cannot move a folder holding one it does not own",
+        }[err]
+        sel().log_api_access(
+            caller=request_app, operation="chat.folder_update",
+            outcome="denied", source="app_isolation",
+            resources=(f"parent={new_parent}" if err == "forbidden_parent" else fid),
+            error=_reason,
+        )
+        return web.json_response(
+            {
+                "error": "this app does not own that folder",
+                "code": "folder_not_owned",
+            },
+            status=403,
         )
     if err == "parent_not_found":
         # The parent was deleted while this request waited for the lock.
@@ -487,9 +659,61 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
     """DELETE /api/chat/folders/{id} — delete a folder, ungroup its slots."""
 
     state: DashboardState = request.app["state"]
+    if (refusal := _refuse_unattributable_caller(state, request)) is not None:
+        return refusal
     fid = request.match_info["id"]
-    if not any(f["id"] == fid for f in state._folders):
+    target = next((f for f in state._folders if f["id"] == fid), None)
+    if target is None:
         return web.json_response({"error": "not found"}, status=404)
+    request_app = _effective_request_app(state, request)
+    # Answered before a single slot is unfiled, so the common refusal costs no
+    # rollback. Sound pre-lock because ``owner_app`` is stamped at create and no
+    # route can reassign it — unlike the child test in ``_remove``, this answer
+    # cannot go stale while the request runs.
+    if request_app and _folder_owner_app(target) != request_app:
+        sel().log_api_access(
+            caller=request_app, operation="chat.folder_delete",
+            outcome="denied", source="app_isolation", resources=fid,
+            error="app cannot delete a folder it does not own",
+        )
+        return web.json_response(
+            {"error": "this app does not own that folder", "code": "folder_not_owned"},
+            status=403,
+        )
+    # An app may not delete a folder at all -- not even an empty one it owns.
+    #
+    # This is the smallest rule that is actually enforceable. A delete relocates
+    # everything the folder contains, and a folder's contents live in a DIFFERENT
+    # store from the folder: sessions are in the slot table and the session
+    # archive, neither of which shares a lock with the folder store. So "is this
+    # folder empty?" cannot be answered atomically with the removal, and every
+    # narrower rule leaked through a different seam -- a session filed while the
+    # archive scan awaited, a child created while the lock was acquired, a
+    # session closing after the scan and writing its folder_id on the way out.
+    # Each was closable in isolation; the class was not.
+    #
+    # Nothing shipped loses a capability: no MCP tool exposes folder deletion
+    # (the set is chat_folder_tree / chat_folder_create / chat_folder_move /
+    # chat_folder_move_session), and the only client of this route is the
+    # dashboard UI, which is the person. An app organizes its own work by
+    # creating, renaming and reparenting its folders and filing its sessions --
+    # cleanup is the person's, who can delete a full folder as they always could.
+    if request_app:
+        sel().log_api_access(
+            caller=request_app, operation="chat.folder_delete",
+            outcome="denied", source="app_isolation", resources=fid,
+            error="app cannot delete folders",
+        )
+        return web.json_response(
+            {
+                "error": (
+                    "an app cannot delete folders - ask the person, or move your "
+                    "sessions out and leave the folder"
+                ),
+                "code": "folder_delete_forbidden",
+            },
+            status=403,
+        )
     # Unfile the folder's slots first, then commit the folder removal. If that
     # commit fails, put the slots back: otherwise the delete half-lands —
     # conversations persistently unfiled while the folder they came from is
@@ -504,18 +728,7 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
             slot.folder_id = ""
             await save_slot_off_loop(state, slot, force=True)
 
-    def _remove(folders: list[dict[str, Any]]) -> tuple[bool, None]:
-        for f in folders:
-            if f.get("parent_id") == fid:
-                f["parent_id"] = ""
-        # In place, not a rebind: mutate_folders snapshots the list object it
-        # was given, and other holders of state._folders must see the removal.
-        folders[:] = [f for f in folders if f["id"] != fid]
-        return True, None
-
-    try:
-        await state.mutate_folders(_remove)
-    except Exception:
+    async def _restore_unfiled() -> None:
         for slot, previous in unfiled:
             # Only put back a slot that is STILL unfiled. Between the unfile
             # above and this rollback the user can move that conversation
@@ -535,6 +748,20 @@ async def api_chat_folder_delete(request: web.Request) -> web.Response:
                     slot.key, previous, exc_info=True,
                 )
         state.push_slots_update()
+
+    def _remove(folders: list[dict[str, Any]]) -> tuple[bool, None]:
+        for f in folders:
+            if f.get("parent_id") == fid:
+                f["parent_id"] = ""
+        # In place, not a rebind: mutate_folders snapshots the list object it
+        # was given, and other holders of state._folders must see the removal.
+        folders[:] = [f for f in folders if f["id"] != fid]
+        return True, None
+
+    try:
+        await state.mutate_folders(_remove)
+    except Exception:
+        await _restore_unfiled()
         raise
     state.push_slots_update()
     source, caller = _audit_origin(request)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5277,11 +5277,51 @@ class DashboardState:
     ]
 
     def load_folders(self) -> None:
-        """Load folder definitions from disk."""
+        """Load folder definitions from disk, dropping rows nothing can use.
+
+        ``folders.json`` is hand-editable, and a bare ``json.loads`` admits
+        whatever it holds: a non-list document, a non-dict entry, or a row with
+        no ``id``. Every consumer matches rows by id, and ``mutate_folders``
+        snapshots the store with ``dict(row)`` -- which raises on a non-dict and
+        surfaces as a 500, since no middleware maps handler exceptions. So ONE
+        bad row would take out every folder read and write until someone edited
+        the file, and hardening each consumer in turn only moves where it dies.
+
+        Filtered here instead, at the single point the rows enter memory. A row
+        with no usable id can never be the row a request addresses, so dropping
+        it is the correct answer and not merely the safe one; it is logged so a
+        silently shrinking sidebar is explainable. Same per-entry isolation the
+        cron loader applies for the same reason.
+
+        The id must be a non-empty STRING, not merely truthy. Ids are minted as
+        ``uuid.uuid4().hex[:12]``, so anything else is already corrupt -- and a
+        merely-truthy test lets a list or dict id through, which then reaches
+        ``counts.get(f["id"])`` in the archived-count join and raises
+        ``TypeError: unhashable type`` from inside the folder GET. Admitting a
+        row that cannot be used is the same failure as not filtering at all.
+        """
         path = config_dir() / self._FOLDERS_FILE
         try:
             if path.exists():
-                self._folders = json.loads(path.read_text(encoding="utf-8"))
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(raw, list):
+                    logger.warning(
+                        "folders.json is a %s, not a list — ignoring it",
+                        type(raw).__name__,
+                    )
+                    return
+                kept = [
+                    f
+                    for f in raw
+                    if isinstance(f, dict) and isinstance(f.get("id"), str) and f["id"]
+                ]
+                if len(kept) != len(raw):
+                    logger.warning(
+                        "dropped %d unusable folder row(s) from folders.json "
+                        "(not a dict, or no id)",
+                        len(raw) - len(kept),
+                    )
+                self._folders = kept
         except Exception:
             logger.warning("Failed to load folders", exc_info=True)
 

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -1036,14 +1036,31 @@ def _send(
         return _transport_failure(str(e), mark_transport_error)
 
 
-def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
+def _post(
+    path: str,
+    body: dict | None = None,
+    *,
+    timeout: float = 30,
+    session_key: str | None = None,
+) -> dict:
+    """POST a gateway endpoint.
+
+    ``session_key``: as in :func:`_patch`, and it matters for the same reason.
+    The default resolution is :func:`_resolve_session_key`, which includes the
+    ``/proc`` ancestor walk, so a caller that already gated itself on
+    :func:`_resolve_session_key_strict` and then let this helper re-resolve
+    would CHECK one identity and WRITE under another — the walk can land on an
+    ancestor slot, which for an app-owned session means the write arrives
+    looking like the unconfined person. Such a caller must pass the key it
+    verified. It is still validated by ``_session_key_header_error``.
+    """
     data = json.dumps(body or {}).encode()
     headers = {
         "Content-Type": "application/json",
         "X-Internal-Secret": _internal_secret(),
         **_caller_header(),
     }
-    sk = _resolve_session_key()
+    sk = _resolve_session_key() if session_key is None else session_key
     _sk_err = _session_key_header_error(sk)
     if _sk_err:
         return {"error": _sk_err}

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -122,9 +122,9 @@ def _tool_definitions() -> list[dict[str, Any]]:
                 "chat_folder_tree; missing path segments are created too (mkdir -p). "
                 "Omit ``parent`` (or pass 'root') for a top-level folder. Creating a "
                 "folder never moves anything — file sessions into it with "
-                "chat_folder_move_session. Not available to an app agent: the folder "
-                "tree is shared with the person and every other app, so an app files "
-                "its own sessions into folders that already exist."
+                "chat_folder_move_session. An app agent may create at the top level "
+                "or inside a folder it created itself, and the new folder belongs to "
+                "it; creating inside one of the person's folders is refused."
             ),
             "inputSchema": {
                 "type": "object",
@@ -152,9 +152,9 @@ def _tool_definitions() -> list[dict[str, Any]]:
                 "(sessions and subfolders travel with it); nothing is deleted. "
                 "Cycle-guarded: a folder cannot become its own descendant. "
                 "``folder`` and ``new_parent`` are each a folder id or human path; "
-                "omit ``new_parent`` (or pass 'root') for the top level. Not available "
-                "to an app agent — reparenting reshapes a tree shared with the person "
-                "and every other app."
+                "omit ``new_parent`` (or pass 'root') for the top level. An app agent "
+                "may move only a folder it created itself, and only to the top level "
+                "or under another of its own."
             ),
             "inputSchema": {
                 "type": "object",
@@ -285,7 +285,7 @@ def _ambiguous_segment_error(seg: str, matches: list[dict]) -> str:
 
 
 def _resolve_chat_folder_ref(
-    ref: str, folders: list[dict], *, create_missing: bool
+    ref: str, folders: list[dict], *, create_missing: bool, session_key: str | None = None
 ) -> tuple[str, list[str], str | None]:
     """Resolve a sidebar-folder reference to a folder id. THE resolution chokepoint.
 
@@ -335,7 +335,7 @@ def _resolve_chat_folder_ref(
     # the two readings are compared would mutate the tree on a reference we are
     # about to refuse.
     walked, created, walk_err = _walk_chat_folder_segments(
-        ref, folders, create_missing=create_missing and not exact
+        ref, folders, create_missing=create_missing and not exact, session_key=session_key
     )
     if walk_err:
         return "", created, walk_err
@@ -358,7 +358,7 @@ def _resolve_chat_folder_ref(
 
 
 def _walk_chat_folder_segments(
-    ref: str, folders: list[dict], *, create_missing: bool
+    ref: str, folders: list[dict], *, create_missing: bool, session_key: str | None = None
 ) -> tuple[str, list[str], str | None]:
     """Walk a ``/``-separated path segment by segment. ONE walk, two modes.
 
@@ -407,7 +407,11 @@ def _walk_chat_folder_segments(
             continue
         if not create_missing:
             return "", created, None
-        made = _post("/api/chat/folders", {"name": seg, "parent_id": parent})
+        made = _post(
+            "/api/chat/folders",
+            {"name": seg, "parent_id": parent},
+            session_key=session_key,
+        )
         if made.get("error"):
             return "", created, str(made["error"])
         folders.append(made)
@@ -423,9 +427,18 @@ def _resolve_chat_folder_id(ref: str, folders: list[dict]) -> tuple[str, str | N
     return fid, err
 
 
-def _ensure_chat_folder_path(ref: str, folders: list[dict]) -> tuple[str, list[str], str | None]:
-    """Resolve a parent-folder reference, creating missing segments (mkdir -p)."""
-    return _resolve_chat_folder_ref(ref, folders, create_missing=True)
+def _ensure_chat_folder_path(
+    ref: str, folders: list[dict], *, session_key: str
+) -> tuple[str, list[str], str | None]:
+    """Resolve a parent-folder reference, creating missing segments (mkdir -p).
+
+    ``session_key`` is REQUIRED because this variant writes: the intermediate
+    segments are real folders, and each must be created under the identity the
+    caller's gate verified rather than one the write helper re-derives.
+    """
+    return _resolve_chat_folder_ref(
+        ref, folders, create_missing=True, session_key=session_key
+    )
 
 
 def _resolve_chat_slot_key(ref: str, slots: list[dict]) -> tuple[str, str | None]:
@@ -606,48 +619,70 @@ def _visible_chat_slots() -> tuple[list[dict], str | None]:
     return [r for r in live if str(r.get("app") or "") == scope], None
 
 
-def _refuse_tree_shaping_if_app_scoped(verb: str) -> str | None:
-    """Error text when the caller may not reshape the folder tree, else None.
+def _refuse_tree_shaping_if_unverifiable(verb: str) -> tuple[str, str | None]:
+    """``(verified_caller_key, error)`` — the key to WRITE under, or why not.
 
-    Folders are ONE tree per instance with no owner field, so there is no "this
-    app's folder" to confine a write to: creating, renaming, reparenting or
-    deleting one lands in the person's sidebar and in every other app's view of
-    it. An app-scoped caller is therefore refused the tree-shaping verbs
-    outright rather than given authority that cannot be bounded.
+    Folders now carry an owner (``chat_folders._folder_owner_app``), so an app
+    HAS a folder of its own to write to and the endpoint bounds each write to
+    it: an app may create at the top level or inside its own folders, and may
+    rename, reparent or delete only what it owns. The person keeps full
+    authority over everything, and an app keeps read of the whole tree plus
+    filing its OWN sessions into any folder.
 
-    What an app KEEPS is everything already scoped to it: reading the tree, and
-    filing its OWN sessions into a folder that exists. The person's own agent is
-    unscoped and keeps full authority — reorganising sessions is the point of
-    these tools.
+    So this layer no longer decides the policy — it would be a second copy of a
+    rule the endpoint enforces under the store lock, and only the endpoint can
+    see the authoritative tree. What stays here is the one question the endpoint
+    cannot answer: whether the caller can be placed at all. An unverifiable or
+    delegated caller has no scope to bound a write to, and a write to shared
+    structure is not the place to assume the caller is the human.
 
-    Identity is resolved strictly, and an unverifiable caller is refused too: a
-    write to shared structure is not the place to assume the caller is the human.
+    The verified key is RETURNED rather than left for the write helpers to
+    re-derive. Those default to :func:`_resolve_session_key`, whose ``/proc``
+    ancestor walk can resolve to a different slot than the strict check above —
+    so re-resolving would check one identity and write under another, and for an
+    app-owned session the walk landing on an ancestor makes the write arrive at
+    the endpoint looking like the unconfined person. Every caller of this gate
+    must pass what it returns straight to the write.
     """
     caller_key = _resolve_session_key_strict()
     if not caller_key:
-        return (
+        return "", (
             f"Error: cannot verify which session is calling, so {verb} is "
             "refused — reshaping the shared folder tree requires a caller "
             "identity the gateway can vouch for."
         )
     rows, err = _get_rows("/api/chat/slots")
     if err:
-        return f"Error: {err}"
+        return "", f"Error: {err}"
     scope = _caller_app_scope(caller_key, rows)
     if scope is None:
-        return (
+        return "", (
             f"Error: cannot establish what this caller is allowed to change, so "
             f"{verb} is refused — a subagent or a scheduled job runs on behalf of "
             "whatever created it and cannot be granted more than that."
         )
-    if scope:
-        return (
-            f"Error: {verb} is not available to an app — the folder tree is "
-            "shared with the person and every other app, and folders carry no "
-            "owner, so there is no app-private folder to change. Filing your "
-            "own sessions into an existing folder still works."
+    if scope and not caller_key.startswith("dashboard:"):
+        # An app-owned LINKED session -- a channel- or cron-bound slot runs its
+        # turns under ``linked_session_key`` -- is the one shape whose staleness
+        # nothing downstream can notice. The endpoint re-derives the app from
+        # this key and refuses a key that NAMES a slot which is gone, but
+        # ``caller_names_a_missing_slot`` is ``dashboard:``-only BY DESIGN: for
+        # any other shape absence is not evidence of a vanished slot, since a
+        # Slack thread or a channel session legitimately never had one, and
+        # refusing those would take these tools from callers no app could have
+        # been attached to.
+        #
+        # So for a linked key the endpoint cannot tell "this app's slot just
+        # closed" from "no app owns this caller", and would read the second and
+        # apply the person's authority. THIS layer can tell, because it resolved
+        # the scope positively a moment ago, so the refusal belongs here.
+        return "", (
+            f"Error: {verb} is refused for a channel- or schedule-bound session "
+            "owned by an app — its identity cannot be re-verified at the point of "
+            "the write, so the folder rules could not be bounded to it. Run this "
+            "from the app's own dashboard session."
         )
-    return None
+    return caller_key, None
 
 
 def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
@@ -719,7 +754,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
 
     if name == "chat_folder_create":
         args = validate_tool_args(args, CHAT_FOLDER_CREATE_SCHEMA)
-        gate = _refuse_tree_shaping_if_app_scoped("creating a folder")
+        caller_key, gate = _refuse_tree_shaping_if_unverifiable("creating a folder")
         if gate:
             return gate
         # A '/' in a NAME is what makes a rendered path ambiguous (a folder named
@@ -738,7 +773,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         # mkdir -p over the parent path: resolve as far as the tree already
         # goes, then create each missing segment.
         parent_id, created_segments, parent_err = _ensure_chat_folder_path(
-            str(args.get("parent") or ""), chat_folders
+            str(args.get("parent") or ""), chat_folders, session_key=caller_key
         )
         made_note = (
             f" (created parent path: {'/'.join(created_segments)})" if created_segments else ""
@@ -763,7 +798,11 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 "characters or fewer"
             )
         body = {"name": safe_name, "parent_id": parent_id}
-        d = _post("/api/chat/folders", body)
+        # The verified key is passed through unchanged: re-resolving inside the
+        # helper would let the write carry a different session's authority than
+        # the one the gate checked, and the endpoint's ownership rule is only as
+        # good as the identity that reaches it.
+        d = _post("/api/chat/folders", body, session_key=caller_key)
         if d.get("error"):
             return redact(f"Error: {d['error']}{made_note}")
         chat_folders.append(d)
@@ -773,7 +812,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
 
     if name == "chat_folder_move":
         args = validate_tool_args(args, CHAT_FOLDER_MOVE_SCHEMA)
-        gate = _refuse_tree_shaping_if_app_scoped("moving a folder")
+        caller_key, gate = _refuse_tree_shaping_if_unverifiable("moving a folder")
         if gate:
             return gate
         chat_folders, folders_err = _get_rows("/api/chat/folders")
@@ -787,7 +826,11 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         dest_id, dest_err = _resolve_chat_folder_id(args.get("new_parent") or "", chat_folders)
         if dest_err:
             return f"Error: {dest_err}"
-        d = _patch(f"/api/chat/folders/{fld_id}", {"parent_id": dest_id})
+        d = _patch(
+            f"/api/chat/folders/{fld_id}",
+            {"parent_id": dest_id},
+            session_key=caller_key,
+        )
         if d.get("error"):
             # The endpoint owns the cycle guard (a folder cannot move into its
             # own descendant) — surface its verdict rather than re-deriving it.

--- a/test/test_chat_folder_ownership.py
+++ b/test/test_chat_folder_ownership.py
@@ -1,0 +1,455 @@
+"""Ownership on the chat-folder tree-shaping endpoints.
+
+A folder created by an app carries it in ``owner_app``; an absent key reads as
+the person's, which is what makes this a field addition rather than a migration.
+An app may create at the top level or inside a folder it owns, and may rename,
+reparent or delete only what it owns. The person is never confined.
+
+The scope is derived from the authenticated calling session, never the body: the
+managed MCP set authenticates with the internal secret, which carries no app
+claim, so an app agent's tool call arrives with ``request["app"]`` empty.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.chat_folders import (
+    api_chat_folder_create,
+    api_chat_folder_delete,
+    api_chat_folder_update,
+)
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+# fldr…01 belongs to the person, …02 to issue-radar, …03 to another app, and
+# …04 predates the field entirely (no key at all) — the legacy row.
+PERSON = "fldr00000001"
+RADAR = "fldr00000002"
+OTHER = "fldr00000003"
+LEGACY = "fldr00000004"
+
+
+def _folders() -> list[dict[str, Any]]:
+    return [
+        {"id": PERSON, "name": "Work", "parent_id": "", "owner_app": ""},
+        {"id": RADAR, "name": "Radar output", "parent_id": "", "owner_app": "issue-radar"},
+        {"id": OTHER, "name": "Specs", "parent_id": "", "owner_app": "spec-builder"},
+        {"id": LEGACY, "name": "Old", "parent_id": ""},
+    ]
+
+
+def _app_slot(key: str, app: str) -> _ChatSlot:
+    slot = _ChatSlot(key)
+    slot._app = app
+    return slot
+
+
+def _state(*slots: _ChatSlot, folders: list[dict[str, Any]] | None = None) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state._folders = _folders() if folders is None else folders
+    state._slots = {s.key: s for s in slots}
+    state.push_slots_update = MagicMock()
+    # No archive by default: _folder_history_counts returns {} early on a falsy
+    # conversation_log, which is what an app's delete consults for emptiness. A
+    # bare MagicMock here would be iterated instead and raise.
+    state.conversation_log = None
+
+    async def _mutate(fn: Any) -> Any:
+        # The real store runs the callback under a lock and hands back its
+        # second element; the ownership decisions live inside that callback, so a
+        # mock that never calls it would prove nothing.
+        _changed, value = fn(state._folders)
+        return value
+
+    state.mutate_folders = AsyncMock(side_effect=_mutate)
+    return state
+
+
+def _make_app(state: DashboardState) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+
+    @web.middleware
+    async def _publish_app(request: web.Request, handler: Any) -> Any:
+        # Stands in for the token middleware. Empty for the internal-secret
+        # (MCP) transport, which is the path an app agent's tool call takes.
+        request["app"] = ""
+        return await handler(request)
+
+    app.middlewares.append(_publish_app)
+    app.router.add_post("/api/chat/folders", api_chat_folder_create)
+    app.router.add_patch("/api/chat/folders/{id}", api_chat_folder_update)
+    app.router.add_delete("/api/chat/folders/{id}", api_chat_folder_delete)
+    return app
+
+
+def _by_id(state: DashboardState, fid: str) -> dict[str, Any] | None:
+    return next((f for f in state._folders if f["id"] == fid), None)
+
+
+class TestCreateStampsTheOwner:
+    @pytest.mark.asyncio
+    async def test_an_apps_folder_is_stamped_with_that_app(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Runs"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 201
+        assert body["owner_app"] == "issue-radar"
+
+    @pytest.mark.asyncio
+    async def test_the_persons_folder_carries_no_owner_key(self) -> None:
+        """Absent, not empty-string: "absent means the person" stays the one
+        representation, and the person's rows keep the shape they have on disk."""
+        state = _state(_ChatSlot("chat-1-100"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Q3"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 201
+        assert "owner_app" not in body
+
+    @pytest.mark.asyncio
+    async def test_the_owner_is_never_taken_from_the_body(self) -> None:
+        """A caller that could name its own owner could name someone else's."""
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Runs", "owner_app": ""},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 201
+        assert body["owner_app"] == "issue-radar"
+
+    @pytest.mark.asyncio
+    async def test_an_app_may_nest_under_its_own_folder(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Runs", "parent_id": RADAR},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 201
+
+    @pytest.mark.asyncio
+    async def test_an_app_may_not_nest_under_the_persons_folder(self) -> None:
+        """Nesting writes to THAT folder's child list."""
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        before = len(state._folders)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Runs", "parent_id": PERSON},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "folder_not_owned"
+        assert len(state._folders) == before
+
+    @pytest.mark.asyncio
+    async def test_a_legacy_row_without_the_key_is_the_persons(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Runs", "parent_id": LEGACY},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 403
+
+
+class TestRenameAndReparentAreBounded:
+    @pytest.mark.asyncio
+    async def test_an_app_can_rename_its_own_folder(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"name": "Renamed"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, RADAR)["name"] == "Renamed"
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_rename_the_persons_folder(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{PERSON}",
+                json={"name": "Hijacked"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "folder_not_owned"
+        assert _by_id(state, PERSON)["name"] == "Work"
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_rename_another_apps_folder(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{OTHER}",
+                json={"name": "Hijacked"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 403
+        assert _by_id(state, OTHER)["name"] == "Specs"
+
+    @pytest.mark.asyncio
+    async def test_the_person_is_not_confined_by_an_apps_ownership(self) -> None:
+        state = _state(_ChatSlot("chat-1-100"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"name": "Tidied up"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, RADAR)["name"] == "Tidied up"
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_reparent_its_folder_into_the_persons(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"parent_id": PERSON},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "folder_not_owned"
+        assert _by_id(state, RADAR)["parent_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_an_app_can_reparent_to_the_top_level(self) -> None:
+        """The top level is not a folder row, so it has no owner to violate —
+        that is where an app's own tree starts."""
+        folders = _folders()
+        nested = {
+            "id": "fldr00000005",
+            "name": "Runs",
+            "parent_id": RADAR,
+            "owner_app": "issue-radar",
+        }
+        folders.append(nested)
+        state = _state(_app_slot("chat-1-100", "issue-radar"), folders=folders)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                "/api/chat/folders/fldr00000005",
+                json={"parent_id": ""},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, "fldr00000005")["parent_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_ownership_cannot_be_reassigned_by_a_patch(self) -> None:
+        """Stamped once at create; not a field a request can hand over or clear."""
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"owner_app": ""},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, RADAR)["owner_app"] == "issue-radar"
+
+    @pytest.mark.asyncio
+    async def test_moving_own_folder_that_holds_a_foreign_one_is_refused(self) -> None:
+        """A move takes the subtree with it, so the person's nested folder would
+        be relocated by an app's write."""
+        folders = _folders()
+        folders.append({"id": "fldr00000007", "name": "Theirs", "parent_id": RADAR})
+        state = _state(_app_slot("chat-1-100", "issue-radar"), folders=folders)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"parent_id": ""},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "folder_not_owned"
+        assert _by_id(state, RADAR)["parent_id"] == ""
+
+    @pytest.mark.asyncio
+    async def test_renaming_a_folder_that_holds_a_foreign_one_is_still_allowed(self) -> None:
+        """Only the MOVE is gated on the subtree -- a rename relocates nothing."""
+        folders = _folders()
+        folders.append({"id": "fldr00000007", "name": "Theirs", "parent_id": RADAR})
+        state = _state(_app_slot("chat-1-100", "issue-radar"), folders=folders)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"name": "Renamed"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, RADAR)["name"] == "Renamed"
+
+    @pytest.mark.asyncio
+    async def test_the_person_can_still_move_a_folder_holding_an_apps(self) -> None:
+        """Containment cuts both ways, but the person is never confined."""
+        folders = _folders()
+        folders.append(
+            {
+                "id": "fldr00000007",
+                "name": "Radar sub",
+                "parent_id": PERSON,
+                "owner_app": "issue-radar",
+            }
+        )
+        state = _state(_ChatSlot("chat-1-100"), folders=folders)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{PERSON}",
+                json={"parent_id": OTHER},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, PERSON)["parent_id"] == OTHER
+
+
+class TestAnAppCannotDeleteFolders:
+    """A delete relocates everything the folder contains, and those contents live
+    in a DIFFERENT store from the folder -- the slot table and the session
+    archive, neither sharing a lock with it. So emptiness cannot be established
+    atomically with the removal, and every narrower rule leaked through another
+    seam. The person keeps the delete they always had.
+
+    Nothing shipped loses a capability: no MCP tool exposes folder deletion, and
+    the only client of the route is the dashboard UI.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_delete_even_an_empty_folder_it_owns(self) -> None:
+        state = _state(_app_slot("chat-1-100", "issue-radar"))
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", AsyncMock()):
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.delete(
+                    f"/api/chat/folders/{RADAR}",
+                    headers={"X-Session-Key": "dashboard:chat-1-100"},
+                )
+                body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "folder_delete_forbidden"
+        assert _by_id(state, RADAR) is not None
+
+    @pytest.mark.asyncio
+    async def test_no_session_is_touched_by_the_refusal(self) -> None:
+        """Refused before the unfile loop, so nothing is written and there is
+        nothing to roll back."""
+        mine = _app_slot("chat-9-900", "issue-radar")
+        mine.folder_id = RADAR
+        state = _state(_app_slot("chat-1-100", "issue-radar"), mine)
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", AsyncMock()):
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.delete(
+                    f"/api/chat/folders/{RADAR}",
+                    headers={"X-Session-Key": "dashboard:chat-1-100"},
+                )
+        assert resp.status == 403
+        assert mine.folder_id == RADAR
+
+    @pytest.mark.asyncio
+    async def test_the_person_can_still_delete_a_full_folder(self) -> None:
+        """The person is not confined: clearing out a folder full of
+        conversations and subfolders is the delete they already had."""
+        theirs = _app_slot("chat-9-900", "issue-radar")
+        theirs.folder_id = RADAR
+        folders = _folders()
+        folders.append({"id": "fldr00000006", "name": "Sub", "parent_id": RADAR})
+        state = _state(_ChatSlot("chat-1-100"), theirs, folders=folders)
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", AsyncMock()):
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.delete(
+                    f"/api/chat/folders/{RADAR}",
+                    headers={"X-Session-Key": "dashboard:chat-1-100"},
+                )
+        assert resp.status == 200
+        assert _by_id(state, RADAR) is None
+        assert theirs.folder_id == ""
+        assert _by_id(state, "fldr00000006")["parent_id"] == ""
+
+
+class TestACallerWhoseSlotIsGoneIsRefused:
+    """An empty scope reads as the person, which is right for a caller that never
+    had a slot (Slack, a channel session, the person's cron) and wrong for a
+    `dashboard:` key, which NAMES one. A tab closing while its tool call is in
+    flight pops the slot without draining, so an app-owned session would arrive
+    unattributable and be handed the person's authority over the person's folders.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_is_refused(self) -> None:
+        state = _state()  # the named slot is absent from the registry
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/folders",
+                json={"name": "Sneaky"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+            body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "caller_unattributable"
+
+    @pytest.mark.asyncio
+    async def test_rename_of_the_persons_folder_is_refused(self) -> None:
+        state = _state()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{PERSON}",
+                json={"name": "Hijacked"},
+                headers={"X-Session-Key": "dashboard:chat-1-100"},
+            )
+        assert resp.status == 403
+        assert _by_id(state, PERSON)["name"] == "Work"
+
+    @pytest.mark.asyncio
+    async def test_delete_is_refused_before_any_slot_is_unfiled(self) -> None:
+        filed = _ChatSlot("chat-9-900")
+        filed.folder_id = PERSON
+        state = _state(filed)
+        with patch("kiro_crew.dashboard.chat_folders.save_slot_off_loop", AsyncMock()):
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.delete(
+                    f"/api/chat/folders/{PERSON}",
+                    headers={"X-Session-Key": "dashboard:chat-1-100"},
+                )
+        assert resp.status == 403
+        assert _by_id(state, PERSON) is not None
+        assert filed.folder_id == PERSON
+
+    @pytest.mark.asyncio
+    async def test_a_caller_that_never_had_a_slot_is_still_the_person(self) -> None:
+        """The refusal must not swallow Slack, channel or cron callers -- they
+        never had a slot to be confined to, which is a different fact."""
+        state = _state()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.patch(
+                f"/api/chat/folders/{RADAR}",
+                json={"name": "Tidied"},
+                headers={"X-Session-Key": "slack:T1/C1"},
+            )
+        assert resp.status == 200
+        assert _by_id(state, RADAR)["name"] == "Tidied"

--- a/test/test_chat_folder_store_shape.py
+++ b/test/test_chat_folder_store_shape.py
@@ -1,0 +1,102 @@
+"""A hand-edited folders.json cannot take out the folder routes.
+
+``folders.json`` is editable by hand and loaded with a bare ``json.loads``, so it
+can hold a non-list document, a non-dict entry, or a row with no ``id``. Every
+consumer matches rows by id, and ``mutate_folders`` snapshots the store with
+``dict(row)``, which RAISES on a non-dict and surfaces as a 500 because no
+middleware maps handler exceptions.
+
+These tests drive the REAL ``DashboardState.load_folders`` and the REAL
+``mutate_folders``. That matters: the ownership tests use a fake
+``mutate_folders`` that does not snapshot, so they can show the handler logic
+tolerating a bad row while proving nothing about whether the request survives.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.dashboard.state import DashboardState
+
+
+def _load_with(tmp_path: Any, payload: object) -> list[dict]:
+    (tmp_path / "folders.json").write_text(json.dumps(payload), encoding="utf-8")
+    state = DashboardState.__new__(DashboardState)
+    state._folders = []
+    with patch("kiro_crew.dashboard.state.config_dir", return_value=tmp_path):
+        DashboardState.load_folders(state)
+    return state._folders
+
+
+class TestLoadFoldersDropsWhatNothingCanUse:
+    def test_a_non_dict_entry_is_dropped(self, tmp_path: Any) -> None:
+        rows = _load_with(
+            tmp_path, ["not even a dict", {"id": "f1", "name": "Work", "parent_id": ""}]
+        )
+        assert [r["id"] for r in rows] == ["f1"]
+
+    def test_a_row_without_an_id_is_dropped(self, tmp_path: Any) -> None:
+        rows = _load_with(
+            tmp_path, [{"name": "no id", "parent_id": ""}, {"id": "f1", "name": "Work"}]
+        )
+        assert [r["id"] for r in rows] == ["f1"]
+
+    def test_a_row_with_an_empty_id_is_dropped(self, tmp_path: Any) -> None:
+        rows = _load_with(tmp_path, [{"id": "", "name": "blank"}, {"id": "f1"}])
+        assert [r["id"] for r in rows] == ["f1"]
+
+    def test_a_non_string_id_is_dropped(self, tmp_path: Any) -> None:
+        """Ids are minted as ``uuid4().hex[:12]``, so anything else is corrupt --
+        and a merely-truthy test lets an UNHASHABLE id through, which raises
+        ``TypeError`` from inside the archived-count join rather than being
+        harmlessly unmatchable."""
+        rows = _load_with(
+            tmp_path,
+            [
+                {"id": [1], "name": "list id"},
+                {"id": {"a": 1}, "name": "dict id"},
+                {"id": 5, "name": "int id"},
+                {"id": "f1", "name": "Work"},
+            ],
+        )
+        assert [r["id"] for r in rows] == ["f1"]
+
+    def test_an_unhashable_id_would_have_broken_the_listing(self, tmp_path: Any) -> None:
+        """Pins the consequence, not just the filter: the surviving rows must be
+        safe as dict KEYS, which is what the listing does with them."""
+        rows = _load_with(tmp_path, [{"id": [1]}, {"id": "f1", "name": "Work"}])
+        counts: dict[str, int] = {}
+        # This is the join GET /api/chat/folders performs; it must not raise.
+        assert [counts.get(r["id"], 0) for r in rows] == [0]
+
+    def test_a_non_list_document_is_ignored_entirely(self, tmp_path: Any) -> None:
+        """Not read as empty and not half-applied: the store keeps its prior
+        value rather than becoming a dict the consumers would iterate as keys."""
+        assert _load_with(tmp_path, {"id": "f1"}) == []
+
+    def test_a_healthy_file_is_unchanged(self, tmp_path: Any) -> None:
+        good = [{"id": "f1", "name": "Work", "parent_id": ""}, {"id": "f2", "name": "Home"}]
+        assert _load_with(tmp_path, good) == good
+
+
+class TestTheRealSnapshotSurvivesWhatLoadAdmits:
+    @pytest.mark.asyncio
+    async def test_mutate_folders_snapshots_what_load_folders_kept(self, tmp_path: Any) -> None:
+        """``mutate_folders`` does ``dict(row)`` on every row, so anything
+        load_folders admits must survive that. This is the assertion the
+        ownership suite's fake mutate_folders cannot make."""
+        (tmp_path / "folders.json").write_text(
+            json.dumps(["bad row", {"id": "f1", "name": "Work", "parent_id": ""}]),
+            encoding="utf-8",
+        )
+        state = DashboardState.__new__(DashboardState)
+        state._folders = []
+        with patch("kiro_crew.dashboard.state.config_dir", return_value=tmp_path):
+            DashboardState.load_folders(state)
+            # dict(row) over the surviving rows must not raise.
+            snapshot = [dict(f) for f in state._folders]
+        assert snapshot == [{"id": "f1", "name": "Work", "parent_id": ""}]

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1052,12 +1052,14 @@ class TestASubagentCannotOutrankItsParent:
         assert "Other app" not in out
 
 
-class TestAppsCannotReshapeTheSharedFolderTree:
-    """Folders are one tree per instance with no owner, so an app gets no
-    tree-shaping authority — there is no app-private folder to bound it to.
+class TestTheFolderPolicyIsTheEndpointsNotThisServers:
+    """Folders carry an owner now, so an app HAS a folder of its own to write to
+    and this server stops deciding the policy: the tool call reaches the
+    endpoint, which bounds the write to the caller's own folders under the store
+    lock. A second copy of that rule here could only drift or race it.
 
-    What an app keeps is what is already scoped to it: reading the tree, and
-    filing its OWN sessions into a folder that exists.
+    What this layer still decides is the one thing the endpoint cannot — whether
+    the caller can be placed at all.
     """
 
     @staticmethod
@@ -1075,27 +1077,41 @@ class TestAppsCannotReshapeTheSharedFolderTree:
             return_value=f"dashboard:{slot}",
         )
 
-    def test_an_app_cannot_create_a_folder(self) -> None:
+    def test_an_apps_create_reaches_the_endpoint(self) -> None:
+        """Previously refused here outright; the endpoint now stamps the owner."""
+        made = {"id": "new000000001", "name": "Radar output", "parent_id": ""}
         with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
             "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
             out = _call_tool_inner("chat_folder_create", {"name": "Radar output"})
-        assert out.startswith("Error:")
-        assert "not available to an app" in out
-        mock_post.assert_not_called()
+        assert not out.startswith("Error:")
+        assert mock_post.called
 
-    def test_an_app_cannot_move_a_folder(self) -> None:
+    def test_an_apps_move_reaches_the_endpoint(self) -> None:
+        moved = {"id": "fldr00000002", "name": "0811", "parent_id": "fldr00000003"}
         with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
             "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+        ), patch("kiro_crew.mcp_dashboard._patch", return_value=moved) as mock_patch:
+            out = _call_tool_inner(
+                "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "Travel"}
+            )
+        assert not out.startswith("Error:")
+        assert mock_patch.called
+
+    def test_the_endpoints_ownership_refusal_is_surfaced_not_reinvented(self) -> None:
+        """The tool must report the endpoint's verdict rather than pre-judging
+        it — that is what keeps one rule in one place."""
+        denied = {"error": "this app does not own that folder", "code": "folder_not_owned"}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
+            "chat-1-100"
+        ), patch("kiro_crew.mcp_dashboard._patch", return_value=denied):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "Travel"}
             )
         assert out.startswith("Error:")
-        mock_patch.assert_not_called()
+        assert "does not own that folder" in out
 
     def test_an_app_can_still_file_its_own_session(self) -> None:
-        """The refusal is about SHARED STRUCTURE, not about the app's own work."""
         with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
             "chat-1-100"
         ), patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch:
@@ -1133,6 +1149,105 @@ class TestAppsCannotReshapeTheSharedFolderTree:
         assert out.startswith("Error:")
         assert "cannot verify which session is calling" in out
         mock_post.assert_not_called()
+
+    def test_an_app_owned_linked_session_is_refused(self) -> None:
+        """A channel- or cron-bound slot runs under linked_session_key, and the
+        endpoint's staleness guard is dashboard:-only BY DESIGN -- for any other
+        shape, absence cannot be told from "never had a slot". So this layer,
+        which resolved the scope positively, has to refuse it."""
+
+        def rows(path: str) -> list[dict]:
+            if path == "/api/chat/folders":
+                return [dict(f) for f in _FOLDERS]
+            return [
+                {
+                    "key": "chat-5-500",
+                    "title": "Radar channel",
+                    "folder_id": "",
+                    "app": "issue-radar",
+                    "linked_session_key": "channel:C123",
+                }
+            ]
+
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=rows), patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+            return_value="channel:C123",
+        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+            out = _call_tool_inner("chat_folder_create", {"name": "Runs"})
+        assert out.startswith("Error:")
+        assert "channel- or schedule-bound" in out
+        mock_post.assert_not_called()
+
+    def test_a_channel_session_with_no_app_still_works(self) -> None:
+        """The refusal is scoped to an APP-owned linked session. A person's own
+        channel session never had an app and keeps full authority."""
+
+        def rows(path: str) -> list[dict]:
+            if path == "/api/chat/folders":
+                return [dict(f) for f in _FOLDERS]
+            return [{"key": "chat-5-500", "title": "Mine", "folder_id": "", "app": ""}]
+
+        made = {"id": "new000000001", "name": "Runs", "parent_id": ""}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=rows), patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+            return_value="slack:T1/C1",
+        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+            out = _call_tool_inner("chat_folder_create", {"name": "Runs"})
+        assert not out.startswith("Error:")
+        assert mock_post.called
+
+
+class TestEveryFolderWriteCarriesTheVerifiedKey:
+    """The endpoint's ownership rule is only as good as the identity that
+    reaches it, so the key the gate STRICTLY verified must be the key the write
+    sends. The write helpers default to the lenient resolver, whose /proc
+    ancestor walk can land on a different slot -- for an app-owned session that
+    makes the write arrive looking like the unconfined person, which would check
+    one identity and write under another.
+    """
+
+    @staticmethod
+    def _mixed(path: str) -> list[dict]:
+        if path == "/api/chat/folders":
+            return [dict(f) for f in _FOLDERS]
+        return [
+            {"key": "chat-1-100", "title": "Radar run", "folder_id": "", "app": "issue-radar"},
+        ]
+
+    def _as(self, slot: str) -> Any:
+        return patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+            return_value=f"dashboard:{slot}",
+        )
+
+    def test_create_sends_the_verified_key(self) -> None:
+        made = {"id": "new000000001", "name": "Runs", "parent_id": ""}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
+            "chat-1-100"
+        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+            _call_tool_inner("chat_folder_create", {"name": "Runs"})
+        assert mock_post.call_args.kwargs["session_key"] == "dashboard:chat-1-100"
+
+    def test_mkdir_p_segments_are_created_under_the_verified_key(self) -> None:
+        """The intermediate segments are real folders, so each write needs it too."""
+        made = {"id": "new000000001", "name": "seg", "parent_id": ""}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
+            "chat-1-100"
+        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+            _call_tool_inner("chat_folder_create", {"name": "Leaf", "parent": "Fresh/Deep"})
+        assert mock_post.call_count > 1
+        for call in mock_post.call_args_list:
+            assert call.kwargs["session_key"] == "dashboard:chat-1-100"
+
+    def test_move_sends_the_verified_key(self) -> None:
+        moved = {"id": "fldr00000002", "name": "0811", "parent_id": "fldr00000003"}
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
+            "chat-1-100"
+        ), patch("kiro_crew.mcp_dashboard._patch", return_value=moved) as mock_patch:
+            _call_tool_inner(
+                "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "Travel"}
+            )
+        assert mock_patch.call_args.kwargs["session_key"] == "dashboard:chat-1-100"
 
 
 class TestTheSessionListIsScopedToTheCaller:


### PR DESCRIPTION
## 1. What is the problem?

Chat folders were a single per-instance tree with no owner field, so the
folder-level mutations had no ownership question they could answer:

- `POST /api/chat/folders` (create)
- `PATCH /api/chat/folders/{id}` (rename / reparent / reorder)
- `DELETE /api/chat/folders/{id}`

Session *filing* is app-scoped -- `PATCH /api/chat/slots/{slot}/folder` compares
the caller's app against the target slot's `_app` -- because a slot has an owner
to compare against. A folder did not.

The conservative answer shipped in #3473 lived one layer up, in the MCP server:
an app-scoped caller was refused `chat_folder_create` and `chat_folder_move`
outright, and no `chat_folder_delete` tool was ever exposed. So this is not a
reachable hole today. It is two other things. An app cannot create even a folder
for its own work, which is a plausible thing to want. And the rule lives in the
tool layer rather than the data layer, so the next route or tool added inherits
the same silence -- which is what the issue was filed to settle.

## 2. Why this issue matters to the user

Two effects, one now and one later.

Now: an app that organizes work on your behalf has nowhere to put it. It can file
its sessions into folders you already made, but it cannot make one, so anything
it produces lands in your tree or nowhere.

Later: "who may reshape the sidebar" had no answer anywhere in the store, only a
refusal bolted onto two tool names. A folder-touching route added without reading
that MCP function would be unguarded by default, and the failure would be silent
-- an app quietly renaming or deleting folders in a surface you own and read.

## 3. How our fix solves it

Chain from the symptom back to the cause: the endpoints could not decide
ownership because the record had no owner, so the fix adds the owner, lets each
verb bound itself to it, and then makes sure the identity the bound write runs
under is the one that was actually verified.

**The field.** A folder created by an app records it in `owner_app`. An absent or
empty key reads as the person's, expressed once in `_folder_owner_app`. That
default is what makes this a field addition rather than a migration -- every
folder written before the field existed is the person's, which is exactly what it
was. `folders.json` needs no rewrite and no version bump.

**The bounds.** An app may create at the top level or inside a folder it owns.
The top level is not a folder row and so has no owner to violate, which is where
an app's own tree starts. Rename, reparent and delete apply only to folders it
owns, and a reparent must also land somewhere it owns.

**A reparent's blast radius is the subtree, not the row.** A move takes
everything beneath the folder with it, so it would relocate a folder the person
nested inside one of the app's -- the same violation as editing that folder
directly, reached one level down. Reparent is therefore refused when the subtree
holds a folder the caller does not own. A rename, colour or collapse is
deliberately NOT gated this way, because it relocates nothing. The rule is about
who may WRITE: the person moving their own folder still carries an app's subtree
with it, which is inherent to containment and is why the person is not confined.

**An app cannot delete a folder at all.** Not even an empty one it owns; the route
answers 403 `folder_delete_forbidden`. A delete relocates everything the folder
contains, and those contents live in a DIFFERENT store from the folder -- sessions
are in the slot table and the session archive, neither sharing a lock with it -- so
"is this folder empty?" cannot be established atomically with the removal.
Successively narrower rules each leaked through another seam over review: ownership
per content type missed archived sessions a live scan cannot see; emptiness then
missed a session filed while the archive scan awaited, then a child created while the
lock was acquired, then a session closing after the scan and writing its `folder_id`
on the way out. Each was closable alone. The class was not, so the verb is withheld
rather than defended by a rule that keeps losing a seam.

Nothing shipped loses a capability, which is what makes that cheap rather than a
concession: no MCP tool exposes folder deletion (the set is `chat_folder_tree` /
`chat_folder_create` / `chat_folder_move` / `chat_folder_move_session`) and the only
client of this route is the dashboard UI, which is the person. An app organizes its
work by creating, renaming and reparenting its own folders and filing its own
sessions; cleanup belongs to the person, who deletes a full folder exactly as
before. The refusal lands before the unfile loop, so nothing is written and there is
nothing to roll back.

**Where the decisions run.** Inside the `mutate_folders` callback, under the
store lock, next to the cycle rule and for the same reason -- a concurrent
reparent can change who a parent or a child belongs to between validation and the
write. The one exception is delete's check of its own target, which is sound
before the lock because `owner_app` is stamped at create and no route can
reassign it; doing it there also means the common refusal costs no rollback.
Delete's existing slot-restore is hoisted into a helper so the new refusal path
and the pre-existing exception path share one copy rather than two.

**The identity the write runs under.** Moving the decision to the endpoint makes
this load-bearing, and it is the part the first revision of this PR got wrong.
The MCP gate verifies the caller with `_resolve_session_key_strict`, but the write
helpers default to `_resolve_session_key`, whose `/proc` ancestor walk can resolve
to a DIFFERENT slot. Letting them re-resolve would check one identity and write
under another: for an app-owned session, an ancestor match makes the write arrive
at the endpoint looking like the unconfined person, reaching the very folders the
ownership rule exists to protect. So the gate now returns the key it verified and
every folder write sends that key unchanged -- create, move, and each intermediate
folder a `mkdir -p` parent path creates. `_post` gains the `session_key`
passthrough `_get` / `_patch` / `_put` already had, whose docstrings already spelled
out this exact hazard. `chat_folder_move_session` already worked this way; this
completes the pattern rather than inventing one.

**What cannot be forged.** `owner_app` is never read from the request body, on
create or on update. A caller that could name its own owner could name someone
else's. On update it is simply not among the accepted fields, so it cannot be
handed over, taken, or cleared after create.

**What the person keeps.** Everything. An unscoped caller is the person's own
agent and is not confined by any of this, including over app-owned folders.

**What an app keeps.** Reading the whole tree, and filing its OWN sessions into
any folder that exists. Neither is narrowed. That is the case a per-app namespace
would have cost, which is why that option was not taken.

**The MCP layer otherwise stops deciding.**
`_refuse_tree_shaping_if_app_scoped` becomes
`_refuse_tree_shaping_if_unverifiable`: it no longer refuses app-scoped callers,
because the endpoint now bounds them. A second copy of the rule there could only
drift from or race the endpoint, which is the only party holding the lock and
seeing the authoritative tree. Delegated and unverifiable callers are still
refused, unchanged -- that is the one question the endpoint cannot answer. Both
tool descriptions advertised the old blanket refusal and are corrected, since
leaving them would have made the advertised contract contradict the behaviour.

Refusals return 403 with `code: "folder_not_owned"` and are recorded to SEL as
`outcome="denied"`, `source="app_isolation"`, matching what `api_chat_slot_folder`
already does. The response does not distinguish which of the two folders in a
reparent was foreign; the audit event does.

## 4. What tests we did

32 new endpoint tests in `test/test_chat_folder_ownership.py`, driving the real
handlers over a live `aiohttp` test server with a `mutate_folders` that actually
runs the callback -- a mock that never ran it would prove nothing, since every
ownership decision lives inside it. They cover create stamping, the person's rows
staying free of the key, the absent-key legacy row reading as the person's,
body-forged ownership on both create and update, nesting under own vs the
person's folder, reparent to a foreign destination and to the top level, the
reparent subtree rule including a foreign folder two levels down with a rename
staying allowed through it, an app's delete refused outright with no session
touched and nothing to roll back, the closed-slot refusal on all three verbs with a
Slack-shaped caller still reading as the person, and the person staying unconfined
throughout -- including moving a folder that holds an app's and deleting a full one.

3 further tests pin that create, each `mkdir -p` segment, and move all send the
strictly-verified key, so the check-then-use gap cannot reopen silently.

Every guard was mutation-verified individually, including the new subtree
predicate and each of its two call sites separately: each neutered guard reddens
its own tests and nothing else, and the source was confirmed free of probe residue
before committing.

The MCP class that pinned the removed refusal is rewritten rather than deleted,
including a test that the tool surfaces the endpoint's ownership verdict instead
of re-deriving it -- that is what keeps one rule in one place.

843 tests pass across the folder, MCP-dashboard, audit-origin, dashboard-chat and
slot-create suites. 554 pass across the `mcp_core` identity, resolver,
governance and security-posture suites, which is where the `_post` signature
change lands. flake8, isort and `scripts/check_black_formatting.py` are clean. All
three source files are pre-existing entries in `.github/black-baseline.txt` and
are deliberately left unformatted -- running black on them would graduate them out
of the baseline and bury this diff.

## 5. Any other suggestions on the work

**The delete rule changed twice during review, and ended as a subtraction.** It
began as "an app may delete what it owns", which cost a round per content type as
reviewers found each thing a delete touches; became "only if empty", which cost
three more rounds as each cross-store race surfaced; and ended withheld. If app
delete is wanted later, the honest prerequisite is a lock spanning the slot table,
the session archive and the folder store, or transactional enumeration of a folder's
contents -- a different change from this one.

**This is the owner half, not a permission model.** The field is the reusable
part; the "own is writable, the person's is read-only" policy is hardcoded rather
than expressed as mode bits. If per-folder permissions are ever wanted, the field
and its no-migration default carry over and only the policy layer needs
extracting. That order is the workable one -- owner first, modes second.

**The top level is deliberately unowned.** There is no root row to attach an
owner to, so an app can always create a top-level folder. If that turns out to be
too permissive in practice, the narrower rule (an app gets exactly one top-level
folder, named for it) is a follow-up, not a redesign.

**The `session_key` default is the wider hazard.** This PR fixes the two call
sites it created, but `_post` and `_patch` still default to the lenient resolver,
so any future gated write that forgets the argument reopens the same class
silently. A safer shape is for the write helpers to require an explicit key at
gated call sites -- worth its own change, not this one.

**Two adjacent things I did not fold in.** #3503 is still open on SEL source
attribution for folder writes, but `_audit_origin` plus `_KNOWN_INTERNAL_CALLERS`
landed in #3473 and appear to cover it -- worth a separate look rather than a
claim here. And the sidebar does not surface ownership to the user at all; whether
an app-owned folder should be visually marked is a design question, not a
correctness one, so it is not in scope.

Refs #3569

