### PR TITLE
fix(mcp): read official registry responses to EOF instead of one chunk

### DIFF
--- a/src/kiro_crew/mcp_providers/official.py
+++ b/src/kiro_crew/mcp_providers/official.py
@@ -49,6 +49,9 @@ _USER_AGENT = "KiroCrew/1.0 (mcp-discovery)"
 # is a few KB; anything bigger is malformed or hostile.
 _MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 
+# Per-chunk read size while streaming a response to EOF (64 KiB).
+_HTTP_READ_CHUNK_BYTES = 64 * 1024
+
 # _meta key under which the registry reports official status metadata.
 _META_OFFICIAL = "io.modelcontextprotocol.registry/official"
 
@@ -87,11 +90,21 @@ async def _fetch_json(url: str) -> Any | None:
                     return None
                 if resp.status != 200:
                     raise ProviderUnavailableError(f"registry returned HTTP {resp.status}")
-                # Bound the read — resp.text() would buffer unbounded.
-                body = await resp.content.read(_MAX_RESPONSE_BYTES + 1)
-                if len(body) > _MAX_RESPONSE_BYTES:
-                    raise ProviderUnavailableError("registry response too large")
-                return json.loads(body.decode("utf-8"))
+                # Stream to EOF in bounded chunks. The registry sends search
+                # pages with no Content-Length, and a single
+                # StreamReader.read(n) returns only the bytes already
+                # buffered, so a multi-chunk document would reach json.loads
+                # truncated. The size cap is checked against the accumulated
+                # total, so an oversized body is refused mid-stream rather
+                # than buffered whole.
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in resp.content.iter_chunked(_HTTP_READ_CHUNK_BYTES):
+                    total += len(chunk)
+                    if total > _MAX_RESPONSE_BYTES:
+                        raise ProviderUnavailableError("registry response too large")
+                    chunks.append(chunk)
+                return json.loads(b"".join(chunks).decode("utf-8"))
     except ProviderUnavailableError:
         raise
     except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, OSError) as exc:

--- a/test/test_mcp_providers.py
+++ b/test/test_mcp_providers.py
@@ -7,6 +7,7 @@ blocked in this environment, and the tests must stay hermetic anyway.
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 
@@ -381,6 +382,140 @@ class TestOfficialTransport:
         monkeypatch.setattr(official_mod, "_fetch_json", boom)
         with pytest.raises(ProviderUnavailableError):
             await OfficialRegistryProvider().fetch_detail("io.github.acme/weather")
+
+
+# ---------------------------------------------------------------------------
+# Response reading — _fetch_json streams the body to EOF
+# ---------------------------------------------------------------------------
+
+
+class _FakeContent:
+    """Stand-in for ``aiohttp.StreamReader`` that hands out queued chunks.
+
+    ``iter_chunked`` yields them in order, one per chunk. ``read(n)`` returns
+    at most one queued chunk (split when longer than *n*) and ``b""`` at EOF —
+    the documented "up to n bytes" contract a single read cannot satisfy for a
+    streamed body, kept so a single-read implementation is still exercised.
+    """
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.reads = 0
+
+    async def iter_chunked(self, n: int):
+        while self._chunks:
+            yield await self.read(n)
+
+    async def read(self, n: int = -1) -> bytes:
+        self.reads += 1
+        if not self._chunks:
+            return b""
+        chunk = self._chunks.pop(0)
+        if n >= 0 and len(chunk) > n:
+            self._chunks.insert(0, chunk[n:])
+            chunk = chunk[:n]
+        return chunk
+
+    @property
+    def undelivered(self) -> int:
+        return sum(len(c) for c in self._chunks)
+
+
+class _FakeResponse:
+    def __init__(self, status: int, chunks):
+        self.status = status
+        self.content = _FakeContent(chunks)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def get(self, url, headers=None):
+        return self._response
+
+
+def _serve(monkeypatch, *chunks, status: int = 200) -> _FakeResponse:
+    """Route ``_fetch_json``'s HTTP call at a response yielding *chunks*."""
+    response = _FakeResponse(status, chunks)
+    monkeypatch.setattr(
+        official_mod.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(response)
+    )
+    return response
+
+
+class TestFetchJsonRead:
+    @pytest.mark.asyncio
+    async def test_multi_chunk_body_is_assembled(self, monkeypatch):
+        """A document split across chunks parses whole, not truncated."""
+        body = json.dumps({"servers": [{"name": f"io.github.a/s{i}"} for i in range(200)]})
+        raw = body.encode("utf-8")
+        third = len(raw) // 3
+        _serve(monkeypatch, raw[:third], raw[third : 2 * third], raw[2 * third :])
+
+        doc = await official_mod._fetch_json("https://registry.example/v0.1/servers")
+
+        assert doc == json.loads(body)
+
+    @pytest.mark.asyncio
+    async def test_heavily_fragmented_body_is_assembled(self, monkeypatch):
+        """Byte-at-a-time delivery still assembles — the loop has no read cap."""
+        raw = json.dumps({"servers": [{"name": "io.github.a/one"}]}).encode("utf-8")
+        _serve(monkeypatch, *[raw[i : i + 1] for i in range(len(raw))])
+
+        doc = await official_mod._fetch_json("https://registry.example/v0.1/servers")
+
+        assert doc == {"servers": [{"name": "io.github.a/one"}]}
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_rejected_mid_stream(self, monkeypatch):
+        """The cap applies to the accumulated total and stops the read early."""
+        monkeypatch.setattr(official_mod, "_MAX_RESPONSE_BYTES", 1024)
+        response = _serve(monkeypatch, *[b"x" * 512] * 20)
+
+        with pytest.raises(ProviderUnavailableError, match="too large"):
+            await official_mod._fetch_json("https://registry.example/v0.1/servers")
+
+        assert response.content.undelivered > 0, "read should abort, not drain the body"
+
+    @pytest.mark.asyncio
+    async def test_body_at_exact_cap_is_accepted(self, monkeypatch):
+        """A body exactly at the cap is not over it."""
+        raw = json.dumps({"servers": []}).encode("utf-8")
+        monkeypatch.setattr(official_mod, "_MAX_RESPONSE_BYTES", len(raw))
+        _serve(monkeypatch, raw[:2], raw[2:])
+
+        assert await official_mod._fetch_json("https://registry.example/v0.1/servers") == {
+            "servers": []
+        }
+
+    @pytest.mark.asyncio
+    async def test_404_returns_none_without_reading(self, monkeypatch):
+        """A missing entry is None, distinct from an unreachable registry."""
+        response = _serve(monkeypatch, b"not json", status=404)
+
+        assert await official_mod._fetch_json("https://registry.example/v0.1/servers") is None
+        assert response.content.reads == 0
+
+    @pytest.mark.asyncio
+    async def test_truncated_body_surfaces_as_provider_unavailable(self, monkeypatch):
+        """A genuinely malformed document is a provider failure, not a crash."""
+        _serve(monkeypatch, b'{"servers": [{"name": "io.git')
+
+        with pytest.raises(ProviderUnavailableError):
+            await official_mod._fetch_json("https://registry.example/v0.1/servers")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

Searching for MCP servers in **Agent Capabilities -> Connections -> MCP Servers -> Add Server** returns `No servers found` for queries that do match entries in the official registry. `aws`, `slack` and `github` all come back empty while a direct request to the same endpoint returns 17+ entries, and the UI shows no error -- a provider failure is indistinguishable from a genuinely empty result.

The failure depends on how the response is chunked, not on the query text: a zero-hit query returns a small body that fits in one chunk and parses fine, which is why the feature looks like it works until you search for something popular.

## Why it matters

Add Server is the only in-product path to the official MCP registry, so this makes registry discovery unusable for exactly the queries a user is most likely to type. Because `ProviderRegistry.search()` isolates provider faults by design, the failure is silent: the user concludes the registry has no `aws` server rather than that the lookup broke, and nothing in the UI suggests otherwise. The only trace is a `WARNING` in the gateway log.

## What changed (motivation → approach → change)

`_fetch_json()` read the whole body with a single call:

```python
body = await resp.content.read(_MAX_RESPONSE_BYTES + 1)
```

`aiohttp.StreamReader.read(n)` returns **up to** `n` bytes -- it resolves as soon as any data is buffered rather than waiting for EOF. The registry streams search pages with no `Content-Length`, so the body arrives in several chunks and that single call returns only the first one (~8-12 KiB here). `json.loads` then fails with `Unterminated string`, `_fetch_json` converts the `JSONDecodeError` into `ProviderUnavailableError`, and `ProviderRegistry.search()` catches it for fault isolation and returns an empty list for that provider -- which the dashboard renders as an ordinary 0-result search.

The fix streams the response to EOF in bounded chunks via `resp.content.iter_chunked()` -- the mechanism already used at nine sites in this repo -- and enforces the existing size cap against the accumulated total, so an oversized body is still refused mid-stream rather than buffered whole. The 404 -> `None` and transport-failure -> `ProviderUnavailableError` contracts are unchanged.

Scope is deliberately limited to the reported defect. The same single-read shape survives in three unrelated readers (`updates.py:740`, `feedback.py:179`, `source_providers.py:2422`); each has its own reachability and consequence argument, and folding them in here was already tried and rejected on this code (#2224's `updates.py` hunk was asked to be reverted as an undeclared change). They are tracked in #4829.

## Tests

Six tests in a new `TestFetchJsonRead` class (`test/test_mcp_providers.py`), all hermetic -- a fake `StreamReader` hands out queued chunks and honours the documented "up to n bytes" contract:

- `test_multi_chunk_body_is_assembled` -- the regression: a document split in three parses whole.
- `test_heavily_fragmented_body_is_assembled` -- byte-at-a-time delivery still assembles.
- `test_oversized_body_rejected_mid_stream` -- the cap applies to the accumulated total, and the read aborts instead of draining the rest.
- `test_body_at_exact_cap_is_accepted` -- the boundary is not off by one.
- `test_404_returns_none_without_reading` -- a missing entry stays distinct from an unreachable registry.
- `test_truncated_body_surfaces_as_provider_unavailable` -- a genuinely malformed document is still a provider failure, not a crash.

Reverting the production hunk fails the first four by name; the last two are contract-preservation tests and correctly stay green either way. The test double models `iter_chunked` and deliberately also keeps `read(n)`, so a single-read implementation is still exercised and the revert proof stays non-vacuous.

## Manual verification

Reproduced and re-verified through three probes, before and after the change:

| probe | before | after |
|---|---|---|
| `_fetch_json` against the live registry (`search=aws&limit=20`, 28,858 bytes, no `Content-Length`) | `ProviderUnavailableError: Unterminated string starting at ... char 7937` | 20 servers parsed |
| `_fetch_json` against a local chunked-stream server (53 KB in 8 KiB chunks) | `Unterminated string ... char 8126` | 120 servers parsed |
| full stack in an isolated instance -- `GET /api/mcp/discover?q=<q>&limit=20`, the request the Add Server dialog issues | `{"results": [], "providers": ["official"]}`, with `WARNING MCP provider official failed for query 'aws'` and the traceback in the log | `aws` 20, `slack` 18, `github` 20 results |

## Related Issues

Fixes #2222

Same defect as #2224 (open, currently conflicting) and #2232 (closed as a duplicate of it); this change is scoped to `_fetch_json` and carries the regression tests. Credit to @ayahiro1729 for the report and the diagnosis, and to @ChickenisLegit for independently finding it.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; the diff touches no frontend path and renders no new UI -- the user-visible effect is the existing Add Server list going from empty to populated, evidenced by the API probe above.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
