### PR TITLE
fix(security): deny self-protection subcommands behind interposed flags

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -1343,7 +1343,14 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="self-protection-restart",
-        pattern=".*kiro.?crew restart.*",
+        # The CLI accepts top-level flags BEFORE the subcommand (``-v``/``--verbose``
+        # is ``action="count"`` and ``--no-jail`` is declared on the top-level parser),
+        # so the four self-protection patterns below allow an interposed flag run
+        # between the program name and the subcommand. The flag-run construct is
+        # byte-identical to the ``credential-exfil-s3-cp``/aws idiom on purpose:
+        # ``_linearize_deny_pattern`` rewrites exactly that spelling into its
+        # linear-time equivalent, so reusing it keeps these rules ReDoS-safe (#4799).
+        pattern=".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+restart.*",
         category="self-protection",
         description=(
             "Blocks 'kirocrew restart' so the agent cannot restart its own gateway process and "
@@ -1352,7 +1359,7 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="self-protection-update",
-        pattern=".*kiro.?crew update.*",
+        pattern=".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+update.*",
         category="self-protection",
         description=(
             "Blocks 'kirocrew update' so the agent cannot self-update (git pull + rebuild + "
@@ -1361,7 +1368,10 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="self-protection-cloud",
-        pattern=".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*",
+        pattern=(
+            ".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+cloud\\s+"
+            "(destroy|stop|start|launch|connect|tunnel|log(in|out)).*"
+        ),
         category="self-protection",
         description=(
             "Blocks 'kirocrew cloud' lifecycle subcommands "
@@ -1389,7 +1399,7 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="self-protection-gateway-restart",
-        pattern=".*kiro.?crew gateway restart.*",
+        pattern=".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+gateway restart.*",
         category="self-protection",
         description=(
             "Blocks 'kirocrew gateway restart' so the agent cannot bounce its own gateway "
@@ -1517,6 +1527,37 @@ _RULES_BY_ID: dict[str, DeniedCommandRule] = {r.id: r for r in BUILTIN_DENIED_RU
 # Reverse map (pattern → rule id) for SEL audit enrichment on a regex-tier match.
 _RULE_ID_BY_PATTERN: dict[str, str] = {r.pattern: r.id for r in BUILTIN_DENIED_RULES}
 
+# Legacy spellings of rules whose patterns were later widened (#4799).  A
+# governance policy persists the pattern STRING it pinned, and the pin resolvers
+# treat a pattern as pinning a built-in rule only when it maps back to a rule id
+# — so a ceiling or profile written against a pre-widening catalog must keep
+# resolving to the rule id after an upgrade (upgrade monotonicity).  Without
+# these aliases a stale pin falls out of the id map: the force-re-add is lost
+# and a user opt-out would drop the rule even though the administrator pinned
+# it.  LOOKUP-ONLY: consulted by :func:`_rule_id_for_pattern` (the pin
+# resolvers), never merged into ``_RULE_ID_BY_PATTERN`` — the legacy spellings
+# must not count as built-ins for ``_DenyMatcher``'s fast-path election or SEL
+# enrichment, and they never enter ``BUILTIN_DENY_PATTERNS`` or the golden
+# manifest.
+_LEGACY_RULE_ID_BY_PATTERN: dict[str, str] = {
+    ".*kiro.?crew restart.*": "self-protection-restart",
+    ".*kiro.?crew update.*": "self-protection-update",
+    ".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*": (
+        "self-protection-cloud"
+    ),
+    ".*kiro.?crew gateway restart.*": "self-protection-gateway-restart",
+}
+
+
+def _rule_id_for_pattern(pattern: str) -> "str | None":
+    """Resolve a governance-pinned pattern string to a built-in rule id.
+
+    Current catalog spellings first, then the legacy (pre-widening) spellings,
+    so a persisted policy keeps its pin across a pattern change.
+    """
+    return _RULE_ID_BY_PATTERN.get(pattern) or _LEGACY_RULE_ID_BY_PATTERN.get(pattern)
+
+
 # ── Git-publish rule patterns are NOT evaluated in the Python regex tier ──
 # The ``git-publish`` category rules exist in the catalog for UI display /
 # opt-out parity, but git-publish enforcement is done UNCONDITIONALLY by the
@@ -1559,14 +1600,29 @@ def floor_enforced_builtin_command_ids() -> frozenset[str]:
     return _FLOOR_ENFORCED_RULE_IDS
 
 
-# The two self-protection rules whose enforcement lives in the argv-structural
-# floor (``_is_credential_mint`` / ``_is_self_kill``) rather than in the regex
-# tier.  Their ``pattern`` is retained as the catalog-visible, human-auditable
-# statement of intent -- and it is a correct SUBSET of the floor -- but it is not
-# fed to ``re`` because a raw-string match cannot resolve shell quoting or
-# redirection, and a pattern loose enough to try would re-block ordinary paths.
+# Self-protection rules that get the argv-structural floor (``_self_token_frames``
+# -> a per-rule predicate), which sees the de-escaped, de-quoted argv that the
+# raw-text regex tier cannot. Two enforcement stories share the mechanism:
+#   * credential-mint / self-kill: floor-PRIMARY. Their catalog ``pattern`` is a
+#     human-auditable SUBSET; a raw-string match cannot resolve shell quoting or
+#     redirection, and a pattern loose enough to try would re-block ordinary
+#     paths, so the floor carries enforcement.
+#   * restart / update / gateway restart / cloud <destructive>: regex+floor UNION.
+#     The widened regex (#4799) catches the real-flag and raw-text forms (incl.
+#     ``bash -c`` payloads and the ``python -m kiro_crew`` module form); the floor
+#     (#4824) additionally catches shell de-escaping the regex cannot -- e.g.
+#     ``kirocrew -\v restart``, ``kirocrew \restart``, a ``\<newline>`` continuation.
+# All members stay in the regex tier (only git-publish is removed from ``re``);
+# the floor is a union with it, never a replacement.
 _SELF_PROTECTION_FLOOR_RULE_IDS: frozenset[str] = frozenset(
-    {"credential-exfil-kirocrew-token", "self-protection-kill"}
+    {
+        "credential-exfil-kirocrew-token",
+        "self-protection-kill",
+        "self-protection-restart",
+        "self-protection-update",
+        "self-protection-gateway-restart",
+        "self-protection-cloud",
+    }
 )
 _SELF_PROTECTION_FLOOR_BY_ID: dict[str, str] = {
     r.id: r.pattern for r in BUILTIN_DENIED_RULES if r.id in _SELF_PROTECTION_FLOOR_RULE_IDS
@@ -1678,7 +1734,8 @@ def pinned_builtin_command_ids() -> set[str]:
         if resolver is None:
             return set()
         pins = resolver(ceiling)
-        return {_RULE_ID_BY_PATTERN[p] for p in pins if p in _RULE_ID_BY_PATTERN}
+        ids = (_rule_id_for_pattern(p) for p in pins)
+        return {rid for rid in ids if rid is not None}
     except PlatformCompositionError:
         raise
     except Exception:
@@ -1714,7 +1771,7 @@ def pinned_builtin_command_ids_for_snapshot() -> set[str]:
         from kiro_crew.platform.governance_profiles import all_profile_pinned_commands
 
         for p in all_profile_pinned_commands():
-            rid = _RULE_ID_BY_PATTERN.get(p)
+            rid = _rule_id_for_pattern(p)
             if rid is not None:
                 ids.add(rid)
     except Exception:
@@ -3849,6 +3906,194 @@ def _is_self_kill(text_lower: str) -> bool:
                 ):
                     return True
     return False
+
+
+# ── Self-protection subcommand floor (argv-structural) ──────────────────────
+# ``restart`` / ``update`` / ``gateway restart`` / ``cloud <destructive>`` each
+# run a privileged self-action. The regex tier matches these on raw text, which
+# the shell's own de-escaping defeats: ``kirocrew -\v restart`` (backslash escape
+# -> ``-v``), ``kirocrew \restart`` (escaped subcommand letter) and
+# ``kirocrew -\<newline>v restart`` (line continuation) all reach the shell as the
+# plain command but split a token in the raw string the regex sees. Matching on
+# the tokenized argv -- the same de-escaped, de-quoted view the kill/token floors
+# use (``_self_token_frames``) -- resolves every such spelling before the check.
+# The floor is a UNION with the regex tier, never a replacement: the regex still
+# catches a payload the tokenizer cannot see into (``bash -c "kirocrew restart"``)
+# and the ``python -m kiro_crew restart`` module form (``kiro.?crew`` + verb) (#4824).
+_SELF_CLOUD_DESTRUCTIVE_VERBS: frozenset[str] = frozenset(
+    {"destroy", "stop", "start", "launch", "connect", "tunnel", "login", "logout"}
+)
+
+# A shell removes ``backslash + newline`` while lexing (line continuation), so
+# ``kirocrew \<newline>restart`` runs ``kirocrew restart``. ``shlex`` instead keeps
+# the escaped newline as a literal in the token, so the floor pre-joins it to
+# model the shell before tokenizing. Scoped to the floor's own tokenizer input
+# (NOT a catalog-wide rewrite of the matched text): it only shapes the argv the
+# self-protection predicates see, so it cannot over-block an unrelated rule.
+_SHELL_LINE_CONTINUATION_RE = re.compile(r"\\\r?\n")
+
+
+def _shell_join_continuations(text: str) -> str:
+    """Collapse bash ``\\<newline>`` line continuations, as the shell does pre-lex."""
+    return _SHELL_LINE_CONTINUATION_RE.sub("", text)
+
+
+def _redirect_consumes_next(token: str) -> "tuple[bool, bool]":
+    """Classify *token* as a shell redirection sitting in argv position.
+
+    Returns ``(is_redirect, expects_separate_target)``. A redirection is removed
+    from argv by the shell and may appear ANYWHERE in a simple command, so it is
+    never a CLI operand: ``kirocrew 2>/tmp/x restart`` and ``kirocrew > /tmp/x
+    restart`` both run ``restart``, and the residue (the fd ``2``, or the target
+    ``/tmp/x``) must not be mistaken for the leading subcommand.
+
+    Quoting is already resolved by tokenization, so a remaining ``<``/``>`` is an
+    operator. The target rides in the SAME token for ``2>/tmp/x`` / ``2>&1`` /
+    ``>>/tmp/x`` (``expects_separate_target`` False); a bare ``>`` / ``2>`` / ``>&``
+    takes the NEXT token as its target (True). A leading fd number is part of the
+    operator, not an operand.
+    """
+    cut = min((token.find(c) for c in "<>" if c in token), default=-1)
+    if cut == -1:
+        return (False, False)
+    return (True, token[cut:].lstrip("<>&") == "")
+
+
+def _self_cli_operands(tokens: "list[str]", i: int) -> "list[str]":
+    """Non-flag operand words the product CLI at program index *i* receives, in order.
+
+    A token that stays a ``-``/``--`` word after quote/redirect normalization is a
+    global flag and is skipped -- the self-protection top-level flags are all
+    valueless (``-v``/``--verbose`` count, ``--no-jail`` bool), so a skipped flag
+    never hides an operand behind it. A shell redirection (and its separate
+    target, if any) is removed from argv by the shell and is skipped too, so
+    ``kirocrew 2>/tmp/x restart`` still reads ``restart`` as the leading operand.
+    Quoting is resolved by ``_normalize_operand``; the walk stops at the argv
+    boundary so a chained later command's words are not attributed here.
+    """
+    operands: "list[str]" = []
+    depth = 0
+    skip_target = False
+    for later in tokens[i + 1 :]:
+        is_redirect, expects_target = _redirect_consumes_next(later)
+        if skip_target:
+            # A separate redirection target (``> FILE``) is a filename: its bytes are
+            # data, not an argv boundary, so a quoted ``;``/``|`` in it (``> 'a;b'``)
+            # must NOT end the scan. Consume it without the boundary/depth bookkeeping.
+            skip_target = False
+            continue
+        if is_redirect:
+            # The redirection operator itself is not an operand and never ends the argv.
+            skip_target = expects_target
+            continue
+        operand = _normalize_operand(later)
+        # ANSI-C ($'...') and locale ($"...") quoting: shlex strips the quotes
+        # but leaves the leading ``$``, so a flag hidden as ``$'-v'`` / the hex
+        # ``$'\x2d\x76'`` reads as a non-flag operand and shoves the subcommand
+        # to second place. Drop the ``$`` and decode the escapes to the value the
+        # shell actually passes -- the same de-quoting _program_basename already
+        # does for the program name.
+        if operand.startswith("$") and not operand.startswith(("$(", "${")):
+            operand = _decode_printf_escapes(operand[1:])
+        if operand and not operand.startswith("-"):
+            operands.append(operand)
+        depth += _substitution_depth_delta(later)
+        if depth <= 0 and _ends_argv(later):
+            break
+        depth = max(depth, 0)
+    return operands
+
+
+def _operands_lead_with(operands: "list[str]", spec: "tuple[object, ...]") -> bool:
+    """True if *operands* begins with the subcommand sequence *spec*.
+
+    Each element of *spec* is an exact word, or a ``frozenset`` of accepted words
+    (used for ``cloud <one of the destructive lifecycle subcommands>``).
+    """
+    if len(operands) < len(spec):
+        return False
+    for got, want in zip(operands, spec):
+        if isinstance(want, frozenset):
+            if got not in want:
+                return False
+        elif got != want:
+            return False
+    return True
+
+
+def _self_module_name_index(tokens: "list[str]", i: int) -> "int | None":
+    """Index of the product module-name token in a ``python -m kiro_crew ...``
+    invocation whose interpreter is at *i*, or None.
+
+    Handles the separate (``-m kiro_crew``) and attached (``-mkiro_crew``) spellings,
+    scanning past other interpreter flags. The ``-c`` inline-program form has no
+    positional subcommand token (the program builds its own argv), so it is left to
+    the credential-mint import gate rather than matched here.
+    """
+    for j in range(i + 1, len(tokens)):
+        tok = _normalize_operand(tokens[j]).strip("\"'")
+        if tok == "-m":
+            nxt = _normalize_operand(tokens[j + 1]).strip("\"'") if j + 1 < len(tokens) else ""
+            return j + 1 if _SELF_IMPORT_RE.search(nxt) else None
+        if tok.startswith("-m") and len(tok) > 2 and _SELF_IMPORT_RE.search(tok[2:]):
+            return j  # attached -mkiro_crew
+    return None
+
+
+def _self_program_index(tokens: "list[str]", i: int) -> "int | None":
+    """The argv index whose trailing operands the product CLI receives when the token
+    at *i* launches it: *i* itself for the direct ``kirocrew`` form, or the module-name
+    index for ``python -m kiro_crew``; else None.
+    """
+    if _is_self_program(tokens[i]):
+        return i
+    if _PYTHON_PROGRAM_RE.match(_program_basename(tokens[i])):
+        return _self_module_name_index(tokens, i)
+    return None
+
+
+def _matches_self_subcommand(text_lower: str, spec: "tuple[object, ...]") -> bool:
+    """True if the product CLI is invoked with leading operand words *spec*.
+
+    Covers the direct form (``kirocrew`` as the argv program) and the module form
+    (``python -m kiro_crew``), collecting operands after the CLI/module so the same
+    shell de-escaping the regex tier cannot see is caught for both -- e.g.
+    ``python -m kiro_crew -\\v restart``, which the interpreter-position regex misses.
+    """
+    if not _self_floor_can_fire(text_lower):
+        return False
+    for tokens in _self_token_frames(_shell_join_continuations(text_lower)):
+        programs = _argv_programs(tokens)
+        for i in range(len(tokens)):
+            prog_idx = _self_program_index(tokens, i)
+            if prog_idx is None:
+                continue
+            # ``echo kirocrew restart`` / ``echo python -m kiro_crew restart`` print words.
+            if _data_consumer_exempt(prog_idx, tokens[prog_idx], programs, tokens):
+                continue
+            if _operands_lead_with(_self_cli_operands(tokens, prog_idx), spec):
+                return True
+    return False
+
+
+def _is_self_restart(text_lower: str) -> bool:
+    """``kirocrew restart`` behind any shell dressing of interposed flags."""
+    return _matches_self_subcommand(text_lower, ("restart",))
+
+
+def _is_self_update(text_lower: str) -> bool:
+    """``kirocrew update`` behind any shell dressing of interposed flags."""
+    return _matches_self_subcommand(text_lower, ("update",))
+
+
+def _is_self_gateway_restart(text_lower: str) -> bool:
+    """``kirocrew gateway restart`` behind any shell dressing of interposed flags."""
+    return _matches_self_subcommand(text_lower, ("gateway", "restart"))
+
+
+def _is_self_cloud_destructive(text_lower: str) -> bool:
+    """``kirocrew cloud <destructive>`` behind any shell dressing of interposed flags."""
+    return _matches_self_subcommand(text_lower, ("cloud", _SELF_CLOUD_DESTRUCTIVE_VERBS))
 
 
 def _is_git_publish(text_lower: str) -> bool:
@@ -8771,6 +9016,10 @@ def is_denied(
     for rule_id, predicate in (
         ("credential-exfil-kirocrew-token", _is_credential_mint),
         ("self-protection-kill", _is_self_kill),
+        ("self-protection-restart", _is_self_restart),
+        ("self-protection-update", _is_self_update),
+        ("self-protection-gateway-restart", _is_self_gateway_restart),
+        ("self-protection-cloud", _is_self_cloud_destructive),
     ):
         pattern = _SELF_PROTECTION_FLOOR_BY_ID.get(rule_id)
         if pattern is None or pattern not in floor_enabled:

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -751,25 +751,25 @@
   },
   {
     "id": "self-protection-restart",
-    "pattern": ".*kiro.?crew restart.*",
+    "pattern": ".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+restart.*",
     "category": "self-protection",
     "description": "Blocks 'kirocrew restart' so the agent cannot restart its own gateway process and disrupt the running session or evade in-flight controls."
   },
   {
     "id": "self-protection-update",
-    "pattern": ".*kiro.?crew update.*",
+    "pattern": ".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+update.*",
     "category": "self-protection",
     "description": "Blocks 'kirocrew update' so the agent cannot self-update (git pull + rebuild + execv restart) and swap out its own running code without operator oversight."
   },
   {
     "id": "self-protection-cloud",
-    "pattern": ".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*",
+    "pattern": ".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*",
     "category": "self-protection",
     "description": "Blocks 'kirocrew cloud' lifecycle subcommands (destroy/stop/start/launch/connect/tunnel/login/logout) so the agent cannot tear down, provision, re-authenticate, or sign out its own cloud instance."
   },
   {
     "id": "self-protection-gateway-restart",
-    "pattern": ".*kiro.?crew gateway restart.*",
+    "pattern": ".*kiro.?crew(?:\\s+--?[a-z-]+(?:[= ]\\S+)?)*\\s+gateway restart.*",
     "category": "self-protection",
     "description": "Blocks 'kirocrew gateway restart' so the agent cannot bounce its own gateway server and interrupt the active session or supervision."
   },

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -200,6 +200,283 @@ class TestCatalog:
         assert pinned_builtin_command_ids() == set()
 
 
+class TestSelfProtectionFlagInterposition:
+    """The whole self-protection category stays deny-closed under interposed flags (#4799).
+
+    The CLI accepts top-level flags BEFORE the subcommand (``-v``/``--verbose`` is
+    ``action="count"`` and ``--no-jail`` sits on the top-level parser), so
+    ``kirocrew -v restart`` runs the same restart as ``kirocrew restart``. Four
+    self-protection patterns anchored the subcommand directly to the program name
+    and were defeated by exactly that spelling. This walk covers EVERY rule in the
+    category so the class cannot regress one rule at a time: a new self-protection
+    rule fails the completeness assertion until it registers its own template here.
+
+    Asserted through ``is_denied`` (the real enforcement path), not against
+    ``rule.pattern`` -- see ``test_token_mint_is_blocked_in_both_the_cli_and_module_forms``
+    for why that distinction matters.
+    """
+
+    # rule id -> command template; ``{flags}`` is where an attacker interposes
+    # flags between the anchor word and the token the rule keys on.
+    _TEMPLATES = {
+        "self-protection-restart": "kirocrew {flags} restart",
+        "self-protection-update": "kirocrew {flags} update",
+        "self-protection-gateway-restart": "kirocrew {flags} gateway restart",
+        "self-protection-cloud": "kirocrew {flags} cloud destroy",
+        # cron-adopt (added on main) already tolerates interposed flags via its own
+        # tempered-greedy pattern, so it needs no widening/floor from this PR -- it
+        # is listed here only to satisfy the category-completeness invariant.
+        "self-protection-cron-adopt": "kirocrew {flags} cron adopt",
+        # The kill rules key on the kill TARGET, not a CLI subcommand; their gap
+        # is between the kill verb and the product name.
+        "self-protection-kill": "pkill {flags} kirocrew",
+        "self-protection-kill-interpreter": (
+            "python -c \"import os; os.system('pkill {flags} -f kirocrew')\""
+        ),
+    }
+    _FLAGS = ("-v", "-vv", "--verbose", "--no-jail", "-v --no-jail")
+
+    @staticmethod
+    def _effective():
+        from kiro_crew import security
+
+        return list(
+            security.compute_effective_denied(security.BUILTIN_DENIED_RULES, (), False, (), ())
+        )
+
+    def test_every_self_protection_rule_has_a_template(self):
+        category_ids = {r.id for r in BUILTIN_DENIED_RULES if r.category == "self-protection"}
+        assert category_ids == set(self._TEMPLATES), (
+            "every self-protection rule must register an interposed-flag template "
+            "in this walk (and every template must name a live rule)"
+        )
+
+    def test_bare_and_flag_interposed_forms_are_all_denied(self):
+        from kiro_crew import security
+
+        effective = self._effective()
+        for rule_id, template in self._TEMPLATES.items():
+            # The bare form first: widening must not have lost the plain match.
+            bare = " ".join(template.format(flags="").split())
+            assert security.is_denied(
+                bare, denied_regexes=effective
+            ), f"{rule_id}: bare form not denied: {bare!r}"
+            for flags in self._FLAGS:
+                cmd = template.format(flags=flags)
+                assert security.is_denied(
+                    cmd, denied_regexes=effective
+                ), f"{rule_id}: flag-interposed form not denied: {cmd!r}"
+
+    def test_cloud_flag_interposition_denied_for_every_lifecycle_subcommand(self):
+        from kiro_crew import security
+
+        effective = self._effective()
+        for sub in ("destroy", "stop", "start", "launch", "connect", "tunnel", "login", "logout"):
+            cmd = f"kirocrew -v cloud {sub}"
+            assert security.is_denied(
+                cmd, denied_regexes=effective
+            ), f"cloud {sub} not denied behind -v: {cmd!r}"
+
+    def test_widened_patterns_still_require_the_subcommand_token(self):
+        """Not over-broad: the flag run alone must never satisfy a rule.
+
+        Benign invocations -- other subcommands behind the same flags, the flags
+        alone, and cloud subcommands outside the destructive list -- stay allowed.
+        """
+        from kiro_crew import security
+
+        effective = self._effective()
+        for allowed in (
+            "kirocrew -v",
+            "kirocrew --verbose",
+            "kirocrew --no-jail doctor",
+            "kirocrew -v status",
+            "kirocrew -vv cloud status",
+        ):
+            assert not security.is_denied(
+                allowed, denied_regexes=effective
+            ), f"false positive on {allowed!r}"
+
+    def test_stale_governance_pin_still_resolves_to_the_rule_id(self):
+        """A persisted policy pins by pattern STRING; widening must not orphan it.
+
+        The pin resolvers treat a governance pattern as pinning a built-in rule
+        only when it maps back to a rule id.  A ceiling/profile written against
+        the pre-widening catalog persists the OLD spelling, so without the legacy
+        aliases the pin would silently fall out of the id map on upgrade and a
+        user opt-out could drop a rule the administrator pinned.
+        """
+        from kiro_crew import security
+
+        legacy_to_id = {
+            ".*kiro.?crew restart.*": "self-protection-restart",
+            ".*kiro.?crew update.*": "self-protection-update",
+            ".*kiro.?crew\\s+cloud\\s+(destroy|stop|start|launch|connect|tunnel|log(in|out)).*": (
+                "self-protection-cloud"
+            ),
+            ".*kiro.?crew gateway restart.*": "self-protection-gateway-restart",
+        }
+        for legacy, rule_id in legacy_to_id.items():
+            # The old spelling resolves to the same rule id...
+            assert security._rule_id_for_pattern(legacy) == rule_id
+            # ...as the current spelling does.
+            current = next(r.pattern for r in BUILTIN_DENIED_RULES if r.id == rule_id)
+            assert security._rule_id_for_pattern(current) == rule_id
+        assert security._rule_id_for_pattern("not a rule") is None
+
+    def test_legacy_alias_spellings_stay_out_of_the_enforced_catalog(self):
+        """Aliases are lookup-only: not enforced, not built-in, not in the golden."""
+        from kiro_crew import security
+
+        golden = json.loads(_GOLDEN.read_text(encoding="utf-8"))
+        golden_patterns = {g["pattern"] for g in golden}
+        for legacy in security._LEGACY_RULE_ID_BY_PATTERN:
+            assert legacy not in BUILTIN_DENY_PATTERNS
+            assert legacy not in security._RULE_ID_BY_PATTERN
+            assert legacy not in golden_patterns
+
+    # Round 2 -> Option 2 (#4824): the four self-protection SUBCOMMAND rules get an
+    # argv-structural floor (``_is_self_*`` evaluated on the de-escaped, de-quoted
+    # argv), because a regex over RAW text cannot see through the shell's own
+    # de-escaping. Every dressing below reaches the shell as the plain command but
+    # splits a token in the raw string the regex tier matches, so only the floor
+    # catches it.
+    _SUBCOMMANDS = {
+        "self-protection-restart": ["restart"],
+        "self-protection-update": ["update"],
+        "self-protection-gateway-restart": ["gateway", "restart"],
+        "self-protection-cloud": ["cloud", "destroy"],
+    }
+
+    @staticmethod
+    def _dressings(words):
+        """Shell spellings that all tokenize to argv ``[kirocrew, *words]``."""
+        rest = " ".join(words)
+        first = words[0]
+        tail = (" " + " ".join(words[1:])) if len(words) > 1 else ""
+        return {
+            "bare": f"kirocrew {rest}",
+            "real-flag": f"kirocrew -v {rest}",
+            "backslash-escaped-flag": f"kirocrew -\\v {rest}",  # -\v -> -v
+            "escaped-verb-letter": f"kirocrew \\{first}{tail}",  # \restart -> restart
+            "line-continuation-flag": f"kirocrew -\\\nv {rest}",
+            "continuation-before-verb": f"kirocrew \\\n{first}{tail}",
+            "each-word-quoted": "kirocrew " + " ".join(f'"{w}"' for w in words),
+        }
+
+    def test_self_protection_subcommands_denied_under_every_shell_dressing(self):
+        from kiro_crew import security
+
+        effective = self._effective()
+        for rule_id, words in self._SUBCOMMANDS.items():
+            for label, cmd in self._dressings(words).items():
+                assert security.is_denied(
+                    cmd, denied_regexes=effective
+                ), f"{rule_id} not denied under {label}: {cmd!r}"
+
+    def test_self_protection_floor_covers_the_four_subcommand_rules(self):
+        """The argv floor must cover every self-protection subcommand rule, so a
+        regex-only rule cannot silently ship bypassable by shell de-escaping.
+        """
+        from kiro_crew import security
+
+        expected = {
+            "self-protection-restart",
+            "self-protection-update",
+            "self-protection-gateway-restart",
+            "self-protection-cloud",
+        }
+        assert expected <= security._SELF_PROTECTION_FLOOR_RULE_IDS
+        # the predicate for each is wired and fires on a de-escaped argv
+        assert security._is_self_restart("kirocrew -\\v restart")
+        assert security._is_self_update("kirocrew \\update")
+        assert security._is_self_gateway_restart("kirocrew -\\v gateway restart")
+        assert security._is_self_cloud_destructive("kirocrew -\\v cloud destroy")
+
+    def test_self_protection_denied_under_interposed_redirection(self):
+        """A redirection is removed from argv by the shell and can sit anywhere in
+        a simple command, so it must not shift the leading subcommand (#4824 r4).
+        """
+        from kiro_crew import security
+
+        effective = self._effective()
+        for cmd in (
+            "kirocrew 2>/tmp/x restart",  # attached redirect leaves fd residue
+            "kirocrew > /tmp/x restart",  # separate target
+            "kirocrew 2>&1 restart",
+            "kirocrew restart 2>/tmp/log",  # redirect AFTER the subcommand
+            "kirocrew >/dev/null -v update",  # redirect + flag
+            "kirocrew > 'audit;log' restart",  # quoted ';' in the target is a filename, not a boundary
+            "kirocrew 2> 'x|y' restart",  # quoted '|' in the target
+        ):
+            assert security.is_denied(
+                cmd, denied_regexes=effective
+            ), f"redirection-interposed form not denied: {cmd!r}"
+        # A redirect whose TARGET is a file named like the subcommand runs no
+        # subcommand, so it must stay allowed by the floor.
+        assert not security._is_self_restart("kirocrew > restart")
+
+    def test_self_protection_denied_under_dollar_quoting(self):
+        """ANSI-C (``$'...'``) and locale (``$"..."``) quoting decode to the value
+        bash passes, so a flag or the verb hidden in them must not slip past the
+        floor -- shlex leaves the ``$`` and does not decode ANSI-C escapes (#4824 r6).
+        """
+        from kiro_crew import security
+
+        effective = self._effective()
+        for cmd in (
+            "kirocrew $'-v' restart",  # ANSI-C flag
+            "kirocrew $'\\x2d\\x76' restart",  # ANSI-C hex -> -v
+            'kirocrew $"-v" restart',  # locale flag
+            "kirocrew $'restart'",  # ANSI-C on the verb
+            "kirocrew $'-v' cloud destroy",
+        ):
+            assert security.is_denied(
+                cmd, denied_regexes=effective
+            ), f"$-quoted self-protection form not denied: {cmd!r}"
+
+    def test_self_protection_module_form_denied_under_shell_dressing(self):
+        """``python -m kiro_crew <subcommand>`` dispatches the same self-action. The
+        escaped module form (``python -m kiro_crew -\\v restart``) slips past the
+        interpreter-position regex, so the floor resolves the module name and checks
+        the operands after it (#4824 r5).
+        """
+        from kiro_crew import security
+
+        effective = self._effective()
+        for cmd in (
+            "python -m kiro_crew restart",
+            r"python -m kiro_crew -\v restart",  # escaped: regex misses, floor catches
+            r"python -mkiro_crew -\v restart",  # attached -m spelling
+            r"python -m kiro_crew \update",
+            "python -m kiro_crew gateway restart",
+            r"python -m kiro_crew -\v cloud destroy",
+        ):
+            assert security.is_denied(
+                cmd, denied_regexes=effective
+            ), f"module-form self-protection not denied: {cmd!r}"
+        # benign module invocations stay allowed at the floor (not a targeted subcommand)
+        assert not security._is_self_restart("python -m kiro_crew status")
+        assert not security._is_self_cloud_destructive("python -m kiro_crew cloud status")
+        assert not security._is_self_restart("python -m pytest test/test_restart.py")
+
+    def test_self_protection_floor_is_not_over_broad(self):
+        """The floor matches a real subcommand invocation, not a mention, a
+        benign subcommand, or a different rule's verb.
+        """
+        from kiro_crew import security
+
+        assert not security._is_self_restart("kirocrew -v status")
+        assert not security._is_self_cloud_destructive("kirocrew cloud status")
+        assert not security._is_self_cloud_destructive("kirocrew -vv cloud status")
+        # a mention inside another program's args is not a run (data-consumer /
+        # non-program position), so the floor itself does not fire on it
+        assert not security._is_self_restart("echo kirocrew restart")
+        assert not security._is_self_restart("grep restart /var/log/kirocrew.log")
+        # gateway-restart is a distinct rule from bare restart
+        assert not security._is_self_restart("kirocrew gateway restart")
+
+
 class TestComputeEffectiveDenied:
     def _ids(self):
         return [r.id for r in BUILTIN_DENIED_RULES]


### PR DESCRIPTION
## What is the problem?

Four of the five self-protection denied-command rules in `BUILTIN_DENIED_RULES` (`self-protection-restart`, `self-protection-update`, `self-protection-gateway-restart`, `self-protection-cloud`) anchor the subcommand directly to the program name, e.g. `.*kiro.?crew restart.*`. But the CLI accepts top-level flags BEFORE the subcommand: `-v`/`--verbose` is `action="count"` and `--no-jail` is declared on the top-level parser. So `kirocrew -v restart`, `-vv`, `--verbose`, and `--no-jail` all slip past the anchored patterns: the bare form is DENIED while the flag-prepended form runs the identical restart/update/cloud action, silently. Reproduced on unmodified main against `security.is_denied`: 4/4 bare forms denied, 16/16 flag-interposed forms allowed.

## Why this issue matters to the user

These four rules are the floor that stops a prompt-injected agent from restarting its own gateway (evading in-flight controls), self-updating (swapping out its own running code), or tearing down / re-authenticating its cloud instance. A two-character `-v` defeats all of them, so the protection the operator relies on is decorative against any attacker who reads the CLI help. The patterns have always had this shape; this is not a regression.

## How our fix solves it

Symptom to root cause: the flagged form is allowed -> the pattern requires the subcommand token IMMEDIATELY after the program name -> the CLI grammar does not (top-level flags interpose) -> the pattern must model the same flag gap the CLI accepts.

The fix widens the four patterns with the flag-run idiom the catalog already uses for this exact shape in `credential-exfil-s3-cp`: `kiro.?crew(?:\s+--?[a-z-]+(?:[= ]\S+)?)*\s+restart` (and the update / gateway restart / cloud equivalents). The construct is byte-identical to `_DANGEROUS_AWS_FLAG_RUN` on purpose: `_linearize_deny_pattern` rewrites exactly that spelling into its linear-time equivalent inside `_DenyMatcher`, so the widened rules stay ReDoS-safe with zero evaluator change. The four matching golden-manifest entries are regenerated (pattern fields only, 4 lines). The already-tight kill rules are untouched, as is every unrelated rule.

A new category-walk test (`TestSelfProtectionFlagInterposition`) registers a representative command per self-protection rule and asserts, through `is_denied` (the real enforcement path, not `rule.pattern`), that the bare form and every flag-interposed spelling (`-v`, `-vv`, `--verbose`, `--no-jail`, `-v --no-jail`) is denied, plus a per-subcommand walk of all eight cloud lifecycle verbs and a not-over-broad check (`kirocrew -v`, `kirocrew --no-jail doctor`, `kirocrew -vv cloud status` stay allowed). A set-equality completeness assertion means a future self-protection rule fails the walk until it registers its own template, so the class cannot regress one rule at a time.

## What tests we did

- Reproduced the bypass on unmodified main (16/16 flag forms allowed), re-ran after the fix (20/20 denied, zero bare-form regressions).
- Mutation-verified: reverting the restart pattern alone reddens the walk test; reverting the cloud pattern alone reddens two tests; both restored and re-verified green (`git diff --stat` clean before commit).
- `test/test_denied_commands_security.py`: 499 passed (includes the golden verbatim-parity test and the ReDoS-resistance suite).
- Full backend gate via `scripts/local-gate.py`: 58953 passed; the 48 failures reproduce identically on stashed unmodified main (host-environment: missing qrcode module, xdist host budget, pty integration), none in security/hooks territory.
- ReDoS probes: hostile flag-spam through the widened patterns is linear (linearizer confirmed applied); the new 4 patterns cost LESS than the old 4 on a 20k-char tail (0.035s vs 0.116s); all 4 pass `is_safe_user_regex` and take the fragment path (not silently disabled).
- Two model-pinned pre-push reviewers (security lane + correctness lane), both VERDICT: CLEAN. The security lane confirmed the only flags argparse accepts before a subcommand are `--version`, `-v`/`--verbose`, `--no-jail`, all inside `[a-z-]+`; digit-flag shapes that evade the pattern are rejected by argparse before any action runs.

## Any other suggestions on the work

One pre-existing, out-of-scope residual surfaced in review and is recorded in the local backlog: `is_denied` matches the raw command string (no quote-normalized re-join), so quoting any token (`'kirocrew' restart`) evades every deny pattern, including `credential-exfil-s3-cp` on main today. It is universal, not introduced or widened by this change, and #4799 is scoped to interposed flags.

Closes #4799
