### PR TITLE
fix(sidebar): publish the rendered row order so tree view digits follow top-to-bottom

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -72,7 +72,7 @@ import {
   isWithinRecentWindow,
 } from './recentWindow'
 import { loadChatConfig, saveChatConfig } from './chat/ChatSettings'
-import { focusSiblingSessionRow } from './chat/sessionRowNav'
+import { focusSiblingSessionRow, SESSION_ROW_SELECTOR } from './chat/sessionRowNav'
 import { focusComposer } from './chat/composerFocus'
 import { compareBySort, comparePinnedThenSort, fmtRelativeTime, slotActivityTs } from './chat/sessionOrder'
 import type { SortKey } from './chat/sessionOrder'
@@ -2558,16 +2558,48 @@ function ChatSidebar({
     })
   }, [filteredSlots, folderFilterActive, filterHiddenSubtree, slotFolders])
 
-  // The order the chat-jump/cycle shortcuts should follow — what this sidebar
-  // displays. Flat view: the flat lane's exact row order. Folder tree and
-  // column layouts: filteredSlots (pinned-first + the user's sort); folder
-  // grouping can visually interleave rows, so those views rely on the held-
-  // modifier badges below to make the digit mapping visible rather than on a
-  // full tree walk here.
-  const shortcutOrderKeys = useMemo(
-    () => (flatView && folders.length > 0 ? flatSlots : filteredSlots).map(s => s.key),
-    [flatView, folders.length, flatSlots, filteredSlots],
-  )
+  // The order the chat-jump/cycle shortcuts should follow — the rows AS
+  // RENDERED, read back from the DOM after every commit. Reading the render
+  // output (instead of re-deriving each lane's composition) means the
+  // published order can never drift from what the user sees: folder tree
+  // order, collapsed folders (children absent), filters, flat view and board
+  // columns all fall out of document order for free. Every session row is
+  // stamped data-session-row={key} in exactly one place (renderSessionRow);
+  // history rows use a separate renderer and are never captured. The no-deps
+  // effect runs after every commit but is double-guarded: setState bails on
+  // an order-identical array, and an empty read (sidebar collapsed, or a
+  // filter matching nothing) keeps the last-known order. For an unmounted
+  // sidebar that preserves the pre-existing behavior; for a rendered sidebar
+  // whose filter matches nothing it is a deliberate change from the old
+  // memo (which published the empty list, falling back to store order) —
+  // stale keys are dropped by both consumers, while backend insertion order
+  // would be actively wrong.
+  const [shortcutOrderKeys, setShortcutOrderKeys] = useState<string[]>([])
+  useEffect(() => {
+    const root = sidebarRootRef.current
+    if (!root) return
+    const rawKeys = Array.from(root.querySelectorAll(SESSION_ROW_SELECTOR))
+      // A row inside a collapsed folder stays MOUNTED (FolderBody animates
+      // height rather than unmounting) but is marked aria-hidden + inert —
+      // the component's own visibility contract. Rows a user cannot see or
+      // click must not be digit targets; the jump handler appends them after
+      // the published list so cycling still reaches them. [inert] alone is
+      // the canonical "hidden row" spelling (matching sessionRowsInScope);
+      // FolderBody always sets it together with aria-hidden.
+      .filter(el => !el.closest('[inert]'))
+      .map(el => el.getAttribute('data-session-row') ?? '')
+      .filter(Boolean)
+    // Board view renders a multi-tag session once per matching column, so the
+    // same key can appear several times in document order. Dedupe to FIRST
+    // occurrence: the jump handler (orderSlotsBySidebar) already collapses to
+    // first-wins, and the badge map must number the same list or a duplicated
+    // row's badge and its digit's target drift apart.
+    const keys = Array.from(new Set(rawKeys))
+    if (keys.length === 0) return
+    setShortcutOrderKeys(prev =>
+      prev.length === keys.length && prev.every((v, i) => v === keys[i]) ? prev : keys,
+    )
+  })
   // Freeze the shortcut order while the jump modifier is held. Under a
   // last-activity sort, background agent events (touchSlotActivity recency
   // bumps) re-sort the list at any moment; without the freeze, the digits

--- a/website/src/test/ChatSidebar.boardDuplicate.test.tsx
+++ b/website/src/test/ChatSidebar.boardDuplicate.test.tsx
@@ -78,6 +78,7 @@ const REVIEW = '22222222-2222-2222-2222-222222222222'
 const COL_PLANNED_BLOCKED = 'col-aaaa'
 const COL_REVIEW = 'col-bbbb'
 const SLOT_KEY = 'chat-cdf-1'
+const SINGLE_KEY = 'chat-single-2'
 
 const tags: ChatTag[] = [
   { id: BLOCKED, name: 'Blocked', color: '#e11', order: 0, status: true },
@@ -96,35 +97,40 @@ const dualTagSlot = {
   running: false, tags: [BLOCKED, REVIEW], created: '', last_ts: '',
 }
 
-function renderSidebar(activeSlot: string | null = null, opts: { foldered?: boolean } = {}) {
+function renderSidebar(activeSlot: string | null = null, opts: { foldered?: boolean; extraSlot?: boolean } = {}) {
   // Foldered: put the slot in a folder that exists in both columns, so each
   // column renders the slot via the renderColumnFolder path (scope
   // `${columnId}:${folder.id}`) instead of the ungrouped path (scope col.id).
   const slot = opts.foldered ? { ...dualTagSlot, folder_id: FOLDER_ID } : dualTagSlot
+  // extraSlot: a second, single-tag session that renders exactly once, so a
+  // test can observe digit assignment AFTER the duplicated session.
+  const slots = opts.extraSlot
+    ? [slot, { key: SINGLE_KEY, title: 'Single Tag', running: false, tags: [REVIEW], created: '', last_ts: '' }]
+    : [slot]
   const folders: ChatFolder[] = opts.foldered
     ? [{ id: FOLDER_ID, name: 'CDF', order: 0 }]
     : []
   const store = createTestStore({
     dashboard: {
-      status: {}, connected: false, slots: [slot], approvalMode: 'normal',
+      status: {}, connected: false, slots, approvalMode: 'normal',
       channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
       subagentRunning: {}, subagentDetails: {}, subagentText: {},
       sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
     } as RootState['dashboard'],
     chat: { activeSlot } as RootState['chat'],
   })
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
   // Seed board config directly so no api round-trip is needed.
   qc.setQueryData(['chat-tags'], tags)
   qc.setQueryData(['tag-columns'], columns)
   qc.setQueryData(['chat-folders'], folders)
-  return render(
+  const result = render(
     <QueryClientProvider client={qc}>
       <Provider store={store}>
         <ThemeProvider>
           <MemoryRouter>
             <ChatSidebar
-              slots={[slot]} activeSlot={activeSlot} unreadSlots={[]}
+              slots={slots} activeSlot={activeSlot} unreadSlots={[]}
               history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
             />
           </MemoryRouter>
@@ -132,6 +138,7 @@ function renderSidebar(activeSlot: string | null = null, opts: { foldered?: bool
       </Provider>
     </QueryClientProvider>,
   )
+  return { ...result, store }
 }
 
 beforeEach(() => localStorage.clear())
@@ -182,5 +189,30 @@ describe('multi-tag session in two columns', () => {
       const row = copy.querySelector('.session-row')
       expect(row?.className).toContain('session-active')
     }
+  })
+
+  it('dedupes the duplicated key in the published shortcut order and keeps digit badges compact', async () => {
+    const { container, store } = renderSidebar(null, { extraSlot: true })
+    const { act, fireEvent } = await import('@testing-library/react')
+    // Flush post-mount effects; staleTime: Infinity keeps the seeded board
+    // config from being clobbered by the mocked api's empty refetch.
+    await act(async () => {})
+    // Precondition: the dual-tag session really renders twice in document order.
+    expect(container.querySelectorAll(`[data-session-row="${SLOT_KEY}"]`)).toHaveLength(2)
+    // The published order must carry each key ONCE, first occurrence winning —
+    // matching orderSlotsBySidebar's first-wins collapse in the jump handler.
+    expect(store.getState().dashboard.sidebarOrder).toEqual([SLOT_KEY, SINGLE_KEY])
+    // Badges: hold the modifier — the single-tag session must badge "2", not
+    // "3". Pre-fix, the duplicate burned a digit (set(k,1) then set(k,2)),
+    // numbering the single-tag row 3 while the handler's digit 2 targeted it.
+    act(() => { fireEvent.keyDown(window, { altKey: true, location: 1 }) })
+    const badges = Array.from(container.querySelectorAll('[data-testid="digit-jump-badge"]'))
+    const byRowKey = new Map(
+      badges.map(b => [b.closest('[data-session-row]')?.getAttribute('data-session-row'), b.textContent]),
+    )
+    expect(byRowKey.get(SINGLE_KEY)).toBe('2')
+    // Both rendered copies of the dual-tag session badge as 1 (map is keyed
+    // by session, so every copy shows the same digit).
+    expect(byRowKey.get(SLOT_KEY)).toBe('1')
   })
 })

--- a/website/src/test/ChatSidebar.digitBadges.test.tsx
+++ b/website/src/test/ChatSidebar.digitBadges.test.tsx
@@ -129,6 +129,37 @@ describe('chat sidebar — published shortcut order', () => {
     const { store } = renderSidebar()
     expect(store.getState().dashboard.sidebarOrder).toEqual(['k-oldest', 'k-middle', 'k-newest'])
   })
+
+  it('tree view: publishes the RENDERED order (folder children first, ungrouped after), not the pinned+sort list', () => {
+    // Under date-desc the pinned+sort list is [k-b, k-c, k-a], but the tree
+    // renders folder Alpha's children first (k-c, k-a in sort order within
+    // the folder) and the ungrouped k-b below the folders. Digit 1 must hit
+    // the row the user sees at the top: k-c.
+    const { store } = renderSidebar(
+      [
+        { key: 'k-a', title: 'A', messages: 1, running: false, modified: 1000, folder_id: 'f1' },
+        { key: 'k-b', title: 'B', messages: 1, running: false, modified: 3000 },
+        { key: 'k-c', title: 'C', messages: 1, running: false, modified: 2000, folder_id: 'f1' },
+      ],
+      [{ id: 'f1', name: 'Alpha', order: 0 }] as ChatFolder[],
+    )
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-c', 'k-a', 'k-b'])
+  })
+
+  it('tree view: a collapsed folder\'s sessions drop out of the published order', () => {
+    // Collapsed children are not rendered, so they cannot be digit targets —
+    // the jump handler appends them after the published list for cycling,
+    // but digits 1..9 belong to visible rows only.
+    const { store } = renderSidebar(
+      [
+        { key: 'k-a', title: 'A', messages: 1, running: false, modified: 1000, folder_id: 'f1' },
+        { key: 'k-b', title: 'B', messages: 1, running: false, modified: 3000 },
+        { key: 'k-c', title: 'C', messages: 1, running: false, modified: 2000, folder_id: 'f1' },
+      ],
+      [{ id: 'f1', name: 'Alpha', order: 0, collapsed: true }] as ChatFolder[],
+    )
+    expect(store.getState().dashboard.sidebarOrder).toEqual(['k-b'])
+  })
 })
 
 describe('chat sidebar — held-modifier digit badges', () => {


### PR DESCRIPTION
## Problem / Motivation

In the standard folder-tree view, Ctrl/Alt+digit still did not follow the sidebar's visual top-to-bottom order. The published shortcut order was `filteredSlots` (pinned-first + user sort) for every non-flat view, but the tree renders folder children first and ungrouped sessions after — so digit 1 could target a row visually mid-list. This was the deliberately deferred scope of #4737, now hit in real use.

## Why it matters

The whole point of the digit shortcuts (#4727) is "press N for the Nth row you see". In the default view — folder tree — the mapping was wrong whenever any session lived in a folder, which is the common case.

## What changed

Instead of re-deriving each lane's composition (folder tree walk, collapse state, filters — logic that would drift from the render), the published order is now read back from the DOM after every commit: every session row is stamped `data-session-row` in exactly one place (`renderSessionRow`), so document order IS the visual order for every view — tree, flat, and board columns. Rows inside a collapsed folder stay mounted but sit in an `aria-hidden`/`inert` `FolderBody`, so they are filtered out — invisible rows cannot be digit targets, while the jump handler still appends them for cycling. The effect is double-guarded (order-identical bail + empty-read keeps last-known order). One declared behavior change rides on the empty-read guard: with the sidebar rendered but a filter matching nothing, digits now keep the last-seen visual order instead of the old memo's fall-through to backend store order — stale keys are dropped by both consumers, while store insertion order would be actively wrong and composes unchanged with the held-modifier freeze from #4773.

## Tests

- New: tree view publishes the rendered order (folder children, then ungrouped) rather than the pinned+sort list — fails on the pre-change memo (mutation-proven).
- New: a collapsed folder's sessions drop out of the published order — also mutation-proven.
- All prior publish/freeze/badge/compaction tests unchanged and green: 115 tests across 6 suites (`digitBadges`, `useKeyboardShortcuts`, `arrowNav`, `flatView`, `boardOverlayPortal`, `createMenu`).

## Manual verification

Verified on a live gateway: folder view with foldered + ungrouped sessions, held-modifier badges number top-to-bottom and digits pick the badged rows; collapsing a folder renumbers past it.

## Screenshots

Deferred with #4773's captures — both PRs' evidence comes from the same Playwright pass (pending a dashboard token only the operator can mint). There IS a visual delta (badge digit placement in tree view), so no waiver marker is used.

Stacked on #4773 (`feat/sidebar-order-freeze-held`); retargets to `main` when it merges.

Closes #4737

