### PR TITLE
fix(subagents): anchor result retention on delivery to the parent

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -13,7 +13,7 @@ import time
 import urllib.parse
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from kiro_crew import mcp_apps_render, model_registry, session_directive
 from kiro_crew.acp.client import (
@@ -222,6 +222,7 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     _EMPTY_AUTO_CONTINUE_MSG,
     _POSTTOKEN_RECOVER_MSG,
     _SYNTHETIC_RECOVERY_MSGS,
+    SUBAGENT_COMPLETION_KIND,
     SYNTHETIC_RECOVERY_KIND,
     RecoveryPayload,
     is_synthetic_payload_item,
@@ -3527,6 +3528,113 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
     )
 
 
+def _arm_queued_delivery_settlement(
+    state: DashboardState,
+    slot: _ChatSlot,
+    task: "asyncio.Task",
+    contents: list[str],
+    consumed: list[bool],
+) -> None:
+    """Open the retention window on a drained completion once its turn has RUN.
+
+    The gateway records the owed agent ids on the slot when it has to QUEUE a
+    sub-agent completion (``KiroCrewGateway._defer_queued_delivery``), keyed on the
+    announce content, which is what keeps each ``result.txt`` alive for as long as
+    the row waits. This is the other half — but it deliberately does not fire at
+    dispatch.
+
+    A ``delivered`` tombstone is durable and excludes the folder from restart
+    orphan reconciliation, while a dispatched turn is not yet durable: the
+    injected row is still being persisted and the model has not necessarily
+    consumed the prompt. Writing the tombstone at dispatch would mean a crash in
+    that window loses the completion for good (no queue row left, no folder to
+    recover, and the result pruned one TTL later). Waiting for the task to finish
+    makes the failure mode fail-safe instead: nothing is written, so the next
+    start's reconciliation still sees the folder and re-delivers it.
+
+    Nothing is settled until the model has CONSUMED the prompt, and that is the
+    only condition. ``_run_chat`` handles a signed-out CLI, a dead provider,
+    exhausted prompt-busy retries, a transient backend error and a stall by
+    rendering a card and RETURNING NORMALLY, several of them after re-queueing the
+    prompt itself for a later retry — so the task's outcome says nothing either way.
+    *consumed* is the evidence that does: ``_run_chat`` sets it on the provider's
+    turn-complete event for a real end-of-turn, or earlier on the first streamed
+    token or fired tool call. Those triggers are exactly the states in which the
+    announce will NOT be replayed. An EMPTY response splits: the FIRST one
+    re-queues this same announce verbatim and RETRACTS the report, so the clock
+    waits for the replay that lands; the second re-queues a continuation instead
+    and stays consumed.
+
+    Consumption is one-way, so a turn cancelled or failed after it still settles:
+    the result is in the model's context either way, and withholding the tombstone
+    would have the next start re-announce a completion the parent already read.
+
+    *consumed* is a cell owned by THIS armed turn, never slot-wide state: a turn's
+    tail-drain starts its successor before the predecessor's callback runs, so a
+    shared field would be reset by the successor and leave the earlier — already
+    consumed — completion unsettled and re-injected after a restart.
+
+    An unconsumed turn settles nothing, which is the fail-safe side: the folder
+    survives for the replay to read and the next start's reconciliation recovers
+    it, where a premature tombstone would have the reaper delete a result the
+    parent never saw.
+    """
+
+    def _on_turn_done(finished: "asyncio.Task") -> None:  # type: ignore[type-arg]
+        # Consumption is the whole predicate, and it is one-way: once the model has
+        # the prompt, nothing later un-delivers it. A turn cancelled or failed AFTER
+        # that point (session close, shutdown, the turn ceiling) does not replay the
+        # announce -- ``build_recovery_requeue`` switches to a continuation once
+        # anything was emitted, a stop suppresses the requeue outright, and the
+        # guarded-turn error path only renders a card -- so skipping settlement
+        # there would leave a consumed result to be re-announced as an orphan by
+        # the next start. The task's own outcome is therefore not consulted.
+        if not consumed[0]:
+            return
+        try:
+            owed = slot.take_pending_subagent_deliveries(contents)
+        except Exception:
+            logger.debug("Could not claim queued sub-agent delivery marks", exc_info=True)
+            return
+        if not owed:
+            return
+        # The manager owns the write: it holds each tombstone until that run's
+        # teardown has finished, so one can never hide a child that is still being
+        # killed from restart reconciliation. There is no second path -- the debt
+        # only ever exists because the manager's own completion callback created
+        # it, so a state without a manager cannot have one to settle. If the call
+        # does not hand back a coroutine (a stubbed manager), skip rather than
+        # invent a write that would bypass the teardown gate; the folder stays
+        # recoverable by the next start's reconciliation.
+        mgr = getattr(state, "subagents", None)
+        settle = getattr(mgr, "settle_queued_delivery", None) if mgr is not None else None
+        work = None
+        if settle is not None:
+            try:
+                candidate = settle(owed)
+            except Exception:
+                logger.debug("Manager-side delivery settlement refused", exc_info=True)
+            else:
+                work = candidate if asyncio.iscoroutine(candidate) else None
+        if work is None:
+            logger.debug(
+                "No sub-agent manager to settle queued delivery for %s; "
+                "leaving the folder for restart reconciliation",
+                owed,
+            )
+            return
+        writer = asyncio.create_task(work)
+        bg = getattr(state, "_background_tasks", None)
+        if isinstance(bg, set):
+            bg.add(writer)
+            writer.add_done_callback(bg.discard)
+
+    try:
+        task.add_done_callback(_on_turn_done)
+    except Exception:
+        logger.debug("Could not arm queued sub-agent delivery settlement", exc_info=True)
+
+
 async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> bool:
     """Dequeue and start one ready Kiro turn, preserving queue semantics."""
 
@@ -3650,12 +3758,56 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
         meta=_row_meta if isinstance(_row_meta, dict) else None,
     )
 
+    # Per-turn consumption cell for a drained sub-agent completion (see
+    # _arm_queued_delivery_settlement): owned by THIS turn, so a successor turn
+    # started by this one's tail-drain cannot reset it. The hook is passed ONLY
+    # for a completion row, so every other row's turn is dispatched exactly as
+    # before.
+    #
+    # Settleable rows are selected by their STRUCTURAL kind, never by the text
+    # prefix ``is_subagent`` reads: the delivery ledger is content-keyed, so a row
+    # whose text merely LOOKS like an announce (a user pasting one back) would
+    # otherwise claim the genuine row's debt and start its retention clock early.
+    # ``chat_utils.is_system_injection_item`` documents the kind tag as the
+    # unforgeable classifier for exactly this reason -- a user-typed row cannot
+    # carry one. Recovery rows are included because a completion that failed before
+    # the model consumed it is re-queued verbatim under that kind.
+    _consumed: list[bool] = [False]
+    _settleable = [
+        item["content"]
+        for item in consumed
+        if item.get("kind") in (SUBAGENT_COMPLETION_KIND, SYNTHETIC_RECOVERY_KIND)
+    ]
+
+    if _settleable and not slot.owes_subagent_delivery(_settleable):
+        # Owes nothing (every ordinary recovery replay, and any completion whose
+        # debt was already settled): dispatch this row exactly as before.
+        _settleable = []
+
+    def _note_consumed(consumed: bool = True) -> None:
+        # False is a RETRACTION: the runner re-queued this exact announce verbatim
+        # (first empty response), so the delivery that counts has not happened yet.
+        _consumed[0] = consumed
+
+    _run_kwargs: dict[str, Any] = {"_synthetic_payload": synthetic_payload}
+    if _settleable:
+        _run_kwargs["_on_consumed"] = _note_consumed
     task = spawn_guarded_turn(
         state,
         slot,
-        _run_chat(state, slot, next_msg, _synthetic_payload=synthetic_payload),
+        _run_chat(state, slot, next_msg, **_run_kwargs),
     )
     slot.task = task
+    if _settleable:
+        # Open the retention clock on the result files this row promises — but
+        # only once the turn has actually run and the model has consumed the
+        # prompt, since a "delivered" tombstone is durable and hides the folder
+        # from restart recovery. The gateway deliberately left them un-tombstoned
+        # while the row waited in the queue, because that clock would otherwise
+        # expire before the row was ever consumed (issue #4839). Claimed by the
+        # row's CONTENT, which is what a pre-consumption retry re-queues: its
+        # queue-entry id is freshly minted and would match no debt.
+        _arm_queued_delivery_settlement(state, slot, task, _settleable, _consumed)
     return True
 
 
@@ -3810,6 +3962,7 @@ async def _run_chat(
     _prompt_depth: int = 0,
     _synthetic_payload: bool = False,
     regenerate_hint: str = "",
+    _on_consumed: "Callable[[bool], None] | None" = None,
 ) -> None:
     """Stream LLM response into *slot*.  Survives browser disconnect."""
 
@@ -4014,6 +4167,38 @@ async def _run_chat(
     # backend 5xx is only retried while this is False, so a re-prompt can't
     # double-stream text or re-run a side-effecting tool.
     _turn_emitted = False
+    # Was this turn's prompt CONSUMED by the model? Reported to whoever armed the
+    # turn (a queued sub-agent completion's retention clock -- see
+    # ``_arm_queued_delivery_settlement``), because every handled-failure path
+    # below returns from here NORMALLY and so the call's own return says nothing.
+    #
+    # Two triggers, and together they are exactly "the announce will NOT be
+    # replayed": the provider's own turn-complete event for a real end-of-turn (so
+    # an EMPTY response, which consumed the prompt and produced nothing, still
+    # counts), and the first streamed token or fired tool call (after which
+    # ``build_recovery_requeue`` switches from replaying the prompt to a
+    # continuation, i.e. treats it as consumed too). A failure before either --
+    # signed-out CLI, dead provider, exhausted prompt-busy retries, transient
+    # backend error -- re-queues the prompt itself, and reports nothing.
+    #
+    # RETRACTABLE for one case only: the FIRST empty response re-queues this exact
+    # message verbatim (see the empty-response branch below), so the announce is
+    # going to be delivered again and the report must be taken back. That decision
+    # is only known after the stream ends, which is why this is a retraction rather
+    # than a later report. The second empty re-queues a continuation instead, and
+    # stays consumed.
+    _consumed_reported = False
+
+    def _report_consumed(consumed: bool = True) -> None:
+        nonlocal _consumed_reported
+        if _on_consumed is None or _consumed_reported == consumed:
+            return
+        _consumed_reported = consumed
+        try:
+            _on_consumed(consumed)
+        except Exception:
+            logger.debug("consumption report failed for slot %s", slot.key, exc_info=True)
+
     # Model-activity marker for the poisoned-conversation streak ONLY:
     # flipped True on thinking chunks. Deliberately separate from
     # _turn_emitted — thinking is ephemeral/broadcast-only, so retrying
@@ -5076,6 +5261,7 @@ async def _run_chat(
                 if _orch_planning:
                     _orch_plan_buf += safe_chunk
                 _turn_emitted = True  # tokens delivered — transient retry now unsafe
+                _report_consumed()
                 # Stream to the wire through the rolling buffer so a credential
                 # split across token boundaries can't cross a broadcast boundary
                 # unredacted. Only the confirmed-safe prefix is emitted;
@@ -5129,6 +5315,7 @@ async def _run_chat(
                     assistant_text = ""
                 in_tool_group = True
                 _turn_emitted = True  # tool side effect — transient retry now unsafe
+                _report_consumed()
                 # Broadcast for real-time visibility and persist
                 _tool_payload = _tool_call_ws_payload(event)
                 _tool_payload["slot"] = slot.key
@@ -6609,6 +6796,22 @@ async def _run_chat(
                         {"id": _card_id, "slot": slot.key, "text": _txt},
                     )
             elif event.kind == EVENT_COMPLETE:
+                # A turn that ran to a real END OF TURN processed this prompt, so it
+                # was consumed even if it produced nothing at all -- an empty
+                # response re-queues a CONTINUATION, not a replay, so whoever armed
+                # this turn must not keep waiting for a delivery that happened.
+                #
+                # Only that stop reason. The same event also carries the reasons
+                # that CUT a turn short -- stale-recover, tool-stall, cancelled, an
+                # unrecognised provider error -- and those re-queue the prompt
+                # itself, so reporting consumption for them would start the
+                # retention clock on a result the retry still has to deliver. An
+                # absent stop reason is deliberately not treated as end-of-turn
+                # either: a provider that streamed anything has already reported
+                # through the token/tool triggers, and the cost of being wrong here
+                # is asymmetric (a duplicate re-announce versus a pruned result).
+                if event.stop_reason == STOP_REASON_END_TURN:
+                    _report_consumed()
                 # Hang-attribution snapshot BEFORE the close-all safety net
                 # below force-marks every card done: only children still
                 # unfinished at the cut may count toward timeout attribution
@@ -7092,6 +7295,12 @@ async def _run_chat(
                     payload=payload_for_replay(_is_synthetic),
                 )
                 _retrying_empty = True
+                # This message is going out again unchanged, so whoever armed the
+                # turn must not treat it as delivered: a queued sub-agent
+                # completion's retention clock has to wait for the replay that
+                # actually lands (issue #4839). Retracts the turn-complete report
+                # made while streaming, when the empty text was not yet known.
+                _report_consumed(False)
             elif (
                 _prompt_depth == 0
                 and slot._empty_response_retries < 2

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import contextlib
+import hashlib
 import json
 import logging
 import math
@@ -157,6 +158,25 @@ NATIVE_SUBAGENT_DONE_RESULT_CAP = 8_000
 NATIVE_SUBAGENT_DONE_TRUNC_MARKER = "…(earlier output truncated)\n"
 NATIVE_SUBAGENT_TERMINAL_KEEP = 50
 NATIVE_SUBAGENT_TERMINAL_TTL_SECS = 3600.0
+
+# Cap on a slot's queued-completion delivery ledger (see
+# ``_ChatSlot.note_pending_subagent_delivery``). Well above any legitimate
+# in-flight set — the slot queue itself is capped at 50 rows — so it only ever
+# evicts entries left behind by rows that vanished from the queue without being
+# consumed, and eviction merely defers those agents' cleanup to the next start.
+_MAX_PENDING_SUBAGENT_DELIVERIES = 128
+
+
+def _delivery_key(content: str) -> str:
+    """Identity of a queued completion for delivery bookkeeping.
+
+    A digest of the announce rather than the text itself: a wave digest runs to
+    tens of kilobytes, and the ledger only needs to recognise the same announce
+    again after a pre-consumption failure re-queues it verbatim under a new
+    queue-entry id. Not a security boundary — nothing is authenticated by it.
+    """
+    return hashlib.sha256(content.encode("utf-8", "replace")).hexdigest()[:32]
+
 
 # Slot-list broadcast coalescing window. The sub-agent slots debouncer in
 # slack/gateway.py hardcodes the same value independently; the two are not shared.
@@ -1418,6 +1438,7 @@ class _ChatSlot:
         "_synthesis_inflight",
         "_subagent_deliveries_inflight",
         "_subagents_inline_collected",
+        "_subagent_delivery_pending",
         "_recovery_retrigger_count",
         "_prompt_busy_retries",
         "_acp_pipe_death_retries",
@@ -1700,6 +1721,14 @@ class _ChatSlot:
         # blocking spawn_sub_agents MCP tool.  _subagent_done skips injection
         # for these to prevent a duplicate turn that clobbers [OPTIONS:] buttons.
         self._subagents_inline_collected: set[str] = set()
+        # Queued sub-agent completions whose delivery tombstone is still owed:
+        # queue-id -> the agent ids whose ``result.txt`` that row promises. A
+        # completion routed into a BUSY slot is queued, so the parent's context
+        # does not contain it until the row drains; the run loop therefore skips
+        # its own ``mark_delivered`` and the drain settles these instead, so the
+        # retention TTL is measured from consumption rather than from run
+        # completion (issue #4839). See ``take_pending_subagent_deliveries``.
+        self._subagent_delivery_pending: dict[str, list[str]] = {}
         self._recovery_retrigger_count: int = 0
         self._prompt_busy_retries: int = 0
         self._acp_pipe_death_retries: int = 0
@@ -2463,6 +2492,65 @@ class _ChatSlot:
     def queue_pop(self, index: int = 0) -> dict[str, str]:
         """Pop a queue item by index. Returns {"id": ..., "content": ...}."""
         return self._queue.pop(index)
+
+    def note_pending_subagent_delivery(self, content: str, agent_ids: list[str]) -> None:
+        """Record that a queued completion still owes *agent_ids* a delivery mark.
+
+        Called by the gateway when a sub-agent completion could not be injected
+        because the slot was busy. Until the row drains AND its turn consumes the
+        prompt, the result is not in the parent's context, so no ``delivered``
+        tombstone is written for those agents -- which is also what keeps their
+        ``result.txt`` alive across an arbitrarily long queue wait (issue #4839).
+
+        Keyed on the ANNOUNCE CONTENT, not the queue-entry id: a turn that fails
+        before the model consumed the prompt re-queues that same announce under a
+        freshly minted id (``build_recovery_requeue`` replays the message verbatim
+        while nothing has been emitted), and a debt keyed on the old id could never
+        be claimed by the retry that actually delivers it. The content embeds the
+        agent ids and their result paths, so it is the identity that survives.
+
+        An empty *agent_ids* records nothing: a stopped or failed member keeps the
+        tombstone its own terminal path wrote, and there is nothing to settle.
+
+        Entries are only ever removed by the row that settles them, because
+        anything cleverer races the drain: a turn's tail-drain pops the NEXT row
+        before the current turn's settlement callback runs, so "no longer queued"
+        does not mean "abandoned". A row that leaves the queue unconsumed therefore
+        leaves its entry behind, so the ledger is capped and evicts oldest-first --
+        in the fail-safe direction, since an unsettled agent keeps its folder and
+        is recovered by the next start's reconciliation.
+        """
+        if not content or not agent_ids:
+            return
+        key = _delivery_key(content)
+        owed = self._subagent_delivery_pending.setdefault(key, [])
+        owed.extend(a for a in agent_ids if a not in owed)
+        while len(self._subagent_delivery_pending) > _MAX_PENDING_SUBAGENT_DELIVERIES:
+            self._subagent_delivery_pending.pop(next(iter(self._subagent_delivery_pending)))
+
+    def owes_subagent_delivery(self, contents: list[str]) -> bool:
+        """Whether any of *contents* still owes a delivery mark. Read-only.
+
+        Lets the drain leave a row's dispatch completely untouched when it owes
+        nothing -- the overwhelmingly common case, including every ordinary
+        recovery replay -- instead of arming settlement machinery for it.
+        """
+        return any(_delivery_key(c) in self._subagent_delivery_pending for c in contents)
+
+    def take_pending_subagent_deliveries(self, contents: list[str]) -> list[str]:
+        """Claim the delivery marks owed by the given consumed completion rows.
+
+        Returns the agent ids whose result is now in the parent's context, in
+        drain order, and forgets them. Only the named rows are touched: sweeping
+        entries whose row is "no longer queued" would delete a SUCCESSOR's debt,
+        because the tail-drain at the end of a turn pops the next row while this
+        turn's settlement callback has not run yet -- and a consumed result left
+        unsettled is re-announced as an orphan by the next start.
+        """
+        claimed: list[str] = []
+        for content in contents:
+            claimed.extend(self._subagent_delivery_pending.pop(_delivery_key(content), []))
+        return claimed
 
     def queue_remove_by_id(self, queue_id: str) -> str | None:
         """Remove a queue item by ID. Returns the content or None if not found."""

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -197,7 +197,7 @@ Set via `kirocrew config set agent.acp_backend kas`.
 | `agent.spawn_min_memory_gb` | Minimum available memory (GB) to spawn a subagent (0 disables the check) | `4.0` |
 | `agent.completion_keep` | Which end of the subagent transcript to keep in the completion event injected into the parent session: `"head"`, `"tail"`, or `"both"` (head + middle marker + tail) | `"head"` |
 | `agent.completion_keep_chars` | Max characters retained in the completion event after applying `completion_keep`. `0` disables truncation. The full transcript stays on disk (see `subagent_result_ttl_secs`) | `3000` |
-| `agent.subagent_result_ttl_secs` | How long a delivered subagent's `result.txt` is retained before the reaper prunes it, so the parent can read the full transcript on demand instead of re-running the subagent | `3600` (1h) |
+| `agent.subagent_result_ttl_secs` | How long a delivered subagent's `result.txt` is retained before the reaper prunes it, so the parent can read the full transcript on demand instead of re-running the subagent. Measured from the moment the completion reaches the parent, not from when the run finished | `3600` (1h) |
 
 ### Session
 

--- a/src/kiro_crew/docs/subagents.md
+++ b/src/kiro_crew/docs/subagents.md
@@ -83,7 +83,7 @@ Three `agent.*` config knobs control what the parent session sees:
 |-----|--------|---------|--------|
 | `agent.completion_keep` | `"head"` / `"tail"` / `"both"` | `"head"` | Which end of the transcript to keep when it exceeds the cap |
 | `agent.completion_keep_chars` | int (`0` disables) | `3000` | Character cap applied after `completion_keep` |
-| `agent.subagent_result_ttl_secs` | int (seconds) | `3600` | How long the delivered `result.txt` is kept before the reaper prunes it |
+| `agent.subagent_result_ttl_secs` | int (seconds) | `3600` | How long the delivered `result.txt` is kept before the reaper prunes it. The window starts when the completion reaches the parent, so a completion queued behind a long turn does not spend it waiting |
 
 Pick the mode that matches how your agents emit their useful output:
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4394,6 +4394,55 @@ class GatewayOrchestrator:
             logger.debug("AutoNudge expiry notification failed", exc_info=True)
 
     @staticmethod
+    def _defer_queued_delivery(
+        slot: Any, announce: str, info: SubagentInfo, *, flush_only: bool
+    ) -> None:
+        """Owe a queued completion's delivery tombstones to the queue drain.
+
+        The retention window for ``result.txt`` (``agent.subagent_result_ttl_secs``)
+        exists so the parent can read the full transcript AFTER the completion
+        event reaches it. Writing the ``delivered`` tombstone when the announce is
+        merely QUEUED starts that clock while the event is still waiting for a
+        turn, so a long-running turn ahead of it lets the reaper prune every file
+        the queued announce points at (issue #4839).
+
+        So the ids are handed to the slot keyed on the announce ITSELF,
+        ``_delivery_queued`` tells the run loop to skip its own ``mark_delivered``,
+        and the drain (``chat_runner._start_next_queued_turn``) settles them once a
+        turn has consumed that announce -- including a retry, because a failure
+        before the model consumed the prompt re-queues the same text under a newly
+        minted queue id, which a debt keyed on the original id could never match. A
+        wave digest carries its held members' ids too: ``_digest_settle_ids`` is
+        transferred (not copied), so the run loop's ``_settle_digest_holds`` becomes
+        a no-op rather than a second writer.
+
+        Best-effort in one direction only: if the slot cannot take the ids (a
+        stubbed slot in tests), nothing is transferred and the previous
+        immediate-tombstone behaviour stands — better a short window than a
+        folder no one ever tombstones.
+        """
+        # A flush-only record is synthetic (no run, no folder of its own). Only a
+        # COMPLETED member owes a delivered mark: ``info.outcome`` is the codebase's
+        # canonical three-way classification precisely because the ``error``-
+        # nullability idiom reports a user-stopped agent as completed, and a
+        # stopped or failed run already carries its own tombstone whose 7-day
+        # post-mortem window a "delivered" write would shorten to the result TTL.
+        owed: list[str] = [] if (flush_only or info.outcome != "completed") else [info.id]
+        held = getattr(info, "_digest_settle_ids", None)
+        if isinstance(held, list):
+            owed.extend(str(h) for h in held)
+        try:
+            slot.note_pending_subagent_delivery(announce, owed)
+        except Exception:
+            logger.debug(
+                "Subagent %s: could not defer queued delivery marks", info.id, exc_info=True
+            )
+            return
+        info._delivery_queued = True
+        if isinstance(held, list):
+            info._digest_settle_ids = []
+
+    @staticmethod
     def _notif_meta(parent_key: str | None) -> dict[str, str] | None:
         """Build notification meta with slot or slack_link for jump-to-source."""
         if not parent_key:
@@ -5466,6 +5515,18 @@ class GatewayOrchestrator:
                                     announce,
                                     kind=SUBAGENT_COMPLETION_KIND,
                                     meta={SUBAGENT_COMPLETION_META_KEY: sub_meta},
+                                )
+                                # Queuing is not delivery. The announce promises
+                                # result paths the parent can read on demand, but
+                                # it will not be in the parent's context until a
+                                # turn drains it — a wait bounded only by the turn
+                                # ceiling, so longer than the retention TTL. Owe
+                                # the delivery tombstones to that drain instead of
+                                # writing them now, or the reaper prunes
+                                # result.txt while the promise is still queued
+                                # and the parent is handed dead paths (#4839).
+                                self._defer_queued_delivery(
+                                    _injection_slot, announce, info, flush_only=_flush_only
                                 )
                                 self.dashboard_state.push_slots_update()
                                 logger.info("Subagent %s → queued in %s", info.id, _slot_name)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -1169,6 +1169,16 @@ class SubagentInfo:
     # digest COMPOSITION would re-open the restart-loss window between
     # composing and routing.
     _digest_settle_ids: list[str] = field(default_factory=list)
+    # True when the gateway QUEUED this completion's injection because the
+    # parent's slot was busy. Delivery is not consumption: the announce sits in
+    # the slot queue until a turn drains it, and that wait is bounded only by the
+    # turn ceiling — far longer than agent.subagent_result_ttl_secs. The run loop
+    # must therefore SKIP mark_delivered() (a "delivered" tombstone starts the
+    # retention clock, so the reaper would prune result.txt while the promise of
+    # it is still queued, and the parent would be handed a dead path). The drain
+    # settles the tombstone instead — see
+    # ``_ChatSlot.take_pending_subagent_deliveries`` (issue #4839).
+    _delivery_queued: bool = False
     max_turns: int = 0
     reaped: bool = False
     streaming_text: str = ""
@@ -1407,6 +1417,17 @@ class SubagentManager:
         except AttributeError:
             pass  # test doubles without the setter
         self._tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
+        # Teardown gates for runs whose terminal report has started, keyed by id and
+        # OUTLIVING both dicts above. A "delivered" tombstone excludes a folder from
+        # restart orphan reconciliation, so it must never be written while the run's
+        # child is still being killed -- and the settlement that writes it can happen
+        # outside the run (the parent's queue drain; issue #4839), long after a
+        # dashboard "clear completed" / "cancel" has popped BOTH ``_agents`` and
+        # ``_tasks`` for a done-but-still-tearing-down run. Reading the gate from
+        # here, rather than inferring "record gone means teardown finished", is what
+        # makes that inference unnecessary. Removed by the same ``finally`` that sets
+        # the event, so a missing entry always means "nothing left to wait for".
+        self._teardown_gates: dict[str, asyncio.Event] = {}
         # Queued spawns store the FULL spawn() kwarg set (not just a 5-tuple), so a
         # drained spawn preserves approval_mode / silent / model / allowed_tools / bare —
         # dropping them made a queued headless/auto spawn hit the deny-by-default gate and
@@ -2442,7 +2463,18 @@ class SubagentManager:
             # result has not reached the parent yet (the gateway marks them when
             # the digest fires), so a restart mid-wave leaves them visible to
             # orphan reconciliation.
-            if mark_delivered_on_success and not info.error and not info._digest_held:
+            #
+            # A QUEUED injection is the same statement about a different wait:
+            # the announce is parked in the parent's slot queue, so the result is
+            # not in its context yet and the retention clock must not start (the
+            # drain settles it). Both flags are set by the gateway inside
+            # _on_done, above.
+            if (
+                mark_delivered_on_success
+                and not info.error
+                and not info._digest_held
+                and not info._delivery_queued
+            ):
                 # Wait for the caller's session teardown before writing the
                 # "delivered" tombstone. This report is deliberately SPAWNED
                 # ahead of teardown (so a cancellation cannot strand it), which
@@ -4678,6 +4710,46 @@ class SubagentManager:
             return
         self._settle_digest_holds(info)
 
+    async def settle_queued_delivery(self, agent_ids: list[str]) -> None:
+        """Write the ``delivered`` tombstones for completions consumed from a queue.
+
+        The queued-injection path (issue #4839) deliberately leaves a completion
+        un-tombstoned until the parent's turn has consumed the announce, so the
+        write lands here — in the parent's drain — rather than in
+        :meth:`_report_terminal`. That is also why it must repeat the gate that
+        report holds: a ``delivered`` tombstone EXCLUDES the folder from restart
+        orphan reconciliation, and the drain can come due while the run's teardown
+        is still killing its child, so writing early would let a crash in that
+        window strand a live child that nothing would ever reap.
+
+        The wait is bounded exactly as the report's is (teardown is itself bounded
+        by ``_RESET_TIMEOUT`` then SIGKILL, and runs in a ``finally``), and a
+        timeout writes anyway rather than abandoning the retention bound — the same
+        trade the report makes. The gate is read from ``_teardown_gates``, which
+        outlives the run's ``_agents``/``_tasks`` records: a dashboard "clear
+        completed" or "cancel" pops both of those for a run that is done but still
+        tearing down, so inferring "record gone means child gone" would tombstone a
+        live child. No gate entry means teardown has finished (or never started).
+
+        The tombstone write itself is offloaded: it fsyncs, and this runs on the
+        gateway event loop.
+        """
+        for agent_id in agent_ids:
+            gate = self._teardown_gates.get(agent_id)
+            if gate is not None and not gate.is_set():
+                try:
+                    await asyncio.wait_for(gate.wait(), timeout=_RESET_TIMEOUT + 30)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Subagent %s: teardown did not complete before the queued "
+                        "delivered tombstone; writing it anyway",
+                        agent_id,
+                    )
+            try:
+                await asyncio.to_thread(mark_delivered, agent_id)
+            except Exception:
+                logger.debug("Failed to mark drained subagent %s delivered", agent_id, exc_info=True)
+
     def _settle_digest_holds(self, info: SubagentInfo) -> None:
         """Settle delivery tombstones for wave members whose injection was
         held for this member's digest. Called ONLY after ``_on_done`` returned
@@ -4847,6 +4919,12 @@ class SubagentManager:
             # already-spawned report holds its "delivered" tombstone until the
             # child is provably gone (see `_report_terminal`).
             teardown_done = asyncio.Event()
+            # Published where it survives this record being evicted: a settlement
+            # that happens OUTSIDE this report (the parent's queue drain, issue
+            # #4839) can come due after a dashboard clear/cancel has removed the run
+            # from _agents AND _tasks, and it still must not tombstone a child that
+            # is being killed.
+            self._teardown_gates[info.id] = teardown_done
             if self._claim_finalize(info):
                 info.elapsed = time.time() - info.started
                 self._record_cost(info)
@@ -4878,6 +4956,10 @@ class SubagentManager:
                 # release the report's delivered-tombstone gate. Unconditional,
                 # so the report can never wedge on a cancelled teardown.
                 teardown_done.set()
+                # Set BEFORE the entry is dropped: a waiter that already holds the
+                # event is released by the line above, and one arriving after finds
+                # no entry, which now means exactly "nothing left to wait for".
+                self._teardown_gates.pop(info.id, None)
 
         # The report itself already ran (or is running) on the shielded task
         # spawned in the finally above; block until it completes so sequencing is

--- a/test/test_subagent_delivery_ttl_anchor.py
+++ b/test/test_subagent_delivery_ttl_anchor.py
@@ -1,0 +1,897 @@
+"""Retention of a sub-agent's ``result.txt`` is anchored on the parent CONSUMING
+the completion, not on the run finishing (issue #4839).
+
+``agent.subagent_result_ttl_secs`` exists so the parent can read the full
+transcript after the completion event arrives. The clock is the ``died`` stamp on
+the ``delivered`` tombstone, and that used to be written as soon as the gateway
+had ROUTED the completion — including the route that only parks the announce in a
+busy slot's queue. A queue wait is bounded by the turn ceiling, not by the TTL, so
+a wave whose events were delivered two hours later handed the parent result paths
+the reaper had already pruned, under the line "Full outputs are on disk".
+
+The fix splits routing from consumption: the gateway records the owed ids on the
+slot and leaves the folder un-tombstoned (so nothing prunes it, and a restart can
+still recover it), and the queue drain writes the tombstone once the row becomes a
+turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.chat_runner import _start_next_queued_turn
+from kiro_crew.dashboard.chat_utils import SUBAGENT_COMPLETION_KIND, SYNTHETIC_RECOVERY_KIND
+from kiro_crew.dashboard.state import (
+    _MAX_PENDING_SUBAGENT_DELIVERIES,
+    SUBAGENT_COMPLETION_PREFIX,
+    _ChatSlot,
+)
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+from kiro_crew.subagent_persistence import (
+    create_agent_folder,
+    prune_stale_tombstones,
+    write_result_chunk,
+)
+
+COMPLETION = f"{SUBAGENT_COMPLETION_PREFIX}\nAgent `a1` completed ✅\nResult saved at: /x"
+SECOND_COMPLETION = f"{SUBAGENT_COMPLETION_PREFIX}\nAgent `a2` completed ✅\nResult saved at: /y"
+
+
+def _ann(tag: str) -> str:
+    """A distinct announce standing in for one queued completion."""
+    return f"{SUBAGENT_COMPLETION_PREFIX}\nAgent `{tag}` completed ✅"
+
+
+def _key(content: str) -> str:
+    """The ledger's key for an announce (a digest, not the text)."""
+    from kiro_crew.dashboard.state import _delivery_key
+
+    return _delivery_key(content)
+
+
+@pytest.fixture()
+def agent_root(tmp_path, monkeypatch):
+    """Point the sub-agent registry at a temp directory."""
+    monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
+    return tmp_path
+
+
+def _finished_run(agent_id: str, root) -> None:
+    """A completed run's folder: state + a non-empty result.txt, no tombstone."""
+    create_agent_folder(agent_id, task="t", parent_session="dashboard:main")
+    write_result_chunk(agent_id, "the full transcript\n")
+
+
+async def _settled(predicate, timeout: float = 3.0) -> None:
+    """Poll until *predicate* holds — settlement lands on a worker thread."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not predicate() and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+    assert predicate()
+
+
+# ── The slot-side ledger of owed delivery marks ───────────────────────
+
+
+class TestPendingDeliveryLedger:
+    def test_note_then_take_returns_ids_in_drain_order(self):
+        slot = _ChatSlot("s1")
+        slot.note_pending_subagent_delivery(_ann("one"), ["a1", "a2"])
+        slot.note_pending_subagent_delivery(_ann("two"), ["a3"])
+
+        assert slot.take_pending_subagent_deliveries([_ann("one"), _ann("two")]) == [
+            "a1",
+            "a2",
+            "a3",
+        ]
+        # Claimed once: a second drain of the same row owes nothing.
+        assert slot.take_pending_subagent_deliveries([_ann("one"), _ann("two")]) == []
+
+    def test_empty_ids_record_nothing(self):
+        """A failed member keeps the tombstone its own error path wrote, and a
+        flush-only record has no folder — neither owes a mark."""
+        slot = _ChatSlot("s1")
+        slot.note_pending_subagent_delivery(_ann("one"), [])
+        assert slot._subagent_delivery_pending == {}
+
+    def test_row_that_left_the_queue_keeps_its_entry(self):
+        """The ledger must NOT sweep entries whose row is no longer queued: the
+        tail-drain at the end of a turn pops the NEXT completion row before this
+        turn's settlement callback runs, so a sweep would delete the successor's
+        debt and the next start would re-announce its consumed result."""
+        slot = _ChatSlot("s1")
+        slot.note_pending_subagent_delivery(_ann("first"), ["a1"])
+        slot.note_pending_subagent_delivery(_ann("second"), ["a2"])
+        slot._queue = []  # both rows drained; only the first turn has finished
+
+        assert slot.take_pending_subagent_deliveries([_ann("first")]) == ["a1"]
+        assert slot._subagent_delivery_pending == {_key(_ann("second")): ["a2"]}
+
+    def test_ledger_is_bounded(self):
+        """Without a sweep, a row that vanishes unconsumed leaves its entry, so
+        the ledger evicts oldest-first instead of growing forever."""
+        slot = _ChatSlot("s1")
+        for i in range(_MAX_PENDING_SUBAGENT_DELIVERIES + 5):
+            slot.note_pending_subagent_delivery(_ann(f"q{i}"), [f"a{i}"])
+
+        assert len(slot._subagent_delivery_pending) == _MAX_PENDING_SUBAGENT_DELIVERIES
+        assert _key(_ann("q0")) not in slot._subagent_delivery_pending  # oldest evicted
+        assert (
+            _key(_ann(f"q{_MAX_PENDING_SUBAGENT_DELIVERIES + 4}"))
+            in slot._subagent_delivery_pending
+        )
+
+
+# ── The gateway side: routing to a queue owes, it does not deliver ────
+
+
+def _member(agent_id: str = "a1", *, error: str = "") -> SubagentInfo:
+    info = SubagentInfo(id=agent_id, task="t", parent_session_key="dashboard:main")
+    info.done = True
+    info.error = error
+    info.result = "r"
+    info.result_path = f"/tmp/{agent_id}/result.txt"
+    return info
+
+
+def _manager() -> SubagentManager:
+    """A manager with no live runs: every settle finds no teardown gate to wait on.
+
+    Production always has one -- the delivery debt only exists because this
+    manager's own completion callback created it -- so a drain test without one
+    would exercise a path the gateway never takes.
+    """
+    return SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+
+
+def _defer(slot, info, *, flush_only: bool = False, announce: str = COMPLETION):
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    GatewayOrchestrator._defer_queued_delivery(slot, announce, info, flush_only=flush_only)
+
+
+class TestDeferQueuedDelivery:
+    def test_owes_the_member_and_flags_the_run_loop(self):
+        slot = _ChatSlot("s1")
+        info = _member()
+
+        _defer(slot, info)
+
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+        # The run loop reads this AFTER _on_done returns and skips its own
+        # mark_delivered, which is what keeps result.txt alive while queued.
+        assert info._delivery_queued is True
+
+    def test_wave_digest_transfers_its_held_ids(self):
+        """A queued digest chunk carries its held members' results too, so their
+        settle list moves to the slot instead of firing at enqueue."""
+        slot = _ChatSlot("s1")
+        info = _member("flusher")
+        info._digest_settle_ids = ["h1", "h2"]
+
+        _defer(slot, info)
+
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["flusher", "h1", "h2"]}
+        # Transferred, not copied: _settle_digest_holds must not double-write.
+        assert info._digest_settle_ids == []
+
+    def test_failed_member_owes_nothing(self):
+        slot = _ChatSlot("s1")
+        info = _member(error="boom")
+
+        _defer(slot, info)
+
+        assert slot._subagent_delivery_pending == {}
+        assert info._delivery_queued is True
+
+    def test_stopped_member_owes_nothing(self):
+        """A user stop leaves ``error`` EMPTY (it is a neutral outcome), so the
+        error-nullability idiom reads it as completed. It already carries a reap
+        tombstone with the 7-day post-mortem window, and a "delivered" write would
+        cut its partial result down to the result TTL."""
+        slot = _ChatSlot("s1")
+        info = _member()
+        info.user_stopped = True
+        assert info.outcome == "stopped" and not info.error
+
+        _defer(slot, info)
+
+        assert slot._subagent_delivery_pending == {}
+
+    def test_flush_only_record_owes_only_the_members_it_releases(self):
+        """The synthetic flush record has no run of its own; only the held ids
+        it is releasing are real folders."""
+        slot = _ChatSlot("s1")
+        info = _member("synthetic")
+        info._digest_settle_ids = ["h1"]
+
+        _defer(slot, info, flush_only=True)
+
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["h1"]}
+
+    def test_slot_that_cannot_take_ids_keeps_the_old_behaviour(self):
+        """Fail in the safe direction: if nothing can hold the debt, leave the
+        run loop to tombstone now (a short window) rather than never."""
+        slot = MagicMock()
+        slot.note_pending_subagent_delivery.side_effect = RuntimeError("no ledger")
+        info = _member()
+        info._digest_settle_ids = ["h1"]
+
+        _defer(slot, info)
+
+        assert info._delivery_queued is False
+        assert info._digest_settle_ids == ["h1"]
+
+
+class TestRunLoopSkipsQueuedDelivery:
+    @pytest.mark.asyncio
+    async def test_no_tombstone_when_on_done_queued_the_completion(self, agent_root):
+        """``_report_terminal`` marks delivered only when the result is actually
+        in the parent's context. ``_on_done`` setting ``_delivery_queued`` says it
+        is not."""
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+        mgr._fire_event = AsyncMock()
+        info = _member()
+        _finished_run(info.id, agent_root)
+
+        async def _on_done_queues(i):
+            i._delivery_queued = True
+
+        mgr._on_done = _on_done_queues
+        await mgr._report_terminal(
+            info,
+            source="test",
+            injection_timeout_reason="x",
+            mark_delivered_on_success=True,
+        )
+
+        assert not (agent_root / info.id / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_tombstone_when_the_completion_was_injected(self, agent_root):
+        """The unqueued route is unchanged: a turn starts immediately, so the
+        clock starts immediately."""
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+        mgr._fire_event = AsyncMock()
+        mgr._on_done = AsyncMock()
+        info = _member("a2")
+        _finished_run(info.id, agent_root)
+
+        await mgr._report_terminal(
+            info,
+            source="test",
+            injection_timeout_reason="x",
+            mark_delivered_on_success=True,
+        )
+
+        ts = json.loads((agent_root / info.id / "tombstone.json").read_text(encoding="utf-8"))
+        assert ts["cause"] == "delivered"
+
+
+# ── The drain side: consumption starts the clock ──────────────────────
+
+
+class TestConsumptionSignalIsPerTurn:
+    """The settlement predicate reads a cell owned by the armed turn, never
+    slot-wide state: a turn's tail-drain starts its successor before the
+    predecessor's callback runs, so a shared field would be reset by the successor
+    and leave the earlier (already consumed) completion unsettled."""
+
+    def test_run_chat_reports_consumption_through_the_callers_hook(self):
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner as mod
+
+        src = inspect.getsource(mod._run_chat)
+        lines = src.splitlines()
+        # Reported on the two transitions that flip _turn_emitted ...
+        reported_after_flip = [
+            i
+            for i, ln in enumerate(lines)
+            if ln.strip() == "_report_consumed()"
+            and lines[i - 1].strip().startswith("_turn_emitted = True")
+        ]
+        assert len(reported_after_flip) == 2
+        # ... and on the provider's turn-complete event, which is what covers a
+        # prompt that was consumed and produced NOTHING -- but only for a real
+        # end-of-turn, since the same event carries the cut-short reasons whose
+        # recovery re-queues the prompt.
+        complete_at = src.index("elif event.kind == EVENT_COMPLETE:")
+        window = src[complete_at : complete_at + 1400]
+        assert "if event.stop_reason == STOP_REASON_END_TURN:\n" in window
+        gate_at = window.index("if event.stop_reason == STOP_REASON_END_TURN:")
+        assert window.index("_report_consumed()") > gate_at
+        # An equality against that one reason -- not a set that could quietly
+        # readmit a cut-short turn (stale-recover, tool-stall, cancelled).
+        gate_line = window[gate_at : window.index("\n", gate_at)]
+        assert " in (" not in gate_line and " or " not in gate_line
+        assert src.count("_report_consumed()") == 3  # 3 report sites
+        # The retraction lives in the FIRST empty-response branch, beside the
+        # verbatim re-queue -- not anywhere a real delivery could hit it.
+        assert "_report_consumed(False)" in src
+        verbatim_at = src.index("# Verbatim replay: ORIGINAL only if")
+        assert 0 < src.index("_report_consumed(False)") - verbatim_at < 900
+        assert "_last_turn_emitted" not in src
+        drain = inspect.getsource(mod._start_next_queued_turn)
+        assert '_run_kwargs["_on_consumed"] = _note_consumed' in drain
+
+    def test_slot_carries_no_shared_consumption_flag(self):
+        assert "_last_turn_emitted" not in _ChatSlot.__slots__
+
+    @pytest.mark.asyncio
+    async def test_a_successor_turn_cannot_unsettle_its_predecessor(self, agent_root, tmp_path):
+        """Two queued completions: the first turn's own cell must still read
+        consumed after a second turn has started and reported nothing."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("successor")
+        _finished_run("a1", agent_root)
+        _finished_run("a2", agent_root)
+        first_done: asyncio.Future = asyncio.get_event_loop().create_future()
+        second_done: asyncio.Future = asyncio.get_event_loop().create_future()
+        spawned: list[dict] = []
+
+        def _spawn(_state, _slot, coro):
+            hook = coro.cr_frame.f_locals.get("_on_consumed")
+            coro.close()
+            fut = second_done if spawned else first_done
+
+            async def _turn():
+                await fut
+
+            spawned.append({"hook": hook})
+            return asyncio.get_event_loop().create_task(_turn())
+
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        with patch("kiro_crew.dashboard.chat_runner.spawn_guarded_turn", _spawn):
+            assert await _start_next_queued_turn(state, slot) is True
+            # First turn is consumed: its own cell records it.
+            spawned[0]["hook"]()
+            # Its tail-drain starts the SECOND completion before it finishes.
+            slot.queue_append(SECOND_COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+            slot.note_pending_subagent_delivery(SECOND_COMPLETION, ["a2"])
+            assert await _start_next_queued_turn(state, slot) is True
+
+        first_done.set_result(None)
+        await _settled(lambda: (agent_root / "a1" / "tombstone.json").exists())
+        # The successor reported nothing, so only the first is settled.
+        assert not (agent_root / "a2" / "tombstone.json").exists()
+
+
+class TestTeardownGateOnQueuedSettlement:
+    """A ``delivered`` tombstone excludes the folder from restart orphan
+    reconciliation, so it must not be written while the run's teardown is still
+    killing its child -- a crash in that window would strand a live process that
+    nothing reaps. ``_report_terminal`` holds its own write for that gate; the
+    queued path settles elsewhere and must honour the same one."""
+
+    @pytest.mark.asyncio
+    async def test_settle_waits_for_the_runs_teardown(self, agent_root):
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+        info = _member()
+        _finished_run(info.id, agent_root)
+        gate = asyncio.Event()
+        mgr._teardown_gates[info.id] = gate
+        mgr._agents[info.id] = info
+
+        task = asyncio.create_task(mgr.settle_queued_delivery([info.id]))
+        await asyncio.sleep(0.05)
+        assert not (agent_root / info.id / "tombstone.json").exists()
+
+        gate.set()  # teardown finished: the child is provably gone
+        await task
+        assert (agent_root / info.id / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_settle_writes_immediately_once_teardown_is_done(self, agent_root):
+        """A set gate -- or a run whose record is already gone -- means teardown
+        has finished, so there is nothing to wait for."""
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+        info = _member()
+        _finished_run(info.id, agent_root)
+        gate = asyncio.Event()
+        gate.set()
+        mgr._teardown_gates[info.id] = gate
+        mgr._agents[info.id] = info
+        _finished_run("evicted", agent_root)
+
+        await mgr.settle_queued_delivery([info.id, "evicted"])
+
+        assert (agent_root / info.id / "tombstone.json").exists()
+        assert (agent_root / "evicted" / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_an_evicted_run_still_waits_for_its_teardown(self, agent_root):
+        """A dashboard "clear completed" / "cancel" pops a done-but-still-tearing-down
+        run from BOTH ``_agents`` and ``_tasks``. The gate lives outside both, so the
+        tombstone still waits -- inferring "record gone means child gone" would hide
+        a live child from restart reconciliation."""
+        mgr = _manager()
+        info = _member()
+        _finished_run(info.id, agent_root)
+        gate = asyncio.Event()
+        mgr._teardown_gates[info.id] = gate
+        # Evicted exactly as api_spawn_clear does it: both records, together.
+        mgr._agents.pop(info.id, None)
+        mgr._tasks.pop(info.id, None)
+
+        task = asyncio.create_task(mgr.settle_queued_delivery([info.id]))
+        await asyncio.sleep(0.05)
+        assert not (agent_root / info.id / "tombstone.json").exists()
+
+        gate.set()
+        await task
+        assert (agent_root / info.id / "tombstone.json").exists()
+
+    def test_the_drain_settles_only_through_the_manager(self):
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner as mod
+
+        src = inspect.getsource(mod._arm_queued_delivery_settlement)
+        assert 'getattr(mgr, "settle_queued_delivery", None)' in src
+        # No second write path: the debt only exists because the manager's own
+        # completion callback created it, so a manager-less state cannot owe one,
+        # and a direct write would bypass the teardown gate.
+        assert not hasattr(mod, "_mark_queued_deliveries")
+        assert "mark_delivered" not in src
+
+
+class TestDrainSettlesDelivery:
+    """Settlement is armed at dispatch and fires when the turn FINISHES.
+
+    Two properties are pinned deliberately: nothing is written while the turn is
+    still running (a durable tombstone before the turn is durable would lose the
+    completion on a crash), and the write never happens inline on the event loop
+    (``mark_delivered`` fsyncs).
+    """
+
+    def _turn_spawner(self, done: "asyncio.Future", *, consumed: bool = True):
+        """Stand in for ``spawn_guarded_turn`` with a task the test controls.
+
+        *consumed* mimics ``_run_chat`` reporting through the caller's hook: True
+        when the model processed the prompt (turn-complete event, or an earlier
+        token / tool call).
+        """
+
+        def _spawn(_state, _slot, coro):
+            hook = coro.cr_frame.f_locals.get("_on_consumed")
+            coro.close()  # the real runner would await it; we are not running a turn
+            if consumed and hook is not None:
+                hook()
+
+            async def _turn():
+                await done
+
+            return asyncio.get_event_loop().create_task(_turn())
+
+        return _spawn
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_written_until_the_turn_completes(self, agent_root, tmp_path):
+        """The dispatch path must not write (nor fsync) inline: the tombstone
+        appears only after the turn it was armed on finishes."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-settles")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        # Turn still running: the promise is intact and the clock has not started.
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+
+        done.set_result(None)
+        await _settled(lambda: (agent_root / "a1" / "tombstone.json").exists())
+        assert slot._subagent_delivery_pending == {}
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_turn_before_consumption_settles_nothing(self, agent_root, tmp_path):
+        """Cancelled before the model got the prompt: it may never have read the
+        result, so leave the folder un-tombstoned -- recoverable beats pruned."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-cancel")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done, consumed=False),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        slot.task.cancel()
+        await asyncio.sleep(0.05)
+
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_turn_after_consumption_still_settles(self, agent_root, tmp_path):
+        """Consumption is one-way: a session close that cancels the turn after the
+        model already has the completion must still settle, or the next start
+        re-announces a result the parent read."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-cancel-late")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done),  # consumed: the turn streamed output
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        slot.task.cancel()
+        await _settled(lambda: (agent_root / "a1" / "tombstone.json").exists())
+
+    @pytest.mark.asyncio
+    async def test_a_failed_turn_before_consumption_settles_nothing(self, agent_root, tmp_path):
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-fail")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done, consumed=False),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        done.set_exception(RuntimeError("turn blew up"))
+        await asyncio.sleep(0.05)
+
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_an_auth_required_turn_settles_nothing(self, agent_root, tmp_path):
+        """A signed-out CLI makes _run_chat render an error card and return
+        NORMALLY, holding the queue for a post-login resume. The model never
+        consumed the prompt, so nothing is reported and the result must survive
+        until the user signs in."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-auth")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done, consumed=False),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        slot._last_turn_auth_required = True
+        done.set_result(None)
+        await asyncio.sleep(0.05)
+
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+
+    @pytest.mark.asyncio
+    async def test_a_requeued_turn_settles_nothing(self, agent_root, tmp_path):
+        """A pre-stream provider death is HANDLED: _run_chat re-queues the prompt
+        for a later retry and returns normally. The task looks successful, so only
+        the emission signal keeps the retry's result alive."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-requeue")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done, consumed=False),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        # What the AcpProcessDied branch does: replay the prompt, end the turn.
+        slot.queue_insert(0, COMPLETION, kind=SYNTHETIC_RECOVERY_KIND)
+        done.set_result(None)
+        await asyncio.sleep(0.05)
+
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_a_second_empty_response_still_settles(self, agent_root, tmp_path):
+        """The SECOND empty response re-queues a continuation, not the announce, so
+        the completion has reached the model and the clock starts -- an emission-only
+        predicate would strand this debt (no tokens were produced)."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-empty")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+        hooks: list = []
+
+        def _spawn(_state, _slot, coro):
+            hooks.append(coro.cr_frame.f_locals.get("_on_consumed"))
+            coro.close()
+
+            async def _turn():
+                await done
+
+            return asyncio.get_event_loop().create_task(_turn())
+
+        with patch("kiro_crew.dashboard.chat_runner.spawn_guarded_turn", _spawn):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        # No tokens, no tool call -- only the provider's turn-complete event.
+        hooks[0]()
+        done.set_result(None)
+        await _settled(lambda: (agent_root / "a1" / "tombstone.json").exists())
+
+    @pytest.mark.asyncio
+    async def test_a_first_empty_response_retracts_and_settles_nothing(self, agent_root, tmp_path):
+        """The FIRST empty response re-queues this exact announce VERBATIM, so the
+        delivery that counts has not happened yet. The turn reports consumption
+        while streaming (it ends on a real end-of-turn) and then retracts it once
+        the empty text is known -- settling here would put the result on a 1h clock
+        that the replay has to beat."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-empty-first")
+        _finished_run("a1", agent_root)
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+        hooks: list = []
+
+        def _spawn(_state, _slot, coro):
+            hooks.append(coro.cr_frame.f_locals.get("_on_consumed"))
+            coro.close()
+
+            async def _turn():
+                await done
+
+            return asyncio.get_event_loop().create_task(_turn())
+
+        with patch("kiro_crew.dashboard.chat_runner.spawn_guarded_turn", _spawn):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        hooks[0]()  # turn-complete on a real end-of-turn
+        hooks[0](False)  # ... then the verbatim re-queue retracts it
+        done.set_result(None)
+        await asyncio.sleep(0.05)
+
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+
+    @pytest.mark.asyncio
+    async def test_a_replayed_completion_can_still_claim_its_debt(self, agent_root, tmp_path):
+        """A pre-consumption failure re-queues the SAME announce under a freshly
+        minted queue id. The debt is keyed on the announce, so the retry that
+        finally delivers it can claim what the first attempt could not."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-replay")
+        _finished_run("a1", agent_root)
+        first_id = slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        first_done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        # Attempt 1: dies before the model consumed the prompt.
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(first_done, consumed=False),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+        first_done.set_result(None)
+        await asyncio.sleep(0.05)
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+
+        # The recovery replays the announce verbatim -- new id, same content.
+        replay_id = slot.queue_insert(0, COMPLETION, kind=SYNTHETIC_RECOVERY_KIND)
+        assert replay_id != first_id
+        second_done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(second_done),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+        second_done.set_result(None)
+        await _settled(lambda: (agent_root / "a1" / "tombstone.json").exists())
+        assert slot._subagent_delivery_pending == {}
+
+    @pytest.mark.asyncio
+    async def test_a_pasted_announce_cannot_claim_the_debt(self, agent_root, tmp_path):
+        """The ledger is content-keyed, so a user row whose TEXT is a copy of the
+        announce would claim the genuine row's debt and start its clock early.
+        Settlement is gated on the structural kind, which a typed row cannot carry."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("spoof")
+        _finished_run("a1", agent_root)
+        # The genuine completion is queued BEHIND the user's copy of its text.
+        slot._queue = [
+            {"id": "u1", "content": COMPLETION, "kind": ""},
+            {"id": "q1", "content": COMPLETION, "kind": SUBAGENT_COMPLETION_KIND},
+        ]
+        slot.note_pending_subagent_delivery(COMPLETION, ["a1"])
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+        done.set_result(None)
+        await asyncio.sleep(0.05)
+
+        # The spoof drained first and settled nothing; the debt is still owed to
+        # the genuine row, which has not run yet.
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+
+    @pytest.mark.asyncio
+    async def test_drained_user_message_settles_nothing(self, agent_root, tmp_path):
+        """Only a completion row owes a mark; a user turn draining past one must
+        not start someone else's retention clock."""
+        from chat_test_helpers import _make_state
+
+        state = _make_state(tmp_path / "state")
+        state.subagents = _manager()
+        slot = state.get_or_create_slot("drain-user")
+        _finished_run("a1", agent_root)
+        slot.note_pending_subagent_delivery(_ann("other"), ["a1"])
+        slot._queue = [{"id": "u1", "content": "carry on", "kind": ""}]
+        done: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner.spawn_guarded_turn",
+            self._turn_spawner(done),
+        ):
+            assert await _start_next_queued_turn(state, slot) is True
+
+        done.set_result(None)
+        await asyncio.sleep(0.05)
+
+        assert not (agent_root / "a1" / "tombstone.json").exists()
+
+
+# ── End to end: the reaper must not outrun the queue ──────────────────
+
+
+class TestReaperDoesNotPruneAQueuedPromise:
+    @pytest.mark.asyncio
+    async def test_result_survives_a_queue_wait_longer_than_the_ttl(self, agent_root):
+        """The reported failure, reduced: the completion is routed while the slot
+        is busy, the parent's turn outlasts the TTL, and the reaper sweeps. The
+        result the queued announce points at must still be there when the row
+        finally drains — and only THEN start its retention window."""
+        ttl = 3600
+        slot = _ChatSlot("s1")
+        info = _member()
+        _finished_run(info.id, agent_root)
+
+        # 1. Routed into a busy slot: queued, not delivered.
+        slot.queue_append(COMPLETION, kind=SUBAGENT_COMPLETION_KIND)
+        _defer(slot, info)
+
+        # 2. The run loop honours the flag, so no clock is started.
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+        mgr._fire_event = AsyncMock()
+        mgr._on_done = AsyncMock()
+        await mgr._report_terminal(
+            info,
+            source="test",
+            injection_timeout_reason="x",
+            mark_delivered_on_success=True,
+        )
+
+        # 3. The parent's turn runs long; the reaper sweeps well past the TTL.
+        with patch("kiro_crew.subagent_persistence.time.time", return_value=time.time() + 4 * ttl):
+            assert prune_stale_tombstones(7, ttl) == 0
+        assert (agent_root / info.id / "result.txt").exists()
+
+        # 4. The row finally drains and its turn runs: the promise is still
+        #    honourable, and the retention window opens from there.
+        await _manager().settle_queued_delivery(slot.take_pending_subagent_deliveries([COMPLETION]))
+        assert (agent_root / info.id / "result.txt").exists()
+        ts = json.loads((agent_root / info.id / "tombstone.json").read_text(encoding="utf-8"))
+        assert ts["cause"] == "delivered" and ts["died"] >= time.time() - 60
+
+        # 5. And it still bounds disk growth: one TTL after consumption, gone.
+        with patch("kiro_crew.subagent_persistence.time.time", return_value=time.time() + 2 * ttl):
+            assert prune_stale_tombstones(7, ttl) == 1
+        assert not (agent_root / info.id).exists()
+
+    @pytest.mark.asyncio
+    async def test_gateway_queue_route_leaves_the_folder_readable(self, agent_root):
+        """Same claim one layer up, through the real ``_subagent_done`` callback:
+        a busy slot's completion is queued and its folder left un-tombstoned."""
+        from test_subagent_scale import _mock_dashboard_state, _mock_sessions
+
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = _ChatSlot("main")
+        blocker = asyncio.create_task(asyncio.sleep(30))
+        slot.task = blocker  # busy: an injection must wait behind this turn
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+
+        with patch("kiro_crew.slack.gateway.SubagentManager") as mock_sm:
+            mock_sm_inst = MagicMock()
+            mock_sm_inst.start_reaper = MagicMock()
+            mock_sm_inst.running_agents_for = MagicMock(return_value=[])
+            mock_sm.return_value = mock_sm_inst
+            with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+                orch._init_subagents()
+            orch.subagent_mgr = mock_sm_inst
+            on_done = mock_sm.call_args.kwargs["on_done"]
+
+        info = _member()
+        _finished_run(info.id, agent_root)
+        try:
+            with patch("kiro_crew.slack.gateway.INJECTION_TIMEOUT", 0.01):
+                await on_done(info)
+        finally:
+            blocker.cancel()
+
+        assert [q["kind"] for q in slot._queue] == [SUBAGENT_COMPLETION_KIND]
+        assert slot._subagent_delivery_pending == {_key(slot._queue[0]["content"]): [info.id]}
+        assert info._delivery_queued is True
+        assert not (agent_root / info.id / "tombstone.json").exists()
+
+
+def _make_orchestrator():
+    from kiro_crew.config import KiroCrewConfig
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    cfg = KiroCrewConfig()
+    with patch.object(cfg, "load_credentials", return_value={"KIROCREW_OWNER_ID": "U_OWNER"}):
+        return GatewayOrchestrator(cfg, no_dashboard=False, no_crons=True, no_open=True)


### PR DESCRIPTION
## What is the problem?

A completed sub-agent's `result.txt` is kept for `agent.subagent_result_ttl_secs` (default 3600) so the parent can read the full transcript after the completion event arrives. That window is the `died` stamp on the `delivered` tombstone, and it was written as soon as the gateway had ROUTED the completion -- including the route that only parks the announce in a busy slot's queue.

A queue wait is bounded by the turn ceiling, not by the TTL. In the reported case 11 sub-agents finished inside a two-minute window, their events reached the parent about two hours later, and every result path in them was already gone -- under the announce's own line `Full outputs are on disk -- read the result paths on demand`.

## Why this issue matters to the user

The parent is told the transcript is on disk and told not to re-run the agent. When the path is dead it can do neither: the full output is unrecoverable, and the only way back to it is re-running work that already succeeded. It also fails silently and selectively -- `timeout` tombstones get the 7-day post-mortem window and survive, so a failed peer's surviving `result.txt` makes the wave look intact.

## How our fix solves it

The chain is delivery-vs-consumption. `_report_terminal` marks delivered once `_on_done` returns, but for a dashboard parent whose slot is busy `_on_done` only calls `queue_append` and returns -- so the clock started while the event was still waiting for a turn, and the reaper (`prune_stale_tombstones`, `cause="delivered"`) pruned the folder the queued announce points at. Nothing re-stats the path at dequeue, so the parent gets the promise and a missing file.

So routing and consumption are split:

- **Gateway (queued route only).** `_defer_queued_delivery` records the owed agent ids on the slot against the row's queue id and sets `_delivery_queued` on the run. A queued wave digest transfers its held members' `_digest_settle_ids` the same way, so `_settle_digest_holds` becomes a no-op instead of a second writer. A failed member owes nothing (its own error path already tombstoned it), and a flush-only record owes only the members it releases.
- **Run loop.** `_report_terminal` skips its own `mark_delivered` when that flag is set -- the same treatment digest-held members already get. No tombstone means the reaper cannot prune the folder, and it stays visible to restart orphan reconciliation, which re-delivers a result whose queued row a restart threw away. Re-notifying beats silent loss.
- **Drain.** `_start_next_queued_turn` arms the settlement on the dispatched turn task and it fires when that turn has actually RUN, so the retention window is measured from consumption and still bounds disk growth. Not at dispatch: a `delivered` tombstone is durable and hides the folder from restart recovery, while a just-dispatched turn is not durable yet, so a crash in that window would lose the completion outright. The writes go through `asyncio.to_thread` because `mark_delivered` fsyncs and this is the turn-dispatch path. A cancelled or failed turn settles nothing, and a row that left the queue without being consumed (evicted) is dropped rather than marked -- in all three the parent may never have read the result, and an un-tombstoned folder is recoverable.

If the slot cannot take the ids the deferral is abandoned and the previous immediate-tombstone behaviour stands: a short window beats a folder no one ever tombstones. The unqueued route is unchanged -- a turn starts immediately, so the clock starts immediately.

## What tests we did

New `test/test_subagent_delivery_ttl_anchor.py`, 18 tests: the slot ledger (claim once, empty ids record nothing, a vanished row is dropped not marked), `_defer_queued_delivery` (owes the member, transfers held digest ids, failed member, flush-only, un-takeable slot falls back), the run loop skipping and not skipping, the drain writing nothing until its turn completes, a cancelled turn and a failed turn settling nothing, the marker surviving a failed write, a user row draining past a debt settling nothing, and two end-to-end claims -- the reduced report (routed while busy, reaper sweeps 4x past the TTL, `result.txt` still there, then pruned one TTL after consumption) and the same through the real `_subagent_done` callback with a busy slot.

Mutation-verified: each hunk reverted independently fails tests (gateway defer -> 1, run-loop skip -> 2, settling inline at dispatch -> 3, dropping the cancelled/failed guard -> 2).

Also green: `test_subagent_scale`, `test_subagent_persistence`, `test_subagent_batch_injection`, `test_queue_during_subagents`, `test_merge_queued_messages`, `test_subagent_coverage`, `test_chat_runner_coverage`, `test_open_slots_persistence`, `test_subagent_reap_race`, `test_subagent_continuable`. Gates: black baseline, isort, flake8, mypy, brand, woke all clean.

No pod e2e: the trigger is a multi-hour queue wait, which the end-to-end tests reproduce deterministically by driving the real callback and the real reaper instead.

## Any other suggestions on the work

Two residuals deliberately left out of scope:

1. The issue's second direction -- re-stat the path at dequeue and inline short results (the observed wave's were 104 to 3831 bytes) or say "result expired". With the anchor fixed there is no reachable case for it in the queued path, so it would be dead code here; it is the right shape for the remaining window below.
2. A turn that runs longer than the TTL can still outlive a result delivered at its start. That is the TTL-vs-turn-length question, not delivery latency, and it wants its own decision (raise the default, or refresh on read).

Closes #4839
