### PR TITLE
fix(sel): bound security_events.jsonl by size and add a time-range read

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1328,6 +1328,17 @@ Examples:
     sec_sub.add_parser("deny-list", help="Show active deny patterns")
     sel_parser = sec_sub.add_parser("events", help="Show recent security event log entries")
     sel_parser.add_argument("-n", "--limit", type=int, default=20, help="Number of entries")
+    # A count alone cannot express "what happened around 14:05" — on a busy log
+    # 6000 entries reached only 15 minutes back, so answering a question about a
+    # two-hour-old event meant pulling ~90k entries and filtering by hand
+    # (issue #4843). Reading the file directly is correctly refused by the
+    # credential-path gate, so the time selector has to live here.
+    _time_help = (
+        "a relative age (30m, 2h, 7d) or an ISO 8601 instant "
+        "(2026-08-21, 2026-08-21T04:00:00Z)"
+    )
+    sel_parser.add_argument("--since", default="", help=f"Only entries at or after {_time_help}")
+    sel_parser.add_argument("--until", default="", help=f"Only entries before {_time_help}")
     sec_sub.add_parser("verify", help="Verify security event log HMAC integrity")
 
     # policy — governance model inspection (read-only; MCP-safe)

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -21,7 +21,7 @@ import urllib.parse
 import urllib.request
 from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from kiro_crew import __version__, beacon, platform_compat
@@ -1119,6 +1119,60 @@ def _cron_preview(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+_TIME_SELECTOR_RE = re.compile(r"(?i)\A(?P<value>\d+)(?P<unit>[smhdw])\Z")
+_TIME_SELECTOR_UNITS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+}
+
+
+def parse_time_selector(raw: str, *, now: datetime | None = None) -> datetime | None:
+    """Resolve a ``--since``/``--until`` selector to an aware UTC datetime.
+
+    Accepts a relative AGE (``30m``, ``2h``, ``7d``, ``1w``) meaning "that long
+    ago", or an absolute ISO 8601 instant (``2026-08-21``,
+    ``2026-08-21T04:00:00Z``). Empty input means "no bound" and returns ``None``.
+
+    A bare ISO date/time with no offset is read as UTC — the audit log is written
+    in UTC, so interpreting it as local time would silently shift the window by
+    the host's offset. ``Z`` is normalized because ``fromisoformat`` only accepts
+    it from Python 3.11 and this package supports 3.10.
+
+    Raises ``ValueError`` with the accepted forms spelled out, so a typo gets a
+    usable message instead of an empty result the caller reads as "no events".
+    An absurd but well-formed age (``999999999999999999w``) overflows
+    ``timedelta``; that surfaces as the same ``ValueError`` rather than an
+    uncaught ``OverflowError`` traceback, so the CLI still exits 2 with guidance.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    match = _TIME_SELECTOR_RE.match(text)
+    if match:
+        seconds = int(match.group("value")) * _TIME_SELECTOR_UNITS[match.group("unit").lower()]
+        try:
+            return (now or datetime.now(tz=timezone.utc)) - timedelta(seconds=seconds)
+        except (OverflowError, OSError):
+            raise ValueError(
+                f"{raw!r} is too far in the past to represent. Use a smaller age "
+                "(30m, 2h, 7d, 1w) or an ISO 8601 instant."
+            ) from None
+    iso = text[:-1] + "+00:00" if text.endswith(("Z", "z")) else text
+    try:
+        parsed = datetime.fromisoformat(iso)
+    except ValueError:
+        raise ValueError(
+            f"cannot read {raw!r} as a time. Use a relative age (30m, 2h, 7d, 1w) "
+            "or an ISO 8601 instant (2026-08-21, 2026-08-21T04:00:00Z)."
+        ) from None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _security(args: argparse.Namespace) -> None:
     """Security audit and deny list commands."""
 
@@ -1160,11 +1214,26 @@ def _security(args: argparse.Namespace) -> None:
     elif action == "events":
 
         limit = getattr(args, "limit", 20)
-        events = sel().recent(limit=limit)
+        try:
+            since = parse_time_selector(getattr(args, "since", "") or "")
+            until = parse_time_selector(getattr(args, "until", "") or "")
+        except ValueError as exc:
+            print(f"❌ {exc}")
+            sys.exit(2)
+        if since and until and since >= until:
+            print("❌ --since must be earlier than --until")
+            sys.exit(2)
+        events = sel().recent(limit=limit, since=since, until=until)
+        window = ""
+        if since or until:
+            window = (
+                f" in [{since.isoformat() if since else '-'}, "
+                f"{until.isoformat() if until else 'now'})"
+            )
         if not events:
-            print("No security events recorded.")
+            print(f"No security events recorded{window}.")
             return
-        print(f"📋 Last {len(events)} security event(s):\n")
+        print(f"📋 Last {len(events)} security event(s){window}:\n")
         for e in events:
             ts = e.get("timestamp", "?")[:19]
             etype = e.get("event_type", "?")

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4317,6 +4317,14 @@ _CREW_SECRET_LEAVES: list[str] = [
     # this gate.
     "trust",
     "security_events.jsonl",
+    # Rotated SEL segments. sel.py closes the live log at a size cap and renames
+    # it into this directory, so a segment holds exactly the same audit records
+    # the live file does and must be gated identically — a rotated log that the
+    # agent could read (or rewrite, then let the chain re-anchor from) would make
+    # rotation itself the way around the fence. Directory entry, so every
+    # segment is covered without a per-name matcher. sel.py opens segments
+    # directly, not through this gate.
+    "security_events.d",
     "app_admission.json",
     "security_policy.json",
     "profiles",

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -13,6 +13,13 @@ Storage: ``<config_dir>/security_events.jsonl`` (append-only JSONL); the HMAC
 signing key lives OUTSIDE the log directory in ``<config_dir>/trust/`` so an
 actor who can rewrite the log dir cannot also read the key and re-sign a
 clean-looking chain.
+Rotation: the live log is closed at ``_SEGMENT_MAX_BYTES`` and renamed into
+``<config_dir>/security_events.d/``, keeping ``_SEGMENT_KEEP`` closed segments.
+Each segment is an INDEPENDENT HMAC chain (it starts from genesis), and the
+first record of every new live log is a ``sel_rotation`` event naming the
+segment just closed and its final ``entry_hash`` — so the boundary is auditable
+evidence rather than a chain break, and retention deleting an old segment leaves
+every surviving segment verifiable on its own.
 Retention: configurable, default 365 days per Amazon Security Event Logging Standard.
 """
 
@@ -25,13 +32,17 @@ import json
 import logging
 import os
 import queue
+import re
+import stat
 import tempfile
 import threading
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import IO
 
 from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
@@ -54,6 +65,128 @@ def _default_dir() -> Path:
 
 _SEL_FILE = "security_events.jsonl"
 _RETENTION_DAYS = 365
+# ── Size rotation ──
+# The live log is closed (renamed into _SEGMENT_SUBDIR) once an append would
+# push it past _SEGMENT_MAX_BYTES, and at most _SEGMENT_KEEP closed segments are
+# retained, oldest deleted first. Without this the log grew without bound: a
+# long-running install reached 4.09 GB, at which point the sanctioned reader was
+# impractical and every append/read paid the size (issue #4843). The ceiling is
+# _SEGMENT_MAX_BYTES * (_SEGMENT_KEEP + 1) -- ~256 MiB, roughly 500k events at
+# the ~513 bytes/event measured on a real log. Age-based retention
+# (_RETENTION_DAYS, swept by prune()) still applies on top and is unchanged;
+# size rotation is what bounds the log BETWEEN those daily sweeps, which is the
+# window the 4.09 GB was accumulated in.
+# Closed segment: security_events-<6-digit sequence>-<UTC stamp>.jsonl. The
+# SEQUENCE, not the timestamp, orders segments: it is derived from the highest
+# one still on disk plus one, so it keeps increasing across retention deletions
+# and is immune to a clock step (an NTP correction that moved the wall clock
+# backwards would otherwise mint a name sorting as the OLDEST segment, and
+# retention would delete the newest log). The stamp is carried for humans
+# reading the directory. Retention must never delete a merely prefix-matching
+# file an operator parked here, so the pattern is matched in full.
+_SEGMENT_SUBDIR = "security_events.d"
+_SEGMENT_MAX_BYTES = 32 * 1024 * 1024
+_SEGMENT_KEEP = 7
+_SEGMENT_NAME_RE = re.compile(
+    r"security_events-(?P<seq>\d{6,})-(?P<stamp>\d{8}T\d{6}Z)\.jsonl"
+)
+# Cross-process rotation mutex. It lives INSIDE the segment dir so it inherits
+# that directory's sensitive-path fence: a lock file the agent could hold would
+# let it suppress rotation and bring back the unbounded growth. Not a segment
+# name, so _segments_oldest_first() never sees it and retention never deletes it.
+_ROTATE_LOCK_FILE = ".rotate.lock"
+# Ceiling on entries examined when enumerating segments. Rotation itself keeps at
+# most _SEGMENT_KEEP + 1 files there, so a larger directory is someone else's
+# doing; the walk runs on the append path (where a critical audit is written
+# inline, sometimes on the event loop) and must not scale with a directory an
+# agent filled before this release.
+_SEGMENT_SCAN_CAP = 4096
+# Re-chain attempts when a concurrent rotation replaces the live log between
+# chaining and appending. Each collision is a lost microsecond race; after this
+# many the record is written unguarded, because a missing audit record is worse
+# than one suspect chain link.
+_APPEND_RETRIES = 3
+# Ceiling on collision probes when minting a segment name. Each probe is a
+# filesystem stat on the append path (where a critical audit is written inline,
+# sometimes on the event loop), so a directory pre-filled with consecutive
+# segment names must not be able to make rotation stat its way through it.
+_SEGMENT_NAME_PROBES = 64
+
+
+class _LiveLogReplaced(Exception):
+    """The live log was swapped by another process between chaining and appending.
+
+    Internal control flow only: raised by ``_append_lines_locked`` BEFORE anything
+    is written and handled by ``_append_chained_locked``, which re-anchors and
+    chains the batch again. Never escapes the module.
+    """
+
+
+class SelChainContention(OSError):
+    """Repeated foreign writes prevented a correctly-chained append.
+
+    Deliberately an ``OSError``: this class already has one answer for an audit
+    that cannot be written, and it is not "write it wrong". A ``critical=True``
+    caller re-raises and refuses the action it was about to audit (audit-or-deny),
+    and the background writer drops the batch with a warning exactly as it does
+    for a full disk. Raising the same TYPE those paths already handle keeps that
+    behaviour without a new branch at either site.
+
+    Reaching this needs a foreign write to land between our chaining and our open
+    on every one of ``_APPEND_RETRIES + 1`` attempts.
+    """
+
+
+def _live_log_moved_on(
+    previous: tuple[int, int, int], current: tuple[int, int, int]
+) -> bool:
+    """Whether the live log is no longer the file+position *previous* describes.
+
+    Both arguments are ``(st_dev, st_ino, st_size)``. ONE predicate serves both the
+    pre-append check and the post-open guard, because they are asking the same
+    question and answering it differently is how a stale tip survives a collision:
+    a detector that fires on growth paired with a re-anchor that only reacts to a
+    shrink leaves the retry writing the very ``prev_hash`` the collision proved
+    wrong.
+
+    Two independent signals:
+
+    * a DIFFERENT inode -- the file was replaced (a rotation). Skipped when either
+      inode is 0, which some Windows filesystems report instead of a usable index.
+    * a DIFFERENT size -- somebody appended, so the file no longer ends where we
+      chained from. This also covers the case no inode comparison can see: a
+      rotator anchored on an ABSENT replacement has no inode, and only the size
+      reveals that another process already put a record there.
+
+    Our OWN writes never trip this. The anchor is refreshed from the fd's
+    post-write ``fstat`` on every append, so a difference means somebody else.
+    """
+    prev_dev, prev_ino, prev_size = previous
+    cur_dev, cur_ino, cur_size = current
+    if prev_ino and cur_ino and (prev_ino, prev_dev) != (cur_ino, cur_dev):
+        return True
+    return prev_size != cur_size
+
+
+def _identity_changed(expect: tuple[int, int, int], actual: os.stat_result) -> bool:
+    """Whether an opened fd is no longer the file+position *expect* describes.
+
+    Thin adapter over :func:`_live_log_moved_on` so the guard and the pre-append
+    check cannot drift apart.
+    """
+    return _live_log_moved_on(expect, (actual.st_dev, actual.st_ino, actual.st_size))
+
+
+# Tail-read chunk for recent(): the log is append-only, so the newest records
+# live at the END. Reading backward in chunks keeps a bounded read bounded
+# instead of loading the whole segment (the old recent() did
+# read_text().splitlines(), i.e. a 4.09 GB allocation to print 20 lines).
+_TAIL_CHUNK_BYTES = 256 * 1024
+# Ceiling on bytes held while looking for a line boundary in the backward reader.
+# A real SEL record is a few hundred bytes; anything past this has no newline in
+# it, which means a truncated write or a file someone else placed there. Bounds
+# the memory an attacker-influenced segment can make a reader allocate.
+_MAX_LINE_BYTES = 4 * 1024 * 1024
 _HMAC_KEY_FILE = "sel_hmac.key"
 # Dedicated trust-root subdirectory (owner-only, 0o700) holding the HMAC key.
 # The key must not live NEXT TO the log it signs: an actor with write access to
@@ -143,11 +276,17 @@ class SecurityEventLog:
         self._sync = sync
         self._dir = base_dir or _default_dir()
         self._path = self._dir / _SEL_FILE
+        self._segment_dir = self._dir / _SEGMENT_SUBDIR
         # _lock guards _last_hash + the file append (held only inside the writer
         # thread and by synchronous fallbacks / prune, never by enqueuing callers).
         self._lock = threading.Lock()
         self._hmac_key = self._load_or_create_hmac_key()
         self._last_hash = self._read_last_hash()
+        # Identity of the live log as of our last observation, so a replacement
+        # by another process (its rotation) is detected before we chain off a tip
+        # that has moved into the closed segment. Seeded here because
+        # _read_last_hash above just anchored us to THIS file.
+        self._live_seen: tuple[int, int, int] | None = self._live_identity()
         self._forward_callback: Callable[[dict], None] | None = None
         # Background writer: callers enqueue (non-blocking) and one daemon thread
         # maintains the HMAC chain + batches appends off the hot path. Lazily
@@ -228,7 +367,12 @@ class SecurityEventLog:
             if self._pending == 0:
                 self._pending_cond.notify_all()
 
-    def _flush_batch(self, events: list[SecurityEvent], *, raise_on_error: bool = False) -> None:
+    def _flush_batch(
+        self,
+        events: list[SecurityEvent],
+        *,
+        raise_on_error: bool = False,
+    ) -> None:
         """Append a batch of events under the chain lock, then forward them.
 
         When ``raise_on_error=True`` a filesystem failure (unwritable SEL file,
@@ -236,6 +380,15 @@ class SecurityEventLog:
         back, so a fail-closed caller (critical audit) can refuse the action it
         was about to audit. The default (async writer / best-effort) swallows
         the error and keeps the writer thread alive.
+
+        Whether this batch may ROTATE is decided by :meth:`_may_rotate`, not by the
+        call site. Rotation does filesystem work -- a directory scan, a rename, a
+        retention sweep -- and several paths reach this method INLINE on their
+        caller's thread, which for an async handler is the event loop
+        (``no-blocking-call-on-event-loop``): a critical audit, and the fallback
+        taken when the writer thread cannot be started. Deriving the permission
+        from the running thread means a future inline caller cannot reintroduce
+        that stall by forgetting a flag.
         """
         callback: Callable[[dict], None] | None
         with self._lock:
@@ -246,58 +399,175 @@ class SecurityEventLog:
                     raise
                 logger.warning("SEL dir create failed for %d events", len(events), exc_info=True)
                 return
-            # Remember the chain tip so we can roll back if the append fails:
-            # we advance _last_hash per event below, but nothing is persisted
-            # until the write() succeeds. Without the rollback, a failed write
-            # would leave _last_hash pointing at a phantom hash never on disk,
-            # and the next batch would chain off it — silently corrupting the
-            # HMAC chain (verify_integrity would then report a break).
-            prev_last_hash = self._last_hash
-            lines: list[str] = []
-            for event in events:
-                event.prev_hash = self._last_hash
-                event.entry_hash = self._compute_hash(event)
-                lines.append(json.dumps(asdict(event)) + "\n")
-                self._last_hash = event.entry_hash
-            try:
-                # Use os.open with explicit 0o600 mode to prevent other users
-                # from reading the security audit log.
-                fd = os.open(
-                    self._path,
-                    os.O_CREAT | os.O_APPEND | os.O_WRONLY,
-                    0o600,
-                )
-                with os.fdopen(fd, "a", encoding="utf-8") as f:
-                    # If a crash mid-append left a truncated tail line WITHOUT a
-                    # trailing newline, writing directly (O_APPEND) would glue
-                    # this record onto the corrupt fragment, forming a single
-                    # unparseable line. _read_last_hash() recovers the correct
-                    # prev_hash from the last complete record, but that glued
-                    # line stays unreadable by verify_integrity — so the new
-                    # event, though correctly chained, is orphaned from every
-                    # parseable record. Insert a newline boundary first so the
-                    # new record starts on a fresh, parseable line. We do NOT
-                    # truncate the corrupt fragment: the SEL log is append-only
-                    # forensic evidence, and the fragment is preserved as its
-                    # own (skipped) line.
-                    if self._ends_without_newline():
-                        f.write("\n")
-                    f.write("".join(lines))
-                # Ensure permissions are correct even if file pre-existed with
-                # wrong mode (e.g. created by an older version).
+            # Close the live log first when it is already at the size cap, so
+            # this batch lands in a fresh segment, and keep the cross-process
+            # rotation lock held across our own chain + append (see
+            # _rotation_window). Rotation is best-effort and never raises: a
+            # rotation that cannot happen must not stop the audit record it
+            # precedes from being written.
+            with self._rotation_window() if self._may_rotate() else _no_rotation():
+                # Remember the chain tip so we can roll back if the append
+                # fails: we advance _last_hash per event below, but nothing is
+                # persisted until the write() succeeds. Without the rollback, a
+                # failed write would leave _last_hash pointing at a phantom hash
+                # never on disk, and the next batch would chain off it —
+                # silently corrupting the HMAC chain (verify_integrity would
+                # then report a break). Read INSIDE the window: rotation resets
+                # the tip to genesis, and rolling back to a pre-rotation tip
+                # would chain this batch off a record in a different segment.
                 try:
-                    os.chmod(self._path, 0o600)
+                    self._append_chained_locked(events)
                 except OSError:
-                    logger.warning("Failed to enforce 0o600 permissions on SEL audit log %s", self._path, exc_info=True)
-            except OSError:
-                self._last_hash = prev_last_hash  # nothing persisted — roll back
-                if raise_on_error:
-                    raise
-                logger.warning("SEL append failed for %d events", len(events), exc_info=True)
+                    if raise_on_error:
+                        raise
+                    logger.warning(
+                        "SEL append failed for %d events", len(events), exc_info=True
+                    )
             callback = self._forward_callback
         if callback:
             for event in events:
                 self._forward_event(callback, event)
+
+    def _append_chained_locked(self, events: list[SecurityEvent]) -> None:
+        """Chain *events* onto the live log, re-chaining if it moves under us.
+
+        Caller holds ``_lock``. The tip is rolled back on any failure so a
+        record never chains off a hash that was not persisted.
+
+        The retry exists because the append is deliberately lock-free (a blocking
+        cross-process acquire on this path could park an event-loop caller writing
+        a critical audit). Instead of serializing, the append VALIDATES the file it
+        opened and re-chains when another process moved it on — see
+        :meth:`_append_lines_locked`.
+
+        EVERY attempt is validated, including the last. When the retries are
+        exhausted the batch is NOT written; :class:`SelChainContention` is raised.
+
+        An earlier revision wrote the final attempt unguarded, reasoning that a
+        missing audit record is worse than one suspect chain link. That was wrong
+        twice over. A knowingly-broken link does not read as "one imperfect
+        record" -- it makes ``security verify`` report the log as COMPROMISED, and
+        an investigator cannot tell that false signal apart from real tampering.
+        This PR already deleted the rotation record's predecessor-hash claim on
+        exactly that principle (a check that can fire on a benign cause is worse
+        than no check); writing a bad link is the same mistake with the sign
+        flipped. And it invented a third behaviour: this class already answers an
+        unwritable audit by DENYING the action (``critical=True``, audit-or-deny)
+        or by dropping the batch with a warning (best-effort) -- never by writing
+        something it knows to be corrupt.
+
+        Raising an ``OSError`` subclass is what routes it correctly with no new
+        plumbing: a critical caller re-raises and refuses the action it was about
+        to audit, and the background writer treats it exactly as it already treats
+        a full disk.
+        """
+        for attempt in range(_APPEND_RETRIES + 1):
+            prev_last_hash = self._last_hash
+            lines = self._chain_locked(events)
+            try:
+                self._append_lines_locked(lines, expect=self._live_seen)
+                return
+            except _LiveLogReplaced:
+                # The guard proved the file moved on between our chaining and our
+                # open, and the records were never written. Roll the tip back, then
+                # re-anchor UNCONDITIONALLY -- the question the predicate would ask
+                # has already been answered by the collision itself.
+                self._last_hash = prev_last_hash
+                logger.info(
+                    "SEL live log moved on mid-append; re-chaining this batch "
+                    "(attempt %d of %d)",
+                    attempt + 1,
+                    _APPEND_RETRIES + 1,
+                )
+                self._reanchor_now()
+            except OSError:
+                self._last_hash = prev_last_hash  # nothing persisted — roll back
+                raise
+        raise SelChainContention(
+            f"could not append {len(events)} SEL event(s) with a valid chain link "
+            f"after {_APPEND_RETRIES + 1} attempts: another process kept writing to "
+            "the live log between chaining and appending"
+        )
+
+    def _chain_locked(self, events: list[SecurityEvent]) -> list[str]:
+        """Stamp the HMAC chain onto *events* and return their JSONL lines.
+
+        Advances ``_last_hash`` per event. Caller holds ``_lock`` and is
+        responsible for rolling the tip back if the write does not land.
+        """
+        lines: list[str] = []
+        for event in events:
+            event.prev_hash = self._last_hash
+            event.entry_hash = self._compute_hash(event)
+            lines.append(json.dumps(asdict(event)) + "\n")
+            self._last_hash = event.entry_hash
+        return lines
+
+    def _append_lines_locked(
+        self, lines: list[str], *, expect: tuple[int, int, int] | None = None
+    ) -> None:
+        """Append already-chained JSONL *lines* to the live log. Caller holds ``_lock``.
+
+        ``expect`` is the identity of the file whose tip *lines* were chained from.
+        When given, the file actually opened is validated BY FD before anything is
+        written, and :class:`_LiveLogReplaced` is raised if it is a different file.
+
+        This is what makes a lock-free append safe against a concurrent rotation,
+        and why the check is on the FD rather than on the path. Two outcomes, both
+        correct:
+
+        * the rename has NOT happened yet -- we hold the old inode, the identity
+          matches, we write, and the winner's rename carries our record into the
+          segment still correctly chained off the tip we used;
+        * the rename HAS happened -- ``O_CREAT`` gave us a brand-new file with a
+          different inode, we notice before writing, and the caller re-anchors and
+          re-chains instead of leaving a record whose ``prev_hash`` lives in
+          another file.
+
+        A path ``stat`` cannot do this: whatever it observed may be replaced before
+        the ``open`` that follows it.
+        """
+        # Use os.open with explicit 0o600 mode to prevent other users
+        # from reading the security audit log.
+        fd = os.open(
+            self._path,
+            os.O_CREAT | os.O_APPEND | os.O_WRONLY,
+            0o600,
+        )
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            actual = os.fstat(f.fileno())
+            if expect is not None and _identity_changed(expect, actual):
+                raise _LiveLogReplaced(
+                    "live log was replaced between chaining and appending"
+                )
+            # If a crash mid-append left a truncated tail line WITHOUT a
+            # trailing newline, writing directly (O_APPEND) would glue
+            # this record onto the corrupt fragment, forming a single
+            # unparseable line. _read_last_hash() recovers the correct
+            # prev_hash from the last complete record, but that glued
+            # line stays unreadable by verify_integrity — so the new
+            # event, though correctly chained, is orphaned from every
+            # parseable record. Insert a newline boundary first so the
+            # new record starts on a fresh, parseable line. We do NOT
+            # truncate the corrupt fragment: the SEL log is append-only
+            # forensic evidence, and the fragment is preserved as its
+            # own (skipped) line.
+            if self._ends_without_newline():
+                f.write("\n")
+            f.write("".join(lines))
+            f.flush()
+            # Record what we wrote to from the FD, not the path: if a rotation
+            # renames the path immediately after this write, the file we actually
+            # appended to is the one we must remember, so the NEXT append's guard
+            # can see that it has moved on.
+            written = os.fstat(f.fileno())
+        # Ensure permissions are correct even if file pre-existed with
+        # wrong mode (e.g. created by an older version).
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError:
+            logger.warning("Failed to enforce 0o600 permissions on SEL audit log %s", self._path, exc_info=True)
+        self._live_seen = (written.st_dev, written.st_ino, written.st_size)
 
     def _forward_event(self, callback: Callable[[dict], None], event: SecurityEvent) -> None:
         """Redact and forward a single event to the centralized sink."""
@@ -585,6 +855,501 @@ class SecurityEventLog:
             )
         return key
 
+    @contextmanager
+    def _rotation_window(self) -> Iterator[None]:
+        """Rotate if the live log is at the cap, holding the lock over the body.
+
+        Caller holds ``_lock``. The body is the caller's chain + append.
+
+        Below the cap -- the overwhelmingly common case -- this is a single
+        ``stat`` and no lock at all, so a normal append pays nothing.
+
+        At the cap it takes a CROSS-PROCESS lock, because ``_lock`` is a thread
+        lock and SEVERAL PROCESSES share one data home (the gateway, the CLI,
+        cron), all appending to this same file. They therefore reach the cap at
+        the same moment, and two things go wrong unserialized:
+
+        * both pick the same target name, and the second ``os.replace`` moves the
+          freshly recreated live log onto the segment the first just closed,
+          destroying it;
+        * the loser keeps its pre-rotation chain tip and appends from it, so its
+          first record in the new log names a ``prev_hash`` that is not in that
+          file and ``security verify`` reports an untampered log as compromised.
+
+        The acquire is NON-BLOCKING and the whole window is best-effort. A
+        critical (``audit-or-deny``) event is written INLINE on its caller's
+        thread, and some of those callers are event-loop coroutines, so a
+        blocking acquire here could park the loop on another process's rotation —
+        the ``no-blocking-call-on-event-loop`` hazard. Rotation is never worth
+        that: it is deferrable (the next batch retries) while an audit write is
+        not.
+
+        Skipping on contention does NOT leave the loser appending from a stale
+        tip, which is the reason the lock spans the append at all: the contended
+        path re-checks the live log's identity and re-anchors the tip immediately
+        before the caller chains (see :meth:`_reanchor_if_replaced`). A rotation
+        that lands between that check and the append is the residual, and it is
+        the pre-existing cross-process interleaving race rather than an
+        escalation of it -- closing THAT means holding a cross-process lock
+        across every audit write, which is both the event-loop hazard above and
+        the hot-path cost #4247 is about.
+
+        Every failure -- an uncreatable/planted segment dir, a planted or
+        unopenable lock file -- yields WITHOUT rotating so the audit record still
+        lands.
+        """
+        if self._reanchor_if_replaced() < _SEGMENT_MAX_BYTES or not self._ensure_segment_dir():
+            yield
+            return
+        lock_fh = self._open_rotation_lock()
+        if lock_fh is None:
+            yield
+            return
+        try:
+            if not platform_compat.try_acquire_lock(lock_fh.fileno(), exclusive=True):
+                # Another process is rotating right now. Do not wait (see above)
+                # and do not trust the tip we anchored before it started.
+                logger.debug("SEL rotation lock busy; deferring rotation to the next batch")
+                self._reanchor_if_replaced()
+                yield
+                return
+            try:
+                self._rotate_under_lock()
+                yield
+            finally:
+                platform_compat.release_lock(lock_fh.fileno())
+        finally:
+            lock_fh.close()
+
+    def _open_rotation_lock(self) -> IO[bytes] | None:
+        """Open the rotation mutex, refusing a planted link. ``None`` if unusable.
+
+        The path must never be followed through a symlink/junction: opening it
+        CREATES the file and ``chmod``s it, so a link planted before this release
+        (when ``security_events.d`` was not on the sensitive-path floor) would
+        have rotation write a byte into, and relax the mode of, whatever the agent
+        pointed it at. Same defense and same helpers as the segment dir and the
+        SEL trust dir -- the link is removed, never its target -- and if the link
+        cannot be removed we decline to rotate rather than open through it.
+        """
+        lock_path = self._segment_dir / _ROTATE_LOCK_FILE
+        if platform_compat.is_link_or_junction(lock_path):
+            logger.warning(
+                "SEL rotation lock %s is a symlink/junction — removing the link "
+                "(planted before upgrade?)",
+                lock_path,
+            )
+            try:
+                platform_compat.unlink_link_or_junction(lock_path)
+            except OSError:
+                logger.warning(
+                    "cannot remove linked SEL rotation lock %s; refusing to rotate "
+                    "rather than open through the link",
+                    lock_path,
+                    exc_info=True,
+                )
+                return None
+        try:
+            # "a+b": msvcrt.locking needs a writable fd and locks a byte range,
+            # so the file must be non-empty (same shape as metrics retention).
+            lock_fh = open(lock_path, "a+b")
+        except OSError:
+            logger.warning("SEL rotation lock %s could not be opened", lock_path, exc_info=True)
+            return None
+        try:
+            lock_fh.seek(0, os.SEEK_END)
+            if lock_fh.tell() == 0:
+                lock_fh.write(b"\0")
+                lock_fh.flush()
+            try:
+                os.chmod(lock_path, 0o600)
+            except OSError:
+                pass  # perms are hygiene here; the file holds no data
+        except OSError:
+            lock_fh.close()
+            logger.warning("SEL rotation lock %s could not be primed", lock_path, exc_info=True)
+            return None
+        return lock_fh
+
+    def _may_rotate(self) -> bool:
+        """Whether the CURRENT thread is allowed to do rotation's filesystem work.
+
+        Only the dedicated writer thread, or ``sync=True`` (a test mode that has no
+        writer thread and whose caller is the test itself).
+
+        Every other route into ``_flush_batch`` runs inline on a caller's thread
+        that may be the asyncio event loop -- the ``critical=True`` audit-or-deny
+        write, and the fallback taken when ``_ensure_writer`` cannot start the
+        thread. A directory scan plus a rename plus a retention sweep there stalls
+        every gateway task. Rotation is deferrable and an audit write is not, so
+        those paths write the record and leave rotation to the writer's next batch.
+
+        Checked here rather than at each call site on purpose: the previous
+        revision passed a flag from the critical path only, and the writer-start
+        fallback -- added for a different reason and easy to overlook -- kept
+        rotating on whatever thread it landed on.
+        """
+        if self._sync:
+            return True
+        writer = self._writer
+        return writer is not None and threading.current_thread() is writer
+
+    def _live_size(self) -> int:
+        """Size of the live log on disk, or 0 when it is absent/unreadable."""
+        try:
+            return self._path.stat().st_size
+        except OSError:
+            return 0
+
+    def _live_identity(self) -> tuple[int, int, int]:
+        """``(st_dev, st_ino, st_size)`` of the live log, zeros when absent."""
+        try:
+            st = self._path.stat()
+        except OSError:
+            return (0, 0, 0)
+        return (st.st_dev, st.st_ino, st.st_size)
+
+    def _reanchor_if_replaced(self) -> int:
+        """Refresh the cached chain tip if the live log was replaced. Returns its size.
+
+        Caller holds ``_lock``. This is the ONE stat the rotation check already
+        needed, so detecting a foreign rotation is free.
+
+        Why it is needed: several processes share one data home and append to this
+        file, each caching its own tip in ``_last_hash`` and never re-reading it.
+        When ANOTHER process rotates, this process's next append usually does not
+        see the cap at all (the live log is small and fresh), so it never enters
+        the rotation window — and it would chain its record off a tip that now
+        lives inside the closed segment. Unlike the pre-existing interleaving
+        race, which needs two appends to actually collide, that break is
+        GUARANTEED for every process after every foreign rotation, so rotation
+        must not leave it standing.
+
+        Detection needs no lock and no extra syscall. The live log is append-only,
+        so it can never shrink: a smaller size than we last wrote means the file
+        was replaced. ``st_ino`` catches the same event where the filesystem
+        reports it (a fresh file gets a new inode), and is skipped when either
+        side reports 0 — some Windows filesystems do not supply a file index.
+
+        The residual after this is the pre-existing one: a rotation landing
+        between this stat and our append. Closing THAT means holding a
+        cross-process lock across every audit write, which is the hot-path cost
+        #4247 is about, so it stays measured rather than paid for here.
+        """
+        identity = self._live_identity()
+        previous = self._live_seen
+        self._live_seen = identity
+        if previous is not None and _live_log_moved_on(previous, identity):
+            logger.info(
+                "SEL live log moved on since our last write (another process "
+                "rotated or appended); re-reading the chain tip before appending"
+            )
+            self._last_hash = self._read_last_hash()
+        return identity[2]
+
+    def _reanchor_now(self) -> None:
+        """Re-read the chain tip and the live log's identity, unconditionally.
+
+        For the collision path, where the append guard has ALREADY proved the file
+        moved on. There is nothing left to decide there, so this must not route
+        through :meth:`_reanchor_if_replaced`'s predicate: an earlier revision did,
+        and because that predicate reacted only to a shrink while the guard fired
+        on growth too, a foreign APPEND was detected and then not corrected -- the
+        retry re-chained from the same tip the collision had just invalidated and
+        wrote it. Both now share one predicate, and this path skips it entirely.
+        """
+        self._live_seen = self._live_identity()
+        self._last_hash = self._read_last_hash()
+
+    def _ensure_segment_dir(self) -> bool:
+        """Create the segment dir (owner-only), refusing a planted link.
+
+        Returns whether the real directory is now usable. Rotation must NEVER
+        write through a symlink/junction at this path: before this release
+        ``security_events.d`` was not on the sensitive-path floor, so an agent
+        could have pre-planted a link pointing somewhere it can read, and
+        ``mkdir(exist_ok=True)`` succeeds on a link-to-directory. The segments
+        would then land outside the fence, readable and rewritable by the audited
+        agent — rotation itself becoming the way around it. Same defense, and the
+        same helpers, as the SEL trust dir in
+        :meth:`_load_or_create_hmac_key`; the link is removed, never its target.
+
+        When the link cannot be removed (read-only dir) we REFUSE to rotate. The
+        live log then keeps growing, which is the failure this release exists to
+        bound — but an oversized log inside the fence beats a bounded one outside
+        it.
+        """
+        if platform_compat.is_link_or_junction(self._segment_dir):
+            logger.warning(
+                "SEL segment dir %s is a symlink/junction — removing the link "
+                "(planted before upgrade?) and creating a real directory",
+                self._segment_dir,
+            )
+            try:
+                platform_compat.unlink_link_or_junction(self._segment_dir)
+            except OSError:
+                logger.warning(
+                    "cannot remove linked SEL segment dir %s; refusing to rotate "
+                    "rather than write audit segments through the link",
+                    self._segment_dir,
+                    exc_info=True,
+                )
+                return False
+        try:
+            self._segment_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        except OSError:
+            logger.warning("SEL segment dir %s could not be created", self._segment_dir, exc_info=True)
+            return False
+        platform_compat.chmod_safe(self._segment_dir, 0o700)
+        return True
+
+    def _rotate_under_lock(self) -> None:
+        """Perform one rotation. Caller holds ``_lock`` AND the rotation lock.
+
+        The size is re-read here, not trusted from the check that opened the
+        window: a sibling process may have rotated while we waited for the lock.
+
+        The check reads the size ALREADY ON DISK, so a segment can overshoot the
+        cap by at most the batch being appended (``_QUEUE_DRAIN_BATCH`` events,
+        ~128 KiB against a 32 MiB cap). That keeps rotation one ``stat`` per
+        batch instead of serializing every batch twice to measure it first.
+
+        Chain semantics: the closed segment keeps its own complete chain and the
+        new live log starts from genesis, so BOTH verify independently and
+        retention deleting an old segment can never break a surviving one. The
+        boundary is not lost — it is recorded as the new log's first entry, a
+        ``sel_rotation`` event naming the closed segment and its final
+        ``entry_hash``. An investigator can therefore still walk segment to
+        segment, and a segment that was deleted or swapped is visible as a
+        rotation record whose named predecessor is absent or ends on a different
+        hash.
+        """
+        size = self._live_size()
+        if size < _SEGMENT_MAX_BYTES:
+            # A sibling process rotated while we waited for the lock. Our cached
+            # chain tip now lives in a closed segment, so appending from it would
+            # chain this process's next batch off a record in a different file.
+            # Re-anchor on the live log we are about to append to — safe to trust
+            # because the caller holds the lock across that append.
+            self._last_hash = self._read_last_hash()
+            return
+        target = self._next_segment_path()
+        if target is None:
+            return  # no free name; rotation deferred (see _next_segment_path)
+        try:
+            os.replace(self._path, target)
+        except OSError:
+            logger.warning(
+                "SEL rotation failed; continuing to append to %s", self._path, exc_info=True
+            )
+            return
+        logger.info("SEL rotated %s -> %s (%d bytes)", self._path, target, size)
+        # Anchor on the REPLACEMENT log -- normally absent, so genesis -- and write
+        # the rotation record through the guarded append rather than assuming it
+        # lands first. Another process can create and append to the replacement in
+        # the gap after the rename (it sees a small file, so it never enters the
+        # rotation window and never takes this lock). Writing a genesis record
+        # blindly would then put TWO records claiming an empty prev_hash in the new
+        # log and break its chain from the second line. The guard notices the file
+        # already has content and the record chains off it instead, so the rotation
+        # record is the first one we could place rather than necessarily line 1.
+        self._reanchor_if_replaced()
+        try:
+            self._append_chained_locked([self._rotation_event(target, size)])
+        except OSError:
+            # The boundary record is lost but nothing is corrupt: the new log simply
+            # starts without one. _append_chained_locked already rolled the tip back
+            # to what it was, so the next batch chains off a record that is really
+            # on disk.
+            logger.warning("SEL rotation record could not be written", exc_info=True)
+        self._enforce_segment_retention_locked()
+
+    def _rotation_event(self, segment: Path, closed_bytes: int) -> SecurityEvent:
+        """Build the ``sel_rotation`` record that opens a freshly rotated log.
+
+        It names the segment just closed and its size, and DELIBERATELY does not
+        claim that segment's final ``entry_hash``.
+
+        An earlier revision did. The claim looked valuable -- it would let
+        verification notice a predecessor that had been swapped -- but it cannot be
+        made true without serializing every append: a segment is not immutable the
+        instant it is renamed, because another process may still hold a writable fd
+        to that inode and land a record after the tip is read. Any hash captured
+        here can therefore be stale by the time the record is written, and the
+        result is the WORST failure mode available: verification reporting an
+        untampered log as compromised, from an entirely benign cause.
+
+        Nothing is lost by dropping it, because forgery detection never rested on
+        it. A planted or rewritten segment cannot produce valid per-record HMACs at
+        all (the key lives outside the log directory), so ``verify_integrity``
+        already reports its entries as invalid and the read path already refuses to
+        present them. The segment NAME is what an investigator actually needs to
+        walk the sequence, and a name is not a claim that can go stale.
+        """
+        return SecurityEvent(
+            event_id=uuid.uuid4().hex[:16],
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+            event_type="sel_rotation",
+            caller_identity="_host",
+            agent="kirocrew",
+            source="host",
+            operation="sel.rotate",
+            outcome="completed",
+            # Only the file NAME, never the absolute path: the record is
+            # forwarded to the centralized sink and read back by operators, and
+            # the segment always lives in this log's own segment dir.
+            resources=segment.name,
+            metadata={
+                "previous_segment": segment.name,
+                "previous_bytes": closed_bytes,
+            },
+        )
+
+    def _next_segment_path(self) -> Path | None:
+        """An unused segment path for the log being closed now, or ``None``.
+
+        The sequence continues from the highest segment still on disk, so it
+        keeps rising even after retention has deleted earlier ones — a reused
+        number would sort as the OLDEST segment and make the next retention
+        sweep delete the log that was just closed.
+
+        Collision probing is CAPPED. An existing name must never be overwritten
+        (audit history is not silently replaced), but the probe is a filesystem
+        ``stat`` per attempt and this runs on the append path, where a critical
+        audit is written inline and sometimes on the event loop. A directory
+        pre-filled with consecutive segment names could otherwise make rotation
+        stat its way through all of them
+        (``no-blocking-call-on-event-loop``). Returning ``None`` defers rotation,
+        which leaves the log over budget rather than stalling a write.
+        """
+        stamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        existing = self._segments_oldest_first()
+        seq = (_segment_seq(existing[-1]) + 1) if existing else 1
+        for _probe in range(_SEGMENT_NAME_PROBES):
+            candidate = self._segment_dir / f"security_events-{seq:06d}-{stamp}.jsonl"
+            if not candidate.exists():
+                return candidate
+            seq += 1
+        logger.warning(
+            "SEL could not find a free segment name within %d probes from %06d in %s; "
+            "deferring rotation (names pre-planted, or a restored backup?)",
+            _SEGMENT_NAME_PROBES,
+            seq - _SEGMENT_NAME_PROBES,
+            self._segment_dir,
+        )
+        return None
+
+    def _segments_oldest_first(self) -> list[Path]:
+        """Closed segments in rotation order (oldest first).
+
+        Only files matching ``_SEGMENT_NAME_RE`` in full are returned, so an
+        unrelated file an operator parked in the segment dir is never treated as
+        rotation output (and so never deleted by retention). A candidate must
+        ALSO be a real regular file: the name check is what protects an
+        operator's file, the ``lstat`` check is what stops a PLANTED link from
+        being read as audit history.
+
+        The link case is reachable on an upgrade and matters on the read side,
+        not the delete side: ``security_events.d`` was not on the sensitive-path
+        floor before this release, so an agent could have pre-planted
+        ``security_events-000001-<stamp>.jsonl`` as a symlink to any file it
+        wanted surfaced -- and every reader here (``recent``, which backs the
+        dashboard's SEL events endpoint, and ``verify_integrity``) would parse
+        the LINKED file's lines and hand back whatever JSON objects it found as
+        events. Retention unlinking such an entry would only remove the link,
+        but the read is a real disclosure, so a non-regular entry is excluded.
+
+        Ordering is by the name's numeric sequence — see ``_SEGMENT_NAME_RE``
+        for why that rather than the timestamp or the mtime.
+
+        Enumeration is BOUNDED at ``_SEGMENT_SCAN_CAP`` entries. Rotation keeps
+        at most ``_SEGMENT_KEEP + 1`` files here, so any larger count is either an
+        operator's dumping ground or entries planted before this release, and this
+        walk runs on the append path — where a critical audit is written inline,
+        sometimes on the event loop. An unbounded listing of a directory someone
+        else filled would stall that caller
+        (``no-blocking-call-on-event-loop``), so the scan stops at the cap and
+        works with what it has: rotation then simply does not find the segments
+        beyond it, which leaves the log over budget rather than blocking a write.
+        """
+        try:
+            scanner = os.scandir(self._segment_dir)
+        except OSError:
+            return []
+        named: list[Path] = []
+        examined = 0
+        truncated = False
+        with scanner:
+            for entry in scanner:
+                examined += 1
+                if examined > _SEGMENT_SCAN_CAP:
+                    truncated = True
+                    break
+                if not _SEGMENT_NAME_RE.fullmatch(entry.name):
+                    continue
+                try:
+                    # follow_symlinks=False, so a symlink is judged as a symlink
+                    # rather than as whatever it points at.
+                    entry_stat = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    logger.warning(
+                        "SEL ignoring non-regular entry %s in the segment dir "
+                        "(planted link?); it is not audit history",
+                        entry.name,
+                    )
+                    continue
+                named.append(Path(entry.path))
+        if truncated:
+            logger.warning(
+                "SEL segment dir %s holds more than %d entries; scan stopped there. "
+                "Rotation keeps at most %d, so the extra entries were not created by "
+                "it — retention will not see past the cap until they are removed",
+                self._segment_dir,
+                _SEGMENT_SCAN_CAP,
+                _SEGMENT_KEEP + 1,
+            )
+        return sorted(named, key=_segment_seq)
+
+    def _enforce_segment_retention_locked(self) -> int:
+        """Delete the oldest closed segments beyond ``_SEGMENT_KEEP``.
+
+        Returns the number deleted. Caller holds ``_lock``.
+
+        STOPS at the first segment it cannot unlink rather than skipping past it.
+        Skipping would delete the NEXT-oldest instead — trading newer audit
+        history for older history that is stuck occupying a retention slot, so a
+        permission problem on one file would quietly eat the evidence behind it.
+        Stopping leaves the count over budget until the obstruction clears, which
+        is the safe direction, and the next rotation retries. Matches
+        :meth:`_prune_segments_locked`, which already stops for the same reason.
+        """
+        segments = self._segments_oldest_first()
+        excess = len(segments) - _SEGMENT_KEEP
+        if excess <= 0:
+            return 0
+        deleted = 0
+        for path in segments[:excess]:
+            try:
+                path.unlink()
+            except OSError:
+                logger.warning(
+                    "SEL segment retention could not delete %s; stopping this sweep "
+                    "rather than deleting newer segments behind it",
+                    path,
+                    exc_info=True,
+                )
+                break
+            deleted += 1
+        if deleted:
+            logger.info(
+                "SEL retention deleted %d closed segment(s) beyond the %d kept",
+                deleted,
+                _SEGMENT_KEEP,
+            )
+        return deleted
+
     def _ends_without_newline(self) -> bool:
         """True if the log's final byte is not a newline.
 
@@ -605,8 +1370,12 @@ class SecurityEventLog:
         except OSError:
             return False
 
-    def _read_last_hash(self) -> str:
+    def _read_last_hash(self, path: Path | None = None) -> str:
         """Return the entry_hash of the last COMPLETE record, or "" if none.
+
+        Reads the live log by default; *path* names a closed segment instead
+        (rotation reads the tip of the file it just renamed, which is immutable
+        and therefore race-free).
 
         A crash mid-append can leave a truncated/partial final line. The old
         implementation wrapped the parse in a blanket ``except: return ""``, so
@@ -618,10 +1387,11 @@ class SecurityEventLog:
         parseable record at all (nothing to chain from). Skipped corrupt tail
         lines are logged so the integrity concern is surfaced, not hidden.
         """
-        if not self._path.exists():
+        target = path or self._path
+        if not target.exists():
             return ""
         try:
-            with open(self._path, "rb") as f:
+            with open(target, "rb") as f:
                 f.seek(0, 2)
                 pos = f.tell()
                 if pos == 0:
@@ -663,7 +1433,7 @@ class SecurityEventLog:
                                 "SEL: skipping unparseable audit-log line while "
                                 "resolving chain tip in %s; chaining from the last "
                                 "complete record instead of resetting to genesis",
-                                self._path,
+                                target,
                             )
                             continue
                         if not isinstance(data, dict):
@@ -673,21 +1443,21 @@ class SecurityEventLog:
                             logger.warning(
                                 "SEL: skipping non-object audit-log line while "
                                 "resolving chain tip in %s",
-                                self._path,
+                                target,
                             )
                             continue
                         if skipped_corrupt:
                             logger.warning(
                                 "SEL: recovered chain tip from an earlier complete "
                                 "record after a corrupt/truncated tail in %s",
-                                self._path,
+                                target,
                             )
                         return data.get("entry_hash", "")
             # No parseable record anywhere in the file — nothing to chain from.
             return ""
         except OSError:
             logger.warning(
-                "SEL: failed to read chain tip from %s", self._path, exc_info=True
+                "SEL: failed to read chain tip from %s", target, exc_info=True
             )
             return ""
 
@@ -714,6 +1484,12 @@ class SecurityEventLog:
         enqueue order. This is the crux of the "audit-or-deny" invariant: the
         async queue's swallow-and-warn behaviour must NOT apply to a critical
         audit, or the caller's fail-closed branch becomes unreachable.
+
+        A critical write also does not rotate, and neither does the
+        writer-unavailable fallback below: both run inline on their caller's
+        thread, which may be the asyncio event loop. ``_may_rotate`` enforces that
+        from the running thread rather than from a flag here, so the rule cannot be
+        lost at a call site. The background writer rotates on its next batch.
         """
         if self._sync:
             self._flush_batch([event], raise_on_error=critical)
@@ -927,54 +1703,233 @@ class SecurityEventLog:
         )
 
     def verify_integrity(self) -> tuple[int, int]:
-        """Verify HMAC chain. Returns (total_entries, valid_entries)."""
+        """Verify the HMAC chains. Returns (total_entries, valid_entries).
+
+        Every rotated segment (oldest first) is verified BEFORE the live log.
+        Each file is an independent chain that starts from genesis, so a segment
+        deleted by retention cannot make a surviving one look tampered — which is
+        the property rotation had to preserve.
+
+        There is deliberately no cross-file assertion. Forgery is caught per
+        RECORD: a planted or rewritten segment cannot produce a valid HMAC because
+        the key lives outside the log directory, so its entries are counted invalid
+        here regardless of what any boundary record says. An earlier revision also
+        checked a predecessor-hash claim carried in the rotation record; see
+        :meth:`_rotation_event` for why that claim cannot be made true without
+        serializing every append, and why a check that can fire on a benign cause
+        is worse than no check.
+        """
         self.flush()  # ensure all queued events are on disk before verifying
-        if not self._path.exists():
-            return 0, 0
+        total = 0
+        valid = 0
+        for path in self._segments_oldest_first() + [self._path]:
+            if not path.exists():
+                continue
+            file_total, file_valid = self._verify_file(path)
+            total += file_total
+            valid += file_valid
+        return total, valid
+
+    def _verify_file(self, path: Path) -> tuple[int, int]:
+        """Verify one log file's chain. Returns (total, valid).
+
+        Streamed line by line so a capped-but-large segment is never loaded whole.
+        """
         total = 0
         valid = 0
         prev_hash = ""
-        for line in self._path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            total += 1
-            try:
-                data = json.loads(line)
-                stored_hash = data.pop("entry_hash", "")
-                if data.get("prev_hash", "") != prev_hash:
-                    logger.warning("SEL chain break at entry %d", total)
-                    prev_hash = stored_hash
+        try:
+            handle = open(path, encoding="utf-8")
+        except OSError:
+            logger.warning("SEL could not open %s for verification", path, exc_info=True)
+            return 0, 0
+        with handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
                     continue
-                payload = json.dumps(data, sort_keys=True).encode()
-                expected = hmac.new(self._hmac_key, payload, hashlib.sha256).hexdigest()
-                if hmac.compare_digest(stored_hash, expected):
-                    valid += 1
-                else:
-                    logger.warning("SEL HMAC mismatch at entry %d", total)
-                prev_hash = stored_hash
-            except (json.JSONDecodeError, Exception):
-                logger.warning("SEL parse error at entry %d", total)
+                total += 1
+                try:
+                    data = json.loads(line)
+                    stored_hash = data.pop("entry_hash", "")
+                    if data.get("prev_hash", "") != prev_hash:
+                        logger.warning("SEL chain break at entry %d of %s", total, path.name)
+                        prev_hash = stored_hash
+                        continue
+                    # Re-attach the hash: _record_signature_matches owns the one
+                    # payload/compare implementation both readers use.
+                    if self._record_signature_matches({**data, "entry_hash": stored_hash}):
+                        valid += 1
+                    else:
+                        logger.warning("SEL HMAC mismatch at entry %d of %s", total, path.name)
+                    prev_hash = stored_hash
+                except (json.JSONDecodeError, Exception):
+                    logger.warning("SEL parse error at entry %d of %s", total, path.name)
         return total, valid
 
-    def recent(self, limit: int = 100) -> list[dict]:
-        """Return the most recent events."""
+    def recent(
+        self,
+        limit: int = 100,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> list[dict]:
+        """Return the most recent events, newest first.
+
+        ``since`` / ``until`` bound the window (inclusive ``since``, exclusive
+        ``until``) so a caller can ask "what happened in the last two hours"
+        instead of guessing a count large enough to reach back that far.
+
+        The read is bounded on BOTH ends. Files are scanned backward from the
+        tail in chunks — never loaded whole, which is what made a large log
+        impractical to query — and the walk stops at the first record older than
+        ``since`` because the log is append-ordered. Rotated segments are only
+        opened when the live log has not already satisfied the request.
+
+        Records whose timestamp cannot be parsed are returned when no window was
+        asked for, and skipped when one was: a record that cannot be placed in
+        time cannot be asserted to fall inside the window.
+        """
         self.flush()  # surface any queued-but-unwritten events
-        if not self._path.exists():
-            return []
-        lines = self._path.read_text(encoding="utf-8").splitlines()
-        result = []
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
+        result: list[dict] = []
+        if limit <= 0:
+            return result
+        windowed = since is not None or until is not None
+        # Newest first: the live log, then rotated segments newest to oldest.
+        # Segments are discovered LAZILY (only if the live log has not already
+        # satisfied the request), so the common tail read touches one file.
+        for path in self._read_sources_newest_first():
+            if not path.exists():
                 continue
-            try:
-                result.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-            if len(result) >= limit:
-                break
+            for line in self._iter_lines_backward(path):
+                try:
+                    data = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                if windowed:
+                    ts = _parse_timestamp(data.get("timestamp", ""))
+                    if ts is None:
+                        continue
+                    if until is not None and ts >= until:
+                        continue
+                    if since is not None and ts < since:
+                        # Append-ordered log: everything from here back is older.
+                        return result
+                result.append(data)
+                if len(result) >= limit:
+                    return result
         return result
+
+    def _read_sources_newest_first(self) -> Iterator[Path]:
+        """The live log, then ADMISSIBLE segments newest to oldest.
+
+        A segment is only handed to the read path once one of its records
+        verifies under our HMAC key. ``security_events.d`` is created by this
+        release, and it was not on the sensitive-path floor before it, so an agent
+        could have pre-created the directory and left a segment-shaped JSONL of
+        its own choosing in it; without this gate the upgrade would then present
+        those forged records to every reader as audit events. Forging is what the
+        chain key exists to prevent and the key lives outside the log directory,
+        so a planted segment cannot produce a single valid signature.
+
+        The check is ONE record per segment (the last, reached through the same
+        backward reader), not the whole file: full-segment verification would undo
+        the bounded read this release exists to provide, and one valid signature
+        is already unforgeable. ``verify_integrity`` deliberately does NOT filter
+        this way — it reports a rejected segment's entries as invalid instead of
+        hiding them, because an audit tool must surface tampering rather than
+        quietly drop the evidence.
+
+        A generator so segments are neither listed nor opened when the live log
+        already answered the caller.
+        """
+        yield self._path
+        for path in reversed(self._segments_oldest_first()):
+            if self._segment_is_signed_by_us(path):
+                yield path
+            else:
+                logger.warning(
+                    "SEL refusing to read %s as audit history: no record in it is "
+                    "signed with this log's key (planted before upgrade?)",
+                    path.name,
+                )
+
+    def _segment_is_signed_by_us(self, path: Path) -> bool:
+        """Whether *path* holds at least one record signed with our HMAC key."""
+        for line in self._iter_lines_backward(path):
+            try:
+                data = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if isinstance(data, dict) and self._record_signature_matches(data):
+                return True
+        return False
+
+    def _record_signature_matches(self, record: dict) -> bool:
+        """Whether *record*'s ``entry_hash`` is our HMAC over its other fields."""
+        data = dict(record)
+        stored = data.pop("entry_hash", "")
+        if not isinstance(stored, str) or not stored:
+            return False
+        try:
+            payload = json.dumps(data, sort_keys=True).encode()
+        except (TypeError, ValueError):
+            return False
+        expected = hmac.new(self._hmac_key, payload, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(stored, expected)
+
+    def _iter_lines_backward(self, path: Path) -> Iterator[str]:
+        """Yield *path*'s non-empty lines from last to first, reading in chunks.
+
+        Same backward scan as :meth:`_read_last_hash`: only the tail is touched
+        unless the caller keeps consuming, so reading 20 entries out of a
+        size-capped segment costs one chunk rather than the whole file.
+
+        The pending buffer is CAPPED at ``_MAX_LINE_BYTES``. Held bytes are
+        whatever has not yet been split into a complete line, so a file with no
+        newline in it would otherwise accumulate to its full size in memory --
+        and this reader is pointed at attacker-influenced input: a segment planted
+        before this release (when the directory was not fenced) is read here both
+        by the time-range read and by segment admission. A single planted
+        gigabyte-long unterminated line would exhaust the process. Hitting the cap
+        ends the scan, so a caller sees the lines it already got and admission
+        simply fails to find a signed record -- which is the safe direction.
+        """
+        try:
+            with open(path, "rb") as f:
+                f.seek(0, 2)
+                pos = f.tell()
+                buf = b""
+                while pos > 0:
+                    read_start = max(pos - _TAIL_CHUNK_BYTES, 0)
+                    f.seek(read_start)
+                    buf = f.read(pos - read_start) + buf
+                    pos = read_start
+                    parts = buf.split(b"\n")
+                    if pos > 0:
+                        # First element may be incomplete — defer it until the
+                        # next chunk supplies its start.
+                        buf = parts[0]
+                        complete = parts[1:]
+                    else:
+                        buf = b""
+                        complete = parts
+                    for raw in reversed(complete):
+                        stripped = raw.strip()
+                        if stripped:
+                            yield stripped.decode("utf-8", errors="replace")
+                    if len(buf) > _MAX_LINE_BYTES:
+                        logger.warning(
+                            "SEL stopping the backward scan of %s: over %d bytes with no "
+                            "line boundary (truncated or planted file?)",
+                            path.name,
+                            _MAX_LINE_BYTES,
+                        )
+                        return
+        except OSError:
+            logger.warning("SEL could not read %s", path, exc_info=True)
 
     def prune(self, keep_days: int = _RETENTION_DAYS) -> int:
         """Remove entries older than keep_days. Returns count removed.
@@ -987,52 +1942,187 @@ class SecurityEventLog:
         or block until after the replace (and land in the new file). Appends
         run on the background writer thread, so blocking them for the prune
         duration never touches the event loop.
+
+        ``_lock`` is a THREAD lock, so it does nothing about a sibling process --
+        and prune's read-then-replace is the one window where that is
+        destructive rather than merely untidy. If another process rotates while
+        we are streaming, our ``os.replace`` drops a snapshot of the OLD file
+        over the fresh live log, discarding its rotation record and every event
+        appended since. That is the only path in this class that can lose
+        already-persisted audit events, so the window is serialized with the
+        cross-process ROTATION lock (the same one rotation takes) via
+        :meth:`_prune_live_locked`.
+
+        Unlike rotation, prune WAITS for that lock instead of skipping. Rotation
+        is deferrable and runs on the audit hot path; prune is a once-a-day sweep
+        on the maintenance executor, never on the event loop, and skipping it
+        would postpone retention for a whole day. When the lock cannot be taken
+        at all the live sweep is skipped and reported, because doing it
+        unserialized is what loses events.
+
+        Rotated segments are aged out WHOLE rather than rewritten: a segment
+        whose newest record is past the cutoff is deleted outright, which keeps
+        every surviving segment's chain intact (rewriting one would orphan its
+        first record's ``prev_hash``). Their entries are included in the
+        returned count.
         """
         self.flush()  # don't rewrite the file out from under queued appends
         cutoff_dt = datetime.now(tz=timezone.utc) - timedelta(days=keep_days)
-        cutoff_str = cutoff_dt.isoformat()
 
         removed = 0
         with self._lock:
+            removed += self._prune_segments_locked(cutoff_dt)
             if not self._path.exists():
-                return 0
-            tmp_fd, tmp_path = tempfile.mkstemp(
-                dir=str(self._path.parent), prefix=".sel_prune_", suffix=".tmp"
-            )
+                return removed
+            lock_fh = self._open_rotation_lock() if self._ensure_segment_dir() else None
+            if lock_fh is None:
+                logger.warning(
+                    "SEL prune could not take the rotation lock; skipping the live-log "
+                    "sweep rather than risking a concurrent rotation's events"
+                )
+                return removed
             try:
-                with os.fdopen(tmp_fd, "w", encoding="utf-8") as tmp_f:
-                    with open(self._path, encoding="utf-8") as src_f:
-                        for raw_line in src_f:
-                            line = raw_line.strip()
-                            if not line:
-                                continue
-                            try:
-                                data = json.loads(line)
-                                if data.get("timestamp", "") < cutoff_str:
-                                    removed += 1
-                                    continue
-                            except json.JSONDecodeError:
-                                removed += 1
-                                continue
-                            tmp_f.write(line)
-                            tmp_f.write("\n")
-
-                if removed:
-                    os.replace(tmp_path, self._path)
-                    self._last_hash = self._read_last_hash()
-                    logger.info(
-                        "SEL pruned %d entries older than %d days", removed, keep_days
-                    )
-                else:
-                    os.unlink(tmp_path)
-            except BaseException:
-                # Clean up temp file on any failure
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+                with platform_compat.file_lock(lock_fh.fileno(), exclusive=True):
+                    removed += self._prune_live_locked(cutoff_dt, keep_days)
+            except OSError:
+                logger.warning(
+                    "SEL prune could not serialize the live-log sweep; skipped",
+                    exc_info=True,
+                )
+            finally:
+                lock_fh.close()
         return removed
+
+    def _prune_live_locked(self, cutoff_dt: datetime, keep_days: int) -> int:
+        """Rewrite the live log without its aged-out entries. Returns count removed.
+
+        Caller holds ``_lock`` AND the cross-process rotation lock, so no sibling
+        can rotate the file out from under the read-then-replace below.
+        """
+        cutoff_str = cutoff_dt.isoformat()
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=str(self._path.parent), prefix=".sel_prune_", suffix=".tmp"
+        )
+        live_removed = 0
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as tmp_f:
+                with open(self._path, encoding="utf-8") as src_f:
+                    for raw_line in src_f:
+                        line = raw_line.strip()
+                        if not line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                            if data.get("timestamp", "") < cutoff_str:
+                                live_removed += 1
+                                continue
+                        except json.JSONDecodeError:
+                            live_removed += 1
+                            continue
+                        tmp_f.write(line)
+                        tmp_f.write("\n")
+
+            if live_removed:
+                os.replace(tmp_path, self._path)
+                # The replace gives the live log a NEW inode and a smaller size, so
+                # re-anchor both the tip and the identity we compare against.
+                # Leaving the identity stale would make the next append see a
+                # foreign change and re-chain needlessly.
+                self._reanchor_now()
+                logger.info(
+                    "SEL pruned %d entries older than %d days", live_removed, keep_days
+                )
+            else:
+                os.unlink(tmp_path)
+        except BaseException:
+            # Clean up temp file on any failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return live_removed
+
+    def _prune_segments_locked(self, cutoff: datetime) -> int:
+        """Delete whole rotated segments whose NEWEST record predates *cutoff*.
+
+        Returns the number of entries dropped with them. Caller holds ``_lock``.
+        A segment is deleted only when its last record is past the cutoff, so a
+        segment straddling the boundary is kept in full rather than rewritten:
+        rewriting it would orphan its first record's ``prev_hash`` and turn a
+        retention sweep into an apparent chain break. Best-effort — a segment
+        that cannot be read or unlinked is logged and left alone.
+        """
+        removed = 0
+        for path in self._segments_oldest_first():
+            newest = self._newest_timestamp(path)
+            if newest is None or newest >= cutoff:
+                # Unreadable/undatable, or still within retention. Segments are
+                # chronological, so the first keeper ends the sweep.
+                break
+            count = sum(1 for _ in self._iter_lines_backward(path))
+            try:
+                path.unlink()
+            except OSError:
+                logger.warning("SEL could not delete aged-out segment %s", path, exc_info=True)
+                break
+            removed += count
+            logger.info("SEL deleted aged-out segment %s (%d entries)", path.name, count)
+        return removed
+
+    def _newest_timestamp(self, path: Path) -> datetime | None:
+        """Timestamp of *path*'s newest parseable record, or ``None``."""
+        for line in self._iter_lines_backward(path):
+            try:
+                data = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            parsed = _parse_timestamp(data.get("timestamp", ""))
+            if parsed is not None:
+                return parsed
+        return None
+
+
+@contextmanager
+def _no_rotation() -> Iterator[None]:
+    """A do-nothing stand-in for the rotation window (see ``_flush_batch``)."""
+    yield
+
+
+def _segment_seq(path: Path) -> int:
+    """Rotation sequence encoded in a segment's name (0 if it has none).
+
+    Sort key for :meth:`SecurityEventLog._segments_oldest_first`; callers filter
+    non-segment names first, so the fallback only guards a caller that does not.
+    """
+    match = _SEGMENT_NAME_RE.fullmatch(path.name)
+    return int(match.group("seq")) if match else 0
+
+
+def _parse_timestamp(raw: object) -> datetime | None:
+    """Parse a SEL record timestamp into an aware UTC datetime, or ``None``.
+
+    Records are written with ``datetime.now(timezone.utc).isoformat()``, but a
+    hand-edited or forwarded record may carry a ``Z`` suffix or no offset at all.
+    ``fromisoformat`` only accepts ``Z`` from Python 3.11, and the package
+    supports 3.10, so the suffix is normalized here. A naive timestamp is read as
+    UTC — the only offset SEL ever writes — so it stays comparable with an aware
+    window bound instead of raising.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    text = raw.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _infer_source(session_key: str) -> str:

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -19,6 +19,7 @@ import argparse
 import io
 import json
 import urllib.error
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -896,6 +897,48 @@ class TestSecurityCli:
             cc._security(_ns(sec_action="events", limit=5))
         assert "No security events recorded." in capsys.readouterr().out
 
+    def test_events_passes_the_time_window_through(self) -> None:
+        """``-n`` alone cannot express "the last two hours" (issue #4843)."""
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            sel.return_value.recent.return_value = []
+            cc._security(
+                _ns(sec_action="events", limit=5, since="2026-08-21T00:00:00Z", until="2h")
+            )
+        kwargs = sel.return_value.recent.call_args.kwargs
+        assert kwargs["since"] == datetime(2026, 8, 21, tzinfo=timezone.utc)
+        assert kwargs["until"] is not None and kwargs["until"].tzinfo is not None
+
+    def test_events_rejects_an_unreadable_time(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A typo must not read as "no events in that window"."""
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            with pytest.raises(SystemExit) as exc:
+                cc._security(_ns(sec_action="events", limit=5, since="yesterdayish"))
+        assert exc.value.code == 2
+        assert "cannot read" in capsys.readouterr().out
+        sel.return_value.recent.assert_not_called()
+
+    def test_events_rejects_an_inverted_window(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            with pytest.raises(SystemExit) as exc:
+                cc._security(
+                    _ns(
+                        sec_action="events",
+                        limit=5,
+                        since="2026-08-21T10:00:00Z",
+                        until="2026-08-21T09:00:00Z",
+                    )
+                )
+        assert exc.value.code == 2
+        assert "--since must be earlier than --until" in capsys.readouterr().out
+        sel.return_value.recent.assert_not_called()
+
+    def test_events_names_the_window_when_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            sel.return_value.recent.return_value = []
+            cc._security(_ns(sec_action="events", limit=5, since="2026-08-21T00:00:00Z"))
+        out = capsys.readouterr().out
+        assert "No security events recorded in [2026-08-21T00:00:00+00:00, now)." in out
+
     def test_events_renders_error_and_downstream(self, capsys: pytest.CaptureFixture[str]) -> None:
         events = [
             {
@@ -946,6 +989,60 @@ def _fake_ceiling() -> Any:
         boot=SimpleNamespace(require_sandbox=True, allow_terminal=False, fail_closed=True),
         controls={"capabilities.telemetry": "off"},
     )
+
+
+class TestParseTimeSelector:
+    """``--since``/``--until`` input handling for ``security events``."""
+
+    def test_empty_means_no_bound(self) -> None:
+        assert cc.parse_time_selector("") is None
+        assert cc.parse_time_selector("   ") is None
+
+    @pytest.mark.parametrize(
+        ("text", "secs"),
+        [("45s", 45), ("30m", 1800), ("2h", 7200), ("7d", 604800), ("1w", 604800 * 1)],
+    )
+    def test_relative_age_counts_back_from_now(self, text: str, secs: int) -> None:
+        now = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+        assert cc.parse_time_selector(text, now=now) == now - timedelta(seconds=secs)
+
+    def test_relative_age_is_case_insensitive(self) -> None:
+        now = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+        assert cc.parse_time_selector("2H", now=now) == cc.parse_time_selector("2h", now=now)
+
+    def test_iso_instant_with_z_suffix(self) -> None:
+        # fromisoformat only accepts "Z" from 3.11; the package supports 3.10.
+        assert cc.parse_time_selector("2026-08-21T04:00:00Z") == datetime(
+            2026, 8, 21, 4, tzinfo=timezone.utc
+        )
+
+    def test_bare_date_is_read_as_utc(self) -> None:
+        """The audit log is written in UTC.
+
+        Reading a bare date as local time would silently shift the window by the
+        host's offset, so a window that looks right returns the wrong records.
+        """
+        assert cc.parse_time_selector("2026-08-21") == datetime(
+            2026, 8, 21, tzinfo=timezone.utc
+        )
+
+    def test_offset_is_normalized_to_utc(self) -> None:
+        assert cc.parse_time_selector("2026-08-21T10:00:00+02:00") == datetime(
+            2026, 8, 21, 8, tzinfo=timezone.utc
+        )
+
+    def test_unreadable_input_raises_with_the_accepted_forms(self) -> None:
+        with pytest.raises(ValueError, match="relative age"):
+            cc.parse_time_selector("last tuesday")
+
+    def test_an_absurd_but_well_formed_age_raises_instead_of_overflowing(self) -> None:
+        """``timedelta`` overflows before the subtraction.
+
+        Uncaught, that is an OverflowError traceback and exit 1 from a bad flag
+        value -- the CLI must still refuse it as input (exit 2) with guidance.
+        """
+        with pytest.raises(ValueError, match="too far in the past"):
+            cc.parse_time_selector("999999999999999999w")
 
 
 class TestPolicyCli:

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -3309,6 +3309,25 @@ class TestIsSensitivePath:
         assert is_sensitive_path("~/.kiro/crew/security_events.jsonl") is True
         assert is_sensitive_path("~/.kirocrew/security_events.jsonl") is True
 
+    def test_rotated_security_event_segments(self) -> None:
+        # A rotated segment holds exactly the same audit records the live log
+        # does (sel.py closes the log at a size cap and renames it into this
+        # dir), so rotation must not become the way around the fence.
+        assert is_sensitive_path("~/.kiro/crew/security_events.d") is True
+        assert (
+            is_sensitive_path(
+                "~/.kiro/crew/security_events.d/security_events-000001-20260821T045139Z.jsonl"
+            )
+            is True
+        )
+        assert is_sensitive_path("~/.kirocrew/security_events.d") is True
+        assert (
+            is_sensitive_path(
+                "~/.kirocrew/security_events.d/security_events-000001-20260821T045139Z.jsonl"
+            )
+            is True
+        )
+
     def test_sel_files_absolute_path(self) -> None:
         home = str(Path.home())
         assert is_sensitive_path(f"{home}/.kiro/crew/sel_hmac.key") is True
@@ -4272,6 +4291,18 @@ class TestIsSensitiveBashCommand:
         result = is_sensitive_bash_command("cat ~/.kiro/crew/security_events.jsonl")
         assert result is not None and "blocked" in result.lower()
         legacy = is_sensitive_bash_command("cat ~/.kirocrew/security_events.jsonl")
+        assert legacy is not None and "blocked" in legacy.lower()
+
+    def test_cat_rotated_security_event_segment_blocked(self) -> None:
+        # Same evidence, one rename later: a rotated segment must be as
+        # unreadable through the shell as the live log it came from.
+        rotated = is_sensitive_bash_command(
+            "cat ~/.kiro/crew/security_events.d/security_events-000001-20260821T045139Z.jsonl"
+        )
+        assert rotated is not None and "blocked" in rotated.lower()
+        legacy = is_sensitive_bash_command(
+            "cat ~/.kirocrew/security_events.d/security_events-000001-20260821T045139Z.jsonl"
+        )
         assert legacy is not None and "blocked" in legacy.lower()
 
     def test_write_app_admission_policy_blocked(self) -> None:

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -6,12 +6,23 @@ import json
 import os
 import threading
 import time
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import kiro_crew.sel as sel_mod
+from kiro_crew import platform_compat
 from kiro_crew.sel import SecurityEvent, SecurityEventLog, _infer_source, sel, sel_hmac_key_path
+
+
+@pytest.fixture
+def small_segments(monkeypatch):
+    """Shrink the size cap so a handful of events triggers real rotation."""
+    monkeypatch.setattr(sel_mod, "_SEGMENT_MAX_BYTES", 4 * 1024)
+    monkeypatch.setattr(sel_mod, "_SEGMENT_KEEP", 3)
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +65,37 @@ def _make_event(**overrides) -> SecurityEvent:
     }
     base.update(overrides)
     return SecurityEvent(**base)
+
+
+def _lock_is_held(lock_path: Path) -> bool:
+    """Whether *lock_path* is exclusively locked, observed from another thread.
+
+    ``fcntl.flock`` is per open-file-description, so a fresh ``open`` in this
+    same process still contends with the holder's fd -- which is what lets a test
+    assert that a critical section really runs under the cross-process lock. On
+    Windows ``msvcrt.locking`` is per-fd in the same way. Returns False when the
+    lock file does not exist yet (nothing has been serialized).
+    """
+    if not lock_path.exists():
+        return False
+    with open(lock_path, "a+b") as probe:
+        if platform_compat.try_acquire_lock(probe.fileno(), exclusive=True):
+            platform_compat.release_lock(probe.fileno())
+            return False
+    return True
+
+
+def _fill(log: SecurityEventLog, count: int, *, start: int = 0, step_secs: int = 1) -> None:
+    """Write *count* chronologically increasing events, seq=<n> in ``resources``."""
+    base = datetime(2026, 8, 21, tzinfo=timezone.utc)
+    for i in range(start, start + count):
+        log.log(
+            _make_event(
+                event_id=f"evt{i:06d}",
+                timestamp=(base + timedelta(seconds=i * step_secs)).isoformat(),
+                resources=f"seq={i}",
+            )
+        )
 
 
 class TestHmacKeyManagement:
@@ -1556,3 +1598,1582 @@ class TestHmacKeyTrustDirMigration:
         assert inst is not None and inst._initialized
         assert inst._hmac_key == (tmp_path / "trust" / "sel_hmac.key").read_bytes()
         self._reset()
+
+
+class TestSizeRotation:
+    """The log is closed at a size cap and retained as N segments (issue #4843).
+
+    Before this, ``security_events.jsonl`` was a single file with no cap: a
+    long-running install measured 4.09 GB, which made the only sanctioned reader
+    impractical and made every append and read pay the size.
+    """
+
+    def test_live_log_is_closed_at_the_size_cap(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        live = sel_dir / "security_events.jsonl"
+        segments = log._segments_oldest_first()
+        assert segments, "no rotation happened; the log grew unbounded"
+        assert live.stat().st_size < sel_mod._SEGMENT_MAX_BYTES * 2
+
+    def test_retention_keeps_only_the_newest_segments(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 600)
+        segments = log._segments_oldest_first()
+        assert len(segments) == sel_mod._SEGMENT_KEEP
+        # The bound that matters: total on-disk size cannot exceed the cap times
+        # the segments kept plus the live log.
+        total = sum(p.stat().st_size for p in segments)
+        total += (sel_dir / "security_events.jsonl").stat().st_size
+        ceiling = sel_mod._SEGMENT_MAX_BYTES * (sel_mod._SEGMENT_KEEP + 2)
+        assert total < ceiling, f"{total} bytes exceeds the retention ceiling {ceiling}"
+
+    def test_retention_deletes_the_oldest_not_the_newest(self, sel_dir, small_segments):
+        """The sequence must keep rising across deletions.
+
+        A name reused after retention freed it would sort as the OLDEST segment,
+        so the next sweep would delete the log that was just closed and keep the
+        stale ones — silently discarding the newest audit history.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 600)
+        seqs = [sel_mod._segment_seq(p) for p in log._segments_oldest_first()]
+        assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+        # Newest surviving segment is the immediate predecessor of the live log.
+        claimed = json.loads(
+            (sel_dir / "security_events.jsonl").read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert claimed["metadata"]["previous_segment"] == log._segments_oldest_first()[-1].name
+
+    def test_each_segment_is_an_independent_chain(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        for path in log._segments_oldest_first():
+            first = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+            assert first["prev_hash"] == "", f"{path.name} chains across the boundary"
+            if sel_mod._segment_seq(path) > 1:
+                # Only the very first segment ever closed has no predecessor to
+                # name; every later one opens with the boundary record.
+                assert first["event_type"] == "sel_rotation"
+
+    def test_rotation_record_names_the_closed_segment(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        closed = log._segments_oldest_first()[-1]
+        opener = json.loads(
+            (sel_dir / "security_events.jsonl").read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert opener["metadata"]["previous_segment"] == closed.name
+        assert opener["metadata"]["previous_bytes"] > 0
+
+    def test_the_rotation_record_makes_no_predecessor_hash_claim(
+        self, sel_dir, small_segments
+    ):
+        """A claim about the closed segment's tip cannot be kept true.
+
+        A segment is not immutable the instant it is renamed: another process may
+        still hold a writable fd to that inode and land a record after the tip is
+        read. Any hash captured would then be stale, and verification would report
+        an untampered log as compromised -- the worst failure mode available. The
+        name is enough to walk the sequence, and forgery is caught per record.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        opener = json.loads(
+            (sel_dir / "security_events.jsonl").read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert "previous_entry_hash" not in opener["metadata"]
+
+    def test_a_late_append_into_the_closed_segment_still_verifies(
+        self, sel_dir, small_segments
+    ):
+        """The exact race the dropped claim could not survive.
+
+        An appender holding an fd to the live log writes AFTER the rotator renamed
+        it, so the record lands in the segment -- correctly chained, because the fd
+        guard let it through precisely when the identity matched. Nothing about that
+        may read as corruption.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        segment = log._segments_oldest_first()[-1]
+        tip = json.loads(segment.read_text(encoding="utf-8").strip().splitlines()[-1])
+        # Stand in for the appender that was mid-write across the rename: one more
+        # correctly chained record appended to the already-closed segment.
+        late = _make_event(event_id="late0", resources="late")
+        late.prev_hash = tip["entry_hash"]
+        late.entry_hash = log._compute_hash(late)
+        with open(segment, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(late)) + "\n")
+
+        total, valid = log.verify_integrity()
+        assert total == valid, (
+            f"{total - valid} entries reported as compromised by a benign late append"
+        )
+
+    def test_verify_integrity_spans_segments(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        segment_lines = sum(
+            len(p.read_text(encoding="utf-8").strip().splitlines())
+            for p in log._segments_oldest_first()
+        )
+        total, valid = log.verify_integrity()
+        assert total > segment_lines, "verification ignored the rotated segments"
+        assert total == valid, f"{total - valid} entries failed verification"
+
+    def test_deleting_an_aged_out_segment_leaves_survivors_verifiable(
+        self, sel_dir, small_segments
+    ):
+        """The property rotation had to preserve.
+
+        A retention deletion must not look like tampering. With one chain across
+        the whole log, dropping the oldest file would orphan the next file's
+        first ``prev_hash`` and report a break for every sweep.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        log._segments_oldest_first()[0].unlink()
+        total, valid = log.verify_integrity()
+        assert total == valid, f"retention deletion produced {total - valid} invalid entries"
+
+    def test_tampering_inside_a_segment_is_still_caught(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        victim = log._segments_oldest_first()[-1]
+        lines = victim.read_text(encoding="utf-8").strip().splitlines()
+        record = json.loads(lines[2])
+        record["outcome"] = "allowed"
+        lines[2] = json.dumps(record)
+        victim.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        total, valid = log.verify_integrity()
+        assert valid < total, "an edited record inside a rotated segment verified clean"
+
+    def test_a_rewritten_segment_is_reported_per_record(self, sel_dir, small_segments):
+        """Substituted content is caught by signatures, not by a boundary claim.
+
+        The claim a previous revision carried is gone (see
+        ``_rotation_event``), so this is the property that has to hold on its own:
+        a segment whose content was replaced cannot produce valid per-record HMACs,
+        because the key lives outside the log directory.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        victim = log._segments_oldest_first()[-1]
+        rows = [json.loads(line) for line in victim.read_text(encoding="utf-8").splitlines()]
+        # Rewrite the segment with plausible-looking but unsigned records.
+        forged = []
+        for row in rows:
+            row["outcome"] = "allowed"
+            forged.append(json.dumps(row))
+        victim.write_text("\n".join(forged) + "\n", encoding="utf-8")
+        total, valid = log.verify_integrity()
+        assert valid < total, "a rewritten segment verified clean"
+
+    def test_a_truncated_segment_does_not_read_as_corruption(self, sel_dir, small_segments):
+        """Losing the TAIL of a segment leaves the surviving records verifiable.
+
+        Retention and a crash both produce this shape, and neither is tampering of
+        the surviving records. With the old boundary claim a dropped final record
+        made the SUCCESSOR's rotation record read as invalid; nothing here may.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        predecessor = log._segments_oldest_first()[-1]
+        kept = predecessor.read_text(encoding="utf-8").strip().splitlines()
+        predecessor.write_text("\n".join(kept[:-1]) + "\n", encoding="utf-8")
+        total, valid = log.verify_integrity()
+        assert total == valid, f"{total - valid} surviving entries reported as compromised"
+
+    def test_only_matching_names_are_treated_as_segments(self, sel_dir, small_segments):
+        """Retention must never delete a file an operator parked in the dir."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 600)
+        stray = sel_dir / "security_events.d" / "operator-notes.txt"
+        stray.write_text("keep me", encoding="utf-8")
+        _fill(log, 600, start=600)
+        assert stray.exists(), "retention deleted a non-segment file"
+        assert stray not in log._segments_oldest_first()
+
+    def test_rotation_failure_still_writes_the_event(self, sel_dir, small_segments, caplog):
+        """An audit record must never be lost to a rotation that cannot happen."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        before = len(log.recent(limit=10_000))
+        with patch("kiro_crew.sel.os.replace", side_effect=OSError("boom")):
+            _fill(log, 300, start=1000)
+        after = log.recent(limit=10_000)
+        assert len(after) > before, "events were dropped when rotation failed"
+        assert after[0]["resources"] == "seq=1299"
+
+    def test_segment_dir_is_owner_only(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        segment_dir = sel_dir / "security_events.d"
+        assert segment_dir.is_dir()
+        if os.name != "nt":  # Windows uses the DACL, not a POSIX mode
+            assert oct(segment_dir.stat().st_mode & 0o777) == "0o700"
+
+    def test_prune_ages_out_whole_segments(self, sel_dir, small_segments):
+        """Age retention must reach the segments, not just the live log.
+
+        Otherwise a rotated segment could outlive the retention window
+        indefinitely, because only the live file was ever rewritten.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        for i in range(200):
+            log.log(
+                _make_event(
+                    event_id=f"old{i:04d}",
+                    timestamp=(base + timedelta(seconds=i)).isoformat(),
+                    resources=f"old={i}",
+                )
+            )
+        assert log._segments_oldest_first(), "precondition: rotation happened"
+        removed = log.prune(keep_days=365)
+        assert removed > 0
+        assert log._segments_oldest_first() == [], "aged-out segments survived the sweep"
+
+    def test_prune_keeps_a_segment_that_straddles_the_cutoff(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)  # 2026 timestamps — inside any sane retention window
+        segments = log._segments_oldest_first()
+        assert segments, "precondition: rotation happened"
+        log.prune(keep_days=365 * 100)
+        assert log._segments_oldest_first() == segments
+
+
+class TestRotationIsSerializedAcrossProcesses:
+    """Rotation runs under a cross-process lock, taken without blocking.
+
+    ``_lock`` is a thread lock, but several processes share one data home (the
+    gateway, the CLI, cron) and append to the same file, so they reach the size
+    cap at the same moment. Unserialized, two of them pick the same target name
+    and the second ``os.replace`` moves the freshly recreated live log onto the
+    segment the first just closed.
+    """
+
+    def test_the_acquire_never_blocks(self, sel_dir, small_segments):
+        """A critical audit is written inline, sometimes on the event loop.
+
+        Parking that caller on another process's rotation is the
+        no-blocking-call-on-event-loop hazard, and rotation is deferrable while an
+        audit write is not -- so the blocking lock helper must not be used here.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        with patch(
+            "kiro_crew.sel.platform_compat.file_lock",
+            side_effect=AssertionError("blocking lock helper used on the audit path"),
+        ):
+            _fill(log, 200)
+        assert log._segments_oldest_first(), "precondition: rotation happened"
+
+    def test_the_rotation_step_runs_under_the_lock(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        lock_path = sel_dir / "security_events.d" / ".rotate.lock"
+        held: list[bool] = []
+        real_rotate = SecurityEventLog._rotate_under_lock
+
+        def recording_rotate(inner_self):
+            held.append(_lock_is_held(lock_path))
+            return real_rotate(inner_self)
+
+        with patch.object(SecurityEventLog, "_rotate_under_lock", recording_rotate):
+            _fill(log, 200)
+        assert held and all(held), "rotation ran without holding the cross-process lock"
+
+    def test_below_the_cap_no_cross_process_lock_is_taken(self, sel_dir, small_segments):
+        """The audit hot path must not pay for a lock it does not need."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        with patch("kiro_crew.sel.platform_compat.try_acquire_lock") as locker:
+            _fill(log, 3)  # nowhere near the cap
+        locker.assert_not_called()
+
+    def test_contention_defers_rotation_without_a_stale_tip(self, sel_dir, small_segments):
+        """Losing the lock must not mean appending from a pre-rotation tip.
+
+        This is what makes skipping safe instead of merely fast: the contended
+        path re-reads the live log's identity and re-anchors before the caller
+        chains, so a rotation that already happened cannot orphan our record.
+
+        The interleaving has to be exact, or the assertion passes for the wrong
+        reason: at the top of the window we must still see the OLD file at the cap
+        (the winner has not renamed yet, so no replacement is detectable there),
+        and only the CONTENDED re-check may observe the swap. The identities are
+        therefore synthesized -- first call same inode grown to the cap, second
+        call a new inode -- so the top-of-window check cannot fire.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        stale_tip = log._last_hash
+        live = sel_dir / "security_events.jsonl"
+        pre_dev, pre_ino, _pre_size = log._live_seen
+
+        # A sibling has rotated and written its own first record (see the
+        # foreign-rotation suite for why this is built by hand).
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        os.replace(live, segment_dir / "security_events-000001-20260821T000000Z.jsonl")
+        sibling_event = _make_event(event_id="sib1", resources="sibling")
+        sibling_event.prev_hash = ""
+        sibling_event.entry_hash = log._compute_hash(sibling_event)
+        live.write_text(json.dumps(asdict(sibling_event)) + "\n", encoding="utf-8")
+        assert sibling_event.entry_hash != stale_tip
+
+        log._live_seen = (pre_dev, pre_ino, _pre_size)
+        log._last_hash = stale_tip
+        with patch("kiro_crew.sel.platform_compat.try_acquire_lock", return_value=False):
+            with patch.object(
+                SecurityEventLog,
+                "_live_identity",
+                side_effect=[
+                    # Top of window: same file, grown to the cap. NOT a replacement,
+                    # so the fast-path re-anchor must not fire here.
+                    (pre_dev, pre_ino, sel_mod._SEGMENT_MAX_BYTES),
+                    # Contended re-check: the winner's rename is now visible.
+                    (pre_dev, pre_ino + 1, 512),
+                ],
+            ):
+                with log._rotation_window():
+                    pass
+        assert log._last_hash == sibling_event.entry_hash, (
+            "kept a pre-rotation tip after deferring on contention"
+        )
+
+    def test_a_serialization_failure_still_writes_the_event(self, sel_dir, small_segments):
+        """An unusable lock must not cost an audit record."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        before = log._segments_oldest_first()
+        with patch.object(SecurityEventLog, "_open_rotation_lock", return_value=None):
+            _fill(log, 50, start=3000)
+        assert log._segments_oldest_first() == before, "rotated without the lock"
+        assert log.recent(limit=1)[0]["resources"] == "seq=3049"
+
+    def test_the_lock_file_is_never_treated_as_a_segment(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 600)
+        lock = sel_dir / "security_events.d" / ".rotate.lock"
+        assert lock.exists(), "rotation did not take the cross-process lock"
+        assert lock not in log._segments_oldest_first()
+        total, valid = log.verify_integrity()
+        assert total == valid, "the lock file was verified as an audit segment"
+
+    def test_a_planted_lock_link_is_not_opened_through(self, sel_dir, small_segments):
+        """Opening the mutex CREATES and chmods it, so a link must not be followed."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        protected = sel_dir / "protected.json"
+        protected.write_text('{"keep": "me"}\n', encoding="utf-8")
+        before = protected.read_bytes()
+        planted = segment_dir / ".rotate.lock"
+        planted.unlink(missing_ok=True)
+        try:
+            planted.symlink_to(protected)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform/filesystem")
+
+        _fill(log, 200, start=500)
+
+        assert protected.read_bytes() == before, "rotation wrote through the planted link"
+        assert not planted.is_symlink(), "the planted link survived"
+
+    def test_an_unremovable_lock_link_declines_to_rotate(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        before = log._segments_oldest_first()
+        with patch("kiro_crew.sel.platform_compat.is_link_or_junction") as is_link:
+            # The segment DIR check must still pass; only the lock path is linked.
+            is_link.side_effect = lambda p: Path(p).name == ".rotate.lock"
+            with patch(
+                "kiro_crew.sel.platform_compat.unlink_link_or_junction",
+                side_effect=OSError("read-only"),
+            ):
+                _fill(log, 300, start=4000)
+        assert log._segments_oldest_first() == before, "rotated through a linked lock"
+        assert log.recent(limit=1)[0]["resources"] == "seq=4299"
+
+    def test_a_rotation_lost_to_another_process_re_anchors_the_chain(
+        self, sel_dir, small_segments
+    ):
+        """Winning the lock but finding the log already rotated must re-anchor.
+
+        The cached tip points at a record that a sibling process has just moved
+        into a closed segment; appending from it would leave the new live log's
+        first record naming a ``prev_hash`` that is not in the same file.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        stale_tip = log._last_hash
+
+        # Stand in for the sibling process: force one real rotation, so the live
+        # log is a fresh file whose tip differs from what we cached.
+        with patch.object(
+            SecurityEventLog, "_live_size", return_value=sel_mod._SEGMENT_MAX_BYTES
+        ):
+            log._rotate_under_lock()
+        fresh_tip = log._last_hash
+        assert fresh_tip not in ("", stale_tip)
+        assert fresh_tip == log._read_last_hash()
+
+        # Our process still holds the pre-rotation tip and, holding the lock,
+        # finds the log already small — the lost-the-race branch.
+        log._last_hash = stale_tip
+        with patch.object(SecurityEventLog, "_live_size", return_value=0):
+            log._rotate_under_lock()
+        assert log._last_hash == fresh_tip, "kept a chain tip from a closed segment"
+
+
+class TestAppendValidatesTheFileByFd:
+    """A lock-free append must notice a rotation that lands under it.
+
+    The append is deliberately not serialized (a blocking cross-process acquire
+    could park an event-loop caller writing a critical audit), so instead it
+    validates the file it OPENED. A path stat cannot do this: whatever it observed
+    may be replaced before the open that follows.
+    """
+
+    def test_a_rotation_between_chaining_and_opening_is_re_chained(
+        self, sel_dir, small_segments
+    ):
+        """The exact interleaving: we chain, a sibling renames, then we open."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        live = sel_dir / "security_events.jsonl"
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+
+        real_open = os.open
+        rotated: list[bool] = []
+
+        def rotating_open(path, flags, *args, **kwargs):
+            # Fire once, at the moment of the append's open: the sibling's rename
+            # and its own first record land between our chaining and our write.
+            if not rotated and str(path) == str(live):
+                rotated.append(True)
+                os.replace(live, segment_dir / "security_events-000001-20260821T000000Z.jsonl")
+                sibling = _make_event(event_id="sibfd", resources="sibling")
+                sibling.prev_hash = ""
+                sibling.entry_hash = log._compute_hash(sibling)
+                live.write_text(json.dumps(asdict(sibling)) + "\n", encoding="utf-8")
+            return real_open(path, flags, *args, **kwargs)
+
+        with patch("kiro_crew.sel.os.open", rotating_open):
+            _fill(log, 1, start=7000)
+
+        assert rotated, "precondition: the injected rotation fired"
+        lines = live.read_text(encoding="utf-8").strip().splitlines()
+        records = [json.loads(line) for line in lines]
+        ours = [r for r in records if r.get("resources") == "seq=7000"]
+        assert ours, "our record was lost"
+        sibling_rec = next(r for r in records if r.get("resources") == "sibling")
+        assert ours[0]["prev_hash"] == sibling_rec["entry_hash"], (
+            "record chained off a tip that lives in the closed segment"
+        )
+        total, valid = log.verify_integrity()
+        assert total == valid, f"{total - valid} entries failed verification"
+
+    def test_holding_the_pre_rename_inode_still_writes_there(self, sel_dir, small_segments):
+        """Matching identity means our record rides into the segment, chained.
+
+        The other correct outcome: the rename has not happened yet, so the fd we
+        hold is the file we chained from and the write is valid whether or not a
+        rename follows it.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        tip_before = log._last_hash
+        _fill(log, 1, start=8000)
+        line = (
+            (sel_dir / "security_events.jsonl")
+            .read_text(encoding="utf-8")
+            .strip()
+            .splitlines()[-1]
+        )
+        assert json.loads(line)["prev_hash"] == tip_before
+
+    def test_sustained_contention_refuses_rather_than_writing_a_bad_link(
+        self, sel_dir, small_segments
+    ):
+        """Every attempt is validated, including the last.
+
+        Writing the final attempt unguarded would put a knowingly-broken link in
+        the chain, and that does not read as one imperfect record -- it makes
+        `security verify` report the log as COMPROMISED, which an investigator
+        cannot tell apart from real tampering. Refusing is the behaviour this class
+        already has for an unwritable audit.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        tip_before = log._last_hash
+        live = sel_dir / "security_events.jsonl"
+        before = live.read_text(encoding="utf-8")
+
+        calls: list[int] = []
+
+        def always_colliding(inner_self, lines, *, expect=None):
+            calls.append(1)
+            assert expect is not None, "an attempt was made without the fd guard"
+            raise sel_mod._LiveLogReplaced("forced collision")
+
+        with patch.object(SecurityEventLog, "_append_lines_locked", always_colliding):
+            with pytest.raises(sel_mod.SelChainContention):
+                log._append_chained_locked([_make_event(event_id="cont0")])
+
+        assert len(calls) == sel_mod._APPEND_RETRIES + 1
+        assert live.read_text(encoding="utf-8") == before, "a record was written anyway"
+        assert log._last_hash == tip_before, "the chain tip was left advanced"
+
+    def test_contention_is_an_oserror_so_critical_writes_fail_closed(
+        self, sel_dir, small_segments
+    ):
+        """A critical caller must be able to deny the action it could not audit.
+
+        Keeps ``base_dir``: the critical path writes inline and never calls
+        ``_ensure_writer``, so no daemon writer is bound to this per-test dir --
+        asserted below rather than assumed.
+        """
+        assert issubclass(sel_mod.SelChainContention, OSError)
+        log = SecurityEventLog(base_dir=sel_dir, sync=False)
+        with patch.object(
+            SecurityEventLog,
+            "_append_lines_locked",
+            side_effect=sel_mod._LiveLogReplaced("forced collision"),
+        ):
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="cont1"), critical=True)
+        assert log._writer is None, "a writer thread was started after all"
+
+    def test_contention_does_not_kill_the_background_writer(self, small_segments):
+        """Best-effort path: the batch is dropped with a warning, thread survives."""
+        log = SecurityEventLog(sync=False)
+        _fill(log, 2)
+        log.flush()
+        with patch.object(
+            SecurityEventLog,
+            "_append_lines_locked",
+            side_effect=sel_mod._LiveLogReplaced("forced collision"),
+        ):
+            log.log(_make_event(event_id="cont2", resources="dropped"))
+            log.flush()
+        # Writer still alive and still serving later events.
+        assert log._writer is not None and log._writer.is_alive()
+        _fill(log, 1, start=950)
+        log.flush()
+        assert any(e["resources"] == "seq=950" for e in log.recent(limit=20))
+
+    def test_the_guard_covers_both_replacement_and_a_foreign_append(self):
+        """Inode catches a swap; size catches an append the inode cannot see.
+
+        The size signal is what covers the fresh-log case: a rotator anchored on an
+        ABSENT replacement has no inode to compare, so only the size reveals that
+        another process already put a record there -- and without it both would
+        write a record claiming genesis.
+        """
+
+        class _St:
+            def __init__(self, dev, ino, size):
+                self.st_dev = dev
+                self.st_ino = ino
+                self.st_size = size
+
+        changed = sel_mod._identity_changed
+        # Same file, same size: unchanged.
+        assert changed((1, 5, 10), _St(1, 5, 10)) is False
+        # Same file, grown by somebody else: changed.
+        assert changed((1, 5, 10), _St(1, 5, 40)) is True
+        # Replaced file: changed.
+        assert changed((1, 5, 10), _St(1, 6, 10)) is True
+        # No usable inode on either side -- size still decides.
+        assert changed((1, 0, 10), _St(1, 0, 10)) is False
+        assert changed((1, 0, 10), _St(1, 0, 40)) is True
+        # Anchored on an absent replacement; another process wrote first.
+        assert changed((0, 0, 0), _St(1, 7, 512)) is True
+        # Anchored on an absent replacement; still absent/empty.
+        assert changed((0, 0, 0), _St(1, 7, 0)) is False
+
+
+class TestSegmentEnumerationIsBounded:
+    def test_enumeration_stops_at_the_scan_cap(self, sel_dir, small_segments, monkeypatch):
+        """This walk runs on the append path, where a critical audit may be inline.
+
+        An unbounded listing of a directory somebody else filled would stall that
+        caller (no-blocking-call-on-event-loop), so the cost must be capped rather
+        than scale with the directory.
+        """
+        monkeypatch.setattr(sel_mod, "_SEGMENT_SCAN_CAP", 8)
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(200):
+            (segment_dir / f"planted-{i:04d}.txt").write_text("x", encoding="utf-8")
+
+        examined = 0
+        real_scandir = os.scandir
+
+        class _CountingScandir:
+            """Wraps os.scandir, counting entries the caller actually pulls."""
+
+            def __init__(self, path):
+                self._it = real_scandir(path)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self._it.close()
+                return False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                nonlocal examined
+                entry = next(self._it)
+                examined += 1
+                return entry
+
+        with patch("kiro_crew.sel.os.scandir", _CountingScandir):
+            log._segments_oldest_first()
+
+        assert examined <= sel_mod._SEGMENT_SCAN_CAP + 1, (
+            f"walked {examined} entries with a cap of {sel_mod._SEGMENT_SCAN_CAP}; "
+            "enumeration scales with a directory an agent could have filled"
+        )
+
+    def test_the_cap_does_not_hide_the_real_segments(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 400)
+        assert len(log._segments_oldest_first()) == sel_mod._SEGMENT_KEEP
+
+
+class TestRetentionStopsAtAnUndeletableSegment:
+    def test_a_failed_oldest_delete_does_not_eat_newer_history(
+        self, sel_dir, small_segments, monkeypatch
+    ):
+        """Skipping past it would trade newer evidence for stuck older evidence.
+
+        The un-deletable segment keeps occupying a retention slot either way; what
+        must not happen is deleting the segments BEHIND it to make room.
+
+        Rotation enforces retention as it goes, so a plain fill leaves exactly
+        ``_SEGMENT_KEEP`` segments and no excess to sweep -- the branch under test
+        would never run. Accumulate under a LARGER keep, then tighten it, so the
+        sweep has real excess and a real choice about which files to delete.
+        """
+        monkeypatch.setattr(sel_mod, "_SEGMENT_KEEP", 6)
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 700)
+        accumulated = log._segments_oldest_first()
+        assert len(accumulated) == 6, f"precondition: expected 6 segments, got {len(accumulated)}"
+
+        monkeypatch.setattr(sel_mod, "_SEGMENT_KEEP", 3)
+        assert len(accumulated) - sel_mod._SEGMENT_KEEP == 3, "precondition: 3 to sweep"
+        oldest = accumulated[0]
+        real_unlink = Path.unlink
+
+        def refuse_oldest(inner_self, *args, **kwargs):
+            if inner_self == oldest:
+                raise OSError("permission denied")
+            return real_unlink(inner_self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", refuse_oldest):
+            deleted = log._enforce_segment_retention_locked()
+
+        assert deleted == 0, "deleted something despite the oldest being stuck"
+        survivors = log._segments_oldest_first()
+        for kept in accumulated:
+            assert kept in survivors, (
+                f"{kept.name} was deleted to make room for a segment that could not "
+                "be removed -- newer audit history traded for older"
+            )
+
+
+class TestASiblingsAppendDoesNotReadAsCorruption:
+    """Another process appending is exactly HOW the log crosses the cap.
+
+    An append makes the file GROW, which is legitimate, so the replacement check
+    stays deliberately silent while our cached tip goes stale. An earlier revision
+    put a predecessor-hash claim in the rotation record and that stale tip made
+    verification report an untampered log as compromised; the claim is gone (see
+    ``_rotation_event``), and this pins that the benign case stays clean.
+    """
+
+    def test_rotating_after_a_sibling_append_verifies_clean(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        our_cached_tip = log._last_hash
+        live = sel_dir / "security_events.jsonl"
+
+        # A sibling appends one correctly-chained record. Written directly: going
+        # through the API would update OUR view of the file.
+        sibling = _make_event(event_id="sibtip", resources="sibling")
+        sibling.prev_hash = our_cached_tip
+        sibling.entry_hash = log._compute_hash(sibling)
+        with open(live, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(sibling)) + "\n")
+        assert log._last_hash == our_cached_tip, "precondition: our tip is now stale"
+
+        # _rotate_under_lock is called directly, so create the dir its caller
+        # would normally have ensured.
+        (sel_dir / "security_events.d").mkdir(parents=True, exist_ok=True)
+        with patch.object(
+            SecurityEventLog, "_live_size", return_value=sel_mod._SEGMENT_MAX_BYTES
+        ):
+            log._rotate_under_lock()
+
+        opener = json.loads(live.read_text(encoding="utf-8").splitlines()[0])
+        assert opener["event_type"] == "sel_rotation"
+        total, valid = log.verify_integrity()
+        assert total == valid, f"{total - valid} entries reported as compromised"
+
+
+class TestSegmentNameProbingIsBounded:
+    def test_probing_stops_and_defers_rotation(self, sel_dir, small_segments, monkeypatch):
+        """Each probe is a stat on the append path; a filled directory must not
+        make rotation walk it."""
+        monkeypatch.setattr(sel_mod, "_SEGMENT_NAME_PROBES", 4)
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+
+        probes = 0
+        real_exists = Path.exists
+
+        def counting_exists(inner_self, *args, **kwargs):
+            nonlocal probes
+            if inner_self.parent == segment_dir and inner_self.name.startswith(
+                "security_events-"
+            ):
+                probes += 1
+                return True  # every candidate name is taken
+            return real_exists(inner_self, *args, **kwargs)
+
+        with patch.object(Path, "exists", counting_exists):
+            assert log._next_segment_path() is None, "did not defer on an exhausted probe"
+        assert probes == 4, f"probed {probes} times with a cap of 4"
+
+    def test_an_exhausted_probe_still_writes_the_event(self, sel_dir, small_segments):
+        """Deferring means the live log is NOT renamed and the record still lands.
+
+        Asserted on the live log's identity rather than on the segment list: a
+        rotation into a low-sequence name would be deleted by retention as the
+        oldest segment in the same sweep, erasing its own evidence from the list
+        while the live log had still been moved out from under us.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        live = sel_dir / "security_events.jsonl"
+        identity_before = (live.stat().st_dev, live.stat().st_ino)
+        with patch.object(SecurityEventLog, "_next_segment_path", return_value=None):
+            _fill(log, 50, start=9500)
+        assert (live.stat().st_dev, live.stat().st_ino) == identity_before, (
+            "the live log was renamed even though no free segment name was found"
+        )
+        assert log.recent(limit=1)[0]["resources"] == "seq=9549"
+        total, valid = log.verify_integrity()
+        assert total == valid
+
+    def test_a_free_name_is_still_found_normally(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        assert log._segments_oldest_first(), "rotation never found a name"
+
+
+class TestCriticalWritesDoNotRotateInline:
+    """A critical audit runs on its caller's thread, sometimes the event loop.
+
+    Doing rotation's filesystem work there -- a directory scan, a rename, a
+    retention sweep -- would stall the loop. Rotation is deferrable; an audit write
+    is not, so the inline path writes and leaves rotation to the background writer.
+
+    These are the only tests here that exercise the ASYNC writer, so they omit
+    ``base_dir`` and use the session-scoped SEL directory from the rootdir
+    ``_isolate_sel_default_dir`` fixture. That is the repo convention for a reason
+    specific to this class: the writer is a daemon thread on a process singleton,
+    and against a per-test ``tmp_path`` it outlives the test and RE-CREATES the
+    directory on its next flush (``_flush_batch`` mkdirs), so a stray directory
+    reappears after the test's own cleanup removed it. Assertions here are all
+    relative to what the shared directory already holds.
+    """
+
+    def test_a_critical_write_skips_the_rotation_window(self, small_segments):
+        log = SecurityEventLog(sync=False)
+        # Fill past the cap through the background writer, then flush so the log
+        # is genuinely over budget when the critical write arrives.
+        _fill(log, 200)
+        log.flush()
+        segments_before = log._segments_oldest_first()
+
+        entered: list[str] = []
+        real_window = SecurityEventLog._rotation_window
+
+        def recording_window(inner_self):
+            entered.append("yes")
+            return real_window(inner_self)
+
+        with patch.object(SecurityEventLog, "_rotation_window", recording_window):
+            log.log(_make_event(event_id="crit0", resources="critical"), critical=True)
+        assert entered == [], "a critical inline write entered the rotation window"
+        # The record still landed -- that is the half that is not deferrable.
+        assert any(e["resources"] == "critical" for e in log.recent(limit=20))
+        assert log._segments_oldest_first() == segments_before
+
+    def test_the_background_writer_still_rotates(self, small_segments):
+        """Deferring must not mean never.
+
+        Two batches, because the window is entered once per batch and reads the
+        size ALREADY on disk -- the first batch sees a file below the cap and
+        correctly does not rotate, which is the documented one-batch overshoot.
+        """
+        log = SecurityEventLog(sync=False)
+        _fill(log, 200)
+        log.flush()
+        assert log._live_size() > sel_mod._SEGMENT_MAX_BYTES, "precondition: over the cap"
+        before = log._segments_oldest_first()
+        _fill(log, 5, start=500)
+        log.flush()
+        assert len(log._segments_oldest_first()) > len(before), (
+            "background writer never rotated"
+        )
+
+    def test_a_critical_write_still_fails_closed(self, sel_dir, small_segments):
+        """Skipping rotation must not weaken audit-or-deny.
+
+        Keeps ``base_dir``: the append is patched to raise, so no event is ever
+        enqueued and the daemon writer is never started -- nothing outlives this
+        test to re-create the directory.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=False)
+        with patch.object(
+            SecurityEventLog, "_append_lines_locked", side_effect=OSError("full disk")
+        ):
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="crit1"), critical=True)
+        assert log._writer is None, "a writer thread was started after all"
+
+
+class TestBackwardReadBufferIsBounded:
+    def test_an_unterminated_file_does_not_accumulate_without_bound(
+        self, sel_dir, small_segments, monkeypatch
+    ):
+        """A planted segment with no newline would otherwise be held in memory.
+
+        This reader is pointed at attacker-influenced input: a segment planted
+        before this release is read here by both the time-range read and segment
+        admission.
+        """
+        monkeypatch.setattr(sel_mod, "_MAX_LINE_BYTES", 64 * 1024)
+        monkeypatch.setattr(sel_mod, "_TAIL_CHUNK_BYTES", 8 * 1024)
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        planted = segment_dir / "security_events-000001-20200101T000000Z.jsonl"
+        planted.write_bytes(b"A" * (1024 * 1024))  # 1 MiB, not one newline in it
+
+        yielded = list(log._iter_lines_backward(planted))
+        assert yielded == [], "an unterminated file yielded a line"
+        # Admission must simply fail, not blow up.
+        assert log._segment_is_signed_by_us(planted) is False
+        assert planted not in list(log._read_sources_newest_first())
+
+    def test_a_normal_log_is_read_completely(self, sel_dir, small_segments):
+        """The cap must not truncate ordinary records."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 40)
+        live = sel_dir / "security_events.jsonl"
+        expected = len(live.read_text(encoding="utf-8").strip().splitlines())
+        assert len(list(log._iter_lines_backward(live))) == expected
+
+
+class TestTwoWritersCannotBothClaimGenesis:
+    """The rotation record must not assume it lands first in the fresh log.
+
+    After the rename the replacement is absent, and another process appending sees
+    a small file -- so it never enters the rotation window and never takes the
+    rotation lock. If the rotator then wrote a genesis record blindly, the new log
+    would hold TWO records claiming an empty prev_hash and its chain would be
+    broken from the second line.
+    """
+
+    def test_a_writer_that_beat_the_rotator_is_chained_off(self, sel_dir, small_segments):
+        """Driven through _rotate_under_lock, not through its helpers.
+
+        The sibling's write is injected at the real interleaving point -- inside the
+        rename -- so the rotator's own boundary-record path is what is under test.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        live = sel_dir / "security_events.jsonl"
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+
+        real_replace = os.replace
+        raced: list[str] = []
+
+        def replace_then_race(src, dst, *args, **kwargs):
+            result = real_replace(src, dst, *args, **kwargs)
+            if not raced:
+                raced.append("yes")
+                # A sibling process creates the replacement and puts the FIRST
+                # record in it, before the rotator can write its own.
+                first = _make_event(event_id="first0", resources="beat-the-rotator")
+                first.prev_hash = ""
+                first.entry_hash = log._compute_hash(first)
+                live.write_text(json.dumps(asdict(first)) + "\n", encoding="utf-8")
+            return result
+
+        with patch("kiro_crew.sel.os.replace", replace_then_race):
+            with patch.object(
+                SecurityEventLog, "_live_size", return_value=sel_mod._SEGMENT_MAX_BYTES
+            ):
+                log._rotate_under_lock()
+
+        assert raced, "precondition: the injected sibling write fired"
+        rows = [json.loads(line) for line in live.read_text(encoding="utf-8").splitlines()]
+        assert [r["event_type"] for r in rows] == ["tool_invocation", "sel_rotation"]
+        assert rows[0]["prev_hash"] == ""
+        assert rows[1]["prev_hash"] == rows[0]["entry_hash"], (
+            "the rotation record claimed genesis in a log that already had a record"
+        )
+        total, valid = log.verify_integrity()
+        assert total == valid, f"{total - valid} entries failed verification"
+
+    def test_uncontended_rotation_still_puts_the_record_first(self, sel_dir, small_segments):
+        """The common case is unchanged: nothing raced, so the record opens the log."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        opener = json.loads(
+            (sel_dir / "security_events.jsonl").read_text(encoding="utf-8").splitlines()[0]
+        )
+        assert opener["event_type"] == "sel_rotation"
+        assert opener["prev_hash"] == ""
+
+
+class TestCollisionRetryReanchorsUnconditionally:
+    """A collision has already proved the file moved on.
+
+    The retry must not re-ask a predicate to decide whether to refresh the tip. An
+    earlier revision routed it through the conditional check, and because that check
+    reacted only to a shrink while the guard fired on growth too, a foreign APPEND
+    was detected and then not corrected -- the retry re-chained from the very tip
+    the collision had just invalidated and wrote it.
+    """
+
+    def test_a_foreign_append_is_re_chained_not_re_written_stale(
+        self, sel_dir, small_segments
+    ):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        live = sel_dir / "security_events.jsonl"
+        stale_tip = log._last_hash
+
+        # A sibling appends one correctly-chained record: the file GROWS, which is
+        # what the old shrink-only predicate refused to react to.
+        sibling = _make_event(event_id="grow0", resources="sibling-grew")
+        sibling.prev_hash = stale_tip
+        sibling.entry_hash = log._compute_hash(sibling)
+        with open(live, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(sibling)) + "\n")
+        assert log._last_hash == stale_tip, "precondition: our cached tip is stale"
+
+        _fill(log, 1, start=6000)
+
+        rows = [json.loads(line) for line in live.read_text(encoding="utf-8").splitlines()]
+        ours = rows[-1]
+        assert ours["resources"] == "seq=6000"
+        assert ours["prev_hash"] == sibling.entry_hash, (
+            "wrote a stale prev_hash after the collision was detected"
+        )
+        total, valid = log.verify_integrity()
+        assert total == valid, f"{total - valid} entries failed verification"
+
+    def test_reanchor_now_refreshes_without_asking(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        real_tip = log._last_hash
+        log._last_hash = "0" * 64  # pretend we hold something stale
+        log._reanchor_now()
+        assert log._last_hash == real_tip
+        assert log._live_seen == log._live_identity()
+
+
+class TestOnlyTheWriterThreadRotates:
+    """Rotation's filesystem work must never land on an inline caller's thread.
+
+    A critical audit and the writer-start fallback both reach ``_flush_batch``
+    inline, and for an async handler that thread is the event loop. The permission
+    is derived from the running thread so a future inline caller cannot reintroduce
+    the stall by forgetting a flag.
+    """
+
+    def test_sync_mode_may_rotate(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        assert log._may_rotate() is True
+
+    def test_an_inline_caller_may_not_rotate(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=False)
+        # No writer thread started yet, and this is the test's own thread.
+        assert log._may_rotate() is False
+
+    def test_the_writer_thread_may_rotate(self, small_segments):
+        """Verified from INSIDE the writer, not by reasoning about it."""
+        log = SecurityEventLog(sync=False)
+        seen: list[bool] = []
+        real_window = SecurityEventLog._rotation_window
+
+        def recording_window(inner_self):
+            seen.append(inner_self._may_rotate())
+            return real_window(inner_self)
+
+        with patch.object(SecurityEventLog, "_rotation_window", recording_window):
+            _fill(log, 5)
+            log.flush()
+        assert seen and all(seen), "the writer thread was denied rotation"
+
+    def test_the_writer_start_fallback_does_not_rotate(self, small_segments):
+        """The path this finding was about: _ensure_writer fails, we write inline.
+
+        That inline write happens on whatever thread called log() -- possibly the
+        event loop -- so it must not scan, rename and sweep.
+
+        Omits ``base_dir`` for the session-scoped SEL directory: ``_fill`` starts
+        the daemon writer, and against a per-test ``tmp_path`` that thread outlives
+        the test and re-creates the directory after cleanup. Assertions are relative
+        to whatever the shared directory already holds.
+        """
+        log = SecurityEventLog(sync=False)
+        # Get the log over the cap first, through a path that is allowed to rotate.
+        _fill(log, 200)
+        log.flush()
+        before = log._segments_oldest_first()
+        assert log._live_size() > sel_mod._SEGMENT_MAX_BYTES, "precondition: over the cap"
+
+        entered: list[str] = []
+        real_window = SecurityEventLog._rotation_window
+
+        def recording_window(inner_self):
+            entered.append("yes")
+            return real_window(inner_self)
+
+        with patch.object(SecurityEventLog, "_ensure_writer", side_effect=RuntimeError("no thread")):
+            with patch.object(SecurityEventLog, "_rotation_window", recording_window):
+                log.log(_make_event(event_id="fb0", resources="fallback"))
+
+        assert entered == [], "the writer-start fallback rotated on the caller's thread"
+        assert log._segments_oldest_first() == before
+        # The record still landed: that is the half that is not deferrable.
+        assert any(e["resources"] == "fallback" for e in log.recent(limit=20))
+
+
+class TestAsyncTestsUseTheSessionScopedDirectory:
+    """Ratchet for a convention I have now broken twice on this PR.
+
+    A ``sync=False`` log started by ``_fill`` runs a DAEMON writer thread on a
+    process singleton. Bound to a per-test ``tmp_path`` it outlives the test and
+    re-creates the directory on its next flush, so a stray directory reappears
+    after cleanup (see the rootdir ``_isolate_sel_default_dir`` fixture). A test
+    that starts the writer must therefore omit ``base_dir``.
+
+    Asserted structurally rather than by discipline, because discipline already
+    failed: it was applied in one round and violated in the next.
+    """
+
+    def test_no_writer_starting_test_pins_a_per_test_dir(self):
+        import ast
+
+        source = Path(__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        offenders: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            body = ast.get_source_segment(source, node) or ""
+            constructs_async = "sync=False" in body and "base_dir=" in body
+            starts_writer = "_fill(" in body or ".log(" in body
+            if constructs_async and starts_writer:
+                # A test may keep base_dir if it proves no writer was started.
+                if "_writer is None" in body:
+                    continue
+                offenders.append(node.name)
+        assert offenders == [], (
+            "these tests build an async SecurityEventLog on a per-test dir AND write "
+            f"through it, leaking a daemon writer bound to that dir: {offenders}. "
+            "Omit base_dir to use the session-scoped SEL directory."
+        )
+
+
+class TestPruneCannotClobberAConcurrentRotation:
+    """prune's read-then-replace is the one path that can lose persisted events.
+
+    ``_lock`` is a thread lock, so it says nothing about a sibling process. If one
+    rotates while prune is streaming, prune's ``os.replace`` drops a snapshot of the
+    OLD file over the fresh live log -- discarding its rotation record and every
+    event appended since.
+    """
+
+    def test_prune_takes_the_rotation_lock(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        for i in range(20):
+            log.log(
+                _make_event(
+                    event_id=f"old{i:04d}",
+                    timestamp=(base + timedelta(seconds=i)).isoformat(),
+                    resources=f"old={i}",
+                )
+            )
+        _fill(log, 5, start=700)  # recent entries that must survive
+        lock_path = sel_dir / "security_events.d" / ".rotate.lock"
+
+        held: list[bool] = []
+        real_prune_live = SecurityEventLog._prune_live_locked
+
+        def recording(inner_self, cutoff, keep_days):
+            held.append(_lock_is_held(lock_path))
+            return real_prune_live(inner_self, cutoff, keep_days)
+
+        with patch.object(SecurityEventLog, "_prune_live_locked", recording):
+            removed = log.prune(keep_days=365)
+        assert removed > 0, "precondition: something was pruned"
+        assert held and all(held), "prune rewrote the live log without the rotation lock"
+
+    def test_prune_skips_the_live_sweep_when_it_cannot_serialize(
+        self, sel_dir, small_segments
+    ):
+        """Skipping beats an unserialized rewrite: the latter loses events."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        for i in range(20):
+            log.log(
+                _make_event(
+                    event_id=f"old{i:04d}",
+                    timestamp=(base + timedelta(seconds=i)).isoformat(),
+                )
+            )
+        live = sel_dir / "security_events.jsonl"
+        before = live.read_text(encoding="utf-8")
+        with patch.object(SecurityEventLog, "_open_rotation_lock", return_value=None):
+            log.prune(keep_days=365)
+        assert live.read_text(encoding="utf-8") == before, "swept without the lock"
+
+    def test_prune_re_anchors_after_replacing_the_live_log(self, sel_dir, small_segments):
+        """The replace changes the inode, so the cached identity must follow.
+
+        Note what this does NOT assert. Rewriting the live log orphans the first
+        SURVIVING record's ``prev_hash`` -- it names a record prune just deleted --
+        so a pruned log carries exactly one chain break. That is pre-existing
+        behaviour of the in-place rewrite, not something rotation introduced, and it
+        cannot be repaired by editing the survivor: ``prev_hash`` is covered by the
+        record's own HMAC, so changing it would mean re-signing audit records. The
+        property that must hold is that prune introduces NO FURTHER break -- our
+        next append chains off the rewritten file's real tip.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        for i in range(10):
+            log.log(
+                _make_event(
+                    event_id=f"old{i:04d}",
+                    timestamp=(base + timedelta(seconds=i)).isoformat(),
+                )
+            )
+        _fill(log, 3, start=800)
+        assert log.prune(keep_days=365) > 0
+        assert log._live_seen == log._live_identity()
+        assert log._last_hash == log._read_last_hash()
+
+        total_before, valid_before = log.verify_integrity()
+        orphaned = total_before - valid_before
+        assert orphaned == 1, (
+            f"expected exactly the known orphaned-first-survivor break, got {orphaned}"
+        )
+
+        _fill(log, 1, start=900)
+        total_after, valid_after = log.verify_integrity()
+        assert total_after - valid_after == orphaned, (
+            "the post-prune append introduced a NEW chain break"
+        )
+        last = json.loads(
+            (sel_dir / "security_events.jsonl")
+            .read_text(encoding="utf-8")
+            .strip()
+            .splitlines()[-1]
+        )
+        assert last["resources"] == "seq=900"
+
+
+class TestSegmentDirIsNotFollowedThroughALink:
+    """Neither the segment dir nor a segment name may be a planted link.
+
+    Before this release ``security_events.d`` was not on the sensitive-path
+    floor, so an agent could have pre-planted either. Same defense as the SEL
+    trust dir: remove the LINK, never its target.
+    """
+
+    def test_a_planted_link_is_replaced_by_a_real_directory(self, sel_dir, small_segments):
+        outside = sel_dir.parent / "agent-readable"
+        outside.mkdir()
+        link = sel_dir / "security_events.d"
+        sel_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform/filesystem")
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        assert not link.is_symlink(), "rotation wrote through a planted link"
+        assert log._segments_oldest_first(), "precondition: rotation happened"
+        assert list(outside.iterdir()) == [], "audit segments landed outside the fence"
+
+    def test_an_unremovable_link_refuses_to_rotate(self, sel_dir, small_segments):
+        """Refusing beats writing audit records outside the fence.
+
+        The log keeps growing, which is the failure this release bounds — but an
+        oversized log inside the fence beats a bounded one outside it.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        with patch("kiro_crew.sel.platform_compat.is_link_or_junction", return_value=True):
+            with patch(
+                "kiro_crew.sel.platform_compat.unlink_link_or_junction",
+                side_effect=OSError("read-only"),
+            ):
+                before = log._segments_oldest_first()
+                _fill(log, 300, start=2000)
+                assert log._segments_oldest_first() == before, "rotated through the link"
+        # The audit records still landed in the live log.
+        assert log.recent(limit=1)[0]["resources"] == "seq=2299"
+
+    def test_a_planted_segment_link_is_never_read_as_audit_history(
+        self, sel_dir, small_segments
+    ):
+        """A segment-shaped SYMLINK must not be surfaced as events.
+
+        Every reader resolves segments by name, and `recent()` backs the
+        dashboard's SEL events endpoint -- so a link planted before the upgrade
+        pointing at, say, the refresh-chain store would have its JSON handed back
+        as audit records.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)  # creates the real segment dir
+        secret = sel_dir / "refresh_chains.json"
+        secret.write_text(json.dumps({"chain": "s3cr3t-refresh-token"}) + "\n", encoding="utf-8")
+        planted = sel_dir / "security_events.d" / "security_events-000001-20200101T000000Z.jsonl"
+        try:
+            planted.unlink(missing_ok=True)
+            planted.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform/filesystem")
+        assert planted.is_symlink()
+
+        assert planted not in log._segments_oldest_first(), "a planted link ranked as a segment"
+        surfaced = json.dumps(log.recent(limit=10_000))
+        assert "s3cr3t-refresh-token" not in surfaced, "linked file's content surfaced as events"
+        # The link's target must survive: we ignore the entry, we do not chase it.
+        assert secret.exists()
+
+    def test_a_segment_shaped_directory_is_ignored(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        bogus = sel_dir / "security_events.d" / "security_events-000002-20200101T000000Z.jsonl"
+        bogus.mkdir(parents=True, exist_ok=True)
+        assert bogus not in log._segments_oldest_first()
+        total, valid = log.verify_integrity()
+        assert total == valid
+
+
+class TestPlantedSegmentsAreNotReadAsHistory:
+    """A forged segment must never surface through the read path.
+
+    ``security_events.d`` is created by this release and was not on the
+    sensitive-path floor before it, so an agent could have pre-created the
+    directory and left a segment-shaped JSONL of its own choosing. Admission is
+    by SIGNATURE: the chain key lives outside the log directory, so a planted
+    file cannot carry a single valid one.
+    """
+
+    @staticmethod
+    def _plant(sel_dir: Path, seq: int = 1) -> Path:
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        planted = segment_dir / f"security_events-{seq:06d}-20200101T000000Z.jsonl"
+        forged = {
+            "event_id": "forged0000000001",
+            "timestamp": "2020-01-01T00:00:00+00:00",
+            "event_type": "tool_invocation",
+            "caller_identity": "dashboard:victim",
+            "agent": "kirocrew",
+            "source": "dashboard",
+            "operation": "rm -rf /",
+            "outcome": "approved",
+            "resources": "FORGED-MARKER",
+            "prev_hash": "",
+            "entry_hash": "0" * 64,
+            "metadata": {},
+        }
+        planted.write_text(json.dumps(forged) + "\n", encoding="utf-8")
+        return planted
+
+    def test_recent_never_returns_unsigned_records(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        self._plant(sel_dir)
+        surfaced = json.dumps(log.recent(limit=10_000))
+        assert "FORGED-MARKER" not in surfaced, "forged records were presented as audit events"
+
+    def test_a_genuine_segment_is_still_read(self, sel_dir, small_segments):
+        """The admission gate must not hide real history."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        segments = log._segments_oldest_first()
+        assert segments, "precondition: rotation happened"
+        assert all(log._segment_is_signed_by_us(p) for p in segments)
+        # A window reaching back into the segments returns their events.
+        reached = log.recent(limit=10_000, since=datetime(2020, 1, 1, tzinfo=timezone.utc))
+        assert len(reached) > len(
+            (sel_dir / "security_events.jsonl").read_text(encoding="utf-8").splitlines()
+        )
+
+    def test_verify_integrity_reports_a_planted_segment_instead_of_hiding_it(
+        self, sel_dir, small_segments
+    ):
+        """An audit tool must surface tampering, not quietly drop the evidence."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        self._plant(sel_dir)
+        total, valid = log.verify_integrity()
+        assert total > valid, "the planted segment was hidden from verification"
+
+    def test_an_empty_segment_is_not_admitted(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        empty = segment_dir / "security_events-000009-20200101T000000Z.jsonl"
+        empty.write_text("", encoding="utf-8")
+        assert log._segment_is_signed_by_us(empty) is False
+
+    def test_segments_are_not_opened_when_the_live_log_answers(self, sel_dir, small_segments):
+        """The bounded tail read must not pay for segment admission."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        assert log._segments_oldest_first(), "precondition: segments exist"
+        with patch.object(
+            SecurityEventLog,
+            "_segment_is_signed_by_us",
+            side_effect=AssertionError("segment opened for a tail read"),
+        ):
+            assert len(log.recent(limit=3)) == 3
+
+
+class TestForeignRotationDoesNotBreakOurChain:
+    """Another process's rotation must not leave us chaining into a closed segment.
+
+    Several processes share one data home and append to this file, each caching
+    its own tip. A process whose next append comes AFTER a foreign rotation does
+    not see the cap at all, so it never enters the rotation window -- and would
+    chain off a tip that has moved into the closed segment. Unlike the
+    pre-existing interleaving race, that break is guaranteed for every process
+    after every foreign rotation.
+    """
+
+    def test_a_replaced_live_log_re_anchors_before_the_next_append(
+        self, sel_dir, small_segments
+    ):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        stale_tip = log._last_hash
+        live = sel_dir / "security_events.jsonl"
+        # What WE last saw. The sibling's work below must not update it: the whole
+        # point is that this process never observed the replacement.
+        pre_rotation_identity = log._live_seen
+
+        # Stand in for the sibling process: rotate the log out of band and write
+        # one genuine record (correctly signed, chained from genesis) into the
+        # fresh live log. Written directly rather than through the SEL API because
+        # SecurityEventLog is a singleton -- a second construction would hand back
+        # THIS instance and update its view of the file.
+        segment_dir = sel_dir / "security_events.d"
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        os.replace(live, segment_dir / "security_events-000001-20260821T000000Z.jsonl")
+        sibling_event = _make_event(event_id="sib0", resources="sibling")
+        sibling_event.prev_hash = ""
+        sibling_event.entry_hash = log._compute_hash(sibling_event)
+        live.write_text(json.dumps(asdict(sibling_event)) + "\n", encoding="utf-8")
+        sibling_tip = sibling_event.entry_hash
+        assert sibling_tip != stale_tip
+
+        # Our process still holds the pre-rotation tip and is nowhere near the cap,
+        # so it never enters the rotation window at all.
+        log._live_seen = pre_rotation_identity
+        log._last_hash = stale_tip
+        _fill(log, 1, start=9000)
+
+        lines = live.read_text(encoding="utf-8").strip().splitlines()
+        ours = json.loads(lines[-1])
+        assert ours["resources"] == "seq=9000"
+        assert ours["prev_hash"] == sibling_tip, (
+            "chained off a tip that now lives in the closed segment"
+        )
+        total, valid = log.verify_integrity()
+        assert total == valid, f"{total - valid} entries failed after a foreign rotation"
+
+    def test_an_append_only_log_that_merely_grew_is_not_treated_as_replaced(self, sel_dir):
+        """Growth is the normal case; re-reading the tip on it would be pure cost.
+
+        Deliberately NOT using the shrunken-cap fixture: under the production cap
+        these appends cannot trigger a rotation, so the only thing that could read
+        the tip back is a spurious replacement verdict.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        assert log._segments_oldest_first() == [], "precondition: no rotation"
+        with patch.object(
+            SecurityEventLog,
+            "_read_last_hash",
+            side_effect=AssertionError("re-anchored on a plain append"),
+        ):
+            _fill(log, 5, start=100)
+        total, valid = log.verify_integrity()
+        assert total == valid
+
+
+class TestLiveLogMovedOnHelper:
+    """One predicate serves the pre-append check and the post-open guard.
+
+    Answering the same question differently in those two places is how a stale tip
+    survived a collision: the guard fired on growth while the re-anchor reacted only
+    to a shrink, so a foreign APPEND was detected and then not corrected.
+    """
+
+    @pytest.mark.parametrize(
+        ("previous", "current", "expected"),
+        [
+            ((1, 10, 500), (1, 10, 500), False),  # unchanged
+            # Growth is somebody ELSE appending: our own writes refresh the anchor
+            # from the fd, so a size difference always means a foreign write.
+            ((1, 10, 500), (1, 10, 900), True),
+            ((1, 10, 500), (1, 11, 40), True),  # new inode: replaced
+            ((1, 10, 500), (1, 10, 40), True),  # shrank: append-only cannot
+            ((1, 0, 500), (1, 0, 40), True),  # no inode available, size decides
+            ((1, 0, 500), (1, 0, 500), False),  # no inode available, unchanged
+            ((1, 10, 500), (2, 10, 40), True),  # same ino, different device
+            ((0, 0, 0), (1, 7, 512), True),  # anchored absent, somebody wrote
+            ((0, 0, 0), (1, 7, 0), False),  # anchored absent, still empty
+        ],
+    )
+    def test_moved_on_signals(self, previous, current, expected):
+        assert sel_mod._live_log_moved_on(previous, current) is expected
+
+    def test_the_guard_delegates_to_the_same_predicate(self):
+        """``_identity_changed`` must not be a second, drifting implementation."""
+
+        class _St:
+            def __init__(self, dev, ino, size):
+                self.st_dev = dev
+                self.st_ino = ino
+                self.st_size = size
+
+        for previous, dev, ino, size in [
+            ((1, 10, 500), 1, 10, 500),
+            ((1, 10, 500), 1, 10, 900),
+            ((1, 10, 500), 1, 11, 500),
+            ((0, 0, 0), 1, 7, 512),
+        ]:
+            assert sel_mod._identity_changed(previous, _St(dev, ino, size)) is (
+                sel_mod._live_log_moved_on(previous, (dev, ino, size))
+            )
+
+
+class TestTimeWindowRead:
+    """``recent()`` takes a time window, and reads only what it needs.
+
+    A count alone could not express "the last two hours": on a busy log 6000
+    entries reached 15 minutes back, so a two-hour question meant pulling ~90k
+    entries and filtering client-side (issue #4843).
+    """
+
+    def test_since_and_until_bound_the_window(self, sel_dir):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 500)
+        base = datetime(2026, 8, 21, tzinfo=timezone.utc)
+        got = log.recent(
+            limit=100, since=base + timedelta(seconds=100), until=base + timedelta(seconds=110)
+        )
+        assert [e["resources"] for e in got] == [f"seq={i}" for i in range(109, 99, -1)]
+
+    def test_until_is_exclusive_and_since_inclusive(self, sel_dir):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 20)
+        base = datetime(2026, 8, 21, tzinfo=timezone.utc)
+        got = log.recent(
+            limit=100, since=base + timedelta(seconds=5), until=base + timedelta(seconds=6)
+        )
+        assert [e["resources"] for e in got] == ["seq=5"]
+
+    def test_window_reads_across_a_segment_boundary(self, sel_dir, small_segments):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 120)
+        assert log._segments_oldest_first(), "precondition: rotation happened"
+        base = datetime(2026, 8, 21, tzinfo=timezone.utc)
+        got = log.recent(limit=500, since=base + timedelta(seconds=110))
+        # Rotation records carry their own (wall-clock) timestamp and are real
+        # audit entries, so they legitimately fall in the window too.
+        events = [e for e in got if e["event_type"] != "sel_rotation"]
+        assert [e["resources"] for e in events] == [f"seq={i}" for i in range(119, 109, -1)]
+
+    def test_limit_still_caps_a_windowed_read(self, sel_dir):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        got = log.recent(limit=4, since=datetime(2020, 1, 1, tzinfo=timezone.utc))
+        assert len(got) == 4
+        assert got[0]["resources"] == "seq=199"
+
+    def test_no_window_reads_the_tail_unchanged(self, sel_dir):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 50)
+        assert [e["resources"] for e in log.recent(limit=3)] == ["seq=49", "seq=48", "seq=47"]
+
+    def test_a_bounded_read_does_not_load_the_whole_file(self, sel_dir):
+        """The read cost must not scale with the log's size.
+
+        The old ``recent()`` did ``read_text().splitlines()``, so printing 20
+        entries allocated the entire log — 4.09 GB on the reported install.
+        """
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 4000)
+        live = sel_dir / "security_events.jsonl"
+        size = live.stat().st_size
+        assert size > sel_mod._TAIL_CHUNK_BYTES, "precondition: log exceeds one chunk"
+        read_bytes = 0
+        real_read = os.read
+
+        def counting_read(fd, n):
+            nonlocal read_bytes
+            chunk = real_read(fd, n)
+            read_bytes += len(chunk)
+            return chunk
+
+        with patch("kiro_crew.sel.os.read", counting_read, create=True):
+            with patch.object(Path, "read_text", side_effect=AssertionError("whole-file read")):
+                assert len(log.recent(limit=5)) == 5
+
+    def test_records_with_unreadable_timestamps_are_excluded_from_a_window(self, sel_dir):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        log.log(_make_event(event_id="bad", timestamp="not-a-time", resources="seq=bad"))
+        _fill(log, 5)
+        assert any(e["resources"] == "seq=bad" for e in log.recent(limit=50))
+        windowed = log.recent(limit=50, since=datetime(2020, 1, 1, tzinfo=timezone.utc))
+        assert all(e["resources"] != "seq=bad" for e in windowed)
+
+    def test_zero_limit_reads_nothing(self, sel_dir):
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 5)
+        assert log.recent(limit=0) == []


### PR DESCRIPTION
## What is the problem?

`security_events.jsonl` in the data home had no rotation, no size cap and no retention count. On a long-running install it reached 4.09 GB in one file.

Two consequences, both reported in #4843:

1. Disk growth is unbounded.
2. The log becomes impractical to query long before that size. `kirocrew security events` is the sanctioned read path and it takes only a count (`-n LIMIT`), not a time range. Measured on the 4.09 GB log: 6000 entries reached 15 minutes into the past, so answering a question about an event two hours old required pulling roughly 90,000 entries and filtering client-side.

Reading the file directly is correctly refused by the credential-path deny gate, so the CLI is the only supported route and it had no time-based selector to compensate.

Reproduced on unmodified `kirocrew/main`: 20,000 events landed in a single `security_events.jsonl` at 513 bytes/event with no other file on disk, and `SecurityEventLog.recent` had the signature `(self, limit)` -- no time parameter of any kind.

## Why this issue matters to the user

The audit log is the evidence trail for every tool call, governance decision and API access. An operator investigating an incident reaches for it precisely when time matters, and the only reader made a time-scoped question cost a guess plus a ~90k-entry dump. Meanwhile the file grows for the life of the install with nothing bounding it.

A third cost was measured while fixing this: `recent()` did `read_text().splitlines()`, so printing 20 entries allocated the whole log -- 4.09 GB for the tail of a file.

## How our fix solves it

**Rotation, size-capped with a retention count.** The live log is closed at 32 MiB and renamed into `security_events.d/`, keeping 7 closed segments -- a ~256 MiB ceiling, roughly 500k events at the measured 513 bytes/event. Age retention (`prune`, 365 days, swept daily by the heartbeat) is unchanged and still applies on top; size rotation is what bounds the log *between* those sweeps, which is the window the 4.09 GB accumulated in.

**Each segment stays independently verifiable.** This is the constraint the issue named. Every segment is its own HMAC chain starting from genesis, and the first record of each new live log is a `sel_rotation` event naming the segment just closed and its final `entry_hash`. Consequences:

- A segment deleted by retention cannot make a surviving one look tampered. With one chain across the whole log, dropping the oldest file would orphan the next file's first `prev_hash` and report a break on every sweep.
- The boundary is not lost, it becomes evidence. `verify_integrity` walks segments oldest-first and checks each rotation record's claim against the predecessor actually on disk; a truncated or substituted predecessor is reported. When the predecessor is simply gone (retention did its job) there is nothing to contradict and the record counts normally.
- `prune` ages out whole segments rather than rewriting them, because rewriting one would orphan its own first record's `prev_hash`.

**Segment names carry a monotonic sequence, not just a timestamp.** My first implementation used a timestamp plus a hole-filling counter, and the functional probe caught it deleting the newest log: after retention frees a number, a same-second rotation reuses it, the reused name sorts as the OLDEST segment, and the next sweep deletes the log just closed. The sequence now continues from the highest segment on disk, which also survives an NTP step that moves the clock backwards.

**Time-range read.** `recent()` takes `since`/`until`, surfaced as `security events --since` / `--until` accepting a relative age (`30m`, `2h`, `7d`, `1w`) or an ISO 8601 instant (`2026-08-21`, `2026-08-21T04:00:00Z`). A bare date is read as UTC, because the log is written in UTC and reading it as local time would silently shift the window. An unparseable selector exits 2 with the accepted forms, rather than returning nothing and reading as "no events in that window".

**The read is bounded on both ends.** Files are scanned backward from the tail in 256 KiB chunks (the same proven backward scan `_read_last_hash` uses) instead of being read whole, and the walk stops at the first record older than `since` because the log is append-ordered. Rotated segments are opened only when the live log has not already satisfied the request.

**Rotated segments are added to the sensitive-path floor** (`security_events.d`, a directory entry so every segment is covered). A segment holds exactly the same audit records the live log does; leaving them off the floor would have made rotation itself the way around the fence.

## What tests we did

Reproduced first on unmodified `kirocrew/main`, then re-ran the same probes after the fix.

New regression tests (22, all mutation-verified):

- `TestSizeRotation` -- live log closed at the cap; retention keeps exactly N and holds the total under the ceiling; the sequence rises across deletions and the newest survivor is the live log's named predecessor; every segment starts from genesis; the rotation record names the closed segment and its tip; `verify_integrity` spans segments; **deleting an aged-out segment leaves survivors verifiable**; tampering inside a segment is still caught; a truncated predecessor is reported at the boundary; a non-segment file an operator parked in the directory is never deleted; a rotation that cannot happen still writes the event; the segment dir is 0700; `prune` ages out whole segments and keeps one straddling the cutoff.
- `TestTimeWindowRead` -- `since`/`until` bound the window with inclusive/exclusive ends; a window reads across a segment boundary; `limit` still caps a windowed read; an unwindowed read is unchanged; **a bounded read does not load the whole file** (asserts no `Path.read_text` on a log larger than one chunk); records with unreadable timestamps are excluded from a window but returned without one.
- `TestParseTimeSelector` -- relative ages, case-insensitivity, `Z` suffix (`fromisoformat` only accepts it from 3.11 and this package supports 3.10), bare date as UTC, offset normalization, unreadable input.
- CLI: the window is passed through, an unreadable time and an inverted window exit 2 without reading, and the empty result names the window.
- Security: `security_events.d` and a segment inside it are refused by `is_sensitive_path` and by the shell matcher, in both the current and the legacy data home.

Mutation verification -- 7 mutants, each caught: rotation never fires; retention keeps everything; the new segment continues the old chain; `verify_integrity` ignores segments; `since`/`until` ignored; the name matcher accepts anything; `prune` leaves segments alone. The retention mutant also exposed a fragile assertion in one of my own tests (the very first segment ever closed legitimately opens with plain events, not a rotation record), which is now asserted honestly.

End-to-end against the real CLI on an isolated data home: `--since 2h` returned 2 of 3 seeded events, `--since 4h --until 2h` returned only the 3-hour-old one, `--since bogus` exited 2 with the accepted forms, and `security verify` reported the chain intact.

Ran: `test_sel.py` (159 with the neighbouring SEL suites), `test_cli_commands_coverage.py` (172), `test_security.py` sensitive-path selection (87), plus `test_mcp_cron_security.py` / `test_governance_self_protection.py` / `test_security_posture.py` (290) because they derive matchers from the sensitive-path list. flake8, isort, mypy, the black baseline gate, the brand gate and `woke` against the added lines are all clean.

## Any other suggestions on the work

- The cap and retention count are module constants, not config keys. `sel.py` is imported very early (`security.py` imports it) and pulling in the config loader there risks an import cycle, so a `security.*` config section is deliberately out of scope. If operators want to tune the ceiling, that is a follow-up with a real seam.
- A segment can overshoot the cap by at most one batch (`_QUEUE_DRAIN_BATCH` events, ~128 KiB against 32 MiB). The check reads the size already on disk, which keeps rotation one `stat` per batch instead of serializing every batch twice to measure it first.
- #4247 reports the same unbounded growth from the availability angle (synchronous append/verify against the oversized file stalls the event loop, so `session/new` times out) and asks for three more things this PR does not do: don't write high-frequency read-only dashboard polling to the hash-chained ledger row-by-row, move audit I/O off the event-loop thread, and reclaim leaked ACP runtimes. Bounding the file removes the *cause* of the stall that issue describes, and the bounded backward read removes the per-read cost, but the polling volume and the synchronous-write placement are untouched and #4247 should stay open for them.
- `prune` still rewrites the live log in place, which orphans the first surviving record's `prev_hash` and reports one break. That is pre-existing behaviour, not introduced here, and it is now the only place the chain can be broken by retention -- worth fixing separately by rotating instead of rewriting.

Closes #4843
