### PR TITLE
fix(tailnet): validate the Windows CLI path

### DIFF
--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -37,6 +37,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew import github_runner
 from kiro_crew.dashboard.urls import is_loopback
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.platform.governance_profiles import (
@@ -97,31 +98,40 @@ def _cli_path() -> str | None:
 
     Deliberately does **not** consult ``PATH`` — see ``_CLI_CANDIDATE_PATHS``.
 
-    A candidate is additionally refused when the binary or its directory is
-    writable by the gateway user (checked on POSIX; the Windows entry needs
-    elevation to write). The pinned list mostly needs root, but two entries do
-    not everywhere: Homebrew chowns ``/opt/homebrew/bin`` (and sometimes
-    ``/usr/local/bin``) to the console user, and identity resolution makes
-    this a request-triggered execution on the auth path — an agent that can
-    write there must not be able to plant a ``tailscale`` the next
-    credential-bearing request executes. A refused Homebrew install degrades
-    exactly like a missing binary: the feature contributes nothing and the
-    documented ``dashboard.url`` fallback still works.
+    A candidate is additionally refused when its platform's ownership policy
+    cannot establish trusted provenance. POSIX keeps the stricter local check
+    below; Windows reuses the shared executable validator, which reads the
+    binary and parent ACLs because mode bits carry no useful signal there. A
+    refusal degrades exactly like a missing binary: the feature contributes
+    nothing and the documented ``dashboard.url`` fallback still works.
     """
     # getattr: os.geteuid does not exist on Windows, and tests exercise this
     # path with IS_POSIX patched True on every platform.
     for candidate in _CLI_CANDIDATE_PATHS:
         if not (os.path.isfile(candidate) and os.access(candidate, os.X_OK)):
             continue
-        if IS_POSIX and not _posix_candidate_trusted(candidate):
-            logger.debug(
-                "tailscale CLI at %s is in a location this deployment cannot "
-                "trust; refusing to execute it (planted-binary defence). Use "
-                "an explicit dashboard.url instead.",
-                candidate,
-            )
-            continue
-        return candidate
+        validated = candidate
+        if IS_POSIX:
+            if not _posix_candidate_trusted(candidate):
+                logger.debug(
+                    "tailscale CLI at %s is in a location this deployment cannot "
+                    "trust; refusing to execute it (planted-binary defence). Use "
+                    "an explicit dashboard.url instead.",
+                    candidate,
+                )
+                continue
+        else:
+            try:
+                validated = github_runner.validate_provider_executable(candidate)
+            except ValueError as exc:
+                logger.debug(
+                    "tailscale CLI at %s failed executable trust validation: %s. "
+                    "Use an explicit dashboard.url instead.",
+                    candidate,
+                    exc,
+                )
+                continue
+        return validated
     return None
 
 

--- a/test/test_tailnet_e2e.py
+++ b/test/test_tailnet_e2e.py
@@ -163,16 +163,20 @@ def env(tmp_path, monkeypatch):
     monkeypatch.setenv("KIROCREW_HOME", str(home))
     monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(cli),))
     # SECOND deliberate seam, and it disables a security guard, so it is stated
-    # loudly rather than quietly worked around. `_cli_path` refuses any candidate the
-    # gateway user can write (planted-binary defence): the pinned list needs root,
-    # and an agent that can write a `tailscale` there would get it executed on the
-    # auth path. An unprivileged E2E cannot satisfy that — its fake lives in a
+    # loudly rather than quietly worked around. `_cli_path` vets the executable's
+    # ownership and permissions on POSIX and its ACL hierarchy on Windows. An
+    # unprivileged E2E cannot satisfy that provenance policy — its fake lives in a
     # user-owned tmp dir by construction.
     #
     # `test_the_planted_binary_defence_refuses_this_fake` below asserts the guard
     # really does reject this fake when NOT patched, so this bypass is proven
     # deliberate and cannot rot into an accidentally-disabled control.
-    monkeypatch.setattr(tailnet, "_posix_candidate_trusted", lambda _c: True)
+    if tailnet.IS_POSIX:
+        monkeypatch.setattr(tailnet, "_posix_candidate_trusted", lambda _c: True)
+    else:
+        monkeypatch.setattr(
+            tailnet.github_runner, "validate_provider_executable", lambda candidate: candidate
+        )
     monkeypatch.setenv("KIROCREW_PORT", str(_DASH_PORT))
     return {"cli": cli, "state": state, "home": home}
 
@@ -209,8 +213,6 @@ class TestTheSeamIsDeliberate:
         # Undo only the trust bypass; the candidate list still points at the fake.
         monkeypatch.undo()
         monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(env["cli"]),))
-        if not tailnet.IS_POSIX:
-            pytest.skip("the writability guard is POSIX-only")
         assert tailnet._cli_path() is None, (
             "a user-writable fake must be refused — if this passes, the guard the "
             "fixture bypasses is no longer doing anything"

--- a/test/test_tailnet_origin.py
+++ b/test/test_tailnet_origin.py
@@ -286,6 +286,19 @@ class TestSpawnHardening:
             assert candidate.startswith(("/", "C:\\")), candidate
             assert "tailscale" in candidate.lower(), candidate
 
+    def test_windows_candidate_must_pass_acl_validation(self, monkeypatch) -> None:
+        candidate = r"C:\Program Files\Tailscale\tailscale.exe"
+        monkeypatch.setattr(tailnet, "IS_POSIX", False)
+        monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (candidate,))
+        monkeypatch.setattr(tailnet.os.path, "isfile", lambda _path: True)
+        monkeypatch.setattr(tailnet.os, "access", lambda _path, _mode: True)
+        with patch(
+            "kiro_crew.github_runner.validate_provider_executable",
+            side_effect=ValueError("executable can be replaced by Everyone"),
+        ) as validate:
+            assert tailnet._cli_path() is None
+        validate.assert_called_once_with(candidate)
+
     def test_credentials_are_not_inherited(self) -> None:
         """The child gets a scrubbed environment, not ``os.environ``."""
         witness = "AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
## Problem / Motivation

`tailnet._cli_path()` spawns `C:\Program Files\Tailscale\tailscale.exe` behind `_posix_candidate_trusted` — a POSIX `st_uid` + `S_IWGRP|S_IWOTH` predicate. On Windows that predicate carries **no information, in either direction**:

- `os.stat().st_uid` is always `0`, so an ownership test whitelisting `0` as root-owned always passes.
- `st_mode` is always `0o777`, so a world-writable test always fires.

The executable trust check is therefore skipped entirely on Windows: the spawn happens either way.

## Why it matters

The check exists so a substituted binary cannot be executed with the gateway's privileges — and Tailscale CLI resolution runs on the **auth path**, triggered by a request. A guard that reads as a planted-binary defence while enforcing nothing is worse than a documented absence, because nobody goes looking for it.

Its two siblings (`terminal_commands.py`, `pptx_maker/preview_tools.py`) both fail closed on Windows; `tailnet` alone runs the binary. This is the last executable-trust site with that shape after #4613 fixed the provider-CLI (`gh` / `glab`) one, and it was raised by the First Principles review on that PR as accepted-and-deferred.

Exposure is bounded by what `tailscale.exe` can do, which is why this is a correctness-of-a-security-control fix rather than a critical break.

## What changed

**Symptom** — on Windows, a `tailscale.exe` candidate is executed regardless of its ownership or ACL.

**Root cause** — the trust question is asked with a POSIX-only predicate whose inputs are constant on Windows, so the answer is fixed rather than computed.

**Change** — route the non-POSIX branch through `github_runner.validate_provider_executable`, the platform-dispatched validator #4613 added for exactly this question. It answers ownership and substitutability from the object's ACL via `kiro_crew.windows_acl`, refuses an elevated gateway, and returns the canonical path.

Reusing that validator rather than re-deriving the predicate is the deliberate choice: it keeps the two executable-trust sites from drifting, and it inherits the trap #4613 documents — mask bits `0x2`/`0x4` mean `ADD_FILE`/`ADD_SUBDIRECTORY` on a *directory* and cannot touch an existing entry, so reading them as write grants would refuse every default Windows install (`C:\` grants `ADD_SUBDIRECTORY` to `Authenticated Users`).

**POSIX is deliberately unchanged.** `_posix_candidate_trusted` is *stricter* than the validator's default policy, which intentionally accepts ordinary user-owned Homebrew/asdf installs. Routing POSIX through the shared path would **loosen** an existing control rather than tighten one, so this fix is Windows-only by construction.

A refusal degrades exactly like a missing Tailscale install: gateway startup behaviour is preserved, the feature contributes nothing, and the documented `dashboard.url` fallback still works. The debug log retains the validator's refusal reason for diagnosis.

One production file; no new abstraction and no change to `github_runner`.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_windows_candidate_must_pass_acl_validation` (new) | a Windows candidate the ACL validator rejects is no longer returned from `_cli_path()` |
| `test_the_planted_binary_defence_refuses_this_fake` (skip removed) | the E2E fixture's deliberate trust bypass is now enforced on Windows too |

The E2E fixture's deliberate trust bypass gains a Windows arm, which is what lets `test_the_planted_binary_defence_refuses_this_fake` stop skipping there. That test is what proves the bypass stays deliberate rather than rotting into an accidentally-disabled control — it was previously unenforced on the one platform where the guard was inert.

Suite run across the affected areas — `test_tailnet_origin.py`, `test_tailnet_e2e.py`, `test_github_runner.py`, `test_windows_acl.py`: **136 passed, 31 skipped**.

Gates: `isort` · `flake8` · `mypy` · diff-check. `src/kiro_crew/dashboard/tailnet.py` is **not** in `.github/black-baseline.txt`, so black is enforced on it and passes.

Two further tests covering the *accepting* half of the contract (a binary the ACL walk clears still runs, asserted against the validator's canonical return) and a guard that POSIX does not consult the shared validator are offered as an applyable diff in [this comment](https://github.com/kirodotdev/KiroCrew/pull/4817#issuecomment-5364574561), carried over from duplicate PR #4819.

## Manual verification

N/A — unit coverage sufficient: the trust decision is a pure predicate over the candidate path, and the test drives the real `_cli_path()` with the validator seam patched, so the dispatch and the refusal behaviour are both production code. Verifying the ACL walk itself against a genuinely mis-ACLed binary would require an elevated Windows host to plant one, which is out of reach of CI; `test_windows_acl.py` covers that layer separately.

## Related Issues

Closes #4639.

Follows #4613, which introduced the shared validator and deferred this site. Duplicate PR #4819 was closed in favour of this one.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(tailnet): validate the Windows CLI path`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no spec documents `_cli_path()`'s trust check; the function docstring is the record and is updated in this commit
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The template carries a placeholder here pending OSPO-supplied wording, so no CLA text is reproduced. Happy to agree to the CLA once it is published in the template.
