### PR TITLE
fix(desktop): recover the dashboard when its renderer process dies

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -16,6 +16,7 @@ const {
 } = require("./bundle-integrity");
 const { findConfiguredDashboardPort } = require("./data-home");
 const { createTokenRetryHandler } = require("./token-retry");
+const { createRendererRecovery } = require("./renderer-recovery");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { exitImmersiveModes } = require("./blocking-prompt");
 const { shouldRetryLocalTokenMint, tokenMintRetryDelayMs, TOKEN_MINT_MAX_RETRIES } = require("./token-acquire");
@@ -2049,6 +2050,69 @@ function createWindow() {
   });
   mainWindow.webContents.on("did-navigate", (_e, _url, httpCode) => {
     onNavigate(httpCode).catch((err) => console.error("Token retry failed:", err));
+  });
+
+  // Renderer-crash self-healing. Without this a dead renderer leaves the window
+  // mapped but permanently BLACK — the SPA and its top tab strip both lived in
+  // that process, so the user is left with no UI and no way back short of
+  // quitting. Re-load through the same fresh-token path `did-navigate` uses, so
+  // recovery also survives a gateway secret that rotated while we were down.
+  // Bounded (see renderer-recovery.js): repeated deaths inside the window stop
+  // the loop instead of spinning on a broken build.
+  const rendererRecovery = createRendererRecovery({
+    isQuitting: () => isQuitting,
+    log: glog,
+    // Snapshot every Electron process at the moment of death. A macOS crash
+    // report names the thread that aborted but NOT what the process had grown
+    // to, so without this a post-mortem cannot tell "renderer hit a memory
+    // ceiling" from "renderer was pegged on CPU" — the two hypotheses this
+    // window's black-screen crashes leave open. Totals plus the worst offender
+    // keep it to one log line.
+    describeProcesses: () => {
+      const metrics = app.getAppMetrics() || [];
+      let totalCpu = 0;
+      let totalMb = 0;
+      let worst = null;
+      for (const m of metrics) {
+        const cpu = (m.cpu && m.cpu.percentCPUUsage) || 0;
+        const mb = ((m.memory && m.memory.workingSetSize) || 0) / 1024;
+        totalCpu += cpu;
+        totalMb += mb;
+        if (!worst || mb > worst.mb) worst = { type: m.type, pid: m.pid, mb, cpu };
+      }
+      const parts = [
+        `procs=${metrics.length}`,
+        `totalCpu=${totalCpu.toFixed(1)}%`,
+        `totalWorkingSet=${Math.round(totalMb)}MB`,
+      ];
+      if (worst) {
+        parts.push(
+          `largest=${worst.type}:${worst.pid}@${Math.round(worst.mb)}MB/${worst.cpu.toFixed(1)}%`
+        );
+      }
+      return parts.join(" ");
+    },
+    reload: () => {
+      if (mainWindow.isDestroyed()) return;
+      (async () => {
+        let token = await fetchLocalToken(BACKEND_URL);
+        if (!token) ({ token } = await fetchRemoteToken(PORT));
+        if (mainWindow.isDestroyed()) return;
+        mainWindow.webContents.loadURL(
+          token ? `${BACKEND_URL}?token=${token}` : BACKEND_URL
+        );
+      })().catch((err) => glog(`renderer recovery reload failed: ${err && err.message}`));
+    },
+    onGiveUp: ({ reason }) => {
+      // Deliberately log-only. Reloading again is the thing we must NOT do here
+      // (that is the loop this budget exists to stop), and the window is already
+      // showing the failure — it is blank. The log line is what tells a human
+      // WHY it stayed blank, which a silent give-up would not.
+      glog(`renderer recovery exhausted (reason=${reason}); leaving the window as-is`);
+    },
+  });
+  mainWindow.webContents.on("render-process-gone", (_e, details) => {
+    rendererRecovery.handleGone(details || {});
   });
 
   mainWindow.on("close", (e) => {

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -158,6 +158,7 @@
       "global-hotkey.js",
       "gateway-liveness.js",
       "gateway-recovery.js",
+      "renderer-recovery.js",
       "pyspy-dump.js",
       "perf-metrics.js",
       "host-config.js",

--- a/website/electron/renderer-recovery.js
+++ b/website/electron/renderer-recovery.js
@@ -1,0 +1,150 @@
+"use strict";
+//
+// Renderer-crash self-healing for the main dashboard window.
+//
+// The problem this solves: when the dashboard's renderer process dies, Electron
+// leaves the window mapped but BLANK — and nothing brings it back. The user sees
+// a permanently black window with no top tab strip (the whole SPA, tab bar
+// included, lived in that renderer), and the only way out is quitting the app.
+// Observed in the wild as a repeating daily crash: `EXC_BREAKPOINT` (a V8 fatal
+// abort) raised on a DedicatedWorker thread after a long session, in a renderer
+// hosting many remote-crew dashboard SPAs at once.
+//
+// Electron does emit `render-process-gone` for exactly this, but the app never
+// listened, so a dead renderer was terminal. This module decides whether a given
+// death warrants an automatic reload, and bounds how often that may happen.
+//
+// Why bounded rather than always-reload: a renderer that dies DURING startup
+// (bad build, integrity failure, immediate OOM) would otherwise reload forever,
+// spinning CPU and hiding the failure. After `maxAttempts` deaths inside
+// `windowMs`, this stops and reports, so a genuinely broken build surfaces as a
+// visible error instead of an invisible loop.
+//
+// Pure logic + injected dependencies: Electron main is not exercised by the unit
+// test runner, so the decision has to be testable without a live BrowserWindow
+// (same pattern as perf-metrics.js / token-retry.js).
+//
+
+// Reasons that mean "the renderer died unexpectedly and a reload may fix it".
+// `clean-exit` is a normal teardown and must never trigger a reload.
+const RECOVERABLE_REASONS = new Set([
+  "crashed",
+  "oom",
+  "abnormal-exit",
+  "launch-failed",
+  "integrity-failure",
+  // `killed` reaches us both when the OS reaps the process and when the app
+  // itself is tearing down; the isQuitting gate below separates those.
+  "killed",
+]);
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_WINDOW_MS = 60_000;
+
+/**
+ * Whether `reason` from `render-process-gone` describes a recoverable death.
+ */
+function isRecoverableReason(reason) {
+  return RECOVERABLE_REASONS.has(String(reason || ""));
+}
+
+/**
+ * Create the recovery coordinator.
+ *
+ * @param {object} deps
+ * @param {() => void} deps.reload          Re-load the dashboard into the window.
+ * @param {() => boolean} [deps.isQuitting] True while the app is shutting down.
+ * @param {(msg: string) => void} [deps.log]
+ * @param {() => string} [deps.describeProcesses] One-line process snapshot
+ *   (CPU + working set) captured AT CRASH TIME. This is the whole reason a
+ *   post-mortem can tell a memory problem from a CPU problem: macOS crash
+ *   reports carry the thread that aborted but not what the process had grown to,
+ *   and by the time a human looks the process is gone.
+ * @param {(info: object) => void} [deps.onGiveUp] Called once the budget is spent.
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.maxAttempts]
+ * @param {number} [deps.windowMs]
+ * @returns {{handleGone: (details: object) => string, attempts: number, reset: () => void}}
+ *   `handleGone` returns the decision taken, one of:
+ *   "reloaded" | "ignored-clean-exit" | "ignored-quitting" | "gave-up".
+ */
+function createRendererRecovery({
+  reload,
+  isQuitting = () => false,
+  log = () => {},
+  describeProcesses = () => "",
+  onGiveUp = () => {},
+  now = () => Date.now(),
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  windowMs = DEFAULT_WINDOW_MS,
+} = {}) {
+  // Timestamps of recent recovery attempts, pruned to the sliding window so a
+  // stable app that crashes once a day never exhausts its budget.
+  let recent = [];
+  const cap = Math.max(1, Number(maxAttempts) || DEFAULT_MAX_ATTEMPTS);
+  const span = Math.max(1, Number(windowMs) || DEFAULT_WINDOW_MS);
+
+  function handleGone(details = {}) {
+    const reason = details.reason;
+    // A deliberate teardown is not a crash: reloading here would fight the quit.
+    if (isQuitting()) {
+      log(`renderer gone during quit (reason=${reason}) — not recovering`);
+      return "ignored-quitting";
+    }
+    if (!isRecoverableReason(reason)) {
+      log(`renderer exited cleanly (reason=${reason}) — not recovering`);
+      return "ignored-clean-exit";
+    }
+
+    const t = now();
+    recent = recent.filter((ts) => t - ts < span);
+    // Captured BEFORE the reload so it describes the crashed state, not the
+    // recovered one. Never allowed to block recovery if the probe throws.
+    let snapshot = "";
+    try {
+      snapshot = describeProcesses() || "";
+    } catch (e) {
+      snapshot = `snapshot failed: ${e && e.message}`;
+    }
+    const detail =
+      `reason=${reason}, exitCode=${details.exitCode}` +
+      (snapshot ? `, ${snapshot}` : "");
+
+    if (recent.length >= cap) {
+      log(
+        `renderer died ${recent.length + 1}x within ${span}ms (${detail}) — ` +
+          `giving up to avoid a reload loop`
+      );
+      onGiveUp({ reason, exitCode: details.exitCode, attempts: recent.length, snapshot });
+      return "gave-up";
+    }
+
+    recent.push(t);
+    log(`renderer died (${detail}) — reloading dashboard (attempt ${recent.length}/${cap})`);
+    try {
+      reload();
+    } catch (e) {
+      // Never let a failed reload escape into Electron's event emitter.
+      log(`renderer reload failed: ${e && e.message}`);
+    }
+    return "reloaded";
+  }
+
+  return {
+    handleGone,
+    reset() {
+      recent = [];
+    },
+    get attempts() {
+      return recent.length;
+    },
+  };
+}
+
+module.exports = {
+  createRendererRecovery,
+  isRecoverableReason,
+  RECOVERABLE_REASONS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_WINDOW_MS,
+};

--- a/website/electron/test/renderer-recovery.test.js
+++ b/website/electron/test/renderer-recovery.test.js
@@ -1,0 +1,151 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const {
+  createRendererRecovery,
+  isRecoverableReason,
+  DEFAULT_MAX_ATTEMPTS,
+} = require("../renderer-recovery");
+
+// A coordinator wired entirely to fakes: Electron main is not available here,
+// and a real BrowserWindow would make these tests slow and order-dependent.
+function harness(overrides = {}) {
+  const reloads = [];
+  const logs = [];
+  const gaveUp = [];
+  let t = 0;
+  let quitting = false;
+  const rec = createRendererRecovery({
+    reload: () => reloads.push(t),
+    isQuitting: () => quitting,
+    log: (m) => logs.push(m),
+    onGiveUp: (info) => gaveUp.push(info),
+    now: () => t,
+    ...overrides,
+  });
+  return {
+    rec,
+    reloads,
+    logs,
+    gaveUp,
+    advance: (ms) => {
+      t += ms;
+    },
+    setQuitting: (v) => {
+      quitting = v;
+    },
+  };
+}
+
+test("a crashed renderer triggers a reload", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleGone({ reason: "crashed", exitCode: 5 }), "reloaded");
+  assert.strictEqual(h.reloads.length, 1);
+});
+
+test("an OOM renderer triggers a reload (the observed V8 abort class)", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleGone({ reason: "oom" }), "reloaded");
+  assert.strictEqual(h.reloads.length, 1);
+});
+
+test("a clean exit is NOT treated as a crash", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleGone({ reason: "clean-exit" }), "ignored-clean-exit");
+  assert.strictEqual(h.reloads.length, 0, "a normal teardown must never reload");
+});
+
+test("a death during quit is ignored so recovery cannot fight the shutdown", () => {
+  const h = harness();
+  h.setQuitting(true);
+  assert.strictEqual(h.rec.handleGone({ reason: "killed" }), "ignored-quitting");
+  assert.strictEqual(h.reloads.length, 0);
+});
+
+test("repeated crashes inside the window stop instead of reload-looping", () => {
+  const h = harness({ maxAttempts: 3, windowMs: 60_000 });
+  for (let i = 0; i < 3; i++) {
+    assert.strictEqual(h.rec.handleGone({ reason: "crashed" }), "reloaded");
+    h.advance(1000);
+  }
+  // Budget spent — the 4th death must not reload.
+  assert.strictEqual(h.rec.handleGone({ reason: "crashed" }), "gave-up");
+  assert.strictEqual(h.reloads.length, 3);
+  assert.strictEqual(h.gaveUp.length, 1);
+  assert.match(h.logs.join("\n"), /giving up/);
+});
+
+test("the budget is a SLIDING window, so a once-a-day crash always recovers", () => {
+  const h = harness({ maxAttempts: 3, windowMs: 60_000 });
+  for (let i = 0; i < 6; i++) {
+    assert.strictEqual(
+      h.rec.handleGone({ reason: "crashed" }),
+      "reloaded",
+      `crash ${i} should still recover`
+    );
+    h.advance(24 * 60 * 60 * 1000); // a day apart, like the observed crashes
+  }
+  assert.strictEqual(h.reloads.length, 6);
+  assert.strictEqual(h.gaveUp.length, 0);
+});
+
+test("a throwing reload is contained and reported, never rethrown", () => {
+  const h = harness({
+    reload: () => {
+      throw new Error("window destroyed");
+    },
+  });
+  assert.strictEqual(h.rec.handleGone({ reason: "crashed" }), "reloaded");
+  assert.match(h.logs.join("\n"), /reload failed/);
+});
+
+test("reset clears the attempt budget", () => {
+  const h = harness({ maxAttempts: 1 });
+  h.rec.handleGone({ reason: "crashed" });
+  assert.strictEqual(h.rec.handleGone({ reason: "crashed" }), "gave-up");
+  h.rec.reset();
+  assert.strictEqual(h.rec.attempts, 0);
+  assert.strictEqual(h.rec.handleGone({ reason: "crashed" }), "reloaded");
+});
+
+test("reason classification covers the unexpected-death set only", () => {
+  for (const r of ["crashed", "oom", "abnormal-exit", "launch-failed", "integrity-failure", "killed"]) {
+    assert.strictEqual(isRecoverableReason(r), true, `${r} should be recoverable`);
+  }
+  for (const r of ["clean-exit", "", null, undefined, "nonsense"]) {
+    assert.strictEqual(isRecoverableReason(r), false, `${r} should not be recoverable`);
+  }
+});
+
+test("the default attempt budget is small enough to surface a broken build", () => {
+  assert.ok(DEFAULT_MAX_ATTEMPTS >= 1 && DEFAULT_MAX_ATTEMPTS <= 5);
+});
+
+test("the crash log carries a process snapshot so memory vs CPU is decidable later", () => {
+  const h = harness({
+    describeProcesses: () => "procs=7 totalCpu=133.7% totalWorkingSet=4211MB",
+  });
+  h.rec.handleGone({ reason: "crashed", exitCode: 5 });
+  const line = h.logs.join("\n");
+  assert.match(line, /totalWorkingSet=4211MB/);
+  assert.match(line, /totalCpu=133\.7%/);
+  assert.match(line, /reason=crashed/);
+});
+
+test("the snapshot is captured for the give-up line too, and handed to onGiveUp", () => {
+  const h = harness({ maxAttempts: 1, describeProcesses: () => "procs=3 totalWorkingSet=99MB" });
+  h.rec.handleGone({ reason: "crashed" });
+  h.rec.handleGone({ reason: "crashed" });
+  assert.match(h.logs.join("\n"), /giving up[\s\S]*|totalWorkingSet=99MB/);
+  assert.strictEqual(h.gaveUp[0].snapshot, "procs=3 totalWorkingSet=99MB");
+});
+
+test("a throwing snapshot probe never blocks recovery", () => {
+  const h = harness({
+    describeProcesses: () => {
+      throw new Error("metrics unavailable");
+    },
+  });
+  assert.strictEqual(h.rec.handleGone({ reason: "crashed" }), "reloaded");
+  assert.strictEqual(h.reloads.length, 1, "recovery must still happen");
+  assert.match(h.logs.join("\n"), /snapshot failed/);
+});

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider } from './hooks/useTheme'
 import { UIModeProvider } from './hooks/useUIMode'
 import ThemeExperienceLayer from './components/ThemeExperienceLayer'
 import { initRum } from './rum'
+import { isEmbeddedPane } from './lib/embedded'
 // i18n must initialize before the first render — a component rendering ahead of
 // init would emit its bare translation key instead of text.
 import { initI18n } from './i18n'
@@ -85,9 +86,25 @@ if (import.meta.env.DEV) {
 // creates the module-level highlight worker pool, so the first code surface a
 // user opens paints immediately instead of paying chunk + worker + grammar
 // startup on click.
+//
+// NOT in an embedded remote-instance pane. Each warm pane is a full copy of this
+// SPA in its own realm, and every realm that evaluates PierreImpl spawns
+// PIERRE_WORKER_POOL_SIZE workers, each loading its own highlighter bundle + WASM
+// regex engine. With the default warm-set cap that is 4 workers x 5 panes = 20
+// eagerly-spawned workers in one renderer process, and the background panes paint
+// nothing, so 16 of them buy no responsiveness at all. Observed consequence: the
+// renderer accumulated 20 DedicatedWorker threads and was killed by a V8 fatal
+// abort raised on one of them, taking the whole window black.
+//
+// Panes are not left slower than before in any case a user can see: the lazy
+// import in pierre/index.tsx still creates the pool on the first real code
+// surface, so a pane the user actually opens a diff in pays exactly the
+// pre-warm cost it used to pay on click.
 const idle: (cb: () => void) => void =
   typeof requestIdleCallback === 'function' ? cb => requestIdleCallback(cb) : cb => setTimeout(cb, 2000)
-idle(() => { import('./pierre/PierreImpl').catch(() => { /* warmed on first use instead */ }) })
+if (!isEmbeddedPane()) {
+  idle(() => { import('./pierre/PierreImpl').catch(() => { /* warmed on first use instead */ }) })
+}
 
 const WorldsPopout = lazy(() => import('./pages/WorldsPopout'))
 


### PR DESCRIPTION
## Problem / Motivation

When the dashboard's renderer process dies, the app is left **permanently black**. The SPA and its top tab strip both live in that renderer, so the window stays mapped with no UI at all — no tabs, no escape hatch — and the only way out is force-quitting the app, losing every warm pane.

This is not hypothetical. On one machine it reproduced four times across three days, every time with the same signature: `EXC_BREAKPOINT` / `SIGTRAP` (a V8 fatal abort) raised on a `DedicatedWorker` thread.

```
08-18 20:45  EXC_BREAKPOINT  faulting=DedicatedWorker  workers=17 sw=5
08-19 20:00  EXC_BREAKPOINT  faulting=DedicatedWorker  workers=20 sw=5
08-20 21:13  EXC_BREAKPOINT  faulting=DedicatedWorker  workers=20 sw=5
08-20 21:55  EXC_BREAKPOINT  faulting=DedicatedWorker  workers=20 sw=5
```

## Why it matters

Electron already emits `render-process-gone` for exactly this case, but nothing in the app listened, so **every renderer death was terminal for the session**. A user with several remote crews connected loses all of their warm panes and has to restart the app.

The second cost is diagnostic: a macOS crash report names the thread that aborted but not what the process had grown to, and by the time anyone looks the process is gone. That left the two competing explanations — a memory ceiling versus a CPU peg — undecidable after the fact, so each recurrence produced no new information.

## What changed (motivation → approach → change)

Three parts, in the order the investigation established them.

**1. Recover instead of staying black.** Symptom: black window that never returns. Root cause: no `render-process-gone` listener, so a dead renderer was never reloaded. Change: a bounded recovery coordinator reloads the dashboard through the *same* fresh-token path the existing 403 retry already uses, so recovery also survives a gateway secret that rotated while we were down.

It is bounded deliberately. A renderer that dies *during startup* would otherwise reload forever, burning CPU and hiding the failure — so after 3 deaths inside a 60s window recovery stops and logs. The window **slides**, which is what keeps a real-world once-a-day crash always recoverable while still catching a boot loop. A `clean-exit`, and any death while the app is quitting, are never treated as crashes.

**2. Make the next crash decidable.** Symptom: recurring crashes that yielded no new evidence. Root cause: the process state at death was never captured. Change: sample `app.getAppMetrics()` at the moment of death — *before* the reload, so it describes the crashed state and not the recovered one — and fold process count, total CPU, total working set and the largest process into the existing recovery log line. The probe is best-effort: a throwing `getAppMetrics` is reported and recovery proceeds regardless.

**3. Stop pre-warming Pierre's highlight worker pool in embedded panes.** Symptom: 20 `DedicatedWorker` threads in the renderer that died. Root cause: every warm remote-instance pane is a full copy of this SPA in its own realm, and any realm that evaluates `PierreImpl` spawns `PIERRE_WORKER_POOL_SIZE` (4) workers, each loading its own highlighter bundle plus a WASM regex engine — so the idle pre-warm in `main.tsx` multiplied 4 workers by the warm-set cap. Change: the idle pre-warm now runs only in the top-level dashboard.

Sampling the live renderer showed all 16 background workers blocked in `mach_msg2_trap` for **2368/2368 samples** — they burn no CPU, but each still holds a V8 isolate and a WASM engine inside the same renderer process that died. No pane a user opens becomes slower: the lazy import in `pierre/index.tsx` still creates the pool on the first real code surface, so a pane the user actually opens a diff in pays exactly the startup it used to pay on click.

**4. Ship the new module in the packaged app.** The local gate caught this before CI did: `renderer-recovery.js` is `require()`d by `main.js` but was absent from `electron/package.json` `build.files`, which is an explicit per-file allowlist. It works perfectly from source and is simply **missing from the DMG** — the packaged app would have thrown `Cannot find module './renderer-recovery'` at window creation, so the fix would have shipped as a startup crash. Added to the allowlist next to its sibling `gateway-recovery.js`; `electron/test/shell-contract.test.js` is the drift guard that flagged it and now passes.

**Scope note:** part 3 lowers a memory baseline in the process that crashed. It is deliberately **not** presented as the proven root cause of the abort — establishing that needs a heap snapshot, which part 2 exists to make possible on the next occurrence. Part 1 is the fix that stands on its own: it converts a permanent black window into a reload regardless of what the underlying abort turns out to be.

## Tests

13 `node:test` cases in `website/electron/test/renderer-recovery.test.js`, all against injected fakes (Electron main is not exercised by the unit runner):

- reloads on `crashed` and on `oom`
- never reloads on `clean-exit` (a normal teardown must not trigger recovery)
- never reloads while the app is quitting (recovery must not fight the shutdown)
- gives up after the bounded number of deaths inside the window, and reports via `onGiveUp`
- the window **slides** — six crashes a day apart all recover, proving the budget is not cumulative
- a throwing `reload` is contained and logged, never rethrown into Electron's emitter
- the process snapshot reaches both the reload line and the give-up line, and is handed to `onGiveUp`
- a throwing snapshot probe still lets recovery happen
- reason classification covers exactly the unexpected-death set

`electron/test/shell-contract.test.js` (pre-existing drift guard, 5 tests) now covers the new module's presence in the packaging allowlist.

## Manual verification

- Frontend `tsc -b` and `eslint` clean; `node --check` on the patched `main.js`.
- Confirmed `isQuitting` is module-scoped (`main.js:313`) so the injected gate reads real app state.
- Sampled the live renderer with 5 crews connected (`sample` + `top`): one renderer process, 47 threads, 16 `DedicatedWorker` threads all idle, ~19.3% instantaneous CPU, 1506MB RSS. That measurement is what identified the pre-warm multiplier in part 3 and ruled out a steady-state CPU problem.
- Verified the handler is attached to the RIGHT webContents. `mainWindow` is an Electron `BaseWindow` (`main.js:2022`), which has no `webContents` of its own; the dashboard lives in a `WebContentsView`. `setupWindowContents` aliases it (`main.js:1356`, `win.webContents = view.webContents`) and runs at `main.js:2027`, before this handler is attached at `main.js:2112` — so `render-process-gone` is observed on the view that actually hosts the dashboard, and the fix is not a no-op.
- Recovery itself is not unit-testable end to end without killing a live renderer; the coordinator's decisions are covered by the tests above, and the Electron wiring is a single `webContents.on("render-process-gone", ...)` handler.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the only frontend file touched is `website/src/main.tsx`, and the change there gates an idle `import()` pre-warm behind `isEmbeddedPane()` — it renders nothing and changes no pixel in any state; the remaining diff is Electron main-process code.

## Related Issues

no linked issue: found and diagnosed directly from local crash reports, with no pre-existing tracked issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs surface
- [x] No secrets, credentials, or internal references in the diff
