### PR TITLE
docs(ci): correct fork-workflow-guard header — advisory signal, not a required check

### DIFF
--- a/.github/workflows/fork-workflow-guard.yml
+++ b/.github/workflows/fork-workflow-guard.yml
@@ -1,8 +1,9 @@
 name: Fork Workflow-Change Guard
 
-# Blocks a FORK pull request that modifies CI/workflow files under `.github/**`
+# Flags a FORK pull request that modifies CI/workflow files under `.github/**`
 # — the vector a fork could use to fake basic-CI results (rewrite ci.yml to pass)
-# or tamper with CODEOWNERS/other automation.
+# or tamper with CODEOWNERS/other automation. This posts an ADVISORY check-run
+# signal; it is not itself a merge gate (see the enforcement note below).
 #
 # WHY DETERMINISTIC (no model): "does the diff touch .github/**" is a file-path
 # check — a grep on the authentic changed-file list is 100% reliable, instant,
@@ -16,8 +17,14 @@ name: Fork Workflow-Change Guard
 #
 # OVERRIDE: a maintainer who has reviewed a legitimate workflow change applies
 # the `allow-fork-workflow-change` label; the guard then re-evaluates green.
-# Complements a CODEOWNERS rule on `.github/workflows/**` (which forces review;
-# this enforces it as a required, blocking check).
+# ENFORCEMENT (what actually stops a malicious fork workflow change): this
+# guard is an advisory signal only — it is NOT listed in any branch/ruleset
+# `required_status_checks` and pr-readiness.yml does not consult it. The real
+# protection is two-fold: (1) fork workflow_run jobs require maintainer approval
+# before they run (repo "require approval for all external contributors"
+# setting), and (2) the catch-all `*` rule in CODEOWNERS forces code-owner
+# review, which covers `.github/**` by inheritance. Wiring this guard in as a
+# required, blocking check is a maintainer policy decision, not yet configured.
 
 on:
   workflow_run:


### PR DESCRIPTION
## Problem / Motivation

`.github/workflows/fork-workflow-guard.yml`'s header claims the guard is enforced as "a required, blocking check" complementing "a CODEOWNERS rule on `.github/workflows/**`". Both claims are false per the configuration audit in #2878: the guard's check-run appears in no ruleset's `required_status_checks` (ruleset 20088190 requires exactly one context, `PR Readiness`), `pr-readiness.yml`'s enumerated allowlist never consults it, and CODEOWNERS has only a catch-all entry.

## Why it matters

This is a security-relevant file: the next person reasoning about the fork workflow-change vector will reason from this header, and today it describes mechanical protection that is actually review-based.

## What changed (motivation → approach → change)

Documentation-only, comments-only — no `on:`, `jobs:`, or step logic touched. "Blocks a FORK pull request…" becomes "Flags…" with an explicit ADVISORY note; the enforcement paragraph now states what actually protects workflow changes from forks (fork-run maintainer approval + catch-all code-owner review), and records that wiring the guard as blocking is a maintainer policy decision not yet configured — the open half of #2878. This PR is safe to merge independently of that ruling.

## Tests

No test pins this workflow's content (verified by grep across `test/` and `.github/`). YAML validated parseable after the edit. Diff is 1 file, +11/−4, comments only.

## Manual verification

N/A — comment-only change; the YAML parse check is the complete verification.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow comment change; no rendered UI.

## Related Issues

no linked issue closure: `Refs #2878` only — the issue's wiring-as-blocking policy question remains open for a maintainer, so this PR must not auto-close it.

Refs #2878

## Checklist

- [x] Tests added/updated (N/A — no test pins workflow comments)
- [x] Lint/type checks pass locally (YAML parse verified)
- [x] Linked issue (Refs only, deliberate)
