### PR TITLE
fix: redact caller text once in the SEL metadata write path (#4892)

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -1473,9 +1473,12 @@ Two things computer use still shares with this module, neither of them a decisio
 ## Audit
 
 `sel.log_governance_decision` records a `governance_decision` event
-(`outcome ∈ {allowed, denied}` — the existing permit vocabulary). On-disk SEL is
-not redacted by the writer and the HMAC chain signs the bytes as written, so the
-operation / item / reason are redacted via `redact_via_context` **before** `log`.
+(`outcome ∈ {allowed, denied}` — the existing permit vocabulary). The SEL writer
+applies the baseline credential/exfiltration passes to `metadata` values and the
+free-form top-level strings (`operation` / `resources` / `error`) before
+persisting, but `redact_via_context` is broader than those passes — so the
+operation / item / reason are ALSO redacted via `redact_via_context` **before**
+`log`; the writer's pass is a second layer, not a replacement.
 
 ## CLI
 

--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -23,13 +23,13 @@ Each entry records:
 | `operation` | Tool name or `METHOD /api/path` |
 | `tool_kind` | Tool category (`execute_bash`, `fs_write`, `mcp_core`, `mcp_cron`, etc.) |
 | `outcome` | `invoked`, `auto_approved`, `approved`, `rejected`, `denied`, `completed`, `failed`, `clamped`, `degraded` (a governance chokepoint failed OPEN) |
-| `resources` | Affected resources summary (truncated to 500 chars) |
+| `resources` | Affected resources summary (redacted, then truncated to 500 chars — see `metadata`) |
 | `downstream_service` | MCP server name if applicable (`kirocrew-core`, `kirocrew-cron`, `internal-mcp`) |
 | `request_id` | ACP permission request ID |
 | `error` | Error message if failed/denied |
 | `prev_hash` | HMAC of previous entry (chain link) |
 | `entry_hash` | HMAC-SHA256 of this entry |
-| `metadata` | Additional context (approval reason, step index, etc.) |
+| `metadata` | Additional context (approval reason, step index, etc.). Free-form string values are **redacted at write time**: the writer applies `security.redact` (credential + exfiltration-URL passes) to string values at any nesting depth before the entry is hashed and persisted, so caller-supplied text (a search query, a document title) never lands a secret on disk. Keys and non-string values pass through; the caller's dict is never mutated (the writer redacts a copy). The same write-time pass covers the free-form top-level strings `operation` / `resources` / `error` (an exception message can quote a command body or URL); identity-shaped fields (`caller_identity`, `agent`, `source`, `downstream_service`, `request_id`) are constrained vocabularies and stay verbatim. Where a `log_*` helper CLIPS a field to 500 chars it redacts first and clips second: clipping first can cut a credential in half, and the surviving prefix matches no full-token grammar, so the writer's pass could not recover it. The HMAC chain signs the redacted bytes |
 
 The `config_bounds_clamped` event (`outcome=clamped`, `source=background`, `operation=config.load`, `caller_identity=config_loader`) is emitted by `config/loader.py`'s `_log_config_clamp_event` when an out-of-range security-bounded knob (`agent.subagent_auto_max` / `agent.max_subagents` / `agent.subagent_max_turns` / `session.pool_size`) is clamped to its API-enforced ceiling at load time, recording `metadata` `{file_value, clamped_to, min, max}`. Best-effort: a SEL failure never makes config loading raise.
 

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -211,6 +211,102 @@ _QUEUE_DRAIN_BATCH = 256  # max events appended per open() in the writer loop
 _FLUSH_TIMEOUT_SECS = 5.0  # bound on flush() so a stuck writer can't hang reads
 
 
+def _redact_deep(obj: object, redactor: Callable[[str], str]) -> object:
+    """Apply *redactor* to every string reachable in *obj*, copying containers.
+
+    Shared by the on-disk write path (:func:`_redacted_metadata_copy`) and the
+    forward-callback path (``_forward_event``) so the two surfaces can never
+    silently diverge in which shapes they cover. Sequences are rebuilt as plain
+    ``list``/``tuple`` (mirroring json's own array degradation) rather than via
+    ``type(obj)(...)``: a namedtuple or a subclass with a different constructor
+    signature is legal metadata today (json serializes it fine), and a
+    ``TypeError`` here would cost a whole writer batch. Keys and non-string
+    leaves pass through unchanged.
+    """
+    if isinstance(obj, str):
+        return redactor(obj)
+    if isinstance(obj, dict):
+        return {k: _redact_deep(v, redactor) for k, v in obj.items()}
+    if isinstance(obj, tuple):
+        return tuple(_redact_deep(i, redactor) for i in obj)
+    if isinstance(obj, list):
+        return [_redact_deep(i, redactor) for i in obj]
+    return obj
+
+
+# AWS access-key ids case-insensitively. The shared redactor's pattern is
+# case-SENSITIVE (a real key is upper-case, and loosening it there would
+# false-positive on ordinary prose across every egress surface). SEL callers,
+# however, log NORMALIZED text — e.g. the dashboard file-search handler
+# lowercases the query before logging it in ``resources`` — and a lowercased
+# key is trivially reversible, so the audit trail needs the case-insensitive
+# net that ordinary egress does not. Bounded on both sides so a longer
+# alphanumeric run (where extra chars change the case-restore candidates)
+# stays out of scope.
+_AWS_KEY_ANYCASE_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:AKIA|ASIA)[A-Za-z0-9]{16}(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
+
+
+def _redact_text(text: str) -> str:
+    """Apply the baseline credential/exfiltration passes to one string.
+
+    Adds a case-insensitive AWS access-key pass on top of ``security.redact``:
+    SEL callers may normalize case before logging (see ``_AWS_KEY_ANYCASE_RE``),
+    which would slip a lowercased key past the shared case-sensitive pattern.
+    """
+    # circular import: kiro_crew.security imports SecurityEvent/SecurityEventLog
+    # from this module at top level, so the redactor can only be imported
+    # lazily here (same pattern as _forward_event / log_governance_decision).
+    from kiro_crew.security import redact
+
+    return _AWS_KEY_ANYCASE_RE.sub("[REDACTED: credential]", redact(text))
+
+
+# Free-form string fields on SecurityEvent that carry caller-influenced text
+# (a tool/operation name, a resources summary, an exception message) and are
+# therefore redacted by the writer alongside metadata. The identity-shaped
+# fields (caller_identity, agent, source, downstream_service, request_id) are
+# constrained vocabularies, not caller free-text, and stay verbatim.
+_REDACTED_TEXT_FIELDS = ("operation", "resources", "error")
+
+
+def _redact_and_clip(text: str) -> str:
+    """Redact *text*, THEN clip it to ``_MAX_ARG_LEN``.
+
+    Order is the whole point. Clipping first can cut a credential in half, and
+    the surviving prefix no longer matches any credential grammar (they are all
+    anchored on a full-length token), so the writer's own pass cannot recover
+    it: a long ``resources`` line with a key straddling byte 500 would persist
+    most of that key. Redacting the FULL string first replaces the token
+    outright, and only then is the (now secret-free) text clipped.
+
+    Used by the ``log_*`` helpers, which are where the clip happens. The
+    writer's pass in ``_flush_batch`` stays as the backstop for events built by
+    constructing :class:`SecurityEvent` directly.
+    """
+    return _redact_text(text)[:_MAX_ARG_LEN]
+
+
+def _redacted_metadata_copy(metadata: dict) -> dict:
+    """Return a copy of *metadata* with credential/exfiltration text redacted.
+
+    ``metadata`` is a free-form dict whose string values often carry
+    caller-supplied text verbatim (search queries, document titles). The SEL
+    file is persisted and dashboard-readable, so a secret pasted into such a
+    field must never land on disk. String VALUES are redacted at any nesting
+    depth (dicts, lists, tuples); keys and non-string values pass through
+    unchanged.
+
+    Always builds a NEW structure: callers may reuse their metadata dict after
+    logging, so redaction must never be observable through the object they
+    passed in. May raise on a pathological value; the writer contains that
+    per event by persisting a placeholder — the raw text is never written.
+    """
+    return {k: _redact_deep(v, _redact_text) for k, v in metadata.items()}
+
+
 @dataclass
 class SecurityEvent:
     """A single auditable security event."""
@@ -391,6 +487,69 @@ class SecurityEventLog:
         from the running thread means a future inline caller cannot reintroduce
         that stall by forgetting a flag.
         """
+        # Redact caller-supplied text before the chain hash is computed, so the
+        # persisted bytes and the HMAC signature agree on the redacted form.
+        # This is the single convergence point for every CALLER-originated event
+        # (async writer, sync mode, and the critical fail-closed path all land
+        # here), so a credential pasted into a free-form field — a metadata
+        # value, an exception message in ``error``, a resources summary — never
+        # reaches disk regardless of which log_* helper recorded it. The one
+        # write that bypasses this method, the ``sel_rotation`` boundary record,
+        # carries no caller text (a generated segment name and a byte count), so
+        # it needs no pass. Covered surfaces: ``metadata`` values (any nesting
+        # depth) and the free-form top-level strings in
+        # ``_REDACTED_TEXT_FIELDS``; identity-shaped fields stay verbatim.
+        # Caller-side passes (the governance helpers'
+        # ``redact_via_context``) remain as a broader first layer. Runs outside
+        # the chain lock: regex cost must not extend the critical section that
+        # synchronous fallbacks and prune contend on. Fail-closed per event: a
+        # redaction failure replaces the offending text with a placeholder —
+        # the raw text is never persisted, and one bad value never costs the
+        # rest of the batch.
+        for event in events:
+            for field_name in _REDACTED_TEXT_FIELDS:
+                value = getattr(event, field_name)
+                if not value:
+                    continue
+                try:
+                    cleaned = _redact_text(value)
+                except Exception as exc:
+                    logger.warning(
+                        "SEL: %s redaction failed for a %s event; persisting a "
+                        "placeholder instead of the raw text",
+                        field_name,
+                        event.event_type,
+                        exc_info=True,
+                    )
+                    cleaned = f"[redaction_error: {type(exc).__name__}]"
+                if cleaned != value:
+                    logger.info(
+                        "SEL: redacted %s text in a %s event",
+                        field_name,
+                        event.event_type,
+                    )
+                    setattr(event, field_name, cleaned)
+            if not event.metadata:
+                continue
+            try:
+                redacted = _redacted_metadata_copy(event.metadata)
+            except Exception as exc:
+                logger.warning(
+                    "SEL: metadata redaction failed for a %s event; persisting "
+                    "a placeholder instead of the raw metadata",
+                    event.event_type,
+                    exc_info=True,
+                )
+                redacted = {"redaction_error": type(exc).__name__}
+            if redacted != event.metadata:
+                # Observability only — a secret reaching audit metadata signals
+                # an upstream handling defect. Keys only, never values.
+                logger.info(
+                    "SEL: redacted metadata value(s) in a %s event (keys: %s)",
+                    event.event_type,
+                    list(event.metadata),
+                )
+            event.metadata = redacted
         callback: Callable[[dict], None] | None
         with self._lock:
             try:
@@ -578,16 +737,7 @@ class SecurityEventLog:
             # only be imported lazily here.
             from kiro_crew.security import redact
 
-            def _redact_deep(obj: object) -> object:
-                if isinstance(obj, str):
-                    return redact(obj)
-                if isinstance(obj, dict):
-                    return {k: _redact_deep(v) for k, v in obj.items()}
-                if isinstance(obj, (list, tuple)):
-                    return type(obj)(_redact_deep(i) for i in obj)
-                return obj
-
-            callback(_redact_deep(asdict(event)))  # type: ignore[arg-type]
+            callback(_redact_deep(asdict(event), redact))  # type: ignore[arg-type]
         except Exception:
             logger.warning("forward_callback failed", exc_info=True)
 
@@ -1564,8 +1714,8 @@ class SecurityEventLog:
                 outcome=outcome,
                 request_id=str(request_id),
                 downstream_service=downstream_service,
-                resources=resources[:_MAX_ARG_LEN] if resources else "",
-                error=error[:_MAX_ARG_LEN] if error else "",
+                resources=_redact_and_clip(resources) if resources else "",
+                error=_redact_and_clip(error) if error else "",
                 metadata=metadata or {},
             ),
             critical=critical,
@@ -1592,11 +1742,14 @@ class SecurityEventLog:
         codebase).  ``scope``/``item``/``rule``/``layer`` go in ``metadata`` for
         ``policy explain`` and forensic queries.
 
-        On-disk SEL records are NOT redacted by the writer, and the persisted
-        HMAC chain signs the bytes as-written, so the operation/resources/reason
-        are redacted HERE (before ``log``) via ``redact_via_context`` — a command
-        body or path that tripped governance must not leak a credential into the
-        audit log.
+        The writer applies the baseline credential/exfiltration passes to
+        ``operation``/``resources``/``error`` and metadata values before
+        persisting, but ``redact_via_context`` is broader (a loaded
+        companion's extra regexes apply) — so ``operation``/``item``/``reason``
+        are ALSO redacted HERE (before ``log``): a command body or path that
+        tripped governance must not leak anything the broader pass would have
+        caught. The writer's narrower pass is a second layer, not a
+        replacement.
 
         Pass ``critical=True`` when the caller enforces "audit-or-deny" for a
         GOVERNED decision (e.g. a governed transport-start allow): the event is
@@ -1622,14 +1775,14 @@ class SecurityEventLog:
                 caller_identity=session_key,
                 agent=agent,
                 source=_infer_source(session_key),
-                operation=safe_operation[:_MAX_ARG_LEN],
+                operation=_redact_and_clip(safe_operation),
                 outcome=outcome,
-                resources=safe_item[:_MAX_ARG_LEN],
+                resources=_redact_and_clip(safe_item),
                 metadata={
                     "scope": scope,
                     "rule": rule,
                     "layer": layer,
-                    "reason": safe_reason[:_MAX_ARG_LEN],
+                    "reason": _redact_and_clip(safe_reason),
                 },
             ),
             critical=critical,
@@ -1674,13 +1827,13 @@ class SecurityEventLog:
                 caller_identity=session_key,
                 agent="kirocrew",
                 source=_infer_source(session_key),
-                operation=chokepoint[:_MAX_ARG_LEN],
+                operation=_redact_and_clip(chokepoint),
                 outcome="blocked" if failed_closed else "degraded",
                 resources="",
                 metadata={
                     "scope": scope,
                     "app": app,
-                    "reason": safe_reason[:_MAX_ARG_LEN],
+                    "reason": _redact_and_clip(safe_reason),
                     "disposition": "failed_closed" if failed_closed else "failed_open",
                 },
             ),
@@ -1714,8 +1867,8 @@ class SecurityEventLog:
                 source=source,
                 operation=operation,
                 outcome=outcome,
-                resources=resources[:_MAX_ARG_LEN] if resources else "",
-                error=error[:_MAX_ARG_LEN] if error else "",
+                resources=_redact_and_clip(resources) if resources else "",
+                error=_redact_and_clip(error) if error else "",
             ),
             critical=critical,
         )

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -3403,3 +3403,295 @@ class TestTimeWindowRead:
         log = SecurityEventLog(base_dir=sel_dir, sync=True)
         _fill(log, 5)
         assert log.recent(limit=0) == []
+
+
+def _shutdown_writer(log: SecurityEventLog) -> None:
+    """Deterministically stop *log*'s background writer inside the test.
+
+    An async SecurityEventLog binds its directory into a daemon writer thread;
+    without an explicit shutdown the thread outlives the test while holding a
+    reference to a deleted per-test tmp_path. Flush, send the shutdown
+    sentinel, and join so nothing survives teardown.
+    """
+    log.flush()
+    log._queue.put(None)
+    writer = log._writer
+    if writer is not None:
+        writer.join(timeout=5)
+
+
+class TestMetadataRedaction:
+    """The writer redacts caller-supplied metadata values before persistence.
+
+    The acceptance is "never reaches disk": every assertion here reads the raw
+    on-disk JSONL back, not a mock. The token is assembled from parts so this
+    test file itself never contains a credential-shaped literal.
+    """
+
+    AKIA_TOKEN = "AKIA" + "IOSFODNN7EXAMPLE"
+    EXFIL_URL = "https://attacker.example/upload/" + "AKIA" + "IOSFODNN7EXAMPLE"
+
+    def _disk_text(self, sel_dir: Path) -> str:
+        return (sel_dir / "security_events.jsonl").read_text(encoding="utf-8")
+
+    def test_credential_in_metadata_never_reaches_disk(self, log, sel_dir):
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="discover_skills",
+            outcome="success",
+            metadata={"query": f"find {self.AKIA_TOKEN} docs", "result_count": "3"},
+        )
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        data = json.loads(raw.strip())
+        assert "[REDACTED: credential]" in data["metadata"]["query"]
+        # Non-secret values pass through untouched.
+        assert data["metadata"]["result_count"] == "3"
+
+    def test_exfiltration_url_in_metadata_never_reaches_disk(self, log, sel_dir):
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="discover_mcp_servers",
+            outcome="success",
+            metadata={"query": self.EXFIL_URL},
+        )
+        raw = self._disk_text(sel_dir)
+        assert self.EXFIL_URL not in raw
+        assert self.AKIA_TOKEN not in raw
+
+    def test_nested_metadata_values_are_redacted(self, log, sel_dir):
+        log.log(_make_event(
+            event_id="nested1",
+            metadata={
+                "outer": {"inner": self.AKIA_TOKEN},
+                "items": [self.AKIA_TOKEN, 7, None],
+            },
+        ))
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        data = json.loads(raw.strip())
+        # Keys and non-string values are untouched.
+        assert "outer" in data["metadata"] and "inner" in data["metadata"]["outer"]
+        assert data["metadata"]["items"][1] == 7
+        assert data["metadata"]["items"][2] is None
+
+    def test_caller_metadata_dict_is_not_mutated(self, log):
+        caller_metadata = {"query": self.AKIA_TOKEN, "nested": {"k": self.AKIA_TOKEN}}
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="discover_skills",
+            outcome="success",
+            metadata=caller_metadata,
+        )
+        assert caller_metadata["query"] == self.AKIA_TOKEN
+        assert caller_metadata["nested"]["k"] == self.AKIA_TOKEN
+
+    def test_redacted_events_chain_verifies(self, log):
+        """The HMAC chain signs the redacted bytes, so verify stays green."""
+        for i in range(3):
+            log.log(_make_event(
+                event_id=f"chain{i}",
+                metadata={"query": f"{self.AKIA_TOKEN} #{i}"},
+            ))
+        total, valid = log.verify_integrity()
+        assert total == 3
+        assert valid == 3
+
+    def test_async_writer_path_redacts(self, tmp_path: Path) -> None:
+        """The production background-writer path redacts too, not just sync."""
+        log = SecurityEventLog(base_dir=tmp_path)  # async (default)
+        try:
+            log.log_tool_invocation(
+                session_key="dashboard:slot1",
+                tool_name="discover_skills",
+                outcome="success",
+                metadata={"query": self.AKIA_TOKEN},
+            )
+            log.flush()
+            raw = (tmp_path / "security_events.jsonl").read_text(encoding="utf-8")
+            assert self.AKIA_TOKEN not in raw
+        finally:
+            _shutdown_writer(log)
+
+    def test_events_without_metadata_are_untouched(self, log, sel_dir):
+        log.log(_make_event(event_id="plain1"))
+        data = json.loads(self._disk_text(sel_dir).strip())
+        assert data["metadata"] == {}
+
+    def test_namedtuple_metadata_value_does_not_cost_the_event(self, log, sel_dir):
+        """A sequence subclass with a different constructor (json-legal today)
+        must not raise out of the walker; it degrades to a plain array."""
+        from collections import namedtuple
+
+        point = namedtuple("point", ["x", "y"])
+        log.log(_make_event(
+            event_id="nt1",
+            metadata={"pos": point(self.AKIA_TOKEN, 2)},
+        ))
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        data = json.loads(raw.strip())
+        assert data["metadata"]["pos"][1] == 2
+
+    def test_redaction_failure_persists_placeholder_not_raw(self, log, sel_dir):
+        """Fail-closed containment: if the redactor raises, the event lands
+        with placeholder metadata and the raw text never reaches disk."""
+        with patch(
+            "kiro_crew.sel._redacted_metadata_copy",
+            side_effect=RuntimeError("simulated redactor failure"),
+        ):
+            log.log(_make_event(
+                event_id="rf1",
+                metadata={"query": self.AKIA_TOKEN},
+            ))
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        data = json.loads(raw.strip())
+        assert data["metadata"] == {"redaction_error": "RuntimeError"}
+
+    def test_redaction_failure_does_not_drop_batch_siblings(self, tmp_path: Path) -> None:
+        """One pathological metadata value must not cost unrelated events
+        queued in the same writer batch."""
+        log = SecurityEventLog(base_dir=tmp_path)  # async: events batch together
+
+        def _flaky(metadata: dict) -> dict:
+            if "poison" in metadata:
+                raise RuntimeError("simulated redactor failure")
+            return {k: v for k, v in metadata.items()}
+
+        try:
+            with patch("kiro_crew.sel._redacted_metadata_copy", side_effect=_flaky):
+                log.log(_make_event(event_id="ok1", metadata={"query": "fine"}))
+                log.log(_make_event(event_id="bad1", metadata={"poison": "x"}))
+                log.log(_make_event(event_id="ok2", metadata={"query": "also fine"}))
+                log.flush()
+        finally:
+            _shutdown_writer(log)
+        lines = (tmp_path / "security_events.jsonl").read_text(encoding="utf-8").splitlines()
+        ids = [json.loads(ln)["event_id"] for ln in lines if ln.strip()]
+        assert ids == ["ok1", "bad1", "ok2"]
+
+    def test_forward_callback_uses_shared_walker_on_namedtuple(self, log):
+        """The forward path shares the walker, so a namedtuple degrades to a
+        plain array there too instead of raising."""
+        from collections import namedtuple
+
+        received: list[dict] = []
+        log.set_forward_callback(received.append)
+        point = namedtuple("point", ["x", "y"])
+        log.log(_make_event(event_id="fw1", metadata={"pos": point(self.AKIA_TOKEN, 2)}))
+        assert len(received) == 1
+        assert received[0]["metadata"]["pos"][1] == 2
+        assert self.AKIA_TOKEN not in json.dumps(received[0])
+
+    def test_error_and_resources_fields_never_reach_disk_raw(self, log, sel_dir):
+        """Top-level free-form strings get the same write-time pass: an
+        exception message quoting a credential must not persist raw."""
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="execute_bash",
+            outcome="failed",
+            resources=f"curl -H 'X-Key: {self.AKIA_TOKEN}'",
+            error=f"RuntimeError: auth failed for {self.AKIA_TOKEN}",
+        )
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        data = json.loads(raw.strip())
+        assert "[REDACTED: credential]" in data["resources"]
+        assert "[REDACTED: credential]" in data["error"]
+        # The plain parts of the strings survive.
+        assert data["error"].startswith("RuntimeError: auth failed for ")
+
+    def test_identity_fields_stay_verbatim(self, log, sel_dir):
+        """Identity-shaped fields are constrained vocabularies, not free text —
+        the writer must not rewrite them."""
+        log.log(_make_event(
+            event_id="ident1",
+            caller_identity="dashboard:slot-AKIA-not-a-key",
+            downstream_service="kirocrew-core",
+        ))
+        data = json.loads(self._disk_text(sel_dir).strip())
+        assert data["caller_identity"] == "dashboard:slot-AKIA-not-a-key"
+        assert data["downstream_service"] == "kirocrew-core"
+
+    def test_lowercased_aws_key_never_reaches_disk(self, log, sel_dir):
+        """SEL callers may normalize case before logging (the file-search
+        handler lowercases its query); a lowercased key is trivially
+        reversible, so the write-time pass must catch it case-insensitively."""
+        lowered = self.AKIA_TOKEN.lower()
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="file_search",
+            outcome="allowed",
+            resources=f"q={lowered} kinds=all",
+            metadata={"query": lowered},
+        )
+        raw = self._disk_text(sel_dir)
+        assert lowered not in raw
+        data = json.loads(raw.strip())
+        assert "[REDACTED: credential]" in data["resources"]
+        assert "[REDACTED: credential]" in data["metadata"]["query"]
+
+    def test_anycase_pass_leaves_ordinary_words_alone(self, log, sel_dir):
+        """The case-insensitive net is bounded: prose containing 'akia' or
+        'asia' inside longer tokens must not be rewritten."""
+        text = "asian markets akiary search results for East Asia region"
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="file_search",
+            outcome="allowed",
+            resources=text,
+            metadata={"query": text},
+        )
+        data = json.loads(self._disk_text(sel_dir).strip())
+        assert data["resources"] == text
+        assert data["metadata"]["query"] == text
+
+    def test_credential_straddling_the_truncation_boundary_is_gone(self, log, sel_dir):
+        """The log_* helpers clip free-form text to _MAX_ARG_LEN. Clipping FIRST
+        would cut a credential in half and leave a prefix that no full-token
+        grammar matches, so redaction must run on the whole string BEFORE the
+        clip. Place the key so the clip lands mid-token."""
+        from kiro_crew.sel import _MAX_ARG_LEN
+
+        # Key starts 10 chars before the clip point, so a clip-first order would
+        # keep its first 10 characters and drop the rest.
+        prefix = "q=" + ("x" * (_MAX_ARG_LEN - 12))
+        resources = prefix + self.AKIA_TOKEN + " kinds=all"
+        assert len(prefix) < _MAX_ARG_LEN < len(prefix) + len(self.AKIA_TOKEN)
+        log.log_tool_invocation(
+            session_key="dashboard:slot1",
+            tool_name="file_search",
+            outcome="allowed",
+            resources=resources,
+            error=resources,
+        )
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        # No partial prefix of the key survives either.
+        assert self.AKIA_TOKEN[:10] not in raw
+        data = json.loads(raw.strip())
+        # The replacement marker is longer than the token it replaces, so the
+        # clip can cut the MARKER — harmless, and proof the order is right: a
+        # marker fragment sits where the credential's first characters would be
+        # under a clip-first order.
+        assert "[REDACTED" in data["resources"]
+        assert "[REDACTED" in data["error"]
+        # The clip is still enforced.
+        assert len(data["resources"]) <= _MAX_ARG_LEN
+        assert len(data["error"]) <= _MAX_ARG_LEN
+
+    def test_api_access_helper_also_redacts_before_clipping(self, log, sel_dir):
+        from kiro_crew.sel import _MAX_ARG_LEN
+
+        prefix = "path=" + ("y" * (_MAX_ARG_LEN - 15))
+        log.log_api_access(
+            caller="token:abc",
+            operation="GET /api/file-search",
+            outcome="allowed",
+            resources=prefix + self.AKIA_TOKEN,
+        )
+        raw = self._disk_text(sel_dir)
+        assert self.AKIA_TOKEN not in raw
+        assert self.AKIA_TOKEN[:10] not in raw
+        assert len(json.loads(raw.strip())["resources"]) <= _MAX_ARG_LEN


### PR DESCRIPTION
## Problem / Motivation

Caller-supplied free-form text was persisted verbatim into `SecurityEvent.metadata` in the SEL audit trail (`security_events.jsonl`), which the dashboard can read. A credential pasted into a search box landed on disk in cleartext: `dashboard/handlers/discover.py` and `dashboard/handlers/mcp_discover.py` pass `metadata={"query": query, ...}` to `log_tool_invocation` unredacted, and `mcp_tools/knowledge.py`'s `local_knowledge_search` does the same. Prior work redacted individual call sites one at a time (`audit_title` in `knowledge.py`); the two dashboard handlers were the next known siblings of the class.

## Why it matters

The SEL is a persisted, HMAC-signed, dashboard-readable file with a 365-day retention default. A secret that lands there stays there — and per-site redaction guarantees the *next* `log_*` caller reintroduces the leak. The class needs exactly one spelling of the rule.

## What changed (motivation → approach → change)

Symptom: raw caller text on disk. Root cause: redaction was the caller's job, at ~475 `log_tool_invocation(` call sites plus sibling helpers. Fix: redact once at the single point every event's metadata converges.

- **Chokepoint chosen: `_flush_batch` in `src/kiro_crew/sel.py`** — the one write path shared by the async background writer, `sync=True` mode, and the `critical=True` fail-closed path (`prune` only rewrites already-redacted lines). Redacting only inside `log_tool_invocation` would have left the sibling `log_*` helpers uncovered. Redaction runs *before* the entry hash is computed, so the HMAC chain signs the redacted bytes as-written, and *outside* the chain lock (regex cost stays off the critical section; on the async path it runs in the writer thread, off the request path).
- **Circular import resolved by deferred import.** `security.py:33` imports `SecurityEvent`/`SecurityEventLog` from `sel.py` at module scope, so `sel.py` imports `security.redact` lazily inside the redaction helper — the same documented pattern `_forward_event` and `log_governance_decision` already use (the `top-level-imports` rule's circular-import exemption, with the comment). Moving the redactors to a leaf module was rejected: they are woven into `security.py`'s regex/exemption stack and extracting them is a large refactor this fix does not need. Proven with cold `import kiro_crew.dashboard.server` (and both import orders) in fresh interpreters, not only unit tests.
- **Coverage:** metadata string *values* at any nesting depth, plus the free-form top-level strings `operation` / `resources` / `error` (an exception message can quote a command body or URL — the same secret through a different field). Identity-shaped fields (`caller_identity`, `agent`, `source`, `downstream_service`, `request_id`) are constrained vocabularies and stay verbatim. For metadata: keys and non-string values untouched; the caller's dict is never mutated (the writer redacts a copy — a caller that reuses its metadata dict never observes the redaction). Sequences rebuild as plain `list`/`tuple` (a namedtuple is json-legal metadata today and must not raise). Fail-closed per event: if the redactor itself raises, that event persists with placeholder metadata (`{"redaction_error": ...}`) — the raw text is never written and one bad value never costs the rest of a writer batch. A rewrite logs keys-only observability (a secret reaching audit metadata signals an upstream defect). The walker is shared with `_forward_event` so the disk path and the forward-callback path cannot silently diverge.
- **One supplemental grammar, declared:** `_redact_text` layers a bounded case-insensitive AWS access-key pass (`(?:AKIA|ASIA)[A-Za-z0-9]{16}`, alnum-bounded) on top of `security.redact`. It exists because a SEL caller demonstrably normalizes case before logging — `dashboard/handlers/files.py:2272` lowercases the file-search query and then logs it in `resources` — and the shared pattern in `security.py` is deliberately case-sensitive (loosening it there would false-positive on ordinary prose across every egress surface). It lives in the SEL layer, not the shared redactor, for exactly that reason. The alternative of making the handler log the un-normalized query is narrower but leaves the writer trusting ~475 call sites to never normalize, which is the per-site model this PR retires; a follow-up can still do it as defence in depth.
- **No event-schema, HMAC-chain, `_MAX_ARG_LEN`, or `critical=True` semantics changes.** No config flag; one rule, always on. The two dashboard handler sites needed no edits — the chokepoint covers them.

**Per-site redaction copies removed or justified:**
- `knowledge.py` `audit_title` — **retained**: it also feeds the user-facing return string (`"Added {audit_title!r} to the knowledge library …"`, rendered into chat and persisted in the transcript), a surface the SEL chokepoint does not cover. Removing it would silently unredact a user-visible string.
- `knowledge.py` `audit_query` — does not exist on `main`; the raw `query` in `local_knowledge_search` metadata is now covered by the chokepoint. (The `redact_*` calls on `output` at the ends of `local_knowledge_search`/`knowledge_dedup` are LLM-output-surface redaction required by `backend-security-controls`, not audit copies — untouched.)
- `log_governance_decision`'s `redact_via_context` on `operation`/`item`/`reason` — **retained**: `operation`/`item` are top-level fields outside the metadata chokepoint, and `redact_via_context` is broader (a loaded companion's extra regexes apply); the writer's pass is a second layer, not a replacement. Docstrings and `docs/system-specs/modules/governance.md` updated to state the current split.

Docs updated in the same commit: `docs/system-specs/modules/sel.md` (metadata row) and `docs/system-specs/modules/governance.md` (the stale "not redacted by the writer" sister sentence).

## Tests

`test/test_sel.py::TestMetadataRedaction` (13 tests, all asserting on the on-disk JSONL, not mocks — the issue's acceptance is "never reaches disk"):
- an `AKIA…`-shaped token in metadata never reaches disk (sync path) — **fail-before verified** against the unfixed `sel.py`
- an exfiltration-shaped URL in metadata never reaches disk
- nested dict/list values are redacted; keys and non-string values pass through — **fail-before verified**
- the caller's metadata dict is not mutated — locks the copy-not-mutate contract
- the HMAC chain verifies over the redacted bytes (`verify_integrity` green)
- the production async-writer path redacts too (not just `sync=True`)
- events without metadata are byte-identical in behavior
- a namedtuple metadata value degrades to a plain array instead of raising
- a redactor failure persists placeholder metadata, never the raw text
- one poisoned event does not cost its batch siblings (async batch of 3)
- the forward-callback path shares the walker (namedtuple safe there too)
- a credential in `error=` / `resources=` never reaches disk; the plain parts of the strings survive
- identity-shaped fields stay verbatim (no over-redaction)

Repo-wide: full backend suite run twice (before and after review fixes): 59,354 passed; the only failures are 5 environment-only tests (terminal PTY WS, history sidecar mtime, peak-RSS shim) that reproduce identically on pristine `main` on this host. isort / flake8 / mypy / baselined-black / docs-lint all exit 0.

## Manual verification

Cold-process proof beyond unit tests: fresh interpreters ran `import kiro_crew.sel; import kiro_crew.security`, the reverse order, and `import kiro_crew.dashboard.server` (no cycle), plus an end-to-end cold-process log of a credential-bearing query verified redacted on disk.

## Related Issues

Closes #4892

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (SEL writer + tests + docs); no frontend files touched, no rendered delta.


