### PR TITLE
ci: create the GitHub Release even when the graph skips a job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -653,9 +653,24 @@ jobs:
       promotion_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || '' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
 
+  # `needs` alone is not enough here. With no `if:`, the default condition is
+  # success(), which is false when ANY job in the needs closure was SKIPPED --
+  # and that verdict propagates THROUGH an always()-guarded job that itself
+  # succeeded (actions/runner#2205). sign-and-notarize is always()-guarded and
+  # every release graph skips something upstream by design: resolve-promotion on
+  # insider, the build jobs on stable. So this job silently skipped on every
+  # release after immutable-digest promotion landed, and nothing went red --
+  # a skip is not a failure, so the run still concluded success. v0.3.0 shipped
+  # to Stable with no GitHub Release page and no assets. Naming each dependency
+  # explicitly is the documented workaround and the pattern every other lane in
+  # this file already uses.
   github-release:
     name: Create GitHub Release
     needs: [version, stable-gate, sign-and-notarize]
+    if: >-
+      ${{ always() && needs.version.result == 'success' &&
+          needs.stable-gate.result == 'success' &&
+          needs.sign-and-notarize.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/test/test_stable_release_gate.py
+++ b/test/test_stable_release_gate.py
@@ -60,6 +60,12 @@ def _workflow() -> dict:
     return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
 
+def _needs(spec: dict) -> list[str]:
+    """A job's ``needs``, normalized -- the key accepts a bare string too."""
+    needs = spec.get("needs") or []
+    return [needs] if isinstance(needs, str) else list(needs)
+
+
 def _gate_step() -> dict:
     steps = _workflow()["jobs"][GATE_JOB]["steps"]
     step = next((item for item in steps if item.get("name") == STEP_NAME), None)
@@ -180,6 +186,54 @@ def test_gate_job_has_no_job_level_condition() -> None:
     the step body.
     """
     assert "if" not in _workflow()["jobs"][GATE_JOB]
+
+
+def _skippable_jobs(jobs: dict) -> set[str]:
+    """Every job that can report ``skipped``, transitively.
+
+    A job with an ``if:`` can skip on its own. A job without one skips whenever
+    anything it needs skipped, so the property propagates down the graph -- and
+    it propagates THROUGH an ``always()``-guarded job that itself succeeded,
+    which is the part that is not obvious (actions/runner#2205).
+    """
+    skippable = {name for name, spec in jobs.items() if "if" in spec}
+    while True:
+        grown = {
+            name
+            for name, spec in jobs.items()
+            if name not in skippable and any(n in skippable for n in _needs(spec))
+        }
+        if not grown:
+            return skippable
+        skippable |= grown
+
+
+def test_no_job_downstream_of_a_skippable_one_relies_on_the_default_condition() -> None:
+    """A job with no ``if:`` does not run in a graph that skips anything.
+
+    With no ``if:`` the condition is ``success()``, which is false when ANY job
+    in the needs closure was skipped. Every release graph skips something by
+    design -- ``resolve-promotion`` on insider, the build jobs on stable -- so a
+    lane that leans on the default never executes. It also never goes red: a
+    skip is not a failure, so the run still concludes ``success``. That is how
+    five consecutive releases, v0.3.0 among them, published bytes to a channel
+    with no GitHub Release page and nobody noticed.
+
+    ``stable-gate`` and ``build-windows`` are not exempted by name: they need
+    only ``version``, which has no dependencies and therefore cannot skip.
+    """
+    jobs = _workflow()["jobs"]
+    skippable = _skippable_jobs(jobs)
+    offenders = {
+        name: str(spec.get("if", ""))
+        for name, spec in jobs.items()
+        if any(n in skippable for n in _needs(spec)) and "needs." not in str(spec.get("if", ""))
+    }
+    assert not offenders, (
+        "these jobs depend on a job that can be skipped, but their condition "
+        "does not name their dependencies' results, so a skip upstream silently "
+        f"skips them: {offenders}"
+    )
 
 
 def test_gate_checks_out_full_history() -> None:


### PR DESCRIPTION
## The defect

`github-release` was the only downstream job in `release.yml` with no `if:`. With
no condition, GitHub applies `success()` — and `success()` is **false when any job
in the needs closure was skipped**, a verdict that propagates *through* an
`always()`-guarded job that itself succeeded ([actions/runner#2205](https://github.com/actions/runner/issues/2205)).

Every release graph skips something on purpose:

| channel | skipped by design |
|---|---|
| insider | `resolve-promotion` |
| stable | `release-candidate-tests`, `build-wheel`, `build-desktop`, macOS sign + notarize, `record-promotion` |

`sign-and-notarize` sits between them and is `always()`-guarded, so it ran and
succeeded — and the skip verdict still reached `github-release`, which skipped.

## Why nobody noticed for five releases

A skipped job is not a failed one, so every run still concluded `success`.

| run | first skip in the graph | Create GitHub Release |
|---|---|---|
| `v0.2.0` | none | ✅ success |
| `v0.3.0-insider.11` | `resolve-promotion` | skipped |
| `v0.3.0-insider.12` | `resolve-promotion` | skipped |
| `v0.3.0-insider.13` | `resolve-promotion` | skipped |
| `v0.3.0` | RC tests, both build jobs, sign, notarize | skipped |

`v0.2.0` is the control: the last graph with zero skips and the last release page
created. The first skip appeared when `ecb716124` (#996) introduced
`resolve-promotion`, and every release since has published bytes with no GitHub
Release page and no assets — `v0.3.0` reached Stable that way, and `gh release list`
still reports `v0.2.0` as Latest.

## The fix

Name the three dependencies' results explicitly. This is the workaround the
upstream issue documents, and the pattern the other 16 conditional lanes in this
file already use — the author clearly knew the trap; this job was the one that
missed it.

```yaml
  github-release:
    needs: [version, stable-gate, sign-and-notarize]
    if: >-
      ${{ always() && needs.version.result == 'success' &&
          needs.stable-gate.result == 'success' &&
          needs.sign-and-notarize.result == 'success' }}
```

The publishing behaviour is unchanged: it still runs only when all three
dependencies succeeded, and `stable-gate` remains a hard dependency, so
`test_every_publish_job_depends_on_the_gate` keeps holding.

## The test derives the rule instead of listing the job

`test_no_job_downstream_of_a_skippable_one_relies_on_the_default_condition`
computes which jobs can report `skipped` from the graph — a job with an `if:`,
plus anything transitively downstream of one — and asserts every job needing one
of them names its dependencies' results. Verified both ways:

- with this fix: **0 offenders** (32 passed in `test_stable_release_gate.py`)
- with the `if:` spliced back out: fails with `{'github-release': ''}` — the exact
  real defect, and nothing else

`stable-gate` and `build-windows` are not exempted by name. They need only
`version`, which has no dependencies and therefore cannot skip, so the derivation
clears them on its own.

## Verification

- `python3 -m pytest test/test_stable_release_gate.py` → 32 passed
- negative control above
- `flake8`, `isort --check-only`, `check_black_formatting.py` clean
- `yaml.safe_load` parses the workflow; the `if:` is one expression across three lines

**Why no screenshot:** CI workflow condition, no user-visible surface.

## Not in this PR

`v0.3.0`'s page cannot be recovered by this change — its run is over and the job
will not re-execute. That page is being created manually with the same asset set
`files: release/*` would have published.