### PR TITLE
fix(slack): rebind the auto-title lock when the event loop changes (#4789)

### DIFF
--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -4162,13 +4162,21 @@ async def handle_message(
 # ── Slack thread auto-title ─────────────────────────────────────────────
 
 _auto_title_lock: asyncio.Lock | None = None
+_auto_title_lock_loop: asyncio.AbstractEventLoop | None = None
 
 
 def _get_auto_title_lock() -> asyncio.Lock:
-    """Lazily create the lock inside a running event loop."""
-    global _auto_title_lock
-    if _auto_title_lock is None:
+    """Return an auto-title lock bound to the current event loop (Python 3.10 compat).
+
+    Lazily created inside a running loop, and rebound when the running loop
+    changes: a cached ``asyncio.Lock`` raises ``RuntimeError`` when acquired
+    from a different loop than the one it was first used on.
+    """
+    global _auto_title_lock, _auto_title_lock_loop
+    loop = asyncio.get_running_loop()
+    if _auto_title_lock is None or _auto_title_lock_loop is not loop:
         _auto_title_lock = asyncio.Lock()
+        _auto_title_lock_loop = loop
     return _auto_title_lock
 
 

--- a/test/test_slack_handler_more_coverage.py
+++ b/test/test_slack_handler_more_coverage.py
@@ -603,6 +603,51 @@ class TestAutoTitleToolRejection:
         assert "slack:t2" not in h._titled_threads
         assert not [a for a in slack.actions if a[0] == "set_thread_title"]
 
+    def test_lock_is_rebound_when_the_event_loop_changes(self):
+        """Regression for #4789: the module-global auto-title lock must be
+        rebound when the running event loop changes.
+
+        ``pytest-asyncio`` gives every async test a fresh loop, and on
+        Python 3.10+ acquiring an ``asyncio.Lock`` from a loop other than the
+        one it was first used on raises ``RuntimeError`` — which the bare
+        ``except Exception:`` in ``_maybe_auto_title_slack`` then swallowed,
+        silently skipping the permission-rejection branch. Prove the contract
+        deterministically with two distinct loops instead of replaying the
+        order-dependent CI flake.
+        """
+
+        def _run_once(session_key: str):
+            provider = FakeProvider(
+                [
+                    AcpEvent(kind=EVENT_PERMISSION_REQUEST, request_id="rq1", title="Bash"),
+                    AcpEvent(kind=EVENT_TEXT_CHUNK, text="Deploy plan review"),
+                    AcpEvent(kind=EVENT_COMPLETE),
+                ]
+            )
+            slack = MockSlackClient()
+
+            async def _go():
+                # Touch the lock on this loop first, then run the real path.
+                lock = h._get_auto_title_lock()
+                await h._maybe_auto_title_slack(
+                    slack, _TitleSessions(provider), "C1", session_key, None, "u", "a"
+                )
+                return lock
+
+            return asyncio.run(_go()), provider, slack
+
+        lock1, provider1, _ = _run_once("slack:loop1")
+        lock2, provider2, slack2 = _run_once("slack:loop2")
+
+        # The second, distinct loop must get a fresh lock object…
+        assert lock2 is not lock1
+        # …and the real path must still work there: the rejection is recorded
+        # (this was the exact assertion the flake broke) and the title lands.
+        assert provider1.rejected == ["rq1"]
+        assert provider2.rejected == ["rq1"]
+        titles = [a for a in slack2.actions if a[0] == "set_thread_title"]
+        assert titles and titles[0][1]["title"] == "Deploy plan review"
+
 
 # ──────────────────────────────────────────────────────────────────────
 # handle_interaction — defence-in-depth re-checks


### PR DESCRIPTION
## Summary

Fixes the third Slack-handler CI flake class (split from #4177): `TestAutoTitleToolRejection::test_permission_request_is_rejected_and_title_still_set` failing with `assert [] == ['rq1']` on PRs whose diff touches zero Python source.

**Root cause.** `src/kiro_crew/slack/handler.py` caches a module-global `_auto_title_lock` with no event-loop tracking. `pytest-asyncio` gives every async test a fresh loop, and on Python 3.10+ `asyncio.Lock.acquire()` raises `RuntimeError` when the running loop differs from the one captured at first use. The bare `except Exception:` wrapping `_maybe_auto_title_slack` swallowed that error at debug level, so the second test to reach the path in an xdist worker silently skipped both the titling and the permission-rejection branch. Order-dependent, not time-dependent — which is why it fired on unrelated PRs and took `Coverage Gate` → `PR Readiness` down with it.

**Fix.** Mirror the existing `_get_config_lock` rebind pattern from `dashboard/handlers/agents.py`: track the binding loop in a companion `_auto_title_lock_loop` global and rebind the lock when `asyncio.get_running_loop()` changes.

## Verification

- Verified by a **deterministic cross-loop regression test** (two successive `asyncio.run` loops in one test; asserts the lock object is rebound AND the rejection is recorded on the second loop), not by replaying the order-dependent CI flake. The test was confirmed to FAIL against the pre-fix code and PASS after.
- `pytest test/test_slack_handler_more_coverage.py` (56 passed) and the file + `test_slack_handler_coverage_branches.py` under xdist `-n 4` (108 passed).
- Full local gates: isort / flake8 / mypy (repo-pinned versions) / black baseline gate / full pytest (58,890 passed; 7 failures reproduced identically on pristine main — environmental, none in Slack handler files).

## Scope

Deliberately **not** bundled here, deferred to follow-up #4800: narrowing the bare `except Exception:` that masked this failure for three flake classes, and ~40 sibling module-global `asyncio.Lock` instances lacking loop tracking.

No UI change, so no screenshots are required.

Closes #4789
