### PR TITLE
docs: link the Insider deb, rpm and Windows installer now that they publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ remote Gateway over an SSH tunnel. See the
 [desktop app guide](docs/build/desktop-app.md).
 
 - **macOS** (Apple Silicon/Intel): [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew.dmg) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew.dmg) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew.dmg)
-- **Windows** (x64): Stable — none, use a [source install](#build-from-source) | Insider — from 0.4.0 | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup.exe) · [why](docs/guides/windows-install.md#desktop-installer)
+- **Windows** (x64): Stable — none, use a [source install](#build-from-source) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-Setup.exe) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-Setup.exe) · [why](docs/guides/windows-install.md#desktop-installer)
 
 **On Linux, start with the one-line install** — it is the smoothest path, works
 on every distro and both architectures, and puts `kirocrew` on your `PATH`,
@@ -81,14 +81,12 @@ carries a manual sandbox step. `uname -m` prints which architecture you need.
 
 | Linux desktop package | x86_64 | aarch64 (Graviton, Raspberry Pi, ARM laptops) |
 |---|---|---|
-| **`.deb`** (Debian, Ubuntu) — **Nightly only for now** | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.deb) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.deb) |
-| **`.rpm`** (Fedora, RHEL, CentOS Stream, Amazon Linux 2023) — **Nightly only for now** | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.rpm) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.rpm) |
+| **`.deb`** (Debian, Ubuntu) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.deb) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.deb) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.deb) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.deb) |
+| **`.rpm`** (Fedora, RHEL, CentOS Stream, Amazon Linux 2023) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.rpm) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.rpm) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.rpm) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.rpm) |
 | **AppImage** (no root, any distro) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.AppImage) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.AppImage) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.AppImage) | [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-aarch64.AppImage) · [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-aarch64.AppImage) · [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-aarch64.AppImage) |
 
-**`.deb` and `.rpm` publish on Nightly only until 0.4.0**, as does the Windows
-installer's Insider lane — the per-format publish lanes landed after the 0.3.0
-release branch was cut. On Stable and Insider, take the AppImage or the one-line
-CLI install above.
+**`.deb` and `.rpm` reach Stable when 0.4.0 does** — their publish lanes landed
+after the 0.3.0 release branch was cut, so Stable serves the AppImage for now.
 
 ```bash
 sudo apt install ./KiroCrew-x86_64.deb     # Debian, Ubuntu


### PR DESCRIPTION
The follow-up promised in [#4820](https://github.com/kirodotdev/KiroCrew/pull/4820). `v0.4.0-insider.1` was the first RC cut from a branch that carries the per-format publish lanes, so the five keys that PR had to leave unlinked are now live.

## Measured before writing, at the versioned key

Not only at `latest` — rc1's `Publish Windows Desktop` job reported **success while publishing nothing**, so a green lane is not evidence:

| key | code | size |
|---|---|---|
| `desktop/insider/0.4.0-insider.2/KiroCrew-x86_64.deb` | 200 | 213 MB |
| `desktop/insider/0.4.0-insider.2/KiroCrew-aarch64.rpm` | 200 | 170 MB |
| `desktop/insider/0.4.0-insider.2/KiroCrew-Setup.exe` | 200 | 191 MB |

All four Insider deb/rpm keys and the Windows installer return 200 at `latest` too, and the Windows feed `feed/insider/latest.yml` is serving `0.4.0-insider.2`.

## What changed

```diff
-| **`.deb`** (Debian, Ubuntu) — **Nightly only for now** | [Nightly](…) | [Nightly](…) |
+| **`.deb`** (Debian, Ubuntu) | [Insider](…) · [Nightly](…) | [Insider](…) · [Nightly](…) |
-| **`.rpm`** (…) — **Nightly only for now** | [Nightly](…) | [Nightly](…) |
+| **`.rpm`** (…) | [Insider](…) · [Nightly](…) | [Insider](…) · [Nightly](…) |

-- **Windows** (x64): Stable — none, … | Insider — from 0.4.0 | [Nightly](…)
+- **Windows** (x64): Stable — none, … | [Insider](…KiroCrew-Setup.exe) | [Nightly](…)
```

and the caveat paragraph shrinks to what is still true:

```
**`.deb` and `.rpm` reach Stable when 0.4.0 does** — their publish lanes landed
after the 0.3.0 release branch was cut, so Stable serves the AppImage for now.
```

## Two things deliberately left alone

**Stable is still absent from the deb and rpm rows.** Those keys return 403 today and only appear when 0.4.0 is promoted; adding them now would reintroduce exactly the 403s #4820 removed.

**Stable Windows still reads "none", not "pending".** A stable release republishes the promotion bundle, which carries no Windows installer, so `WINDOWS_CHANNELS` in `auto-update.js` admits only nightly and insider. That lane is not late — it does not exist, and "pending" would promise a build that never arrives.

## Verification

Every download link in the file re-curled: **19 of 20 return 200**, and the twentieth is the `<version>` placeholder inside the pin-a-wheel example, which is not a link. `docs-lint.sh` and the brand gate are clean.

**Why no screenshot:** documentation links; the status table above is the evidence a screenshot could not give.