### PR TITLE
fix(apps): min-version install gate silently disabled on insider installs (PEP 440 rc stamp)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -182,7 +182,6 @@ src/kiro_crew/apps/route_registry.py
 src/kiro_crew/apps/routes.py
 src/kiro_crew/apps/scaffold.py
 src/kiro_crew/apps/teardown.py
-src/kiro_crew/apps/version.py
 src/kiro_crew/artifact_source.py
 src/kiro_crew/artifacts.py
 src/kiro_crew/atomic_write.py
@@ -1413,7 +1412,6 @@ test/test_workflows_runner.py
 test/test_workflows_store.py
 test/test_workspace_absolute_paths.py
 test/test_workspace_symlink_resume.py
-test/test_worktree_create.py
 test/test_write_secret_file.py
 test/test_ws_and_plan_memory_fixes.py
 test/test_ws_event_scoping.py

--- a/src/kiro_crew/apps/version.py
+++ b/src/kiro_crew/apps/version.py
@@ -1,16 +1,29 @@
 """Shared version parsing and compatibility checks for app management."""
+
 from __future__ import annotations
+
+import re
+
+# Leading numeric release segment: "0.4.0rc3" -> "0.4.0", "1.2.0-rc.1" -> "1.2.0",
+# "1.0+build.42" -> "1.0". An optional leading "v" is tolerated ("v1.2.3").
+_RELEASE_RE = re.compile(r"^\s*v?(\d+(?:\.\d+)*)")
 
 
 def parse_version(v: str) -> tuple[int, ...]:
-    """Parse a semver-like string into a comparable 3-element tuple.
+    """Parse a semver- or PEP 440-like string into a comparable 3-element tuple.
 
-    Strips pre-release (``-beta``) and build metadata (``+build.42``)
-    before parsing so that ``"1.2.0-rc.1"`` is treated as ``(1, 2, 0)``.
-    Always pads to 3 elements so ``parse_version("1.0") == parse_version("1.0.0")``.
+    Only the leading numeric release segment is compared: semver pre-release
+    (``1.2.0-rc.1``) and build metadata (``+build.42``) are stripped, and PEP 440
+    suffixes that attach WITHOUT a separator (``0.4.0rc3``, as stamped into every
+    insider wheel) are stripped too -- the old ``split("-")`` approach raised
+    ``ValueError`` on those, which silently disabled ``check_min_version`` on
+    insider installs. Always pads to 3 elements so
+    ``parse_version("1.0") == parse_version("1.0.0")``.
     """
-    v = v.split("-")[0].split("+")[0]  # strip pre-release / build metadata
-    parts = [int(x) for x in v.split(".")[:3]]
+    m = _RELEASE_RE.match(v)
+    if not m:
+        raise ValueError(f"unparseable version: {v!r}")
+    parts = [int(x) for x in m.group(1).split(".")[:3]]
     return tuple(parts + [0] * (3 - len(parts)))
 
 
@@ -23,6 +36,7 @@ def check_min_version(min_version: str) -> str | None:
         return None
     try:
         from kiro_crew import __version__ as current
+
         if parse_version(current) < parse_version(min_version):
             return (
                 f"App requires Kiro Crew >= {min_version}, "

--- a/test/test_apps_version.py
+++ b/test/test_apps_version.py
@@ -1,0 +1,61 @@
+"""Tests for kiro_crew.apps.version — parsing and the min-version install gate.
+
+Regression anchor: every insider wheel is stamped with a PEP 440 version like
+``0.4.0rc3`` (no separator before ``rc``). The old ``parse_version`` raised
+``ValueError`` on that shape, and ``check_min_version`` swallows exceptions, so
+the min-version install gate was silently DISABLED on every insider install --
+caught by the v0.4.0-insider.3 release-candidate gate
+(test_min_version_gate_rejects_before_copying: 201 instead of 400).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.apps.version import check_min_version, parse_version
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("1.2.3", (1, 2, 3)),
+            ("1.0", (1, 0, 0)),  # pads to 3 elements
+            ("1", (1, 0, 0)),
+            ("v1.2.3", (1, 2, 3)),  # tolerates leading v
+            ("1.2.0-rc.1", (1, 2, 0)),  # semver pre-release
+            ("1.2.3+build.42", (1, 2, 3)),  # build metadata
+            ("0.4.0-insider.3", (0, 4, 0)),  # desktop stamp
+            ("0.4.0rc3", (0, 4, 0)),  # PEP 440 wheel stamp -- the regression
+            ("0.4.0a1", (0, 4, 0)),
+            ("0.4.0.dev5", (0, 4, 0)),  # extra numeric parts beyond 3 are ignored
+            ("1.2.3.4", (1, 2, 3)),
+        ],
+    )
+    def test_parses_release_segment(self, raw: str, expected: tuple[int, ...]) -> None:
+        assert parse_version(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["", "garbage", "rc3", "-1.2.3"])
+    def test_unparseable_raises(self, raw: str) -> None:
+        with pytest.raises(ValueError):
+            parse_version(raw)
+
+
+class TestCheckMinVersion:
+    def test_gate_rejects_on_insider_rc_stamp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The exact RC-gate scenario: running version is a PEP 440 rc stamp.
+        monkeypatch.setattr("kiro_crew.__version__", "0.4.0rc3")
+        err = check_min_version("999.0.0")
+        assert err is not None
+        assert "999.0.0" in err
+
+    def test_gate_accepts_on_insider_rc_stamp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("kiro_crew.__version__", "0.4.0rc3")
+        assert check_min_version("0.4.0") is None
+
+    def test_gate_rejects_on_bare_stamp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("kiro_crew.__version__", "0.4.0")
+        assert check_min_version("999.0.0") is not None
+
+    def test_empty_min_version_passes(self) -> None:
+        assert check_min_version("") is None

--- a/test/test_worktree_create.py
+++ b/test/test_worktree_create.py
@@ -44,9 +44,7 @@ def _branch_exists(root: str, branch: str) -> bool:
     return bool(_resolve_commit(root, f"refs/heads/{branch}"))
 
 
-def _make_app(
-    *projects: str, app_claim: str | None = "", user: str = "owner"
-) -> web.Application:
+def _make_app(*projects: str, app_claim: str | None = "", user: str = "owner") -> web.Application:
     """App whose state exposes one slot per allowed project directory.
 
     ``app_claim`` mirrors ``token_auth_middleware``'s ``request["app"]``: ``""``
@@ -67,9 +65,7 @@ def _make_app(
     # (GPT review round 12), so the mock must carry a matching owner_id — a bare
     # MagicMock attribute here would 403 every request for the wrong reason.
     state.owner_id = "owner"
-    state._slots = {
-        f"chat-{i}": MagicMock(project=str(p)) for i, p in enumerate(projects) if p
-    }
+    state._slots = {f"chat-{i}": MagicMock(project=str(p)) for i, p in enumerate(projects) if p}
     app["state"] = state
     app.router.add_post("/api/worktree/create", api_worktree_create)
     return app
@@ -101,7 +97,7 @@ def _git(*args: str, cwd) -> None:
 
 @functools.lru_cache(maxsize=1)
 def _sandbox_exec_reason() -> str:
-    """"" if a sandboxed git can actually run here, else why it cannot.
+    """ "" if a sandboxed git can actually run here, else why it cannot.
 
     `_run_git` routes through the OS-sandbox chokepoint, and the endpoint refuses
     with a 503 when isolation cannot be established. That is a real platform
@@ -156,6 +152,14 @@ def _repo_template(tmp_path_factory):
     _git("init", "-q", "-b", "main", cwd=template)
     _git("config", "user.email", "test@example.com", cwd=template)
     _git("config", "user.name", "Test", cwd=template)
+    # The commit below can spawn background auto-maintenance (gc / maintenance
+    # run --auto), whose transient .git/objects/maintenance.lock races the
+    # per-test shutil.copytree of this template -- the lock is listed by the
+    # directory scan, then gone by the time copytree opens it (seen as a
+    # shutil.Error in the v0.4.0-insider.3 RC gate). Session scope makes the
+    # window span into the first tests, so switch maintenance off entirely.
+    _git("config", "gc.auto", "0", cwd=template)
+    _git("config", "maintenance.auto", "false", cwd=template)
     (template / "README.md").write_text("hi\n")
     _git("add", "README.md", cwd=template)
     _git("commit", "-q", "-m", "init", cwd=template)
@@ -445,9 +449,7 @@ class TestIdempotentReentry:
             return real_run_git(args, cwd)
 
         async with TestClient(TestServer(_make_app(str(repo)))) as client:
-            with patch(
-                "kiro_crew.dashboard.handlers.worktree._run_git", side_effect=fail_add
-            ):
+            with patch("kiro_crew.dashboard.handlers.worktree._run_git", side_effect=fail_add):
                 resp = await client.post(
                     "/api/worktree/create", json={"repo": str(repo), "branch": "feat/doomed"}
                 )
@@ -513,9 +515,7 @@ class TestConcurrencySafety:
         assert _run_git(["worktree", "add", theirs, "feat/theirs"], str(repo)).returncode == 0
         # A different request unwinds ITS branch, whose derived dest collides.
         assert _claim_branch(str(repo), "feat/ours", sha) is True
-        _cleanup_partial(
-            str(repo), theirs, "feat/ours", claimed=True, created=True, base_sha=sha
-        )
+        _cleanup_partial(str(repo), theirs, "feat/ours", claimed=True, created=True, base_sha=sha)
         assert os.path.isdir(theirs), "another branch's worktree was destroyed"
         assert _branch_exists(str(repo), "feat/theirs")
         assert not _branch_exists(str(repo), "feat/ours")
@@ -529,9 +529,7 @@ class TestConcurrencySafety:
         squatter = repo.parent / "proj-wt-untouched"
         squatter.mkdir()
         (squatter / "precious.txt").write_text("do not delete")
-        _cleanup_partial(
-            str(repo), str(squatter), "feat/whatever", claimed=False, created=False
-        )
+        _cleanup_partial(str(repo), str(squatter), "feat/whatever", claimed=False, created=False)
         assert (squatter / "precious.txt").is_file()
 
     def test_cleanup_survives_a_failed_worktree_listing(self, repo):
@@ -539,9 +537,7 @@ class TestConcurrencySafety:
         ours = repo.parent / "proj-wt-ours"
         ours.mkdir()
         (ours / "marker").write_text("x")
-        with patch(
-            "kiro_crew.dashboard.handlers.worktree._worktree_branches", return_value=None
-        ):
+        with patch("kiro_crew.dashboard.handlers.worktree._worktree_branches", return_value=None):
             # created=True: the mkdir claim is what authorizes removal, not the
             # (unavailable) listing.
             _cleanup_partial(str(repo), str(ours), "feat/ours", claimed=False, created=True)
@@ -590,9 +586,7 @@ class TestConcurrencySafety:
         theirs = str(repo.parent / "proj-wt-adopted")
         assert _run_git(["worktree", "add", theirs, "feat/adopted"], str(repo)).returncode == 0
         ours = str(repo.parent / "proj-wt-ours-failed")
-        _cleanup_partial(
-            str(repo), ours, "feat/adopted", claimed=True, created=False, base_sha=sha
-        )
+        _cleanup_partial(str(repo), ours, "feat/adopted", claimed=True, created=False, base_sha=sha)
         assert _branch_exists(str(repo), "feat/adopted"), "deleted a branch in use"
         head = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], theirs)
         assert head.stdout.strip() == "feat/adopted"
@@ -602,9 +596,7 @@ class TestConcurrencySafety:
         reporting "already exists" is recoverable where a broken worktree is not."""
         sha = _resolve_commit(str(repo), "HEAD")
         assert _claim_branch(str(repo), "feat/unknown", sha) is True
-        with patch(
-            "kiro_crew.dashboard.handlers.worktree._worktree_branches", return_value=None
-        ):
+        with patch("kiro_crew.dashboard.handlers.worktree._worktree_branches", return_value=None):
             _cleanup_partial(
                 str(repo),
                 str(repo.parent / "proj-wt-unknown"),
@@ -626,9 +618,7 @@ class TestConcurrencySafety:
         assert _claim_branch(str(repo), "feat/advanced", sha) is True
         # A concurrent process advances the claimed ref (a commit pushed into it).
         wt = tmp_path / "concurrent"
-        assert _run_git(
-            ["worktree", "add", str(wt), "feat/advanced"], str(repo)
-        ).returncode == 0
+        assert _run_git(["worktree", "add", str(wt), "feat/advanced"], str(repo)).returncode == 0
         (wt / "new.txt").write_text("work someone else did\n")
         _git("add", "new.txt", cwd=wt)
         _git("-c", "user.email=a@b.c", "-c", "user.name=a", "commit", "-qm", "concurrent", cwd=wt)
@@ -643,9 +633,9 @@ class TestConcurrencySafety:
             created=False,
             base_sha=sha,
         )
-        assert _resolve_commit(str(repo), "refs/heads/feat/advanced") == advanced, (
-            "cleanup discarded commits added after the claim"
-        )
+        assert (
+            _resolve_commit(str(repo), "refs/heads/feat/advanced") == advanced
+        ), "cleanup discarded commits added after the claim"
 
     def test_cleanup_leaves_a_branch_it_did_not_claim(self, repo):
         sha = _resolve_commit(str(repo), "HEAD")
@@ -797,9 +787,7 @@ class TestCheckoutFilters:
     def test_probe_failure_fails_closed(self, repo):
         """An unreadable config scope refuses rather than assuming "no filter"."""
         failed = subprocess.CompletedProcess(args=["git"], returncode=128, stdout="", stderr="x")
-        with patch(
-            "kiro_crew.dashboard.handlers.worktree._run_git", return_value=failed
-        ):
+        with patch("kiro_crew.dashboard.handlers.worktree._run_git", return_value=failed):
             assert _checkout_filter(str(repo)) == _FILTER_PROBE_FAILED
 
     @pytest.mark.asyncio
@@ -873,9 +861,7 @@ class TestRound9Hardening:
         """Fail CLOSED: no OS isolation available means the git spawn does not run."""
         from kiro_crew.dashboard.handlers import worktree as wt
 
-        with patch.object(
-            wt, "sandboxed_spawn_argv", side_effect=RuntimeError("no backend")
-        ):
+        with patch.object(wt, "sandboxed_spawn_argv", side_effect=RuntimeError("no backend")):
             async with TestClient(TestServer(_make_app(str(repo)))) as client:
                 resp = await client.post(
                     "/api/worktree/create", json={"repo": str(repo), "branch": "feat/nosbx"}
@@ -900,8 +886,9 @@ class TestRound9Hardening:
             return list(argv), {}, None
 
         ok = subprocess.CompletedProcess(args=["git"], returncode=0, stdout="", stderr="")
-        with patch.object(wt, "sandboxed_spawn_argv", side_effect=fake_spawn), patch.object(
-            wt.subprocess, "run", return_value=ok
+        with (
+            patch.object(wt, "sandboxed_spawn_argv", side_effect=fake_spawn),
+            patch.object(wt.subprocess, "run", return_value=ok),
         ):
             wt._run_git(["--version"], os.getcwd())
         assert seen["mode"] == "strict"
@@ -924,9 +911,10 @@ class TestRound9Hardening:
             stdout="",
             stderr="sandbox: unshare(NEWNS) failed: errno 1\n",
         )
-        with patch.object(
-            wt, "sandboxed_spawn_argv", side_effect=_passthrough_spawn
-        ), patch.object(wt.subprocess, "run", return_value=denied):
+        with (
+            patch.object(wt, "sandboxed_spawn_argv", side_effect=_passthrough_spawn),
+            patch.object(wt.subprocess, "run", return_value=denied),
+        ):
             with pytest.raises(SandboxUnavailable):
                 wt._run_git(["--version"], os.getcwd())
 
@@ -938,9 +926,10 @@ class TestRound9Hardening:
         failed = subprocess.CompletedProcess(
             args=["git"], returncode=128, stdout="", stderr="fatal: not a git repository\n"
         )
-        with patch.object(
-            wt, "sandboxed_spawn_argv", side_effect=_passthrough_spawn
-        ), patch.object(wt.subprocess, "run", return_value=failed):
+        with (
+            patch.object(wt, "sandboxed_spawn_argv", side_effect=_passthrough_spawn),
+            patch.object(wt.subprocess, "run", return_value=failed),
+        ):
             proc = wt._run_git(["status"], os.getcwd())
         assert proc.returncode == 128
 
@@ -950,9 +939,10 @@ class TestRound9Hardening:
         if os.name != "posix":
             pytest.skip("NTFS rejects newlines in path components")
         dest = tmp_path / "wt\nnewline"
-        assert _run_git(
-            ["worktree", "add", str(dest), "-b", "feat/nl", "HEAD"], str(repo)
-        ).returncode == 0
+        assert (
+            _run_git(["worktree", "add", str(dest), "-b", "feat/nl", "HEAD"], str(repo)).returncode
+            == 0
+        )
         trees = _worktree_branches(str(repo))
         assert trees is not None
         assert trees.get(os.path.normcase(os.path.realpath(str(dest)))) == "feat/nl"
@@ -1165,9 +1155,7 @@ class TestLauncherAdvisoryIsNotARefusal:
 
         severities = {
             token.split()[0]
-            for token in re.findall(
-                r"sandbox: ([^'\"%\\\n]+)", _build_launcher_script("strict")
-            )
+            for token in re.findall(r"sandbox: ([^'\"%\\\n]+)", _build_launcher_script("strict"))
         }
 
         assert severities == {"unshare(NEWUSER)", "unshare(NEWNS)", "BLOCKED", "WARNING"}


### PR DESCRIPTION
## What

The `v0.4.0-insider.3` RC gate ([run 32460906500](https://github.com/kirodotdev/KiroCrew/actions/runs/32460906500/job/96707507314)) failed with 1 FAILED + 1 ERROR. Both are fixed here, on main.

### 1. FAILED: `test_min_version_gate_rejects_before_copying` (201 instead of 400) — a real product bug, not a test bug

`parse_version()` only stripped semver `-`/`+` suffixes. The PEP 440 version stamped into **every insider wheel** (`0.4.0rc3`) therefore hit `int('0rc3')` → `ValueError` — and `check_min_version()` swallows exceptions, so the min-version install gate was **silently disabled on every insider install**. An app declaring `minKiroCrewVersion: 999.0.0` installs anyway.

Main CI never sees this because main's `__version__` is bare (`0.5.0`); it only surfaces on the RC gate, which runs on the release branch where #4887 stamped `0.4.0rc3` into source. The desktop stamp (`0.4.0-insider.3`) was unaffected (the `-` split handled it).

**Fix**: parse the leading numeric release segment via regex — `0.4.0rc3`, `0.4.0-insider.3`, `1.2.0-rc.1`, `v1.2.3`, `+build` all compare by base release; garbage still raises. New `test/test_apps_version.py` pins the exact regression (gate rejects under a monkeypatched `0.4.0rc3` stamp).

### 2. ERROR: `test_worktree_create.py` `shutil.Error` on `.git/objects/maintenance.lock`

The session-scoped `_repo_template` fixture's `git commit` can spawn background auto-maintenance; its transient `maintenance.lock` races the per-test `shutil.copytree` (listed by the directory scan, gone by open). **Fix**: `gc.auto=0` + `maintenance.auto=false` in the template.

### Housekeeping
Black-baseline: 2 graduated entries pruned (`check_black_formatting.py --update-baseline`).

## Testing
- `test/test_apps_version.py` (new, 19 tests) + `test/test_apps_routes_coverage.py::TestInstallValidation` + full `test/test_worktree_create.py`: **109 passed** locally
- Full local CI lint: black gate passed, isort clean, flake8 clean, mypy 1008 files clean

**Why no screenshot:** backend-only change (version parsing + test fixture); no UI surface.

## Follow-up
After merge this must be cherry-picked to `release/0.4.0` — the fix has to be in the next RC's bytes for the RC gate to pass and for insider installs to regain the min-version gate.