### PR TITLE
ci: create the GitHub Release even when the graph skips a job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -653,9 +653,24 @@ jobs:
       promotion_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || '' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
 
+  # `needs` alone is not enough here. With no `if:`, the default condition is
+  # success(), which is false when ANY job in the needs closure was SKIPPED --
+  # and that verdict propagates THROUGH an always()-guarded job that itself
+  # succeeded (actions/runner#2205). sign-and-notarize is always()-guarded and
+  # every release graph skips something upstream by design: resolve-promotion on
+  # insider, the build jobs on stable. So this job silently skipped on every
+  # release after immutable-digest promotion landed, and nothing went red --
+  # a skip is not a failure, so the run still concluded success. v0.3.0 shipped
+  # to Stable with no GitHub Release page and no assets. Naming each dependency
+  # explicitly is the documented workaround and the pattern every other lane in
+  # this file already uses.
   github-release:
     name: Create GitHub Release
     needs: [version, stable-gate, sign-and-notarize]
+    if: >-
+      ${{ always() && needs.version.result == 'success' &&
+          needs.stable-gate.result == 'success' &&
+          needs.sign-and-notarize.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/test/test_stable_release_gate.py
+++ b/test/test_stable_release_gate.py
@@ -60,6 +60,12 @@ def _workflow() -> dict:
     return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
 
+def _needs(spec: dict) -> list[str]:
+    """A job's ``needs``, normalized -- the key accepts a bare string too."""
+    needs = spec.get("needs") or []
+    return [needs] if isinstance(needs, str) else list(needs)
+
+
 def _gate_step() -> dict:
     steps = _workflow()["jobs"][GATE_JOB]["steps"]
     step = next((item for item in steps if item.get("name") == STEP_NAME), None)
@@ -180,6 +186,54 @@ def test_gate_job_has_no_job_level_condition() -> None:
     the step body.
     """
     assert "if" not in _workflow()["jobs"][GATE_JOB]
+
+
+def _skippable_jobs(jobs: dict) -> set[str]:
+    """Every job that can report ``skipped``, transitively.
+
+    A job with an ``if:`` can skip on its own. A job without one skips whenever
+    anything it needs skipped, so the property propagates down the graph -- and
+    it propagates THROUGH an ``always()``-guarded job that itself succeeded,
+    which is the part that is not obvious (actions/runner#2205).
+    """
+    skippable = {name for name, spec in jobs.items() if "if" in spec}
+    while True:
+        grown = {
+            name
+            for name, spec in jobs.items()
+            if name not in skippable and any(n in skippable for n in _needs(spec))
+        }
+        if not grown:
+            return skippable
+        skippable |= grown
+
+
+def test_no_job_downstream_of_a_skippable_one_relies_on_the_default_condition() -> None:
+    """A job with no ``if:`` does not run in a graph that skips anything.
+
+    With no ``if:`` the condition is ``success()``, which is false when ANY job
+    in the needs closure was skipped. Every release graph skips something by
+    design -- ``resolve-promotion`` on insider, the build jobs on stable -- so a
+    lane that leans on the default never executes. It also never goes red: a
+    skip is not a failure, so the run still concludes ``success``. That is how
+    five consecutive releases, v0.3.0 among them, published bytes to a channel
+    with no GitHub Release page and nobody noticed.
+
+    ``stable-gate`` and ``build-windows`` are not exempted by name: they need
+    only ``version``, which has no dependencies and therefore cannot skip.
+    """
+    jobs = _workflow()["jobs"]
+    skippable = _skippable_jobs(jobs)
+    offenders = {
+        name: str(spec.get("if", ""))
+        for name, spec in jobs.items()
+        if any(n in skippable for n in _needs(spec)) and "needs." not in str(spec.get("if", ""))
+    }
+    assert not offenders, (
+        "these jobs depend on a job that can be skipped, but their condition "
+        "does not name their dependencies' results, so a skip upstream silently "
+        f"skips them: {offenders}"
+    )
 
 
 def test_gate_checks_out_full_history() -> None:


### PR DESCRIPTION
Cherry-pick of `b541a587e` from [#4826](https://github.com/kirodotdev/KiroCrew/pull/4826) onto `release/0.4.0`. **Applied verbatim** — `.github/workflows/release.yml` and
`test/test_stable_release_gate.py` are byte-identical between `main` and this
branch, so the pick had zero conflicts and the resulting diff is identical to the
`main`-side commit (`diff` of the two patches produces no output).

## Why it belongs on the release branch, not only on main

`github-release` had no `if:`, so its condition defaulted to `success()`, which is
false when any job in the needs closure was skipped — a verdict that propagates
through an `always()`-guarded job that succeeded ([actions/runner#2205](https://github.com/actions/runner/issues/2205)). An insider
graph always skips `resolve-promotion`, so **every RC cut from this branch would
publish with no prerelease page and no assets**, exactly as `v0.3.0-insider.11`
through `.13` did.

`v0.4.0-insider.1` is not tagged yet. Landing this first is what makes rc1 the
first RC in five releases to get a prerelease page — and the eventual bare
`v0.4.0` the first stable release page since `v0.2.0`.

## Verification on this branch

- `python3 -m pytest test/test_stable_release_gate.py` → 32 passed
- the derived check reports 0 offenders here; with the `if:` spliced out it reports
  `{'github-release': ''}`
- `yaml.safe_load` parses the workflow

**Why no screenshot:** CI workflow condition, no user-visible surface.