### PR TITLE
refactor(store): one structural comparator for both slices, not two

### DIFF
--- a/website/docs/frontend-conventions.md
+++ b/website/docs/frontend-conventions.md
@@ -178,7 +178,10 @@ What a merge has to hold:
   that enumerates the type's fields stops seeing a newly added one and pins a
   stale row — a correctness bug, where a redundant re-render is only a cost. A
   serialization compare calls a locally patched row unequal forever, because an
-  in-place patch can append a key the server payload spells earlier.
+  in-place patch can append a key the server payload spells earlier. Use the
+  shared `jsonEqual` (`utils/structuralEqual.ts`) rather than writing a second
+  comparator — it already holds both properties, and a private copy is a second
+  set of guarantees to keep in sync.
 
 `applySlots` in `dashboardSlice.ts` is the reference implementation, driving both
 authoritative writers (`sseSlots` and the `fetchSlots` refetch);
@@ -186,6 +189,14 @@ authoritative writers (`sseSlots` and the `fetchSlots` refetch);
 row inside a freshly assigned array is safe — a draft found in the assigned value
 is finalized within the same scope, so an untouched row resolves back to its base
 object and keeps its identity.
+
+This is a convention for new and touched code, not a description of the current
+store. Two dashboard collections still assign wholesale and are known gaps rather
+than counterexamples: `sseSubagentStatus` rebuilds its `agents` array every frame,
+and `sseStatus` replaces `state.status` as a whole object that several panels
+subscribe to entirely. Converting them is worthwhile but is its own change —
+`state.status` in particular needs its consumers narrowed first, or the merge buys
+nothing.
 
 Two habits belong to the same concern:
 

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -9,6 +9,7 @@ import type { ChatMessage, ChatSlot, SessionInfo, SubagentActivity, ToolActivity
 import { SOFT_STOP_DEBOUNCE_MS, SPAWN_LAUNCH_MARKER } from '../pages/chat/types'
 import { mergePreservedPastes } from '../utils/pasteTokens'
 import { safeSetItem } from '../utils/safeStorage'
+import { jsonEqual } from '../utils/structuralEqual'
 import type { McpAppRenderPayload } from '../lib/mcpAppSrcdoc'
 import { i18nT } from '../i18n/t'
 import { secureRandomId } from '../utils/secureId'
@@ -416,19 +417,6 @@ export const shouldResolveAskOnSend = (
 /** One queued-message entry as normalized by `fetchSlotDetail` from the backend
  *  slot-detail `queue` field. */
 type SlotQueueItem = { content: string; queueId: string; ts: string }
-
-/** Structural equality for the JSON-shaped message fields (`meta`, `variants`). */
-function jsonEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
-  const aArr = Array.isArray(a), bArr = Array.isArray(b)
-  if (aArr !== bArr) return false
-  if (aArr && bArr) return a.length === b.length && a.every((v, i) => jsonEqual(v, b[i]))
-  const ak = Object.keys(a), bk = Object.keys(b)
-  if (ak.length !== bk.length) return false
-  return ak.every(k => Object.prototype.hasOwnProperty.call(b, k)
-    && jsonEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]))
-}
 
 /** Field-for-field equality over every `ChatMessage` field a consumer can render. */
 function sameMessage(a: ChatMessage, b: ChatMessage): boolean {

--- a/website/src/store/dashboardSlice.ts
+++ b/website/src/store/dashboardSlice.ts
@@ -1,4 +1,5 @@
 import { safeSetItem } from '../utils/safeStorage'
+import { jsonEqual } from '../utils/structuralEqual'
 import { createSlice, createAsyncThunk, createSelector, type PayloadAction } from '@reduxjs/toolkit'
 import { api } from '../api/client'
 import { sanitizeLlmOutput, isUnsafeKey } from '../utils/sanitize'
@@ -136,41 +137,19 @@ const evictSlotSubagents = (state: DashboardState, slotKey: string): void => {
   delete state.subagentText[slotKey]
 }
 
-/** Structural equality over the JSON shapes a slot payload is made of.
- *
- *  Key-order independent on purpose: one side is a fresh server payload, the
- *  other may be a row an in-place reducer (`touchSlotActivity`, `updateSlot`,
- *  `patchSlotLink`) has since patched, and a patch can append a key the payload
- *  spells earlier. A serialization compare would call those unequal forever and
- *  silently give back the wholesale-replacement behaviour this exists to avoid.
- *
- *  Field-agnostic for the same reason: a comparator listing `ChatSlot`'s fields
- *  would stop seeing a newly added one and pin a stale row on screen, which is a
- *  correctness bug where an extra re-render is only a cost. */
-const deepEqual = (a: unknown, b: unknown): boolean => {
-  if (a === b) return true
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
-  const aArr = Array.isArray(a)
-  if (aArr !== Array.isArray(b)) return false
-  if (aArr) {
-    const x = a as unknown[]
-    const y = b as unknown[]
-    return x.length === y.length && x.every((v, i) => deepEqual(v, y[i]))
-  }
-  const x = a as Record<string, unknown>
-  const y = b as Record<string, unknown>
-  const keys = Object.keys(x)
-  if (keys.length !== Object.keys(y).length) return false
-  return keys.every(k => Object.prototype.hasOwnProperty.call(y, k) && deepEqual(x[k], y[k]))
-}
-
 /** Apply an authoritative slot list, reusing the object identity of every row
  *  whose content is unchanged, and touching `state.slots` only when the list
  *  actually moved.
  *
  *  Membership AND order come from `next` — the server is authoritative on both.
  *  Only per-row identity is carried across, and only for a structurally equal
- *  row, so no consumer can read stale content off a reused reference.
+ *  row, so no consumer can read stale content off a reused reference. The
+ *  comparison uses the shared `jsonEqual`, whose key-order independence and
+ *  field-agnosticism this relies on: a row may have been patched in place by
+ *  `touchSlotActivity` / `updateSlot` / `patchSlotLink` since it was stored (so
+ *  its key order can differ from the payload's), and a comparator that listed
+ *  `ChatSlot`'s fields would stop seeing a newly added one and pin a stale row
+ *  on screen — a correctness bug, where an extra re-render is only a cost.
  *
  *  Identity is load-bearing here rather than a micro-optimisation. The sidebar
  *  renders every row as a Framer `motion.div` with `layout="position"` inside one
@@ -195,7 +174,7 @@ const applySlots = (state: DashboardState, next: ChatSlot[]): void => {
     // Reusing a draft row inside a freshly assigned array is fine: Immer
     // finalizes drafts found in the assigned value within the same scope, so an
     // untouched row resolves back to its base object and keeps its identity.
-    const reused = existing !== undefined && deepEqual(existing, incoming) ? existing : incoming
+    const reused = existing !== undefined && jsonEqual(existing, incoming) ? existing : incoming
     // Positional compare, so a pure reorder counts as changed even though every
     // row is individually reusable.
     if (reused !== prev[i]) changed = true

--- a/website/src/utils/structuralEqual.ts
+++ b/website/src/utils/structuralEqual.ts
@@ -1,0 +1,37 @@
+/**
+ * One structural-equality comparator for the JSON-shaped payloads Redux slices
+ * receive from the server.
+ *
+ * Why it lives here rather than inside a slice: two reducers need the exact same
+ * guarantees for the same reason — deciding whether an incoming payload renders
+ * identically to the one already in the store, so the reducer can leave state
+ * untouched and every consumer keeps its existing reference. `chatSlice` uses it
+ * for message `meta`/`variants` (via `sameMessage`), `dashboardSlice` for whole
+ * slot rows (via `applySlots`). A second private copy in the second slice would
+ * be a second set of key-order and field-agnostic guarantees to keep in sync,
+ * and the two would drift.
+ *
+ * Two properties are load-bearing, not incidental:
+ *
+ * **Key-order independent.** One side is a fresh server payload; the other may
+ * be an object an in-place reducer has since patched, and a patch can append a
+ * key the payload spells earlier. A serialization compare (`JSON.stringify`)
+ * would call those unequal forever and silently give back the wholesale
+ * replacement this exists to avoid.
+ *
+ * **Field-agnostic.** A comparator that listed a type's fields would stop seeing
+ * a newly added one and report equal on a payload that actually changed — that
+ * pins stale content on screen, which is a correctness bug, where an extra
+ * re-render is only a cost.
+ */
+export function jsonEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
+  const aArr = Array.isArray(a), bArr = Array.isArray(b)
+  if (aArr !== bArr) return false
+  if (aArr && bArr) return a.length === b.length && a.every((v, i) => jsonEqual(v, b[i]))
+  const ak = Object.keys(a), bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  return ak.every(k => Object.prototype.hasOwnProperty.call(b, k)
+    && jsonEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]))
+}


### PR DESCRIPTION
## What

Extracts one structural-equality comparator to `website/src/utils/structuralEqual.ts` (`jsonEqual`) and points both `chatSlice` and `dashboardSlice` at it, deleting the two private copies.

Follow-up to #4478, whose First Principles reviewer raised this as an advisory `CONCERNS`: that PR added `deepEqual` to `dashboardSlice` while `chatSlice` already carried a byte-identical `jsonEqual` for message `meta`/`variants`.

## Why it is worth a change rather than a comment

The duplication is not the cost — drift is. Two properties are load-bearing, and neither is obvious from reading the function:

- **Key-order independent.** One side is a fresh server payload; the other may be an object an in-place reducer (`touchSlotActivity` / `updateSlot` / `patchSlotLink`) has since patched, and a patch can append a key the payload spells earlier. A `JSON.stringify` compare calls those unequal forever, silently restoring the wholesale-replacement behaviour `applySlots` exists to avoid.
- **Field-agnostic.** A comparator that enumerates a type's fields stops seeing a newly added one and reports equal on a payload that actually changed — that pins stale content on screen. A correctness bug, where a redundant re-render is only a cost.

If one copy drifts, the failure is silent and lands in whichever slice lost the property.

## Behaviour

None. The two implementations were already semantically identical (same short-circuit, same array handling, same key-count + `hasOwnProperty` walk), so this is a dedup, not a fix. `dashboardSlice.slotIdentity.test.ts` (9 cases, pins the `applySlots` contract) and the `chatSlice` coverage suites both pass unchanged.

## Docs

`website/docs/frontend-conventions.md` gains the "use the shared comparator" rule inside the existing **Live-updating collections: merge, don't replace** section, plus an explicit note that the section is a convention for new and touched code rather than a description of the current store — `sseSubagentStatus` and `sseStatus` still assign wholesale and are named as known gaps, so a reader does not take them for counterexamples. `state.status` in particular needs its consumers narrowed before a merge buys anything, which is its own change.

## Verification

- `tsc -b` clean
- `eslint` clean on all three touched source files
- `dashboardSlice.slotIdentity.test.ts` + `ChatSliceCoverageSecondPass.test.tsx` — 76 passed
- per-file coverage on the new module: **100% statements / branches / functions / lines** (the fail-closed gate applies to it as a new file)
- `docs-lint` clean; `lint:i18n`, `lint:theme-colors`, brand check at-or-below baseline with zero findings on the touched files

Full `vitest` suite was run on this work: 22196 passed, 2 failed, both in `CliPanelCoverage.test.tsx` (xterm theme-sync timing) and both green in isolation — untouched by this diff, which is store slices, one new util and docs.

## Scope

No linked issue on purpose: this is a reviewer-requested cleanup on top of #4478, not independently reported behaviour.
