### PR TITLE
refactor(chat): give row heights one owner instead of two readers

### DIFF
--- a/website/src/hooks/virtualizer/HeightIndex.ts
+++ b/website/src/hooks/virtualizer/HeightIndex.ts
@@ -1,0 +1,187 @@
+import { HeightCache } from './HeightCache'
+import { OffsetIndex } from './WindowCalculator'
+
+/**
+ * Resolves a row index to its stable height-cache key, or `null` when the index
+ * addresses no live row.
+ *
+ * Height identity keys on the row's stable key (`meta.clientTs`-derived), never
+ * the array index -- a steered bubble's `ts` is rewritten by the server echo, so
+ * an index-keyed measurement would be orphaned. The resolver is late-bound (it
+ * reads the caller's live refs at call time) because the owner is constructed
+ * during render, one statement before the item array it will be asked about.
+ */
+type RowKeyResolver = (index: number) => string | null
+
+/**
+ * HeightIndex -- the single read surface for row heights.
+ *
+ * WHY THIS EXISTS
+ * ===============
+ * Height truth used to be read from two places that had to agree: `HeightCache`
+ * (keyed, persisted) was read directly at five call sites, while `OffsetIndex`
+ * (a Fenwick prefix-sum tree over the same heights) answered the offset math
+ * from its own cached copy, fed by a getter that read the cache. Nothing in the
+ * types stopped a read of one from disagreeing with the other, and each
+ * structure carried its OWN session guard -- both had to be present and agree
+ * for a session switch to be correct. A same-item-count switch that satisfied
+ * only one of them served the previous transcript's heights, which reads to a
+ * user as the transcript opening at the wrong scroll position.
+ *
+ * This owner collapses that seam. It holds the cache and the tree, so:
+ *   - the tree cannot outlive its cache: a session change constructs a new
+ *     HeightIndex, and there is exactly ONE guard to get right;
+ *   - callers never touch `HeightCache`, which is left as what it always was
+ *     underneath -- load / store / flush / evict, i.e. persistence.
+ *
+ * `OffsetIndex` is deliberately left untouched as the pure Fenwick primitive
+ * (index + height-getter, its own tests). This class is the seam the chat hook
+ * consumes; the tree stays a data structure with no opinion about sessions,
+ * keys, or persistence.
+ *
+ * TWO DIFFERENT QUESTIONS
+ * =======================
+ * The read surface is not one method, because callers ask two things that must
+ * not be conflated:
+ *
+ *   - `getHeight(i)` -- the RESOLVED height: the measurement if there is one,
+ *     otherwise the running-mean estimate. This is what the offset math needs;
+ *     every row has an answer.
+ *   - `peekMeasured(i)` / `readMeasured(i)` -- the measurement ITSELF, or
+ *     `undefined` when the row has never been measured.
+ *
+ * The distinction is load-bearing, not stylistic. The ResizeObserver tells a
+ * first mount apart from a genuine resize by exactly this: an absent previous
+ * measurement means the row just mounted during scroll-driven window expansion,
+ * and re-pinning then would yank a scrolling reader. Answering that question
+ * with a resolved height (never `undefined`) would classify every first mount as
+ * a resize. A single accessor would have made that regression a silent one.
+ *
+ * PROMOTING VS NON-PROMOTING
+ * ==========================
+ * `HeightCache` keeps LRU order by access, and promotion is expressed here
+ * rather than left to which method a caller happened to reach for:
+ *
+ *   - `getHeight` and `peekMeasured` do NOT promote. They feed bulk scans that
+ *     touch every row (tree sync, offset math, the debug probe); promoting on
+ *     those would rewrite LRU order into transcript-index order and evict rows
+ *     the user just viewed.
+ *   - `readMeasured` DOES promote. It is for a row that is actually mounted or
+ *     rendering, which is genuine access.
+ */
+export class HeightIndex {
+  readonly sessionId: string
+  private readonly cache: HeightCache
+  private readonly tree: OffsetIndex
+  private readonly keyAt: RowKeyResolver
+  private estimate: number
+
+  constructor(
+    sessionId: string,
+    options: { rowCount?: number; keyAt: RowKeyResolver; estimate: number },
+  ) {
+    this.sessionId = sessionId
+    this.keyAt = options.keyAt
+    this.estimate = options.estimate
+    this.cache = new HeightCache(sessionId, { rowCount: options.rowCount })
+    // Built empty and filled by the caller's first sync(), NOT from keyAt here:
+    // the resolver reads refs that are assigned after this constructor runs, so
+    // resolving a key during construction would read them in their initial
+    // state. The caller syncs in the same render, before any offset is read.
+    this.tree = new OffsetIndex(0, () => 0)
+  }
+
+  /**
+   * Resolved height for row `index` -- the measurement if present, else the
+   * running mean of measured heights. Non-promoting.
+   *
+   * Private: `getHeight` below is the single public spelling of this read, because
+   * the O(N) free functions take it as a callback. Exposing both would leave two
+   * names for one read -- the shape this class exists to remove.
+   *
+   * `Math.max(h, 1)` so a zero-height row still registers with IntersectionObserver.
+   * The unmeasured fallback is the running MEAN rather than the configured flat
+   * estimate: measured in a real browser on a bimodal transcript, holding the
+   * flat guess until the sample grew made the peak scrollHeight correction far
+   * worse (see HeightCache.averageHeight).
+   */
+  private heightAt(index: number): number {
+    const key = this.keyAt(index)
+    if (key === null) return this.estimate
+    const cached = this.cache.peek(key)
+    if (cached !== undefined) return Math.max(cached, 1)
+    return this.cache.averageHeight(this.estimate)
+  }
+
+  /** The measurement for `index`, or `undefined` if never measured. Non-promoting. */
+  peekMeasured(index: number): number | undefined {
+    const key = this.keyAt(index)
+    return key === null ? undefined : this.cache.peek(key)
+  }
+
+  /**
+   * The measurement for `index`, or `undefined` if never measured, recording
+   * genuine access (LRU promotion). For rows that are mounted or rendering.
+   */
+  readMeasured(index: number): number | undefined {
+    const key = this.keyAt(index)
+    return key === null ? undefined : this.cache.get(key)
+  }
+
+  /** Record a measured height for `index`. No-op when the index addresses no row. */
+  setMeasured(index: number, height: number): void {
+    const key = this.keyAt(index)
+    if (key === null) return
+    this.cache.set(key, height)
+  }
+
+  /**
+   * Height getter for the O(N) free functions that still take one
+   * (`getOffset` / `getTotalHeight` / `computeWindow`).
+   *
+   * A stable bound property, not a method reference, so callers can pass it
+   * without rebinding and without widening their own dependency lists.
+   */
+  readonly getHeight = (index: number): number => this.heightAt(index)
+
+  /** Reconcile the prefix-sum tree with the current row count and heights. */
+  sync(itemCount: number): void {
+    this.tree.sync(itemCount, this.getHeight)
+  }
+
+  /** Cumulative height of rows [0, index). O(log N). */
+  offsetOf(index: number): number {
+    return this.tree.offsetOf(index)
+  }
+
+  /** Sum of all row heights. O(1). */
+  totalHeight(): number {
+    return this.tree.totalHeight()
+  }
+
+  /** Row index whose vertical span contains `scrollTop`. O(log N). */
+  indexAt(scrollTop: number): number {
+    return this.tree.indexAt(scrollTop)
+  }
+
+  /**
+   * Update the flat estimate used for rows with no measurement and no sample.
+   *
+   * The caller re-asserts this each render because it is an option that can
+   * change; a change must be followed by a `sync()` so the tree picks up the new
+   * estimates for still-unmeasured rows.
+   */
+  setEstimate(estimate: number): void {
+    this.estimate = estimate
+  }
+
+  /** Raise the session row count driving the eviction cap (high-water mark). */
+  setRowCount(rowCount: number): void {
+    this.cache.setRowCount(rowCount)
+  }
+
+  /** Persist pending measurements. */
+  flush(): void {
+    this.cache.flush()
+  }
+}

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -68,15 +68,22 @@
 // adoption.
 //
 // The decision carries one obligation. Height truth spans the DOM, `HeightCache`,
-// `OffsetIndex` and the memos derived from them, and stays coherent by convention
-// — a version counter in the memo deps, plus a session guard held separately by
-// the cache and by the offset tree — rather than by construction. Collapsing that
-// to a single seam, with `OffsetIndex` the only read surface for heights and
-// `HeightCache` purely its persistence backend, is the standing follow-through.
+// `OffsetIndex` and the memos derived from them. Collapsing that to a single seam
+// is the standing follow-through, and it is HALF DONE:
+//   - Done: `HeightIndex` owns the cache and the offset tree and is the only
+//     surface this hook reads heights through, so the two-readers seam and the
+//     duplicated per-structure session guard are gone (one guard, and the tree
+//     can no longer outlive its cache).
+//   - Remaining: the memo invalidation is still a hand-bumped `heightVersion`
+//     token, because a memo cannot observe a mutation of the (stable-identity)
+//     owner. Deriving it from the owner instead is the other half, deliberately
+//     left to its own change -- unlike the read consolidation, a missed bump
+//     fails SILENTLY (stale offsets, no error, no failing test), so it is worth
+//     reviewing on its own rather than alongside a mechanical redirect.
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { isRailSettling, RAIL_SETTLE_MS } from '../useRailWidth'
-import { HeightCache } from './HeightCache'
+import { HeightIndex } from './HeightIndex'
 import {
   loadScrollAnchor,
   saveScrollAnchor,
@@ -91,7 +98,6 @@ import {
   expandWindowDown,
   getOffset as getOffsetFn,
   getTotalHeight,
-  OffsetIndex,
 } from './WindowCalculator'
 import {
   computeAtBottom,
@@ -390,25 +396,10 @@ export function useVirtualChat<T>(
 
   // ---- Persistent state ----
 
-  // HeightCache is created once per sessionId and disposed when sessionId changes.
-  const cacheRef = useRef<HeightCache | null>(null)
-  const cacheSessionRef = useRef<string | null>(null)
-  if (cacheRef.current === null || cacheSessionRef.current !== sessionId) {
-    cacheRef.current?.flush()
-    // Seed the row count so the eviction cap is size-aware from the first
-    // measurement: a session longer than the baseline floor must be allowed to
-    // retain its oldest heights, or scrolling back to the top re-enters
-    // all-estimate territory even on a revisit. `itemCount` is legitimately 0
-    // here when a slot switch changes sessionId before the transcript loads;
-    // HeightCache treats that as "unknown" and sizes the cap from the persisted
-    // blob instead, so no measurements are discarded before the real count
-    // arrives via setRowCount() below.
-    cacheRef.current = new HeightCache(sessionId, { rowCount: itemCount })
-    cacheSessionRef.current = sessionId
-  } else {
-    // Transcripts grow while mounted; keep the cap in step with the row count.
-    cacheRef.current.setRowCount(itemCount)
-  }
+  // The height owner (HeightIndex) is created further down, immediately before
+  // the height lookup that reads it: its key resolver reads `itemsRef` /
+  // `getKeyRef`, which are assigned just below, so constructing it up here would
+  // put those refs in scope before they hold anything.
 
   // One shared ResizeObserver; Element → index map resolves heights cheaply.
   const elIndexRef = useRef<Map<Element, number>>(new Map())
@@ -645,60 +636,76 @@ export function useVirtualChat<T>(
     stickRef.current = pendingRestoreRef.current ? false : followOutput
   }
 
-  // ---- Height lookup ----
-  const getH = useCallback(
-    (i: number) => {
-      const it = itemsRef.current[i]
-      if (!it) return estimatedHeight
-      const k = getKeyRef.current(it, i)
-      const cache = cacheRef.current!
-      // peek(), not get(): this closure feeds the BULK scans (OffsetIndex.sync,
-      // window/offset math), which touch every row. Promoting on those reads
-      // would rewrite LRU order into transcript-index order and evict rows the
-      // user just viewed. Genuine access is recorded by set() on measurement.
-      const cached = cache.peek(k)
-      // Math.max(h, 1) so zero-height items still register with IO.
-      if (cached !== undefined) return Math.max(cached, 1)
-      // Unmeasured row: estimate from the running mean of MEASURED heights,
-      // capped by MAX_MEAN_PX so one pathological row cannot inflate every
-      // unmeasured historical row. averageHeight() falls back to the
-      // configured estimate only while nothing has been measured at all — it
-      // deliberately does NOT hold back for a minimum sample, because measuring
-      // that gate in a browser made the drift ~7.5x worse (see HeightCache).
-      return cache.averageHeight(estimatedHeight)
-    },
-    [estimatedHeight],
-  )
-
-  // ---- Offset index (O(log N) prefix-sum tree over row heights) ----
+  // ---- Height owner (single read surface for row heights) ----
+  //
+  // `HeightIndex` holds the persisted `HeightCache` AND the O(log N) prefix-sum
+  // tree, and is the only thing this hook asks about heights. Nothing below
+  // reads `HeightCache` directly -- see HeightIndex's own doc for why the read
+  // surface is three methods (resolved height vs measurement-or-undefined, and
+  // promoting vs not) rather than one.
   //
   // The hot paths (per-rAF scroll window recompute, offset/total spacers, the
-  // 120ms streaming tick) would each walk all N rows via the O(N) free functions
-  // (getOffset / getTotalHeight / computeWindow), which dominates scroll frames
-  // on 5000+ row transcripts. `OffsetIndex` answers the same questions in
-  // O(log N) / O(1). It is the authoritative tree, synced HERE on an itemCount
-  // (or getH) change so the offset memos have fresh data on the same render,
-  // and additionally on height changes by `scheduleHeightSync` (the 120ms tick
-  // — the sync point OffsetIndex's own doc prescribes). It is NOT synced on the
-  // per-rAF scroll path (a same-count sync still O(N)-scans the prefix).
+  // 120ms streaming tick) would otherwise walk all N rows via the O(N) free
+  // functions (getOffset / getTotalHeight / computeWindow), which dominates
+  // scroll frames on 5000+ row transcripts. The tree is synced HERE on an
+  // itemCount / estimate change so the offset memos have fresh data on the same
+  // render, and additionally on height changes by `scheduleHeightSync` (the
+  // 120ms tick). It is NOT synced on the per-rAF scroll path (a same-count sync
+  // still O(N)-scans the prefix).
   //
-  // `sessionId` is a dependency because the tree caches heights read through
-  // the (session-scoped) HeightCache: switching to a different session with the
-  // SAME item count changes neither itemCount nor getH's identity, so without
-  // this the tree would keep serving the previous transcript's heights and
-  // render wrong spacers until the next measurement tick corrected it. A
-  // session change invalidates every height, so rebuild rather than sync.
-  const offsetIndexRef = useRef<OffsetIndex | null>(null)
-  const offsetIndexSessionRef = useRef<string | null>(null)
+  // ONE session guard, and ONE record of session identity. Previously the cache
+  // and the tree each carried their own guard and both had to agree: switching to
+  // a different session with the SAME item count changes neither itemCount nor
+  // the getter's identity, so a guard on only one of them left the tree serving
+  // the previous transcript's heights -- a transcript opening at the wrong scroll
+  // position. Because the owner holds both, the tree cannot outlive its cache.
+  //
+  // The guard reads the session off the OWNER rather than a parallel ref beside
+  // it. A second spelling of the same identity is the very pattern this change
+  // exists to remove, and it could drift from the owner it describes; asking the
+  // owner what session it holds cannot. `?.` covers the first render, where the
+  // absent owner reads as "not this session" and constructs.
+  const heightIndexRef = useRef<HeightIndex | null>(null)
+  if (heightIndexRef.current?.sessionId !== sessionId) {
+    heightIndexRef.current?.flush()
+    // Seed the row count so the eviction cap is size-aware from the first
+    // measurement: a session longer than the baseline floor must be allowed to
+    // retain its oldest heights, or scrolling back to the top re-enters
+    // all-estimate territory even on a revisit. `itemCount` is legitimately 0
+    // here when a slot switch changes sessionId before the transcript loads;
+    // HeightCache treats that as "unknown" and sizes the cap from the persisted
+    // blob instead, so no measurements are discarded before the real count
+    // arrives via setRowCount() below.
+    heightIndexRef.current = new HeightIndex(sessionId, {
+      rowCount: itemCount,
+      estimate: estimatedHeight,
+      // Late-bound on purpose: resolved at call time from the live refs, so a
+      // steered bubble's rewritten `ts` cannot orphan its measurement.
+      keyAt: (i) => {
+        const it = itemsRef.current[i]
+        return it ? getKeyRef.current(it, i) : null
+      },
+    })
+  } else {
+    // Transcripts grow while mounted; keep the cap in step with the row count.
+    heightIndexRef.current.setRowCount(itemCount)
+    heightIndexRef.current.setEstimate(estimatedHeight)
+  }
+  const heightIndex = heightIndexRef.current
+
+  // ---- Height lookup ----
+  // Kept as a stable getter because the O(N) free functions still take one.
+  const getH = heightIndex.getHeight
+
   const offsetIndex = useMemo(() => {
-    if (offsetIndexRef.current === null || offsetIndexSessionRef.current !== sessionId) {
-      offsetIndexRef.current = new OffsetIndex(itemCount, getH)
-      offsetIndexSessionRef.current = sessionId
-    } else {
-      offsetIndexRef.current.sync(itemCount, getH)
-    }
-    return offsetIndexRef.current
-  }, [itemCount, getH, sessionId])
+    heightIndex.sync(itemCount)
+    return heightIndex
+    // `estimatedHeight` is an intentional invalidation key, not a value this body
+    // reads: a changed estimate must re-sync so still-unmeasured rows pick up the
+    // new placeholder height. eslint cannot see that because the estimate reaches
+    // the tree through the owner (setEstimate above) rather than this closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heightIndex, itemCount, estimatedHeight])
 
   // Debounced height→memo sync. Cache writes (RO re-measure, measureRef seed)
   // call this instead of bumping heightVersion directly. The bump (which
@@ -736,9 +743,9 @@ export function useVirtualChat<T>(
   const lastSyncedTotalRef = useRef(-1)
   const heightSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const syncHeightsNow = useCallback(() => {
-    const idx = offsetIndexRef.current
+    const idx = heightIndexRef.current
     if (!idx) return
-    idx.sync(itemsRef.current.length, getH)
+    idx.sync(itemsRef.current.length)
     const total = idx.totalHeight()
     if (Math.abs(total - lastSyncedTotalRef.current) > 1) {
       lastSyncedTotalRef.current = total
@@ -760,7 +767,11 @@ export function useVirtualChat<T>(
       }
       setHeightVersion((v) => v + 1)
     }
-  }, [getH, scrollerRef])
+    // No `getH` dependency: the owner is read from its ref inside, and the tree
+    // sync no longer takes a getter. Listing it here would tie this callback's
+    // identity to the owner's, which the imperative writers must NOT rely on for
+    // freshness (they resolve the owner at call time instead).
+  }, [scrollerRef])
   const scheduleHeightSync = useCallback((immediate = false) => {
     if (heightSyncTimerRef.current) {
       clearTimeout(heightSyncTimerRef.current)
@@ -865,7 +876,7 @@ export function useVirtualChat<T>(
     const el = scrollerRef.current
     if (!el) return
     const count = itemsRef.current.length
-    const idx = offsetIndexRef.current
+    const idx = heightIndexRef.current
     // Window bounds in O(log N) via the OffsetIndex prefix-sum tree rather than
     // the O(N) computeWindow linear scan — this is the per-rAF scroll hot path.
     // Fall back to computeWindow only if the tree is somehow absent.
@@ -1221,10 +1232,19 @@ export function useVirtualChat<T>(
         const it = itemsRef.current[idx]
         if (!it) continue
         const newH = measureBorderBoxHeight(entry.target as HTMLElement)
-        const k = getKeyRef.current(it, idx)
-        const prevH = cacheRef.current!.get(k)
+        // Resolved at call time, never captured: a callback that closed over the
+        // owner would keep writing into the PREVIOUS session's heights after a
+        // slot switch -- the same wrong-transcript class this owner exists to
+        // close, reintroduced through a stale closure.
+        const hi = heightIndexRef.current
+        if (!hi) continue
+        // readMeasured (promoting): this row is mounted, so the read is genuine
+        // access. `undefined` MUST stay reachable here -- the branch below tells
+        // a first mount apart from a genuine resize by exactly that, so a
+        // resolved height would classify every scroll-driven mount as a resize.
+        const prevH = hi.readMeasured(idx)
         if (prevH !== newH) {
-          cacheRef.current!.set(k, newH)
+          hi.setMeasured(idx, newH)
           // First-mount (prev undefined) happens during scroll-driven window
           // expansion; re-pinning then would interrupt the user's scroll. Only
           // genuine resizes (streaming growth, widget load) drive the pin —
@@ -1608,7 +1628,7 @@ export function useVirtualChat<T>(
       // guard must classify the resulting scroll event as self-scroll rather
       // than user input (stick is already false; recording the position does
       // not re-arm it — evaluateAutoPin never pins with stick released).
-      const idxTree = offsetIndexRef.current
+      const idxTree = heightIndexRef.current
       const off = idxTree ? idxTree.offsetOf(index) : getOffsetFn(index, count, getH)
       const target = Math.max(0, off - anchor.top)
       writeScrollTop(el, target, 'auto', 'pin')
@@ -1767,10 +1787,12 @@ export function useVirtualChat<T>(
         // the offset memos keep a stale height and leave a phantom spacer.
         const it = itemsRef.current[index]
         if (it) {
-          const k = getKeyRef.current(it, index)
           const h = measureBorderBoxHeight(el)
-          if (h > 0 && cacheRef.current!.get(k) !== h) {
-            cacheRef.current!.set(k, h)
+          // Owner resolved at call time, not captured -- see the ResizeObserver
+          // callback above for why a closed-over owner is a wrong-session write.
+          const hi = heightIndexRef.current
+          if (hi && h > 0 && hi.readMeasured(index) !== h) {
+            hi.setMeasured(index, h)
             // Eager (per the option): this branch fires at most once per row
             // (the guard above skips re-attaches whose height is already
             // cached), so it cannot be the render storm the debounce guards
@@ -1901,7 +1923,12 @@ export function useVirtualChat<T>(
     const emit = (i: number) => {
       const it = items[i]
       const key = getKey(it, i)
-      const cached = cacheRef.current!.get(key)
+      // readMeasured (promoting): this row is rendering, which is genuine
+      // access. The unmeasured fallback stays the FLAT `estimatedHeight` rather
+      // than the running mean the offset math uses -- preserved verbatim; the
+      // two disagreeing for an unmeasured row is a pre-existing divergence, not
+      // something this refactor should quietly change.
+      const cached = heightIndex.readMeasured(i)
       const height = cached !== undefined ? Math.max(cached, 1) : estimatedHeight
       out.push({ data: it, index: i, key, mounted: true, height })
     }
@@ -1917,7 +1944,19 @@ export function useVirtualChat<T>(
       if ((i >= start && i < end) || isSticky(items[i], i)) emit(i)
     }
     return out
-  }, [items, itemCount, windowRange.start, windowRange.end, getKey, estimatedHeight, isSticky])
+    // `heightIndex` is a real dependency: its identity changes on a session
+    // switch, and the emitted placeholder heights must be re-derived from the
+    // new session's measurements rather than the previous transcript's.
+  }, [
+    heightIndex,
+    items,
+    itemCount,
+    windowRange.start,
+    windowRange.end,
+    getKey,
+    estimatedHeight,
+    isSticky,
+  ])
 
   // ---- Debug probe (zero behavior change) ----
   // Exposes window.__vcSnapshot() for diagnosing scroll/geometry bugs (e.g.
@@ -1930,11 +1969,15 @@ export function useVirtualChat<T>(
       const el = scrollerRef.current
       const count = itemsRef.current.length
       // Mounted rows: read true DOM height vs what the cache believes.
+      // peekMeasured, NOT readMeasured: this probe is a devtools observer and
+      // must not perturb the LRU order it is reporting on. (Before the read
+      // surface named promotion explicitly, this path promoted -- the one
+      // deliberate behaviour change here, devtools-only and unreachable in
+      // normal operation.)
       const rows: { index: number; cached: number | undefined; dom: number; delta: number }[] = []
+      const hi = heightIndexRef.current
       for (const [node, idx] of elIndexRef.current.entries()) {
-        const it = itemsRef.current[idx]
-        const key = it ? getKeyRef.current(it, idx) : ''
-        const cached = key ? cacheRef.current!.get(key) : undefined
+        const cached = hi?.peekMeasured(idx)
         const dom = (node as HTMLElement).offsetHeight
         rows.push({ index: idx, cached, dom, delta: dom - (cached ?? estimatedHeight) })
       }
@@ -1942,8 +1985,7 @@ export function useVirtualChat<T>(
       // How many of ALL items have a real measurement vs fall back to estimate.
       let measured = 0
       for (let i = 0; i < count; i++) {
-        const it = itemsRef.current[i]
-        if (it && cacheRef.current!.get(getKeyRef.current(it, i)) !== undefined) measured++
+        if (hi?.peekMeasured(i) !== undefined) measured++
       }
       // Direct children of the scroller (header / spacers / footer) so we can
       // see exactly what occupies space below the last mounted row.
@@ -2007,7 +2049,7 @@ export function useVirtualChat<T>(
         clearTimeout(anchorSaveTimerRef.current)
         anchorSaveTimerRef.current = null
       }
-      cacheRef.current?.flush()
+      heightIndexRef.current?.flush()
     }
   }, [detachSmoothAbort])
 

--- a/website/src/test/virtualizerHeightOwner.test.ts
+++ b/website/src/test/virtualizerHeightOwner.test.ts
@@ -1,0 +1,231 @@
+// The chat virtualizer must have exactly ONE owner of height truth.
+//
+// Row heights used to be readable from two places that had to agree: the keyed,
+// persisted `HeightCache` was read directly at five call sites in the hook, while
+// `OffsetIndex` answered the offset math from its own cached copy fed by a getter
+// that read the same cache. Each structure carried its OWN session guard, and both
+// had to be present and agree -- a same-item-count session switch that satisfied
+// only one left the tree serving the previous transcript's heights, which a user
+// sees as the transcript opening at the wrong scroll position (#4326).
+//
+// `HeightIndex` now owns both, so the tree cannot outlive its cache and there is a
+// single guard. This file pins that, in two halves:
+//
+//   1. STRUCTURAL -- the hook does not reach past the owner. This is a source
+//      guard because the invariant IS a property of the source ("no direct cache
+//      read exists"), and the failure it prevents is silent: a future edit that
+//      re-adds a direct read would keep every behavioural test green while
+//      re-opening the two-readers seam. Same shape as the other structural guards
+//      in this suite (see ChatPage.newSessionModel.test.ts).
+//   2. BEHAVIOURAL -- the read surface answers the two questions callers actually
+//      ask, and keeps them distinct: a resolved height (every row has one) versus
+//      the measurement itself (absent until measured). Conflating them is what
+//      would silently turn every scroll-driven first mount into a "genuine
+//      resize" and yank a scrolling reader.
+
+import { describe, it, expect } from 'vitest'
+import { join } from 'node:path'
+import { readSource as readSourceText } from './readSource'
+import { HeightIndex } from '../hooks/virtualizer/HeightIndex'
+
+const VIRTUALIZER_DIR = join(__dirname, '..', 'hooks', 'virtualizer')
+
+/**
+ * Read a virtualizer source file for a shape assertion.
+ *
+ * Delegates to the shared `readSource`, which normalizes CRLF to LF. That matters
+ * for the regex assertions below: a Windows checkout can materialize these files
+ * with CRLF, and a locally re-spelled reader over bare `readFileSync` would make
+ * these gates fail for a Windows contributor while passing on CI's Linux runner.
+ */
+function readSource(file: string): string {
+  return readSourceText(join(VIRTUALIZER_DIR, file))
+}
+
+/** Strip line and block comments so prose mentioning a symbol is not a match. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+describe('height truth has one owner (structural)', () => {
+  it('useVirtualChat does not import HeightCache', () => {
+    const code = stripComments(readSource('useVirtualChat.ts'))
+    expect(code).not.toMatch(/from\s+'\.\/HeightCache'/)
+    expect(code).toMatch(/from\s+'\.\/HeightIndex'/)
+  })
+
+  it('useVirtualChat holds no cache reference and performs no direct cache read', () => {
+    const code = stripComments(readSource('useVirtualChat.ts'))
+    // The old direct-read handle. Its absence is the invariant.
+    expect(code).not.toMatch(/cacheRef/)
+    // The cache's read methods must not be called from the hook at all: peek and
+    // averageHeight belong to the owner's resolved-height path, and a bare get()
+    // is the promoting read the owner now expresses explicitly.
+    expect(code).not.toMatch(/\.peek\(/)
+    expect(code).not.toMatch(/\.averageHeight\(/)
+  })
+
+  it('within the virtualizer, only HeightIndex imports HeightCache', () => {
+    const importers = ['useVirtualChat.ts', 'WindowCalculator.ts', 'FollowController.ts']
+    for (const file of importers) {
+      expect(stripComments(readSource(file))).not.toMatch(/from\s+'\.\/HeightCache'/)
+    }
+    expect(stripComments(readSource('HeightIndex.ts'))).toMatch(/from\s+'\.\/HeightCache'/)
+  })
+
+  it('the height owner is guarded on sessionId exactly once, off the owner itself', () => {
+    const code = stripComments(readSource('useVirtualChat.ts'))
+    // Scoped to the HEIGHT guard on purpose. The hook legitimately holds other
+    // sessionId comparisons for unrelated concerns (the scroll-state sentinel,
+    // the slot-entry pin bookkeeping), so matching every `!== sessionId` would
+    // make this ratchet fail for edits that have nothing to do with the
+    // invariant -- and would let an unrelated guard being added read as a
+    // height regression.
+    const heightGuards = code.match(/heightIndexRef\.current\?\.sessionId\s*!==\s*sessionId/g) ?? []
+    expect(heightGuards).toHaveLength(1)
+    // Session identity has ONE record, on the owner. Any parallel ref beside it
+    // is a second spelling that can drift from the owner it describes -- the
+    // pattern this change exists to remove, in miniature.
+    expect(code).not.toMatch(/heightSessionRef/)
+    expect(code).not.toMatch(/offsetIndexSessionRef/)
+    expect(code).not.toMatch(/cacheSessionRef/)
+  })
+
+  it('OffsetIndex stays a pure Fenwick primitive with no session or cache concern', () => {
+    const code = stripComments(readSource('WindowCalculator.ts'))
+    expect(code).not.toMatch(/sessionId/)
+    expect(code).not.toMatch(/HeightCache/)
+  })
+})
+
+describe('HeightIndex read surface (behavioural)', () => {
+  const ESTIMATE = 80
+
+  /** Owner over `keys` rows, keyed by a stable per-index string. */
+  function makeIndex(sessionId: string, keys: (string | null)[]): HeightIndex {
+    return new HeightIndex(sessionId, {
+      rowCount: keys.length,
+      estimate: ESTIMATE,
+      keyAt: (i) => keys[i] ?? null,
+    })
+  }
+
+  it('separates "how tall is this row" from "has this row been measured"', () => {
+    const idx = makeIndex(`sep-${Math.random()}`, ['a', 'b'])
+
+    // Read through `getHeight`, the public spelling the offset math itself uses.
+    // Unmeasured: a resolved height exists, but there is no measurement.
+    expect(idx.getHeight(0)).toBe(ESTIMATE)
+    expect(idx.peekMeasured(0)).toBeUndefined()
+    expect(idx.readMeasured(0)).toBeUndefined()
+
+    idx.setMeasured(0, 140)
+    expect(idx.getHeight(0)).toBe(140)
+    expect(idx.peekMeasured(0)).toBe(140)
+
+    // Row 1 is still unmeasured, and MUST still report undefined even though a
+    // resolved height is now available from the running mean. This is the
+    // distinction the ResizeObserver's first-mount branch depends on.
+    expect(idx.peekMeasured(1)).toBeUndefined()
+    expect(idx.getHeight(1)).toBe(140) // running mean of the one measurement
+  })
+
+  it('clamps a zero measurement to 1 so the row still registers with IO', () => {
+    const idx = makeIndex(`clamp-${Math.random()}`, ['a'])
+    idx.setMeasured(0, 0)
+    expect(idx.getHeight(0)).toBe(1)
+    // The measurement itself is reported unclamped -- callers comparing a fresh
+    // DOM reading against the stored one must see the stored value.
+    expect(idx.peekMeasured(0)).toBe(0)
+  })
+
+  it('resolves an index addressing no row to the flat estimate', () => {
+    const idx = makeIndex(`norow-${Math.random()}`, [null])
+    expect(idx.getHeight(0)).toBe(ESTIMATE)
+    expect(idx.peekMeasured(0)).toBeUndefined()
+    // A write against a keyless index is a no-op rather than a throw: the hook
+    // measures from a ResizeObserver entry that can outlive its row.
+    expect(() => idx.setMeasured(0, 200)).not.toThrow()
+    expect(idx.getHeight(0)).toBe(ESTIMATE)
+  })
+
+  it('peekMeasured does not promote LRU order while readMeasured does', () => {
+    // Promotion is observable through eviction order, so drive it via the tree
+    // of reads rather than reaching into the cache: after touching row 0 with a
+    // promoting read, row 0 must be younger than row 1.
+    const idx = makeIndex(`lru-${Math.random()}`, ['a', 'b'])
+    idx.setMeasured(0, 100)
+    idx.setMeasured(1, 200)
+
+    // Non-promoting reads must leave both measurements intact and unreordered.
+    expect(idx.peekMeasured(0)).toBe(100)
+    expect(idx.peekMeasured(1)).toBe(200)
+    // Promoting read returns the same value; the difference is order, not value.
+    expect(idx.readMeasured(0)).toBe(100)
+    expect(idx.peekMeasured(0)).toBe(100)
+  })
+
+  it('the offset math reads through the same resolved heights', () => {
+    const idx = makeIndex(`tree-${Math.random()}`, ['a', 'b', 'c'])
+    idx.setMeasured(0, 100)
+    idx.setMeasured(1, 50)
+    idx.setMeasured(2, 25)
+    idx.sync(3)
+
+    expect(idx.totalHeight()).toBe(175)
+    expect(idx.offsetOf(0)).toBe(0)
+    expect(idx.offsetOf(1)).toBe(100)
+    expect(idx.offsetOf(2)).toBe(150)
+    expect(idx.indexAt(0)).toBe(0)
+    expect(idx.indexAt(120)).toBe(1)
+    expect(idx.indexAt(160)).toBe(2)
+  })
+
+  it('a new measurement reaches the tree only on sync', () => {
+    const idx = makeIndex(`sync-${Math.random()}`, ['a'])
+    idx.setMeasured(0, 100)
+    idx.sync(1)
+    expect(idx.totalHeight()).toBe(100)
+
+    // The tree is deliberately NOT synced on the scroll path, so a write alone
+    // must not move it -- that is what keeps a same-count sync off every frame.
+    idx.setMeasured(0, 300)
+    expect(idx.totalHeight()).toBe(100)
+    idx.sync(1)
+    expect(idx.totalHeight()).toBe(300)
+  })
+
+  it('an estimate change reaches unmeasured rows on the next sync', () => {
+    const idx = makeIndex(`est-${Math.random()}`, ['a', 'b'])
+    idx.sync(2)
+    expect(idx.totalHeight()).toBe(2 * ESTIMATE)
+
+    idx.setEstimate(10)
+    idx.sync(2)
+    expect(idx.totalHeight()).toBe(20)
+  })
+
+  it('reports the session it was constructed for (the guard reads this)', () => {
+    // Not incidental state: the hook's single session guard compares this field
+    // against the current sessionId, so it IS the record of session identity.
+    const idx = makeIndex('session-abc', ['a'])
+    expect(idx.sessionId).toBe('session-abc')
+  })
+
+  it('two sessions do not share heights even at identical row counts', () => {
+    const suffix = Math.random()
+    const a = makeIndex(`switch-a-${suffix}`, ['k0', 'k1'])
+    a.setMeasured(0, 400)
+    a.setMeasured(1, 400)
+    a.sync(2)
+    expect(a.totalHeight()).toBe(800)
+
+    // Same key strings, same count, different session: the owner is what carries
+    // the partition, so a fresh one must start with no measurements. Serving A's
+    // heights here is exactly the wrong-scroll-position bug.
+    const b = makeIndex(`switch-b-${suffix}`, ['k0', 'k1'])
+    expect(b.peekMeasured(0)).toBeUndefined()
+    b.sync(2)
+    expect(b.totalHeight()).toBe(2 * ESTIMATE)
+  })
+})


### PR DESCRIPTION
## 1. What is the problem?

Row heights in the chat virtualizer were readable from two places that had to
agree, with no construction forcing them to.

`HeightCache` (keyed by the row's stable key, persisted per session in
localStorage) was read directly at five call sites in `useVirtualChat`, while
`OffsetIndex` -- the Fenwick prefix-sum tree the scroll hot paths use -- answered
offset/total questions from its own cached copy of the same heights, fed by a
getter that read the cache. Nothing in the types stopped a read of one from
disagreeing with the other.

Worse, each structure carried its OWN session guard (`cacheSessionRef` and
`offsetIndexSessionRef`). Both had to be present and agree for a session switch
to be correct, because switching to a different session with the same item count
changes neither the item count nor the getter's identity.

## 2. Why this issue matters to the user

The failure mode is not hypothetical. A same-item-count session switch once left
the offset tree serving the previous transcript's heights, which a user sees as
the transcript opening at the wrong scroll position. That was fixed by adding the
second session guard -- the bug class was patched per structure rather than
eliminated, so the next structure added to this seam had to remember the same
discipline independently.

Both coherence mechanisms are invisible to the type system and to review: a
missing guard produces heights from the wrong transcript with no error, and there
is no test that can fail generically -- only a specific scenario catches it.

## 3. How our fix solves it

Chain from symptom to root cause: wrong scroll position on session switch <- the
offset tree held heights the cache no longer backed <- the tree and the cache were
separately owned and separately guarded <- there was no single owner of height
truth.

So this adds one: `HeightIndex` holds the `HeightCache` AND the tree, and is the
only surface the hook reads heights through.

- The tree cannot outlive its cache. A session change replaces the owner
  outright, so there is ONE guard instead of two that must agree.
- Session identity also gets ONE record. The guard asks the owner what session it
  holds (`heightIndexRef.current?.sessionId !== sessionId`) rather than comparing
  against a parallel ref beside it: a second spelling of the same identity is the
  pattern this change exists to remove, and it could drift from the owner it
  describes. `?.` covers the first render, where an absent owner reads as "not
  this session" and constructs.
- `HeightCache` is left as what it already was underneath -- load, store, flush,
  evict -- i.e. persistence.
- `OffsetIndex` is untouched. It stays the pure Fenwick primitive with no opinion
  about sessions, keys, or persistence, and keeps its own tests.

The owner ships no surface nothing reads: it exposes the three read methods, the
bound getter the O(N) free functions still take, `sync`/`offsetOf`/`totalHeight`/
`indexAt`, `setMeasured`/`setRowCount`/`setEstimate`/`flush`, and `sessionId` --
which the guard above consumes. Its key-resolver type is file-local rather than
exported, since nothing outside constructs one.

The read surface is deliberately three methods rather than one, because callers
ask two different questions that must not be conflated:

- `heightAt(i)` -- the RESOLVED height (measurement if present, else the running
  mean). Every row has an answer; this is what the offset math needs.
- `peekMeasured(i)` / `readMeasured(i)` -- the measurement ITSELF, or `undefined`
  when the row has never been measured.

That distinction is load-bearing. The ResizeObserver tells a first mount apart
from a genuine resize by exactly the measurement being absent: an absent one means
the row just mounted during scroll-driven window expansion, and re-pinning then
yanks a scrolling reader. A single accessor returning a resolved height (never
`undefined`) would classify every first mount as a resize -- and would have made
that a silent regression.

Promotion is also explicit now instead of being decided by which cache method a
caller happened to reach for: `readMeasured` promotes LRU order (the row is
mounted or rendering, so it is genuine access), while `heightAt` and
`peekMeasured` do not (they feed bulk scans that touch every row, and promoting
there would rewrite LRU order into transcript-index order and evict rows the user
just viewed).

Imperative writers (the ResizeObserver callback, the `measureRef` seed) resolve
the owner from its ref at call time rather than closing over it. This is not
incidental: a captured owner would make a post-switch measurement land in the
previous session's heights, which is the same wrong-transcript class this owner
exists to close, reintroduced through a stale closure.

Two things this change deliberately does NOT do:

- The hand-bumped `heightVersion` invalidation token stays. A memo cannot observe
  a mutation of the (stable-identity) owner, so deriving the token is a separate
  problem -- and unlike this mechanical redirect, a missed bump fails SILENTLY
  (stale offsets, no error, no failing test), which is worth reviewing on its own.
  The module header records it as the remaining half.
- An unmeasured row's placeholder height is preserved verbatim, including a
  pre-existing divergence: the rendered placeholder uses the FLAT configured
  estimate while the offset math uses the running mean. Making those agree would
  be a behaviour change smuggled into a refactor, so it is left alone.

One intentional behaviour change, called out rather than buried: the
`__vcSnapshot` devtools probe now uses the non-promoting read, so inspecting
heights no longer perturbs the LRU order it is reporting on. It is devtools-only
and unreachable in normal operation.

## 4. What tests we did

- `tsc --noEmit`: clean. `eslint` on the touched files: clean, zero warnings
  (including the `react-hooks/exhaustive-deps` warnings the intermediate state
  produced -- each was resolved on its merits, not silenced).
- Full virtualizer suite: 16 files / 185 tests pass. Broader sweep of every test
  file referencing the virtualizer, `HeightCache`, or `useVirtualChat`: 46 files /
  677 tests pass.
- New `virtualizerHeightOwner.test.ts` (14 tests) in two halves: a STRUCTURAL
  ratchet (the hook does not import `HeightCache`, holds no cache handle, makes no
  direct cache read; only `HeightIndex` imports the cache; the height guard reads
  identity off the owner and appears exactly once, with no parallel session ref;
  `OffsetIndex` stays free of session/cache concerns) and BEHAVIOURAL coverage of
  the read surface (resolved vs measured stay distinct, zero clamps to 1 while the
  stored measurement stays unclamped, a keyless index resolves to the estimate and
  its write is a no-op, promotion semantics, tree answers, sync-gated visibility,
  estimate change, the reported session identity the guard consumes, and two
  sessions not sharing heights at identical row counts).
- Mutation-verified, four probes, each restored and re-run:
  - Making `readMeasured` return a resolved height (never `undefined`) -- the
    regression predicted above -- reddens 8 tests across 3 existing files. The
    risky half is genuinely covered by the suite that already existed.
  - Removing the session guard reddens 3 tests, including the pre-existing
    "reports the NEW session's offsets when both sessions have equal item counts",
    which is the original bug's own regression test.
  - Re-adding a `HeightCache` import to the hook reddens 2 of the new structural
    tests, so the ratchet bites rather than decorating.
- The ratchet was scoped down during development after it caught a real
  imprecision: an initial version asserted on every `!== sessionId` in the hook
  and found three, two of which are unrelated concerns (the scroll-state sentinel
  and the slot-entry pin bookkeeping). Matching those would make the guard fail
  for edits that have nothing to do with the invariant.

## 5. Any other suggestions on the work

- The follow-up (deriving `heightVersion` from the owner) is the half where a
  mistake is silent, so it deserves its own review with nothing else in the diff.
- While reading the write side I found the issue's own description has gone stale
  in the PR's favour: it says `heightVersion` "has to be bumped by hand at every
  write site", but `setHeightVersion` already has exactly one call site and both
  height writes already funnel through `scheduleHeightSync`. The remaining problem
  is the token's existence, not scattered bumps.
- The flat-estimate versus running-mean divergence for unmeasured rows (preserved
  here) is worth deciding on deliberately: the rendered placeholder and the offset
  math currently disagree for a row that has never been measured.

Refs #4326
