### PR TITLE
feat: scope knowledge search seeds by source_id + list sources (#4852)

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -535,8 +535,8 @@ answers `tools/list` from):
   `artifact_get_comments`, `artifact_post_comment`, `artifact_reply_comment`,
   `artifact_delete_comment`, `artifact_mark_review`, `deploy_artifact`
 - **Knowledge and skills:** `local_knowledge_search`, `knowledge_dedup`,
-  `skill_discover`, `skill_search`, `skill_fetch`, `browse_outline`,
-  `browse_search`
+  `knowledge_list_sources`, `skill_discover`, `skill_search`, `skill_fetch`,
+  `browse_outline`, `browse_search`
 - **Workflows and hooks:** `workflow_author`, `workflow_list`,
   `workflow_cancel`, `workflow_rerun_subtree`, `register_hook`
 - **Diagnostics:** `resource_status`, `issue_radar_record_investigation`

--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -359,7 +359,9 @@ Both entity extraction (`EntityExtractor`) and internal-URL fetch (`agent_fetch.
 The LLM reaches retrieval through the `kirocrew-core` MCP tool `local_knowledge_search`:
 - DB path: `config_dir()/workspace/knowledge/knowledge.db`; a missing DB returns "Knowledge Library is not configured…" (SEL `not_configured`).
 - `_get_knowledge_search` caches the `(KnowledgeStore, embedder)` pair across calls and rebuilds only when the knowledge DB (or its `-wal`) or `config.json` changes — avoiding the per-call schema DDL / migrate / graph-load and the Ollama availability probe.
-- Default `limit` is 3; results below `min_score = 0.012` are dropped. Output is run through `redact_exfiltration_urls()` + `redact_credentials()` before returning, and every call emits an SEL audit event (`success` / `no_results` / `not_configured`). Input is validated against `LOCAL_KNOWLEDGE_SEARCH_SCHEMA` (`validation.py`).
+- Default `limit` is 3; results below `min_score = 0.012` are dropped. Output is run through `redact_exfiltration_urls()` + `redact_credentials()` before returning, and every call emits an SEL audit event (`success` / `no_results` / `not_configured` / `unknown_source`). Input is validated against `LOCAL_KNOWLEDGE_SEARCH_SCHEMA` (`validation.py`).
+- Optional `source_id` scopes the SEED legs only (FTS5 keyword + vector similarity, via parameterized WHERE clauses in `HybridRetriever`); the graph leg stays unfiltered so cross-source entity connections still contribute traversal context. Scope membership is ownership OR location — `items.source_id` or a `source_locations` row, so an item surviving a cross-source dedup collapse still belongs to the losing source's scope (the same rule as `/api/knowledge/graph`'s filter). Omitting it keeps the unscoped behavior. A nonexistent id returns a guidance message naming `knowledge_list_sources` (SEL `unknown_source`), not an exception.
+- The companion tool `knowledge_list_sources` (no arguments; `KNOWLEDGE_LIST_SOURCES_SCHEMA`) returns one `name — id (N item(s))` line per source, counting **active** items only (superseded/deduped copies would overstate a source's coverage) — so agents discover valid `source_id` values instead of guessing.
 - **The response is written through a private stdout descriptor, not fd 1.** The first search's availability probe (`InProcessEmbedder.is_available` → `embed`) kicks the background GGUF load, and the vendored llama-cpp wraps that load in `suppress_stdout_stderr`, which `dup2`s **fd 1 process-wide to `/dev/null`** for the duration (~0.7s) *and* rebinds the `sys.stdout` object. Because the probe returns `None` immediately, the search answers keyword-only in milliseconds — so its JSON-RPC response raced that window and was silently destroyed: no exception, no short write, SEL still logging `success`, and the client hanging until the ACP tool-stall watchdog (`acp/client.py::_TOOL_STALL_TIMEOUT`, 600s) killed the turn. `mcp_shared.run_mcp_stdio_loop` now takes an `os.dup(1)` snapshot (`snapshot_stdout_fd`) at server startup before any tool can run, and `respond()` writes through it under a lock, so responses (and `ping` / `tools/list` replies, which were equally exposed) always reach the client. Falls back to `sys.stdout` when stdout is not fd-backed. Note that "has `sys.stdout` been swapped?" is *not* a usable guard — the suppressor swaps the object too, so it reads as swapped exactly inside the window that must be survived.
 
 The dashboard Knowledge tab uses the same store via a lazily-initialized `KnowledgeStore` on `DashboardState` (`dashboard/state.py`).
@@ -386,8 +388,9 @@ Scopes the page to a single source. Composes with the existing `type`, `status`,
   (`_search_until_exhausted`: `_SCOPED_SEARCH_START` doubling to
   `_SCOPED_SEARCH_MAX`) until the retriever short-reads, so the scoped total is
   exact rather than truncated by a fixed window. At the cap the total may
-  understate; pushing `source_id` into `HybridRetriever` is the tracked
-  follow-up. Unscoped searches keep the cheap `limit * 3` window.
+  understate. `HybridRetriever.search` now accepts `source_id` (seed-scoped —
+  see §4); adopting it in this branch is the remaining follow-up. Unscoped
+  searches keep the cheap `limit * 3` window.
 
 ### `GET /api/knowledge/source-counts`
 

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1225,7 +1225,7 @@ Searches the Knowledge Library for relevant content. Escalated from App Store to
 
 - **Trigger rules**: strict — only fires on explicit user signals (e.g. "search my knowledge", "check my docs on X"), not on general questions
 - **Schema**: `LOCAL_KNOWLEDGE_SEARCH_SCHEMA` in `validation.py`
-- **Parameters**: `query` (required string), `limit` (optional integer, default 3, hard max 5)
+- **Parameters**: `query` (required string), `limit` (optional integer, default 3, hard max 5), `source_id` (optional string — scopes the FTS5-keyword and vector seed legs to one source; graph traversal stays unfiltered. Unknown ids return a guidance message naming `knowledge_list_sources`, the no-argument companion tool that lists each source's `name — id (N item(s))` with active-item counts)
 - **Confidence threshold**: `MIN_SCORE=0.012` filters noise
 - **Output format**: source + content only, no score metadata (~2500 token budget)
 - **Graceful degradation**: returns helpful message when knowledge DB not configured

--- a/src/kiro_crew/knowledge/retrieval.py
+++ b/src/kiro_crew/knowledge/retrieval.py
@@ -42,11 +42,18 @@ class HybridRetriever:
         self.store = store
         self.embedder = embedder
 
-    def search(self, query: str, limit: int = 10) -> list[dict]:
-        """Hybrid search with RRF fusion. Returns [{id, title, summary, content, score, source, match_type}]."""
-        kw = self._keyword_search(query, limit=limit * 2)
+    def search(self, query: str, limit: int = 10, source_id: str | None = None) -> list[dict]:
+        """Hybrid search with RRF fusion. Returns [{id, title, summary, content, score, source, match_type}].
+
+        ``source_id`` scopes the SEED legs only (FTS5 keyword + vector
+        similarity): it stops other sources from dominating the seeds when
+        vocabularies collide across a heterogeneous corpus. The graph leg is
+        deliberately left unfiltered so cross-source entity connections can
+        still contribute traversal context to the fused ranking.
+        """
+        kw = self._keyword_search(query, limit=limit * 2, source_id=source_id)
         gr = self._graph_search(query, limit=limit * 2)
-        vec = self._vector_search(query, limit=limit * 2)
+        vec = self._vector_search(query, limit=limit * 2, source_id=source_id)
 
         # Vector leg is weighted higher so semantic matches dominate when the
         # keyword leg is weak. Weights align positionally
@@ -218,18 +225,36 @@ class HybridRetriever:
             if artifact:
                 result["artifact_slug"], result["artifact_name"] = artifact
 
-    def _keyword_search(self, query: str, limit: int = 20) -> list[tuple[str, int]]:
-        """FTS5 search. Returns [(item_id, rank)] where rank is position (1=best)."""
+    def _keyword_search(
+        self, query: str, limit: int = 20, source_id: str | None = None
+    ) -> list[tuple[str, int]]:
+        """FTS5 search. Returns [(item_id, rank)] where rank is position (1=best).
+
+        ``source_id`` narrows matches to items of one source via a
+        parameterized WHERE clause (never string interpolation).
+        """
         safe_query = self._sanitize_fts5_query(query)
         if not safe_query:
             return []
+        sql = (
+            "SELECT i.id FROM items_fts fts "
+            "JOIN items i ON i.rowid = fts.rowid "
+            "WHERE items_fts MATCH ?"
+        )
+        params: list[object] = [safe_query]
+        if source_id is not None:
+            # An item belongs to a source by ownership (items.source_id) OR by
+            # location (source_locations: the surviving copy of a cross-source
+            # dedup collapse still lives in the other source's files).
+            sql += (
+                " AND (i.source_id = ? OR i.id IN"
+                " (SELECT sl.item_id FROM source_locations sl WHERE sl.source_id = ?))"
+            )
+            params.extend([source_id, source_id])
+        sql += " ORDER BY fts.rank LIMIT ?"
+        params.append(limit)
         try:
-            rows = self.store.db.execute(
-                "SELECT i.id FROM items_fts fts "
-                "JOIN items i ON i.rowid = fts.rowid "
-                "WHERE items_fts MATCH ? ORDER BY fts.rank LIMIT ?",
-                (safe_query, limit),
-            ).fetchall()
+            rows = self.store.db.execute(sql, params).fetchall()
         except sqlite3.OperationalError:
             return []
         return [(row["id"], rank + 1) for rank, row in enumerate(rows)]
@@ -293,17 +318,30 @@ class HybridRetriever:
         sorted_items = sorted(item_counts.items(), key=lambda x: x[1], reverse=True)
         return [(item_id, rank + 1) for rank, (item_id, _) in enumerate(sorted_items)]
 
-    def _vector_search(self, query: str, limit: int = 20) -> list[tuple[str, int]] | None:
-        """Brute-force cosine similarity against stored embeddings. Returns None if no embedder."""
+    def _vector_search(
+        self, query: str, limit: int = 20, source_id: str | None = None
+    ) -> list[tuple[str, int]] | None:
+        """Brute-force cosine similarity against stored embeddings. Returns None if no embedder.
+
+        ``source_id`` narrows candidates to items of one source via a
+        parameterized WHERE clause (never string interpolation).
+        """
         if self.embedder is None:
             return None
 
         query_vec = self.embedder(query)
         if not query_vec:
             return None
-        rows = self.store.db.execute(
-            "SELECT id, embedding FROM items WHERE embedding IS NOT NULL AND status = 'active'"
-        ).fetchall()
+        sql = "SELECT id, embedding FROM items WHERE embedding IS NOT NULL AND status = 'active'"
+        params: tuple[str, ...] = ()
+        if source_id is not None:
+            # Ownership OR location — same membership rule as _keyword_search.
+            sql += (
+                " AND (source_id = ? OR id IN"
+                " (SELECT sl.item_id FROM source_locations sl WHERE sl.source_id = ?))"
+            )
+            params = (source_id, source_id)
+        rows = self.store.db.execute(sql, params).fetchall()
 
         scored = []
         mismatched = 0

--- a/src/kiro_crew/mcp_tools/knowledge.py
+++ b/src/kiro_crew/mcp_tools/knowledge.py
@@ -25,6 +25,7 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.validation import (
     KNOWLEDGE_ADD_DOCUMENT_SCHEMA,
     KNOWLEDGE_DEDUP_SCHEMA,
+    KNOWLEDGE_LIST_SOURCES_SCHEMA,
     LOCAL_KNOWLEDGE_SEARCH_SCHEMA,
     validate_tool_args,
 )
@@ -58,8 +59,29 @@ def schemas() -> list[dict[str, Any]]:
                         "description": "Max results to return (default 3, max 5)",
                         "default": 3,
                     },
+                    "source_id": {
+                        "type": "string",
+                        "description": (
+                            "Optional source ID to scope keyword/vector seeding "
+                            "to one knowledge source (graph traversal still "
+                            "surfaces cross-source connections). Discover valid "
+                            "IDs with knowledge_list_sources."
+                        ),
+                    },
                 },
                 "required": ["query"],
+            },
+        },
+        {
+            "name": "knowledge_list_sources",
+            "description": (
+                "List the knowledge library's sources as 'name — id (N items)' "
+                "lines. Use it to discover a valid source_id before scoping "
+                "local_knowledge_search to a single source."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
             },
         },
         {
@@ -153,6 +175,7 @@ def local_knowledge_search(name: str, args: dict[str, Any]) -> str:
     args = validate_tool_args(args, LOCAL_KNOWLEDGE_SEARCH_SCHEMA)
     query = args["query"]
     limit = args.get("limit", 3)
+    source_id = args.get("source_id") or None
 
     db_path = Path(mcp_core.config_dir()) / "workspace" / "knowledge" / "knowledge.db"
     if not db_path.exists():
@@ -170,10 +193,39 @@ def local_knowledge_search(name: str, args: dict[str, Any]) -> str:
     # and the embedder availability probe.
     cfg_path = Path(mcp_core.config_dir()) / "config.json"
     store, embedder = mcp_core._get_knowledge_search(db_path, cfg_path)
+
+    # The query is caller-supplied free text and SEL is persisted and
+    # dashboard-readable, so redact it before any audit write (mirrors
+    # knowledge_add_document's audit_title). The search itself keeps the
+    # raw query.
+    audit_query, _ = redact_credentials(query)
+    audit_query, _ = redact_exfiltration_urls(audit_query)
+
+    if source_id is not None:
+        # An unknown source would silently degrade the seed legs to empty; tell
+        # the caller which tool discovers valid IDs instead of raising.
+        row = store.db.execute("SELECT 1 FROM sources WHERE id = ?", (source_id,)).fetchone()
+        if row is None:
+            mcp_core.sel().log_tool_invocation(
+                session_key=mcp_core._resolve_session_key(),
+                source="mcp",
+                tool_name="local_knowledge_search",
+                outcome="unknown_source",
+                metadata={"query": audit_query},
+            )
+            message = (
+                f"No knowledge source with id {source_id!r}. "
+                "Call knowledge_list_sources to see the valid source IDs."
+            )
+            # The id is caller-supplied free text echoed back into chat.
+            message, _ = redact_exfiltration_urls(message)
+            message, _ = redact_credentials(message)
+            return message
+
     embed_fn = embedder.embed if embedder and embedder.is_available() else None
     retriever = mcp_core.HybridRetriever(store, embedder=embed_fn)
 
-    results = retriever.search(query, limit=limit)
+    results = retriever.search(query, limit=limit, source_id=source_id)
 
     # Filter by minimum confidence score
     min_score = 0.012
@@ -185,7 +237,7 @@ def local_knowledge_search(name: str, args: dict[str, Any]) -> str:
             source="mcp",
             tool_name="local_knowledge_search",
             outcome="no_results",
-            metadata={"query": query},
+            metadata={"query": audit_query},
         )
         return "No relevant knowledge found."
 
@@ -245,7 +297,7 @@ def local_knowledge_search(name: str, args: dict[str, Any]) -> str:
         source="mcp",
         tool_name="local_knowledge_search",
         outcome="success",
-        metadata={"query": query, "result_count": len(results)},
+        metadata={"query": audit_query, "result_count": len(results)},
     )
     return output
 
@@ -336,8 +388,53 @@ def knowledge_dedup(name: str, args: dict[str, Any]) -> str:
     return output
 
 
+def knowledge_list_sources(name: str, args: dict[str, Any]) -> str:
+    validate_tool_args(args, KNOWLEDGE_LIST_SOURCES_SCHEMA)
+    db_path = Path(mcp_core.config_dir()) / "workspace" / "knowledge" / "knowledge.db"
+    if not db_path.exists():
+        mcp_core.sel().log_tool_invocation(
+            session_key=mcp_core._resolve_session_key(),
+            source="mcp",
+            tool_name="knowledge_list_sources",
+            outcome="not_configured",
+        )
+        return "Knowledge Library is not configured. Ingest documents via the dashboard first."
+    # Same cached (store, embedder) pair the search handler uses — skips the
+    # per-call schema-DDL/migrate/graph-load. The store is shared: never close it.
+    cfg_path = Path(mcp_core.config_dir()) / "config.json"
+    store, _embedder = mcp_core._get_knowledge_search(db_path, cfg_path)
+    # Count active items only — superseded/deduped copies would overstate
+    # how much a source_id scope is likely to surface. Membership matches the
+    # retriever's scoped seed queries: ownership (items.source_id) OR location
+    # (source_locations, for items surviving a cross-source dedup collapse).
+    rows = store.db.execute(
+        "SELECT s.id, s.name, COUNT(DISTINCT i.id) AS item_count "
+        "FROM sources s LEFT JOIN items i ON i.status = 'active' AND ("
+        "  i.source_id = s.id"
+        "  OR i.id IN (SELECT sl.item_id FROM source_locations sl WHERE sl.source_id = s.id)"
+        ") GROUP BY s.id, s.name ORDER BY s.name"
+    ).fetchall()
+    mcp_core.sel().log_tool_invocation(
+        session_key=mcp_core._resolve_session_key(),
+        source="mcp",
+        tool_name="knowledge_list_sources",
+        outcome="success",
+        metadata={"source_count": len(rows)},
+    )
+    if not rows:
+        return "The knowledge library has no sources yet."
+    lines = [f"Knowledge sources ({len(rows)}):"]
+    for row in rows:
+        lines.append(f"- {row['name']} — id: {row['id']} ({row['item_count']} item(s))")
+    output = "\n".join(lines)
+    output, _ = redact_exfiltration_urls(output)
+    output, _ = redact_credentials(output)
+    return output
+
+
 HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
     "local_knowledge_search": local_knowledge_search,
     "knowledge_add_document": knowledge_add_document,
     "knowledge_dedup": knowledge_dedup,
+    "knowledge_list_sources": knowledge_list_sources,
 }

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2442,7 +2442,16 @@ LOCAL_KNOWLEDGE_SEARCH_SCHEMA = ToolSchema(
     fields=[
         FieldSpec("query", str, required=True, max_len=500),
         FieldSpec("limit", int, required=False, min_val=1, max_val=5, default=3),
+        # Opaque source id (uuid4 today). No pattern: an unknown id must reach
+        # the handler for a graceful "use knowledge_list_sources" reply, not a
+        # ValidationError; every downstream use is a parameterized SQL bind.
+        FieldSpec("source_id", str, required=False, max_len=64),
     ],
+)
+
+KNOWLEDGE_LIST_SOURCES_SCHEMA = ToolSchema(
+    tool_name="knowledge_list_sources",
+    fields=[],
 )
 
 KNOWLEDGE_DEDUP_SCHEMA = ToolSchema(
@@ -2522,6 +2531,7 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "local_knowledge_search": LOCAL_KNOWLEDGE_SEARCH_SCHEMA,
     "knowledge_dedup": KNOWLEDGE_DEDUP_SCHEMA,
     "knowledge_add_document": KNOWLEDGE_ADD_DOCUMENT_SCHEMA,
+    "knowledge_list_sources": KNOWLEDGE_LIST_SOURCES_SCHEMA,
     "search_chat_history": SEARCH_CHAT_HISTORY_SCHEMA,
     "get_chat_session": GET_CHAT_SESSION_SCHEMA,
     "list_sessions": LIST_SESSIONS_SCHEMA,

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -462,6 +462,76 @@ class TestHybridRetriever:
         assert top["artifact_name"] == "OP Vision Plan"
 
 
+class TestHybridRetrieverSourceFilter:
+    def test_source_id_narrows_keyword_seeds(self, store):
+        # Both items match the query; scoping to one source keeps only its item
+        # (no entities exist, so the unfiltered graph leg contributes nothing).
+        src_a = store.add_source("Docs A", "local_folder", "/tmp/a")
+        src_b = store.add_source("Docs B", "local_folder", "/tmp/b")
+        store.add_item("Auth A", "JWT tokens for service alpha", "doc", source_id=src_a)
+        store.add_item("Auth B", "JWT tokens for service beta", "doc", source_id=src_b)
+        retriever = HybridRetriever(store)
+        results = retriever.search("JWT", source_id=src_a)
+        assert [r["title"] for r in results] == ["Auth A"]
+
+    def test_omitted_source_id_keeps_current_behavior(self, store):
+        # Regression: no source_id == the pre-filter result set.
+        src_a = store.add_source("Docs A", "local_folder", "/tmp/a")
+        src_b = store.add_source("Docs B", "local_folder", "/tmp/b")
+        store.add_item("Auth A", "JWT tokens for service alpha", "doc", source_id=src_a)
+        store.add_item("Auth B", "JWT tokens for service beta", "doc", source_id=src_b)
+        retriever = HybridRetriever(store)
+        results = retriever.search("JWT")
+        assert {r["title"] for r in results} == {"Auth A", "Auth B"}
+
+    def test_graph_leg_still_reaches_other_sources(self, store):
+        # The graph leg is deliberately unfiltered: an entity hit in another
+        # source still surfaces, marked as a graph match, while the keyword
+        # seeds stay scoped to the requested source.
+        src_a = store.add_source("Docs A", "local_folder", "/tmp/a")
+        src_b = store.add_source("Docs B", "local_folder", "/tmp/b")
+        store.add_item("Auth A", "JWT tokens for service alpha", "doc", source_id=src_a)
+        item_b = store.add_item("Gateway Doc", "routing notes", "doc", source_id=src_b)
+        ent = store.add_entity("Gateway", "service")
+        store.add_mention(item_b, ent)
+        retriever = HybridRetriever(store)
+        results = retriever.search("JWT Gateway", source_id=src_a)
+        by_title = {r["title"]: r for r in results}
+        assert "Auth A" in by_title
+        assert "Gateway Doc" in by_title
+        assert by_title["Gateway Doc"]["match_type"] == "graph"
+
+    def test_source_id_narrows_vector_seeds(self, store):
+        # Identical embeddings in two sources; scoping keeps one. The query
+        # shares no tokens with the content, isolating the vector leg.
+        src_a = store.add_source("Docs A", "local_folder", "/tmp/a")
+        src_b = store.add_source("Docs B", "local_folder", "/tmp/b")
+        vec = json.dumps([1.0, 0.0, 0.0, 0.0]).encode()
+        store.add_item("Vec A", "alpha content", "doc", source_id=src_a, embedding=vec)
+        store.add_item("Vec B", "beta content", "doc", source_id=src_b, embedding=vec)
+        retriever = HybridRetriever(store, embedder=lambda q: [1.0, 0.0, 0.0, 0.0])
+        results = retriever.search("unrelatedquerytoken", source_id=src_a)
+        assert [r["title"] for r in results] == ["Vec A"]
+
+    def test_unknown_source_id_returns_graph_only_results(self, store):
+        # A nonexistent id empties the seed legs without raising; the tool
+        # layer is what turns this into a guidance message.
+        store.add_item("Auth", "JWT tokens", "doc")
+        retriever = HybridRetriever(store)
+        assert retriever.search("JWT", source_id="no-such-source") == []
+
+    def test_scoped_search_includes_dedup_survivor_via_source_locations(self, store):
+        # An item owned by source A but located in source B (the surviving copy
+        # of a cross-source dedup collapse) still belongs to B's scope — the
+        # same ownership-OR-location rule the /api/knowledge/graph filter uses.
+        src_a = store.add_source("Owner", "local_folder", "/tmp/owner")
+        src_b = store.add_source("Location", "local_folder", "/tmp/loc")
+        item = store.add_item("Shared Doc", "JWT tokens shared", "doc", source_id=src_a)
+        store.add_source_location(item, src_b)
+        retriever = HybridRetriever(store)
+        assert [r["title"] for r in retriever.search("JWT", source_id=src_b)] == ["Shared Doc"]
+
+
 # ---------------------------------------------------------------------------
 # 6. SimpleDiGraph
 # ---------------------------------------------------------------------------

--- a/test/test_mcp_knowledge_search.py
+++ b/test/test_mcp_knowledge_search.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -128,7 +128,9 @@ class TestKnowledgeSearchResults:
         from kiro_crew.mcp_core import _call_tool_inner
 
         _call_tool_inner("local_knowledge_search", {"query": "test"})
-        mock_retriever_cls.return_value.search.assert_called_once_with("test", limit=3)
+        mock_retriever_cls.return_value.search.assert_called_once_with(
+            "test", limit=3, source_id=None
+        )
 
     @patch("kiro_crew.mcp_core.config_dir")
     @patch("kiro_crew.mcp_core.HybridRetriever")
@@ -249,3 +251,152 @@ class TestKnowledgeSearchToolDefinition:
         tools = _list_tools()
         tool = next(t for t in tools if t["name"] == "local_knowledge_search")
         assert "query" in tool["inputSchema"]["required"]
+
+    def test_source_id_is_optional(self):
+        from kiro_crew.mcp_core import _list_tools
+
+        tools = _list_tools()
+        tool = next(t for t in tools if t["name"] == "local_knowledge_search")
+        assert "source_id" in tool["inputSchema"]["properties"]
+        assert "source_id" not in tool["inputSchema"]["required"]
+
+    def test_list_sources_tool_listed(self):
+        from kiro_crew.mcp_core import _list_tools
+
+        tools = _list_tools()
+        names = [t["name"] for t in tools]
+        assert "knowledge_list_sources" in names
+
+
+class TestKnowledgeSearchSourceFilter:
+    def test_source_id_rejects_non_string(self):
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        with pytest.raises(ValidationError):
+            _call_tool_inner("local_knowledge_search", {"query": "q", "source_id": 7})
+
+    def test_source_id_rejects_overlong_value(self):
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        with pytest.raises(ValidationError):
+            _call_tool_inner("local_knowledge_search", {"query": "q", "source_id": "x" * 65})
+
+    @patch("kiro_crew.mcp_core.config_dir")
+    @patch("kiro_crew.mcp_core.HybridRetriever")
+    @patch("kiro_crew.mcp_core._get_knowledge_search")
+    def test_source_id_passed_through_to_retriever(
+        self, mock_get_search, mock_retriever_cls, mock_config_dir, mock_db_exists
+    ):
+        mock_config_dir.return_value = mock_db_exists
+        mock_store = MagicMock()
+        mock_store.db.execute.return_value.fetchone.return_value = (1,)  # source exists
+        mock_get_search.return_value = (mock_store, None)
+        mock_retriever_cls.return_value.search.return_value = []
+
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        _call_tool_inner("local_knowledge_search", {"query": "auth", "source_id": "src-1"})
+        mock_retriever_cls.return_value.search.assert_called_once_with(
+            "auth", limit=3, source_id="src-1"
+        )
+
+    @patch("kiro_crew.mcp_core.config_dir")
+    @patch("kiro_crew.mcp_core._get_knowledge_search")
+    def test_unknown_source_id_names_discovery_tool(
+        self, mock_get_search, mock_config_dir, mock_db_exists
+    ):
+        # A nonexistent source id gets guidance, not an exception and not a
+        # silent empty search.
+        mock_config_dir.return_value = mock_db_exists
+        mock_store = MagicMock()
+        mock_store.db.execute.return_value.fetchone.return_value = None
+        mock_get_search.return_value = (mock_store, None)
+
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        result = _call_tool_inner(
+            "local_knowledge_search", {"query": "auth", "source_id": "no-such-id"}
+        )
+        assert "knowledge_list_sources" in result
+        assert "no-such-id" in result
+
+    @patch("kiro_crew.mcp_core.sel")
+    @patch("kiro_crew.mcp_core.config_dir")
+    @patch("kiro_crew.mcp_core._get_knowledge_search")
+    def test_unknown_source_audit_redacts_query(
+        self, mock_get_search, mock_config_dir, mock_sel, mock_db_exists
+    ):
+        # SEL is persisted and dashboard-readable: a credential-bearing query
+        # must be redacted before the unknown_source audit write.
+        mock_config_dir.return_value = mock_db_exists
+        mock_store = MagicMock()
+        mock_store.db.execute.return_value.fetchone.return_value = None
+        mock_get_search.return_value = (mock_store, None)
+
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        _call_tool_inner(
+            "local_knowledge_search",
+            {"query": "key AKIAIOSFODNN7EXAMPLE leak", "source_id": "no-such-id"},
+        )
+        logged = mock_sel.return_value.log_tool_invocation.call_args.kwargs
+        assert logged["outcome"] == "unknown_source"
+        assert "AKIAIOSFODNN7EXAMPLE" not in logged["metadata"]["query"]
+
+
+class TestKnowledgeListSources:
+    @patch("kiro_crew.mcp_core.config_dir")
+    def test_returns_not_configured_when_db_missing(self, mock_config_dir, tmp_path):
+        mock_config_dir.return_value = tmp_path  # no knowledge.db here
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        result = _call_tool_inner("knowledge_list_sources", {})
+        assert "not configured" in result
+
+    @patch("kiro_crew.mcp_core.config_dir")
+    def test_lists_sources_with_active_item_counts(self, mock_config_dir, tmp_path):
+        from kiro_crew.knowledge.store import KnowledgeStore
+
+        db_dir = tmp_path / "workspace" / "knowledge"
+        db_dir.mkdir(parents=True)
+        store = KnowledgeStore(str(db_dir / "knowledge.db"))
+        src_a = store.add_source("Design Docs", "local_folder", "/tmp/a")
+        src_b = store.add_source("Runbooks", "local_folder", "/tmp/b")
+        doc1 = store.add_item("Doc 1", "content", "note", source_id=src_a)
+        store.add_item("Doc 2", "content two", "note", source_id=src_a)
+        gone = store.add_item("Doc 3", "content three", "note", source_id=src_b)
+        # Non-active items are outside what search can return, so they must not
+        # inflate the advertised count.
+        store.db.execute("UPDATE items SET status = 'deleted' WHERE id = ?", (gone,))
+        store.db.commit()
+        # A dedup survivor owned by A but located in B counts for B too —
+        # membership matches the retriever's scoped seed queries.
+        store.add_source_location(doc1, src_b)
+        store.close()
+        mock_config_dir.return_value = tmp_path
+
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        result = _call_tool_inner("knowledge_list_sources", {})
+        assert f"Design Docs — id: {src_a} (2 item(s))" in result
+        assert f"Runbooks — id: {src_b} (1 item(s))" in result
+
+    @patch("kiro_crew.mcp_core.config_dir")
+    def test_empty_library_reports_no_sources(self, mock_config_dir, tmp_path):
+        from kiro_crew.knowledge.store import KnowledgeStore
+
+        db_dir = tmp_path / "workspace" / "knowledge"
+        db_dir.mkdir(parents=True)
+        KnowledgeStore(str(db_dir / "knowledge.db")).close()
+        mock_config_dir.return_value = tmp_path
+
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        result = _call_tool_inner("knowledge_list_sources", {})
+        assert "no sources yet" in result
+
+    def test_rejects_unknown_fields(self):
+        from kiro_crew.mcp_core import _call_tool_inner
+
+        with pytest.raises(ValidationError):
+            _call_tool_inner("knowledge_list_sources", {"filter": "x"})


### PR DESCRIPTION
## Problem / Motivation

When a knowledge base holds heterogeneous sources, `local_knowledge_search` returns cross-domain noise: shared vocabulary ("deployment", "pipeline", "service") lets one source's chunks dominate the small seed window (limit ≤ 5), so the relevant source's material never reaches the results and ranking alone cannot disambiguate. Merged PR #4640 already added `source_id` filtering to the dashboard's `/api/knowledge/graph` endpoint, but the agent-facing search path has no way to scope retrieval — and no way to discover which source IDs exist.

## Why it matters

Agents using the knowledge library against a multi-source corpus waste their whole retrieval budget on vocabulary collisions: the answer is in the KB, scoped to a known source, but unreachable through the tool. This blunts the core value of ingesting more than one source.

## What changed (motivation → approach → change)

Goal: let a caller scope retrieval to one source without losing the cross-source connections that make hybrid retrieval useful. Approach: extend the validated PR #4640 pattern (parameterized `source_id` predicates) to the retrieval path, but scope only the SEED legs — filtering the graph leg too would amputate exactly the cross-source entity context the graph exists to provide.

- `HybridRetriever.search()` accepts optional `source_id`; the FTS5-keyword and vector-similarity legs gain parameterized `WHERE` clauses (never string interpolation). Graph traversal stays unfiltered by design, with a code comment stating why.
- Scope membership is ownership OR location: `items.source_id` or a `source_locations` row, so an item surviving a cross-source dedup collapse still belongs to the losing source's scope — the same membership rule as PR #4640's `/api/knowledge/graph` filter. `knowledge_list_sources` counts by the same rule.
- `local_knowledge_search` gains an optional `source_id` param. A nonexistent id returns a guidance message naming the discovery tool (SEL outcome `unknown_source`) instead of a silently empty search or an exception.
- New companion tool `knowledge_list_sources` returns one `name — id (N item(s))` line per source (active items only), so agents discover valid IDs instead of guessing. Registered in the same domain module (descriptor + handler), with SEL audit events and credential/exfiltration redaction matching the module's other tools.
- `validation.py`: `source_id` FieldSpec (optional string, max 64; deliberately no pattern so an unknown id reaches the handler's graceful reply rather than raising `ValidationError`) and `KNOWLEDGE_LIST_SOURCES_SCHEMA` (no args), both in `MCP_CORE_SCHEMAS`.
- Docs: `docs/system-specs/modules/knowledge.md` (tool section + the §5 follow-up note now points at adopting the retriever param in the dashboard branch), `docs/system-specs/modules/learn-cron-dashboard.md` (parameter list), `docs/architecture/mcp.md` (tool inventory).

Also in this commit (declared): the pre-existing `no_results`/`success` SEL events in `local_knowledge_search` now log a redacted copy of the query, matching the new `unknown_source` event — SEL is persisted and dashboard-readable, and this closes the same credential-leak class `knowledge_add_document` already closed with `audit_title`. The search itself still uses the raw query.

Backward compatible: omitting `source_id` is byte-identical to current behavior; the new retriever parameter is keyword-only-with-default so both existing dashboard call sites are untouched.

## Tests

- `test_knowledge.py::TestHybridRetrieverSourceFilter` — keyword seeds narrowed to the scoped source; omitted `source_id` keeps the pre-filter result set (regression); graph leg still reaches another source's item (asserted `match_type == "graph"`); vector seeds narrowed under a stub embedder with the keyword leg isolated away; nonexistent id yields empty results at the retriever layer without raising.
- `test_mcp_knowledge_search.py` — `source_id` passed through to `HybridRetriever.search`; unknown id returns a message naming `knowledge_list_sources`; schema rejects non-string and >64-char values; `knowledge_list_sources` lists real sources with active-only item counts (a `deleted`-status row is excluded), reports an empty library, returns not-configured without a DB, and rejects unknown fields; both tools advertised via `tools/list` with `source_id` optional.
- Updated `test_default_limit_is_3` for the widened call signature.

## Manual verification

N/A — unit coverage sufficient: the new SQL runs against real SQLite stores in the retrieval tests and a real `KnowledgeStore` in the list-sources tests; no UI or external-service path is touched.

<!-- no-visual-delta -->
**Why no screenshot:** backend MCP tool + docs change only; no frontend file touched and no rendered surface changes.

## Related Issues

Closes #4852

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

