### PR TITLE
chore: strip full _PYTHON_ENV_PREFIXES set in transcribe spawn (#4816)

### DIFF
--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import platform_compat
+from kiro_crew.sandbox import _PYTHON_ENV_PREFIXES
 
 # Transcribe-path deps are an OPTIONAL 'aws' extra (amazon-transcribe + boto3).
 # The module MUST stay importable when they're absent (default install, partial
@@ -687,9 +688,12 @@ def _whisper_thread_count() -> int:
 def _thread_capped_env() -> dict[str, str]:
     """Return the subprocess environment with intra-op threads bounded.
 
-    Also strips ``PYTHONPATH``/``PYTHONHOME``: the Whisper CLIs are installed
+    Also strips every var matching a prefix in
+    :data:`sandbox._PYTHON_ENV_PREFIXES` (``PYTHONPATH``/``PYTHONHOME``/…): the Whisper CLIs are installed
     out-of-band and run under their own interpreter, so Kiro Crew's bundled
-    packages (numpy, torch) must not leak into their runtime.
+    packages (numpy, torch) must not leak into their runtime. Reusing the
+    shared list instead of hand-listing keys keeps this scrub site from
+    drifting when the interpreter-env set grows.
 
     An operator who has set ANY of :data:`_THREAD_ENV_VARS` is left completely
     alone — all of them, not just the one they set. Someone who pins
@@ -700,8 +704,12 @@ def _thread_capped_env() -> dict[str, str]:
     setting.
     """
     env = os.environ.copy()
-    env.pop("PYTHONPATH", None)
-    env.pop("PYTHONHOME", None)
+    # Prefix match, not exact-name match: sandbox consumes _PYTHON_ENV_PREFIXES
+    # via startswith (scrub_env), so this site must too or a genuine prefix
+    # entry added to the list would be scrubbed there and missed here.
+    python_env_prefixes = tuple(_PYTHON_ENV_PREFIXES)
+    for key in [k for k in env if k.startswith(python_env_prefixes)]:
+        del env[key]
     if any(env.get(var) for var in _THREAD_ENV_VARS):
         return env
     threads = str(_whisper_thread_count())

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -12,6 +12,7 @@ import pytest
 
 from kiro_crew import platform_compat as _pc
 from kiro_crew.config.loader import SttConfig
+from kiro_crew.sandbox import _PYTHON_ENV_PREFIXES
 from kiro_crew.transcribe import (
     _THREAD_ENV_VARS,
     _WHISPER_THREAD_CEILING,
@@ -360,6 +361,23 @@ class TestWhisperThreadCap:
         )
         assert "PYTHONPATH" not in env
         assert "PYTHONHOME" not in env
+
+    def test_every_shared_python_env_prefix_is_stripped(self, monkeypatch):
+        """The scrub tracks sandbox._PYTHON_ENV_PREFIXES, not a hand-kept copy.
+
+        Iterating the shared list is the point: when a new interpreter env var
+        joins the agent-spawn scrub, this test covers it here with no edit —
+        the drift this wiring exists to eliminate. The list's semantics are
+        PREFIXES (sandbox.scrub_env matches via startswith), so a var that
+        merely starts with an entry must be stripped too, exactly as the
+        sandbox scrub would strip it.
+        """
+        preset = {var: f"/opt/kirocrew/{var.lower()}" for var in _PYTHON_ENV_PREFIXES}
+        preset.update({f"{var}_SUFFIX": "x" for var in _PYTHON_ENV_PREFIXES})
+        env = self._env(monkeypatch, cpus=32, preset=preset)
+        for var in _PYTHON_ENV_PREFIXES:
+            assert var not in env
+            assert f"{var}_SUFFIX" not in env
 
     def test_unrelated_environment_survives(self, monkeypatch):
         # ffmpeg is found via PATH, so the env must be a copy, not a clean slate.


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/transcribe.py`'s Whisper-CLI env scrub (`_thread_capped_env`) hand-pops only `PYTHONPATH` and `PYTHONHOME`, while `sandbox._PYTHON_ENV_PREFIXES` is the shared source of truth for the Python-interpreter env scrub. Issue #4816 (a First Principles follow-up counted on PR #3247, deliberately deferred to keep that fork PR at its author's scope) asks for the last hand-listed sibling to be routed through the shared list. As long as it stays hand-listed, any var added to the shared list — e.g. `PYTHONPYCACHEPREFIX`, which #3247 adds so the out-of-band Whisper interpreter stops mirroring its stdlib into the shared bytecode cache — silently never reaches this scrub site.

## Why it matters

This is exactly the drift pattern the shared list exists to eliminate: two scrub sites that must agree but are kept in sync by hand. Today the behavior gap is nil (the list currently holds exactly the two keys this site pops); the day #3247 merges, the gap becomes real — the Whisper interpreter would inherit `PYTHONPYCACHEPREFIX` and mint a stdlib mirror in the shared bytecode cache (bounded by `pycache_gc`, but avoidable entirely).

## What changed (motivation → approach → change)

Hand-listed scrub keys drift from the shared list → reuse the list instead of re-listing the names, mirroring the exact replacement PR #3247 makes in `mcp_gateway/gatewayd.py`'s pooled spawn → `_thread_capped_env` now strips every env var matching a prefix in `sandbox._PYTHON_ENV_PREFIXES` (via `startswith`, mirroring `scrub_env`'s consumption semantics — exact-name popping here would itself be a second, quieter drift channel, per the Design Review suggestion taken in this PR), and the docstring names the mechanism rather than enumerating two vars. This is a deliberate, declared widening: for the canonical names the behavior is unchanged, and additionally any var merely *starting with* `PYTHONPATH`/`PYTHONHOME` is now stripped too, exactly as the sandbox scrub would strip it for agent spawns (no standard interpreter env var has that shape, so the practical delta is nil). When the list grows, this site follows with no edit. No import cycle: `sandbox`'s dependency closure does not import `transcribe`, and `sandbox` executes nothing at module scope beyond logger/constant definitions.

## Tests

- `test_every_shared_python_env_prefix_is_stripped` (new): presets every var in `sandbox._PYTHON_ENV_PREFIXES` and asserts each is absent from the Whisper spawn env. It iterates the shared list rather than hand-listing names, so a var added to the list is covered here automatically — the same anti-drift property as the code change.
- `test_bundled_python_env_is_still_stripped` (pre-existing): still pins the `PYTHONPATH`/`PYTHONHOME` contract explicitly.

## Manual verification

N/A — unit coverage sufficient: the change is a pure source-of-truth rewiring with behavior pinned by the env-scrub tests, and the existing wiring test (`test_cap_reaches_the_real_subprocess`) already proves `_thread_capped_env`'s output reaches the real subprocess.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (env-var scrub in the Whisper subprocess spawn); no rendered UI is touched.

## Related Issues

Closes #4816

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no spec documents this scrub site's key list; the docstring is updated in the same commit
- [x] No secrets, credentials, or internal references in the diff

