### PR TITLE
docs: keep the contributor list out of the GitHub Release body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,10 +309,12 @@ Format, which the `[0.2.0]` section is the reference for:
   left out. Derive it from the release's own range rather than by hand:
   `gh api repos/kirodotdev/KiroCrew/releases/generate-notes -f tag_name=<tag>
   -f previous_tag_name=<last-tag>` names the author of every merged PR, so nobody
-  is dropped for having a quiet commit subject. The GitHub Release page gets this
-  for free from `generate_release_notes: true`, but that page is not what ships:
-  the changelog section is the copy inside the wheel and behind the dashboard's
-  Releases page, so it needs its own.
+  is dropped for having a quiet commit subject. **This belongs to the changelog
+  only.** A GitHub Release page renders its own contributor block from the tag
+  range, natively, whatever its body says — so putting a list in the release notes
+  duplicates it on the page, immediately above GitHub's own. The changelog needs
+  its own because that copy is what ships inside the wheel and what the
+  dashboard's Releases page reads, where no such block exists.
 
 ## The gate before you commit
 


### PR DESCRIPTION
Follow-up to [#4833](https://github.com/kirodotdev/KiroCrew/pull/4833), correcting a rule I got wrong in it.

## What happened

A GitHub Release page **renders its own contributor block from the tag range,
natively, whatever the body says**. The rule as merged says the page "gets this for
free from `generate_release_notes: true`", which reads as though the credit is a
property of the generated notes — so when notes are supplied by hand, as v0.3.0's
were, adding a list to the body looks like the right move.

It is not. v0.3.0's page carried two Contributors blocks, one directly above the
other: a hand-written list of 72 handles, then GitHub's own avatar row reading
"Zedmor, tlobinger, and 70 other contributors". The manual list has been removed
from that page.

Worth keeping as evidence rather than just a correction: **GitHub's own count agreed
with the derived one exactly** — 72 either way. So the `generate-notes` extraction the
rule prescribes is sound; it was aimed at the wrong surface.

## The rule now

```
This belongs to the changelog only. A GitHub Release page renders its own
contributor block from the tag range, natively, whatever its body says — so
putting a list in the release notes duplicates it on the page, immediately
above GitHub's own. The changelog needs its own because that copy is what ships
inside the wheel and what the dashboard's Releases page reads, where no such
block exists.
```

The changelog section itself is unchanged and still required: that copy ships inside
the wheel and backs the dashboard's Releases page, which has no native block.

**Why no screenshot:** documentation wording; the duplicate it describes is already
removed from the live v0.3.0 page.

Verified: `docs-lint.sh` and the brand gate clean.