### PR TITLE
fix(prepare-pr): degrade when a token cannot read statusCheckRollup

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
@@ -736,6 +736,7 @@ def decide(
     readiness_context,
     marker_eval=None,
     head_run="skip",
+    rollup_unreadable=False,
 ):
     """Resolve PR state to (exit_code, status line). Fail-closed.
 
@@ -794,7 +795,16 @@ def decide(
         reasons.append("{} reported action required".format(readiness_context))
     elif readiness_kind is None and n_fail > 0:
         reasons.append("{} check(s) failed".format(n_fail))
-    if n_checks == 0:
+    if rollup_unreadable:
+        # Distinct from "none reported": the checks may well be green, we
+        # simply could not see them. Both fail closed, but only this wording
+        # points at the token instead of sending the reader to look for a CI
+        # config that is not the problem.
+        reasons.append(
+            "CI checks could not be read - the GitHub token cannot see "
+            "statusCheckRollup (fail-closed)"
+        )
+    elif n_checks == 0:
         reasons.append("no CI checks reported - cannot confirm CI (fail-closed)")
     if marker_eval is not None:
         if not marker_eval.get("ok"):
@@ -864,10 +874,63 @@ def main(argv):
         "reviewDecision,url,headRefName,headRefOid,statusCheckRollup,"
         "body,closingIssuesReferences"
     )
-    rc, out, _ = run(["gh", "pr", "view", pr, "--json", fields])
+    rc, out, view_err = run(["gh", "pr", "view", pr, "--json", fields])
+    rollup_unreadable = False
     if rc != 0 or not out:
-        err("ERROR: could not read PR #" + str(pr))
-        return 2
+        # ``statusCheckRollup`` mixes Check Runs with legacy commit-status
+        # contexts, and the fine-grained-PAT permission model has no grant
+        # that covers the Check Runs half: it exposes no usable ``Checks``
+        # permission, and ``Commit statuses: Read-only`` covers only the
+        # legacy contexts. So the field can be refused
+        # (``Resource not accessible by personal access token``) on a token
+        # that already holds every grant the interface offers -- this is not
+        # a missing scope the caller can go and add.
+        #
+        # gh fails the WHOLE query when one field is refused. Every other
+        # field this script needs -- state, mergeability, review decision,
+        # body, linked issues -- is readable with plain repository access,
+        # so one unreadable field was taking the entire status check down.
+        #
+        # Retry without it. The retry is NOT conditioned on the error text:
+        # gh's message for a field-level permission denial is not a stable
+        # contract, and a text match that stops matching would silently
+        # restore the hard failure. A genuinely missing PR fails the retry
+        # too and still errors out.
+        rc2, out2, _ = run(
+            ["gh", "pr", "view", pr, "--json", fields.replace(",statusCheckRollup", "")]
+        )
+        if rc2 != 0 or not out2:
+            err("ERROR: could not read PR #" + str(pr))
+            return 2
+        # Degraded, never silent: the verdict below fails closed on the
+        # missing rollup, so this can only ever withhold a CLEAN, never
+        # manufacture one.
+        err(
+            "WARNING: could not read statusCheckRollup for PR #{}; continuing "
+            "without CI checks (commonly a fine-grained-PAT limitation). CI "
+            "status remains fail-closed.".format(pr)
+        )
+        # HEDGED on purpose, twice over.
+        #
+        # The retry is unconditional, so a transient first-query failure also
+        # lands here. Asserting *why* the field was refused would state a
+        # diagnosis this code never verified -- the same species of
+        # misdirection the whole change exists to remove. The echoed
+        # ``gh reported:`` line below carries the actual evidence.
+        #
+        # And the cause, when it IS the token, is not phrased as a grant to go
+        # and add: a fine-grained PAT can be unable to read the Check Runs
+        # portion of the rollup even WITH ``Commit statuses: Read-only``, so
+        # naming that grant would send the reader to enable a permission they
+        # may already hold.
+        err(
+            "  Note: fine-grained PATs may be unable to read the Check Runs "
+            "portion of statusCheckRollup even with Commit statuses: Read-only."
+        )
+        if view_err:
+            err("  gh reported: " + view_err.splitlines()[0])
+        out = out2
+        rollup_unreadable = True
     d = json.loads(out)
 
     state = (d.get("state") or "").upper()
@@ -889,6 +952,8 @@ def main(argv):
     )
 
     print("-- CI checks " + "-" * 40)
+    if rollup_unreadable:
+        print("  (unreadable - token cannot see statusCheckRollup)")
     n_running = n_fail = 0
     failing_checks = []
     readiness_kind = None
@@ -1006,6 +1071,7 @@ def main(argv):
         readiness_context=readiness_context,
         marker_eval=marker_eval,
         head_run=head_run,
+        rollup_unreadable=rollup_unreadable,
     )
     print(status)
     if "--json" in argv[1:]:

--- a/test/test_prepare_pr_status.py
+++ b/test/test_prepare_pr_status.py
@@ -1170,3 +1170,131 @@ def test_stampless_advisory_lane_comment_does_not_block_discovery_mode() -> None
     assert module.main(["pr_status.py", "42"]) == 0
     # Pinned: UX is explicitly required -> its stampless state blocks.
     assert module.main(["pr_status.py", "42", "--reviewers", "GPT,UX"]) == 20
+
+
+# ── A token that cannot read statusCheckRollup ──────────────────────────────
+# ``statusCheckRollup`` mixes Check Runs with legacy commit-status contexts,
+# and the fine-grained-PAT model has no grant covering the Check Runs half --
+# no usable ``Checks`` permission exists, and ``Commit statuses: Read-only``
+# covers only the legacy contexts. #4546's reporter HELD that grant and was
+# still refused the field, so this is not a scope the caller can add.
+#
+# gh fails the whole `pr view` when one field is refused, so one unreadable
+# field took the entire status check down and the prepare-pr integration
+# reported an environment failure.
+
+
+def _install_rollup_denied_gh(module: ModuleType, comments: str = "[]") -> dict:
+    """Fake gh where only the statusCheckRollup-bearing query is refused.
+
+    Returns a dict recording the field lists requested, so a test can assert the
+    retry actually dropped the field rather than succeeding for some other
+    reason.
+    """
+    seen: dict = {"field_lists": []}
+    payload = json.loads(_pr_payload([{"context": "PR Readiness", "state": "SUCCESS"}]))
+    payload.pop("statusCheckRollup")
+    reduced_payload = json.dumps(payload)
+
+    def fake_run(args: list[str]) -> tuple[int, str, str]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return 0, "", ""
+        if args[:3] == ["gh", "pr", "view"]:
+            fields = args[args.index("--json") + 1]
+            seen["field_lists"].append(fields)
+            if "statusCheckRollup" in fields:
+                # The verbatim error #4546 reports, so the fixture reproduces
+                # the real refusal rather than a generic scope complaint.
+                return (
+                    1,
+                    "",
+                    "GraphQL: Resource not accessible by personal access token "
+                    "(repository.pullRequest.statusCheckRollup.nodes.0.commit."
+                    "statusCheckRollup.contexts.nodes.0)",
+                )
+            return 0, reduced_payload, ""
+        if args[:3] == ["gh", "repo", "view"]:
+            return 0, "example/repo", ""
+        if args[:2] == ["gh", "api"] and "/issues/" in args[2] and "/comments" in args[2]:
+            return 0, comments, ""
+        if args[:2] == ["gh", "api"] and "/actions/runs" in args[2]:
+            return 0, json.dumps({"total_count": 1, "workflow_runs": [{"event": "pull_request"}]}), ""
+        raise AssertionError("unexpected command: {}".format(args))
+
+    module.run = fake_run
+    module.unresolved_thread_count = lambda _number: 0
+    return seen
+
+
+def test_unreadable_rollup_does_not_fail_the_whole_status_read(capsys) -> None:
+    """The PR still reports, instead of erroring out on one refused field."""
+    module = _load_script()
+    seen = _install_rollup_denied_gh(module)
+
+    code = module.main(["pr_status.py", "42"])
+
+    assert code != 2, "one unauthorized field must not take the whole read down"
+    out = capsys.readouterr()
+    assert "PR #42" in out.out, "the readable fields should still be reported"
+    assert len(seen["field_lists"]) == 2, "expected exactly one retry"
+    assert "statusCheckRollup" in seen["field_lists"][0]
+    assert "statusCheckRollup" not in seen["field_lists"][1], (
+        "the retry must drop the refused field, not repeat the same query"
+    )
+
+
+def test_unreadable_rollup_still_fails_closed(capsys) -> None:
+    """Degrading must never manufacture a CLEAN verdict.
+
+    The checks may well be green -- we simply cannot see them. Reporting CLEAN
+    here would let an unattended caller merge on CI it never read, which is a
+    strictly worse failure than the error this replaces.
+    """
+    module = _load_script()
+    _install_rollup_denied_gh(module)
+
+    code = module.main(["pr_status.py", "42"])
+
+    assert code == 20, "unreadable CI must block, not pass"
+    out = capsys.readouterr()
+    assert "STATUS: BLOCKED" in out.out
+    assert "statusCheckRollup" in out.out, (
+        "the reason must name the refused field so the reader looks at the "
+        "token, not at a CI config that is not the problem"
+    )
+    assert "no CI checks reported" not in out.out, (
+        "'none reported' is a different diagnosis and sends the reader the "
+        "wrong way"
+    )
+    assert "could not read statusCheckRollup" in out.err, (
+        "the warning should say what could not be read"
+    )
+    # The retry is unconditional, so a transient failure reaches this line
+    # too. The warning must not assert a cause it never verified -- that is
+    # the same misdirection this change removes.
+    assert "commonly" in out.err, "the cause must be hedged, not asserted"
+    assert not re.search(r"[Tt]he (current )?GitHub token cannot", out.err), (
+        "must not state an unverified diagnosis as fact"
+    )
+    # The reporter of #4546 HELD 'Commit statuses: Read-only' and was still
+    # refused, so the warning must never present that grant as the remedy --
+    # it would send the reader to enable a permission they already have.
+    assert not re.search(r"[Gg]rant .{0,40}Commit statuses", out.err), (
+        "must not tell the user to grant a permission they may already hold"
+    )
+
+
+def test_a_genuinely_missing_pr_still_errors(capsys) -> None:
+    """The retry must not turn a real read failure into a degraded success."""
+    module = _load_script()
+
+    def fake_run(args: list[str]) -> tuple[int, str, str]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return 0, "", ""
+        if args[:3] == ["gh", "pr", "view"]:
+            return 1, "", "could not resolve to a PullRequest with the number of 42."
+        raise AssertionError("unexpected command: {}".format(args))
+
+    module.run = fake_run
+    assert module.main(["pr_status.py", "42"]) == 2
+    assert "could not read PR #42" in capsys.readouterr().err


### PR DESCRIPTION
## Problem / Motivation

`statusCheckRollup` mixes **Check Runs** with legacy **commit-status contexts**, and the fine-grained-PAT permission model has no grant covering the Check Runs half — the interface exposes no usable `Checks` permission, and `Commit statuses: Read-only` covers only the legacy contexts.

So the field is refused on a token that already holds every grant the interface offers. #4546's reporter **held** `Commit statuses: Read-only` and still got:

```
GraphQL: Resource not accessible by personal access token
(repository.pullRequest.statusCheckRollup.nodes.0.commit.statusCheckRollup.contexts.nodes.0)
```

`gh` fails the **whole** `pr view` query when one field is refused, and `pr_status.py` asked for the rollup in the same request as everything else it needs:

```
number,title,state,isDraft,mergeable,mergeStateStatus,
reviewDecision,url,headRefName,headRefOid,statusCheckRollup,
body,closingIssuesReferences
```

Every other field there is readable with plain repository access. One unreadable field took the entire status check down:

```python
rc, out, _ = run(["gh", "pr", "view", pr, "--json", fields])
if rc != 0 or not out:
    err("ERROR: could not read PR #" + str(pr))
    return 2
```

## Why it matters

The failure is total and the message is misdirecting. `ERROR: could not read PR #N` reads as "the PR is unreachable" — wrong repo, wrong number, bad auth — so the reporter checks all of those, finds them fine, and has nothing left to go on.

Critically, **there is no permission the user can add to fix it.** The reporter chose a fine-grained PAT deliberately, to bound the blast radius of giving an agent `gh` access. Telling them to widen the grant is both wrong (they already hold it) and against the reason they scoped the token in the first place. The right outcome is for the script to keep working on the data the token *can* read.

It is also self-inflicted: the script already fails closed on missing CI, so it could have degraded and still been safe. Instead it refuses to report at all, including the parts of the verdict — state, mergeability, review decision, linked issues — that need no check access.

## What changed (motivation → approach → change)

**Symptom** — a token that can read the PR gets `ERROR: could not read PR #N` and exit 2.

**Root cause** — one query carries every field, so a field-level refusal is indistinguishable from the PR being unreadable, and is handled as the latter.

**Change** — on failure, retry once with `statusCheckRollup` dropped. If the retry succeeds, continue with the CI section marked unreadable and a permission-neutral warning on stderr.

This picks **option 3 of the three** the triage comment listed ("report the status data as explicitly unavailable"), and deliberately not options 1 or 2, for this script only. Reasoning offered for the maintainer to overrule:

- **Not option 2 (REST fallback).** Reconstructing the rollup from REST commit-statuses + Actions invents a second, differently-shaped source of CI truth in a script whose verdict logic is tuned to the rollup's `CheckRun | StatusContext` union. That is a contract worth deciding deliberately, not a side effect of a bug fix.
- **Not option 1 (split into an optional query) as a separate concern.** Dropping the field on retry *is* the minimal form of the split; a standing second query would be a shape change with no consumer yet.

Three decisions worth reviewing:

- **The retry is not conditioned on the error text.** `gh`'s message for a field-level refusal is not a stable contract, and a text match that quietly stopped matching would silently restore the hard failure. An unconditional retry is the fail-safe direction because the degraded path is itself safe (below).
- **A genuinely missing PR still errors.** The retry fails too and the original `return 2` stands — pinned by its own regression test so the retry cannot turn a real read failure into a degraded success.
- **Degrading never manufactures a pass.** `decide()` already fails closed on an empty rollup, so the verdict is `BLOCKED` (exit 20), never `CLEAN`. This adds a *distinct* reason rather than reusing `no CI checks reported`: the checks may well be green and simply invisible, and "none reported" sends the reader to look for a CI configuration that is not the problem.

Reporting `CLEAN` here would be strictly worse than the bug being fixed — it would let an unattended caller merge on CI it never read — which is why the exit code deliberately does not improve.

**The warning is hedged, and names no grant.** Because the retry is unconditional, a transient first-query failure reaches the same line — so the warning says the rollup could not be read "(commonly a fine-grained-PAT limitation)" rather than asserting a cause this code never verified; the echoed `gh reported:` line carries the actual evidence. It also never names a grant to go and add, since a PAT can be refused the Check Runs portion *even with* `Commit statuses: Read-only`. Two tests pin this: the warning must be hedged, and it must never tell the user to grant a permission they may already hold. (Hedging added in response to the Design Review suggestion on `911fad1e3`.)

**Wire shape is unchanged.** `--json` gains no field; the distinction reaches a consumer only through the human-readable `status` string. Whether the chat-sidebar integration should receive a structured `checks_unreadable` flag is part of the open contract below, so this PR does not pre-empt it.

One production file. A fully-authorized token takes the first request and never retries.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_unreadable_rollup_does_not_fail_the_whole_status_read` | the PR still reports; exactly one retry; the retry drops the refused field rather than repeating the query |
| `test_unreadable_rollup_still_fails_closed` | exit 20 `BLOCKED`; the reason names `statusCheckRollup`; it is *not* the `no CI checks reported` wording; and the warning never tells the user to grant a permission they may already hold |
| `test_a_genuinely_missing_pr_still_errors` | a real read failure is still exit 2 — the retry cannot mask it |

The fake `gh` refuses **only** the `statusCheckRollup`-bearing query, serves the reduced one, and returns #4546's verbatim `Resource not accessible by personal access token` error — so it reproduces the reported condition rather than a generic scope complaint. It records the field lists requested, which is what lets the first test assert the retry actually dropped the field instead of passing for some unrelated reason.

Fail-before / pass-after on `origin/main`, with the test file added and `pr_status.py` restored to its `origin/main` contents:

```
=== pr_status.py = origin/main ===
FAILED test_unreadable_rollup_does_not_fail_the_whole_status_read
       - one unauthorized field must not take the whole read down
FAILED test_unreadable_rollup_still_fails_closed
       - unreadable CI must block, not pass
2 failed, 2 passed

=== fix applied ===
65 passed        (whole test_prepare_pr_status.py)
```

`test_a_genuinely_missing_pr_still_errors` passes on both sides by design — it is a regression guard on behaviour this PR must *not* change.

Related suites — `test_prepare_pr_status.py`, `test_prepare_pr_findings.py`, `test_prepare_pr_profiles.py`, `test_redaction_mirror_parity.py`: **113 passed, 1 failed**. The failure is `test_symlinked_config_is_refused`, which needs `os.symlink` elevation on Windows (`WinError 1314`) and fails identically on unmodified `main`.

Gates: `flake8` · `isort` · `scripts/check_black_formatting.py` · `mypy` (no errors in the changed file) · `scripts/check_brand_name.py`.

## Manual verification

N/A — unit coverage sufficient: the defect is entirely in how a `gh` non-zero exit is handled, and the tests drive the real `main()` with `run()` stubbed to reproduce the exact refusal, so the retry, the verdict and the exit code are all production code. Reproducing against a live fine-grained PAT would need a token minted for this purpose, which cannot be done in CI; the stub encodes the reporter's verbatim error.

## Related Issues

Addresses the `pr_status.py` portion of #4546. **Deliberately does not close it.**

The companion `pr_findings.py` path is out of scope. It requests `statusCheckRollup` in the same shape and fails the same way on current `main`, but it exists to collect *actionable failing-check detail*, so its degradation contract is a genuine decision — recover findings from REST Actions, fall back to commit statuses, report no findings, or error — and the triage comment on #4546 says that contract "should be decided before coding". The metadata-preserving fallback that is obviously right for a status verdict is not obviously right there, and guessing would be the worse outcome.

Happy to follow up on `pr_findings.py`, and on a structured `checks_unreadable` field for the sidebar, once a direction is chosen.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(prepare-pr): degrade when a token cannot read statusCheckRollup`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: `prepare-pr/SKILL.md` does not document `pr_status.py`'s failure modes, so there is no documented behaviour to keep in sync; the reasoning lives in comments at the changed sites
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
