### PR TITLE
chore: bump main in-code version to 0.5.0 (one minor ahead of the 0.4 insider line)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.4.0"
+version = "0.5.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
Per the version numbering policy (docs/build/release.md): `main` (nightly) stays one MINOR ahead of the active insider release line. With `release/0.4.0` stabilizing at `0.4.x`, `main` declares `0.5.0`, so every nightly is strictly newer than any RC of the shipping line and is never offered what looks like a downgrade to an RC.

Bare `X.Y.Z` across all three version files (`__init__.py`, `pyproject.toml`, `website/electron/package.json`), as CONTRIBUTING requires for `main` (nightly.yml derives its semver + PEP 440 stamps from it).

Local gates: black/isort/flake8 clean.