### PR TITLE
test(meetings): anchor the transition-table read to the repo root

### DIFF
--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -37,6 +37,12 @@ from kiro_crew.apps.builtins.meetings.backend.routes import _common
 
 BASE = k.API_BASE
 
+# Repo-root anchor for tests that read a checked-in source file. A relative
+# literal resolves against the process CWD, which no test owns: another test
+# chdir-ing away makes the read fail, and under `-n auto` the loser is decided
+# by worker scheduling rather than by anything in this file.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 async def _start(client, meeting_id: str = "standup", **body) -> dict:
     await client.post(f"{BASE}/meetings/{meeting_id}/init", json={"title": "Standup"})
@@ -913,9 +919,10 @@ class TestAgentRoutes:
         assertion breaks when either side changes alone.
         """
         import re
-        from pathlib import Path as _Path
 
-        source = _Path("website/src/apps/meetings/hooks/useMeetingSession.ts").read_text()
+        source = (
+            _REPO_ROOT / "website/src/apps/meetings/hooks/useMeetingSession.ts"
+        ).read_text()
         block = re.search(
             r"ALLOWED_TRANSITIONS: Record<MeetingStatus, MeetingStatus\[\]> = \{(.*?)\n\}",
             source,


### PR DESCRIPTION
## Problem / Motivation

`test_the_server_and_client_transition_tables_agree` read the client's TypeScript
source through a **relative** literal:

```python
source = _Path("website/src/apps/meetings/hooks/useMeetingSession.ts").read_text()
```

That resolves against the process CWD, and **no test owns that directory**. Any
test in the same xdist worker that chdirs away turns the read into
`FileNotFoundError: [Errno 2] No such file or directory:
'website/src/apps/meetings/hooks/useMeetingSession.ts'` — while the file is
present in the tree the whole time. Under `-n auto`, which test loses is decided
by worker scheduling, not by anything in this file.

## Why it matters

It failed exactly this way in the **`v0.3.0-insider.13` release-candidate gate**:

```
FAILED test/test_meetings_routes.py::TestAgentRoutes::test_the_server_and_client_transition_tables_agree
  - FileNotFoundError: [Errno 2] No such file or directory: 'website/src/apps/meetings/hooks/useMeetingSession.ts'
= 1 failed, 53926 passed, 181 skipped, 6 xfailed in 949.08s =
```

`release.yml`'s `record-promotion` job requires
`needs.release-candidate-tests.result == 'success'`, so that one test held up the
immutable promotion bundle — and therefore the 0.3.0 stable promotion — for a
reason that has nothing to do with what the release contains.

`ci.yml`'s four-shard split rarely co-schedules the offending pair, which is why
this surfaces in the single-job full-suite RC run rather than on a normal push. The
release branch already carries two commits about this class: `ec51018bb` deselected
two siblings, and `0587013bd` converted the rest to `_REPO_ROOT` — **this file was
missed.**

## What changed (motivation → approach → change)

Symptom: a read that depends on CWD → cause: a relative literal in a suite where
CWD is shared and unowned → change: anchor it to the file's own location.

```diff
+BASE = k.API_BASE
+
+# Repo-root anchor for tests that read a checked-in source file. A relative
+# literal resolves against the process CWD, which no test owns [...]
+_REPO_ROOT = Path(__file__).resolve().parents[1]
```
```diff
         import re
-        from pathlib import Path as _Path
-
-        source = _Path("website/src/apps/meetings/hooks/useMeetingSession.ts").read_text()
+        source = (
+            _REPO_ROOT / "website/src/apps/meetings/hooks/useMeetingSession.ts"
+        ).read_text()
```

Same `_REPO_ROOT` pattern `0587013bd` used for the siblings, so there is one
convention in the suite rather than two.

## This is the last one, not the first of a series

Audited the whole class rather than patching the one the gate happened to name.
Grepping `test/` and the eight app test trees for a relative read of a
checked-in directory (`src|website|docs|scripts|config|packaging|agents|skills`,
via `Path(`/`_Path(`/`open(`) returns exactly two hits:

| Hit | Verdict |
|---|---|
| `test/test_meetings_routes.py:918` | the bug — fixed here |
| `test/test_portability.py:559` | `PurePosixPath("skills/my-skill/SKILL.md")` used as an **assertion value**, never read from disk — not this class |

## Tests

No new test. The change makes an existing assertion independent of an ambient
condition, and a test that a test is CWD-independent would be pinning the fix's
mechanism rather than any product behavior.

Verified **under the condition that causes the failure** rather than only from the
repo root:

```
# from /tmp, before this change
FAILED ...test_the_server_and_client_transition_tables_agree - FileNotFoundError
# from /tmp, after
1 passed
```

Whole file from the repo root: **184 passed.** flake8 and isort clean.

## Manual verification

N/A — the reproduce-then-fix run above is the verification, and it is the one that
matters here: running from the repo root passes either way and would have proved
nothing.

## Related Issues

Unblocks the `v0.3.0-insider.13` release-candidate gate (run 32435909108). Landing
this does **not** invalidate rc13: the promotion tag targets commit `880d8695f`, so
a later commit on the branch is independent of it.

`main` carries the identical unfixed line (`test/test_meetings_routes.py:942`) and
gets the same fix in a separate PR.

**Why no screenshot:** test-only path resolution; no user-visible surface.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — no new behavior)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
