### PR TITLE
fix(autopilot): observe a plan cancel at every stage-advance gate

### DIFF
--- a/docs/system-specs/modules/autopilot.md
+++ b/docs/system-specs/modules/autopilot.md
@@ -170,7 +170,8 @@ in the prompt. It creates the tracker if absent (timeout from
 `orchestrator.stage_timeout_seconds`), resumes at `tracker.current_stage` when
 rounds already exist, and for each stage index:
 
-1. Break if `slot._stopping`.
+1. Break if `_orchestration_stopped(slot, tracker)` — see
+   [Stop and Cancel](#stop-and-cancel) for why both flags are read.
 2. **Clamp**: break if `stage_idx >= slot._plan_stage_count`. `total` is
    captured once when the range is built, so a plan that shrank mid-run would
    otherwise emit a phantom "Stage N of M" with N > M.
@@ -266,11 +267,31 @@ model may ignore, tier 2 is `is_force_failed()` in Python.
 |------|---------|----------|
 | Cancel button | `plan-action` with `cancel` | Always available: stop tracker, clear `_auto_run`, cancel sub-agent tasks, post `🛑 Plan cancelled.`, no LLM call |
 | Typed `stop` / `cancel` / `abort` | `api_chat`, only while `tracker.has_escalated` and not already stopped | Same teardown, posts `🛑 [SYSTEM] Orchestration stopped by user.` |
-| Stop button | `POST /api/chat/slots/{slot}/stop` | Generic cooperative stop with hard-kill escalation on a second press; sets `_stopping`, which every `_stage_loop` checkpoint honors |
+| Stop button | `POST /api/chat/slots/{slot}/stop` | Generic cooperative stop with hard-kill escalation on a second press; sets `_stopping` |
 
 Typed stop words are gated on `has_escalated` so an ordinary "cancel that idea"
 mid-plan is not read as a control command; the Cancel and Stop buttons are
 unconditional.
+
+**Two flags, two meanings — every advancement gate reads both.** Stop sets
+`slot._stopping`: the slot is being torn down, so nothing on it may keep running.
+Cancel and the typed stop words set `tracker.stopped` and leave `_stopping`
+alone: the slot stays alive and usable, and only the plan ends. A gate reading
+one flag therefore observes only half the stops, and the window that matters is
+`_run_chat` — the loop's longest await, so the likeliest place for a cancel to
+land, and the point it would otherwise resume from straight into the next stage
+against a revoked approval. `_orchestration_stopped(slot, tracker)` is the single
+predicate all four gates (top-of-iteration, post-`_run_chat`, the sub-agent poll
+condition, and pre-capture) call, so the two channels cannot drift apart again.
+
+The inverse — having Cancel set `slot._stopping` — is deliberately **not** what
+this does: that flag carries teardown semantics for paths outside the stage loop,
+and cancelling a plan is not a request to tear the session down.
+
+The all-stages-complete summary still reads `slot._stopping` alone. A cancel that
+lands after the final stage's gate has already passed leaves a plan whose stages
+all genuinely ran, and suppressing a truthful completion summary there would be
+the wrong trade.
 
 ## Configuration
 

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -184,6 +184,27 @@ def _completion_excerpts(result_paths: tuple[tuple[int, str], ...]) -> dict[int,
     return excerpts
 
 
+def _orchestration_stopped(slot: "_ChatSlot", tracker: OrchestrationTracker) -> bool:
+    """True when the stage loop must not advance the plan any further.
+
+    Two independent channels revoke a run, and they do not mean the same thing:
+
+    * ``slot._stopping`` — session/ACP teardown. The slot itself is going away,
+      so nothing on it may keep running.
+    * ``tracker.stopped`` — the user revoked approval to keep ORCHESTRATING, via
+      the plan Cancel control (``api_chat_plan_action``) or an orchestrator stop
+      word. The slot stays alive and usable; only the plan ends.
+
+    A plan cancel sets the second and deliberately not the first, so an
+    advancement gate reading one flag observes only half the cancels. Every gate
+    below therefore reads both. The inverse fix — having Cancel set
+    ``slot._stopping`` — would hand a plan cancel the teardown semantics that
+    flag carries for paths outside this loop, which is not what the user asked
+    for by cancelling a plan.
+    """
+    return bool(slot._stopping) or bool(tracker.stopped)
+
+
 async def _stage_loop(
     state: "DashboardState",
     slot: "_ChatSlot",
@@ -232,7 +253,7 @@ async def _stage_loop(
     slot._in_stage_execution = True
     try:
         for stage_idx in range(start_idx, total):
-            if slot._stopping:
+            if _orchestration_stopped(slot, tracker):
                 break
 
             stage_num = stage_idx + 1  # 1-based for display
@@ -387,7 +408,7 @@ async def _stage_loop(
                 )
                 break
 
-            if slot._stopping:
+            if _orchestration_stopped(slot, tracker):
                 break
 
             # Wait for pending subagents spawned during this stage
@@ -479,7 +500,7 @@ async def _stage_loop(
                 while (
                     _pending
                     and _sa_rounds < _sa_max_rounds
-                    and not slot._stopping
+                    and not _orchestration_stopped(slot, tracker)
                 ):
                     _sa_rounds += 1
                     await asyncio.sleep(2)
@@ -555,7 +576,7 @@ async def _stage_loop(
                 )
                 break
 
-            if slot._stopping:
+            if _orchestration_stopped(slot, tracker):
                 break
 
             # Capture result to disk

--- a/test/test_orchestrator_cancel_stops_advance.py
+++ b/test/test_orchestrator_cancel_stops_advance.py
@@ -1,0 +1,205 @@
+"""A plan cancel must stop the stage loop, whatever the loop is awaiting.
+
+The Cancel control (``api_chat_plan_action`` with ``action="cancel"``) revokes the
+user's approval to keep orchestrating: it calls ``tracker.stop()`` and clears
+``slot._auto_run``. It deliberately does NOT set ``slot._stopping`` -- that flag
+carries session/ACP teardown, which a plan cancel is not asking for.
+
+``_stage_loop``'s advancement checks read only ``slot._stopping``, so none of them
+observe the cancel. The window that matters is ``_run_chat``: it is the longest
+await in the loop, so it is where a cancel most often lands, and the loop resumes
+from it and runs the next stage against a revoked approval.
+
+These tests drive the real HTTP cancel handler concurrently with a real
+``_stage_loop`` and assert the loop stops. Each also asserts ``slot._stopping``
+stays False, pinning the fix to reading the tracker rather than to widening what
+a plan cancel means.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path, monkeypatch):
+    """Stage results are captured under ``config_dir()`` -- keep them per-test.
+
+    ``chat_orchestrator`` imports ``config_dir`` into its own namespace, so
+    patching only ``state`` would leave results writing to the live data home.
+    """
+    for module in ("state", "chat", "chat_orchestrator"):
+        monkeypatch.setattr(f"kiro_crew.dashboard.{module}.config_dir", lambda: tmp_path)
+
+
+def _make_orchestrator_state(tmp_path, slot_key, titles):
+    """A state whose subagent manager reports nothing pending.
+
+    The loop is fail-closed on the subagent check: a missing manager, or a
+    ``running_agents_for`` returning None, breaks out of the loop on its own. A
+    test that left either unset would see the loop stop for that reason and pass
+    without the cancel doing anything -- so this wires the permissive case, where
+    the ONLY thing that can stop the loop is the cancel.
+    """
+    state = _make_state(tmp_path)
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    state.subagents._tasks = {}
+    slot = state.get_or_create_slot(slot_key, mode="orchestrator")
+    slot._stage_titles = list(titles)
+    slot._plan_goal = "Test goal"
+    slot._auto_run = True
+    return state, slot
+
+
+class _AsyncioFastSleep:
+    """The real ``asyncio`` module with only ``sleep`` substituted.
+
+    Replacing ``asyncio.sleep`` itself would reach every coroutine in the process
+    for the duration of the test -- including the aiohttp client the cancel is
+    issued through, which the substitute itself awaits. Rebinding the module
+    reference ``chat_orchestrator`` holds keeps the substitution to the one call
+    site under test; every other attribute (``to_thread``, ``create_task``)
+    resolves to the real module.
+    """
+
+    def __init__(self, sleep):
+        self.sleep = sleep
+
+    def __getattr__(self, name):
+        return getattr(asyncio, name)
+
+
+async def _cancel(client, slot_key):
+    resp = await client.post(f"/api/chat/slots/{slot_key}/plan-action", json={"action": "cancel"})
+    assert resp.status == 200
+    assert (await resp.json())["cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_run_chat_does_not_advance(tmp_path, monkeypatch):
+    """Cancel while stage 1 is inside ``_run_chat`` -- stage 2 must never run."""
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-mid-chat", ["First", "Second"])
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    stages_run: list[int] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+        if len(stages_run) == 1:
+            entered.set()
+            await release.wait()
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        loop_task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+        # Suspend the loop exactly inside _run_chat, then cancel from outside.
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        await _cancel(client, "cancel-mid-chat")
+
+        tracker = slot._orch_tracker
+        assert tracker is not None and tracker.stopped is True
+        assert slot._auto_run is False
+        assert slot._stopping is False, (
+            "plan cancel must not claim session teardown -- the loop is expected "
+            "to observe the tracker, not this flag"
+        )
+
+        release.set()
+        await asyncio.wait_for(loop_task, timeout=5)
+
+    assert stages_run == [1], f"cancel landed inside _run_chat but the loop ran {stages_run}"
+
+
+@pytest.mark.asyncio
+async def test_cancel_between_stages_blocks_reentry(tmp_path, monkeypatch):
+    """A cancel taken between stages must stop the re-entered loop at the top.
+
+    Under manual "Go" each stage is its own ``_stage_loop`` entry: the loop runs
+    one stage, emits the approval prompt and returns, and the tracker carries the
+    progress to the next entry. A cancel taken while the slot sits idle at that
+    prompt has to be observed by the top-of-iteration check when the user's next
+    Go re-enters -- so this runs stage 1 for real first, which is also what puts
+    a tracker on the slot for Cancel to stop.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-between", ["First", "Second"])
+    slot._auto_run = False
+
+    stages_run: list[int] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        # First Go: runs stage 1, then pauses for approval and returns.
+        await asyncio.wait_for(_stage_loop(state, slot, auto_run=False), timeout=5)
+        assert stages_run == [1], "setup: the first Go should have run exactly stage 1"
+
+        await _cancel(client, "cancel-between")
+        assert slot._orch_tracker.stopped is True
+        assert slot._stopping is False
+
+        # A later Go re-enters the loop, which resumes at stage 2.
+        await asyncio.wait_for(_stage_loop(state, slot, auto_run=False), timeout=5)
+
+    assert stages_run == [1], f"cancelled plan still advanced: ran {stages_run}"
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_subagent_wait_does_not_advance(tmp_path, monkeypatch):
+    """Cancel while the loop polls for pending subagents -- stage 2 must not run.
+
+    The poll is the loop's other long await. Its sleep is replaced so the poll
+    turns over immediately, and the cancel is issued from inside that sleep --
+    i.e. exactly between two evaluations of the poll's own stop condition, which
+    is what makes the timing deterministic rather than a race against a 2s tick.
+    """
+    from kiro_crew.dashboard import chat_orchestrator
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-subagent", ["First", "Second"])
+    # Never drains on its own: only the cancel can end this wait.
+    state.subagents.running_agents_for = MagicMock(return_value=[{"id": "sa-1"}])
+
+    stages_run: list[int] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        polls = {"n": 0}
+        real_sleep = asyncio.sleep
+
+        async def _fast_sleep(_delay, *args, **kwargs):
+            polls["n"] += 1
+            if polls["n"] == 1:
+                await _cancel(client, "cancel-subagent")
+            elif polls["n"] > 10:
+                raise AssertionError("subagent poll kept spinning after the plan was cancelled")
+            await real_sleep(0)
+
+        monkeypatch.setattr(
+            chat_orchestrator, "asyncio", _AsyncioFastSleep(_fast_sleep), raising=True
+        )
+        await asyncio.wait_for(_stage_loop(state, slot, auto_run=True), timeout=5)
+
+    assert slot._stopping is False
+    assert stages_run == [1], f"cancel landed in the subagent wait but the loop ran {stages_run}"


### PR DESCRIPTION
## Problem / Motivation

Cancelling a plan does not stop the plan. The user clicks **Cancel**, the UI posts `🛑 Plan cancelled.`, and the orchestrator then runs the next stage anyway — against an approval the user has just revoked.

Two independent channels revoke an orchestration run, and they mean different things:

| Flag | Set by | Means |
|---|---|---|
| `slot._stopping` | the **Stop** button (`POST /api/chat/slots/{slot}/stop`) | the slot itself is being torn down — nothing on it may keep running |
| `tracker.stopped` | the **Cancel** control (`api_chat_plan_action`, `action="cancel"`) and the typed `stop`/`cancel`/`abort` words | the user revoked approval to keep **orchestrating** — the slot stays alive, only the plan ends |

`_stage_loop` has four advancement gates, and on `main` all four read `slot._stopping` only. Cancel never sets that flag, so **no gate observes a cancel**. `grep tracker.stopped` inside the loop on `main` returns zero readers.

## Why it matters

The window that matters is `_run_chat`. It is the loop's longest await, so it is the likeliest place for a cancel to land — and it is the exact point the loop resumes from directly into the next stage.

So the failure lands on the user who is trying hardest to stop the agent: someone who sees a plan going wrong mid-stage and hits Cancel gets one more full stage of LLM turns and tool calls executed on their behalf, after the product told them the plan was cancelled. Sub-agent tasks are cancelled and `_auto_run` is cleared, which makes the UI look stopped, so the extra stage is not obviously attributable to the ignored cancel.

The existing test `test_cancel_clears_auto_run` asserts only `slot._auto_run is False` — it never asserted that the loop stops, which is why the gap survived.

## What changed (motivation → approach → change)

**Symptom** — a cancel that lands during `_run_chat` is followed by the next stage running.

**Root cause** — the four advancement gates read one of the two stop channels. The cancel handler sets `tracker.stopped` and `slot._auto_run`, and deliberately not `slot._stopping`; the gates test only `slot._stopping`. The two channels were never wired together.

**Change** — one predicate, `_orchestration_stopped(slot, tracker)`, reading both channels, called from all four gates (top-of-iteration, post-`_run_chat`, the sub-agent poll condition, pre-capture). Routing them through a single predicate rather than repeating a two-term condition four times is the point: it is what stops the two channels drifting apart again.

**Deliberately not the other direction.** #4783 offered a second option — have Cancel set `slot._stopping`. That flag carries session/ACP teardown semantics for paths *outside* this loop, and cancelling a plan is not a request to tear the session down. Folding one into the other would trade this bug for a semantics conflation.

**One gate is deliberately left alone.** The all-stages-complete summary still reads `slot._stopping` by itself. A cancel that arrives after the final stage's gate has already passed leaves a plan whose stages all genuinely ran, and suppressing a truthful completion summary there would be the worse trade. This is called out in the spec so it reads as a decision rather than an oversight.

**Not touched:** cancellation-handler semantics, `slot._stopping`, and the `auto_run` approval gate. With the gates fixed, a cancelled run breaks before reaching that gate, so the parameter-snapshot question #4783 also raises is moot here and stays available for separate work. One production file, one test file, one spec.

`docs/system-specs/modules/autopilot.md` documented the old single-flag behavior in two places (the step list, and the Stop-and-Cancel table); both are updated in the same commit, per `AGENTS.md`.

## Tests

Three tests added in `test/test_orchestrator_cancel_stops_advance.py`, each driving the **real** HTTP cancel handler concurrently with a **real** `_stage_loop` — not a simulated flag flip.

| Test | Behavior locked in |
|---|---|
| `test_cancel_during_run_chat_does_not_advance` | a cancel landing inside `_run_chat` stops the loop before stage 2 |
| `test_cancel_between_stages_blocks_reentry` | a cancel taken at the manual-Go approval prompt is observed when the next Go re-enters the loop |
| `test_cancel_during_subagent_wait_does_not_advance` | a cancel landing in the sub-agent poll ends the wait instead of spinning |

Fail-before / pass-after, measured on pristine `main` (`c505a877`) by reverting only the production file:

```
=== production reverted ===
FAILED test_cancel_during_run_chat_does_not_advance      - cancel landed inside _run_chat but the loop ran [1, 2]
FAILED test_cancel_between_stages_blocks_reentry         - cancelled plan still advanced: ran [1, 2]
FAILED test_cancel_during_subagent_wait_does_not_advance - subagent poll kept spinning after the plan was cancelled
3 failed

=== fix restored ===
3 passed
```

Each test also asserts `slot._stopping is False`, which pins the fix to reading the tracker rather than to widening what a plan cancel means — the assertion fails if someone later "fixes" this by conflating the flags.

Two details that produce a green-for-the-wrong-reason test if got wrong, both handled and commented in the fixture:

- The sub-agent check is **fail-closed**: a missing manager, or `running_agents_for` returning `None`, breaks the loop on its own. The fixture wires the permissive case (`running_agents_for` → `[]`) so the cancel is the only thing that can stop the loop.
- `test_cancel_between_stages_blocks_reentry` runs stage 1 for real before cancelling. Cancel no-ops when `slot._orch_tracker` is still `None`, so a test that cancels before any stage has run cancels nothing and passes vacuously.

The sub-agent test substitutes the poll's sleep via the module reference `chat_orchestrator` holds, rather than patching `asyncio.sleep` itself — the substitute awaits the aiohttp client to issue the cancel, so a global patch would reach the very call it depends on.

Regression run — `test_dashboard_chat.py` plus both existing `_stage_loop` suites: **654 passed**.

Gates: `flake8` · `isort` · `scripts/check_black_formatting.py` (3 files in scope) · `mypy` · `scripts/docs_lint.py` · `scripts/check_brand_name.py` — all clean.

## Manual verification

N/A — unit coverage sufficient: the tests exercise the real `api_chat_plan_action` handler over a real aiohttp `TestClient` against a real `_stage_loop`, so the HTTP cancel path and the orchestration loop are both the production code rather than stand-ins. The only mocked component is `_run_chat` (the LLM turn), which is what makes the cancel's arrival deterministic instead of a race.

## Related Issues

Closes #4783.

Sibling context: the write-window case of this same failure shape was fixed in #3771; umbrella #1783.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(autopilot): observe a plan cancel at every stage-advance gate`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/autopilot.md`, same commit)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The template carries a placeholder here pending OSPO-supplied wording, so no CLA text is reproduced. Happy to agree to the CLA once it is published in the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
