### PR TITLE
docs: port the 0.4.0 section to main and refuse a draft section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,20 +230,30 @@ One logical change per commit.
 ## Release Changelog
 
 `CHANGELOG.md` is written **only when a version is bumped**, and everything
-already in it is immutable. Enforced by the `changelog-is-written-at-version-bump-only`
-rule in `AUTOSDE.yaml`; the parser that renders it is `src/kiro_crew/changelog.py`.
+already in it is immutable. Two halves enforce that: the
+`changelog-is-written-at-version-bump-only` rule in `AUTOSDE.yaml` applies the
+judgment a reviewer has to make (is this a commit dump? should this PR be touching
+the file at all?), and `scripts/check_changelog_history.py` enforces what needs no
+reading — every section the base documents as shipped survives byte-identical, and
+the file contains **only** shipped sections. The parser that renders it is
+`src/kiro_crew/changelog.py`.
 
 - **Your feature PR does not touch `CHANGELOG.md`.** The release PR writes the
   section covering everything that shipped. A per-PR changelog line is how the
   file grows into something nobody reads, and how it acquires an `## [Unreleased]`
   section that then has to be untangled at release time. The commit subject is
   the record until a bump names it.
-- **There is no `## [Unreleased]` section.** To see what is pending, read
-  `git log --oneline <last-tag>..HEAD`.
+- **There is no `## [Unreleased]` section, and the gate refuses one.** To see what
+  is pending, read `git log --oneline <last-tag>..HEAD`. With shipped sections
+  frozen, that leaves exactly one legal shape for a changelog diff — prepend one new
+  section — because there is nowhere to append a per-PR line to.
 - **One section per release, newest first**, headed exactly
   `## [X.Y.Z] — YYYY-MM-DD`. Never a prerelease spelling: `0.3.0-insider.9` and
   `0.3.0-rc.2` are drafts of `0.3.0`, are folded onto it by the parser, and must
-  not get their own heading.
+  not get their own heading. The gate refuses those too, so a release branch writes
+  its section once, under the release's final heading, rather than carrying a draft
+  it renames later.
+
 - **Never delete or edit a shipped section.** A release PR prepends one section
   and leaves every earlier one byte-identical. This has already gone wrong once:
   a section was *replaced* rather than prepended and 322 lines of released
@@ -290,7 +300,19 @@ Format, which the `[0.2.0]` section is the reference for:
   Partition `git log <last-tag>..HEAD` and account for every commit, because the
   omissions are systematic rather than random: a change whose subject names one
   subsystem while touching a shared surface is exactly what a keyword or path
-  scan misses, and nothing downstream ever reports it.
+  scan misses, and nothing downstream ever reports it. It is also systematically
+  biased *against* the release's headline: the PR that lands a large surface is
+  the least likely to have spent effort on a changelog line, so an accumulated
+  file over-represents small fixes and omits the features people upgraded for.
+- **The section ends with `### Contributors`**, crediting everyone whose code
+  shipped in it — `@handle`, alphabetical by username case-insensitively, bots
+  left out. Derive it from the release's own range rather than by hand:
+  `gh api repos/kirodotdev/KiroCrew/releases/generate-notes -f tag_name=<tag>
+  -f previous_tag_name=<last-tag>` names the author of every merged PR, so nobody
+  is dropped for having a quiet commit subject. The GitHub Release page gets this
+  for free from `generate_release_notes: true`, but that page is not what ships:
+  the changelog section is the copy inside the wheel and behind the dashboard's
+  Releases page, so it needs its own.
 
 ## The gate before you commit
 

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -407,6 +407,9 @@ custom-rules:
       - FLAG a new `## [Unreleased]` section. There is no Unreleased section:
         unshipped changes live in the commit log until a bump names them. Use
         `git log --oneline <last-tag>..HEAD` to see what is pending.
+        `scripts/check_changelog_history.py` also refuses this mechanically, so
+        spend your attention on the section's CONTENT rather than re-deriving
+        this; report it only if the gate somehow did not.
       - FLAG a section assembled from a commit dump — a bare list of commit
         subjects, a "Bug Fixes (N total)" count, or a trailing "and N more
         (see commit log)". That is not a changelog entry; it is the thing a
@@ -417,7 +420,9 @@ custom-rules:
         `## [0.3.0-rc.2]` and similar prerelease spellings must not appear.
         A prerelease is a draft of its base version and is folded onto it by
         src/kiro_crew/changelog.py; giving it its own heading puts a build
-        stamp in the reader's version archive.
+        stamp in the reader's version archive. Mechanically refused by
+        `scripts/check_changelog_history.py` as well; a release branch writes
+        its section once, under the release's final heading.
 
       Allowed (do NOT flag):
       - A release PR that prepends one new `## [X.Y.Z] — YYYY-MM-DD` section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,729 +2,315 @@
 
 All notable changes to KiroCrew are documented in this file.
 
-## [Unreleased]
+## [0.4.0] — 2026-08-21
 
-- **MCP servers can now be measured for shareability on purpose, and the answer
-  survives until the server itself changes.** The Sharing assessment could only
-  say as much as the number of servers carrying a measurement, and reaching one
-  was neither deliberate nor durable: the only trigger was an icon-only refresh
-  that evaluated two servers per press, so a fleet of thirty needed fifteen
-  presses and a guess about what the icon did. MCP Management now carries a
-  labelled action that names how much is left ("Measure 2 unmeasured servers")
-  and runs the whole set as a background pass with progress, while the
-  per-request budget of two stays exactly where it was. Two gaps in the
-  measurement itself are closed at the same time. The pre-flight already spawned
-  each server twice under two client identities, but compared only the
-  `initialize` capabilities, so a server that served a different TOOL SET per
-  caller passed; it now compares the tool list too, which costs no extra spawn
-  because the probe already fetched it and is the one facet decidable on a server
-  too old to send tool annotations at all. Which facet diverged is logged for
-  diagnosis but not reported per-row: every consumer of a stored measurement
-  reduces it to one boolean, so naming the facet to an operator is a change to
-  that whole path rather than to the prober. And a stored verdict now records the
-  version the server reported, so a runtime-resolved launch (`npx thing@latest`)
-  that swaps its own code upstream is re-measured instead of trusted -- the
-  launch fingerprint cannot see that, since command, environment and interpreter
-  all stay byte-identical.
+The dashboard became a place to work on code rather than only talk about it: real
+side-by-side diffs, an editable file tree, a transcript you can scroll back
+forever, and a terminal and browser that dock where you want them. Underneath,
+Kiro Crew got measurably lighter and stopped guessing about MCP — servers are
+probed instead of assumed, and the panel tells you what is genuinely usable.
+Windows joins macOS and Linux as a first-class target, down to driving native
+desktop applications.
 
-- **Switching Kiro accounts mid-session no longer leaves the chat showing a raw
-  `The bearer token included in the request is invalid.` with no way out.** A
-  `kiro-cli` child holds its credential for the life of the session, so an
-  external account switch invalidates it underneath a running session. That
-  rejection carries no status code and never uses expiry wording, so it matched
-  none of the auth classifiers: it reached the user as the raw upstream string
-  with no sign-in affordance, and counted as a retryable backend fault that
-  spent the whole retry ladder on a credential no retry can revive. A rejected
-  credential is now classified alongside session expiry — terminal, and carrying
-  the existing actionable "run `kiro-cli login`, then start a new chat"
-  guidance. (#3393)
+### Before you upgrade
 
-- **Issue Radar's AI summaries now follow the dashboard language.** The issue
-  triage summary, the PR summary, and the label-taxonomy recommendation always
-  produced English prose regardless of `dashboard.language`, making the AI card
-  the one unlocalized surface in an otherwise localized UI. When a dashboard
-  language is configured, each one-shot prompt now carries an output-language
-  directive for its prose (summary, per-label `reason`, recommendation
-  `rationale`) while label names — and a recommendation's `name`/`description`,
-  which become repo content on GitHub — stay untranslated. Caches regenerate on
-  a language switch instead of serving the old language: the PR-summary cache
-  folds the tag into its fingerprint, and the issue-AI cache stores the tag
-  beside the payload and treats a mismatch as a miss (recommendations remain
-  regenerate-only via their explicit button). Installs with no configured
-  language send byte-identical prompts and keep their cached digests. (#4290)
+- **The automatic move from `~/.kirocrew` to `~/.kiro/crew` is gone.** An install
+  that never ran that migration must move its data home by hand before upgrading.
+- **Updates follow Stable by default.** An Insider install that never recorded a
+  channel preference moves to Stable; re-opt into Insider from About. This is what
+  keeps a promoted release from drifting its users onto the prerelease lane.
+- **The installer provisions Python with a pinned `uv`** instead of the
+  apt/dnf/yum/mise ladder. Hosts that relied on system packages get a user-owned
+  interpreter beside the data home; set `KIROCREW_PYTHON_DIR` to relocate it.
+- **A self-frozen build is no longer supported.** Use the bundled-interpreter
+  install or the wheel.
+- **The git update lane is gated on how you installed, not just where you are.** A
+  release install launched from inside a clone no longer updates by pulling that
+  clone; use an editable install if you want that path.
+- **The built-in browser is the default.** The browser tool drives the dashboard's
+  own panel; turn it off in Settings → Browser if you depend on `playwright-cli`.
+- **Board view is opt-in.** Enable it explicitly, or the layout shows as a list.
+- **Creating a crew requires choosing an agent template.** A crew without one no
+  longer creates.
+- **An MCP server that declares its own `env` is pooled by default.** Set the
+  env-forwarding option or an absolute command path to keep one unpooled.
+- **Numeric settings are bounds-enforced, and several are now actually read.** The
+  subagent memory floor and the per-kind session counts take effect where they were
+  silently ignored — including a `0` you set to disable the memory gate — fractional
+  container limits are refused, and out-of-range values are clamped. Re-check what
+  you configured.
+- **A path containing an unexpanded `$VAR` is denied, and an app token can no longer
+  flip global auto-approve or resolve an approval.** Adjust any workflow that passed
+  an unexpanded variable inside a path.
+- **The skip-permissions setting must be a real boolean.** A quoted string no longer
+  auto-approves every tool call, and no longer takes effect at all.
+- **Publishing an artifact to a public URL needs an explicit acknowledgement**, and
+  an operator can close the path entirely. If you had already narrowed the allowed
+  destinations, add the AWS web deploy target to keep deploying.
+- **"Run in terminal" sends the command to the terminal dock** instead of
+  transferring it into the chat.
+- **Private Slack channels need the app manifest re-imported.** Update or re-import
+  the manifest, reinstall the app to the workspace, and copy the new bot token.
+- **Explore is sourced from registries only.** Content that came from anywhere else
+  no longer appears there; add it through a registry.
+- **Nightly is no longer a one-click switch on the About page**, and **Apply &
+  Restart has left the overview page** — use the per-server restart or Reload
+  session instead.
+- **Duplicate skill keys are removed.** An edition holding a stored reference to one
+  of them must re-point it at the skill's canonical key.
 
-- **xlsx files now render inline in the file viewer** instead of a
-  download-only card. A new `GET /api/file-sheet` endpoint parses OOXML
-  workbooks server-side with openpyxl (read-only, worker thread, ZIP
-  magic-byte check, 500x100 per-sheet cap with explicit truncation flags) and
-  the new `SheetViewer` renders sheet tabs, a column-letter header, and a
-  row-number gutter. Formula cells with no cached value — the shape of every
-  agent-generated workbook — show the formula source rather than an empty
-  cell. Legacy `.xls` and ODF formats keep the download card, and any parse
-  failure degrades to it. (#3865)
+### Work on code in the dashboard
 
-- **A session that times out on startup now names the MCP server it was waiting
-  for.** Every cause of a stalled session start reported the same sentence,
-  `Request session/new timed out`, which named none of them: a slow MCP fleet, a
-  single unreachable remote server, a pending authorization, and an expired
-  credential were indistinguishable. The runtime already held both halves of the
-  answer at that moment and threw them away. It sends the server roster in the
-  request's own `mcpServers` array, and the reader loop stages every
-  `server_initialized` / `server_init_failure` / `oauth_request` frame that
-  arrives before the response, each carrying its server's name. A session-start
-  timeout now reads both and reports the difference, so the error says how many
-  servers reported out of how many were expected, which ones never reported,
-  which failed and why, and which are waiting on authorization. `session/load`
-  shares the budget and the staging, so it gets the same report. A failed
-  server's error text takes the same redaction the dashboard banner applies,
-  because a server's startup error can carry its own connection string, and each
-  listed name is redacted, collapsed onto one line and length-capped as well --
-  a name is config-derived, so an installed app chooses it, and an embedded
-  newline would otherwise forge a line in the gateway log while an unbounded one
-  would defeat the cap on how many names are listed. The reported count is taken
-  against the roster rather than against every staged frame, since the agent
-  spec's own servers report too and counting them produced impossible readings
-  like "2/1 reported". Timeouts now raise a dedicated `AcpRequestTimeout`, a subclass of
-  `AcpRuntimeError`, so a stall is distinguishable from a protocol fault without
-  changing what existing handlers catch. Startup telemetry also stops losing the
-  starts that failed: the `session_new` phase duration is recorded in a `finally`
-  like `session_load` already was, instead of only on success.
+- **Side-by-side diffs, inline editing, and a project file tree** — review and edit
+  a change where you are already talking about it, instead of leaving for an editor.
+- **The transcript scrolls back forever** — reaching the top loads older messages
+  instead of stopping at the window the session opened with.
+- **Reasoning streams as it happens** — the collapsed thinking row shows the model's
+  reasoning live, one block per burst rather than a whole turn flattened into one,
+  and the blocks survive a tab switch.
+- **Pinned messages get their own side-panel tab** instead of stacking up in the
+  conversation.
+- **Click an inline code span to copy it.**
+- **A command launcher** — an opt-in quick-search gesture opens a launcher whose
+  rows say what kind of thing each one is.
+- **Design Tweak** — click an element on a rendered page and edit it visually
+  instead of describing the change you want.
+- **A local Markdown link opens in the side panel** rather than failing.
 
-- **Subagent rows in System → Sessions now report their process and MCP-stub
-  counts.** Both columns rendered an em dash on every task row, which read as
-  "a subagent carries no MCP stubs" — the opposite of the truth: a subagent
-  session spawns its own poolable stub set and reaches the shared backends
-  through the same gateway daemon a top-level session does (measured on a live
-  host: 18 `--poolable` stubs under one shared runtime, none of them falling
-  back to a private spawn). The reason was structural, not cosmetic: nothing
-  ever counted them. `task_memory_rows()` carried no `procs`/`mcp` fields at
-  all, and the reaper sweep that samples a task's RSS and CPU took no such
-  reading, so the frontend hardcoded both to null. The sweep now counts the
-  run's subtree in the same pass (one walk, no extra syscalls per column) and
-  attributes the counts the way RSS and CPU are already attributed — split
-  across the co-tenants of a shared runtime — with two rules a count needs and
-  a byte figure does not: the quotient rounds to a whole process, and a nonzero
-  total never rounds down to zero. Unmeasured stays null rather than becoming
-  "0", so an unsampled task still reads as an em dash instead of claiming to be
-  empty. The stub cmdline fingerprint is now one constant shared by the
-  rewriter that emits the launch line and both counters that match it, pinned
-  by a test: a private copy that drifted would not fail loudly, it would report
-  zero stubs.
+### Sessions that keep up
 
-- **The subagent cost sweep no longer runs on the gateway event loop.**
-  ``_sample_live_costs`` walks ``/proc`` several times per live agent, and the
-  reaper called it inline, so every chat turn and heartbeat waited behind those
-  walks. It now runs on the maintenance executor. The body was made
-  thread-safe to go with it: the agent registry is snapshotted once and the
-  sharer count is derived from that snapshot, because iterating the live
-  registry from a worker thread raises ``RuntimeError`` the moment a spawn or
-  eviction lands mid-sweep.
+- **Reload a session in place** — relaunch its agent to pick up new MCP servers or
+  a config change without restarting the gateway or losing the conversation.
+- **Search across every connected instance** from one box, and **find a chat by its
+  PR, MR, or issue number**.
+- **Filter the session list by tag**, and give a session **any colour you like**
+  rather than one of seven.
+- **Search inside a folder tab recursively** — nested files are found, not just the
+  folder's top level.
+- **The model footer says when "auto" chose** — you can see which model actually
+  served the turn and that it was picked for you.
+- **Crew Mode is labelled experimental** in the create menu, so its stability is
+  clear before you pick it.
+- **The summary panel bounds its height** and keeps more history within raised
+  limits, and the session-pulse survey is back with consent and scope safeguards.
+- **The "+N" source-link chip expands**, so you can open every linked source.
 
-- **A delivered message no longer warns that it may not have been delivered.**
-  Every message typed in the dashboard composer grew a "Message not confirmed —
-  may not have been delivered" warning 30 seconds after it was sent, for the rest
-  of the turn, while the agent was visibly answering it. The indicator's
-  "delivered" signal was a `chat_message` echo of the user row — but that echo is
-  suppressed for dashboard sends by design (`DashboardState.append` defaults
-  `broadcast_user=False` precisely BECAUSE the composer already rendered the
-  bubble; only a row replayed from a channel transcript opts in). So the
-  pending-confirmation flag survived every composer send, the 30s sweep flagged
-  all of them, and the flag cleared only as a side effect of the end-of-turn
-  transcript refresh. Both composer surfaces now confirm from the send's own HTTP
-  response, which is the actual delivery receipt: an accepted immediate dispatch
-  retires the pending state and keeps the correlation id so a later echo still
-  reconciles in place instead of pushing a duplicate bubble. A `queued`
-  acceptance is deliberately NOT a receipt for that bubble -- the busy branch
-  queues only a non-empty message yet answers `{ok, queued}` either way, and when
-  it does queue, its own `queue_push` card owns the message, so cancelling it
-  leaves the bubble behind. The genuine failure paths are untouched -- a rejected
-  response, a transport error and the 10s client-side abort all leave the bubble
-  unconfirmed, which is what the indicator exists to say.
+### Reach it from more places
 
-- **Video and audio files now play inline in the file viewer.** Opening
-  `.mp4`, `.webm`, `.mp3`, `.wav` and friends previously fell through to the
-  code renderer, which displayed the binary as mojibake. A new
-  `GET /api/file-stream` endpoint serves media with HTTP Range support
-  (seeking needs 206 Partial Content) through the same security envelope as
-  the other file endpoints -- path validation, sensitive-path block,
-  symlink-refusing open, content sniffing so the served bytes decide the
-  type, and bounded chunked reads so memory stays constant regardless of
-  file size. The viewer routes video to an inline `<video>` player and audio
-  to an `<audio>` bar; any playback failure degrades to the download card.
-  (#4021)
+- **Computer use on Windows** — drive native Windows desktop applications through
+  the accessibility layer, not only macOS.
+- **Windows publishes on the Stable channel** with its updater enabled, and a
+  spawned agent tree is bounded by a real resource ceiling there.
+- **Native `.deb` and `.rpm` packages**, each with its own update lane.
+- **Import from Gemini CLI and Antigravity** during first-run setup.
+- **Switch Kiro accounts from the CLI**, and **open the dashboard login from
+  Telegram** for signing in on a phone.
+- **The installer remembers your managed-Python choice**, and Doctor now warns when
+  a source checkout is stale or on the wrong branch.
+- **A managed deployment can supply its own update provider**, pointing self-update
+  at an internal source.
 
-- **A succeeded publish no longer renders as a blank error, and a failed
-  re-publish no longer renders as a success.** The Publish panel recognized only
-  the deploy-shaped `{url}` response, so a provider that hands its confirmed
-  publish to `POST /api/artifacts/{slug}/publish` — the supported way to reuse the
-  core's single publish authorization and audit trail rather than growing a second
-  one — got its serialized-artifact response read as "no url", fell through to
-  `{url: ''}` and rendered the ERROR branch with an undefined message: a bare red
-  icon, no text, on a publish that had in fact succeeded (the bytes were pushed
-  and `publication` was persisted). `readPublishOutcome` now reads both shapes and
-  returns an outcome rather than a url: success is signalled by the return shape
-  instead of inferred from a non-empty url (a destination can publish and expose
-  no browsable link), an `error` field wins over anything else in the same body,
-  `publication: null` is not success, and an unrecognized shape is reported as a
-  NAMED error instead of an empty one. The mirror-image lie is fixed too — a 200
-  whose `publication.last_error` is non-empty is now reported as that error rather
-  than as "Published!", because `publish_sync.publish()` treats the version push
-  as best-effort on a re-publish: it persists the failure and returns normally, so
-  the remote content is stale behind a 200. The public-exposure warning and its
-  blocking acknowledgment are unchanged and still unconditional.
+### MCP and tools stop guessing
 
-- **Every builtin app now starts its content 8px from a phone screen edge, not 24px.**
-  The narrow-first page gutter (`px-2 md:px-6`) reached the core pages and Issue
-  Radar, while the remaining builtin apps kept an unconditional `px-6`, so their
-  content was inset 24px before any card inset stacked on top. Meetings, Code
-  Review Sage, Auto Research, Workflows, Mochi, Papyrus, PPTX Maker and Ops
-  Mission Control now carry the same gutter, converted a whole file at a time so
-  a header and the rows beneath it cannot render on two different left edges.
-  Centered empty states keep their `px-6`, where it is the element's only inset
-  and flushing it would push centered copy toward the edge for no width gain; a
-  guard test states that exclusion so a later pass does not read it as a miss.
+- **Measure every MCP server's shareability on purpose** — one labelled action that
+  names how much is left and runs the whole fleet as a background pass, instead of
+  an icon that quietly did two at a time. The probe now compares tool lists as well
+  as capabilities, and records the version a server reported, so a
+  `@latest`-style launch that changes upstream is re-measured rather than trusted.
+- **A server that would degrade is no longer silently downgraded** — opted-in
+  servers stop falling back to an unpooled backend behind your back, and the warning
+  names the fix.
+- **The Online badge means the tools are usable**, and says when it was checked,
+  instead of presenting a stale reading as current.
+- **Apply & Restart actually mounts a newly installed server** — and says so
+  honestly when it could not, rather than skipping the change or reporting success.
+- **Two servers can expose the same tool name** — the collision resolves through
+  registry aliases instead of one of them losing.
+- **A server that declares its own PATH keeps the inherited one too**, and every
+  configuration surface expands it the same way, so a server can no longer work
+  under one consumer and fail under another.
+- **A guided five-whys mode** drives structured root-cause research step by step.
+- **Choose whether the browser tool drives the native panel** or falls back to
+  `playwright-cli`.
 
-- **Destructive buttons look destructive on a phone.** `Btn`'s `danger`
-  variant coloured its label only on `:hover`, and a touch viewport never
-  produces `hover` — so a destructive button rendered identically to the
-  non-destructive buttons beside it. Same class of defect as a hover-revealed
-  control: the affordance existed only under a pointer. Found on the Channels
-  page at 390px, where `Close` (which dismisses every agent in the channel) sat
-  in a wrapped header row beside the frequent `3 agents` and `Clear Context`
-  buttons at identical visual weight. The label is now `text-danger`
-  unconditionally; hover still raises the border and adds a subtle fill, so the
-  pointer affordance is not lost, only made unnecessary for recognising the
-  control. (#3937)
+### Autonomy with a ceiling
 
-- **A parent agent can read its own sub-agent's result file again on a host
-  whose home is a symlink.** The result path handed back in a completion event
-  was built through `Path.resolve()`, which is correct for the traversal check
-  it exists to serve and wrong for a path somebody is told to go read: on an
-  Amazon cloud desktop, where `/home/<user>` is a symlink to
-  `/local/home/<user>`, that resolved spelling carries a `/local/home/...`
-  prefix the reader's own path allowlist -- keyed on the `$HOME` it was given --
-  does not match. The file was always readable; only the spelling was
-  unrecognized. So the read was refused, and refused as an approval prompt that
-  times out rather than as an error, which made a whole wave of sub-agent
-  results look unreadable while the parent concluded it lacked permission.
-  Paths emitted as TEXT (the completion event, the batch digest, `spawn_status`,
-  the prior-result hint on an unresumable conversation, and `info.result_path`
-  wherever it surfaces) now carry the declared home spelling, while every path
-  used to open a file stays symlink-resolved so the traversal check is unchanged.
-  Validation is delegated to the resolving helper rather than duplicated, so the
-  two cannot drift apart.
-- **Code Review Sage's "Ask the reviewer" no longer dies with the review's
-  session.** The reviewer's reasoning lives in the session that produced the
-  findings, and that session was kept resident only briefly — a 1800s idle TTL,
-  a 6h cap, a 4-session LRU cap, and gateway restart. Worse than "unloaded":
-  retiring it called `handle.destroy()`, which unlinks the kiro-cli transcript
-  unless `keep_transcript` is set, so the reasoning was DELETED and no amount of
-  waiting or re-opening could bring it back. Sage now keeps the transcript and
-  a follow-up RESUMES it as an ordinary chat session (`session/load`), filed in
-  a `Sage Review` folder and titled `followup-pr#<n>-<title>`. Nothing is held
-  resident between the review and the question: asking is the rare case, so a
-  follow-up pays a cold load from disk instead of pinning the shared reviewer
-  subprocess on the chance that someone asks. Because the follow-up is a normal
-  session, its tool use now runs through the dashboard's approval pipeline,
-  which sees real permission requests and can reject BEFORE execution — closing
-  the documented limitation that Sage's own gate was post-hoc for
-  spec-pre-approved tools. A resume that would not restore the review is refused
-  rather than attempted: the dashboard's fallback for a failed resume is to
-  replay Kiro Crew's conversation log, and a follow-up session has none, so a
-  session opened anyway would answer confidently about a review it knows nothing
-  about; the same reason a run that is still going is not offerable, since a
-  second coverage pass can replace the findings a mid-run conversation was
-  opened on. Follow-up offers are retired after two weeks with no activity,
-  measured from the transcript's own mtime so a conversation still in use keeps
-  its offer. Retiring an offer removes only Sage's own descriptor: the one
-  session id available there comes from a file the reviewer can write, so
-  deleting on that authority would let a prompt-injected review name any session
-  on the machine and have this app remove it.
+- **Concurrent subagents share one memory and process ceiling**, so many small
+  spawns can no longer add up past what the host has.
+- **A monitoring loop stops itself when it stops making progress** instead of
+  running to its cycle cap.
+- **Hooks match by regex or substring** and can inject a skill declaratively, and a
+  Stop hook that blocks now continues the turn with its feedback instead of halting.
+- **Toggle auto-approve for the task runner from its compose panel**, without
+  leaving the view.
+- **The crew editor shows what wakes each crew.**
 
-- **A long-running cron job's next tick is no longer dispatched up to 30s
-  late.** A job is invisible to the scheduler's wake computation while it's
-  executing (`_next_wake_secs` skips anything in `self._executing`), so for
-  a job whose run takes most of its interval, the timer's last wake before
-  completion — capped at the 30s poll interval — is what the next dispatch
-  had to wait for, since finishing a job never re-armed the timer. Measured
-  in the field on a 60s-interval job with a ~57s run: 20% of ticks landed
-  ≥20s late, costing roughly double the job's own `interval - duration`
-  idle-time floor. Job completion now re-arms the timer with its real
-  next-due delay. The naive version of this fix is unsafe: a job's
-  completion runs on its own task, not the timer's, so a blind
-  `_arm_timer()` call racing the timer's own in-flight dispatch sweep
-  (`_on_timer`, yielded at its worker-thread scan) would cancel that sweep
-  mid-flight and drop any due jobs not yet spawned for that tick. A job
-  completing in that narrow window now no-ops instead — `_on_timer`'s own
-  tick already unconditionally re-arms once the sweep finishes, by which
-  point the completed job is no longer `_executing`, so the corrected delay
-  still gets picked up, just moments later rather than being computed
-  twice.
+### Memory, knowledge, and secrets
 
-- **Reload session: relaunch a session's agent process in place.** A live
-  agent process mounts its MCP servers and builds its tool table once, at
-  session-init time, so config that changes afterwards — a newly added MCP
-  server, an env or agent-spec fix — never reaches an already-open session;
-  the only remedies were restarting the whole gateway or abandoning the
-  conversation for a new chat. The session actions menu now carries a
-  "Reload session" item (disabled while a turn runs) backed by
-  `POST /api/chat/slots/{slot}/reload`: it targets the slot's linked session
-  key, applies the cancel-route app-isolation policy, refuses with 409 while
-  a turn is in flight or sub-agent children are attached, tears the process
-  down through the same chokepoint the agent/workspace switches use, appends
-  a feed notice, and eagerly re-arms the resume spawn, so the relaunched
-  process re-reads its agent spec and environment and re-initializes MCP
-  servers via session/load with the conversation preserved. The busy check
-  is evaluated atomically with the session pop, closing the check-then-reset
-  race, and the notice kind is skipped by the last-real-message scans on
-  both backend and frontend.
+- **An encrypted secrets vault** — store a credential where the agent is denied from
+  reading it.
+- **Scope a lesson to one repository**, so it applies only where it belongs.
+- **Filter the knowledge graph by source** to look at one origin at a time.
+- **A notebook can sync itself** on an interval you choose, in the background.
+- **Read the memory layer from the command line**, not only the dashboard.
+- **A lesson embedded by an older model is no longer deleted as a duplicate** or
+  offered to you as a false contradiction.
 
-- **Removing a worktree in Dev Fleet no longer strands its pod's isolated
-  HOME.** Reclamation was gated on the pod's unit still being ACTIVE, which the
-  ordinary path never is: you stop the pod when testing ends and prune days
-  later once the PR merges. So the delete path that reclaims the HOME was
-  effectively never called, and every removal leaked a full isolated
-  `KIROCREW_HOME` — dominated by a per-instance copy of the embedding model, so
-  ~0.6 GB each — with the directory becoming unattributable the moment the
-  worktree's env pin went away. Removal now reclaims the HOME whether or not the
-  pod is running, using the same `orphan_homes` predicate as `pod ls` / `pod
-  prune` (so symlinks are skipped, and a macOS name mid-`up` is treated as
-  installed rather than orphaned). Attribution and teardown are ONE transaction
-  held under `pod_name_mutex`: pod identities are global basenames, so checking
-  ownership in one process and tearing down in another leaves a window where a
-  concurrent `pod up` from a different checkout claims the same name and the
-  teardown would stop that pod and delete its HOME. Both call sites — the
-  live-unit path and the orphaned-HOME path — go through the one locked helper,
-  which is necessarily in-process: the mutex is held per open-file-description
-  and `stop_pod` re-acquires it, so holding it around a `pod down` shell-out
-  would block the child being waited on. Because the delete needs positive
-  attribution, an ABSENT checkout pin refuses rather than assuming ownership
-  (`pod prune` still reclaims those), and a name handed to a new pod mid-teardown
-  refuses the removal outright, since that pod may be running out of the very
-  worktree about to be deleted.
-  The two outcomes are reported separately (`stopped_pod` vs
-  `reclaimed_pod_home`) rather than conflated into a shutdown that never
-  happened. Liveness checks keep failing CLOSED — they guard against deleting a
-  checkout under a live pod — while a reclamation that cannot run now degrades
-  to a logged leftover instead of refusing the removal, and a provably absent
-  pod backend logs the HOME it is leaving behind at WARNING with the verb that
-  reclaims it, replacing a debug-level line that hid the residue entirely.
+### Apps and the store
 
-- **The one-time config migration no longer leaves a `.json.bak` orphan beside a
-  config path it does not own.** `KiroCrewConfig.load()` copied the
-  pre-migration config to `<path>.bak`, where `<path>` is whatever
-  `config_path()` resolved to -- so every caller that redirects the loader at
-  its own `tempfile` entry (tests and embedders do) silently accumulated one
-  orphan per load, since the caller unlinks the path it created and never learns
-  a sibling appeared. One dev host reached 72,327 such files in `/tmp`, 7% of a
-  tmpfs inode budget whose exhaustion fails every process on the box. The copy
-  is now gated on the config living in `config_dir()`, the one directory whose
-  contents we own; the production backup is unchanged, and a copy that fails
-  still aborts the migration save exactly as before, so a config we could not
-  copy aside is not rewritten either. The name is also built by
-  appending rather than `with_suffix(".json.bak")`, which REPLACED the final
-  suffix and so renamed a non-`*.json` config instead of backing it up.
+- **Install what the official catalog lists**, each app pinned to a vetted commit.
+- **A managed deployment can pin its own registry** and assign trust tiers to the
+  apps it serves.
+- **External registries appear in the store when the catalog is online** — a
+  configured registry's apps were previously visible only offline.
+- **Issue Radar** — edit an issue's assignees from the detail pane, and its
+  Investigate, Review, summary and label agents write in your dashboard language.
+- **Notes** — mermaid diagrams and images render in the preview, fenced code blocks
+  are syntax-coloured, and headings follow a clearer ramp.
+- **Channels, Dev Fleet, and Workflows each have their own icon.**
 
+### Voice, terminal, and files
 
-- **A knowledge source that errored during ingestion is no longer re-synced on
-  every sweep.** `KnowledgeIngestion` marks failure in the `sync_status`
-  **column**, but `SyncScheduler.sync_all`'s skip predicate read only the
-  `sync_status` copy inside the properties JSON, which the ingestion path never
-  sets. So an ingestion-errored source (bad credentials, deleted remote,
-  unparseable content) was retried on every sweep forever, flooding logs with
-  the same failing network call and giving the user no way to quiesce it short
-  of deleting the source. `sync_all` now treats an `'error'` value in EITHER
-  store as errored (legacy JSON-only rows are still skipped), and
-  `_record_failure` writes the column alongside the properties copy it keeps for
-  `consecutive_failures`.
+- **Local speech-to-text with Parakeet**, alongside the existing engines.
+- **Choose the terminal's font** from a searchable list, and **stop voice read-back
+  with Escape** instead of waiting it out.
+- **A terminal dock for the whole app** receives "Run in terminal" output.
+- **Spreadsheets open inline** with sheet tabs and headers, and **video and audio
+  play inline** with seeking, instead of a download card or garbled binary.
 
-- **`test_redaction_timing_scales_linearly` no longer fails CI
-  intermittently** (observed "Redaction scaled super-linearly: 3.2x, limit
-  3.0x" on an otherwise-healthy matcher). The test took ONE
-  `perf_counter` sample per input size, so it billed itself for whatever
-  the OS gave the core to the sibling pytest-xdist workers — and one
-  unlucky reading of the SMALL input, the ratio's denominator, was enough
-  to push it over the bound. It now measures with `time.thread_time()`
-  (redaction is single-threaded pure-regex work, so per-thread CPU is its
-  complete cost) and takes best-of-3 per size, since scheduler noise only
-  ever adds and the minimum is the closest estimate of the true cost —
-  the same two techniques `TestIsDeniedReDoSResistance` already uses for
-  this class of assertion. The 3.0x bound is unchanged and detection is
-  intact: a genuinely quadratic implementation still measures ~4.3x.
+### Security and governance
 
-- **Opted-in MCP servers no longer silently fall back to unpooled backends.**
-  On one live host, 988 degradations accrued in 15 hours with no signal: 79%
-  were guaranteed-ENOENT pooled spawns of bare commands the gateway daemon's
-  systemd PATH cannot resolve, and 20% were crash-loops of servers whose
-  declared `env` the shared backend deliberately withholds
-  (`mcp_gateway.forward_declared_env` off). The rewriter now resolves bare
-  commands through the same augmented search path the MCP probe uses and
-  refuses to emit a stub it can prove will degrade — such servers are left
-  for the session to launch directly, with a warning naming the fix (absolute
-  path / the forwarding knob). The fallback audit log gains the reader it
-  never had: gatewayd's `stats` reply now carries per-server fallback counts
-  for the last 24 h, and the log rotates at 1 MiB instead of growing without
-  bound. (#3495)
+- **`kirocrew policy show` prints the 139 built-in denied-command rules**, grouped by
+  category, so the agent can read what is blocked instead of discovering it by
+  refusal.
+- **A managed deployment can close external access** — the skill and MCP registries
+  and cloud provisioning are no longer offered unconditionally.
+- **An operator policy can declare a fallback looser than deny-all**, instead of
+  being forced to block everything.
+- **The skill auto-approve grant is visible and controllable** from the review panel
+  and its notification.
+- **The agents configuration directory is write-protected**, so an agent cannot
+  plant an unsandboxed backend there.
 
-- **`TestIsDeniedReDoSResistance::test_cpu_cost_is_immune_to_other_threads_where_process_time_is_not`
-  no longer intermittently fails CI** (observed "process_time did not exceed
-  thread_time under a 2-spinner burst"). The test's 5-sample loop required
-  every single process-time/thread-time comparison to succeed, so one sample
-  where a shared CI runner's scheduler didn't interleave the burst threads
-  within the narrow measurement window failed the whole test even though the
-  invariant it checks — that `_cpu_cost` doesn't see other threads' CPU —
-  held on every other sample. Now tolerates a minority (≤1 of 5) of failed
-  samples; a genuine break in `_cpu_cost` still fails every sample. (The
-  companion flake in `test_mid_dotstar_chain_spam_stays_linear`, tracked in
-  the same upstream issue kirodotdev/KiroCrew#3080, was independently fixed
-  by #3692 while this PR was open — this change covers the one flaky
-  assertion #3692 didn't touch.)
+### Faster and lighter
 
-- **The instance token-mint timeout is now user-configurable.** The remote
-  `kirocrew token` mint ran with a hardcoded 30s budget, so a user behind a
-  slow ProxyCommand/jump host timed out in the mint step even when the ssh
-  forward itself came up (the connect flow spawns two proxy-bound ssh
-  children, and the mint is the second one). A new
-  `instances.mint_timeout_secs` (unset by default: SSH 30s, SSM 90s; clamped
-  to [10, 120]) now threads through the tunnel manager to both the SSH and
-  SSM mint paths; an explicit value applies to both transports, including a
-  value equal to either transport's default. (#3566)
+- **CLI startup: 1.3s and 112 MB of imports down to 0.5s and 54 MB** — about 0.8s
+  and 58 MB saved for every MCP stdio server as well, which is per server, per
+  session.
+- **Computer use costs nothing when it is off** — no ~109 MB backend per chat when
+  it is disabled or unsupported. One Linux host was carrying 16 of them, 1.75 GB.
+- **The browser baseline installs Chromium only**, not every engine.
+- **Chat turns no longer queue behind subagent cost sampling**, which moved off the
+  main loop.
+- **Leaks closed**: an orphaned MCP gateway daemon self-exits instead of staying
+  resident at ~27 MB, removing a Dev Fleet worktree reclaims its ~0.6 GB pod home,
+  and the one-time config migration stops littering backup files — one host had
+  reached 72,327 of them.
 
-- **A Teams answer no longer gets silently truncated by a rate-limited
-  chunk.** The Bot Framework Connector API enforces per-bot rate limits and
-  can return HTTP 429, but the Teams outbound send raised immediately with
-  no retry, unlike the Discord/Telegram/Webex clients (which all absorb a
-  single 429 honoring the server's back-off hint). A multi-chunk answer
-  stops at its first failed chunk, so a throttled chunk dropped it and
-  everything after it, with only a backend log line. Outbound sends now
-  retry once on 429, honoring the Connector API's `Retry-After` header. (#3738)
+### Notable fixes
 
-- **Telegram slash commands (`/new`, `/compact`, `/model`, `/yolo`, `/link`,
-  `/unlink`, `/stop`, `/help`, `/queue`, `/steer`) no longer silently break
-  in a group or forum-topic chat — without executing a command addressed to
-  a different bot in the same group.** Telegram's own clients append
-  `@BotUsername` to a slash command in any chat with more than one
-  participant/bot — standard client behavior triggered by registering a
-  command menu, not something the bot's UI controls — but the command
-  parser matched the raw token verbatim against alias sets defined without
-  that suffix. In the forum-topic supergroups this integration explicitly
-  supports, every command fell through to being sent to the LLM as ordinary
-  chat text with no error. A trailing `@BotUsername` is now stripped before
-  alias matching — but only when it names THIS bot: Telegram fans a command
-  addressed to a different bot in the same group out to every bot present
-  (Bot API convention is to ignore what isn't addressed to you), so
-  stripping any mention unconditionally would let e.g. `/yolo@OtherBot on`
-  match this bot's own alias and enable auto-approval here. The gateway now
-  resolves its own username via `getMe` at startup and only strips a mention
-  that matches it (case-insensitively); any other mention, or none resolved
-  yet, is left attached and falls through as unrecognized. (#3734)
+**Chat transcript correctness** — Sending several messages quickly no longer
+produces duplicate bubbles or strands a half-sent row, and switching sessions
+cancels an in-flight history load so an old conversation cannot land in the one you
+just opened. Steering mid-turn keeps reasoning above the answer, text that merely
+looks like a tag renders as the characters you typed, the rename box stays attached
+to the session you opened it on, and the composer reliably takes focus.
 
-- **`agent.dangerously_skip_permissions` no longer treats a string value as an
-  affirmative grant.** The config loader coerced this field with a bare
-  `bool(...)`, so a plausible config shape like `"dangerously_skip_permissions":
-  "false"` (any non-empty string is truthy in Python) silently activated the
-  standing, unattended tool-auto-approve grant this key controls — every tool
-  call gets auto-approved with no confirmation prompt — instead of the
-  explicit disable the value said. Now requires a real boolean, matching
-  every other boolean field in the loader; a non-bool value falls through to
-  the next accepted spelling instead of being read as a grant. (#3730)
+**Session list ordering and freshness** — The list ranks by when a conversation
+actually settled rather than reshuffling on every streamed line, so a session you
+are watching stays where you expect and a running turn stays near the top. Digit
+shortcuts jump in the order the sidebar shows and hold that order while the modifier
+is down, your open tabs no longer clutter the older-sessions list, and the
+capabilities roster stops blinking empty while it refreshes. History also stops
+serving a stale view after a rename, and duplicate saved messages and leftover
+streamed fragments are cleaned up rather than accumulating.
 
-- **A session no longer risks two interleaved turns after a mid-turn reset.**
-  `record_failure`'s circuit breaker calls `reset(key)` while the failing
-  caller still nominally holds that session's turn semaphore; `reset` pops the
-  session and tears it down without touching the semaphore. If a concurrent
-  `get_or_create` for the same key registered a replacement session in that
-  window, the original caller's later `release(key)` — a fresh lookup by key,
-  not the specific session object it acquired — released the REPLACEMENT's
-  semaphore instead, an over-release that could hand out a surplus permit and
-  let a third message start a turn while a second was still in flight on the
-  same live provider session. The per-session semaphore is now a
-  `BoundedSemaphore`, so a stray release beyond its one permit raises instead
-  of silently succeeding; `release()` catches that specific error and logs a
-  warning rather than propagating into a caller's `finally`. (#3749)
+**Staying up under stress** — A partial or malformed status update no longer takes
+the dashboard down with it. MCP servers start even when a worker is still booting, a
+backend that wedges on its first handshake is replaced instead of hanging forever,
+and flipping one server's switch no longer rebuilds the entire broker. A slow probe
+stops greying out the Continue button, a scheduled turn resumes after a transient
+hiccup rather than stalling silently, ineffective auto-compaction backs off instead
+of firing repeatedly, and orphaned agent processes are reaped even when their parent
+was re-parented.
 
-- **Notes: a failed GitHub token Save/Clear in Settings no longer gets stuck
-  disabled with no explanation.** Neither the Save/Clear button handlers nor
-  the `savePat` action they call had any error handling, so a rejected
-  request (an invalid token, a transient network error) left `busy` stuck
-  `true` — the button permanently disabled — with neither the success
-  confirmation nor any error shown, an unhandled promise rejection, and the
-  only recovery being to close and reopen Settings. Failures are now caught
-  and reported inline next to the button, styled like the sibling per-vault
-  knowledge-toggle error state, and the button always recovers. A review
-  pass caught a sibling with the same root cause: the vault Remove confirm
-  button's `onForget` call still swallowed its failure into the shared
-  `error` banner, which only renders in the main-editor branch and is
-  invisible while Settings is open — the confirm bar also dismissed itself
-  immediately, so nothing indicated the removal was even attempted. Remove
-  now catches inline too, keeps the confirm bar up on failure so the user
-  can retry without reopening it, and clears on success. (#3743)
+**Scheduling and background jobs** — A recurring job's next run is scheduled the
+moment the previous one finishes instead of waiting for the next sweep, so it fires
+on time rather than up to half a minute late. A command job clears its last result on
+every exit path, one malformed stored entry no longer takes your other jobs down
+with it, and in the jobs table the message column keeps its width while the actions
+column stays pinned as you scroll.
 
-- **A folder knowledge source added from the dashboard can now be started.**
-  The row's `sync_status` was stored twice — as a table column and inside the
-  properties JSON — and the create path wrote `pending_confirmation` only into
-  the JSON, leaving the column at its `pending` default. The dashboard list
-  reads the column, so a freshly-added `local_folder` / `obsidian_vault` source
-  showed a Pause button instead of the Confirm button that starts the scan and
-  sat at "pending · 0 items · never synced" forever (the workaround was Pause
-  then Resume). Both insert paths (`add_source` and the auto-source path used
-  by drop-folder and project-docs sources) now derive the column from the
-  passed properties, and the store migration repairs already-divergent rows on
-  open, so existing stuck sources become startable without the workaround. (#3701)
+**Security and credential handling** — A credential path can no longer be respelled
+past the guard through a shell variable or a directory change, command boundaries
+respect quoted and escaped separators so a disguised second command is caught, and
+appending `--help` no longer runs a command without its approval prompt. A generated
+skill cannot slip code past the validator, a file read cannot climb out of the
+sandbox, and a busy temp directory or a stray thread no longer quietly turns
+isolation off. A corrupted Slack configuration fails closed instead of reopening the
+enterprise allowlist, changing one session's mode no longer revokes your
+workspace-wide auto-approve grant, per-host integration tokens are stored on a
+hardened path, the internal API credential is bound to the port it protects, and the
+security panel distinguishes an unusable profile from a deliberate lockdown. A batch
+of externally reported disclosure findings is closed.
 
-- **The Speech-to-Text settings page no longer offers to install Whisper when
-  the provider is AWS Transcribe.** With `stt.provider = "transcribe"` the page
-  showed an "Install Whisper" button (installing an engine Transcribe never
-  uses, so Status stayed "Not installed" forever), listed a Python/Whisper
-  prerequisite toolchain that is irrelevant to Transcribe, and rendered a
-  Runtime row that could only ever read "Native" because the backend never
-  serves `docker_mode`. The install button is now hidden for Transcribe, the
-  prerequisite block surfaces the real requirement — installing the `voice`
-  extra into the gateway's own interpreter, plus a restart hint — the backend
-  refuses `POST /api/stt/install` for Transcribe instead of silently installing
-  the wrong package, and the dead Runtime row is gone. Where no install channel
-  can make the extra importable (frozen build, pip-less interpreter, PEP 668
-  externally-managed python) the page shows an honest unsupported notice
-  instead of a command that cannot succeed, and a missing ffmpeg — which
-  Transcribe's availability check treats as optional even though browser
-  recordings need it — is now flagged with its install command even while the
-  status reads ready. (#3559)
+**Windows, installs, and international input** — The desktop gateway recovers its
+ports after a restart and the launcher survives the install being moved. A failed app
+clone's partial checkout is actually removed, Windows absolute paths are accepted
+where they used to be rejected, renaming agent configuration retries through a
+file-sharing conflict, and uninstalling reclaims the update cache. The app refuses to
+launch from a half-extracted backend rather than starting broken, rebuilding an
+environment relinks its interpreter, an update shows an installing overlay and resets
+cleanly when aborted, and small macOS icons render instead of coming up blank.
+Pressing Enter to choose a candidate while composing Chinese, Japanese, or Korean no
+longer sends the message.
 
-- **`kirocrew` commands start up to ~0.8 s faster, and each MCP stdio server
-  drops ~58 MB of resident memory.** `cli.py` imported its full 132-subcommand
-  dispatch table at module scope — including the Slack gateway, the dashboard
-  state module and (through it) numpy — so every CLI invocation and every
-  long-lived MCP backend process (`mcp-core`, `mcp-cron`, `mcp-computer`) paid
-  ~1.3 s and ~112 MB for subcommands that never run. The four heavy import
-  statements now execute inside the one dispatch branch that uses each name,
-  cutting a fresh `import kiro_crew.cli` to ~0.5 s / ~54 MB. Each command now
-  pays only for the modules its own branch uses: the MCP stdio servers and
-  most verbs save the full ~0.8 s / ~58 MB, while commands that dispatch into
-  the deferred modules (e.g. `gateway`, `cron`) save the portion they don't
-  touch. A ratchet test keeps the deferred modules out of module scope and
-  verifies every deferred import still resolves. Behavior is unchanged: the
-  entry point, the fail-closed security prelude, and all subcommand dispatch
-  are untouched. (#3504)
+**Messaging and connectors** — Markdown images survive into Slack instead of turning
+into broken links, replies route to the correct thread, automatic thread titling
+recovers instead of silently breaking, and Discord is told when a resumed session
+loses its binding. A server name containing a colon is accepted, the pre-resolve
+check no longer reports a false all-clear, content that should be shareable is not
+wrongly refused, tools can reach a gateway on a non-default port, and "auto" falls
+back to a model that works on GovCloud.
 
-- **A managed deployment can now withhold the external services the core offers
-  unconditionally.**
-  Three surfaces had no composition point. Two are installable-content registries
-  — skill discovery (skills.sh) and MCP server discovery (the official MCP
-  registry) — which fetch from the public internet and then offer to install what
-  they return, but hardcoded their public provider at registration time. The third
-  is cloud deployment: `kiro_crew/deploy/` provisions S3, CloudFront, IAM roles and
-  a reaper Lambda in the operator's own account and carried no capability gate at
-  all, so `capabilities.publish` (which bounds publish-provider destinations) did
-  not reach it. Together that made "source installable code only from our own
-  registry, and never provision cloud infrastructure" impossible to express without
-  patching the core — a hard blocker for any deployment where third-party code must
-  be reviewed first, or where provisioning is centrally controlled. A new
-  `external_access` platform slot adds `admits_registry(kind, name, api_base)` and
-  `admits_cloud_deployment(target)`. A refused registry is never registered, so it
-  is absent rather than failing per request; a refused cloud deployment makes the
-  deploy surface report itself disabled — so the UI hides the console instead of
-  rendering one whose every button 403s — and refuses every mutating route, wrapped
-  at registration so a new endpoint is gated by being listed rather than by
-  remembering an in-handler check. Both decisions take the concrete target as well
-  as a label, because a name is self-chosen while the URL or target determines
-  where bytes go, so an allowlist stops admitting a provider that later repoints at
-  a different host instead of letting it inherit trust from its name. Both outcomes
-  are SEL-audited: a log carrying only denials cannot show whether the permitted
-  path was ever taken. The public default admits everything, so an ordinary install
-  is unchanged.
+**Interface polish and accessibility** — The keyboard focus ring is back and appears
+only when you are actually navigating by keyboard, the notification badge is no
+longer clipped, and notification text stays legible over a busy background. Meter
+numbers stay readable against their bar, project and activity lists hold a stable
+newest-first order when timestamps tie so rows stop shuffling, sidebar labels show
+the right relative day, and a long subagent digest stays inside its card. Animations
+that were silently dead now play, a destructive button shows its colour on a touch
+device and an armed Delete explains itself, the paste preview is reachable by
+keyboard and screen reader, and builtin app pages start their content at the same
+distance from a phone edge as the core pages do.
 
-- **An MCP server that declares `env.PATH` no longer loses its inherited PATH.**
-  A spec's `env` is applied per key, so naming one directory to add — a Node
-  version manager's shim dir, say — replaced the child's PATH instead of
-  extending it, leaving the server with only that one directory. A launcher that
-  execs a sibling binary then died with "not found" for a binary that was
-  plainly installed, while the dashboard probe — which merged rather than
-  replaced — reported the same server healthy, so nothing in the UI
-  distinguished it from a working server. The full effective PATH (the spec's
-  own entries first, deduped) now backs the probe, command resolution, and the
-  value written into the agent config, so "probes healthy" and "works in a
-  session" can no longer disagree.
+**Clearer messages when something goes wrong** — A denied file send gives the real
+reason, a rejected connection names the setting to fix, and a session that stalls on
+startup names which servers reported, which failed and why, and which are waiting for
+authorization. A rejected credential is reported as an authentication failure rather
+than a backend outage, switching accounts mid-session offers a way out instead of a
+raw token error, a failed subagent keeps its error type and request id, background
+cleanup that fails surfaces a warning and a count, and a subagent result is reported
+with a path you can open. The Publish panel reports what actually happened, the top
+bar tells a warming-up credit balance apart from one that failed to load, and an
+over-long question refusal quotes a limit that is true for the script you are
+writing in.
 
-- **Every emitted MCP config surface now goes through one env normalization
-  point (`env.emit_env`).** The agent config, the kiro-global entries the sync
-  creates, and the Claude Code `~/.mcp.json` sidecar all expand a declared
-  `env.PATH` the same way, so a server can no longer work under one consumer
-  and die under another. The cosmetic `kiro-cli mcp add` subprocess inside the
-  sync — an unsynchronized second writer whose output the rebuild overwrote —
-  is removed, and the discover→write sequence is a single mutex-serialized
-  entry point (`sync_discovered_servers`) shared by the sync endpoint, the
-  restart pre-sync, and the config watcher, closing their read-modify-write
-  race.
+### Contributors
 
-- **The Online badge now means "tools usable", dated.** A probe whose
-  `initialize` succeeds but whose `tools/list` fails reports an error instead
-  of `ok` with an empty list; every probe result carries `probedAt` so the
-  dashboard can show when a status was established instead of presenting a
-  cached one as current; and a managed server served from its in-process
-  declaration is marked `declared` — the tool list is correct, but nothing
-  verified the server can start — instead of rendering identically to a
-  handshake-proven server.
+59 people wrote the code in this release. Thank you:
 
-- **Apply & Restart now really mounts a newly installed server, and says so
-  honestly when it cannot.** The restart path runs the one serialized
-  discover→write entry point and reconciles the consumed agent config
-  unconditionally, so an edit that produces an empty discovery delta (a
-  `disabled: true` flip, a changed `env`) is still written out instead of
-  being skipped as "nothing new". A reconcile that FAILS is reported through
-  `mcp_sync_ok` on the restart response rather than being dressed up as a
-  successful apply.
+@adiarora06, @amadsalmon, @anant-kaushik, @andreyaurelien, @aniketshukla1,
+@atomsbaza, @bolichen97, @buluoray, @cabbey, @chenmingwei23, @chuqijiang2026,
+@cixuuz, @coozgan, @CrysisDeu, @DeryFerd, @dwu96, @dwzhangx, @el-pedrito,
+@gbrunoo, @greysonevins, @gspivey, @iamwhatever, @isotope14, @jeeshofone,
+@josej4m, @kaizawa97, @konippi, @krishdhasmana, @kyleseaman, @leeclarkuk,
+@leonlaiyc, @leozhad, @LeTeutz, @logesh4v, @LucaButBoring, @Luccas-carvalho,
+@mcryan77, @miamanav, @michellemxm, @NicholasRBowers, @patrigao, @pepmach,
+@pkot1980, @Premshay, @rnoack1, @RohanK6, @rubencu, @SebastianYuSun,
+@severity1, @ShotaroKataoka, @shrihan-vijay, @srinivasrk, @tjdwlsdlaek,
+@tlobinger, @unstablebrainiac, @veerjain-1, @Xianwen-Peng, @xuejinT, @zakil-02.
 
-- **Publishing an artifact to the public internet now requires an explicit
-  acknowledgment, and an operator can remove the path entirely.** The warning
-  next to each confirm button could be scrolled past and read as decoration, and
-  the public-web destination was the one publish destination exempt from the
-  operator's publish policy — `deploy-web-aws` was appended to
-  `/api/publish-providers` unconditionally and `POST /api/deploy/deploy` consulted
-  no ceiling, so a team that had closed every other destination still had a
-  one-click path to a world-readable URL. Every surface that creates the public
-  resource (the Publish panel, its scan-override branch, and **Confirm deploy** on
-  a pending entry) now ends at a blocking dialog that names the artifact, states
-  that anyone with the link can view it, states how long the link stays public,
-  and requires pressing **I understand, publish publicly** — a button that is
-  neither pre-focused nor the default action, so no keystroke that dismisses an
-  ordinary dialog can publish by accident. The destination itself now goes through
-  the same `capabilities.publish` chokepoint as artifact publish: closing it in the
-  trust-root policy (or narrowing `publish.allowed_destinations` in `config.json`)
-  removes the button from the provider registry **and** answers 403 from
-  `/api/deploy/deploy` and `/api/deploy/pending/{id}/confirm`, including for the
-  agent-mediated `deploy_artifact` preview. Operators who had already narrowed
-  `publish.allowed_destinations` must add `deploy-web-aws` to keep deploying. (#3599)
-
-- **The Linux desktop app no longer shows two title bars on GNOME-family
-  Wayland desktops.** The window manager's native decoration used to stack on
-  top of the dashboard's own 42px header, wasting vertical space and
-  duplicating controls. On Wayland sessions of desktops that prefer
-  client-side decorations (GNOME, Ubuntu, Unity, Pantheon, Budgie) the window
-  now drops the native frame: the header doubles as the title bar via an
-  injected drag region, and a minimize/maximize/close cluster is injected at
-  the header's top-right (frameless Linux gets no OS-painted controls, unlike
-  the macOS traffic lights and the Windows caption overlay). X11 sessions,
-  desktops that expect server-side decorations (KDE, XFCE, tiling window
-  managers — including hybrids like Regolith that also report a GNOME token),
-  and unknown environments keep the native frame: frameless X11 windows lose
-  mouse edge-resize, which would be worse than the doubled bar. The
-  `linuxFrameless` key in the desktop app's own config (Connection → Open
-  Config File, also in the tray menu; read once at launch) forces either
-  shape. On frameless windows the menu bar auto-hides (press Alt to reveal
-  it) — kept visible it would re-create the stacked-bars problem, removed it
-  would take the menu away entirely. Connection windows follow the same
-  decision. (#3606)
-
-- **A lesson from a previous embedding-model generation could no longer get
-  silently deleted or offered as a false contradiction.** `write_lesson`'s
-  semantic dedup and `find_contradiction_candidates` compared raw embeddings
-  with a cosine helper that silently truncated a dimension mismatch to the
-  shorter vector instead of rejecting it, so a row embedded at a different
-  dimensionality (e.g. left over from an old embedding model) could score a
-  plausible-looking ~0.5 similarity against an unrelated new rule — landing
-  either past the 0.85 dedup line (deleting the old lesson as a "duplicate")
-  or inside the [0.4, 0.85) contradiction band (offered as a false
-  contradiction candidate). Both paths now converge onto the same
-  dimension-checked, float64-precision scorer the ranking paths already use,
-  which also removes a per-row query re-derivation from both loops. (#3466)
-
-- **Computer use no longer costs a 109 MB backend process per chat when it is
-  off — or on platforms where it cannot run at all.** `kirocrew-computer` was
-  registered into the agent spec unconditionally, and the keystone enable was
-  only checked *inside* the process the spec had already caused kiro-cli to
-  spawn: it suppressed the tool list, never the process. Every chat process paid
-  ~109 MB for a disabled capability, including every `spawn_run` subagent, and
-  on Linux/Windows it paid that for a feature with no driver (macOS is the only
-  supported platform) — measured at 16 processes / 1.75 GB on one Linux host.
-  The server is now withheld from the emitted spec, unless this is macOS *and*
-  the keystone is on; enabling it from Settings rebuilds the spec before
-  restarting sessions, so the tools still appear in the session you are sitting
-  in. Your `tools` entries are left untouched — a ref whose server the spec does
-  not define resolves to nothing, so a mount you had narrowed to a single tool
-  comes back exactly as you left it. Only the entry's own `autoApprove` and
-  custom `env` keys are reset by an off/on cycle and need re-applying,
-  deliberately: restoring an approval from a file the agent can write would
-  bypass the PreToolUse gate. The two in-process checks are kept as defence in
-  depth for a mid-session disable. (#3482)
-
-- **Folder-write audit lines now name the internal component that made the
-  write, instead of inferring the caller's identity from the internal secret's
-  presence.** Every MCP stdio server now declares its component name on
-  loopback gateway requests (`X-Internal-Caller`, attached centrally by the
-  shared request helpers), and the folder endpoints validate it against a
-  known-caller set before trusting it into the security event log's `caller`
-  field — `source` stays in SEL's interface vocabulary (`mcp`), so operator
-  queries over `source == "mcp"` keep matching folder writes. The old
-  inference was correct only while exactly one internal caller existed — a
-  second internal caller would have silently inherited the same label. An
-  authenticated internal write with a missing or unrecognized caller name is
-  audited as `caller="unknown-internal"` with a warning, so a new caller shows
-  up loudly until it is added to the known set alongside its own test. Browser
-  writes still audit as `dashboard`; the caller header alone grants nothing.
-  (#3503)
-
-- **`kirocrew policy show` no longer hides the 139 built-in denied-command
-  rules from the agent.** The rules are visible and configurable to the
-  user (Settings → Security), but the agent's only way to discover them was
-  to attempt a command and be refused — so it could plan multi-step work
-  that turned out to be impossible from the first step, walking the user
-  through setup effort (e.g. exporting AWS credentials) for a task a
-  hard-denied command would block later anyway. `policy show` now prints
-  the rule count grouped by category on every install, enterprise policy or
-  not; `--ids` lists each category's rule ids for citing a specific rule
-  when relaying a refusal. (#3454)
-
-- **Side-panel oversize-question refusal now reports an accurate character
-  target for every script, not just emoji.** The refusal derived its
-  character count from a fixed worst-case floor (4 bytes/char, the emoji
-  case), so an ASCII user over the byte budget was told to cut to ~8,192
-  characters when trimming a single character would do (4x over-deletion),
-  and a zh-CN user (3 bytes/char) was told 8,192 when ~10,922 actually fit.
-  The target is now derived from the submitted question's own byte density,
-  so it's accurate per script — the all-emoji case is unaffected (it already
-  sat at the 4-byte floor). (#3432)
-
-- **The skill browser no longer serves a different skill than the one you asked
-  for.** Three `package/` lookups compared a bare leaf name and returned the
-  first hit, so a request for `package/<name>` could answer with a file under
-  `<root>/<Pkg>/<name>`, or with whichever of two identically named files the
-  filesystem happened to yield. Exact keys now decide first, leaf matching
-  survives only where it is unambiguous, and a real collision resolves to
-  nothing — a 404, with the competing candidates logged — because the
-  `package/<path>` key cannot express which of the two files was meant. Every
-  lookup that previously resolved correctly still resolves to the same file.
-  **Edition maintainers:** roots the core already keys itself (`~/.kiro/skills`,
-  the data home, configured extra paths) are no longer *also* enumerated under
-  `package/`, which previously presented an editable skill as a read-only
-  package one. A stored reference to one of those duplicate `package/` keys
-  stops resolving; the file itself is untouched and still reachable under its
-  canonical key, but the stored reference has to be re-pointed. (#3369)
-
-- **MCP gateway daemons no longer leak when their launcher dies.** A `gatewayd`
-  whose launcher exited without signalling it (a torn-down `pytest` run, for
-  example) used to stay resident forever — invisible to every sweep, ~27 MB
-  each, accumulating without bound. The daemon now watches its own listening
-  socket path and gracefully self-exits once the path is gone (three
-  consecutive checks, POSIX only), and the untracked-orphan sweep reaps any
-  gatewayd whose `--socket` path no longer exists on disk, TERM-first so
-  pooled backends drain cleanly. (#3315)
-
-- **Aggregate memory ceiling across all concurrent agent spawns.** The cgroup
-  memory limit was per-spawn only (65% of RAM each), so many concurrent
-  subagents could collectively request several times host RAM without any
-  single limit breaching. The gateway now also caps their shared parent slice
-  (`kirocrew-agents.slice`) at 80% of RAM plus an aggregate task ceiling —
-  override via `resource_limits.max_total_memory_mb` /
-  `max_total_processes` — and logs which scopes were OOM-killed when the
-  aggregate ceiling engages. (#3316)
-
-- **Slack manifest: private channels now work out of the box.** The shipped app
-  manifest adds the `groups:history` and `users:read` bot scopes and subscribes
-  to the `message.groups` event, so a tracked private channel actually delivers
-  messages and profile lookups resolve real names. **Existing installs are not
-  fixed by upgrading alone**: Slack only grants new scopes on reinstall — update
-  the app's manifest (or re-import it), then reinstall the app to the workspace
-  and copy the new bot token. (#3206)
 
 ## [0.3.0] — 2026-08-17
 

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -797,11 +797,20 @@ The rules that keep the two from drifting:
 - **`main` is the recovery source.** If a release branch's changelog is damaged,
   restore from `main` rather than reconstructing by hand; `main` is never rewound
   by a release cut, so its copy is the one that still has the full history.
-- **Never carry a release branch's `Unreleased` entries into its own section by
-  assumption.** Entries accumulated on `main` after the release branch was cut
-  describe commits that branch does not contain — check with
-  `git merge-base --is-ancestor <sha> origin/release/<x.y.z>` before folding
-  anything in, or the release gets credited with work it does not ship.
+- **Write it from the commit range, under the release's final heading.** There is no
+  `## [Unreleased]` section to accumulate into and no in-progress prerelease heading
+  to rename later — `scripts/check_changelog_history.py` refuses both, at head, with
+  or without a base ref. So the section is composed once, from
+  `git log --oneline <last-tag>..HEAD`, and every commit in that range is accounted
+  for rather than sampled. 0.4.0 is the cautionary case: its per-PR accumulation
+  reached 721 lines while describing about 11% of the 453 commits it covered, and it
+  named none of the eighteen breaking changes it shipped.
+- **Editing the in-flight section after it is written needs the documented human
+  override**, because the immutability rule cannot tell a not-yet-shipped section
+  from a shipped one without a tag lookup, and a shallow CI checkout has no tags.
+  This is the intended trade: a fix cherry-picked into a later RC that deserves a
+  changelog line is rare, and the alternative — an exemption keyed on position in
+  the file — once made the most recently shipped section the only editable one.
 
 ## Deliberately not built
 

--- a/scripts/check_changelog_history.py
+++ b/scripts/check_changelog_history.py
@@ -16,22 +16,34 @@ what a reader looks at and the deletions were buried in the same hunk. Nothing
 failed; the loss surfaced only when a user noticed the dashboard's Releases page
 had gone nearly empty.
 
-So the judgment half of the rule (is this a commit dump? is this heading a
-prerelease? should this PR be touching the file at all?) stays in
-``AUTOSDE.yaml`` where a reviewer applies it, and the **mechanically checkable**
-half lives here, where no reviewer has to notice anything:
+So the judgment half of the rule (is this a commit dump? should this PR be
+touching the file at all?) stays in ``AUTOSDE.yaml`` where a reviewer applies it,
+and the **mechanically checkable** half lives here, where no reviewer has to
+notice anything. Two invariants:
 
-    every version section present at the base ref must still be present at head,
-    byte-identical
+    1. every version section present at the base ref must still be present at
+       head, byte-identical
+    2. head must contain ONLY shipped sections -- no ``## [Unreleased]``, no
+       prerelease heading
 
 with **no exemptions**. A section whose heading is a bare ``X.Y.Z`` describes
 shipped software and is immutable, full stop.
 
+Rule 2 is what makes rule 1 sufficient. Together they leave exactly one legal
+shape for a changelog diff -- prepend one new section -- because there is no
+draft section to append a per-PR line to and every released one is frozen. A
+release's notes are written once, when the version is bumped, under the
+release's own heading.
+
 A **prerelease** heading (``## [0.3.0-insider.9]``, ``## [0.3.0-rc.2]``) is not a
-shipped section at all -- it is a draft of a release that has not happened -- so it
-is skipped here exactly like ``## [Unreleased]``. That is what lets a release
-branch replace its own in-progress ``[0.3.0-insider.9]`` heading with the written
-``[0.3.0]`` entry: nothing shipped is being touched.
+shipped section -- it is a draft of a release that has not happened -- so
+:func:`compare` skips it there exactly like ``## [Unreleased]``, and
+:func:`draft_headings` refuses it at head. The two are not in tension: history is
+read from refs that may legitimately contain such a heading, while the tree being
+proposed may not introduce one. An earlier design used a prerelease heading as a
+deliberate in-progress state on a release branch, to be renamed when the entry
+was written. That state is what accumulated 0.4.0's 721-line unedited draft, and
+it renders as "no notes" against the version the reader is actually running.
 
 An earlier version of this check exempted "the newest section at the base ref" so
 a release branch could redraft its own entry. That was wrong in a way worth
@@ -257,6 +269,49 @@ def parse_sections(text: str, grammar: Grammar = HEAD_GRAMMAR) -> list[tuple[str
 #: decide whether a base text that parsed to zero shipped releases is genuinely
 #: empty or was mis-parsed -- never to extract a version.
 _ANY_BRACKET_H2 = re.compile(r"^##\s+\[", re.MULTILINE)
+
+
+def draft_headings(text: str, grammar: Grammar = HEAD_GRAMMAR) -> list[str]:
+    """Return every level-2 heading that does not name a shipped release.
+
+    ``## [Unreleased]``, ``## [0.4.0-rc.1]``, ``## [0.4.0-insider.3]``, and the
+    unbracketed ``## Unreleased`` all qualify: each heads a section describing
+    software nobody has installed.
+
+    This is a HEAD-only invariant and deliberately not part of :func:`compare`.
+    ``compare`` answers "did this change rewrite history", and a draft heading is
+    not a rewrite of anything -- so mixing the two would make the immutability
+    rule's verdict depend on whether a draft happened to be present. Two
+    invariants, checked separately, in :func:`main`:
+
+    1. every section the base documents as shipped is byte-identical at head
+    2. head contains **only** shipped sections
+
+    Together they leave exactly one legal shape for a changelog diff: prepend one
+    new ``## [X.Y.Z] — YYYY-MM-DD`` section. There is nowhere to append a per-PR
+    line, because there is no draft section to append it to and the released ones
+    cannot be edited. That is the enforcement half of AGENTS.md ->
+    "Release Changelog"; the file is written when a version is bumped and at no
+    other time.
+
+    A draft section is not merely untidy. ``build_release_list`` groups by
+    ``base_version``, and ``base_version("Unreleased") == "Unreleased"``, so it
+    never folds onto the version actually running -- while ``_sort_key`` ranks it
+    ``(-1,)`` and sinks it below every release. A ``## [Unreleased]`` section
+    therefore renders on the dashboard's Releases page as the running version
+    with **no notes at all**, plus a trailing "Unreleased" row at the bottom of
+    the archive carrying the entire body. 0.4.0's draft reached 721 lines that
+    way, and nothing reported it.
+    """
+    drafts: list[str] = []
+    for line in text.splitlines():
+        if not grammar.h2_re.match(line):
+            continue
+        heading = grammar.section_re.match(line)
+        raw = heading.group("version").strip() if heading else line.lstrip("#").strip()
+        if not is_shipped_heading(raw, grammar):
+            drafts.append(raw)
+    return drafts
 
 
 def compare(
@@ -516,11 +571,33 @@ def _self_test() -> int:
     if compare("# Changelog\n\n## Unreleased\n\npending\n", dateless_head):
         failures.append("a base with no version headings at all is wrongly flagged")
 
+    # The draft-section rule. Probed here as well as in the test suite because
+    # ci.yml runs --test immediately before enforcement, so a weakened rule fails
+    # in the same job instead of passing green.
+    draft_probes: list[tuple[str, str, bool]] = [
+        ("an [Unreleased] section is caught", "# Changelog\n\n## [Unreleased]\n\npending\n", True),
+        ("an unbracketed ## Unreleased is caught", "# Changelog\n\n## Unreleased\n\np\n", True),
+        (
+            "a prerelease heading is caught even when dated",
+            "# Changelog\n\n## [0.4.0-rc.1] \u2014 2026-08-21\n\ndrafting\n",
+            True,
+        ),
+        (
+            "a draft below shipped sections is caught wherever it sits",
+            f"# Changelog\n\n{latest}{shipped}## [Unreleased]\n\npending\n",
+            True,
+        ),
+        ("a file of shipped sections only is clean", base, False),
+    ]
+    for label, probe_text, should_flag in draft_probes:
+        if bool(draft_headings(probe_text)) != should_flag:
+            failures.append(f"draft-section rule: {label}")
+
     if failures:
         for line in failures:
             print(f"self-test FAILED: {line}", file=sys.stderr)
         return 1
-    print(f"changelog-history self-test: {len(cases) + 2} probes, all correct")
+    print(f"changelog-history self-test: {len(cases) + 2 + len(draft_probes)} probes, all correct")
     return 0
 
 
@@ -528,11 +605,45 @@ def main(argv: list[str]) -> int:
     if "--test" in argv:
         return _self_test()
 
+    # Read head FIRST: the draft-section rule is a property of the file as it
+    # stands and needs no base ref, so it must also hold when this is run locally
+    # with nothing to compare against.
+    try:
+        with open(CHANGELOG, encoding="utf-8") as handle:
+            head_text: str | None = handle.read()
+    except FileNotFoundError:
+        head_text = None
+
+    if head_text is not None:
+        drafts = draft_headings(head_text)
+        if drafts:
+            for heading in drafts:
+                print(
+                    f"::error::changelog-history: [{heading}] is a draft section. "
+                    f"{CHANGELOG} holds shipped releases only -- a section is written "
+                    f"when a version is bumped, under the release's own "
+                    f"'## [X.Y.Z] — YYYY-MM-DD' heading, and never before.",
+                    file=sys.stderr,
+                )
+            print(
+                "\nThere is no Unreleased section and no prerelease heading: a "
+                "prerelease is a draft of its base version, and the renderer folds "
+                "it there, so its own heading only puts a build stamp in the "
+                "reader's archive. An [Unreleased] section is worse -- it folds onto "
+                "nothing, so the Releases page shows the running version with no "
+                "notes and hangs the whole body off a row at the bottom.\n"
+                "To see what is pending instead: git log --oneline <last-tag>..HEAD\n"
+                'See AGENTS.md -> "Release Changelog".',
+                file=sys.stderr,
+            )
+            return 1
+
     base_ref = os.environ.get("CHANGELOG_BASE_REF", "").strip()
     if not base_ref:
         print(
-            "changelog-history: no CHANGELOG_BASE_REF, nothing to compare against "
-            "(set it to enforce, e.g. CHANGELOG_BASE_REF=origin/main)"
+            "changelog-history: no draft sections ✓; no CHANGELOG_BASE_REF, so "
+            "nothing to compare shipped history against (set it to enforce, e.g. "
+            "CHANGELOG_BASE_REF=origin/main)"
         )
         return 0
 
@@ -543,10 +654,7 @@ def main(argv: list[str]) -> int:
             f"nothing shipped to protect"
         )
         return 0
-    try:
-        with open(CHANGELOG, encoding="utf-8") as handle:
-            head_text = handle.read()
-    except FileNotFoundError:
+    if head_text is None:
         print(
             f"::error::{CHANGELOG} is missing at head but exists at {base_ref}. "
             f"The changelog is append-only history and cannot be deleted.",

--- a/test/test_changelog_history_gate.py
+++ b/test/test_changelog_history_gate.py
@@ -290,3 +290,75 @@ def test_the_gate_reads_the_grammar_from_the_renderer_it_is_given() -> None:
     assert grammar.section_re is renderer._SECTION_RE
     assert grammar.h2_re is renderer._H2_RE
     assert grammar.fold("0.3.0-insider.9") == "0.3.0"
+
+
+# ── head carries shipped sections and nothing else ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "## [Unreleased]",
+        "## Unreleased",
+        "## [0.4.0-rc.1]",
+        "## [0.4.0-rc.1] — 2026-08-21",
+        "## [0.4.0-insider.3]",
+        "## [0.4.0-nightly.20260821t000000]",
+    ],
+)
+def test_a_draft_heading_is_refused_at_head(heading: str) -> None:
+    """No section may describe software nobody has installed.
+
+    This is what leaves prepending a new section as the only legal changelog
+    diff: with no draft section present, a feature PR has nowhere to append a
+    per-PR line, and ``compare`` already freezes every released section.
+    """
+    assert gate.draft_headings(f"# Changelog\n\n{heading}\n\nbody\n"), heading
+
+
+def test_a_draft_is_found_wherever_it_sits() -> None:
+    """Position must not matter -- a draft below shipped history still renders."""
+    text = (
+        "# Changelog\n\n## [0.3.0] — 2026-08-17\n\nshipped\n\n"
+        "## [Unreleased]\n\npending\n\n## [0.2.0] — 2026-08-09\n\nolder\n"
+    )
+    assert gate.draft_headings(text) == ["Unreleased"]
+
+
+def test_a_file_of_shipped_sections_only_is_clean() -> None:
+    text = "# Changelog\n\n## [0.3.0] — 2026-08-17\n\na\n\n## [0.2.0] — 2026-08-09\n\nb\n"
+    assert gate.draft_headings(text) == []
+
+
+def test_a_level_three_heading_inside_a_section_is_not_a_draft() -> None:
+    """The rule reads level-2 headings only; a section's own `###` groups are its body."""
+    text = (
+        "# Changelog\n\n## [0.3.0] — 2026-08-17\n\n"
+        "### Before you upgrade\n\n- a thing\n\n### Notable fixes\n\n- another\n"
+    )
+    assert gate.draft_headings(text) == []
+
+
+def test_the_repos_own_changelog_carries_no_draft_section() -> None:
+    """The live invariant, not just the diff.
+
+    A diff-based check only fires on the PR that introduces a draft. Asserting
+    the file itself means the state cannot persist even if one slipped in.
+    """
+    text = (_REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert gate.draft_headings(text) == []
+
+
+def test_compare_still_reads_a_draft_heading_in_HISTORY_without_flagging_it() -> None:
+    """The two rules are separate on purpose, and this is the case that needs it.
+
+    ``compare`` answers "did this change rewrite shipped history" and is fed base
+    text from refs that legitimately predate the draft-section rule. Folding the
+    head-only rule into it would make the immutability verdict depend on whether
+    a draft happened to be present in history.
+    """
+    base = "# Changelog\n\n## [0.3.0-insider.9]\n\ngenerated\n\n## [0.2.0]\n\nshipped\n\n"
+    head = "# Changelog\n\n## [0.3.0] — 2026-08-17\n\nwritten\n\n## [0.2.0]\n\nshipped\n\n"
+    assert gate.compare(base, head) == []
+    assert gate.draft_headings(base) == ["0.3.0-insider.9"]
+    assert gate.draft_headings(head) == []


### PR DESCRIPTION
**Merge [#4822](https://github.com/kirodotdev/KiroCrew/pull/4822) first.** This PR ports that section, so the two must not diverge.

## What main was doing

`main` carried a `## [Unreleased]` section that every feature PR appended a line
to. The renderer groups by `base_version`, and `base_version("Unreleased")` returns
itself, so that section never joined the version a reader is running — while
`_sort_key` ranks it `(-1,)` and sinks it below every release. On the dashboard's
Releases page that renders as the running version with **no notes**, plus a
trailing `Unreleased` row under 0.1.2 carrying all 721 lines. Nothing failed, so
nobody reported it.

## Two changes, and the second is why the first cannot regress

**1. Port the written 0.4.0 section from `release/0.4.0`, verbatim.** `diff` of the
whole file against that branch produces no output — byte-identical, which is the
documented direction: the release branch's copy is what ships and `main` is the
recovery source. The draft section is removed by being *replaced*, not deleted;
`main`'s `CHANGELOG.md` was already byte-identical to the branch's before this
(`git diff` over the cut point is empty), so nothing accumulated on `main` is lost.

**2. `check_changelog_history.py` gains a head-only rule:** every level-2 heading
must name a shipped release. `## [Unreleased]`, `## [0.4.0-rc.1]`, and the
unbracketed `## Unreleased` are all refused — with or without a base ref, so it
holds when run locally too.

It is **deliberately not part of `compare()`**. That function answers "did this
change rewrite shipped history", and it is fed base text from refs that legitimately
contain such a heading; folding the rule in would make the immutability verdict
depend on whether a draft happened to be present in history. Two invariants,
checked separately:

1. every section the base documents as shipped is byte-identical at head
2. head contains **only** shipped sections

Together they leave exactly one legal shape for a changelog diff — prepend one new
section — because there is nowhere to append a per-PR line and every released
section is frozen. That is the enforcement half of a rule `AGENTS.md` has stated
all along and nothing checked.

## Verification

- gate self-test: **20 probes, all correct** (5 new: `[Unreleased]`, unbracketed
  `## Unreleased`, a dated `[0.4.0-rc.1]`, a draft hidden *below* shipped sections,
  and a clean shipped-only file)
- against `main` as it stands today → **exit 1**, naming `[Unreleased]`; against
  this branch → `4 shipped section(s) at origin/main are intact at head ✓`
- `pytest test/test_changelog_history_gate.py test/test_changelog_handler.py tests/test_changelog_parse.py` → **95 passed**, including
  `test_the_repos_own_changelog_carries_no_draft_section`, which asserts the live
  file rather than the diff — so the state cannot persist even if one slipped in
- `test_compare_still_reads_a_draft_heading_in_HISTORY_without_flagging_it` pins the
  separation above, and the existing
  `test_a_prerelease_for_an_unshipped_release_is_allowed` is untouched and still passes
- `flake8`, `isort`, `mypy`, `black --check`, `docs-lint.sh`, brand gate: clean
- `AUTOSDE.yaml` parses; 7 rules

**Why no screenshot:** the affected surface is the Releases page, whose input is the
shipped `CHANGELOG.md`; the renderer's own output for this file is asserted in the
tests above, which is what a screenshot would be showing.

## Docs updated in the same commit

- `AGENTS.md` → "Release Changelog": names both halves and what they jointly imply.
- `AUTOSDE.yaml`: the two now-mechanical FLAG bullets point at the gate, so a
  reviewer spends attention on the section's content instead of re-deriving them.
- `docs/build/release.md`: replaces the "never carry a release branch's `Unreleased`
  entries into its own section" rule — there is no `Unreleased` section to carry —
  with "write it from the commit range, under the release's final heading", and 0.4.0
  as the cautionary case.

## One cost, named rather than papered over

Editing the in-flight section **after** it is written now needs the documented human
override: the immutability rule cannot tell a not-yet-shipped section from a shipped
one without a tag lookup, and CI checks out shallow. So a fix cherry-picked into a
later RC that earns a changelog line costs one override with a stated reason.

The obvious alternative — exempt the newest section — was tried and removed for
cause: on `main` the newest section is the *last shipped release*, so it made the
section the most users are running the only editable one. Keying the exemption on
the in-development `__version__` instead would work and is deterministic, but it
redesigns the exemption model and belongs in its own PR, not bundled with a port.