### PR TITLE
fix(tailnet): validate the tailscale binary's trust on Windows too

### DIFF
--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -37,6 +37,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew import github_runner
 from kiro_crew.dashboard.urls import is_loopback
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.platform.governance_profiles import (
@@ -97,31 +98,40 @@ def _cli_path() -> str | None:
 
     Deliberately does **not** consult ``PATH`` — see ``_CLI_CANDIDATE_PATHS``.
 
-    A candidate is additionally refused when the binary or its directory is
-    writable by the gateway user (checked on POSIX; the Windows entry needs
-    elevation to write). The pinned list mostly needs root, but two entries do
-    not everywhere: Homebrew chowns ``/opt/homebrew/bin`` (and sometimes
-    ``/usr/local/bin``) to the console user, and identity resolution makes
-    this a request-triggered execution on the auth path — an agent that can
-    write there must not be able to plant a ``tailscale`` the next
-    credential-bearing request executes. A refused Homebrew install degrades
-    exactly like a missing binary: the feature contributes nothing and the
-    documented ``dashboard.url`` fallback still works.
+    A candidate is additionally refused when its platform's ownership policy
+    cannot establish trusted provenance. POSIX keeps the stricter local check
+    below; Windows reuses the shared executable validator, which reads the
+    binary and parent ACLs because mode bits carry no useful signal there. A
+    refusal degrades exactly like a missing binary: the feature contributes
+    nothing and the documented ``dashboard.url`` fallback still works.
     """
     # getattr: os.geteuid does not exist on Windows, and tests exercise this
     # path with IS_POSIX patched True on every platform.
     for candidate in _CLI_CANDIDATE_PATHS:
         if not (os.path.isfile(candidate) and os.access(candidate, os.X_OK)):
             continue
-        if IS_POSIX and not _posix_candidate_trusted(candidate):
-            logger.debug(
-                "tailscale CLI at %s is in a location this deployment cannot "
-                "trust; refusing to execute it (planted-binary defence). Use "
-                "an explicit dashboard.url instead.",
-                candidate,
-            )
-            continue
-        return candidate
+        validated = candidate
+        if IS_POSIX:
+            if not _posix_candidate_trusted(candidate):
+                logger.debug(
+                    "tailscale CLI at %s is in a location this deployment cannot "
+                    "trust; refusing to execute it (planted-binary defence). Use "
+                    "an explicit dashboard.url instead.",
+                    candidate,
+                )
+                continue
+        else:
+            try:
+                validated = github_runner.validate_provider_executable(candidate)
+            except ValueError as exc:
+                logger.debug(
+                    "tailscale CLI at %s failed executable trust validation: %s. "
+                    "Use an explicit dashboard.url instead.",
+                    candidate,
+                    exc,
+                )
+                continue
+        return validated
     return None
 
 

--- a/test/test_tailnet_e2e.py
+++ b/test/test_tailnet_e2e.py
@@ -163,16 +163,20 @@ def env(tmp_path, monkeypatch):
     monkeypatch.setenv("KIROCREW_HOME", str(home))
     monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(cli),))
     # SECOND deliberate seam, and it disables a security guard, so it is stated
-    # loudly rather than quietly worked around. `_cli_path` refuses any candidate the
-    # gateway user can write (planted-binary defence): the pinned list needs root,
-    # and an agent that can write a `tailscale` there would get it executed on the
-    # auth path. An unprivileged E2E cannot satisfy that — its fake lives in a
+    # loudly rather than quietly worked around. `_cli_path` vets the executable's
+    # ownership and permissions on POSIX and its ACL hierarchy on Windows. An
+    # unprivileged E2E cannot satisfy that provenance policy — its fake lives in a
     # user-owned tmp dir by construction.
     #
     # `test_the_planted_binary_defence_refuses_this_fake` below asserts the guard
     # really does reject this fake when NOT patched, so this bypass is proven
     # deliberate and cannot rot into an accidentally-disabled control.
-    monkeypatch.setattr(tailnet, "_posix_candidate_trusted", lambda _c: True)
+    if tailnet.IS_POSIX:
+        monkeypatch.setattr(tailnet, "_posix_candidate_trusted", lambda _c: True)
+    else:
+        monkeypatch.setattr(
+            tailnet.github_runner, "validate_provider_executable", lambda candidate: candidate
+        )
     monkeypatch.setenv("KIROCREW_PORT", str(_DASH_PORT))
     return {"cli": cli, "state": state, "home": home}
 
@@ -209,8 +213,6 @@ class TestTheSeamIsDeliberate:
         # Undo only the trust bypass; the candidate list still points at the fake.
         monkeypatch.undo()
         monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(env["cli"]),))
-        if not tailnet.IS_POSIX:
-            pytest.skip("the writability guard is POSIX-only")
         assert tailnet._cli_path() is None, (
             "a user-writable fake must be refused — if this passes, the guard the "
             "fixture bypasses is no longer doing anything"

--- a/test/test_tailnet_origin.py
+++ b/test/test_tailnet_origin.py
@@ -286,6 +286,74 @@ class TestSpawnHardening:
             assert candidate.startswith(("/", "C:\\")), candidate
             assert "tailscale" in candidate.lower(), candidate
 
+    @staticmethod
+    def _windows_candidate(monkeypatch, candidate: str) -> None:
+        """Present *candidate* as an existing, executable file on a Windows gateway.
+
+        ``isfile``/``access`` are stubbed because the pinned Tailscale install
+        path does not exist on a test runner, and the question under test is what
+        the TRUST check does once a candidate is otherwise viable -- not whether
+        the file is there.
+        """
+        monkeypatch.setattr(tailnet, "IS_POSIX", False)
+        monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (candidate,))
+        monkeypatch.setattr(tailnet.os.path, "isfile", lambda _path: True)
+        monkeypatch.setattr(tailnet.os, "access", lambda _path, _mode: True)
+
+    def test_windows_candidate_must_pass_acl_validation(self, monkeypatch) -> None:
+        """A refused Windows binary is not executed.
+
+        The POSIX predicate this replaced read nothing on Windows -- ``st_uid`` is
+        always 0 and ``st_mode`` always ``0o777`` there -- so the guard passed
+        unconditionally and the spawn happened either way.
+        """
+        candidate = r"C:\Program Files\Tailscale\tailscale.exe"
+        self._windows_candidate(monkeypatch, candidate)
+        with patch(
+            "kiro_crew.github_runner.validate_provider_executable",
+            side_effect=ValueError("executable can be replaced by Everyone"),
+        ) as validate:
+            assert tailnet._cli_path() is None
+        validate.assert_called_once_with(candidate)
+
+    def test_windows_candidate_cleared_by_the_acl_walk_is_used(self, monkeypatch) -> None:
+        """The other half of the contract: a cleared binary still runs.
+
+        A guard that refused every Windows install would "pass" the refusal test
+        above while removing the feature, so the accepting path is pinned too --
+        and pinned to the validator's CANONICAL return rather than to the raw
+        candidate, because that is the path actually spawned.
+        """
+        candidate = r"C:\Program Files\Tailscale\tailscale.exe"
+        canonical = r"C:\Program Files\Tailscale\TAILSCALE.EXE"
+        self._windows_candidate(monkeypatch, candidate)
+        with patch(
+            "kiro_crew.github_runner.validate_provider_executable",
+            return_value=canonical,
+        ) as validate:
+            assert tailnet._cli_path() == canonical
+        validate.assert_called_once_with(candidate)
+
+    def test_posix_keeps_its_own_stricter_check(self, monkeypatch) -> None:
+        """POSIX behaviour is unchanged -- the shared validator is not consulted.
+
+        ``_posix_candidate_trusted`` is stricter than the validator's default
+        policy (which deliberately accepts ordinary user-owned Homebrew installs),
+        so routing POSIX through the shared path would LOOSEN an existing control.
+        This fix is Windows-only by construction.
+        """
+        candidate = "/usr/bin/tailscale"
+        monkeypatch.setattr(tailnet, "IS_POSIX", True)
+        monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (candidate,))
+        monkeypatch.setattr(tailnet.os.path, "isfile", lambda _path: True)
+        monkeypatch.setattr(tailnet.os, "access", lambda _path, _mode: True)
+        monkeypatch.setattr(tailnet, "_posix_candidate_trusted", lambda _c: True)
+        with patch(
+            "kiro_crew.github_runner.validate_provider_executable"
+        ) as validate:
+            assert tailnet._cli_path() == candidate
+        validate.assert_not_called()
+
     def test_credentials_are_not_inherited(self) -> None:
         """The child gets a scrubbed environment, not ``os.environ``."""
         witness = "AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
Closes #4639.

## The defect

`_cli_path()` spawns `C:\Program Files\Tailscale\tailscale.exe` behind `_posix_candidate_trusted` — a POSIX `st_uid` + `S_IWGRP|S_IWOTH` predicate. On Windows that predicate carries **no information, in either direction**:

- `os.stat().st_uid` is always `0`, so an ownership test whitelisting `0` as root-owned always passes.
- `st_mode` is always `0o777`, so a world-writable test always fires.

So the guard reads as a planted-binary defence while providing none — the spawn happens either way. Its two siblings (`terminal_commands.py`, `pptx_maker/preview_tools.py`) fail closed on Windows; `tailnet` alone runs the binary. This is the last executable-trust site with that shape after #4613 fixed the provider-CLI one, and it was raised by First Principles on that PR as accepted-and-deferred.

## The fix

Route the non-POSIX branch through `github_runner.validate_provider_executable` — the platform-dispatched validator #4613 added for exactly this question. It answers ownership and substitutability from the object's ACL via `kiro_crew.windows_acl`, refuses an elevated gateway, and returns the canonical path.

Reusing it rather than re-deriving the predicate is the point: it is what keeps the two sites from drifting, and it inherits the trap #4613 documents — mask bits `0x2`/`0x4` mean `ADD_FILE`/`ADD_SUBDIRECTORY` on a *directory* and cannot touch an existing entry, so reading them as write grants would refuse every default Windows install (`C:\` grants `ADD_SUBDIRECTORY` to `Authenticated Users`).

**POSIX is deliberately unchanged.** `_posix_candidate_trusted` is *stricter* than the validator's default policy, which intentionally accepts ordinary user-owned Homebrew/asdf installs. Routing POSIX through the shared path would **loosen** an existing control rather than tighten one, so this fix is Windows-only by construction — and there is a test pinning that the shared validator is not consulted on POSIX.

A refusal degrades exactly like a missing binary: the feature contributes nothing and the documented `dashboard.url` fallback still works.

## Evidence

Fail-before / pass-after, measured by reverting only the production file on `e5fbd31dd`:

```
=== production reverted ===
FAILED test_windows_candidate_must_pass_acl_validation
       - assert 'C:\Program Files\Tailscale\tailscale.exe' is None
FAILED test_windows_candidate_cleared_by_the_acl_walk_is_used
       - assert 'C:\Program ...tailscale.exe' == 'C:\Program ...TAILSCALE.EXE'
2 failed, 4 passed

=== fix restored ===
6 passed
```

The first failure *is* the bug in one line: the validator raised, and the candidate was returned and would have been executed.

Both halves of the issue's acceptance criterion are pinned, deliberately:

- **Refusal** — a binary the ACL walk rejects is not executed.
- **Acceptance** — a binary it clears still runs, asserted against the validator's **canonical return** rather than the raw candidate, because that is the path actually spawned. Without this test a guard that refused every Windows install would pass the refusal test while silently removing the feature.
- **POSIX unchanged** — `validate_provider_executable` is asserted *not called*, so the loosening described above cannot land unnoticed.

The E2E fixture's deliberate trust bypass gains the Windows arm, which lets `test_the_planted_binary_defence_refuses_this_fake` stop skipping on Windows. That test is what proves the bypass stays deliberate rather than rotting into an accidentally-disabled control — it was previously unenforced on the one platform where the guard was inert.

`test_tailnet_origin.py` + `test_tailnet_e2e.py` + `test_github_runner.py`: **78 passed, 30 skipped**.

## Gates

`flake8` · `isort` · `scripts/check_black_formatting.py` (3 files in scope; `dashboard/tailnet.py` is **not** baselined, so black is enforced on it and passes) · `mypy` (no errors in the changed file) · `scripts/check_brand_name.py`.

## Scope

One production file. No new abstraction, no change to `github_runner`, no change to POSIX behaviour, and no widening of the trust policy — the fix is entirely "call the validator that already exists on the platform where the old check was blind".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
