### PR TITLE
test: stop leaving bytecode in the checked-out skill tree

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
@@ -99,13 +99,26 @@ def run(args: list[str], cwd: Optional[str] = None) -> tuple[int, str, str]:
 
 
 def _load_sibling(module_name: str, filename: str) -> Any:
-    """Import a sibling script by path (the scripts dir is not a package)."""
+    """Import a sibling script by path (the scripts dir is not a package).
+
+    Bytecode writing is disabled for the exec. This script is run from a
+    checked-out worktree, so an ordinary import drops a ``__pycache__`` beside
+    the sibling and leaves it there -- an untracked directory appearing inside
+    the user's source tree every time the reviewer runs. prove.py takes the same
+    position from the other side, passing ``PYTHONDONTWRITEBYTECODE`` to the
+    pytest it spawns.
+    """
     path = os.path.join(HERE, filename)
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:  # pragma: no cover - defensive
         raise ParityError("cannot import sibling script {}".format(path))
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
     return module
 
 

--- a/test/skill_script_helpers.py
+++ b/test/skill_script_helpers.py
@@ -1,0 +1,69 @@
+"""Load a checked-in skill script as a module without leaving bytecode behind.
+
+The prepare-pr scripts live inside the checked-out source tree, so importing one
+the ordinary way drops a ``__pycache__`` entry beside it that outlives the run --
+a persistent mutation of the working copy, which the no-test-side-effects rule
+forbids.
+
+Five test modules each grew their own loader and none of them carried the guard.
+Measured one file at a time from a clean tree, they left this in
+``src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/__pycache__/``:
+
+===================================  ==========================================
+test module                          residue
+===================================  ==========================================
+``test_push_guard``                  ``push_guard.pyc``
+``test_prepare_pr_status``           ``pr_status.pyc``
+``test_prepare_pr_profiles``         ``pr_status.pyc``, ``resolve_profile.pyc``
+``test_prepare_pr_local_review``     ``local_review.pyc``, ``resolve_profile.pyc``
+``test_prepare_pr_findings``         ``pr_findings.pyc``, ``pr_status.pyc``
+===================================  ==========================================
+
+One helper rather than six copies of a three-line guard, because a guard that has
+to be remembered at each call site is one that will be missing at the seventh.
+``test_prepare_pr_prove`` had it and the others did not, which is exactly how
+that shape fails.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+
+@contextlib.contextmanager
+def no_bytecode() -> Iterator[None]:
+    """Disable bytecode writing for imports performed inside the block.
+
+    For call sites that import by NAME off ``sys.path`` (or reload), where there
+    is no spec to hand to :func:`load_skill_script`. Restores the previous value
+    rather than clearing it, so nesting and a caller that deliberately enables
+    writing both survive.
+    """
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        yield
+    finally:
+        sys.dont_write_bytecode = previous
+
+
+def load_skill_script(module_name: str, path: Path | str) -> ModuleType:
+    """Import the script at ``path`` under ``module_name``, writing no bytecode.
+
+    Not registered in ``sys.modules``: these scripts are loaded for unit-level
+    assertions on their helpers, and several test modules load the SAME script
+    under different names, so registering would let one test's copy answer
+    another's import.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, str(path))
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path} as {module_name}")
+    module = importlib.util.module_from_spec(spec)
+    with no_bytecode():
+        spec.loader.exec_module(module)
+    return module

--- a/test/test_prepare_pr_findings.py
+++ b/test/test_prepare_pr_findings.py
@@ -13,9 +13,10 @@ before the fix and prove nothing.
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
 from types import ModuleType
+
+from skill_script_helpers import load_skill_script
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
@@ -32,12 +33,7 @@ _SIG = "gVhM4aKLA8dyFH-oZlQx6SpYSNPkXA07kpDhWd6UhZI"  # 43 chars, base64url
 
 
 def _load_script() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("prepare_pr_findings", SCRIPT)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_skill_script("prepare_pr_findings", SCRIPT)
 
 
 class TestCredentialRedaction:
@@ -131,12 +127,7 @@ _OLD = "a" * 40
 
 
 def _load_status() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("prepare_pr_status_parity", STATUS_SCRIPT)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_skill_script("prepare_pr_status_parity", STATUS_SCRIPT)
 
 
 class TestMarkerRegexParity:

--- a/test/test_prepare_pr_local_review.py
+++ b/test/test_prepare_pr_local_review.py
@@ -21,7 +21,6 @@ test_prepare_pr_profiles.py. Everything here is stdlib and hermetic: the
 synthetic repos are real local git repos (as in test_push_guard.py) and every
 ``gh`` call is forced to fail so no test touches the network.
 """
-import importlib.util
 import inspect
 import json
 import os
@@ -32,6 +31,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from skill_script_helpers import load_skill_script
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_DIR = REPO_ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "prepare-pr"
@@ -45,15 +45,15 @@ OPUS_WORKFLOW = WORKFLOWS_DIR / "claude-review.yml"
 
 
 def _load(module_name, filename):
-    path = SCRIPTS_DIR / filename
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_skill_script(module_name, SCRIPTS_DIR / filename)
 
 
 local_review = _load("_pp_local_review", "local_review.py")
+
+#: The child processes below run local_review.py, which loads resolve_profile
+#: from the checked-out skill tree. A parent-side sys.dont_write_bytecode cannot
+#: reach another process, so the child needs the environment variable.
+NO_PYC = {"PYTHONDONTWRITEBYTECODE": "1"}
 
 KIROCREW_PROFILE = json.loads((PROFILES_DIR / "kirocrew.json").read_text(encoding="utf-8"))
 PROFILE_MODELS = {r["name"]: r for r in KIROCREW_PROFILE["reviewers"]}
@@ -523,7 +523,7 @@ def test_cli_exits_40_on_a_contract_that_escapes_the_repo(parity_repo, tmp_path)
             ],
             capture_output=True,
             text=True,
-            env={**os.environ, "PATH": os.environ.get("PATH", "")},
+            env={**os.environ, "PATH": os.environ.get("PATH", ""), **NO_PYC},
         )
         assert proc.returncode == local_review.EXIT_PARITY, proc.stderr
         assert "PARITY FAILURE" in proc.stderr
@@ -1223,7 +1223,7 @@ def test_cli_exits_40_when_the_prompt_heredoc_is_gone(parity_repo, tmp_path):
         ],
         capture_output=True,
         text=True,
-        env={**os.environ, "PATH": os.environ.get("PATH", "")},
+        env={**os.environ, "PATH": os.environ.get("PATH", ""), **NO_PYC},
     )
     assert proc.returncode == local_review.EXIT_PARITY, proc.stderr
     assert "PARITY FAILURE" in proc.stderr
@@ -1319,6 +1319,7 @@ def test_cli_json_summary_is_machine_readable(parity_repo, tmp_path):
         ],
         capture_output=True,
         text=True,
+        env={**os.environ, **NO_PYC},
     )
     assert proc.returncode == local_review.EXIT_OK, proc.stderr
     payload = json.loads(proc.stdout)

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -11,12 +11,13 @@ package, so we load them by path with importlib. Everything here is stdlib and
 runs on the full CI matrix (3.10 + 3.12); the TOML path is version-guarded
 because tomllib is 3.11+.
 """
-import importlib.util
 import json
 import os
 import re
 import sys
 from pathlib import Path
+
+from skill_script_helpers import load_skill_script
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_DIR = REPO_ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "prepare-pr"
@@ -25,12 +26,7 @@ PROFILES_DIR = SKILL_DIR / "profiles"
 
 
 def _load(module_name, filename):
-    path = SCRIPTS_DIR / filename
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_skill_script(module_name, SCRIPTS_DIR / filename)
 
 
 resolve_profile = _load("_pp_resolve_profile", "resolve_profile.py")

--- a/test/test_prepare_pr_prove.py
+++ b/test/test_prepare_pr_prove.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from skill_script_helpers import no_bytecode
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PROVE = str(
     REPO_ROOT
@@ -44,12 +46,10 @@ def _load_prove():
     dir, which the blocking no-test-side-effects rule forbids.
     """
     sys.path.insert(0, str(Path(PROVE).parent))
-    previous = sys.dont_write_bytecode
-    sys.dont_write_bytecode = True
     try:
-        return importlib.import_module("prove")
+        with no_bytecode():
+            return importlib.import_module("prove")
     finally:
-        sys.dont_write_bytecode = previous
         sys.path.pop(0)
 
 
@@ -410,17 +410,29 @@ def test_importing_prove_leaves_no_bytecode_in_the_checkout() -> None:
     nothing, which is the worse of the two failure directions. Evicting the
     module and removing the cache file first makes the import real and the
     verdict this loader's own.
+
+    Removing it is net-zero, and that matters: the same no-test-side-effects rule
+    this test enforces also binds the test. The file is restored byte-for-byte on
+    every exit path, so a working copy that had a stale .pyc still has it
+    afterwards, and one that did not is not given one by a failing assertion.
     """
     cache = Path(importlib.util.cache_from_source(PROVE))
+    existing = cache.read_bytes() if cache.exists() else None
     sys.modules.pop("prove", None)
     cache.unlink(missing_ok=True)
+    try:
+        module = _load_prove()
 
-    module = _load_prove()
-
-    cached = getattr(module, "__cached__", None)
-    assert cached, "expected __cached__ to be set"
-    assert Path(cached) == cache, f"cache path moved: {cached} is not {cache}"
-    assert not cache.exists(), f"import wrote bytecode to {cached}"
+        cached = getattr(module, "__cached__", None)
+        assert cached, "expected __cached__ to be set"
+        assert Path(cached) == cache, f"cache path moved: {cached} is not {cache}"
+        assert not cache.exists(), f"import wrote bytecode to {cached}"
+    finally:
+        if existing is None:
+            cache.unlink(missing_ok=True)
+        else:
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            cache.write_bytes(existing)
 
 
 def test_a_call_phase_exception_is_not_proof(tmp_path: Path) -> None:

--- a/test/test_prepare_pr_status.py
+++ b/test/test_prepare_pr_status.py
@@ -2,23 +2,19 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import re
 from pathlib import Path
 from types import ModuleType
+
+from skill_script_helpers import load_skill_script
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "prepare-pr" / "scripts" / "pr_status.py"
 
 
 def _load_script() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("prepare_pr_status", SCRIPT)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_skill_script("prepare_pr_status", SCRIPT)
 
 
 def _pr_payload(checks: list[dict[str, str]], **overrides: object) -> str:

--- a/test/test_push_guard.py
+++ b/test/test_push_guard.py
@@ -24,6 +24,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from skill_script_helpers import no_bytecode
 
 # Resolve the push_guard.py script path relative to the repo root.
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -1353,10 +1354,11 @@ class TestReplayFailClosed:
         if scripts_dir not in sys.path:
             sys.path.insert(0, scripts_dir)
 
-        import push_guard
+        with no_bytecode():
+            import push_guard
 
-        # Reload to get a fresh module state (avoids cross-test contamination).
-        importlib.reload(push_guard)
+            # Reload for fresh module state (avoids cross-test contamination).
+            importlib.reload(push_guard)
 
         # Monkeypatch the git command injection point.
         if fake_git_cmd is not None:
@@ -1544,7 +1546,8 @@ class TestClassifyFetchError:
         )
         if scripts_dir not in sys.path:
             sys.path.insert(0, scripts_dir)
-        from push_guard import _classify_fetch_error
+        with no_bytecode():
+            from push_guard import _classify_fetch_error
 
         return _classify_fetch_error
 
@@ -1650,9 +1653,10 @@ class TestFetchDiagnosticIntegration:
         )
         if scripts_dir not in sys.path:
             sys.path.insert(0, scripts_dir)
-        import push_guard
+        with no_bytecode():
+            import push_guard
 
-        importlib.reload(push_guard)
+            importlib.reload(push_guard)
         return push_guard
 
     def test_fetch_failure_with_bare_token_no_leak(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Closes out both follow-ups from [#4846](https://github.com/kirodotdev/KiroCrew/pull/4846) / [#4848](https://github.com/kirodotdev/KiroCrew/pull/4848): the five polluting test modules, and GPT's blocking finding on the prove test itself.

## What was actually wrong

Six loaders import prepare-pr scripts out of the checked-out source tree. **One disabled bytecode writing; five did not.** Measured one file at a time from a clean tree:

| test module | residue in `prepare-pr/scripts/__pycache__/` |
|---|---|
| `test_push_guard` | `push_guard.pyc` |
| `test_prepare_pr_status` | `pr_status.pyc` |
| `test_prepare_pr_profiles` | `pr_status.pyc`, `resolve_profile.pyc` |
| `test_prepare_pr_local_review` | `local_review.pyc`, `resolve_profile.pyc` |
| `test_prepare_pr_findings` | `pr_findings.pyc`, `pr_status.pyc` |
| `test_prepare_pr_prove` | *(none — it had the guard)* |

That is a persistent mutation of the working copy, which the no-test-side-effects rule forbids, and it is the residue that made a release-gate test blame a loader behaving correctly.

## One helper, not six copies of a guard

`test/skill_script_helpers.py` (following the existing `test/*_helpers.py` convention) provides `load_skill_script()` and a `no_bytecode()` context manager for the call sites that import by name off `sys.path`. Six bespoke loaders now route through it — because a guard that must be remembered at each call site is one that will be missing at the seventh, which is exactly how five of six ended up without it.

## Two of the six needed more than a guard

**A child process.** `test_prepare_pr_local_review` spawns `local_review.py`, and a parent-side `sys.dont_write_bytecode` cannot reach another process. Its three invocations now pass `PYTHONDONTWRITEBYTECODE` — the same thing `prove.py` already does for the pytest it spawns.

**Production code.** One residue survived every test-side fix, and the cause is not in the tests: `local_review.py`'s own `_load_sibling` imports `resolve_profile` by path, **lazily, inside `assemble()`**, with bytecode writing on. So the reviewer drops an untracked `__pycache__` into the user's own source tree on **every real run**, not just under pytest. Fixed there rather than papered over in the test — it is the same position `prove.py` already takes from the other side.

This is the only `src/` change in the PR. If it is unwanted, the honest consequence is that `test_prepare_pr_local_review` keeps leaving `resolve_profile.pyc` — there is no test-side workaround, since the calls are in-process.

## GPT's finding on the prove test, taken but not as prescribed

GPT blocked [#4848](https://github.com/kirodotdev/KiroCrew/pull/4848) with: *"test deletes a shared checkout cache it did not create"*, prescribing *"revert the cache-deletion hunk"*. The finding is right in letter — the test did mutate the checkout — but the prescription would restore the flake that #4846 fixed. So the mutation is now **net-zero** instead: the cache file is snapshotted and restored byte-for-byte on every exit path, including the failing one. A working copy that had a stale `.pyc` still has it afterwards; one that did not is not given one by a failed assertion.

## Verification

| probe | result |
|---|---|
| six files, each alone from a clean tree | residue **none** for all six |
| all six together | **306 passed**, residue none |
| net-zero: plant `PLANTED-BYTES`, run the prove test | sha256 **identical** before and after |
| absent stays absent | none |
| **sabotage the shared guard** → prove test | **fails** — still catches the regression it exists for |
| `test_local_gate.py` + `test_skills.py` (they read these files) | 153 passed |

`flake8`, `isort`, `mypy`, and the black gate are clean.

One thing worth flagging about the diff: an early `black` run on `test_prepare_pr_local_review.py` — a file in the black baseline — reformatted 117 unrelated lines and buried the ~20 lines of real change. That churn was reverted; the file's diff is 19 lines and the black gate passes without a baseline prune.

**Why no screenshot:** test and dev-script change, no user-visible surface.