### PR TITLE
ci(security): port five CodeQL classes to Semgrep for the fork lane

### DIFF
--- a/.semgrep/codeql-parity.yaml
+++ b/.semgrep/codeql-parity.yaml
@@ -1,0 +1,293 @@
+# CodeQL parity rules for the fork lane.
+#
+# WHY THIS FILE EXISTS
+# CodeQL runs via GitHub's *default setup*, which uploads to code-scanning and
+# therefore needs `security-events: write`. A fork-triggered `pull_request`
+# workflow only gets a read-only token, so fork PRs never produce a CodeQL
+# check-run. Semgrep has no such constraint -- it fails on exit code instead of
+# uploading -- so it is the only SAST that actually runs on fork contributions.
+#
+# These rules port CodeQL query classes into syntactic Semgrep rules, chosen
+# for being portable at a low false-positive rate, so a fork PR gets some
+# coverage of those classes instead of none.
+#
+# HONEST SCOPE -- what this file does NOT do
+# This is a low-frequency tripwire, not fork-lane parity. Measured against
+# this repository's real code-scanning alert history (fixed + dismissed, all
+# states), the classes ported here are not where findings actually occur:
+#
+#     py/path-injection                        230   <- not portable, see below
+#     js/prototype-polluting-assignment         46   <- different query than the
+#                                                       utility-shape one below
+#     py/clear-text-logging-sensitive-data      20   <- packs cover %-args only
+#     py/polynomial-redos                       18   <- python polynomial, not
+#                                                       the JS nesting below
+#     py/incomplete-url-substring-sanitization  17   <- not ported yet
+#     py/cookie-injection                        8
+#     py/clear-text-storage-sensitive-data       6   <- ported below
+#     js/redos                                   1   <- ported below
+#     js/prototype-pollution-utility             1   <- NOT ported, see below
+#     js/identity-replacement                    0   <- ported below
+#     js/incomplete-multi-character-sanitization 0   <- ported below
+#     js/clear-text-storage-of-sensitive-data    0   <- ported below
+#
+# So: of the five rules here, one targets a class with real history, one
+# targets a class seen once, and three target classes this repo has never
+# produced an alert for. They cost nothing (validated at zero findings across
+# main and 2000 commits of history) and they fail closed on shapes that are
+# genuinely bugs, but nobody should read this file as "the fork lane is
+# covered now". The py-heavy top of that table is the real work, and is not
+# done.
+#
+# SCOPE AND LIMITS -- read before adding rules here
+#   * Already covered by the community packs, do NOT re-add:
+#       py/weak-cryptographic-algorithm, py/weak-sensitive-data-hashing,
+#       py/clear-text-logging-sensitive-data (%-style args only)
+#   * Deliberately NOT ported, needs cross-function taint tracking that a
+#     syntactic engine cannot do without either missing everything or
+#     flagging every open():
+#       py/path-injection
+#     That class remains a genuine fork-lane gap, and per the table above it
+#     is over half of this repo's entire alert history. Closing it requires
+#     running CodeQL itself in a privileged `workflow_run` context with
+#     `build-mode: none`, not another rule here.
+#   * Deliberately NOT ported, cannot be expressed soundly in semgrep 1.78:
+#       js/prototype-pollution-utility
+#     An unguarded key-copy rule needs two scoped judgements: "is this loop
+#     a for-in rather than a for-of" and "is this comparison the guard for
+#     THIS copy". Semgrep 1.78 normalises for-in and for-of to the same AST
+#     node, so the first is only reachable by a regex over source text; and
+#     `pattern-not-regex` applies to the entire matched range, so the second
+#     cannot be scoped to the guard statement -- an unrelated "__proto__"
+#     literal, or a nested for-of, anywhere in the loop body silently
+#     suppresses a genuinely vulnerable copy. A rule was written, and each
+#     iteration closed one bypass and exposed the next (for-of normalisation,
+#     a range-shrinking positive regex that silently disabled its own guard,
+#     hasOwnProperty counted as a guard, `prototype` matched as a substring,
+#     then range-scope suppression). It was withdrawn rather than patched
+#     further: the class has one alert in this repo's whole history, and an
+#     unsound security rule is worse than a missing one because it reads as
+#     coverage. This one also needs real CodeQL.
+#     Note the higher-frequency sibling js/prototype-polluting-assignment
+#     (46 alerts) is a DIFFERENT query -- single-point assignment from a
+#     tainted key -- and was never covered by that rule anyway.
+#
+# Note also that semgrep 1.78's TypeScript parser does not understand the
+# `satisfies` operator (TS 4.9+), so a handful of files on main fail to parse
+# and are skipped by EVERY semgrep rule, these included. That is a
+# pre-existing hole in the fork lane, not one this file introduces.
+#
+# Severity below is documentation only: code-review.yml runs semgrep with
+# `--error`, so ANY match fails the SAST job regardless of severity. Every
+# rule here must therefore be low-false-positive by construction. Validate
+# against real commit history before adding one.
+
+rules:
+  # ─── js/identity-replacement ────────────────────────────────────────
+  # A replace() whose search and replacement are the same value does
+  # nothing. It reads like sanitization while removing nothing at all.
+
+  - id: kirocrew.identity-replacement
+    patterns:
+      - pattern-either:
+          - pattern: $S.replace($X, $X)
+          - pattern: $S.replaceAll($X, $X)
+    paths:
+      include:
+        - website/src/**
+      exclude:
+        - website/src/**/*.test.*
+        - website/src/**/*.spec.*
+        # Vendored third-party bundle (anime.js v3.2.2, MIT), dropped in
+        # wholesale. Upstream's own code is not ours to gate on.
+        - website/src/lib/anime.es.js
+    message: >
+      This replace() substitutes a value with itself, so it is a no-op.
+      If it is meant to sanitize or normalize input, the replacement is
+      missing and the value passes through unchanged.
+    severity: ERROR
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      subcategory: sanitization
+      codeql-parity: js/identity-replacement
+      cwe: "CWE-116: Improper Encoding or Escaping of Output"
+
+  # ─── js/incomplete-multi-character-sanitization ─────────────────────
+  # Removing a dangerous multi-character sequence with a non-global
+  # replace only strips the FIRST occurrence. `<scr<script>ipt>` then
+  # survives one pass. String first-args are never global in JS, and a
+  # regex first-arg is non-global unless it carries the `g` flag.
+  #
+  # Narrowed to removals (replacement is the empty string) of sequences
+  # that contain HTML/URL-dangerous characters, so ordinary text munging
+  # like s.replace("foo", "") is not flagged.
+
+  - id: kirocrew.incomplete-multi-char-sanitization
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern: $S.replace($SEARCH, "")
+              - metavariable-regex:
+                  metavariable: $SEARCH
+                  regex: ^["'][^"']*<[a-zA-Z][^"']*["']$
+          - patterns:
+              - pattern: $S.replace($SEARCH, "")
+              # An anchored pattern is already complete in one pass, so
+              # those are exempt -- but ONLY a real anchor counts. `^` as
+              # the first character is a start anchor; `$` as the last is
+              # an end anchor. A `^` just inside `[` is class negation
+              # (`[^>]`) and a `$` inside a class is a literal, neither of
+              # which bounds the match. Testing for `[\^$]` anywhere in the
+              # source therefore exempted `/<script[^>]*>/`, a genuinely
+              # incomplete strip. Position is checked instead of presence.
+              - metavariable-regex:
+                  metavariable: $SEARCH
+                  regex: ^/(?!\^)[^/]*<[a-zA-Z][^/]*[^$/]/[^g]*$
+          # ...and the exemption above holds only WITHOUT the m flag. With
+          # /m, `^` and `$` match at every line boundary rather than once,
+          # so `replace(/^<script>/m, "")` strips the first line's tag and
+          # leaves the rest. Anchored-plus-m is therefore still incomplete
+          # and is matched here regardless of anchor position.
+          - patterns:
+              - pattern: $S.replace($SEARCH, "")
+              - metavariable-regex:
+                  metavariable: $SEARCH
+                  regex: ^/[^/]*<[a-zA-Z][^/]*/[^g]*m[^g]*$
+    paths:
+      include:
+        - website/src/**
+      exclude:
+        - website/src/**/*.test.*
+        - website/src/**/*.spec.*
+        # Vendored third-party bundle (anime.js v3.2.2, MIT), dropped in
+        # wholesale. Upstream's own code is not ours to gate on.
+        - website/src/lib/anime.es.js
+    message: >
+      Non-global replace() removing a dangerous multi-character sequence
+      strips only the first occurrence, so a nested or repeated payload
+      survives sanitization. Use a global regex (/.../g) or, preferably,
+      an encoding function rather than blocklist removal.
+    severity: ERROR
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      subcategory: sanitization
+      codeql-parity: js/incomplete-multi-character-sanitization
+      cwe: "CWE-80: Improper Neutralization of Script-Related HTML Tags"
+
+  # ─── js/redos ───────────────────────────────────────────────────────
+  # A quantified group whose own body ends in a quantifier -- (a+)+,
+  # ([\s\S]*)* -- backtracks exponentially on a non-matching suffix.
+
+  - id: kirocrew.redos-nested-quantifier
+    patterns:
+      # Matched as an EXPRESSION, not as raw file text. A bare
+      # `pattern-regex` scans the whole file, so a code comment or a
+      # prose/error string that merely mentions `(a+)+` failed the SAST
+      # job. Binding a metavariable first restricts this to real syntax,
+      # and requiring the text to open with `/` and close with
+      # `/<flags>` keeps string literals out.
+      - pattern: $RE
+      # The trailing class enumerates EVERY JavaScript regex flag --
+      # d(hasIndices) g i m s u v(unicodeSets) y. That set is closed by
+      # the language, so unlike a heuristic this cannot be bypassed by a
+      # flag variant; omitting d and v let `/(a+)+/d` through.
+      - metavariable-regex:
+          metavariable: $RE
+          regex: ^/.*\((?:\?:)?(?:\[[^\]]+\]|\\[a-zA-Z]|[a-zA-Z0-9])[+*]\)[+*].*/[dgimsuvy]*$
+    paths:
+      include:
+        - website/src/**
+      exclude:
+        - website/src/**/*.test.*
+        - website/src/**/*.spec.*
+        # Vendored third-party bundle (anime.js v3.2.2, MIT), dropped in
+        # wholesale. Upstream's own code is not ours to gate on.
+        - website/src/lib/anime.es.js
+    message: >
+      Regular expression contains a nested quantifier (a quantified group
+      whose body is itself quantified). This backtracks exponentially on
+      crafted input, so any externally supplied string reaching it is a
+      denial-of-service vector. Rewrite the group so the inner and outer
+      quantifiers cannot match the same characters.
+    severity: ERROR
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      subcategory: dos
+      codeql-parity: js/redos
+      cwe: "CWE-1333: Inefficient Regular Expression Complexity"
+
+  # ─── js/clear-text-storage-of-sensitive-data ────────────────────────
+  # Web storage is readable by any script on the origin and survives the
+  # tab. Credentials belong in memory or an httpOnly cookie.
+
+  - id: kirocrew.clear-text-web-storage
+    patterns:
+      - pattern-either:
+          - pattern: localStorage.setItem($KEY, ...)
+          - pattern: sessionStorage.setItem($KEY, ...)
+          - pattern: window.localStorage.setItem($KEY, ...)
+          - pattern: window.sessionStorage.setItem($KEY, ...)
+      - metavariable-regex:
+          metavariable: $KEY
+          regex: (?i)^["'].*(token|passwd|password|secret|credential|apikey|api_key|privatekey|private_key|session_key).*["']$
+    paths:
+      include:
+        - website/src/**
+      exclude:
+        - website/src/**/*.test.*
+        - website/src/**/*.spec.*
+        # Vendored third-party bundle (anime.js v3.2.2, MIT), dropped in
+        # wholesale. Upstream's own code is not ours to gate on.
+        - website/src/lib/anime.es.js
+    message: >
+      Credential-like value written to web storage in clear text. Any
+      script on this origin can read it and it persists beyond the tab.
+      Keep it in memory for the lifetime of the session instead.
+    severity: ERROR
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      subcategory: credential-storage
+      codeql-parity: js/clear-text-storage-of-sensitive-data
+      cwe: "CWE-312: Cleartext Storage of Sensitive Information"
+
+  # ─── py/clear-text-storage-sensitive-data ──────────────────────────
+  # Narrowed to the shape a syntactic engine can judge: a dict literal
+  # that names a credential field, serialized straight to disk. Writing
+  # a credential-named *variable* is not flagged, because this codebase
+  # legitimately persists its own gateway secret to a 0600 file and that
+  # distinction is not visible syntactically.
+
+  - id: kirocrew.clear-text-credential-dump
+    patterns:
+      # A stream argument is required. Without one, yaml.[safe_]dump
+      # returns a string and nothing is persisted, so firing on it
+      # contradicted this rule's own message about reaching disk.
+      - pattern-either:
+          - pattern: "json.dump({..., $KEY: $V, ...}, $STREAM, ...)"
+          - pattern: "yaml.dump({..., $KEY: $V, ...}, $STREAM, ...)"
+          - pattern: "yaml.safe_dump({..., $KEY: $V, ...}, $STREAM, ...)"
+          - pattern: "yaml.dump({..., $KEY: $V, ...}, stream=$STREAM, ...)"
+          - pattern: "yaml.safe_dump({..., $KEY: $V, ...}, stream=$STREAM, ...)"
+      - metavariable-regex:
+          metavariable: $KEY
+          regex: (?i)^["'](.*_)?(password|passwd|secret|credential|api_key|apikey|private_key|privatekey)(_.*)?["']$
+    paths:
+      include:
+        - src/kiro_crew/**
+      exclude:
+        - src/kiro_crew/_vendor/**
+    message: >
+      A credential-named field is serialized to a file in clear text.
+      Confirm the destination is created with 0600 permissions inside a
+      user-private directory, or move the value into the encrypted vault.
+    severity: WARNING
+    languages: [python]
+    metadata:
+      category: security
+      subcategory: credential-storage
+      codeql-parity: py/clear-text-storage-sensitive-data
+      cwe: "CWE-312: Cleartext Storage of Sensitive Information"


### PR DESCRIPTION
## Problem / Motivation

CodeQL on this repo runs through GitHub's **default setup**, which uploads results to code-scanning and therefore needs `security-events: write`. A fork-triggered `pull_request` workflow only ever gets a read-only token, so **fork PRs never produce a CodeQL check-run at all**. Verified on live PRs — every fork PR sampled had `SAST (Semgrep) pass` and no CodeQL check present, while same-repo PRs had both.

Semgrep is not subject to that: it fails on exit code rather than uploading, so it is the only SAST that actually runs on fork contributions.

I measured the resulting gap instead of assuming it. Writing a minimal reproduction of each CodeQL class this repo has alerted on and scanning it with the configured packs (`p/python`, `p/typescript`, `p/security-audit`, `p/secrets`, `p/owasp-top-ten`) gave **3 of 13 classes covered**, with the TypeScript side close to zero. A canary containing `eval(userInput)`, `el.innerHTML = userInput`, `new Function(userInput)` and a hardcoded AWS key produced **one** finding. The mechanism is not a missing pack — most Semgrep security rules require a *recognised taint source* (`req.query.x`, `process.argv`), and a bare function parameter is not one. CodeQL does whole-program analysis and can reach a real entrypoint across files.

## Why it matters

Fork contributions are the code we have the least prior trust in, and today they get the weakest static analysis of anything entering the repo — the asymmetry runs the wrong way. This does not fix that asymmetry (see the honest-scope section), but it removes the part of it that is cheap to remove, and it replaces guesswork about the gap's size with a measurement.

## What changed (motivation → approach → change)

Adds `.semgrep/codeql-parity.yaml` with five rules — the CodeQL classes that can be expressed *soundly* in a syntactic engine:

| Rule | CodeQL class |
|---|---|
| `kirocrew.identity-replacement` | `js/identity-replacement` |
| `kirocrew.incomplete-multi-char-sanitization` | `js/incomplete-multi-character-sanitization` |
| `kirocrew.redos-nested-quantifier` | `js/redos` |
| `kirocrew.clear-text-web-storage` | `js/clear-text-storage-of-sensitive-data` |
| `kirocrew.clear-text-credential-dump` | `py/clear-text-storage-sensitive-data` |

No existing file is touched — `supply-chain.yaml` is untouched and there is no rule-id collision (verified by loading the directory the way CI does; it reports 10 custom rules across both files).

**Why the precision bar is unusually high here.** `code-review.yml` runs `semgrep --config .semgrep/ --error`. That flag fails the SAST job on **any** match regardless of declared severity, and `--config .semgrep/` loads every YAML in the directory. So one false positive is a hard CI failure on somebody else's PR, and one false negative is a rule that reads as coverage while delivering none. Severity in this file is documentation only. Both directions were validated in every round.

### The main judgement call: a sixth rule was written and withdrawn

A `js/prototype-pollution-utility` rule was part of this PR and has been **removed**. It is worth reading before approving, because "we shipped five instead of six" is the substantive decision here.

An unguarded key-copy rule needs two *scoped* judgements: "is this loop a `for-in` rather than a `for-of`", and "is this comparison the guard for **this** copy". Neither is expressible in semgrep 1.78:

- for-in and for-of are **normalised to the same AST node**, so discriminating them is only reachable by a regex over source text;
- `pattern-not-regex` applies to the **entire matched range** with no scoping construct, so a guard check cannot be tied to the copy it guards.

Consequently every iteration closed one bypass and exposed the next — seven distinct defects in all: for-of normalisation (27 false positives on loops over declared key arrays like `ALL_SLOT_KEYS`), a positive `pattern-regex` that shrank the reported range and thereby **silently disabled its own `__proto__` guard**, a dead `Object.keys().forEach` arm, two false positives from widening to for-of-over-`Object.keys`, `hasOwnProperty` wrongly treated as a guard (`JSON.parse('{"__proto__":{}}')` makes `__proto__` an *own* property), `prototype` matching as a substring inside `Object.prototype.hasOwnProperty`, and finally an unrelated `"__proto__"` literal or nested `for...of` anywhere in a loop body suppressing a genuinely vulnerable copy.

That is the signature of a wrong premise, not of missing details. Set against it: the class has **1 alert in this repository's entire history**, and the higher-frequency sibling `js/prototype-polluting-assignment` (46 alerts) is a *different* query — single-point assignment from a tainted key — that the rule never covered anyway. An unsound security rule is worse than a missing one because it reads as coverage, so the class is documented in the file header as needing real CodeQL, next to `py/path-injection`.

## Tests

Rules are validated by fixture, by full-tree scan, and by replaying real merged history — the last of which is what caught the false positives.

| Check | Result |
|---|---|
| Fixture positives (each rule must fire on its target defect) | **10/10** fire |
| Fixture negatives (safe idioms must stay clean) | all clean |
| Full current tree (2150 files) | **0 findings** |
| Replay of 2000 commits / 7247 changed-file versions (2026-07-31 → 2026-08-20) | **0 findings** |
| Exact CI invocation (`--config p/… --config .semgrep/ --baseline-commit … --error`) | **0 findings** |

The replay materialises each commit's own version of every `.ts`/`.tsx`/`.js`/`.py` file that commit changed and scans it, mirroring what the diff-scoped SAST job would have seen. Zero findings means no PR merged in that three-week window would have been blocked by these rules.

### Precision defects found and fixed in the five that remain

**False positives — each would have hard-failed a safe PR:**

- **The ReDoS rule scanned raw file text.** As a bare `pattern-regex` it fired on a **code comment** and on a prose error string that merely mentioned `(a+)+`. It now binds a metavariable first, so only real regex-literal syntax is considered.
- **The ReDoS heuristic flagged a safe idiom.** `X+(?:sepX+)+` is linear, because every iteration must consume a separator. 5/5 findings were false, including a textbook unrolled-loop regex.
- **The sanitization rule flagged anchored strips.** `/<mcwidget[\s\S]*$/` has a `$` anchor, so a single non-global replacement is already complete. 4/4 false.
- **`yaml.[safe_]dump` with no stream.** `...` matches zero arguments, so the no-stream form fired even though it returns a string and persists nothing — contradicting the rule's own message about reaching disk. A stream is now required.

**False negatives — each was a rule that could not catch its own target:**

- **The anchor exemption treated character-class negation as an anchor.** It tested for `[\^$]` *anywhere* in the regex source, so the `^` in `[^>]` counted, and `s.replace(/<script[^>]*>/, "")` — a genuinely incomplete strip — went unflagged. Anchor **position** is now checked instead of presence.
- **…and it still held under the `m` flag,** where `^`/`$` match at every line boundary rather than once, so `replace(/^<script>/m, "")` strips only the first line's tag. Anchored-plus-`m` is now treated as incomplete.
- **The ReDoS flag class omitted `d` and `v`,** so `/(a+)+/d` was missed. All eight JavaScript flags are now enumerated — a set closed by the language spec, which makes this complete rather than heuristic.

There was also a near-miss worth recording, because it argues for keeping the negative fixtures: constraining a shape with a **positive** `pattern-regex` looked correct and passed every positive case, but an AND-ed regex **shrinks the reported match range**, which silently disabled the guard above it. Only the negative fixtures going red caught it.

The vendored anime.js v3.2.2 bundle (`website/src/lib/anime.es.js`, MIT, dropped in wholesale) is excluded from the frontend rules — upstream's code is not ours to gate on.

## Manual verification

N/A — the validation above *is* the verification, and it is automated and reproducible: every rule is exercised by a positive and a negative fixture, then measured against the real tree and 2000 commits of real history using the CI-pinned semgrep 1.78 image.

## What this does NOT do — please read before approving

**This is a low-frequency tripwire, not fork-lane parity, and the file header says so in the same terms.** Pulling this repo's real code-scanning alert history (fixed + dismissed, all states, paginated) shows the ported classes are not where findings actually occur:

| CodeQL class | alerts | status |
|---|---|---|
| `py/path-injection` | **230** | not portable — needs real CodeQL |
| `js/prototype-polluting-assignment` | **46** | *different query* from the withdrawn utility-shape rule |
| `py/clear-text-logging-sensitive-data` | 20 | packs cover `%`-style args only, f-strings missed |
| `py/polynomial-redos` | 18 | Python polynomial, not the JS nesting ported here |
| `py/incomplete-url-substring-sanitization` | 17 | not ported |
| `py/cookie-injection` | 8 | not ported |
| `py/clear-text-storage-sensitive-data` | 6 | **ported here** |
| `js/redos` | 1 | **ported here** |
| `js/prototype-pollution-utility` | 1 | **withdrawn** — not soundly expressible (see above) |
| `js/identity-replacement` | 0 | **ported here** |
| `js/incomplete-multi-character-sanitization` | 0 | **ported here** |
| `js/clear-text-storage-of-sensitive-data` | 0 | **ported here** |

So of the five: one targets a class with real history, one a class seen once, three classes this repo has never alerted on. They cost nothing and they fail closed on shapes that are genuinely bugs — the JS sanitization and ReDoS family in particular is one this repo has repeatedly hit — but nobody should merge this thinking the fork lane is now covered.

`py/path-injection` alone is over half of the entire alert history and is not portable: a syntactic rule either matches only single-function direct flows (misses nearly everything) or matches every `open(join(...))` (drowns the signal). Closing it requires running CodeQL itself in a privileged `workflow_run` context with `build-mode: none` — reusing the trust model `fork-gpt-review.yml` already established, but with stage 2 performing its own analysis rather than trusting a stage-1 artifact, since an analysis *result* cannot be re-derived from the API the way a diff can. That is follow-up work, not this PR.

## Separate pre-existing issue found along the way

**semgrep 1.78 (the pinned version) does not parse the TypeScript `satisfies` operator** (TS 4.9+). On the current tree this makes 11 files fail to parse partially or entirely — `website/src/pages/ChatPage.tsx` fails at line 1 and is **never analyzed by any Semgrep rule**. This is a silent coverage hole affecting *all* Semgrep rules, not something this PR introduces, and it means real fork-lane coverage is somewhat worse than the 3/13 figure above. Worth its own issue.

## Related Issues

no linked issue: this is self-directed CI hardening with no tracking issue behind it. The three follow-ups it identifies (workflow-based CodeQL for the fork lane, `js/prototype-pollution-utility` needing that same lane, and the `satisfies` parse gap) are named in the sections above and in the file header so they are not lost.

<!-- no-visual-delta -->
**Why no screenshot:** adds a Semgrep rules YAML consumed by CI only — no runtime code and no user-visible surface.
