### PR TITLE
refactor(dashboard): flatten the telemetry shard walk and one ternary

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3638,7 +3638,12 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     # rendering as speech. `synthetic_payload` is the existing answer to exactly
     # that question, so reuse it rather than inventing a second signal.
     if row_role == "inject":
-        _inject_kind = "cron" if is_cron else "recovery" if synthetic_payload else "user_replay"
+        if is_cron:
+            _inject_kind = "cron"
+        elif synthetic_payload:
+            _inject_kind = "recovery"
+        else:
+            _inject_kind = "user_replay"
         _inject_meta: dict = {"injectKind": _inject_kind}
         if is_cron:
             _inject_meta["cronLabel"] = cron_label

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -31,7 +31,7 @@ import logging
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Iterator, NamedTuple
 
 from aiohttp import web
 
@@ -69,11 +69,11 @@ _COST_WINDOW_DAYS = 7
 # two entries wide and needs no cap.
 _OTHER_SPLIT_ATTRS = frozenset({"warm"})
 
-# F4: only terminal-fault outcomes count toward fault_rate. The two watchdog
+# Only terminal-fault outcomes count toward fault_rate. The two watchdog
 # recovery outcomes ("tool_stall" and "stale_recover") are NOT faults: a
 # recovered stall is re-driven in place and tracked separately under
-# kirocrew.watchdog.recovery.outcome. Counting them as faults inflated the
-# fault rate and hid the true error population. Use an explicit allowlist so
+# kirocrew.watchdog.recovery.outcome. Counting them as faults would inflate the
+# fault rate and hide the true error population. Use an explicit allowlist so
 # future outcome labels added to _turn_outcome() must actively opt in — a
 # cross-module test (test_telemetry_handler) fails on any label that is
 # neither here nor explicitly excluded, so drift can't silently deflate
@@ -394,6 +394,13 @@ class _Hist:
 
 
 def _day_of(dp: dict[str, Any], fallback: str) -> str:
+    """The local calendar day a data point was recorded on, else *fallback*.
+
+    ``OSError`` belongs in the except tuple below: ``astimezone()`` raises it on a
+    broken tz database, and this is the only OS-touching call in the aggregation
+    loop — which runs outside the shard reader's own ``OSError`` handler, so an
+    escape here would 500 the whole panel over one malformed ``time_unix_nano``.
+    """
     ns = dp.get("time_unix_nano")
     if ns:
         try:
@@ -405,6 +412,112 @@ def _day_of(dp: dict[str, Any], fallback: str) -> str:
         except (ValueError, OverflowError, OSError):
             pass
     return fallback
+
+
+def _iter_export_cycles(
+    shard_paths: list[Path],
+) -> Iterator[tuple[dict[str, Any], str]]:
+    """Yield ``(export cycle, shard day)`` for every parseable line of each shard.
+
+    One JSONL line is one ``MetricsData.to_json()`` export cycle. Corruption is
+    skipped at the narrowest scope that can still be salvaged: one unparseable
+    line, or one shard that is unreadable / not valid UTF-8. Cycles already
+    yielded from a shard that then fails mid-read are kept — a torn tail must not
+    discard the cycles ahead of it.
+    """
+    for p in shard_paths:
+        shard_day = "-".join(p.stem.split("-")[1:4])
+        try:
+            with p.open(encoding="utf-8") as fh:
+                for line in fh:
+                    try:
+                        obj = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    yield obj, shard_day
+        except (OSError, UnicodeDecodeError):
+            continue
+
+
+def _iter_metric_points(
+    shard_paths: list[Path],
+) -> Iterator[tuple[str, dict[str, Any], str]]:
+    """Yield ``(metric name, data point, shard day)`` for every ``kirocrew.*`` point.
+
+    The name filter is load-bearing rather than defensive. One meter carries all
+    three namespaces the recorder accepts — ``kirocrew.*``, ``gen_ai.*`` and
+    ``app.<app_id>.*`` (``metrics/schema.py``) — so points from every one of them
+    reach this shard. Dropping the other two here is what keeps them out of
+    :func:`_other_series`, whose rows the startup panel renders as core metrics.
+    """
+    for obj, shard_day in _iter_export_cycles(shard_paths):
+        # resource -> scope -> metric is pure OTLP grouping; nothing below reads
+        # the resource or the scope.
+        metrics = (
+            m
+            for rm in obj.get("resource_metrics", []) or []
+            for sm in rm.get("scope_metrics", []) or []
+            for m in sm.get("metrics", []) or []
+        )
+        for metric in metrics:
+            name = metric.get("name") or ""
+            if not name.startswith("kirocrew."):
+                continue
+            data = metric.get("data") or {}
+            for dp in data.get("data_points", []) or []:
+                yield name, dp, shard_day
+
+
+def _daily_series(daily: dict[str, dict[str, _Hist]]) -> list[dict[str, Any]]:
+    """Per-day startup percentiles (cold p50/p90, warm p50), oldest day first."""
+    out: list[dict[str, Any]] = []
+    for day in sorted(daily):
+        c, w = daily[day]["cold"], daily[day]["warm"]
+        out.append(
+            {
+                "date": day,
+                "count": c.count + w.count,
+                "cold_p50_ms": round(_pct_from_buckets(c.buckets, c.bounds, 0.50), 1),
+                "cold_p90_ms": round(_pct_from_buckets(c.buckets, c.bounds, 0.90), 1),
+                "warm_p50_ms": round(_pct_from_buckets(w.buckets, w.bounds, 0.50), 1),
+            }
+        )
+    return out
+
+
+def _other_series(
+    other_hist: dict[str, _Hist],
+    other_split: dict[str, dict[str, _Hist]],
+    other_ctr: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """The generic surface: every point that no dedicated block claimed.
+
+    Selection is by data-point SHAPE, not by metric name, so a startup or turn
+    point that is not a histogram lands here under its own name instead of in the
+    block named after it.
+
+    Histograms first, then counters, each group name-sorted, so a panel reading
+    this list renders the same order on every request.
+    """
+    out: list[dict[str, Any]] = []
+    for name in sorted(other_hist):
+        s = other_hist[name].stats()
+        s.update({"name": name, "kind": "histogram"})
+        splits = other_split.get(name)
+        if splits:
+            s["splits"] = {sig: splits[sig].stats() for sig in sorted(splits)}
+        out.append(s)
+    for name in sorted(other_ctr):
+        rec = other_ctr[name]
+        out.append(
+            {
+                "name": name,
+                "kind": "counter",
+                "total": round(rec["total"], 3),
+                "by_attr": {k: round(v, 3) for k, v in rec["by_attr"].items()},
+            }
+        )
+    return out
 
 
 def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
@@ -421,124 +534,55 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
     other_ctr: dict[str, dict[str, Any]] = {}  # name -> {total, by_attr}
     turn = _Hist()
 
-    for p in shard_paths:
-        shard_day = "-".join(p.stem.split("-")[1:4])
-        try:
-            with p.open(encoding="utf-8") as fh:
-                for line in fh:
-                    try:
-                        obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
-                        continue
-                    for rm in obj.get("resource_metrics", []) or []:
-                        for sm in rm.get("scope_metrics", []) or []:
-                            for m in sm.get("metrics", []) or []:
-                                name = m.get("name") or ""
-                                if not name.startswith("kirocrew."):
-                                    continue
-                                data = m.get("data") or {}
-                                for dp in data.get("data_points", []) or []:
-                                    attrs = dp.get("attributes") or {}
-                                    is_hist = "bucket_counts" in dp
-                                    if name == _STARTUP_METRIC and is_hist:
-                                        # One startup emits an end-to-end point
-                                        # (phase absent, or phase=total from the
-                                        # kiro path) PLUS one point per internal
-                                        # phase. Only the end-to-end point is a
-                                        # startup: counting the phase points too
-                                        # would multiply the startup count by ~4
-                                        # and sum four unrelated latency
-                                        # distributions into one set of buckets,
-                                        # a bimodal "distribution" that is really
-                                        # set_model + session_new + spawn_init +
-                                        # total stacked together.
-                                        phase = str(attrs.get("phase", _PHASE_TOTAL))
-                                        if phase != _PHASE_TOTAL:
-                                            phases.setdefault(phase, _Hist()).add(dp)
-                                            continue
-                                        spawned = bool(attrs.get("spawned"))
-                                        oc = str(attrs.get("outcome", "unknown"))
-                                        (cold if spawned else warm).add(dp)
-                                        # Which conversation source paid this
-                                        # startup. Older shards predate the
-                                        # attribute, so they aggregate under
-                                        # "unknown" rather than being dropped.
-                                        by_channel.setdefault(
-                                            str(attrs.get("channel", "unknown")), _Hist()
-                                        ).add(dp)
-                                        # Outcomes go through _Hist so they are
-                                        # scoped to the same bounds generation as
-                                        # the count and percentiles reported.
-                                        overall.add(dp, outcome=oc)
-                                        day = _day_of(dp, shard_day)
-                                        db = daily.setdefault(
-                                            day, {"cold": _Hist(), "warm": _Hist()}
-                                        )
-                                        db["cold" if spawned else "warm"].add(dp)
-                                    elif name == _TURN_METRIC and is_hist:
-                                        turn.add(
-                                            dp,
-                                            outcome=str(
-                                                attrs.get("outcome", "unknown")
-                                            ),
-                                        )
-                                    elif is_hist:
-                                        other_hist.setdefault(name, _Hist()).add(dp)
-                                        for ak in _OTHER_SPLIT_ATTRS:
-                                            if ak not in attrs:
-                                                continue
-                                            sig = f"{ak}={str(attrs[ak]).lower()}"
-                                            other_split.setdefault(
-                                                name, {}
-                                            ).setdefault(sig, _Hist()).add(dp)
-                                    elif "value" in dp:
-                                        rec = other_ctr.setdefault(
-                                            name, {"total": 0.0, "by_attr": {}}
-                                        )
-                                        val = float(dp.get("value", 0.0) or 0.0)
-                                        rec["total"] += val
-                                        if attrs:
-                                            key = ",".join(
-                                                f"{k}={attrs[k]}"
-                                                for k in sorted(attrs)
-                                            )
-                                            rec["by_attr"][key] = (
-                                                rec["by_attr"].get(key, 0.0) + val
-                                            )
-        except (OSError, UnicodeDecodeError):
-            continue
+    for name, dp, shard_day in _iter_metric_points(shard_paths):
+        attrs = dp.get("attributes") or {}
+        is_hist = "bucket_counts" in dp
+        if name == _STARTUP_METRIC and is_hist:
+            # One startup emits an end-to-end point (phase absent, or
+            # phase=total from the kiro path) PLUS one point per internal phase.
+            # Only the end-to-end point is a startup: counting the phase points
+            # too would multiply the startup count by ~4 and sum four unrelated
+            # latency distributions into one set of buckets, a bimodal
+            # "distribution" that is really set_model + session_new +
+            # spawn_init + total stacked together.
+            phase = str(attrs.get("phase", _PHASE_TOTAL))
+            if phase != _PHASE_TOTAL:
+                phases.setdefault(phase, _Hist()).add(dp)
+                continue
+            spawned = bool(attrs.get("spawned"))
+            oc = str(attrs.get("outcome", "unknown"))
+            (cold if spawned else warm).add(dp)
+            # Which conversation source paid this startup. Older shards predate
+            # the attribute, so they aggregate under "unknown" rather than being
+            # dropped.
+            by_channel.setdefault(
+                str(attrs.get("channel", "unknown")), _Hist()
+            ).add(dp)
+            # Outcomes go through _Hist so they are scoped to the same bounds
+            # generation as the count and percentiles reported.
+            overall.add(dp, outcome=oc)
+            day = _day_of(dp, shard_day)
+            db = daily.setdefault(day, {"cold": _Hist(), "warm": _Hist()})
+            db["cold" if spawned else "warm"].add(dp)
+        elif name == _TURN_METRIC and is_hist:
+            turn.add(dp, outcome=str(attrs.get("outcome", "unknown")))
+        elif is_hist:
+            other_hist.setdefault(name, _Hist()).add(dp)
+            for ak in _OTHER_SPLIT_ATTRS:
+                if ak not in attrs:
+                    continue
+                sig = f"{ak}={str(attrs[ak]).lower()}"
+                other_split.setdefault(name, {}).setdefault(sig, _Hist()).add(dp)
+        elif "value" in dp:
+            rec = other_ctr.setdefault(name, {"total": 0.0, "by_attr": {}})
+            val = float(dp.get("value", 0.0) or 0.0)
+            rec["total"] += val
+            if attrs:
+                key = ",".join(f"{k}={attrs[k]}" for k in sorted(attrs))
+                rec["by_attr"][key] = rec["by_attr"].get(key, 0.0) + val
 
-    daily_out = []
-    for day in sorted(daily):
-        c, w = daily[day]["cold"], daily[day]["warm"]
-        daily_out.append(
-            {
-                "date": day,
-                "count": c.count + w.count,
-                "cold_p50_ms": round(_pct_from_buckets(c.buckets, c.bounds, 0.50), 1),
-                "cold_p90_ms": round(_pct_from_buckets(c.buckets, c.bounds, 0.90), 1),
-                "warm_p50_ms": round(_pct_from_buckets(w.buckets, w.bounds, 0.50), 1),
-            }
-        )
-
-    other = []
-    for name in sorted(other_hist):
-        s = other_hist[name].stats()
-        s.update({"name": name, "kind": "histogram"})
-        splits = other_split.get(name)
-        if splits:
-            s["splits"] = {sig: splits[sig].stats() for sig in sorted(splits)}
-        other.append(s)
-    for name in sorted(other_ctr):
-        rec = other_ctr[name]
-        other.append(
-            {
-                "name": name,
-                "kind": "counter",
-                "total": round(rec["total"], 3),
-                "by_attr": {k: round(v, 3) for k, v in rec["by_attr"].items()},
-            }
-        )
+    daily_out = _daily_series(daily)
+    other = _other_series(other_hist, other_split, other_ctr)
 
     turn_outcome = turn.outcomes
     turn_total = sum(turn_outcome.values())


### PR DESCRIPTION
## Problem / Motivation

`_aggregate` in `src/kiro_crew/dashboard/handlers/telemetry.py` carried the
deepest nesting in the backend — **eleven levels**, measured across
`src/kiro_crew/` excluding `_vendor/`. The pyramid ran per-shard file → `try` →
`with` → per-line → `resource_metrics` → `scope_metrics` → `metrics` →
`data_points` → the classification `if`/`elif` chain → the per-attribute split
loop → its guard, and both derived-output builders sat inside the same function.

Two concrete costs to a reader:

- Answering "which accumulator does this line feed?" means tracking eight
  enclosing statements, none of which is about the data point in hand.
- The `continue` that skips a per-phase startup point was five loops away from
  the loop it targets, so its scope had to be re-derived from indentation.

The detector bundled with the module-simplification pass also flagged one
`chained-ternary` site in `src/kiro_crew/dashboard/chat_runner.py`, in the same
module.

## Why it matters

This function is the whole of `GET /api/telemetry/startup`'s aggregation, and
it is where every new `kirocrew.*` emit site lands without a code change here.
Its nesting is what makes each such arrival expensive to review: a change to one
branch cannot be read without re-deriving the other seven levels around it, and
the classification chain — which decides whether a point counts as a startup, a
turn, a generic histogram, or a counter — is exactly the part where a
misplacement is invisible in the rendered panel.

## What changed (motivation → approach → change)

**Goal:** cut the nesting without changing a single output byte. The function
already had clean seams — reading shards, walking the OTLP envelope, classifying
points, and building the two derived lists are four separable jobs sharing one
indentation stack. Splitting along those seams needed no new abstraction, only
extraction.

**What was built** (all four are module-private, no call site outside this file):

| New unit | Job |
|---|---|
| `_iter_export_cycles` | Reads the shards, yields `(export cycle, shard day)`. Owns the corruption handling: one unparseable line, or one unreadable / non-UTF-8 shard, is skipped at the narrowest scope that can still be salvaged. |
| `_iter_metric_points` | Walks the OTLP envelope and applies the `kirocrew.*` name filter. The three grouping levels collapse into one generator expression, since nothing downstream reads the resource or the scope. |
| `_daily_series` | Builds the per-day cold/warm percentile rows. |
| `_other_series` | Builds the generic `other` list (histograms then counters, each name-sorted). |

`_aggregate` is now one flat loop over data points followed by three calls. Its
nesting depth is **4**; the deepest new unit is **5**. The `continue` sits one
level from the loop it targets.

**Also in this diff, same module:**

- `dashboard/chat_runner.py` — the flagged chained ternary for `_inject_kind`
  becomes the `if`/`elif`/`else` form that the two sibling assignments
  immediately above it (`row_role`, `row_cls`) already use. Python's conditional
  expression is right-associative, so the guard order is unchanged; both
  operands (`is_cron`, `synthetic_payload`) are strict `bool`, so no truthiness
  edge exists.
- The comment above `_TERMINAL_FAULT_OUTCOMES` loses a leading `F4:` review-round
  marker and one past-tense narration ("inflated … and hid" → "would inflate …
  and hide"), both of which `AGENTS.md`'s comment rule forbids. `F4` is not a
  documented invariant id — the sanctioned bare-id form is the harness-parity
  series — and the comment still names the test that pins the behaviour.
- `_day_of` gains a docstring pinning **why `OSError` is in its except tuple**.
  That catch is now load-bearing: it is the only OS-touching call in the
  aggregation loop, which sits outside the shard reader's own `OSError` handler,
  so an escape there would 500 the panel over one malformed `time_unix_nano`.

**No behaviour changed.** No JSON key, value, ordering, route, or response shape
moves; no security control, guard, or validation call is touched. `shard_paths`
still arrives already vetted by `validate_file_path` in `_shards_in_window`, and
the synchronous read still runs under `asyncio.to_thread(_parse_startup_metrics)`.

## Tests

No new tests: this is a behaviour-preserving refactor, and the existing suite
already pins the behaviour at the boundary that matters. What it locks in:

- `test/metrics/test_telemetry_handler.py` — `_aggregate` over real shard
  fixtures: the phase-vs-total startup split, the cold/warm split, the outcome
  breakdown, `fault_rate`, and the `_TERMINAL_FAULT_OUTCOMES` allowlist.
- `test/metrics/test_generation_disclosure.py` — the mixed bucket-boundary
  window, `other_generations` / `total_count`.
- `test/test_telemetry_handlers_cov80.py` — the two corruption paths that the
  extraction moves: a bad JSON line plus a foreign metric name, and an
  unreadable shard followed by a good one.
- `test/test_chat_runner_coverage.py` — asserts all four `injectKind` values as
  data, so the ternary rewrite is covered on every branch.

Run green locally on the Python 3.12 CI-parity venv: **879 passed** across
`test/metrics/`, `test_telemetry_handlers_cov80`, `test_chat_runner_coverage`,
`test_interaction_telemetry`, `test_usage`, `test_kiro_usage_api`,
`test_cron_origin_injection`, `test_recovery_card_parity`,
`test_recovery_card_prefixes`, `test_recovery_marker_parity`,
`test_steer_requeue`. Static gates all exit 0: `flake8`, `isort --check-only`,
`mypy`, `check_black_formatting.py`, `check_brand_name.py`,
`check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`.

## Manual verification

**Differential equivalence, not inspection.** The pre- and post-diff `_aggregate`
were loaded side by side as two modules and run over the same inputs, comparing
`json.dumps(..., sort_keys=True)` so key order is part of the comparison:
**300 randomised shard corpora, zero mismatches.** The generator covered corrupt
JSON lines, empty lines, shards with invalid UTF-8 mid-file, shard paths that do
not exist, mixed bucket-boundary generations under one metric name, nameless
metrics, `data: None`, `data_points: None`, absent `attributes`, non-`kirocrew.*`
names, and counter points with and without attributes.

The one semantic difference worth naming, since a reviewer will look for it:
the `except (OSError, UnicodeDecodeError)` previously wrapped the aggregation
body as well as the file read, and now wraps only the read. Every expression in
the new consumer body and in both output builders was enumerated; none can raise
either type. `_day_of` is the only OS-touching call and catches its own `OSError`
— which is why this PR documents that catch as an invariant rather than leaving
it as an accident.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff (two files under `src/kiro_crew/`, nothing
under `website/`), so the Screenshot Evidence gate's path filter does not match and
there is no rendered delta; `only_backend` is true.

## Related Issues

no linked issue: an internal readability refactor with no filed report behind it.

**One sequencing note for the maintainer:** PR #4788 also modifies `_aggregate`
(it adds a `_finite` scalar guard and gauge handling inside the same ingest
loop). Neither PR deletes or rewrites the other's work, but whichever lands
second needs a manual rebase of that function. #4788 carries a behaviour change
and this one carries none, so landing #4788 first and rebasing this on top is the
cheaper order.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass; no new tests needed (behaviour-preserving refactor, see Tests)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — not applicable: no API, schema, or documented behaviour changed. `docs/system-specs/modules/metrics.md` documents this handler at route level only and never `_aggregate`'s internal shape; `docs/system-specs/common/injected-messages.md` documents `meta.injectKind`, whose value set and precedence are unchanged.
- [x] No secrets, credentials, or internal references in the diff
