### PR TITLE
docs: publish only the download links each channel actually serves

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ running, updates itself on the channel you download, and can connect to a
 remote Gateway over an SSH tunnel. See the
 [desktop app guide](docs/build/desktop-app.md).
 
-- **macOS** (one universal DMG, Apple Silicon + Intel): [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew.dmg) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew.dmg) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew.dmg)
-- **Windows**: no desktop build yet, so run the Gateway from a [source install](#build-from-source) and open the dashboard in your browser
+- **macOS** (Apple Silicon/Intel): [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew.dmg) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew.dmg) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew.dmg)
+- **Windows** (x64): Stable — none, use a [source install](#build-from-source) | Insider — from 0.4.0 | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup.exe) · [why](docs/guides/windows-install.md#desktop-installer)
 
 **On Linux, start with the one-line install** — it is the smoothest path, works
 on every distro and both architectures, and puts `kirocrew` on your `PATH`,
@@ -81,9 +81,14 @@ carries a manual sandbox step. `uname -m` prints which architecture you need.
 
 | Linux desktop package | x86_64 | aarch64 (Graviton, Raspberry Pi, ARM laptops) |
 |---|---|---|
-| **`.deb`** (Debian, Ubuntu) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.deb) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.deb) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.deb) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.deb) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.deb) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.deb) |
-| **`.rpm`** (Fedora, RHEL, CentOS Stream, Amazon Linux 2023) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.rpm) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.rpm) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.rpm) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.rpm) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.rpm) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.rpm) |
+| **`.deb`** (Debian, Ubuntu) — **Nightly only for now** | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.deb) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.deb) |
+| **`.rpm`** (Fedora, RHEL, CentOS Stream, Amazon Linux 2023) — **Nightly only for now** | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.rpm) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.rpm) |
 | **AppImage** (no root, any distro) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.AppImage) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.AppImage) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.AppImage) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.AppImage) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.AppImage) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.AppImage) |
+
+**`.deb` and `.rpm` publish on Nightly only until 0.4.0**, as does the Windows
+installer's Insider lane — the per-format publish lanes landed after the 0.3.0
+release branch was cut. On Stable and Insider, take the AppImage or the one-line
+CLI install above.
 
 ```bash
 sudo apt install ./KiroCrew-x86_64.deb     # Debian, Ubuntu


### PR DESCRIPTION
## What

Two corrections to the README's download tables, both verified against the live CDN rather than against the workflow files.

**`.deb` / `.rpm` are Nightly-only for now.** The table advertised Stable and Insider links for both formats. All eight 403. Only Nightly serves them.

**Windows has a desktop installer.** The README said "no desktop build yet". `desktop/nightly/latest/KiroCrew-Setup.exe` has been live and Authenticode-signed; the bullet now links it and states the channel situation.

## Why the gap exists

One root cause for both. The per-`(arch, format)` Linux publish lanes and `publish-windows.yml` landed on `main` **after** `release/0.3.0` was cut:

| ref | `publish-windows` in release.yml | `publish-linux` format param |
|---|---|---|
| `v0.3.0` / `v0.3.0-insider.13` | absent | absent (`arch` only) |
| `origin/main` | present | present |

So the 0.3.0 line builds and smoke-tests deb, rpm and the Windows installer, then uploads none of them. Nightly builds from `main`, which is why Nightly has all three. Insider gets them with the 0.4.0 cut.

**Stable Windows is a different, permanent case, not a gap.** A stable release republishes the immutable promotion bundle, whose artifact roles include no Windows installer, so `WINDOWS_CHANNELS` in `auto-update.js` admits only `nightly` and `insider` and a stable Windows client reports updates unavailable instead of resolving a feed nobody wrote (`docs/guides/windows-install.md` § Desktop installer). The bullet says so and routes Stable users to the source install.

## Verification

Every `download.crew.kiro.dev` URL in the file was fetched. 15 real links, **all 200**; the only non-200 is the intentional `<version>` placeholder in the pin-an-exact-wheel example.

`scripts/docs-lint.sh` clean, `check_brand_name.py` clean, `scrub-lint.sh` content checks clean (its history-author FAIL is a pre-existing repo condition, unrelated).

## Follow-up

Once `v0.4.0-insider.1` publishes, the Insider deb/rpm/exe links can be restored and the "Nightly only for now" qualifier dropped. Keeping that as a separate change rather than pre-writing links that 403 today.

**Why no screenshot:** documentation-only change, no rendered UI surface.