### PR TITLE
fix(update): follow stable by default so a promoted release stays stable

### DIFF
--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -546,6 +546,30 @@ nightly and insider stamp is a semver prerelease and would otherwise be
 invisible to its own channel). The library still refuses an equal version before
 the `allowDowngrade` branch, which is what prevents a self-reinstall loop.
 
+**Which channel a build follows is a default plus an opt-in, not a property of
+the bytes.** `channelForVersion()` classifies the version stamp and `nightly`
+stays pinned by it, but for the two production lanes `resolveChannel()` honours
+the persisted Settings → About preference and defaults to **stable** when none is
+set. It cannot read the lane out of the stamp, because stable is PROMOTED: the
+stable and insider downloads of a promoted version are the same notarized file
+carrying the same `-insider.N` stamp, so a stamp-derived channel would send every
+promoted-stable install to the insider feed. The consequences to know:
+
+- **Insider is an explicit opt-in.** Any install with no recorded preference
+  follows stable — including one installed from the insider DMG, and including an
+  insider install that predates this rule. The two downloads are identical files,
+  so nothing in them can record which page one came from, and nothing already on
+  disk distinguishes an insider install from a stable one that has been offered
+  the promoted build. Insider is reached by the switcher, once, per install.
+- **There is no way to seed that preference retroactively.** A migration would
+  have to read the channel from the version stamp, and the first build carrying
+  any such migration is itself promotion-stamped, so it would write `insider` for
+  every stable install — the defect this rule exists to remove, made permanent.
+  A future transition could use a persisted last-run version; this one cannot.
+- **The "you are running prerelease bytes" note still keys on the stamp**
+  (`stampedChannel`), not on the followed channel, because that statement is
+  about the bytes and stays literally true on a promoted stable install.
+
 The specific to Kiro Crew part is install ordering: the app supervises a bundled
 Python gateway child, so before `quitAndInstall` the client stops it gracefully
 (`POST /api/shutdown`, then SIGTERM, then SIGKILL) and disarms the liveness

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -215,20 +215,33 @@ function channelForVersion(version) {
  *   migrate the dev app onto a production channel.
  * - unstamped (dev, stamped === null) builds have no update lane; the
  *   preference cannot conjure one.
- * - production stamps (insider/stable) follow the preference when set,
- *   else their own stamp. Switching BACK can be a downgrade mid-cycle
- *   (insider 0.2.0-insider.1 -> stable 0.1.0), which is why allowDowngrade
- *   is enabled in configureUpdater.
+ * - production builds (insider/stable stamps) follow the preference when set,
+ *   and default to STABLE when it is not. Switching BACK can be a downgrade
+ *   mid-cycle (insider 0.2.0-insider.1 -> stable 0.1.0), which is why
+ *   allowDowngrade is enabled in configureUpdater.
+ *
+ * Why the unset default is stable rather than the stamp: a stable release is
+ * PROMOTED, meaning the exact notarized candidate bytes are re-pointed at the
+ * stable channel without a rebuild, so the stable download and the insider
+ * download of a promoted version are the SAME FILE and carry the same
+ * prerelease stamp (`0.3.0-insider.13`). The channel therefore cannot be a
+ * property of the bytes, and reading it out of the version string sends every
+ * promoted-stable install to the insider feed. It is a default plus an opt-in,
+ * which is what this function's own contract above already describes.
+ *
+ * `channelForVersion` deliberately keeps classifying the BYTES (it is what the
+ * About panel's "you are running prerelease bytes" note is keyed on); only the
+ * followed feed is decoupled from it here.
  *
  * @param {"nightly"|"insider"|"stable"|null} stamped - channelForVersion(version)
- * @param {"insider"|"stable"|""|null|undefined} preference - user opt-in, falsy = follow stamp
+ * @param {"insider"|"stable"|""|null|undefined} preference - user opt-in, falsy = default
  * @returns {"nightly"|"insider"|"stable"|null}
  */
 function resolveChannel(stamped, preference) {
   if (stamped === "nightly") return "nightly";
   if (stamped === null) return null;
   if (preference === "insider" || preference === "stable") return preference;
-  return stamped;
+  return "stable";
 }
 
 /**

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -135,7 +135,7 @@ const store = new Store({
     globalHotkey: null,                    // system-wide summon accelerator: null = platform default, "" = disabled, string = custom (see global-hotkey.js)
     lastNudgedVersion: "",                 // last update version announced via native notification (nudge once per version)
     themeAccent: "",                       // user's resolved theme accent hex; injected into the boot splash
-    updateChannel: "",                     // "" = follow build stamp; "insider"|"stable" = user opt-in (Settings > About)
+    updateChannel: "",                     // "" = follow the stable default; "insider"|"stable" = user opt-in (Settings > About)
     runLocalGateway: true,                 // false = act as a pure client; never start a gateway on this machine
     linuxFrameless: null,                  // Linux window chrome: true = frameless, false = native frame, null = follow the desktop environment (see linux-frame.js)
   },

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -58,11 +58,42 @@ test("resolveChannel: production stamps follow the preference when set", () => {
   assert.strictEqual(resolveChannel("insider", "stable"), "stable");
 });
 
-test("resolveChannel: no/invalid preference falls back to the stamp", () => {
+test("resolveChannel: no/invalid preference defaults to STABLE, not to the stamp", () => {
+  // A stable release is PROMOTED, not rebuilt: the stable and insider downloads
+  // of a promoted version are the same file carrying the same prerelease stamp,
+  // so the stamp cannot say which feed to follow. Insider is an explicit opt-in.
   assert.strictEqual(resolveChannel("stable", ""), "stable");
-  assert.strictEqual(resolveChannel("insider", undefined), "insider");
+  assert.strictEqual(resolveChannel("insider", undefined), "stable");
   assert.strictEqual(resolveChannel("stable", "nightly"), "stable"); // nightly is not a valid opt-in
-  assert.strictEqual(resolveChannel("insider", "bogus"), "insider");
+  assert.strictEqual(resolveChannel("insider", "bogus"), "stable");
+});
+
+test("a promoted -insider.N build with no preference follows the STABLE feed", async () => {
+  // The regression this exists for: promoting 0.3.0 publishes the insider
+  // candidate's exact bytes to stable, so every stable install would otherwise
+  // read its own version stamp and migrate itself onto the insider feed.
+  const { deps, calls } = makeDeps({ appVersion: "0.3.0-insider.13" });
+  deps.getChannelPreference = () => "";
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(calls.setFeedURL.length >= 1);
+  assert.ok(
+    calls.setFeedURL.every((o) => o.url === "https://cdn.example.dev/feed/stable/"),
+    `expected stable feed urls, got: ${calls.setFeedURL.map((o) => o.url)}`,
+  );
+  assert.strictEqual(u.getInfo().channel, "stable");
+});
+
+test("an explicit insider preference still selects insider on promoted bytes", async () => {
+  const { deps, calls } = makeDeps({ appVersion: "0.3.0-insider.13" });
+  deps.getChannelPreference = () => "insider";
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(
+    calls.setFeedURL.every((o) => o.url === "https://cdn.example.dev/feed/insider/"),
+    `expected insider feed urls, got: ${calls.setFeedURL.map((o) => o.url)}`,
+  );
+  assert.strictEqual(u.getInfo().channel, "insider");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

Port to `main` of `880d8695f` from `release/0.3.0` ([#4791](https://github.com/kirodotdev/KiroCrew/pull/4791)), which ships in `v0.3.0-insider.13` and in the 0.3.0 stable promotion. `main` still has the defect.

A stable release is *promoted*, not rebuilt: `release.yml` resolves the recorded
candidate and re-points its exact notarized bytes at the stable channel, passing
`resolve-promotion.outputs.source_version` to every publish lane. So the stable
download and the insider download of a promoted version are **the same file**,
carrying the same `-insider.N` stamp. But the followed channel was derived from
that stamp, and `channelForVersion()` maps any non-nightly prerelease to insider:

```js
function resolveChannel(stamped, preference) {
  if (preference === "insider" || preference === "stable") return preference;
  return stamped;                              // ← unset preference followed the bytes
}
```

Chain: a stable install polls stable → is offered the promoted build → installs it
→ from the next poll identifies as insider → follows `feed/insider/`. Tag the next
insider RC and people who chose stable start receiving previews.

## Why it matters

`main` is what the next release branch is cut from, so leaving it unported means
0.4.0 re-ships the defect. It is also unrollbackable once a promotion has run: CDN
keys are immutable and recovery is a new version.

Worth recording why three shipped releases never surfaced it: `v0.2.0`'s release run
(31441740869) executed `Build Wheel` and `Build Desktop` with **no**
`Resolve Tested Candidate` job — it was a same-tag rebuild, so its stable artifacts
carried a bare `0.2.0`. The 0.3.0 promotion is the first the pipeline has ever
performed, and RC soak cannot catch this because soak validates the bytes while the
defect only appears when those bytes are re-pointed at a second channel.

## What changed (motivation → approach → change)

Channel was treated as a property of the bytes, and the bytes are byte-identical
across two lanes, so it cannot be recovered from them even in principle. It becomes
what `resolveChannel`'s own docstring already described — a default plus an opt-in:

```diff
 function resolveChannel(stamped, preference) {
   if (stamped === "nightly") return "nightly";      // pinned, untouched
   if (stamped === null) return null;                // dev has no lane
   if (preference === "insider" || preference === "stable") return preference;
-  return stamped;
+  return "stable";
 }
```

That is the whole functional change. `channelForVersion()` is deliberately
**unchanged**: it still classifies the *bytes*, which is what the About panel's
"you are running prerelease bytes" note is keyed on (`stampedChannel`).

## Port fidelity

Cherry-picked from `880d8695f` with **zero conflicts and no adaptation** — the four
files auto-merged, and `resolveChannel` was already byte-identical between the two
branches. The diff on `main` is the same diff that shipped.

## The cost, stated plainly

An install with no recorded preference follows stable, so an insider install that
predates this rule migrates once and re-opts in through Settings → About. Same for a
fresh install from the insider DMG: the two DMGs are identical files, so nothing in
them can record which page one came from.

**Deliberately not sweetened with a migration.** The first revision of the release-branch
PR carried a `channelPreferenceSeed()`, and both blocking reviewers were right to kill
it: the first build carrying any seed **is** the promotion-stamped one, so a stable
upgrader's first seeded launch would read `-insider.N` and write `insider`
explicitly and permanently — the exact defect this removes, for the exact population
it protects. A fresh promoted install was hit too, since its first run persists theme
state and its second launch then satisfies "has prior state". Distinguishing "ran
before this build" from "ran before at all" needs a persisted last-run version, which
no existing install has ever written — so that can serve a future transition, not this
one.

## Tests

`website/electron/test/auto-update.test.js`:

- **changed** — `resolveChannel: no/invalid preference defaults to STABLE, not to the stamp`
- **new** — a promoted `-insider.N` build with no preference follows the STABLE feed
- **new** — an explicit insider preference still selects insider on promoted bytes

Must-not-regress and verified green: nightly pinning, the `#709` equal-version
contract, `buildFeedBase`.

**Full Electron suite on this branch: 1101 passed, 1 skipped, 0 failed** (run twice,
identical). `docs-lint` and the brand-name gate pass.

## Manual verification

Not performed — it needs two real signed builds and a promoted feed, which is
`ota-test.yml`'s job and cannot be reproduced locally. The change is a pure function
plus the feed url it selects, both covered above.

## Documentation

`docs/build/release.md` § "Client auto-update" gains the rule, the opt-in cost, and
why no retroactive seed is possible.

## Known follow-up (not in this PR)

UX review's CONCERNS on the release-branch PR, left out because it needs new
user-facing strings across 12 locales: after a promotion a default install shows a
`-insider` version, the "thanks for running early builds" prompt, and a switcher
reading **Stable** — three signals a reader cannot reconcile. Worth deciding at the
same time whether that prompt should key on the followed channel rather than the byte
stamp, since "early build" stops being a true description of what a promoted stable
user runs.

## Related Issues

Port of #4791. Shipped in `v0.3.0-insider.13`.

**Why no screenshot:** update-channel resolution in the Electron main process; the
About panel's switcher reads the resolved channel and follows automatically with no
markup change.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
