### PR TITLE
fix(updates): display a clean base version to stable users (keep promotion)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -280,7 +280,6 @@ src/kiro_crew/dashboard/handlers/telemetry.py
 src/kiro_crew/dashboard/handlers/terminal.py
 src/kiro_crew/dashboard/handlers/themes.py
 src/kiro_crew/dashboard/handlers/tunnel.py
-src/kiro_crew/dashboard/handlers/updates.py
 src/kiro_crew/dashboard/handlers/usage.py
 src/kiro_crew/dashboard/handlers/webapp_preview.py
 src/kiro_crew/dashboard/handlers/weixin_qr.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,13 @@ One logical change per commit.
 
 ## Release Changelog
 
+> **Releasing or promoting a version? Read `docs/build/release.md` first.** It is
+> the authority on the channel model, version stamping, and the **RC → stable
+> promotion runbook** — including why anything a stable user will see (a clean
+> version number, a finalized changelog) must be baked into the RC bytes *before
+> the RC is cut*, since promotion never rebuilds. This section covers only the
+> changelog rules.
+
 `CHANGELOG.md` is written **only when a version is bumped**, and everything
 already in it is immutable. Two halves enforce that: the
 `changelog-is-written-at-version-bump-only` rule in `AUTOSDE.yaml` applies the

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -62,8 +62,51 @@ rebuild that hopes for reproducibility. The mechanism:
   identity. pip users selecting a promoted (prerelease-versioned) wheel by
   version must allow prereleases; the stable channel feed remains
   channel-sticky.
+- **Stable DISPLAYS a clean base version even though the bytes keep the RC
+  stamp.** The embedded version cannot change under promotion, so the remedy is
+  at the read layer: `_display_version()` in
+  `src/kiro_crew/dashboard/handlers/updates.py` folds the running version to its
+  bare `X.Y.Z` on the **stable** channel only (insider/nightly keep the full
+  stamp), so About and the Releases page show `0.4.0`, not `0.4.0rc3` /
+  `0.4.0-insider.3`. It is DISPLAY-ONLY — every version *comparison* still reads
+  the raw `__version__`, so it cannot cause an update loop —
+  `test/test_stable_version_display.py` is the regression gate. **This fix must
+  ride in the RC bytes**: promotion never rebuilds, so a display change added
+  after the RC is cut can never reach the promoted stable. Land it before the RC
+  is cut, or stable shows the RC stamp with no in-band remedy.
 - **Hot patches follow the same rule**: at least one recorded RC before the
   bare patch tag.
+
+### Runbook: promoting an RC to stable
+
+The constraint that shapes the whole timeline: **promotion is byte-for-byte, so
+anything a stable user will see must already be in the RC that gets promoted** —
+there is no build step at stable-tag time to add it.
+
+1. **Before the RC is cut — bake the fix in.**
+   - *CHANGELOG*: the release branch already carries `## [X.Y.Z] — <date>` (no
+     `[Unreleased]`, enforced by the changelog gate). Confirm at cut time.
+   - *Version display*: the base-version fold above must be merged to `main`
+     and cherry-picked to `release/X.Y` **before the RC is cut**, or stable will
+     show the RC stamp.
+2. **Cut the RC — verify content, not PR status.** On the target commit confirm:
+   `github-release` has an `if:`; `CHANGELOG.md` line 5 is `## [X.Y.Z]` with zero
+   non-bare-release `##` headings; exactly one `### Contributors`;
+   `__version__ = "X.Y.Z"`; the bytecode/pycache test fix is present; the
+   base-version fold is present (stable About shows `X.Y.Z`); no existing bare
+   `vX.Y.Z` tag. Then tag `vX.Y.Z-insider.N`.
+3. **Soak.** Ship the RC on insider and let real users run it. **Do not push any
+   byte-affecting change to the release branch between soak and promote** — the
+   guarantee is that stable gets exactly the soaked bytes.
+4. **Promote (bare tag).** Confirm the `vX.Y.Z-insider.N` run at the target
+   commit is SUCCESS (`resolve-promotion` finds the candidate by it). Push a bare
+   `vX.Y.Z` tag on that commit. The build lanes skip; `resolve-promotion`
+   re-verifies the recorded bundle and republishes it to stable.
+   `Create GitHub Release` runs (the `if:` fix) and renders GitHub's own
+   contributor block — **do not hand-write a contributors list in the body**
+   (that duplicated the native block on v0.3.0). Verify: stable feed points at
+   the RC's version, About shows the clean `X.Y.Z` via the fold, CHANGELOG shows
+   no draft heading.
 
 ## Workflows in the release path
 
@@ -350,6 +393,41 @@ number collapse onto the same PEP 440 wheel version, because `release.yml` maps
 by trailing number alone. `v0.2.0-rc.1` and `v0.2.0-insider.1` both map to
 `0.2.0rc1`, and the second publish fails as a republish of an immutable key.
 Stick to one convention (`-rc.N`) per base version.
+
+### Version numbering policy
+
+`__version__` in `src/kiro_crew/__init__.py` is the branch's DECLARED identity.
+A tagged build overrides all three manifests from the tag (the table above), so
+the in-code value is what a non-tag build reports and what the promote sequence
+manipulates — the final byte stamp is decided by the tag, not this value.
+
+- **On an insider release branch, `__version__` carries the RC suffix, and the
+  tag matches.** The branch reads as what it is: `__version__ = "X.Y.ZrcN"`,
+  tags `vX.Y.Z-insider.N`. Do not leave a release branch declaring a bare
+  `X.Y.Z` while it is still cutting RCs.
+- **Promoting an insider line to stable is a three-step sequence:**
+  1. **Drop the RC in a PR** — change `__version__` from `X.Y.ZrcN` to the bare
+     `X.Y.Z`. This is the release commit; it also sets the base the stable
+     display folds to (`_display_version`, see "Client auto-update").
+  2. **Cut one more RC tag** (`vX.Y.Z-insider.<N+1>`) on that commit and let it
+     soak. This bare-`__version__` commit is the promotion candidate.
+  3. **Tag the bare `vX.Y.Z`** on the same commit to promote — promotion
+     republishes the soaked candidate's exact bytes (see "Stable promotion").
+- **`main` (nightly) is always one MINOR ahead of the active insider line.**
+  While `release/0.4` stabilizes on insider at `0.4.x`, `main`'s `__version__`
+  is already `0.5.0`. The release branch owns the version being shipped; `main`
+  owns the next one. This keeps every nightly strictly newer than any RC of the
+  shipping line, so a nightly user is never offered what looks like a downgrade
+  to an RC.
+
+**Why the display still folds even after step 1.** The build stamps the version
+FROM THE TAG, and the desktop's embedded version MUST equal the feed version or
+the auto-updater's compare gate breaks (see "Client auto-update"). So the
+promotion candidate's *bytes* still carry the RC/insider stamp (`0.4.0rcN` /
+`0.4.0-insider.N`) even though the branch declares a bare `__version__`. The
+bare declaration sets the source-of-truth and the fold's base; `_display_version`
+is what actually shows a stable user `0.4.0`. The two are complementary, not
+alternatives.
 
 ## CLI channel and the signed manifest
 

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -18,7 +18,7 @@ from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import __version__ as _local_version
 from kiro_crew import shutdown_event
-from kiro_crew.changelog import Release, build_release_list
+from kiro_crew.changelog import Release, base_version, build_release_list
 from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
@@ -154,6 +154,36 @@ def remediation_command(info: dict[str, object]) -> str:
     return ""
 
 
+def _display_version(version: str, channel: str) -> str:
+    """The version string shown to the user for the CURRENT build.
+
+    Promotion never re-stamps: a promoted STABLE build carries the soaked
+    candidate's prerelease stamp (``0.3.0rc13`` for the wheel, ``0.3.0-insider.13``
+    for the desktop), because that stamp is baked into the bytes at insider-build
+    time and is load-bearing there -- it keeps two insider RCs on distinct
+    immutable per-version keys, and the auto-updater's compare gate requires the
+    app version to equal the feed version. It therefore cannot be made clean in
+    the bytes without abandoning promotion. So fold it to its clean base
+    (``0.3.0``) for DISPLAY on the stable channel only; insider and nightly keep
+    their full stamp, where the prerelease number is meaningful.
+
+    Pure by design: the ``channel`` is passed in (from the off-loop
+    ``_update_info["channel"]``) rather than read here, so this never touches the
+    event loop. DISPLAY ONLY -- every version COMPARISON (``_is_newer``,
+    ``update_required``, the feed check) still uses the raw ``__version__``, so
+    folding here can never make a client miscompare or loop on updates.
+    """
+    return base_version(version) if channel == "stable" else version
+
+
+def _display_local_version() -> str:
+    """``_local_version`` folded for display, keyed on the off-loop channel that
+    a prior ``_do_update_check`` resolved into ``_update_info`` -- a plain dict
+    read, so this stays off the event loop.
+    """
+    return _display_version(_local_version, str(_update_info.get("channel") or ""))
+
+
 def status_update_fields() -> dict[str, object]:
     """The update fields ``/api/status`` and the WebSocket push both carry.
 
@@ -187,7 +217,7 @@ async def api_update_check(request: web.Request) -> web.Response:
     return web.json_response(
         {
             **_update_info,
-            "current_version": _local_version,
+            "current_version": _display_local_version(),
             "auto_update": cfg.auto_update,
             # Surface the pin so the dashboard can say WHY an update is mandatory
             # rather than showing a bare button.
@@ -959,12 +989,12 @@ async def api_releases(request: web.Request) -> web.Response:
     """
 
     def _read_and_parse() -> list[Release]:
-        return build_release_list(_read_changelog(), _local_version)
+        return build_release_list(_read_changelog(), _display_local_version())
 
     releases = await asyncio.to_thread(_read_and_parse)
     return web.json_response(
         {
-            "current_version": _local_version,
+            "current_version": _display_local_version(),
             "releases": [r._asdict() for r in releases],
             "stale": any(r.in_progress for r in releases),
         }
@@ -1093,9 +1123,7 @@ async def api_update_apply(request: web.Request) -> web.Response:
         if not applied:
             # A configured provider's failure is a failure. Falling through to
             # the git path would be the bypass the policy exists to prevent.
-            state.push_update_progress(
-                "failed", "Policy-defined update command failed — see logs"
-            )
+            state.push_update_progress("failed", "Policy-defined update command failed — see logs")
             return web.json_response(
                 {
                     "error": "policy-defined update command failed",
@@ -1544,7 +1572,7 @@ async def api_stream(request: web.Request) -> web.StreamResponse:
                     # `status_update_fields()` is the one reader; /api/status and the
                     # WebSocket push already go through it.
                     **state.status_snapshot(**status_update_fields()),  # type: ignore[arg-type]
-                    "version": _local_version,
+                    "version": _display_local_version(),
                 }
             )
             await resp.write(f"event: dashboard\ndata: {data}\n\n".encode())

--- a/test/test_stable_version_display.py
+++ b/test/test_stable_version_display.py
@@ -1,0 +1,42 @@
+"""Guard: a promoted STABLE build must DISPLAY a clean base version.
+
+Promotion ships the soaked candidate's exact bytes, which carry a prerelease
+stamp (``0.3.0rc13`` wheel / ``0.3.0-insider.13`` desktop) baked in at
+insider-build time. That stamp is load-bearing on insider (distinct immutable
+per-version keys) and for the auto-updater compare gate (app version == feed
+version), so it cannot be made clean in the bytes without abandoning promotion.
+The fix therefore lives at the DISPLAY layer: ``_display_version`` folds to the
+clean base on the stable channel only. This test is the regression gate that
+keeps a stable user from ever being shown an ``-rc``/``-insider`` version again.
+
+``_display_version`` is pure (channel passed in, not read) so it never touches
+the event loop; these cases assert the fold directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.dashboard.handlers.updates import _display_version
+
+
+@pytest.mark.parametrize(
+    "stamped, expected",
+    [
+        ("0.3.0rc13", "0.3.0"),  # promoted wheel stamp
+        ("0.3.0-insider.13", "0.3.0"),  # promoted desktop stamp
+        ("0.4.0rc2", "0.4.0"),
+        ("0.4.0-insider.2", "0.4.0"),
+        ("1.2.3", "1.2.3"),  # already clean -> unchanged
+    ],
+)
+def test_stable_folds_display_to_clean_base(stamped, expected):
+    assert _display_version(stamped, "stable") == expected
+
+
+@pytest.mark.parametrize("channel", ["insider", "nightly", ""])
+@pytest.mark.parametrize("stamped", ["0.4.0rc2", "0.4.0-insider.2", "0.4.0-nightly.20260821"])
+def test_non_stable_keeps_the_full_stamp(channel, stamped):
+    # The prerelease number is meaningful off the stable channel (and an unknown
+    # "" channel must not fold either) -- never touch it.
+    assert _display_version(stamped, channel) == stamped


### PR DESCRIPTION
## Problem, at the right layer

Keeping **promotion** (we are not changing the release model), the version a stable user sees comes from the bytes, and the bytes are the soaked candidate's:

- **Into the bytes**: `build-wheel` / `build-desktop` / `build-windows` `sed` the tag-derived version into `pyproject [project].version`, `src/kiro_crew/__init__.py` `__version__`, and `website/electron/package.json` at **insider-build** time — `0.3.0rc13` (wheel) / `0.3.0-insider.13` (desktop). Promotion republishes those exact bytes and never re-stamps.
- That stamp is **load-bearing where it is baked**: it keeps two insider RCs on distinct immutable `cli/<channel>/<version>/` keys, and `build-desktop` documents that the electron version **must equal the feed version** or the auto-updater's compare gate breaks. So it cannot be made clean in the bytes without abandoning promotion.

Therefore the only correct place to fix, while keeping promotion, is **display**.

## Fix

`_display_version()` folds the current build's version to its clean base **on the stable channel only** (insider/nightly keep their full stamp — the prerelease number is meaningful there). Applied to the three surfaces that report the running version to the UI:

- `GET /api/update/check` → `current_version`
- the Releases handler → `current_version` **and** the version handed to `build_release_list`, so the running row matches the `[x.y.z]` CHANGELOG section cleanly and is **not** badged a prerelease (this is the CHANGELOG half — the RC's bundled CHANGELOG already carries the finalized `[x.y.z]` section via the changelog gate)
- the dashboard SSE push → `version`

**Display-only.** Every version *comparison* (`_is_newer`, `update_required`, the feed check) still uses the raw `__version__`, so this cannot cause a miscompare or an update loop.

## Guard

`test/test_stable_version_display.py` locks it: stable folds `0.3.0rc13` / `0.3.0-insider.13` → `0.3.0`; insider/nightly/dev keep their full string. This is the durable gate against reintroducing an `-rc`/`-insider` version on stable.

## Rollout

Must land in the bytes that get promoted, so: merge to `main`, then cherry-pick to `release/0.4.0` **before** the final 0.4.0 RC is cut, so the promoted 0.4.0 stable displays `0.4.0`. Does not affect already-shipped 0.3.0 (that was handled separately).

## Testing

Logic verified against the worktree source (folds on stable, untouched off-stable, module imports clean). Full pytest/flake8/isort/mypy run in CI.
