### PR TITLE
fix(acp): reply once to ownerless server request (#4864)

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -501,6 +501,18 @@ handshake: it issues `session/load` directly under the original sessionId and
 registers the session queue **after** the load response so replayed transcript
 frames are dropped rather than counted against the current turn.
 
+**An ownerless server→client request is answered ONCE, at connection level.**
+An inbound frame carrying an `id` **and** a `method` but no `params.sessionId`
+is a request that names no session — it expects exactly one response, so the
+reader answers it itself with `-32601 Method not found`
+(`_answer_ownerless_request`, run off the reader loop like the KAS auth
+callback) and never broadcasts it. Broadcasting would hand it to every
+registered session's dispatch loop, each of which would reply `-32601` on the
+shared stdin — one request id, N responses, widening with session sharing. Only
+true notifications (method, no id) broadcast. The routed case — an unknown
+request **with** a `sessionId` — still gets its single per-session reply from
+that session's dispatch loop (`server_request_unknown`).
+
 **Unroutable frames are counted, not logged per frame.** The reader drops any
 frame it cannot route; the drop itself is correct and unchanged, but logging one
 `DEBUG` line per dropped frame is a log-retention hazard on a multiplexed

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -142,6 +142,10 @@ _STDOUT_BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB
 # _send_and_await timeout — naming what was in flight at the drop makes that
 # timeout attributable instead of a mystery. Capped so the line stays bounded.
 _DROP_IDS_IN_LOG = 8
+# JSON-RPC 2.0 "Method not found" — the reader loop answers an ownerless
+# server→client request with this itself (see _answer_ownerless_request);
+# mirrors the private constant AcpClient keeps for its own dispatch sites.
+_JSONRPC_METHOD_NOT_FOUND = -32601
 _INIT_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 30.0
 # Session start (session/new, session/load) gets its own budget because kiro-cli
@@ -1560,7 +1564,9 @@ class AcpRuntime:
           1. Response with id in _pending_requests → resolve Future
           2. Response with id in _routed_requests → put in session queue
           3. Notification with params.sessionId → session queue
-          4. No sessionId → broadcast to all queues
+          4. Request (method + id) with no sessionId → answered ONCE at
+             connection level (-32601), never broadcast
+          5. No sessionId → broadcast to all queues
         """
         assert self._process and self._process.stdout
         stdout = self._process.stdout
@@ -1830,6 +1836,34 @@ class AcpRuntime:
                         self._note_dropped_frame(session_id, msg.method)
                     continue
 
+                # No sessionId. An id-carrying frame that still has a method is
+                # a server→client REQUEST that names no session — it expects
+                # exactly ONE response, so the runtime answers it at connection
+                # level (same shape as the KAS auth callback above) instead of
+                # broadcasting. Broadcasting would hand it to EVERY registered
+                # session's dispatch loop, each of which replies -32601 on the
+                # shared stdin: one id, N responses — a JSON-RPC protocol
+                # violation that widens with session sharing. Frames with an id
+                # but NO method are responses (e.g. a result of null slips past
+                # the result/error check above); their handling is unchanged.
+                if msg.id is not None and msg.method is not None:
+                    # Same volume bound as the permission auto-answers: each
+                    # reply can block on stdin drain() against a backend that
+                    # floods frames while never reading, so the task must be
+                    # retained (a bare ensure_future can be GC'd mid-flight)
+                    # and counted. Past the cap the frame takes the counted-
+                    # drop path — the flooding backend hangs on its own
+                    # unanswered request instead of growing the task set.
+                    if len(self._answer_tasks) >= self._max_answer_tasks:
+                        self._note_dropped_frame(_DROP_NO_SESSION, msg.method)
+                        continue
+                    _t = asyncio.ensure_future(
+                        self._answer_ownerless_request(msg.id, msg.method)
+                    )
+                    self._answer_tasks.add(_t)
+                    _t.add_done_callback(self._answer_tasks.discard)
+                    continue
+
                 # No sessionId → genuinely global notification; broadcast to all.
                 if self._session_queues:
                     # Snapshot: `await queue.put` yields, and a concurrent
@@ -1863,6 +1897,29 @@ class AcpRuntime:
             # crash) so a trickle that never reached the interval is still
             # accounted for instead of vanishing with the task.
             self._flush_dropped_frames()
+
+    async def _answer_ownerless_request(
+        self, request_id: int | str, method: str
+    ) -> None:
+        """Answer a server→client request that names no session with -32601.
+
+        Runs OFF the reader loop (same shape as the KAS auth callback) so a
+        stalled stdin drain cannot block stdout demux for every multiplexed
+        session. The routed case — an unknown request WITH a sessionId — is
+        deliberately not handled here: it is delivered to that session's queue
+        and answered once by its dispatch loop (``server_request_unknown``).
+        """
+        logger.debug(
+            "Ownerless server request answered -32601 — method=%s id=%r",
+            method,
+            request_id,
+        )
+        try:
+            await self.send_error(
+                request_id, _JSONRPC_METHOD_NOT_FOUND, "Method not found"
+            )
+        except AcpRuntimeDead:
+            pass
 
     async def _answer_get_access_token(self, request_id: int | str) -> None:
         """Answer KAS's ``_kiro/auth/getAccessToken`` callback (see :mod:`kas_auth`).

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -7,6 +7,8 @@ each frame to the right destination —
   - JSON-RPC response whose id is in _pending_requests  → resolve that Future
   - JSON-RPC response whose id is in _routed_requests   → that session's queue
   - notification carrying params.sessionId              → that session's queue
+  - request (method + id) with no sessionId             → answered ONCE at
+                                                           connection level (-32601)
   - notification with no sessionId                       → broadcast to all
   - empty read (process exit)                            → _mark_dead: fail all
                                                            futures + poison queues
@@ -298,6 +300,61 @@ async def test_null_session_notification_broadcasts_to_all():
         b = await asyncio.wait_for(q["sB"].get(), timeout=1.0)
         assert a.method == "some/global"
         assert b.method == "some/global"
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_ownerless_request_answered_once_not_broadcast():
+    """A server→client REQUEST with no sessionId gets exactly ONE -32601 reply.
+
+    Before the fix it took the broadcast branch: every registered session's
+    dispatch loop classified it as server_request_unknown and each replied
+    -32601 on the shared stdin — one request id, N responses (issue #4864).
+    The runtime now answers it once at connection level and never enqueues it.
+    """
+    rt, reader, proc = _make_runtime()
+    q = _register(rt, "sA", "sB")
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"id": 4864, "method": "unknown/ownerless", "params": {}})
+        # The answer task runs off the reader loop; give it ticks to complete.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        replies = [
+            json.loads(call.args[0].decode())
+            for call in proc.stdin.write.call_args_list
+        ]
+        errors = [r for r in replies if r.get("id") == 4864 and "error" in r]
+        assert len(errors) == 1, f"expected exactly one reply, got {replies}"
+        assert errors[0]["error"]["code"] == -32601
+        # Not enqueued to ANY session — no dispatch loop ever sees it.
+        assert q["sA"].empty()
+        assert q["sB"].empty()
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_ownerless_response_with_null_result_is_not_answered():
+    """An id-carrying frame with NO method is a response, not a request.
+
+    A response whose result is null slips past the result/error routing check;
+    it must not be mistaken for an ownerless request and answered -32601 —
+    that would inject a spurious error reply for an id the backend owns.
+    """
+    rt, reader, proc = _make_runtime()
+    _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"id": 77, "result": None})  # response shape, no method
+        for _ in range(20):
+            await asyncio.sleep(0)
+        replies = [
+            json.loads(call.args[0].decode())
+            for call in proc.stdin.write.call_args_list
+        ]
+        assert not [r for r in replies if r.get("id") == 77]
     finally:
         await _stop_reader(task)
 


### PR DESCRIPTION
## Problem

On a shared `AcpRuntime` (session sharing, default on), an inbound server-initiated JSON-RPC **request** that carries no `sessionId` fell through to the reader loop's no-`sessionId` broadcast branch, which did not distinguish a request (has an `id`, expects exactly one response) from a notification. Every registered session's dispatch loop then classified the frame as `server_request_unknown` and each replied `-32601 Method not found` on the shared stdin — **one request id, N responses**, a JSON-RPC protocol violation whose N scales with session-sharing width (routinely 2–4 during subagent fan-out). The branch is latent today (no current method reaches it) but goes live the moment the backend adds a session-less request method the client has not caught up with.

## Fix

`AcpRuntime._reader_loop` now intercepts an id-carrying frame that has a `method` but no `sessionId` **before** the broadcast branch and answers it **once at connection level** with `-32601` (`_answer_ownerless_request`, run off the reader loop — the same shape as the KAS auth callback — so a stalled stdin drain cannot block stdout demux). The answer task is retained and bounded by the existing `_answer_tasks` cap, so a backend that floods such frames while never reading stdin cannot grow the task set unboundedly; past the cap the frame takes the existing counted-drop path.

Deliberately unchanged:
- **Notifications** (method, no id) with no `sessionId` still broadcast to all session queues.
- **Responses** (id, no method — including a `result: null` response that slips past the result/error routing check) keep their existing handling and are never answered.
- The **routed** case — an unknown request WITH a `sessionId` — still gets its single per-session reply from that session's dispatch loop (`server_request_unknown` in `_dispatch.py` / `session_handle.py`, untouched).

`docs/system-specs/modules/acp-client.md` documents the new routing rule in the same commit.

## Tests

- `test_ownerless_request_answered_once_not_broadcast` — an ownerless unknown request on a runtime with 2 registered sessions yields exactly ONE `-32601` reply and is enqueued to no session queue (fails on main: two dispatch loops each reply).
- `test_ownerless_response_with_null_result_is_not_answered` — an id-carrying frame with no method is a response, never answered `-32601`.
- Existing `test_null_session_notification_broadcasts_to_all` and `test_dispatch_unknown_server_request_gets_error_response` lock the preserved notification-broadcast and routed-reply behavior.

Verified locally: isort / flake8 / mypy / black gate / brand gate / harness gate all green; full backend suite 59,085 passed (14 failures are pre-existing host/environment flakes that reproduce identically on a clean origin/main tree — artifact-source classification under a `/tmp` checkout, xdist host-budget CPU shape, PTY integration).

Closes #4864
