### PR TITLE
perf(website): use 3 vitest workers so a shard's runner is not half idle

### DIFF
--- a/website/src/test/vitestMemoryConfig.test.ts
+++ b/website/src/test/vitestMemoryConfig.test.ts
@@ -3,10 +3,25 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('vitest worker memory configuration', () => {
+  // Asserts the INVARIANT — a concurrency cap exists and stays small enough that
+  // aggregate fork RSS fits a hosted runner — rather than one literal value. The
+  // previous form pinned `maxWorkers: 2` exactly, so tuning the cap to the
+  // runner's real core count (4 vCPU on ubuntu-latest) failed this test for a
+  // change that does not touch the memory budget it is named for. A bound keeps
+  // the protection that matters: what would break CI is the cap being REMOVED
+  // (one fork per core on a high-core fleet, which is the OOM this guards) or
+  // raised far past what the per-fork heap ceiling can cover.
   it('keeps coverage forks within the hosted runner memory budget', () => {
     const config = readFileSync(resolve(process.cwd(), 'vite.config.ts'), 'utf8')
 
-    expect(config).toMatch(/maxWorkers:\s*2,/)
+    const workers = config.match(/maxWorkers:\s*(\d+),/)
+    expect(workers, 'vite.config.ts must cap maxWorkers').not.toBeNull()
+    // Peak single-fork RSS measured at ~1.0-1.4 GB under --coverage, so a
+    // 4-worker ceiling keeps the aggregate near 3.5 GB — comfortably inside a
+    // hosted runner, with room for the main process.
+    expect(Number(workers![1])).toBeGreaterThanOrEqual(1)
+    expect(Number(workers![1])).toBeLessThanOrEqual(4)
+
     expect(config).toMatch(/execArgv:\s*\['--max-old-space-size=3072'\],/)
   })
 })

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -572,7 +572,21 @@ export default defineConfig({
     // ceiling that fails a genuine leak loudly instead of dragging the host down.
     // (Vitest 4 pool rework: these are top-level, not poolOptions; minWorkers
     // was removed — only maxWorkers has effect.)
-    maxWorkers: 2,
+    //
+    // 3, not 2: `ubuntu-latest` has 4 vCPU (this workflow's own backend job
+    // documents "4 cores via -n auto"), so 2 left half of every shard's runner
+    // idle. 3 is exactly what vitest itself would pick there when uncapped
+    // (`max(availableParallelism - 1, 1)` in run mode), leaving a core for the
+    // main process — so this raises throughput without oversubscribing, and the
+    // cap still protects the high-core fleet the paragraph above is about.
+    //
+    // MEASURED on 6 of the heaviest files with --coverage, same input each time:
+    //   maxWorkers 2 -> 106.7s, peak 2001 MB total
+    //   maxWorkers 3 ->  81.2s, peak 2674 MB total   <- chosen
+    //   maxWorkers 4 ->  83.3s, peak 3475 MB total
+    // 3 is both the fastest and cheaper in memory than 4; peak single-fork RSS
+    // was ~1.0-1.4 GB against the 3072 MB per-fork heap ceiling below.
+    maxWorkers: 3,
     execArgv: ['--max-old-space-size=3072'],
     // Default 5s is too tight for tests that ``await import(...)`` inside the
     // body: under a full concurrent forks run the collect phase can starve the


### PR DESCRIPTION
## Problem

`maxWorkers: 2` in `website/vite.config.ts` left **half of every frontend-test runner idle**. Each of the four `Frontend Tests` shards runs on `ubuntu-latest`, which has 4 vCPU — this same workflow's backend job documents *"4 cores via `-n auto`"* — so two forks could never saturate it.

## Why it matters

The frontend suite is ~1428 files across 4 shards, and it is the long pole on many PRs. Half-idle runners are wall-clock and CI minutes spent for nothing.

## Fix (symptoms → root cause → change)

The cap was added for a real reason, which the surrounding comment records: uncapped, vitest spawns **one fork per core**, and on a high-core fleet the aggregate RSS under `--coverage` exceeded host RAM and the kernel OOM-killed a worker (surfacing as `Worker exited unexpectedly`). The root cause of the *idleness*, though, is that the cap was set for that fleet rather than for the 4-vCPU runner the shards actually use.

**3, not 4.** Uncapped, vitest itself picks `max(availableParallelism - 1, 1)` in run mode — exactly 3 on a 4-vCPU runner, leaving a core for the main process. So this raises concurrency to what vitest would have chosen anyway, without oversubscribing, and the cap still protects the high-core fleet the comment is about.

Measured on the six heaviest files with `--coverage`, identical input each run:

| `maxWorkers` | duration | peak total node RSS |
|---|---|---|
| 2 | 106.7s | 2001 MB |
| **3** | **81.2s** | **2674 MB** |
| 4 | 83.3s | 3475 MB |

3 is both the fastest and cheaper in memory than 4. Peak *single-fork* RSS was 1.0–1.4 GB against the **unchanged** 3072 MB per-fork heap ceiling.

## Tests

`src/test/vitestMemoryConfig.test.ts` pinned the literal `maxWorkers: 2`, so it failed for a change that does not touch the memory budget it is named for. It now asserts the **invariant** — a cap exists and is ≤ 4, sized against the measured per-fork RSS — so *removing* the cap (the actual OOM hazard) still fails it, while tuning it to the runner does not. Mutation-verified: deleting the `maxWorkers` line fails the test with `must cap maxWorkers`.

## Manual verification

- `npx tsc -b` = 0.
- **The failure mode the cap exists to prevent does not recur:** `npx vitest run --coverage --shard=1/4` completes with exit 0, **zero failing files** and **zero** `Worker exited unexpectedly` / `ERR_IPC_CHANNEL_CLOSED` errors.

## Two findings from the same audit that I measured and am NOT changing

Recording these so they are not re-proposed:
- **`css: false`** — no meaningful win. Measured 5.69s→5.04s on one file and 6.18s→**6.44s** (slower) on another; both within noise. And 7 test files read `getComputedStyle` while components do `import './x.css'`, so flipping it risks real coverage for nothing.
- **Stubbing the 12 non-English locale catalogs** — this one *is* a large win (measured 5.08s→2.22s, −56%, on a file that needs only English), but ~41 test files legitimately need real catalogs and they are scattered across five directories, so any split needs an explicit file list that will drift. Worth a dedicated change with its own design, not a rider here.

<!-- no-visual-delta -->
**Why no screenshot:** this changes only `vite.config.ts`'s vitest worker count and the config-assertion test that guards it. No component, style, or rendered output is touched.
