### PR TITLE
refactor(chat): derive the height invalidation instead of bumping it by hand

### DIFF
--- a/website/src/hooks/virtualizer/HeightIndex.ts
+++ b/website/src/hooks/virtualizer/HeightIndex.ts
@@ -68,13 +68,41 @@ type RowKeyResolver = (index: number) => string | null
  *     the user just viewed.
  *   - `readMeasured` DOES promote. It is for a row that is actually mounted or
  *     rendering, which is genuine access.
+ *
+ * ANNOUNCING A CHANGE
+ * ===================
+ * The owner is also the subscribable store for "the geometry moved". Callers do
+ * NOT maintain an invalidation token: `syncAndAnnounce` mutates the tree and, if
+ * the total actually moved, bumps a version and notifies subscribers in one step,
+ * so a mutation cannot reach the tree without being announced. Read the version
+ * through `subscribe` / `getVersion` (React's `useSyncExternalStore` shape).
+ *
+ * The announce threshold lives here rather than at the call site because it is a
+ * property of height truth, not of any one consumer: a sub-pixel total change is
+ * not worth a re-render, and announcing every sync would re-render on every
+ * measurement -- the render storm the caller's debounce exists to prevent.
  */
+
+/**
+ * Minimum total-height movement, in px, that counts as a change worth
+ * announcing. Sub-pixel drift from re-measuring the same rows must not schedule
+ * a render, and the spacer cannot express it anyway.
+ */
+const ANNOUNCE_EPSILON_PX = 1
+
 export class HeightIndex {
   readonly sessionId: string
   private readonly cache: HeightCache
   private readonly tree: OffsetIndex
   private readonly keyAt: RowKeyResolver
   private estimate: number
+  // Bumped only by syncAndAnnounce, and only when the total actually moved. The
+  // subscribed value is what tells a consumer its cached geometry is stale.
+  private version = 0
+  // Total as of the last ANNOUNCED change. Starts at -1 ("nothing announced
+  // yet") so the first real total always announces, including a total of 0.
+  private lastAnnouncedTotal = -1
+  private readonly listeners = new Set<() => void>()
 
   constructor(
     sessionId: string,
@@ -148,6 +176,57 @@ export class HeightIndex {
   sync(itemCount: number): void {
     this.tree.sync(itemCount, this.getHeight)
   }
+
+  /**
+   * Reconcile the tree and, if the total moved, announce it to subscribers.
+   *
+   * For a mutation that happens OUTSIDE render (a measurement batch settling, the
+   * streaming tick). Use plain `sync` from inside render, where the reader is
+   * about to read fresh values anyway and notifying would be a state update
+   * during render.
+   *
+   * `beforeNotify` runs synchronously AFTER the tree is mutated but BEFORE
+   * subscribers are notified, and only when a change is actually being announced.
+   * That slot exists because the caller has to capture pre-commit DOM geometry
+   * (the top visible row, so a spacer reprice can be compensated) and the capture
+   * is only valid before the re-render this announcement schedules. Passing it in
+   * makes the ordering unconditional instead of relying on when React happens to
+   * flush the update.
+   *
+   * Deliberately does NOT update the announced baseline when nothing is
+   * announced, so a later sync still sees the full accumulated delta.
+   */
+  syncAndAnnounce(itemCount: number, beforeNotify?: () => void): void {
+    this.tree.sync(itemCount, this.getHeight)
+    const total = this.tree.totalHeight()
+    if (Math.abs(total - this.lastAnnouncedTotal) <= ANNOUNCE_EPSILON_PX) return
+    this.lastAnnouncedTotal = total
+    beforeNotify?.()
+    this.version += 1
+    for (const listener of this.listeners) listener()
+  }
+
+  /**
+   * Subscribe to announced geometry changes. Returns an unsubscribe function.
+   *
+   * A stable bound property so React's `useSyncExternalStore` does not resubscribe
+   * on every render; its identity changes only when the owner itself is replaced,
+   * which is exactly when a consumer should rebind (a session switch).
+   */
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  /**
+   * Current announced version -- the `getSnapshot` half of the store.
+   *
+   * A plain number so successive reads are `Object.is`-equal until something is
+   * actually announced, which is what keeps `useSyncExternalStore` from looping.
+   */
+  readonly getVersion = (): number => this.version
 
   /** Cumulative height of rows [0, index). O(log N). */
   offsetOf(index: number): number {

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -67,21 +67,27 @@
 // the question is convergence between two strategies rather than first-time
 // adoption.
 //
-// The decision carries one obligation. Height truth spans the DOM, `HeightCache`,
-// `OffsetIndex` and the memos derived from them. Collapsing that to a single seam
-// is the standing follow-through, and it is HALF DONE:
-//   - Done: `HeightIndex` owns the cache and the offset tree and is the only
-//     surface this hook reads heights through, so the two-readers seam and the
-//     duplicated per-structure session guard are gone (one guard, and the tree
-//     can no longer outlive its cache).
-//   - Remaining: the memo invalidation is still a hand-bumped `heightVersion`
-//     token, because a memo cannot observe a mutation of the (stable-identity)
-//     owner. Deriving it from the owner instead is the other half, deliberately
-//     left to its own change -- unlike the read consolidation, a missed bump
-//     fails SILENTLY (stale offsets, no error, no failing test), so it is worth
-//     reviewing on its own rather than alongside a mechanical redirect.
+// The decision carries one obligation, and it is now DISCHARGED. Height truth
+// spans the DOM, `HeightCache`, the offset tree and the geometry derived from
+// them; it used to stay coherent by convention -- a hand-bumped version counter
+// in memo dependency arrays, plus a session guard held separately by the cache
+// and by the tree. `HeightIndex` now owns all of it:
+//   - it holds the cache and the tree, and is the only surface this hook reads
+//     heights through, so the two-readers seam and the duplicated session guard
+//     are gone (one guard, and the tree cannot outlive its cache);
+//   - it announces a geometry change in the same call that mutates the tree, so
+//     the invalidation is subscribed to rather than maintained by hand -- there
+//     is no bump site left to forget.
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { isRailSettling, RAIL_SETTLE_MS } from '../useRailWidth'
 import { HeightIndex } from './HeightIndex'
 import {
@@ -459,7 +465,7 @@ export function useVirtualChat<T>(
   // SEPARATE from anchorPendingRef: that one is consumed by the
   // windowRange-keyed effect, and window commits land constantly while rows
   // mount — sharing the slot lets an unrelated window commit consume (and
-  // clear) the anchor before the heightVersion commit it was captured for,
+  // clear) the anchor before the height-sync commit it was captured for,
   // leaving the repricing shift uncompensated (observed as a nondeterministic
   // 170-190px lurch after a far jump with scroll anchoring unavailable).
   const heightAnchorPendingRef = useRef<{ key: string; top: number } | null>(null)
@@ -535,17 +541,15 @@ export function useVirtualChat<T>(
   // caller's jump-to-bottom pill).
   const [isAtBottom, setIsAtBottom] = useState<boolean>(true)
 
-  // Bumped whenever a mounted row's measured height changes IN PLACE (a
-  // ResizeObserver re-measure with no window/itemCount change). The offset
-  // memos below read the mutable HeightCache through `getH`, whose identity is
-  // stable, so they only recompute when windowRange/itemCount change — NOT
-  // when heights change. After a content SHRINK (streaming finalize, widget
-  // settle, markdown reflow) `totalHeight` would stay stale-large and
-  // `offsetAfter = totalHeight - offset(end)` would inflate into a phantom
-  // bottom spacer (the "blank space at the bottom" bug, and the "flicker when
-  // the scroll stops"). Including this version in the memo deps forces a
-  // recompute on every genuine height change so the spacers track reality.
-  const [heightVersion, setHeightVersion] = useState(0)
+  // NOTE: geometry invalidation is NOT a piece of state here. It lives on the
+  // height owner, which announces a change in the same call that mutates the
+  // tree -- see the `useSyncExternalStore` subscription further down, and
+  // HeightIndex.syncAndAnnounce. A local counter used to serve this role, which
+  // meant every writer had to remember to bump it: after a content SHRINK
+  // (streaming finalize, widget settle, markdown reflow) a missed bump left
+  // `totalHeight` stale-large and inflated `offsetAfter` into a phantom bottom
+  // spacer (the "blank space at the bottom" bug, and the "flicker when the
+  // scroll stops"), with nothing to catch it.
 
   // ---- Reading-position anchor (persisted; see ScrollAnchorCache) ----
   //
@@ -707,9 +711,9 @@ export function useVirtualChat<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [heightIndex, itemCount, estimatedHeight])
 
-  // Debounced height→memo sync. Cache writes (RO re-measure, measureRef seed)
-  // call this instead of bumping heightVersion directly. The bump (which
-  // invalidates the offset memos) fires only after heights have been STABLE
+  // Debounced height sync. Cache writes (RO re-measure, measureRef seed) call
+  // this; the owner announces the change (which invalidates the geometry reads)
+  // only after heights have been STABLE
   // for HEIGHT_SYNC_DEBOUNCE_MS, and only if the total actually changed. This
   // (a) corrects a one-time shrink's phantom spacer a beat later, and
   // (b) refuses to re-render during a continuous height oscillation (an
@@ -740,24 +744,24 @@ export function useVirtualChat<T>(
   // fires for a user who was actually following.
   const railSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const railSettleFollowRef = useRef(false)
-  const lastSyncedTotalRef = useRef(-1)
   const heightSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const syncHeightsNow = useCallback(() => {
     const idx = heightIndexRef.current
     if (!idx) return
-    idx.sync(itemsRef.current.length)
-    const total = idx.totalHeight()
-    if (Math.abs(total - lastSyncedTotalRef.current) > 1) {
-      lastSyncedTotalRef.current = total
+    // The owner mutates the tree, decides whether the total actually moved, and
+    // announces it -- there is no version to bump here, so there is no bump to
+    // forget. The callback runs only when a change IS being announced, after the
+    // mutation and before subscribers see it.
+    idx.syncAndAnnounce(itemsRef.current.length, () => {
       // Spacer repricing about to commit: rows ABOVE the viewport re-price
       // (estimates replaced by real heights), which moves everything below by
       // the delta. Chrome's native scroll anchoring absorbs that shift; iOS
       // Safari has none, so a reader sees the transcript slide under their
       // finger (measured 13-25px right after a far jump, when a whole streak
       // of first measurements lands in one sync). Capture the top visible row
-      // now so the anchor-compensation layout effect (keyed on heightVersion
-      // below) can hold it steady across the commit. Skipped while stick is
-      // armed — the bottom pin owns positioning there.
+      // now so the anchor-compensation layout effect below can hold it steady
+      // across the commit. Skipped while stick is armed -- the bottom pin owns
+      // positioning there.
       if (!stickRef.current && scrollerRef.current) {
         const a = captureTopAnchorFrom(scrollerRef.current, elIndexRef.current.entries(), (i) => {
           const it = itemsRef.current[i]
@@ -765,8 +769,7 @@ export function useVirtualChat<T>(
         })
         if (a) heightAnchorPendingRef.current = a
       }
-      setHeightVersion((v) => v + 1)
-    }
+    })
     // No `getH` dependency: the owner is read from its ref inside, and the tree
     // sync no longer takes a getter. Listing it here would tie this callback's
     // identity to the owner's, which the imperative writers must NOT rely on for
@@ -787,27 +790,19 @@ export function useVirtualChat<T>(
     }, HEIGHT_SYNC_DEBOUNCE_MS)
   }, [syncHeightsNow])
 
-  // NOTE: `heightVersion` is an intentional manual-invalidation key in the
-  // three memos below — it is not referenced in the bodies, so eslint flags it
-  // as "unnecessary", but removing it reintroduces the stale-spacer bug
-  // (memos reading the mutable OffsetIndex never recompute on a height change).
-  // Do NOT remove it. `offsetIndex` has a STABLE ref identity (it is the same
-  // tree object mutated in place by sync), so it is listed for clarity but the
-  // real triggers are itemCount / heightVersion / windowRange.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const totalHeight = useMemo(() => offsetIndex.totalHeight(), [offsetIndex, itemCount, heightVersion])
-  const offsetBefore = useMemo(
-    () => offsetIndex.offsetOf(windowRange.start),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [offsetIndex, windowRange.start, itemCount, heightVersion],
-  )
+  // Geometry is READ, not memoized-and-invalidated. Subscribing to the owner is
+  // what schedules a re-render when heights move; the three values below are then
+  // read fresh during that render, so there is no invalidation token to list in a
+  // dependency array and no way for one to go stale. `totalHeight()` is O(1) and
+  // `offsetOf` is O(log N), so memoizing them was never buying much -- and what it
+  // cost was a hand-maintained key that eslint could not see and review could not
+  // check.
+  const heightCommit = useSyncExternalStore(offsetIndex.subscribe, offsetIndex.getVersion)
+  const totalHeight = offsetIndex.totalHeight()
+  const offsetBefore = offsetIndex.offsetOf(windowRange.start)
   // Height of all items AFTER the window — used as the bottom spacer so the
   // scroll content keeps its full size while only the window renders real DOM.
-  const offsetAfter = useMemo(
-    () => Math.max(0, offsetIndex.totalHeight() - offsetIndex.offsetOf(windowRange.end)),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [offsetIndex, windowRange.end, itemCount, totalHeight, heightVersion],
-  )
+  const offsetAfter = Math.max(0, totalHeight - offsetIndex.offsetOf(windowRange.end))
 
   // Topmost visible mounted row, resolved against the LIVE items. Used by the
   // scroll-anchor preservation path and the debounced reading-position save.
@@ -1522,9 +1517,16 @@ export function useVirtualChat<T>(
     recomputeWindow()
   }, [windowRange, scrollerRef, writeScrollTop, recomputeWindow])
 
-  // Same correction for a HEIGHT-SYNC commit (spacer repricing): keyed on
-  // heightVersion, consuming the anchor syncHeightsNow captured. See
-  // heightAnchorPendingRef for why this cannot share the window effect's slot.
+  // Same correction for a HEIGHT-SYNC commit (spacer repricing), keyed on the
+  // owner's announced version. See heightAnchorPendingRef for why this cannot
+  // share the window effect's slot.
+  //
+  // `heightCommit` is the invalidation key: the effect must run in the commit the
+  // announcement scheduled, and the version identifies it. Unlike the counter this
+  // replaced, it cannot go stale or be forgotten -- the owner bumps it in the same
+  // call that mutates the tree, so there is no bump site to miss. It is also a
+  // real subscribed value rather than a token invisible to tooling, which is why
+  // no exhaustive-deps exemption is needed here any more.
   useLayoutEffect(() => {
     const pending = heightAnchorPendingRef.current
     heightAnchorPendingRef.current = null
@@ -1540,7 +1542,7 @@ export function useVirtualChat<T>(
     if (Math.abs(delta) > 0.5) {
       writeScrollTop(el, el.scrollTop + delta, 'auto', 'pin')
     }
-  }, [heightVersion, scrollerRef, writeScrollTop])
+  }, [heightCommit, scrollerRef, writeScrollTop])
 
 
   // ---- Follow-output: pin to bottom when items append ----
@@ -1782,9 +1784,9 @@ export function useVirtualChat<T>(
         ro?.observe(el)
         // Seed the cache with the current height so the next render has a real
         // height for placeholders. A changed value must also bump
-        // heightVersion: this seed is the SECOND cache writer (besides the RO)
+        // reach the tree: this seed is the SECOND cache writer (besides the RO)
         // and the RO won't re-fire for a value we just seeded, so without this
-        // the offset memos keep a stale height and leave a phantom spacer.
+        // the geometry keeps a stale height and leaves a phantom spacer.
         const it = itemsRef.current[index]
         if (it) {
           const h = measureBorderBoxHeight(el)

--- a/website/src/test/virtualizerHeightOwner.test.ts
+++ b/website/src/test/virtualizerHeightOwner.test.ts
@@ -96,6 +96,27 @@ describe('height truth has one owner (structural)', () => {
     expect(code).not.toMatch(/sessionId/)
     expect(code).not.toMatch(/HeightCache/)
   })
+
+  it('the hook holds no hand-bumped geometry version', () => {
+    const code = stripComments(readSource('useVirtualChat.ts'))
+    // The counter this replaced lived in the hook as React state and had to be
+    // bumped at every write site and listed in every memo dependency array. Its
+    // absence is the invariant: invalidation is subscribed to, not maintained.
+    expect(code).not.toMatch(/heightVersion/)
+    expect(code).not.toMatch(/setHeightVersion/)
+    // And the subscription is what replaces it.
+    expect(code).toMatch(/useSyncExternalStore\(/)
+  })
+
+  it('the offset math is read, not memoized behind an invisible key', () => {
+    const code = stripComments(readSource('useVirtualChat.ts'))
+    // Three memos used to carry an invalidation token their bodies never read,
+    // each needing an exhaustive-deps exemption plus a "Do NOT remove it" note.
+    // Reading the values directly is what removed all three exemptions.
+    expect(code).not.toMatch(/useMemo\(\(\)\s*=>\s*offsetIndex\.totalHeight\(\)/)
+    expect(code).toMatch(/const totalHeight = offsetIndex\.totalHeight\(\)/)
+    expect(code).toMatch(/const offsetBefore = offsetIndex\.offsetOf\(/)
+  })
 })
 
 describe('HeightIndex read surface (behavioural)', () => {
@@ -227,5 +248,156 @@ describe('HeightIndex read surface (behavioural)', () => {
     expect(b.peekMeasured(0)).toBeUndefined()
     b.sync(2)
     expect(b.totalHeight()).toBe(2 * ESTIMATE)
+  })
+})
+
+// The owner is also the store that announces "the geometry moved". This half
+// replaces a counter the hook used to bump by hand and list in memo dependency
+// arrays -- a token eslint could not see, guarded only by a "Do NOT remove it"
+// comment, whose failure mode was silent (stale spacers, no error, no red test).
+// Announcing inside the same call that mutates the tree removes the bump site,
+// so these tests pin the contract that makes that safe.
+describe('HeightIndex announces geometry changes (store contract)', () => {
+  const ESTIMATE = 80
+
+  function makeIndex(sessionId: string, keys: (string | null)[]): HeightIndex {
+    return new HeightIndex(sessionId, {
+      rowCount: keys.length,
+      estimate: ESTIMATE,
+      keyAt: (i) => keys[i] ?? null,
+    })
+  }
+
+  it('plain sync does NOT notify, so the render path cannot update during render', () => {
+    // Load-bearing: the hook syncs the tree during render (so that render's reads
+    // are fresh). If that call notified, React would be told to re-render while
+    // rendering. This is the one property the announcing path must not acquire.
+    const idx = makeIndex(`nosync-${Math.random()}`, ['a'])
+    let calls = 0
+    idx.subscribe(() => {
+      calls += 1
+    })
+
+    idx.setMeasured(0, 500)
+    idx.sync(1)
+
+    expect(idx.totalHeight()).toBe(500) // the tree DID update
+    expect(calls).toBe(0) // and nobody was notified
+    expect(idx.getVersion()).toBe(0)
+  })
+
+  it('syncAndAnnounce notifies once when the total moves', () => {
+    const idx = makeIndex(`announce-${Math.random()}`, ['a'])
+    let calls = 0
+    idx.subscribe(() => {
+      calls += 1
+    })
+
+    idx.setMeasured(0, 500)
+    idx.syncAndAnnounce(1)
+
+    expect(calls).toBe(1)
+    expect(idx.getVersion()).toBe(1)
+    expect(idx.totalHeight()).toBe(500)
+  })
+
+  it('does not announce a sub-pixel move, and holds the version steady', () => {
+    const idx = makeIndex(`epsilon-${Math.random()}`, ['a'])
+    idx.setMeasured(0, 500)
+    idx.syncAndAnnounce(1)
+    const settled = idx.getVersion()
+
+    let calls = 0
+    idx.subscribe(() => {
+      calls += 1
+    })
+    // Within the epsilon: re-measuring the same row must not schedule a render.
+    idx.setMeasured(0, 500.4)
+    idx.syncAndAnnounce(1)
+
+    expect(calls).toBe(0)
+    // A steady version is what stops useSyncExternalStore from looping: repeated
+    // reads have to be Object.is-equal until something is actually announced.
+    expect(idx.getVersion()).toBe(settled)
+    expect(idx.getVersion()).toBe(settled)
+  })
+
+  it('still announces once the accumulated drift clears the epsilon', () => {
+    // The baseline must NOT advance on a swallowed sync, or a slow drift of
+    // sub-epsilon steps would never announce and the spacer would rot.
+    const idx = makeIndex(`drift-${Math.random()}`, ['a'])
+    idx.setMeasured(0, 500)
+    idx.syncAndAnnounce(1)
+    const settled = idx.getVersion()
+
+    idx.setMeasured(0, 500.4)
+    idx.syncAndAnnounce(1)
+    expect(idx.getVersion()).toBe(settled)
+
+    idx.setMeasured(0, 500.8)
+    idx.syncAndAnnounce(1)
+    expect(idx.getVersion()).toBe(settled)
+
+    // 502 is 2px from the ANNOUNCED 500, so it clears -- even though each step
+    // was under the epsilon.
+    idx.setMeasured(0, 502)
+    idx.syncAndAnnounce(1)
+    expect(idx.getVersion()).toBe(settled + 1)
+  })
+
+  it('runs beforeNotify after the mutation and before subscribers', () => {
+    // The caller captures pre-commit DOM geometry in this slot, so it must see
+    // the NEW total (mutation done) while no subscriber has been told yet
+    // (the re-render it schedules has not happened).
+    const idx = makeIndex(`order-${Math.random()}`, ['a'])
+    const order: string[] = []
+    let totalSeenByCallback = -1
+    idx.subscribe(() => {
+      order.push('listener')
+    })
+
+    idx.setMeasured(0, 500)
+    idx.syncAndAnnounce(1, () => {
+      order.push('beforeNotify')
+      totalSeenByCallback = idx.totalHeight()
+    })
+
+    expect(order).toEqual(['beforeNotify', 'listener'])
+    expect(totalSeenByCallback).toBe(500)
+  })
+
+  it('skips beforeNotify entirely when nothing is announced', () => {
+    // Otherwise the caller would capture an anchor for a commit that never comes
+    // and a later unrelated commit would consume it.
+    const idx = makeIndex(`skip-${Math.random()}`, ['a'])
+    idx.setMeasured(0, 500)
+    idx.syncAndAnnounce(1)
+
+    let ran = 0
+    idx.setMeasured(0, 500.2)
+    idx.syncAndAnnounce(1, () => {
+      ran += 1
+    })
+
+    expect(ran).toBe(0)
+  })
+
+  it('stops delivering after unsubscribe', () => {
+    const idx = makeIndex(`unsub-${Math.random()}`, ['a'])
+    let calls = 0
+    const unsubscribe = idx.subscribe(() => {
+      calls += 1
+    })
+
+    idx.setMeasured(0, 500)
+    idx.syncAndAnnounce(1)
+    expect(calls).toBe(1)
+
+    unsubscribe()
+    idx.setMeasured(0, 900)
+    idx.syncAndAnnounce(1)
+    expect(calls).toBe(1)
+    // The announcement still happened -- only delivery to this listener stopped.
+    expect(idx.getVersion()).toBe(2)
   })
 })


### PR DESCRIPTION
## 1. What is the problem?

The chat virtualizer's offset geometry was invalidated by a counter the hook held
in React state and bumped by hand.

Three memos (`totalHeight`, `offsetBefore`, `offsetAfter`) listed that counter in
their dependency arrays without ever reading it, because what they actually read
is a mutable tree whose identity never changes. So each memo needed a
`react-hooks/exhaustive-deps` exemption, and the block carried a `Do NOT remove
it` warning explaining why the "unnecessary" dependency had to stay.

Nothing enforced the pairing between mutating the tree and bumping the counter.
It was a convention held by a comment.

This is the second half of #4326. The first half (#4803) gave row heights one
owner and collapsed the two session guards; it deliberately left this token
alone, because the two halves fail in opposite ways and deserved separate review.

## 2. Why this issue matters to the user

The failure mode is silent. A tree mutation with no matching bump leaves
`totalHeight` stale, and `offsetAfter = totalHeight - offsetOf(end)` then inflates
into a phantom bottom spacer: blank space under the last message after a content
shrink (streaming finalize, widget settle, markdown reflow), and the "flicker
when the scroll stops" that goes with it.

There is no error, no warning, and nothing in the type system or in lint that can
see the mistake -- the exemption comments exist precisely because the tooling
cannot. A reviewer reading a diff that adds a cache write has no mechanical way to
notice the missing bump.

## 3. How our fix solves it

Chain from symptom to root cause: blank space below the transcript <- `totalHeight`
was stale <- the memos were not invalidated <- someone had to bump a counter and
did not <- invalidation was a manual step separate from the mutation it describes.

So the fix removes the step. `HeightIndex.syncAndAnnounce` mutates the tree and,
when the total actually moved, bumps a version and notifies subscribers in the
same call. There is no bump site left to forget, because there is no bump site.

The hook subscribes with `useSyncExternalStore` -- already the established store
shape in this codebase -- and reads the three values directly during render
instead of memoizing them behind a key the tooling cannot see. `totalHeight()` is
O(1) and `offsetOf` is O(log N), so the memos were buying very little; what they
cost was a correctness rule only a comment could enforce.

Three details carry the design, and each is pinned by a test rather than by prose:

**Plain `sync` stays non-announcing.** The hook syncs the tree during render so
that render's reads are fresh. If that call notified, React would be told to
re-render while rendering. This is the one property the announcing path must not
acquire, and it is the hazard this change introduces, so it gets its own test.

**The announce threshold moved onto the owner, with the version it guards.** A
sub-pixel total change is not worth a render and the spacer cannot express it;
announcing every sync would re-render on every measurement, which is the storm
the caller's debounce exists to prevent. The threshold is a property of height
truth, not of any one consumer. The announced baseline deliberately does not
advance on a swallowed sync, so a drift of sub-epsilon steps still announces once
it accumulates past the threshold rather than rotting forever.

**`beforeNotify` is a slot, not a convenience.** The caller has to capture
pre-commit DOM geometry (the top visible row, so a spacer reprice can be
compensated on browsers without native scroll anchoring), and that capture is
only valid before the re-render the announcement schedules. Passing it into the
announcing call makes the ordering unconditional instead of relying on when React
happens to flush an update from a timer callback.

Net effect on the module: three exhaustive-deps exemptions and the `Do NOT remove
it` warning are gone (7 exemptions in the file before, 4 now, the rest unrelated
and pre-existing), and the hook no longer holds geometry state at all.

## 4. What tests we did

- `tsc --noEmit` clean. `eslint` on the touched files clean with zero warnings.
- Every test file referencing the virtualizer, `HeightCache`, `HeightIndex` or
  `useVirtualChat`: 46 files / 687 tests pass.
- Nine new store-contract tests in `virtualizerHeightOwner.test.ts` (14 -> 23 in
  that file): plain `sync` does not notify while still updating the tree; an
  announcing sync notifies once and moves the version; a sub-pixel move announces
  nothing and holds the version steady across repeated reads (the
  `useSyncExternalStore` no-loop contract); accumulated sub-epsilon drift still
  announces once it clears; `beforeNotify` runs after the mutation and before
  subscribers, and sees the new total; `beforeNotify` is skipped entirely when
  nothing is announced (otherwise an anchor is captured for a commit that never
  comes and a later unrelated commit consumes it); unsubscribe stops delivery
  without stopping the announcement.
- Three structural ratchets added: the hook holds no `heightVersion` state and
  does subscribe via `useSyncExternalStore`; the offset math is read rather than
  memoized behind an invisible key.
- Mutation-verified, each probe restored and re-run:
  - Making plain `sync` notify reddens the render-path test -- the new hazard is
    covered by a test rather than by an argument.
  - Dropping the epsilon gate reddens 3 tests (sub-pixel, accumulated drift, and
    the skipped-callback case).
  - Swallowing the notification entirely reddens **11 pre-existing tests** across
    3 files, including the height-sync anchor compensation test and both
    spacer-lurch tests. That is the useful measurement here: the half I expected
    to be uncovered turned out to be well covered already, because the observable
    consequence (stale spacer, uncompensated scroll) is exactly what those tests
    assert.

## 5. Any other suggestions on the work

- I expected the eslint exemption on the anchor-compensation effect to survive,
  since its body does not read the version. It did not: with the version coming
  from a subscribed store rather than local state, eslint stops reporting it, so
  that exemption was removed too. Worth knowing as a general point -- moving an
  invalidation key from `useState` to a store makes it legible to tooling, not
  just structurally safer.
- The pre-existing divergence flagged in #4803 is still open and still
  deliberately untouched: an unmeasured row's rendered placeholder uses the flat
  configured estimate while the offset math uses the running mean, so the two
  disagree for a row that has never been measured. It deserves a decision of its
  own rather than being folded into a refactor.

Closes #4326
