### PR TITLE
test: let the prove bytecode test own its precondition

### DIFF
--- a/test/test_prepare_pr_prove.py
+++ b/test/test_prepare_pr_prove.py
@@ -394,16 +394,33 @@ def test_an_option_like_base_cannot_suppress_the_diff(tmp_path: Path) -> None:
 
 
 def test_importing_prove_leaves_no_bytecode_in_the_checkout() -> None:
-    """The helper import must not write __pycache__ into the skill tree.
+    """``_load_prove`` must not write ``__pycache__`` into the skill tree.
 
     prove.py sits in the checked-out source tree, so an ordinary import drops a
     .pyc beside it that outlives the run -- the same bytecode pollution the
     script itself guards against when it launches pytest.
+
+    The two lines of setup are load-bearing, and both come from this test having
+    failed the release gate. Asserting only that the file is ABSENT measures the
+    ambient filesystem rather than this loader: the gate runs all 59k tests in
+    one process tree, and anything else that imports from that directory leaves
+    residue this would then blame on ``_load_prove``. And because ``sys.modules``
+    caches ``prove``, a run where something imported it first makes
+    ``_load_prove`` a no-op -- the assertion then passes while exercising
+    nothing, which is the worse of the two failure directions. Evicting the
+    module and removing the cache file first makes the import real and the
+    verdict this loader's own.
     """
+    cache = Path(importlib.util.cache_from_source(PROVE))
+    sys.modules.pop("prove", None)
+    cache.unlink(missing_ok=True)
+
     module = _load_prove()
+
     cached = getattr(module, "__cached__", None)
     assert cached, "expected __cached__ to be set"
-    assert not Path(cached).exists(), f"import wrote bytecode to {cached}"
+    assert Path(cached) == cache, f"cache path moved: {cached} is not {cache}"
+    assert not cache.exists(), f"import wrote bytecode to {cached}"
 
 
 def test_a_call_phase_exception_is_not_proof(tmp_path: Path) -> None:


### PR DESCRIPTION
Failed the `v0.4.0-insider.1` release gate: **1 failed, 59154 passed** — with the loader under test working correctly.

```
FAILED test/test_prepare_pr_prove.py::test_importing_prove_leaves_no_bytecode_in_the_checkout
  AssertionError: import wrote bytecode to
    …/builtin_skills/kirocrew-dev/prepare-pr/scripts/__pycache__/prove.cpython-312.pyc
```

## Why it is the test that is wrong

The assertion is `not Path(cached).exists()` — it measures **the ambient filesystem**, while the name and docstring claim a property of `_load_prove`. Those two coincide only in a process where nothing else touches that directory. The release gate is the one job that runs all 59k tests in a single process tree, so it is exactly where they diverge.

The reverse direction is worse, and was equally live: `sys.modules` caches `prove`, so on any run where something imported it first, `_load_prove` returns the cached module **without importing at all** — and the assertion passes while exercising nothing. A test that can silently stop testing is a worse defect than one that occasionally goes red.

## The fix

Own the precondition, then import for real:

```python
cache = Path(importlib.util.cache_from_source(PROVE))
sys.modules.pop("prove", None)
cache.unlink(missing_ok=True)

module = _load_prove()

assert Path(cached) == cache          # the cache path did not move
assert not cache.exists()             # this loader wrote nothing
```

The added same-path assertion is not decoration: without it, a cache location that moves out from under the check would make the absence assertion vacuously true.

## Verification, including the control that matters

| probe | result |
|---|---|
| residue present, **old** test | **fails** — reproduces the gate failure locally |
| residue present, **new** test | passes |
| whole file, clean tree | 17 passed, and leaves no residue of its own |
| **loader sabotaged** (`dont_write_bytecode = False`), new test | **fails** — still catches the regression it exists for |

`flake8`, `isort`, and the black gate are clean.

**Why no screenshot:** test-only change, no user-visible surface.

## A separate, reproducible finding this turned up

Five sibling tests **do** leave bytecode in the checked-out skill tree, which the no-test-side-effects rule forbids. Each loads its script with `spec_from_file_location` + `exec_module` and no `dont_write_bytecode` guard, unlike `_load_prove`. Measured one file at a time from a clean tree:

| test file | residue left in `prepare-pr/scripts/__pycache__/` |
|---|---|
| `test_push_guard.py` | `push_guard.pyc` |
| `test_prepare_pr_status.py` | `pr_status.pyc` |
| `test_prepare_pr_profiles.py` | `pr_status.pyc`, `resolve_profile.pyc` |
| `test_prepare_pr_local_review.py` | `local_review.pyc`, `resolve_profile.pyc` |
| `test_prepare_pr_findings.py` | `pr_findings.pyc`, `pr_status.pyc` |

Deliberately **not** fixed here — it is five more files and a different invariant, and this PR is unblocking a release gate. Worth noting that none of them writes `prove.pyc`, so they are not the source of this particular failure: running all five together with the failing test (306 passed) does not reproduce it. Whatever writes that one file lives elsewhere in the full-suite process, which is precisely why the fix above does not depend on identifying it.