### PR TITLE
fix(cron): make preview ctx.notify accept production kwargs

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1085,8 +1085,18 @@ def _cron_preview(args: argparse.Namespace) -> None:
                 )
             return result
 
-        def notify(self, message: str) -> None:
-            print(f"[notify suppressed]: {message}")
+        def notify(self, text: str, **kwargs: object) -> dict:
+            # Signature mirrors production ScriptContext.notify: scripts pass routing
+            # kwargs (session="origin" is the documented way for a cron to reach the
+            # chat that created it), so a positional-only stub made preview crash on
+            # the one branch a monitor cron exists for. Redaction mirrors production
+            # too -- this prints to the user's terminal, and kwargs values are
+            # script-supplied. Returns an empty dict: nothing was delivered.
+            safe_text = redact(text)
+            safe_kwargs = json.loads(redact(json.dumps(kwargs))) if kwargs else {}
+            routing = f" (kwargs: {safe_kwargs})" if safe_kwargs else ""
+            print(f"[notify suppressed]: {safe_text}{routing}")
+            return {}
 
         def close(self):
             pass

--- a/test/test_cron_preview_cmd.py
+++ b/test/test_cron_preview_cmd.py
@@ -182,3 +182,74 @@ class TestCronPreviewCallToolPath:
         out = capsys.readouterr().out
         assert "[notify suppressed]" in out
         assert "hello world" in out
+
+
+class TestCronPreviewNotifyParity:
+    """The preview ctx must accept everything production ScriptContext.notify accepts.
+
+    A monitor cron exists to speak up; `session="origin"` is the documented way to
+    reach the chat that created it. A preview that only validates the silent branch
+    validates nothing that matters, and a TypeError there reads exactly like a script
+    bug -- inviting the "fix" of dropping the kwarg, which silently breaks delivery.
+    """
+
+    def test_notify_accepts_documented_routing_kwarg(self, tmp_path: Path, capsys):
+        _write_script(
+            tmp_path,
+            "s.py",
+            "from kiro_crew.cron_script import Report\n"
+            "def run(ctx):\n"
+            "    ctx.notify('stall suspected', session='origin')\n"
+            "    raise Report('done')\n",
+        )
+        with _patch_resolve(tmp_path):
+            _cron_preview(_make_args(f"{tmp_path / 's.py'}:run"))
+        out = capsys.readouterr().out
+        assert "[notify suppressed]" in out
+        assert "stall suspected" in out
+        # Routing surfaced, not swallowed: preview is how you confirm where it goes.
+        assert "origin" in out
+        assert "Error" not in out
+
+    def test_notify_signature_derived_from_production(self, tmp_path: Path, capsys):
+        """Expectations come from ScriptContext.notify itself, so future drift fails here."""
+        _write_script(
+            tmp_path,
+            "s.py",
+            "import inspect\n"
+            "from kiro_crew.cron_script import Report, ScriptContext\n"
+            "def run(ctx):\n"
+            "    prod = inspect.signature(ScriptContext.notify)\n"
+            "    stub = inspect.signature(ctx.notify)\n"
+            "    # Same first parameter name, so keyword calls work in both.\n"
+            "    assert list(stub.parameters)[0] == list(prod.parameters)[1]\n"
+            "    # Anything production can bind, the stub must bind too.\n"
+            "    call = {'session': 'origin', 'channel': 'C123'}\n"
+            "    prod.bind(object(), 'x', **call)\n"
+            "    stub.bind('x', **call)\n"
+            "    raise Report('parity ok')\n",
+        )
+        with _patch_resolve(tmp_path):
+            _cron_preview(_make_args(f"{tmp_path / 's.py'}:run"))
+        out = capsys.readouterr().out
+        assert "parity ok" in out
+        assert "Error" not in out
+
+    def test_notify_redacts_credentials_in_text_and_kwargs(self, tmp_path: Path, capsys):
+        """Production redacts before sending; preview must redact before printing."""
+        _write_script(
+            tmp_path,
+            "s.py",
+            "from kiro_crew.cron_script import Report\n"
+            "def run(ctx):\n"
+            "    ctx.notify('leak aws_secret_access_key=AKIAIOSFODNN7EXAMPLE',\n"
+            "               detail='aws_secret_access_key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY')\n"
+            "    raise Report('done')\n",
+        )
+        with _patch_resolve(tmp_path):
+            _cron_preview(_make_args(f"{tmp_path / 's.py'}:run"))
+        out = capsys.readouterr().out
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+        # The kwarg value is redacted too, not just the text.
+        assert "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY" not in out
+        assert "REDACTED" in out


### PR DESCRIPTION
## Problem / Motivation

`kirocrew cron preview` handed scripts a stub context whose `notify` was positional only, while the production context accepts routing kwargs:

| | signature | location |
|---|---|---|
| preview stub | `notify(self, message: str) -> None` | `src/kiro_crew/cli_commands.py:1088` |
| production | `notify(self, text: str, **kwargs: Any) -> dict` | `src/kiro_crew/cron_script.py:276` |

`src/kiro_crew/config/prompt.md:79` tells agents to pass `session="origin"` so a cron's message reaches the chat that created it. Any monitor script following that instruction died under preview:

```
TypeError: _cron_preview.<locals>._LiveTestCtx.notify() got an unexpected keyword argument 'session'
```

Fixes #4863

## Why it matters

The gate was inverted. A monitor cron exists in order to speak up, and preview could only validate the silent `Skip` path, so previewing a monitor validated nothing that mattered. That matters concretely because a cron whose entry point misbehaves accrues `consecutive_failures` and is auto-disabled after 8 ticks, which is the reason previewing before registering is advised in the first place.

The second-order effect is worse than the crash. The `TypeError` is indistinguishable from a bug in the user's own script, and the obvious "fix" is to delete the kwarg. That makes preview pass while silently rerouting the real notification to the default channel instead of the originating session, so a monitor looks healthy and reports nowhere.

## What changed (motivation → approach → change)

Root cause: the stub was written to satisfy the simplest call shape (`notify("text")`) rather than to mirror the production contract, and the only test covering it used exactly that shape, so the divergence was invisible to CI.

Approach: make the stub mirror production rather than approximate it, and derive the test's expectation from the production signature so the same drift cannot silently reappear.

Change, in `_LiveTestCtx.notify`:

- Signature is now `notify(self, text: str, **kwargs: object) -> dict`, matching production's parameter name and accepting arbitrary routing kwargs. `object` rather than `Any` avoids adding a `typing` import for two lines.
- Routing kwargs are printed rather than swallowed, since seeing where a notification would go is the point of previewing it.
- Text and kwargs are redacted before printing. Production redacts both before sending, and the sibling `call_tool` stub already redacts its args for the same reason. The stub was printing script-supplied text raw, so adding kwargs to the output without redaction would have widened that gap rather than closed it.
- Returns `{}`, since nothing was delivered. Production returns the gateway result dict, so a script that inspects the return value no longer gets `None`.

## Tests

New `TestCronPreviewNotifyParity` in `test/test_cron_preview_cmd.py`:

- `test_notify_accepts_documented_routing_kwarg` covers the reported crash directly: `ctx.notify('stall suspected', session='origin')` must not raise, and the routing must appear in the output rather than be dropped.
- `test_notify_signature_derived_from_production` reads `inspect.signature(ScriptContext.notify)` and asserts the stub binds everything production binds, plus that the first parameter names match so keyword calls work against both. Its expectation comes from production code, not a hardcoded signature, so a future change on either side fails here instead of quietly reopening this bug.
- `test_notify_redacts_credentials_in_text_and_kwargs` asserts credential-shaped values in both the text and a kwarg are redacted before printing.

All three fail against the unfixed stub and pass with it. The pre-existing `test_notify_prints_suppressed` is unchanged and still passes, which is the point: it only called `notify` positionally, so it never covered this.

Only the newly added lines were black-formatted. The rest of this test file predates black and is on the baseline list, so it is left untouched to keep the diff free of unrelated churn.

## Manual verification

Reproduced the crash and confirmed the fix against a real preview run, not just unit tests.

Before:
```
TypeError: _cron_preview.<locals>._LiveTestCtx.notify() got an unexpected keyword argument 'session'
_cron_preview exited 1
```

After: the suppressed notification prints with its routing, and the run ends on `Skip` as expected.

Local gates, all green:

- `python3 scripts/check_black_formatting.py` passed, scope `origin/main...HEAD`, 2 changed files
- `isort --check-only src/kiro_crew test conftest.py` clean
- `flake8` clean on both changed files
- `pytest test/test_cron_preview_cmd.py test/test_cron_script.py` 117 passed, 1 skipped
- `mypy src/kiro_crew/cli_commands.py` reports 4 errors, all in unrelated files and all reproduced identically on unmodified `origin/main`; zero come from the changed file

## Related Issues

Fixes #4863

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no doc change needed; `prompt.md` already documents `session="origin"` correctly, this makes the tooling match the docs
- [x] No secrets, credentials, or internal references in the diff
