### PR TITLE
test(session-pool): isolate the wedged-shutdown test from the shared executor

### DIFF
--- a/test/test_session_pool.py
+++ b/test/test_session_pool.py
@@ -1332,7 +1332,22 @@ class TestDiscardReaping:
         wedged.shutdown = _never_returns
         self._expired_entry(mgr, wedged)
 
-        with patch("kiro_crew.session._sync_kill_provider") as mock_kill:
+        # Give the hard-kill offload a PRIVATE executor. Production dispatches it
+        # to `subprocess_executor()`, a process-wide 8-worker singleton shared by
+        # every test in this xdist worker, and a started run_in_executor future
+        # cannot be cancelled — so a sibling test holding those threads (a wedged
+        # PTY close, a real `taskkill` on Windows) makes this offload queue behind
+        # them. That queue wait is unbounded and is NOT covered by
+        # `_POOL_DISCARD_TIMEOUT`, so it could consume the 5s budget below and
+        # fail with a TimeoutError naming the wedged shutdown — the one thing this
+        # test had already bounded, to 0.05s. A dedicated executor keeps the
+        # assertion about escalation ordering instead of about the shared pool's
+        # spare capacity.
+        with ThreadPoolExecutor(max_workers=1) as private_executor, patch(
+            "kiro_crew.session._sync_kill_provider"
+        ) as mock_kill, patch(
+            "kiro_crew.session.subprocess_executor", return_value=private_executor
+        ):
             pooled = await asyncio.wait_for(mgr._drain_and_claim("kirocrew"), timeout=5)
 
         assert pooled is None


### PR DESCRIPTION
## Problem / Motivation

`test/test_session_pool.py::TestDiscardReaping::test_wedged_shutdown_is_bounded_and_hard_killed` fails intermittently with `TimeoutError`, most visibly on the Windows backend shards. It last failed on a commit whose Linux 3.10 shards (1 to 4), Windows shards 1 to 3, namespace-sandbox shard, and E2E job all passed — a single-shard, single-platform failure on an otherwise green commit.

The test is fully mocked and asserts a timing bound it monkeypatches to 0.05s, wrapped in a 5s `asyncio.wait_for`. A 100x margin blowing out looked like Windows timer quantisation, but it is not: the test has a real dependency on a process-wide shared resource.

## Why it matters

The failure names the wrong thing. It reports a `TimeoutError` on the wedged `shutdown()` — the one code path the test had already bounded to 0.05s — so the message points at production behaviour that is working correctly. That sends anyone triaging it to read `_discard_pool_provider` instead of the test's own coupling.

It is also not in `test/windows-expected-failures.txt`, so every occurrence is a red shard someone has to attribute by hand before they can trust their own diff.

## What changed (motivation → approach → change)

- Symptom: `asyncio.wait_for(mgr._drain_and_claim("kirocrew"), timeout=5)` occasionally exhausts its 5s budget even though `_POOL_DISCARD_TIMEOUT` is patched to 0.05s.
- Root cause: `_discard_pool_provider` bounds only the graceful `shutdown()`. The hard kill that follows is offloaded via `run_in_executor(subprocess_executor(), ...)`, and `subprocess_executor()` is a **process-wide 8-worker singleton** (`_MAX_SUBPROCESS_WORKERS = 8`) shared by every test in the xdist worker. A started `run_in_executor` future cannot be cancelled, so when sibling tests hold those threads — a wedged PTY `os.close`, a real `taskkill` on Windows — this offload queues behind them. That queue wait is unbounded and sits **outside** `_POOL_DISCARD_TIMEOUT`, so it can consume the whole 5s budget on its own.
- Change: give the offload a private single-worker `ThreadPoolExecutor` via the `patch("kiro_crew.session.subprocess_executor", ...)` seam that `test_dispatch_hard_kill_never_runs_inline_when_executor_down` already uses in this same file. The test then asserts the escalation ordering it was written to assert (bounded graceful shutdown, then hard kill) rather than how many threads unrelated tests happen to be holding.

**No production code is touched.** The executor offload is deliberate and correct: `_sync_kill_provider` blocks (`os.waitpid` on POSIX, a `taskkill` subprocess on Windows) and must not run on the event loop. Widening the 5s budget was rejected — it would keep the coupling and only make the flake rarer.

## Tests

The mechanism was reproduced rather than the platform, so the causal claim is verified rather than inferred. Saturating the shared executor with 8 uncancellable submissions and then running the single test:

| | Result |
|---|---|
| Pre-fix, shared executor saturated | **FAILED ... TimeoutError** in 8.4s — same signature CI reported |
| Post-fix, shared executor saturated | **passed** in 0.06s |

The pre-fix failure is deterministic under saturation, which is what makes this a coupling defect rather than timer noise. Post-fix the test does not merely pass with more headroom, it stops touching the shared pool at all.

`test/test_session_pool.py` in full: 76 passed serially, 76 passed under `-n 4`.

## Manual verification

Gates green on the change: the repo black gate (`scripts/check_black_formatting.py` — this file is in `.github/black-baseline.txt`, so it is deliberately not reformatted wholesale), `isort --check-only`, `flake8`, and `mypy src/kiro_crew/` unchanged (the diff is test-only).

## Screenshots / video

Not applicable — test-only change, no user-visible surface.

## Related Issues

None. Found while triaging an unrelated PR's red Windows shard; filed separately because the fix is independent of that PR and touches a different file.

## Checklist

- [x] Single commit with a Conventional Commits title (`test: ...`)
- [x] Existing tests pass and new tests added for new functionality — no new test needed; this makes an existing test deterministic, and the pre-fix/post-fix contrast above is the evidence
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — not applicable
- [x] No secrets, credentials, or internal references in the diff
