### PR TITLE
chore(release): declare release/0.4.0 as the RC in-code (0.4.0rc3 / 0.4.0-rc.3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,8 +282,15 @@ is what makes nightlies read as previews of the *next* release:
 | `pyproject.toml` | `[project] version` — what the wheel carries |
 | `website/electron/package.json` | `version` — the updater's version compare |
 
-Keep it a bare `X.Y.Z`: `nightly.yml` builds both a semver and a PEP 440 stamp
-from it, and a suffixed base (`.dev0`) produces invalid versions.
+Keep it a bare `X.Y.Z` **on `main`**: `nightly.yml` builds both a semver and a
+PEP 440 stamp from it, and a suffixed base (`.dev0`) produces invalid versions.
+
+On an **insider release branch** the in-code version instead carries the RC, so
+a source/dev checkout reads as the candidate it is. The three files use their
+own dialects, because one string is not valid in all three: `__init__.py` and
+`pyproject.toml` take the PEP 440 spelling (`0.4.0rc3`), `package.json` takes
+the semver spelling (`0.4.0-rc.3`). The tag still overrides all three at build
+time (see `docs/build/release.md` → "Version numbering policy").
 
 ### One trap worth knowing
 

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -404,7 +404,10 @@ manipulates — the final byte stamp is decided by the tag, not this value.
 - **On an insider release branch, `__version__` carries the RC suffix, and the
   tag matches.** The branch reads as what it is: `__version__ = "X.Y.ZrcN"`,
   tags `vX.Y.Z-insider.N`. Do not leave a release branch declaring a bare
-  `X.Y.Z` while it is still cutting RCs.
+  `X.Y.Z` while it is still cutting RCs. The three version files use their own
+  dialects (one string is not valid in all three): `src/kiro_crew/__init__.py`
+  and `pyproject.toml` take PEP 440 (`0.4.0rc3`), `website/electron/package.json`
+  takes semver (`0.4.0-rc.3`).
 - **Promoting an insider line to stable is a three-step sequence:**
   1. **Drop the RC in a PR** — change `__version__` from `X.Y.ZrcN` to the bare
      `X.Y.Z`. This is the release commit; it also sets the base the stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.4.0"
+version = "0.4.0rc3"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.4.0"
+__version__ = "0.4.0rc3"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.4.0-rc.3",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
Per the version numbering policy (docs/build/release.md): an insider release branch declares the RC in-code so a source/dev checkout reads as the candidate.

Three version files, three dialects (one string is not valid in all three):
- `src/kiro_crew/__init__.py` → `0.4.0rc3` (PEP 440)
- `pyproject.toml` `[project].version` → `0.4.0rc3` (PEP 440)
- `website/electron/package.json` → `0.4.0-rc.3` (semver)

The tag (`v0.4.0-insider.3`) still overrides all three at build time; this only changes what a non-tag build reports. CONTRIBUTING.md’s “keep bare X.Y.Z” now scopes to `main`; the insider-branch exception is documented in both CONTRIBUTING and release.md.

Local gates: black/isort/flake8 clean; version-consistency tests (test_config_meta_stamp, test_pip_deps_consistency, test_nightly_version_contract) 38 passed.