### PR TITLE
test: let the prove bytecode test own its precondition

### DIFF
--- a/test/test_prepare_pr_prove.py
+++ b/test/test_prepare_pr_prove.py
@@ -394,16 +394,33 @@ def test_an_option_like_base_cannot_suppress_the_diff(tmp_path: Path) -> None:
 
 
 def test_importing_prove_leaves_no_bytecode_in_the_checkout() -> None:
-    """The helper import must not write __pycache__ into the skill tree.
+    """``_load_prove`` must not write ``__pycache__`` into the skill tree.
 
     prove.py sits in the checked-out source tree, so an ordinary import drops a
     .pyc beside it that outlives the run -- the same bytecode pollution the
     script itself guards against when it launches pytest.
+
+    The two lines of setup are load-bearing, and both come from this test having
+    failed the release gate. Asserting only that the file is ABSENT measures the
+    ambient filesystem rather than this loader: the gate runs all 59k tests in
+    one process tree, and anything else that imports from that directory leaves
+    residue this would then blame on ``_load_prove``. And because ``sys.modules``
+    caches ``prove``, a run where something imported it first makes
+    ``_load_prove`` a no-op -- the assertion then passes while exercising
+    nothing, which is the worse of the two failure directions. Evicting the
+    module and removing the cache file first makes the import real and the
+    verdict this loader's own.
     """
+    cache = Path(importlib.util.cache_from_source(PROVE))
+    sys.modules.pop("prove", None)
+    cache.unlink(missing_ok=True)
+
     module = _load_prove()
+
     cached = getattr(module, "__cached__", None)
     assert cached, "expected __cached__ to be set"
-    assert not Path(cached).exists(), f"import wrote bytecode to {cached}"
+    assert Path(cached) == cache, f"cache path moved: {cached} is not {cache}"
+    assert not cache.exists(), f"import wrote bytecode to {cached}"
 
 
 def test_a_call_phase_exception_is_not_proof(tmp_path: Path) -> None:


### PR DESCRIPTION
Cherry-pick of `32a2739a8` from [#4846](https://github.com/kirodotdev/KiroCrew/pull/4846). Applied clean; `diff` of the two patches produces no output, so this is byte-identical to the `main`-side commit.

## Why it belongs on the release branch

This test is what failed `v0.4.0-insider.1`'s `Test Release Candidate SHA` gate — **1 failed, 59154 passed** — and that gate is the hard precondition for recording the promotion bundle, so a stable `v0.4.0` cannot be promoted from a candidate whose gate is red.

The failure is order-dependent and only reachable in that gate, which is the one job that runs all 59k tests in a single process tree. Left unfixed on this branch, every future RC cut from it plays the same lottery.

**It does not rescue rc1.** The gate runs against the tagged commit `fbbee2abe`, so rerunning rc1's gate reruns the same code — it may pass on a different test order, but that is luck, not this fix. What this buys is that the next RC tagged from this branch cannot fail that way.

## What the test was doing wrong

It asserted `not Path(cached).exists()` — the ambient filesystem — while claiming to test `_load_prove`. And because `sys.modules` caches `prove`, a run where something imported it first made `_load_prove` a no-op, so the assertion could pass while exercising nothing. It now evicts the module and deletes the cache file before importing, so the verdict is the loader's own.

## Verification on this branch

- with residue planted at the cache path, the whole file: **17 passed**, and it leaves no residue of its own
- `flake8` clean

Full evidence table, including the sabotage control that proves the test still catches the regression it exists for, is on [#4846](https://github.com/kirodotdev/KiroCrew/pull/4846).

**Why no screenshot:** test-only change, no user-visible surface.