### PR TITLE
fix(dashboard): stream HTTP response bodies to EOF instead of one chunk (#4829)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
+import aiohttp
 from aiohttp import web
 
 from kiro_crew.agent_discovery import (
@@ -100,6 +101,36 @@ async def read_bounded_json(
             {"error": "body must be a JSON object", "code": "body_not_object"}, status=400
         )
     return body, None
+
+
+# Chunk size for draining an OUTBOUND HTTP response to EOF. Matches the
+# bounded-read shape in ``mcp_providers.official._fetch_json``: large enough
+# that a typical body arrives in a handful of iterations, small enough that
+# the over-cap check fires long before an oversized body is buffered whole.
+_RESPONSE_READ_CHUNK_BYTES = 64 * 1024
+
+
+async def read_capped_response(resp: "aiohttp.ClientResponse", cap: int) -> bytes:
+    """Read *resp*'s body to EOF, returning at most ``cap + 1`` bytes.
+
+    A single ``StreamReader.read(n)`` resolves as soon as ANY bytes are
+    buffered -- on a chunked response (no Content-Length) that is the first
+    buffered chunk, so the caller silently works on a truncated body. This
+    drains ``iter_chunked`` chunks until EOF, enforcing the cap against the
+    ACCUMULATED total: reading stops as soon as the total exceeds *cap*, so a
+    hostile oversized body is refused mid-stream rather than buffered whole.
+    The return is clamped to ``cap + 1`` bytes so callers keep the established
+    over-cap sentinel (``len(body) > cap`` means "exceeded the cap"), while a
+    body of exactly *cap* bytes is still delivered complete.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in resp.content.iter_chunked(_RESPONSE_READ_CHUNK_BYTES):
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > cap:
+            break
+    return b"".join(chunks)[: cap + 1]
 
 
 def _audit_admission(surface: str, resource: str, allowed: bool, error: str = "") -> None:

--- a/src/kiro_crew/dashboard/handlers/feedback.py
+++ b/src/kiro_crew/dashboard/handlers/feedback.py
@@ -53,7 +53,7 @@ from aiohttp import web
 from kiro_crew import beacon
 from kiro_crew import sel as _sel_mod
 from kiro_crew.config.loader import KiroCrewConfig
-from kiro_crew.dashboard.handlers._shared import read_bounded_json
+from kiro_crew.dashboard.handlers._shared import read_bounded_json, read_capped_response
 from kiro_crew.dashboard.session_pulse_counter import (
     NEW_USER_SESSION_THRESHOLD,
     get_user_session_count,
@@ -176,11 +176,11 @@ def _survey_identity() -> str:
 async def _read_capped_text(resp: aiohttp.ClientResponse) -> str:
     """Read at most ``_MAX_RESP_BYTES`` from *resp*, raising if it exceeds the cap.
 
-    Mirrors ``kiro_usage_api._read_capped``: reads ``_MAX_RESP_BYTES + 1`` bytes
-    and treats an over-cap body as a failure rather than buffering it, so a
-    hostile endpoint cannot OOM the single-threaded gateway.
+    Streams to EOF via ``read_capped_response`` and treats an over-cap body
+    as a failure rather than buffering it, so a hostile endpoint cannot OOM
+    the single-threaded gateway.
     """
-    raw = await resp.content.read(_MAX_RESP_BYTES + 1)
+    raw = await read_capped_response(resp, _MAX_RESP_BYTES)
     if len(raw) > _MAX_RESP_BYTES:
         raise ValueError("aperture response body exceeded cap")
     return raw.decode("utf-8", "replace")

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -30,6 +30,7 @@ from aiohttp import web
 
 from kiro_crew import github_runner, platform_compat
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.handlers._shared import read_capped_response
 
 # Validation policy, well-known install dirs, and the strict-mode toggle are
 # owned by the shared hardened runner (kiro_crew.github_runner) so every
@@ -2418,8 +2419,11 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
                         f"Jira returned HTTP {resp.status} for {issue_key}."
                     )
                 # Bound response size to prevent memory exhaustion from an
-                # oversized or malicious payload before JSON decoding.
-                body = await resp.content.read(_MAX_PAYLOAD_BYTES + 1)
+                # oversized or malicious payload before JSON decoding. Streamed
+                # to EOF: a single read(n) resolves on the first buffered chunk
+                # of a chunked response and would hand json.loads a truncated
+                # document.
+                body = await read_capped_response(resp, _MAX_PAYLOAD_BYTES)
                 if len(body) > _MAX_PAYLOAD_BYTES:
                     raise SourceProviderError(
                         f"Jira response for {issue_key} exceeds the size limit."

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -25,6 +25,7 @@ from kiro_crew.config.loader import (
     config_path,
     update_config_locked,
 )
+from kiro_crew.dashboard.handlers._shared import read_capped_response
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.platform.update_capability import (
     CHECK_DEFERRED,
@@ -733,11 +734,13 @@ async def _fetch_feed_bytes(url: str) -> tuple[int, bytes]:
     timeout = aiohttp.ClientTimeout(total=_FEED_TIMEOUT_SECS)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(url) as resp:
-            # +1 byte so an oversized body is DETECTED rather than silently
-            # truncated into a parse error. Mirrors the installer's
-            # --max-filesize on this very document, and is enforced against
-            # RECEIVED bytes rather than a Content-Length claim.
-            return resp.status, await resp.content.read(_FEED_MAX_BYTES + 1)
+            # Streamed to EOF with the cap enforced against RECEIVED bytes
+            # rather than a Content-Length claim; the extra byte lets the
+            # caller detect an over-cap body (mirroring the installer's
+            # --max-filesize on this very document). A single read(n) would
+            # resolve on the first buffered chunk of a chunked feed and hand
+            # back a truncated document.
+            return resp.status, await read_capped_response(resp, _FEED_MAX_BYTES)
 
 
 async def _check_release_feed(capability: UpdateCapability) -> None:

--- a/test/test_feedback.py
+++ b/test/test_feedback.py
@@ -20,13 +20,17 @@ _TEST_IDENTITY = "install-abc123"
 
 
 class _FakeContent:
-    """Minimal stand-in for ``aiohttp.StreamReader`` exposing ``read(n)``."""
+    """Minimal stand-in for ``aiohttp.StreamReader``."""
 
     def __init__(self, raw: bytes) -> None:
         self._raw = raw
 
     async def read(self, n: int = -1) -> bytes:
         return self._raw
+
+    async def iter_chunked(self, n: int):
+        for i in range(0, len(self._raw), n):
+            yield self._raw[i : i + n]
 
 
 class _FakeResp:

--- a/test/test_read_capped_response.py
+++ b/test/test_read_capped_response.py
@@ -1,0 +1,183 @@
+"""Tests for the shared ``read_capped_response`` helper (issue #4829).
+
+Three dashboard HTTP readers (the release-feed fetch, the Aperture feedback
+reply, and the Jira issue fetch) previously read the body with a single
+``StreamReader.read(cap + 1)``. ``read(n)`` returns UP TO *n* bytes, resolving
+as soon as any data is buffered, so on a chunked response with no
+Content-Length it hands back only the first buffered chunk and the caller
+silently works on a truncated body. These tests pin the shared helper's
+stream-to-EOF contract and exercise the three callers with multi-chunk bodies.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.dashboard.handlers import feedback as feedback_mod
+from kiro_crew.dashboard.handlers import source_providers as source_mod
+from kiro_crew.dashboard.handlers import updates as updates_mod
+from kiro_crew.dashboard.handlers._shared import read_capped_response
+
+# Bind the real coroutine at import time: an autouse conftest guard replaces
+# the ``updates._fetch_feed_bytes`` module attribute with a refuser for every
+# test, and this suite needs to exercise the real read path (against a fake
+# session -- nothing here touches the network).
+_REAL_FETCH_FEED_BYTES = updates_mod._fetch_feed_bytes
+
+
+class _FakeContent:
+    """Stand-in for ``aiohttp.StreamReader`` that hands out queued chunks.
+
+    ``read(n)`` returns at most ONE queued chunk (split when longer than *n*)
+    and ``b""`` at EOF -- the documented "up to n bytes" contract a single read
+    cannot satisfy for a streamed body -- so a single-read implementation is
+    still exercised and fails these tests with a truncated body rather than an
+    AttributeError.
+    """
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    async def iter_chunked(self, n: int):
+        while self._chunks:
+            yield await self.read(n)
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._chunks:
+            return b""
+        chunk = self._chunks.pop(0)
+        if n >= 0 and len(chunk) > n:
+            self._chunks.insert(0, chunk[n:])
+            chunk = chunk[:n]
+        return chunk
+
+    @property
+    def undelivered(self) -> int:
+        """Bytes a caller that stopped early never consumed."""
+        return sum(len(c) for c in self._chunks)
+
+
+class _FakeResponse:
+    def __init__(self, chunks, status: int = 200):
+        self.status = status
+        self.content = _FakeContent(chunks)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def get(self, url, **kwargs):
+        return self._response
+
+
+class TestReadCappedResponse:
+    @pytest.mark.asyncio
+    async def test_multi_chunk_body_read_whole(self):
+        """A body split across chunks is assembled to EOF, not truncated."""
+        resp = _FakeResponse([b"a" * 10, b"b" * 10, b"c" * 5])
+        assert await read_capped_response(resp, 100) == b"a" * 10 + b"b" * 10 + b"c" * 5
+
+    @pytest.mark.asyncio
+    async def test_exact_cap_body_delivered_complete(self):
+        """A body of exactly *cap* bytes arrives whole and does not trip the sentinel."""
+        resp = _FakeResponse([b"x" * 7, b"y" * 9])
+        body = await read_capped_response(resp, 16)
+        assert body == b"x" * 7 + b"y" * 9
+        assert len(body) <= 16  # callers' ``len(body) > cap`` must stay False
+
+    @pytest.mark.asyncio
+    async def test_over_cap_trips_sentinel_and_stops_reading(self):
+        """An oversized body returns cap + 1 bytes and is refused mid-stream."""
+        resp = _FakeResponse([b"x" * 10, b"y" * 10, b"z" * 1000])
+        body = await read_capped_response(resp, 12)
+        assert len(body) == 13  # cap + 1: the established over-cap sentinel
+        assert resp.content.undelivered == 1000  # not buffered whole
+
+    @pytest.mark.asyncio
+    async def test_empty_body(self):
+        resp = _FakeResponse([])
+        assert await read_capped_response(resp, 10) == b""
+
+
+class TestFeedbackReadCappedText:
+    @pytest.mark.asyncio
+    async def test_multi_chunk_response_decoded_whole(self):
+        text = "aperture says thanks " * 500
+        raw = text.encode("utf-8")
+        resp = _FakeResponse([raw[:100], raw[100:5000], raw[5000:]])
+        assert await feedback_mod._read_capped_text(resp) == text
+
+    @pytest.mark.asyncio
+    async def test_over_cap_body_still_raises(self, monkeypatch):
+        monkeypatch.setattr(feedback_mod, "_MAX_RESP_BYTES", 8)
+        resp = _FakeResponse([b"0123", b"456789"])
+        with pytest.raises(ValueError, match="exceeded cap"):
+            await feedback_mod._read_capped_text(resp)
+
+
+class TestFetchFeedBytes:
+    @pytest.mark.asyncio
+    async def test_chunked_feed_read_whole(self, monkeypatch):
+        """The release feed parses complete even when it arrives in chunks."""
+        payload = json.dumps({"version": "9.9.9", "notes": "x" * 30000}).encode("utf-8")
+        resp = _FakeResponse([payload[:8192], payload[8192:16384], payload[16384:]])
+        monkeypatch.setattr(
+            updates_mod.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(resp)
+        )
+        status, raw = await _REAL_FETCH_FEED_BYTES("https://feed.example/latest-cli.json")
+        assert status == 200
+        assert raw == payload
+
+    @pytest.mark.asyncio
+    async def test_oversized_feed_still_detected(self, monkeypatch):
+        """The caller's ``len(raw) > _FEED_MAX_BYTES`` over-cap check still fires."""
+        big = b"x" * (updates_mod._FEED_MAX_BYTES + 100)
+        resp = _FakeResponse([big[:8192], big[8192:]])
+        monkeypatch.setattr(
+            updates_mod.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(resp)
+        )
+        _status, raw = await _REAL_FETCH_FEED_BYTES("https://feed.example/latest-cli.json")
+        assert len(raw) > updates_mod._FEED_MAX_BYTES  # sentinel trips
+        assert len(raw) == updates_mod._FEED_MAX_BYTES + 1  # but never buffers whole
+
+
+class TestJiraFetchStreams:
+    @pytest.mark.asyncio
+    async def test_multi_chunk_jira_response_parses_whole(self, monkeypatch):
+        """A Jira document split across chunks reaches json.loads complete."""
+        description = "long jira description " * 2000  # well past one 8 KiB chunk
+        doc = json.dumps(
+            {
+                "fields": {
+                    "summary": "Streamed issue",
+                    "description": description,
+                    "status": {"statusCategory": {"key": "new"}},
+                }
+            }
+        ).encode("utf-8")
+        resp = _FakeResponse([doc[:8192], doc[8192:16384], doc[16384:]])
+        monkeypatch.setattr(
+            source_mod.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(resp)
+        )
+        monkeypatch.setattr(source_mod, "_get_jira_auth", lambda host: ("e@example.com", "tok"))
+        ref = source_mod.parse_source_url("https://acme.atlassian.net/browse/PROJ-123")
+
+        issue = await source_mod._fetch_jira_issue(ref)
+
+        assert issue["title"] == "Streamed issue"
+        assert description.strip() in issue["description"]


### PR DESCRIPTION
## Problem / Motivation

Three dashboard HTTP readers read a response body with a single
`aiohttp.StreamReader.read(cap + 1)`. `read(n)` returns **up to** `n` bytes,
resolving as soon as any data is buffered rather than waiting for EOF. On a
chunked response with no `Content-Length` it returns only the first buffered
chunk (~8–12 KiB), so the caller silently works on a truncated body:

- `updates.py::_fetch_feed_bytes` — the release feed is parsed from a partial
  document, so the update check can misread or fail on a chunked feed. The
  site also carried a comment claiming an oversized body "is DETECTED rather
  than silently truncated", which was false for a chunked feed.
- `feedback.py::_read_capped_text` — a truncated Aperture response is decoded
  and treated as the full reply.
- `source_providers.py` (Jira fetch) — `json.loads` on a partial Jira document
  surfaces as `SourceProviderError`, so the issue reads as unavailable rather
  than a parse bug.

All three fail silently, reading as "the remote had nothing". Same defect
class as #2222 and the official-registry site fixed in #4814.

## Why it matters

Update checks, feedback submission acknowledgements, and Jira issue loading
each degrade nondeterministically depending on how the remote frames its
response — with no visible error pointing at the real cause. The failure only
appears with chunked transfer encoding, which makes it environment-dependent
and expensive to diagnose.

## What changed (motivation → approach → change)

Symptom: bodies truncated to the first buffered chunk. Root cause: a single
`read(n)` cannot deliver a streamed body; the repo's established fix shape
(#4814, `official.py::_fetch_json`) drains `iter_chunked` to EOF with the cap
enforced against the accumulated total.

Because the single-read shape has now been reintroduced independently more
than once, the fix extracts **one shared helper** instead of three
near-copies: `read_capped_response(resp, cap)` in
`dashboard/handlers/_shared.py`, right next to the request-side
`read_bounded_json` that already consolidated the inbound twin of this
pattern. It streams to EOF, stops reading as soon as the accumulated total
exceeds the cap (an oversized body is refused mid-stream, never buffered
whole), and clamps the return to `cap + 1` bytes so every caller's existing
over-cap sentinel (`len(body) > cap`) keeps working unchanged. All three
sites route through it; cap values and caller error semantics are untouched.
The stale `updates.py` comment is corrected to describe what the code now
actually guarantees.

## Tests

`test/test_read_capped_response.py` (new), with a fake `StreamReader` whose
`read(n)` honors the real "up to n bytes" contract so a single-read
implementation is exercised and fails (all caller tests were proven red
against the pre-fix code):

- helper: a multi-chunk body is assembled whole to EOF
- helper: a body of exactly `cap` bytes arrives complete (sentinel stays off)
- helper: an over-cap body returns `cap + 1` bytes and stops reading
  mid-stream (`undelivered` bytes are never consumed)
- `feedback._read_capped_text`: multi-chunk body decoded whole; over-cap body
  still raises `ValueError`
- `updates._fetch_feed_bytes`: chunked feed read whole; oversized feed still
  trips the caller's `len(raw) > _FEED_MAX_BYTES` check without buffering the
  whole body
- Jira fetch: a multi-chunk Jira document reaches `json.loads` complete and
  parses into the normalized issue payload

## Manual verification

N/A — unit coverage sufficient: the fakes reproduce the exact chunked-stream
semantics of `aiohttp.StreamReader`, and the fix is confined to the read loop.

## Related Issues

Closes #4829

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: caps and caller semantics unchanged; only the read mechanics moved to the documented #4814 shape
- [x] No secrets, credentials, or internal references in the diff
