### PR TITLE
fix(sandbox): probe namespaces in a fresh process, not a fork of the caller

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -725,13 +725,23 @@ def _probe_child_sequence(
 
 
 def _probe_parent_sequence(
-    pid: int, c2p_r: int, p2c_w: int, uid: int, gid: int
+    pid: int,
+    c2p_r: int,
+    p2c_w: int,
+    uid: int,
+    gid: int,
+    death: Callable[[int], str] = _probe_child_death,
 ) -> tuple[bool, bool, str, str]:
-    """Parent half of the probe: drive the handshake and decide the verdict."""
+    """Parent half of the probe: drive the handshake and decide the verdict.
+
+    ``death`` describes a child that stopped reporting. It is injected because the
+    spawned probe's child is owned by a ``Popen`` -- calling ``waitpid`` on it here
+    would race that object's own bookkeeping -- while the forked probe's child is
+    reaped by this module. The verdict logic is identical for both.
+    """
     report = _probe_read_step(c2p_r)
     if report is None:
-        death = _probe_child_death(pid)
-        return (False, True, f"probe child {death}; no {_PROBE_STEP_NEWUSER} result", "")
+        return (False, True, f"probe child {death(pid)}; no {_PROBE_STEP_NEWUSER} result", "")
     step, err = report
     if step == _PROBE_STEP_MULTITHREADED:
         # Same classification and same remedy as a plain EINVAL -- deliberately, see
@@ -764,8 +774,7 @@ def _probe_parent_sequence(
 
     report = _probe_read_step(c2p_r)
     if report is None:
-        death = _probe_child_death(pid)
-        return (False, True, f"probe child {death}; no {_PROBE_STEP_NEWNS} result", "")
+        return (False, True, f"probe child {death(pid)}; no {_PROBE_STEP_NEWNS} result", "")
     step, err = report
     if step != "N":
         return (False, True, f"probe child sent unexpected step {step!r}", "")
@@ -776,6 +785,186 @@ def _probe_parent_sequence(
 
 def _probe_unshare_once() -> tuple[bool, bool, str, str]:
     """One launcher-shaped namespace probe: ``(ok, transient, reason)``.
+
+    Runs in a FRESH interpreter when one can be spawned, and falls back to
+    :func:`_probe_unshare_via_fork` otherwise. The two produce the same verdict
+    tuple through the same classifier; only the process the child half runs in
+    differs. See :data:`_PROBE_SHIM_CODE` for why that difference is the whole
+    point.
+    """
+    spawned = _probe_unshare_via_spawn()
+    if spawned is not None:
+        return spawned
+    return _probe_unshare_via_fork()
+
+
+#: Child half of the probe, run in a FRESH interpreter rather than a fork of the
+#: caller. Same wire protocol as :func:`_probe_child_sequence`, so the reviewed
+#: parent half drives either one unchanged.
+#:
+#: WHY A FRESH PROCESS. ``unshare(CLONE_NEWUSER)`` implies ``CLONE_THREAD`` and the
+#: kernel refuses it with EINVAL unless the caller's thread group holds exactly one
+#: task. A fork child inherits that condition: ``os.register_at_fork`` handlers run
+#: INSIDE ``os.fork()`` before it returns, so a dependency that restarts a thread in
+#: every child -- OpenTelemetry's ``PeriodicExportingMetricReader`` does exactly
+#: this -- makes the child multithreaded before the probe can measure anything. The
+#: verdict is then EINVAL, which is classified permanent and cached, and every later
+#: sandboxed spawn on that process fails closed. A release gate lost 40 tests to one
+#: such probe: all of them pass alone, none of them is a metrics test.
+#:
+#: A fresh interpreter starts single-threaded and runs no after-in-child fork hooks,
+#: so its thread count at ``unshare()`` time is 1 regardless of the caller. This does
+#: NOT soften the fail-closed rule: a genuinely single-threaded process that still
+#: gets EINVAL means the host lacks ``CONFIG_USER_NS``, which stays permanent. It
+#: removes the FALSE EINVAL, not the real one.
+#:
+#: It is also the more faithful probe. The real launcher is already a fresh
+#: interpreter -- ``wrap_argv`` returns ``[sys.executable, launcher_path, ...]`` --
+#: which then forks and unshares. So the fork-based probe was strictly MORE
+#: pessimistic than the spawn it predicts, and this makes the two agree.
+#:
+#: Kept deliberately free of ``kiro_crew`` imports and run under ``-I -S``, like
+#: ``_SPAWN_SHIM_CODE``: no site directory, no ``PYTHON*`` environment influence,
+#: nothing to shadow. It writes ONLY wire steps on fd 1.
+_PROBE_SHIM_CODE = r"""
+import ctypes, errno, os
+
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWNS = 0x00020000
+
+
+def threads():
+    # st_nlink of /proc/self/task is the thread count plus the two dir entries.
+    try:
+        return max(1, os.stat("/proc/self/task").st_nlink - 2)
+    except OSError:
+        return 1
+
+
+def unshare(libc, flags):
+    ctypes.set_errno(0)
+    if libc.unshare(flags) == 0:
+        return 0
+    return ctypes.get_errno() or errno.EPERM
+
+
+def main():
+    try:
+        # dlopen(NULL): resolve unshare() from the libc ALREADY loaded into this
+        # interpreter. Never ctypes.util.find_library here -- on Linux it EXECUTES
+        # helper processes (ldconfig, then a PATH-resolved gcc/cc/objdump on musl
+        # hosts) to locate libc, and this probe runs before any confinement, so a
+        # workspace-controlled `gcc` on PATH would be same-user code execution.
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.unshare.argtypes = [ctypes.c_int]
+        libc.unshare.restype = ctypes.c_int
+    except BaseException:
+        os._exit(1)
+    n = threads()
+    err = unshare(libc, CLONE_NEWUSER)
+    if err == errno.EINVAL and n > 1:
+        os.write(1, b"M:%d\n" % n)
+        os._exit(0)
+    os.write(1, b"U:%d\n" % err)
+    if err:
+        os._exit(0)
+    if not os.read(0, 1):
+        os._exit(0)
+    os.write(1, b"N:%d\n" % unshare(libc, CLONE_NEWNS))
+    os._exit(0)
+
+
+main()
+"""
+
+#: Ceiling on the spawned probe. The child does two syscalls and one blocking read
+#: whose writer is this process, so anything near this is a wedged interpreter, not
+#: slow work. Exceeding it is reported TRANSIENT: a host that cannot start a Python
+#: in 20 seconds is under momentary pressure, not permanently sandbox-less.
+_PROBE_SPAWN_TIMEOUT_SECONDS = 20.0
+
+_probe_spawn_unavailable_logged = False
+
+
+def _probe_spawned_death(proc: "subprocess.Popen[bytes]") -> str:
+    """Describe how the spawned probe child ended, for a transient reason string."""
+    code = proc.poll()
+    if code is None:
+        return "did not report"
+    if code < 0:
+        return f"was killed by signal {-code}"
+    return f"exited with status {code}"
+
+
+def _probe_unshare_via_spawn() -> tuple[bool, bool, str, str] | None:
+    """Probe in a fresh interpreter. ``None`` means "cannot spawn, use the fork path".
+
+    Returning ``None`` rather than a verdict is deliberate: an interpreter this
+    process cannot start says nothing about the host's namespaces, so it must not
+    become a sandbox verdict.
+    """
+    global _probe_spawn_unavailable_logged
+    if not sys.executable:
+        if not _probe_spawn_unavailable_logged:
+            _probe_spawn_unavailable_logged = True
+            logger.warning(
+                "namespace probe cannot spawn a fresh interpreter (sys.executable is "
+                "empty); falling back to a fork-based probe, which reports EINVAL on a "
+                "multithreaded caller even where the sandbox works"
+            )
+        return None
+
+    uid, gid = os.getuid(), os.getgid()
+    try:
+        # close_fds is subprocess's default and does the job the fork path has to do
+        # by hand: the child gets only its standard streams, so an orphaned probe
+        # cannot hold the gateway lock fd or the dashboard listen socket open (#3150).
+        proc = subprocess.Popen(
+            [sys.executable, "-I", "-S", "-c", _PROBE_SHIM_CODE],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except OSError as exc:
+        return _probe_failure("probe spawn", exc.errno or 0)
+    except Exception as exc:  # pragma: no cover - defensive
+        return (False, True, f"probe spawn failed: {exc}", "")
+
+    assert proc.stdin is not None and proc.stdout is not None
+    try:
+        return _probe_parent_sequence(
+            proc.pid,
+            proc.stdout.fileno(),
+            proc.stdin.fileno(),
+            uid,
+            gid,
+            death=lambda _pid: _probe_spawned_death(proc),
+        )
+    finally:
+        # Closing stdin releases a child still waiting on the maps; the wait then
+        # reaps it. Popen owns the pid, so _probe_reap must NOT run here.
+        for stream in (proc.stdin, proc.stdout):
+            try:
+                stream.close()
+            except OSError:
+                pass
+        try:
+            proc.wait(timeout=_PROBE_SPAWN_TIMEOUT_SECONDS)
+        except Exception:  # pragma: no cover - a wedged interpreter
+            proc.kill()
+            try:
+                proc.wait(timeout=_PROBE_SPAWN_TIMEOUT_SECONDS)
+            except Exception:
+                pass
+
+
+def _probe_unshare_via_fork() -> tuple[bool, bool, str, str]:
+    """The fork-based probe: same verdict, but the child inherits fork hooks.
+
+    Retained as the fallback for a process that cannot spawn an interpreter at all.
+    Its child can be made multithreaded by an ``os.register_at_fork`` handler, which
+    is why :func:`_probe_unshare_via_spawn` is preferred whenever it is available.
 
     Mirrors the sequence ``_build_launcher_script()`` actually performs — fork,
     child ``unshare(CLONE_NEWUSER)``, parent writes the identity UID/GID map,

--- a/test/test_sandbox_backend_cache.py
+++ b/test/test_sandbox_backend_cache.py
@@ -252,7 +252,7 @@ def test_probe_child_killed_by_signal_is_transient(monkeypatch):
     fake_libc = FakeLibC()
     monkeypatch.setattr(_ct, "CDLL", lambda *a, **kw: fake_libc)
 
-    ok, transient, reason, _remedy = sb._probe_unshare_once()
+    ok, transient, reason, _remedy = sb._probe_unshare_via_fork()
     assert ok is False
     assert transient is True
     assert "signal 9" in reason

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -571,7 +571,7 @@ class TestProbeScaffolding:
         monkeypatch.setattr(sb.os, "close", tracking_close)
         monkeypatch.setattr(sb.os, "fork", boom)
 
-        ok, transient, reason, _remedy = sb._probe_unshare_once()
+        ok, transient, reason, _remedy = sb._probe_unshare_via_fork()
 
         assert (ok, transient) == (False, True)
         assert reason == "fork failed with errno 11 (EAGAIN)"
@@ -586,7 +586,7 @@ class TestProbeScaffolding:
         monkeypatch.setattr(sb, "_probe_reap", reaped.append)
         monkeypatch.setattr(sb, "_probe_parent_sequence", lambda *_a: (True, False, "ok", ""))
 
-        assert sb._probe_unshare_once() == (True, False, "ok", "")
+        assert sb._probe_unshare_via_fork() == (True, False, "ok", "")
         assert reaped == [4242]
 
     @_linux_only
@@ -601,7 +601,7 @@ class TestProbeScaffolding:
         monkeypatch.setattr(sb, "_probe_parent_sequence", boom)
 
         with pytest.raises(RuntimeError):
-            sb._probe_unshare_once()
+            sb._probe_unshare_via_fork()
         assert reaped == [4242]
 
     def test_non_linux_never_probes(self, monkeypatch):
@@ -794,3 +794,101 @@ class TestProbeChildFdSweep:
 
         assert os.waitstatus_to_exitcode(status) == 0
         assert data == b"01", "sentinel lock fd must close; kept report pipe must survive"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="the userns probe is Linux-only")
+class TestProbeRunsInAFreshProcess:
+    """The probe child must not inherit the caller's fork hooks.
+
+    ``unshare(CLONE_NEWUSER)`` implies ``CLONE_THREAD``, so the kernel returns
+    EINVAL unless the caller's thread group holds exactly one task. An
+    ``os.register_at_fork(after_in_child=...)`` handler runs INSIDE ``os.fork()``,
+    so a dependency that restarts a thread in every child -- OpenTelemetry's
+    metric reader does -- makes a forked probe child multithreaded before it can
+    measure anything. That EINVAL is classified permanent and cached, and every
+    later sandboxed spawn in the process then fails closed: one such probe cost a
+    release gate 40 tests, none of them a metrics test.
+    """
+
+    #: The experiment, run in a DISPOSABLE interpreter. Arming the hook is the point
+    #: of the test and CPython cannot unregister one, so doing it in the pytest worker
+    #: would leave every later fork in that worker starting an unrequested thread --
+    #: the exact side effect this fix exists to remove. The child takes the hook with
+    #: it when it exits. Prints three counts: forked-before, forked-after, spawned.
+    _EXPERIMENT = r"""
+import os, subprocess, sys, threading, time
+
+def forked():
+    r, w = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(r)
+        os.write(w, str(max(1, os.stat("/proc/self/task").st_nlink - 2)).encode())
+        os.close(w)
+        os._exit(0)
+    os.close(w)
+    n = int(os.read(r, 8) or -1)
+    os.close(r)
+    os.waitpid(pid, 0)
+    return n
+
+before = forked()
+os.register_at_fork(after_in_child=lambda: threading.Thread(
+    target=time.sleep, args=(30,), daemon=True).start())
+after = forked()
+code = "import os;print(max(1, os.stat('/proc/self/task').st_nlink - 2))"
+spawned = int(subprocess.run([sys.executable, "-I", "-S", "-c", code],
+                             capture_output=True, text=True, check=True).stdout.strip())
+print(before, after, spawned)
+"""
+
+    def test_a_fork_hook_cannot_reach_the_spawned_child(self):
+        """The property the fix rests on, measured rather than argued.
+
+        Asserted as a DIFFERENCE within one process: a bare "the spawned child has
+        one thread" would pass just as well on a host where nothing armed a hook,
+        which is every host until something does.
+        """
+        out = subprocess.run(
+            [sys.executable, "-I", "-S", "-c", self._EXPERIMENT],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        before, after, spawned = (int(part) for part in out.split())
+
+        assert before == 1, f"the experiment started with a hook already armed ({before})"
+        assert after > 1, "a forked child does not inherit the fork hook; premise gone"
+        assert spawned == 1, "a freshly spawned interpreter must be single-threaded"
+
+    def test_both_paths_report_the_same_verdict_on_this_host(self):
+        """Spawn and fork must agree, or the fix would be changing the answer.
+
+        Only the reason text is compared for its leading step+errno: the spawned
+        path's transient failure strings name a Popen-owned child differently, and
+        that difference is not a verdict.
+        """
+        spawned = sb._probe_unshare_via_spawn()
+        assert spawned is not None, "this host can spawn an interpreter"
+        forked = sb._probe_unshare_via_fork()
+        assert spawned[0] == forked[0], (spawned, forked)
+        assert spawned[1] == forked[1], (spawned, forked)
+        assert spawned[3] == forked[3], (spawned, forked)
+
+    def test_no_executable_falls_back_instead_of_inventing_a_verdict(self, monkeypatch):
+        """An interpreter we cannot start says nothing about the host's namespaces."""
+        monkeypatch.setattr(sb.sys, "executable", "")
+        monkeypatch.setattr(sb, "_probe_spawn_unavailable_logged", False)
+        assert sb._probe_unshare_via_spawn() is None
+
+        monkeypatch.setattr(
+            sb, "_probe_unshare_via_fork", lambda: (True, False, "fork path ran", "")
+        )
+        assert sb._probe_unshare_once() == (True, False, "fork path ran", "")
+
+    def test_the_shim_imports_nothing_first_party(self):
+        """It runs under ``-I -S``: no site directory, so a kiro_crew import would fail."""
+        assert "kiro_crew" not in sb._PROBE_SHIM_CODE
+        for line in sb._PROBE_SHIM_CODE.splitlines():
+            if line.startswith(("import ", "from ")):
+                assert "kiro_crew" not in line, line

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -168,6 +168,16 @@ PREEXEC_EXEMPT: frozenset[str] = frozenset(
 BENIGN_SPAWNS: frozenset[str] = frozenset(
     {
         "acp/runtime.py::_get_rss_mb",
+        # The userns probe child: ONE fixed argv, `sys.executable -I -S -c <shim>`,
+        # no shell, no cwd, stdin/stdout are the two handshake pipes. Nothing is
+        # agent-influenced -- the shim is a module-level string constant and takes
+        # no arguments. It CANNOT route through sandboxed_spawn_argv: this probe is
+        # what decides whether that sandbox exists at all, so routing it would be
+        # circular (wrap_argv consults the verdict this child is producing). The
+        # child does two unshare() calls against its own fresh process and exits;
+        # it executes nothing else (the shim dlopens the already-loaded libc
+        # rather than letting ctypes.util.find_library exec ldconfig/gcc).
+        "sandbox.py::_probe_unshare_via_spawn",
         # _get_rss_tree_mb is deliberately NOT listed: its own spawn moved into
         # _ps_process_table below, so an entry for it would be stale and would
         # mask a future regression that put a spawn back inline.


### PR DESCRIPTION
Root-causes the 40-failure cascade in `v0.4.0-insider.2`'s release gate. All 40 failed with `SandboxUnavailableError`; none of them is a metrics test, and every one passes alone.

## The defect

`unshare(CLONE_NEWUSER)` implies `CLONE_THREAD`, so the kernel refuses it with EINVAL unless the caller's thread group holds exactly one task. **A fork child inherits that condition**: `os.register_at_fork` handlers run *inside* `os.fork()` before it returns, so a dependency that restarts a thread in every child makes the probe child multithreaded before it can measure anything. OpenTelemetry's `PeriodicExportingMetricReader` does exactly this:

```python
os.register_at_fork(after_in_child=lambda: weak_at_fork()())
def _at_fork_reinit(self):
    self._daemon_thread = Thread(name="OtelPeriodicExportingMetricReader", ...); self._daemon_thread.start()
```

EINVAL is classified permanent, cached in `_backend`, and every later sandboxed spawn in that process fails closed. **CPython has no unregister API for a fork hook**, so once armed nothing can clear it — no cleanup fixture can fix this. The probe has to stop forking.

## Why a fresh process is the *accurate* probe, not a laxer one

The real launcher is **already** a fresh interpreter: `wrap_argv` returns `[sys.executable, launcher_path, ...]`, and that process then forks and unshares. So the fork-based probe was **strictly more pessimistic than the spawn it predicts** — it failed on a condition the thing it measures never has. The two now agree.

Fail-closed is untouched. A genuinely single-threaded process that still gets EINVAL means the host lacks `CONFIG_USER_NS`, and that stays permanent. Only the *false* EINVAL goes away. `_TRANSIENT_PROBE_ERRNOS`, `_probe_failure`, the remedy tokens, and the two-step NEWUSER→maps→NEWNS sequence are all unchanged.

## The property, measured rather than argued

As a **difference inside one process**, because "the spawned child has one thread" would pass on any host where nothing armed a hook — which is every host until something does:

```
before arming a hook:  fork child = 1   fresh interpreter = 1
after  arming a hook:  fork child = 2   fresh interpreter = 1
```

Pinned by `test_a_fork_hook_cannot_reach_the_spawned_child`.

Note on this host: it has **no user namespaces at all**, so `unshare` returns EPERM before EINVAL can arise and the false verdict cannot be reproduced end to end here. That is why the regression test asserts the thread count — the actual mechanism — rather than the errno.

## Shape of the change

The reviewed parent half drives either child unchanged. The spawned process is this process's **direct** child, so its pid takes the identity UID/GID map exactly as the forked one did, and its stdout/stdin are the two handshake pipes with the same `U:`/`M:`/`N:` wire protocol.

- `_probe_parent_sequence` gains a `death` hook: a `Popen` owns its pid, so calling `waitpid` on it there would race that object's bookkeeping. Default is the existing `_probe_child_death`, so every other caller is untouched.
- `_probe_unshare_via_fork` retains the old path verbatim for a process that cannot spawn an interpreter. An interpreter we cannot start says nothing about the host's namespaces, so that case **falls back rather than inventing a verdict**.
- `close_fds` replaces the hand-rolled O(`RLIMIT_NOFILE`) fd sweep the fork child needed — a measured 102ms at a 524288 limit. Cold `detect_backend()` is 30ms here, once per process.
- The shim carries no `kiro_crew` import and runs under `-I -S`, the shape `_SPAWN_SHIM_CODE` already uses: no site directory, no `PYTHON*` influence.

## Verification

- **all 13 sandbox suites: 436 passed, 1 skipped**
- both paths return an identical verdict on this host (`test_both_paths_report_the_same_verdict_on_this_host`)
- empty `sys.executable` falls back to the fork path instead of returning a verdict
- `flake8`, `isort`, black gate clean; `mypy` reports the same 4 pre-existing `knowledge/store.py` errors as unmodified `main`

Four tests that monkeypatch `os.fork`/`os.waitpid` now name `_probe_unshare_via_fork` directly — that is what they were always testing. The other ~48 references, which replace `_probe_unshare_once` wholesale, are untouched.

**Why no screenshot:** kernel-level probe mechanics, no user-visible surface.

## What this does not do

It does not explain *which* code armed the hook in that gate run, and deliberately does not need to. Four sub-agents swept the app trees, `tests/`, `test/metrics` (400 tests) and every `PeriodicExportingMetricReader` construction site in the repo and found the tree clean — the root conftest pins `KIROCREW_TELEMETRY=0` per test, so no real reader is built. The fix removes the probe's sensitivity to the condition rather than chasing whichever dependency arms it.

Two smaller containment options remain open and are complementary, not alternatives: the conftest's `pytest_runtest_setup` records the **first** verdict per worker and restores it forever without re-probing, so one invalid measurement is permanent there; and a multithreaded EINVAL is arguably an *unobtainable* verdict rather than a negative one, so caching it at all is questionable.