### PR TITLE
fix(windows): stop a channel uninstall orphaning the other's shortcuts and the gateway tree

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -45,7 +45,15 @@ Current status:
   elevated install under Program Files instead. The per-user default is what
   keeps a nightly install (`KiroCrew Nightly`) side by side with a stable one
   rather than replacing it; nightly additionally pins its own `nsis.guid` so
-  the two channels do not share an uninstall registry key. Either mode leaves
+  the two channels do not share an uninstall registry key, and its own
+  `win.appId` so they do not share a shortcut **AppUserModelID**. That last one
+  is Windows-only on purpose: the shared `appId` is required on macOS, where
+  Squirrel.Mac validates an update against the host's designated requirement,
+  but on Windows it reaches `${APP_ID}`, which the NSIS uninstaller passes to
+  `WinShell::UninstAppUserModelId`. Shared, uninstalling one channel
+  deregisters the identity the *other* channel's desktop and Start Menu
+  shortcuts still carry, and the shell then reports that app as relocated or
+  missing even though its `.exe` is untouched. Either mode leaves
   the Kiro Crew home alone (`deleteAppDataOnUninstall` stays false, and
   `~/.kiro/crew` is outside the install directory).
 - **Guided Kiro Crew artwork** — the welcome and finish pages use the existing

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -562,6 +562,30 @@ log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
       # changing it later orphans installed updaters, so it is pinned from the
       # first shipped build.
       "-c.nsis.guid=0f417bf9-2759-51d6-acfb-f864805d1f41"
+      # WINDOWS-ONLY appId split. The shared appId above is required on macOS
+      # (Squirrel.Mac validates against the host's designated requirement, which
+      # pins the bundle id), but on Windows it reaches ${APP_ID}, which the NSIS
+      # template uses for two registrations that are global per-id rather than
+      # per-install: WinShell::SetLnkAUMI stamps the AppUserModelID onto the
+      # desktop and Start Menu shortcuts, and WinShell::UninstAppUserModelId
+      # removes that registration outright.
+      #
+      # The update path is safe on its own: nsis.allowToChangeInstallationDirectory
+      # is false, so that define is never emitted, setIsTryToKeepShortcuts always
+      # yields "true", and the old uninstaller runs with --keep-shortcuts, which
+      # skips the deregistration. A real UNINSTALL does not. Uninstall one
+      # channel and WinShell::UninstAppUserModelId runs against the id BOTH
+      # channels share, deregistering the AppUserModelID the surviving channel's
+      # shortcuts still carry -- its desktop shortcut then resolves to a dead
+      # registration and the shell reports that app as relocated or missing even
+      # though its .exe is untouched.
+      #
+      # Scoped to `win` deliberately: appInfo.id prefers the platform-specific
+      # value, so a top-level -c.appId would also move the macOS bundle id and
+      # strand every installed mac app's updates. This is the same identity
+      # main.js already claims at runtime via app.setAppUserModelId, so the
+      # packaged shortcuts and the running process finally agree.
+      "-c.win.appId=com.amazon.kiro.crew.nightly"
     )
   fi
   # Start from a pristine output dir. A prior interrupted universal build can

--- a/website/electron/gateway-stop.js
+++ b/website/electron/gateway-stop.js
@@ -198,13 +198,36 @@ function postShutdown({
 /**
  * Stop the gateway child gracefully and await its exit.
  *   1. POST /api/shutdown (clean flush + self-exit)
- *   2. SIGTERM if the endpoint didn't take (older gateway / unreachable)
- *   3. SIGKILL if it still hasn't exited within timeoutMs
+ *   2. the endpoint didn't take (older gateway / unreachable / wedged loop):
+ *      - POSIX:   SIGTERM, then SIGKILL if it still hasn't exited by timeoutMs
+ *      - Windows: a TREE kill (see below) — there is no step 3 to escalate to
  * Resolves once the process is fully gone — callers (quit / auto-update) rely
  * on the exit having completed before proceeding.
  *
+ * WHY WINDOWS TAKES A DIFFERENT STEP 2. The POSIX escalation assumes signals:
+ * SIGTERM reaches the gateway's own handler, which flushes sessions, memory and
+ * cron and reaps its kiro-cli / MCP / app-server children before exiting, and
+ * SIGKILL is a genuinely stronger follow-up for a child that ignored it. Neither
+ * holds on Windows: Node maps BOTH signal names onto TerminateProcess, so no
+ * handler runs, nothing is flushed, and the SIGKILL step is unreachable because
+ * the SIGTERM already hard-terminated the pid. What survives is every
+ * DESCENDANT, reparented and still holding the data home's locks and the same
+ * .local_secret — and because the port frees, the caller's verification reports
+ * success while those orphans race the replacement gateway. Windows has no
+ * process group a single kill can reach, so the tree kill (`taskkill /T /F`) is
+ * the only correct step-2 there. This mirrors the backend, which routes its own
+ * stop path through platform_compat.kill_process_tree for exactly this reason.
+ *
  * @param {import("child_process").ChildProcess} proc
  * @param {object} opts
+ * @param {string} [opts.platform] process.platform override (tests)
+ * @param {(pid:number) => Promise<void>} [opts.killTreeFn] tree-kill used on
+ *   win32. Injected because the real one shells out to taskkill. The single-pid
+ *   kill is the floor: a caller that supplies none keeps it, and a tree kill that
+ *   rejects degrades to it. The caller MUST bound the tree kill's own timeouts to
+ *   fit inside this function's deadline — it is awaited, never pre-empted, since
+ *   cutting it short would kill the parent alone and orphan the very descendants
+ *   it exists to reap.
  * @returns {Promise<void>}
  */
 async function stopGatewayGracefully(
@@ -218,27 +241,83 @@ async function stopGatewayGracefully(
     httpMod,
     fsMod,
     pathMod,
+    platform = process.platform,
+    killTreeFn = null,
   } = {}
 ) {
   if (!proc || proc.exitCode !== null) return;
+  const useTreeKill = platform === "win32" && typeof killTreeFn === "function";
+  // In-flight tree kill, awaited before this function reports the gateway gone.
+  // taskkill /T terminates the PARENT first and then walks the rest of the tree, so
+  // the process 'exit' event fires while descendants are still being reaped —
+  // resolving on that alone would hand the auto-update caller a green light
+  // mid-sweep and let it swap the app's files with children still live on the data
+  // home's locks. Tracked outside the executor so the await below can see it.
+  let treeKillInFlight = null;
   await new Promise((resolve) => {
     let settled = false;
     const done = () => { if (!settled) { settled = true; resolve(); } };
     proc.once("exit", done);
     if (proc.exitCode !== null) return done();
-    // Send SIGKILL at timeoutMs but DON'T resolve here — wait for the real
-    // 'exit' so callers are guaranteed the process is gone (and signalCode is
-    // accurate). A hard safety net resolves even if 'exit' never fires.
+    // Kill with the widest scope available; the single-pid kill is the floor.
+    //
+    // The tree kill is allowed to run to completion rather than being pre-empted
+    // on a timer: cutting it short would kill the PARENT alone and orphan exactly
+    // the descendants it exists to reap, which is the bug, not a mitigation. What
+    // keeps that safe is the CALLER passing timeouts whose sum fits inside this
+    // function's deadline (see main.js) — otherwise the hard timer would resolve
+    // while the kill was still in flight and the auto-update caller would swap the
+    // app's files underneath a live gateway.
+    //
+    // A REJECTION still falls back to the single-pid kill. windowsTaskkill fails
+    // closed by design when its identity probe cannot run or the pid was recycled,
+    // and a swallowed rejection would leave no kill attempted at all — strictly
+    // worse than what it replaced. Losing the descendants is a leak; losing the
+    // parent as well is corruption, so the floor is unconditional.
+    const killWith = (signal) => {
+      const killPid = () => {
+        if (proc.exitCode === null) { try { proc.kill(signal); } catch {} }
+      };
+      if (!useTreeKill) { killPid(); return; }
+      treeKillInFlight = killTreeFn(proc.pid).catch(killPid);
+    };
+    // Escalate at timeoutMs but DON'T resolve here — wait for the real 'exit' so
+    // callers are guaranteed the process is gone (and signalCode is accurate). A
+    // hard safety net resolves even if 'exit' never fires.
     const killTimer = setTimeout(() => {
-      if (proc.exitCode === null) { try { proc.kill("SIGKILL"); } catch {} }
+      if (proc.exitCode === null) {
+        // On Windows the first kill was already terminal, so the only thing left
+        // to add is SCOPE: sweep the tree in case descendants outlived it.
+        killWith("SIGKILL");
+      }
     }, timeoutMs);
     const hardTimer = setTimeout(done, timeoutMs + 3000);
     proc.once("exit", () => { clearTimeout(killTimer); clearTimeout(hardTimer); });
-    // Prefer the clean endpoint; signal-nudge only if it didn't take.
+    // Prefer the clean endpoint; kill only if it didn't take.
     postShutdownFn({ backendUrl, kirocrewHome, secrets, httpMod, fsMod, pathMod }).then((ok) => {
-      if (!ok && proc.exitCode === null) { try { proc.kill("SIGTERM"); } catch {} }
+      if (ok || proc.exitCode !== null) return;
+      killWith("SIGTERM");
     });
   });
+  // The parent is gone (or the deadline expired). Now let the tree sweep finish, so
+  // "the gateway is stopped" covers its descendants too -- taskkill /T kills the
+  // parent FIRST, so the 'exit' above fires mid-sweep.
+  //
+  // Bounded, not open-ended: a tree kill that never settles (a wedged probe, a
+  // hung taskkill) must not hold the caller forever, because every caller of this
+  // function is on a shutdown path with somewhere to be. The caller sizes the tree
+  // kill's own timeouts to fit inside timeoutMs (see main.js), so in practice this
+  // adds only the sweep's remaining tail; the race is the backstop for when that
+  // sizing is wrong.
+  if (treeKillInFlight) {
+    await Promise.race([
+      treeKillInFlight,
+      new Promise((r) => {
+        const t = setTimeout(r, timeoutMs);
+        if (typeof t.unref === "function") t.unref();
+      }),
+    ]);
+  }
 }
 
 /**

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -971,7 +971,13 @@ function spawnGateway(resolve) {
         });
         child.on("exit", (code, signal) => {
           glog(`gateway child exited code=${code} signal=${signal}`);
-          if (signal === "SIGKILL") {
+          // macOS only. The hint is the right first thing to say there, but on
+          // Windows this signalCode is produced by OUR OWN teardown -- Node maps
+          // both .kill("SIGTERM") and .kill("SIGKILL") onto TerminateProcess --
+          // so an ungated hint prints a mac remedy on every wedge recovery and
+          // every fallback stop, in the very log the unrecoverable-gateway dialog
+          // tells the user to read.
+          if (signal === "SIGKILL" && IS_MAC) {
             glog("HINT: SIGKILL on a freshly-spawned bundled binary almost always means macOS Gatekeeper blocked an unsigned/quarantined nested executable. On the recipient's Mac run: xattr -cr <path to KiroCrew.app>");
           }
           // Only the CURRENT child may mutate the shared state. A stale child's
@@ -991,9 +997,11 @@ function spawnGateway(resolve) {
 }
 
 /**
- * Gracefully stop the embedded gateway and await its exit (POST /api/shutdown
- * -> SIGTERM -> SIGKILL). Core logic lives in gateway-stop.js for testability;
- * this thin wrapper binds the module-level child process + config.
+ * Gracefully stop the embedded gateway and await its exit: POST /api/shutdown,
+ * then on POSIX SIGTERM -> SIGKILL, and on Windows a tree kill (no real signals
+ * there, so the escalation is scope rather than force — see gateway-stop.js).
+ * Core logic lives in gateway-stop.js for testability; this thin wrapper binds
+ * the module-level child process + config.
  *
  * Uses call-time home resolution (secretCandidates) rather than the boot-time
  * KIROCREW_HOME pin, so a KIROCREW_HOME change between boot and shutdown is
@@ -1020,8 +1028,81 @@ async function stopGatewayGracefully({ timeoutMs = 15000 } = {}) {
     kirocrewHome,
     secrets,
     timeoutMs,
+    // Windows fallback scope: when /api/shutdown does not take, a single-pid kill
+    // frees the port but leaves the gateway's detached kiro-cli / MCP / app-server
+    // children alive and reparented, holding the data home's locks. Windows has no
+    // process group to signal, so the tree kill is the only way to take them with
+    // the parent. Gated on the same identity check the port sweep uses, so a
+    // recycled pid is refused rather than killed.
+    //
+    // TIMEOUTS ARE PINNED, not defaulted. windowsTaskkill's defaults are sized for
+    // the interactive port sweep (8s PowerShell + 5s WMIC + 10s taskkill = 23s),
+    // which exceeds stopGatewayGracefully's own deadline of timeoutMs + 3000. The
+    // tree kill is awaited rather than pre-empted -- cutting it short would kill
+    // the parent alone and orphan the tree -- so it is the BUDGET that has to fit:
+    // 3+2+5 = 10s, comfortably inside 18s, and still generous for probes that
+    // normally answer in well under a second.
+    killTreeFn: killGatewayTreeOnWindowsBounded,
   });
   gatewayProcess = null;
+}
+
+/**
+ * Tree-kill the gateway pid on Windows for the SHUTDOWN path only, with the
+ * timeouts that path's deadline can afford.
+ *
+ * windowsTaskkill's DEFAULTS (8s PowerShell + 5s WMIC + 10s taskkill = 23s) suit
+ * a caller with no deadline, but exceed stopGatewayGracefully's own
+ * timeoutMs + 3000. The kill is awaited rather than pre-empted — cutting it short
+ * would kill the parent alone and orphan the very descendants it exists to reap —
+ * so the BUDGET is what has to fit: 3+2+5 = 10s, inside 18s, and still generous
+ * for probes that normally answer in well under a second.
+ *
+ * Do NOT reuse this anywhere without such a deadline: shorter probe timeouts only
+ * make an early fallback to the parent-only kill MORE likely, which is the outcome
+ * the tree kill exists to prevent. Unbounded callers use
+ * killGatewayProcessTree().
+ */
+function killGatewayTreeOnWindowsBounded(pid) {
+  return windowsTaskkill(pid, {
+    isTrustedCommand: isTrustedWindowsGatewayCommand,
+    getCommandFn: (probePid) => windowsProcessCommand(probePid, {
+      powershellTimeoutMs: 3000,
+      wmicTimeoutMs: 2000,
+    }),
+    timeoutMs: 5000,
+  });
+}
+
+/**
+ * Kill a gateway child and, on Windows, everything it spawned.
+ *
+ * POSIX needs no tree walk here: the signal reaches the gateway, which reaps its
+ * own children on the way out. Windows has neither — no signal semantics (Node
+ * maps every name onto TerminateProcess) and no process group — so the detached
+ * kiro-cli / MCP / app-server descendants survive a single-pid kill, reparented
+ * and still holding the data home's locks.
+ *
+ * Falls back to the single-pid kill whenever the tree kill refuses (identity
+ * probe unavailable, or a recycled pid): losing the descendants is a leak, while
+ * losing the parent too would leave a live gateway behind a caller that believes
+ * it is gone.
+ */
+async function killGatewayProcessTree(proc, signal) {
+  if (!proc || proc.exitCode !== null) return;
+  const killPid = () => {
+    try { proc.kill(signal); } catch (e) { glog(`${signal} failed: ${e && e.message}`); }
+  };
+  if (!IS_WIN || !proc.pid) { killPid(); return; }
+  try {
+    // windowsTaskkill's OWN defaults: this path has no deadline to fit, so the
+    // identity probe gets its full budget rather than the shutdown path's
+    // shortened one.
+    await windowsTaskkill(proc.pid, { isTrustedCommand: isTrustedWindowsGatewayCommand });
+  } catch (e) {
+    glog(`tree kill refused (${e && e.message}) — falling back to a single-pid kill`);
+    killPid();
+  }
 }
 
 /** Best-effort synchronous-ish stop for the before-quit path (can't await). */
@@ -2559,7 +2640,13 @@ async function recoverWedgedGateway(win) {
       log: (m) => glog(`liveness: ${m}`),
     }).catch((e) => glog(`liveness: py-spy capture threw: ${e && e.message}`));
   }
-  try { if (gatewayProcess) gatewayProcess.kill("SIGKILL"); } catch (e) { glog(`SIGKILL failed: ${e && e.message}`); }
+  // TREE-scoped on Windows. This path deliberately skips /api/shutdown (it runs on
+  // the frozen loop), so it is the one trigger where nothing else reaps the
+  // gateway's detached kiro-cli / MCP children -- and the port sweep below cannot
+  // cover for it, because a single-pid kill FREES the port, after which the sweep
+  // finds no owner and its own /T taskkill is never reached. Awaited so the tree is
+  // gone before the respawn, and it falls back to the pid kill on any refusal.
+  await killGatewayProcessTree(gatewayProcess, "SIGKILL");
   gatewayProcess = null;
   let freed = true;
   let foreignHolder = false;

--- a/website/electron/test/gateway-stop.test.js
+++ b/website/electron/test/gateway-stop.test.js
@@ -186,6 +186,276 @@ test("stopGatewayGracefully: a SIGTERM-ignoring child still dies on Windows", { 
   } finally { server.close(); fs.rmSync(home, { recursive: true, force: true }); }
 });
 
+test("stopGatewayGracefully: the Windows fallback reaps the TREE, not just the gateway pid", async () => {
+  // THE ORPHAN BUG. The happy path is fine on every platform: POST
+  // /api/shutdown sets shutdown_event, and the gateway's own shutdown reaps its
+  // kiro-cli / MCP / app-server children before exiting. This test is about the
+  // FALLBACK -- an unreadable .local_secret, a 403, a timeout, or a wedged loop
+  // -- where the endpoint never takes and the shell resorts to killing.
+  //
+  // On POSIX, kill(SIGTERM) still lets the gateway run its handler and clean up.
+  // On Windows there is no such thing: Node maps both SIGTERM and SIGKILL onto
+  // TerminateProcess, so no handler runs, nothing is flushed, and every
+  // descendant is orphaned and reparented -- still holding the data home's locks
+  // and the same .local_secret. Worse, the port frees, so the caller's
+  // verification reports success while the orphans race the replacement gateway.
+  //
+  // So on Windows the kill must be TREE-scoped. Injected rather than spawning a
+  // real tree: the point is WHICH call the fallback makes, and a test cannot
+  // portably assert on grandchildren it did not create.
+  const treeKills = [];
+  // Collect EVERY 'exit' listener: stopGatewayGracefully registers more than one
+  // (the resolver plus the timer-clearing cleanup), so a mock that keeps only the
+  // last one never resolves and the test hangs instead of failing.
+  const proc = {
+    pid: 4242,
+    exitCode: null,
+    signalCode: null,
+    _onExit: [],
+    kill() { /* single-pid kill: must NOT be the Windows fallback */ },
+    once(event, fn) { if (event === "exit") this._onExit.push(fn); },
+    _finish() { this.exitCode = 1; for (const fn of this._onExit) fn(); },
+  };
+  await stopGatewayGracefully(proc, {
+    backendUrl: "http://127.0.0.1:1",
+    kirocrewHome: "/nope",
+    timeoutMs: 50,
+    // The endpoint fails -- this is the fallback path, by construction.
+    postShutdownFn: async () => false,
+    platform: "win32",
+    killTreeFn: async (pid) => { treeKills.push(pid); proc._finish(); },
+  });
+  assert.deepStrictEqual(
+    treeKills,
+    [4242],
+    "on Windows a failed /api/shutdown must escalate to a TREE kill; a single-pid " +
+      "kill frees the port but orphans every kiro-cli and MCP child"
+  );
+});
+
+test("stopGatewayGracefully: a REJECTED tree kill still falls back to killing the pid", async () => {
+  // A tree kill can legitimately refuse: windowsTaskkill fails closed when the
+  // identity probe cannot run or reports a recycled pid. Swallowing that leaves
+  // NO kill attempted at all -- strictly worse than the single-pid kill it
+  // replaced -- and the hard timer then resolves anyway, so the auto-update
+  // caller proceeds to swap the app's files while the gateway is still running.
+  // Losing the tree is bad; losing the parent too is data loss.
+  const signals = [];
+  const proc = {
+    pid: 4242,
+    exitCode: null,
+    signalCode: null,
+    _onExit: [],
+    kill(sig) { signals.push(sig); this.exitCode = 1; for (const fn of this._onExit) fn(); },
+    once(event, fn) { if (event === "exit") this._onExit.push(fn); },
+  };
+  await stopGatewayGracefully(proc, {
+    backendUrl: "http://127.0.0.1:1",
+    kirocrewHome: "/nope",
+    timeoutMs: 50,
+    postShutdownFn: async () => false,
+    platform: "win32",
+    killTreeFn: async () => { throw new Error("process identity changed"); },
+  });
+  assert.deepStrictEqual(
+    signals,
+    ["SIGTERM"],
+    "a refused tree kill must degrade to the single-pid kill, not to no kill at all"
+  );
+});
+
+test("stopGatewayGracefully: does not resolve while the tree kill is still reaping", async () => {
+  // The parent dies FIRST -- taskkill /T terminates it and then walks the rest of
+  // the tree -- so the process 'exit' event fires while descendants are still being
+  // reaped. Resolving on that event alone hands control back to the auto-update
+  // caller mid-sweep, which then swaps the app's files with kiro-cli / MCP children
+  // still live and holding the data home's locks: exactly the state the tree kill
+  // was added to prevent, reintroduced by resolving too early.
+  let releaseTree;
+  const treeDone = new Promise((r) => { releaseTree = r; });
+  let resolvedBeforeTreeSettled = false;
+  let treeSettled = false;
+  const proc = {
+    pid: 4242,
+    exitCode: null,
+    signalCode: null,
+    _onExit: [],
+    kill() {},
+    once(event, fn) { if (event === "exit") this._onExit.push(fn); },
+  };
+  const stopping = stopGatewayGracefully(proc, {
+    backendUrl: "http://127.0.0.1:1",
+    kirocrewHome: "/nope",
+    timeoutMs: 5000,
+    postShutdownFn: async () => false,
+    platform: "win32",
+    killTreeFn: async () => {
+      // The parent goes down immediately; the rest of the tree lags.
+      proc.exitCode = 1;
+      for (const fn of proc._onExit) fn();
+      await treeDone;
+      treeSettled = true;
+    },
+  }).then(() => { resolvedBeforeTreeSettled = !treeSettled; });
+
+  // Give the parent-exit path every chance to resolve early.
+  await new Promise((r) => setTimeout(r, 150));
+  releaseTree();
+  await stopping;
+  assert.strictEqual(
+    resolvedBeforeTreeSettled,
+    false,
+    "resolved on the parent's exit while the tree kill was still reaping descendants"
+  );
+});
+
+test("stopGatewayGracefully: a HUNG tree kill still resolves, and never pre-empts itself", async () => {
+  // A tree kill is AWAITED, not raced against a timer. Pre-empting it would kill
+  // the parent alone and orphan exactly the descendants it exists to reap -- the
+  // bug, dressed up as a mitigation. So the contract is: the caller sizes the tree
+  // kill's own timeouts to fit this deadline (pinned by the main.js test below),
+  // and this function must not resolve a moment later than it otherwise would.
+  //
+  // Asserted with a kill that NEVER settles, the pathological case: the hard timer
+  // must still resolve, and no single-pid kill may have fired behind the tree
+  // kill's back.
+  const signals = [];
+  const proc = {
+    pid: 4242,
+    exitCode: null,
+    signalCode: null,
+    _onExit: [],
+    kill(sig) { signals.push(sig); this.exitCode = 1; for (const fn of this._onExit) fn(); },
+    once(event, fn) { if (event === "exit") this._onExit.push(fn); },
+  };
+  const started = Date.now();
+  await stopGatewayGracefully(proc, {
+    backendUrl: "http://127.0.0.1:1",
+    kirocrewHome: "/nope",
+    timeoutMs: 60,
+    postShutdownFn: async () => false,
+    platform: "win32",
+    killTreeFn: () => new Promise(() => {}),
+  });
+  assert.deepStrictEqual(
+    signals,
+    [],
+    "the tree kill must not be pre-empted by a single-pid kill; that would orphan " +
+      "the descendants it exists to reap"
+  );
+  // Bounded by the hard safety net (timeoutMs + 3000), not by the hung kill.
+  assert.ok(
+    Date.now() - started < 60 + 3000 + 2000,
+    "a hung tree kill must not delay the caller past the hard deadline"
+  );
+});
+
+test("wedge recovery kills the gateway TREE, not just the wedged pid", () => {
+  // The wedge path deliberately SKIPS /api/shutdown -- that endpoint runs on the
+  // very loop that is frozen -- so it is the one trigger where Windows always
+  // reached a bare single-pid kill. And the port sweep that follows cannot cover
+  // for it: the bare kill frees the LISTEN port, so forceStopGatewayPort then
+  // finds no owner and the /T taskkill inside it is never reached. The detached
+  // kiro-cli / MCP children survive holding the data home's locks and race the
+  // gateway that is about to be respawned.
+  //
+  // Source-asserted because main.js requires electron at load time. The
+  // requirement is that the wedge kill go through a tree-scoped path on win32,
+  // not that it use any particular helper name.
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  const marker = "liveness: backend unresponsive — force-killing wedged gateway";
+  const at = main.indexOf(marker);
+  assert.notStrictEqual(at, -1, "expected the wedge-recovery force-kill path in main.js");
+  // The kill happens within the next few dozen lines of that log line.
+  const region = main.slice(at, at + 2000);
+  assert.match(
+    region,
+    /killGatewayProcessTree|windowsTaskkill|IS_WIN/,
+    "wedge recovery must tree-kill on Windows; a bare pid kill frees the port, so " +
+      "the port sweep that follows finds no owner and never reaps the descendants"
+  );
+  // ...and the helper it goes through must NOT borrow the shutdown path's
+  // shortened timeouts. Those exist only because stopGatewayGracefully has a hard
+  // deadline to fit inside. Wedge recovery has none, so inheriting them would time
+  // the identity probe out early on a slow box, fall back to the parent-only kill,
+  // and respawn beside the very orphans this path exists to reap.
+  const helper = main.indexOf("async function killGatewayProcessTree");
+  assert.notStrictEqual(helper, -1, "expected the shared tree-kill helper in main.js");
+  assert.doesNotMatch(
+    main.slice(helper, helper + 1200),
+    /killGatewayTreeOnWindowsBounded/,
+    "the wedge-recovery tree kill must not reuse the shutdown-BOUNDED helper: it " +
+      "has no deadline to fit, so the shortened probe timeouts only make an early " +
+      "fallback to the parent-only kill more likely"
+  );
+});
+
+test("main.js bounds the shutdown tree kill so it fits inside the hard deadline", () => {
+  // windowsTaskkill's DEFAULTS are sized for the interactive port sweep: identity
+  // revalidation via PowerShell (8s) then WMIC (5s), then taskkill itself (10s) --
+  // 23s worst case, which is longer than stopGatewayGracefully's whole deadline of
+  // timeoutMs + 3000. On the shutdown path that ordering is what matters: the hard
+  // timer resolves on schedule regardless, so an unbounded kill would still be in
+  // flight when the auto-update caller starts swapping the app's files.
+  //
+  // Rather than pre-empting the kill (which would defeat its purpose by killing
+  // the parent alone and orphaning the tree it exists to reap), the call site
+  // passes TIGHTER timeouts so the whole tree kill provably completes first.
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  const start = main.indexOf("function killGatewayTreeOnWindowsBounded");
+  assert.notStrictEqual(start, -1, "main.js must define the bounded Windows tree kill");
+  // Brace-match to the end of the function rather than regex-scanning to the first
+  // "})," -- the call nests one options object inside another, so a lazy pattern
+  // stops early and silently misses the outer timeout.
+  let depth = 0;
+  let end = start;
+  for (; end < main.length; end += 1) {
+    if (main[end] === "{") depth += 1;
+    else if (main[end] === "}") { depth -= 1; if (depth === 0) break; }
+  }
+  const call = main.slice(start, end + 1);
+  const budget = ["powershellTimeoutMs", "wmicTimeoutMs", "timeoutMs"]
+    .map((k) => Number((new RegExp(`${k}:\\s*(\\d+)`).exec(call) || [])[1]));
+  assert.ok(
+    budget.every((n) => Number.isFinite(n) && n > 0),
+    "the shutdown tree kill must pin all three of windowsTaskkill's timeouts " +
+      "(powershell, wmic, taskkill); an unpinned one inherits a default too long " +
+      "for the shutdown deadline"
+  );
+  const worstCase = budget.reduce((a, b) => a + b, 0);
+  assert.ok(
+    worstCase < 15000 + 3000,
+    `the tree kill's worst case (${worstCase}ms) must fit inside the hard deadline, `
+      + "or the caller is told the gateway is gone while the kill is still running"
+  );
+});
+
+test("stopGatewayGracefully: POSIX keeps signalling the child, not a tree kill", async () => {
+  // The Windows branch must not change POSIX behaviour: there, SIGTERM genuinely
+  // reaches the gateway's handler, which is strictly better than a tree kill
+  // because it still flushes sessions/memory/cron before exiting.
+  const signals = [];
+  const treeKills = [];
+  const proc = {
+    pid: 4242,
+    exitCode: null,
+    signalCode: null,
+    _onExit: [],
+    kill(sig) { signals.push(sig); this.exitCode = 1; for (const fn of this._onExit) fn(); },
+    once(event, fn) { if (event === "exit") this._onExit.push(fn); },
+  };
+  await stopGatewayGracefully(proc, {
+    backendUrl: "http://127.0.0.1:1",
+    kirocrewHome: "/nope",
+    timeoutMs: 50,
+    postShutdownFn: async () => false,
+    platform: "linux",
+    killTreeFn: async (pid) => { treeKills.push(pid); },
+  });
+  assert.deepStrictEqual(signals, ["SIGTERM"]);
+  assert.deepStrictEqual(treeKills, [], "POSIX must keep the graceful SIGTERM path");
+});
+
 test("stopGatewayGracefully: no-op on already-dead process", async () => {
   const proc = spawnDummy({ ignoreSigterm: false });
   await new Promise((r) => { proc.once("exit", r); proc.kill("SIGKILL"); });

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -548,4 +548,63 @@ describe("uninstall data preservation contract", () => {
     // rename on either side fails here instead of silently re-sharing.
     assert.equal(electronPkg.name, "kirocrew-desktop");
   });
+
+  it("gives nightly its own Windows appId so a channel update cannot orphan the other's shortcuts", () => {
+    // WHY THIS IS A WINDOWS-ONLY IDENTITY, SEPARATE FROM THE SHARED macOS ONE.
+    //
+    // The shared appId is deliberate on macOS: Squirrel.Mac validates an update
+    // against the host app's designated requirement, which pins the bundle id,
+    // so splitting it would strand every installed mac app. NSIS has no such
+    // constraint -- it keys install identity off nsis.guid and productFilename,
+    // both of which nightly already overrides.
+    //
+    // On Windows the shared id is actively harmful, because ${APP_ID} reaches
+    // TWO shell registrations that are global per-id rather than per-install:
+    //
+    //   WinShell::SetLnkAUMI       stamps the AppUserModelID onto both the
+    //                              desktop and Start Menu shortcuts
+    //   WinShell::UninstAppUserModelId  removes that registration wholesale
+    //
+    // The damaging path is a real UNINSTALL, not the update path: because
+    // nsis.allowToChangeInstallationDirectory is false, the
+    // allowToChangeInstallationDirectory define is never emitted, so
+    // setIsTryToKeepShortcuts always yields "true" and an update runs the old
+    // uninstaller with --keep-shortcuts, which skips the block below. Uninstall
+    // one channel, though, and WinShell::UninstAppUserModelId runs against the
+    // id BOTH channels share -- deregistering the AppUserModelID the surviving
+    // channel's shortcuts still carry. Its desktop shortcut then resolves to a
+    // dead registration and the shell reports that app as relocated or missing
+    // even though its .exe is untouched.
+    //
+    // main.js already splits the RUNTIME id (app.setAppUserModelId picks
+    // com.amazon.kiro.crew.nightly for a nightly stamp). Leaving the PACKAGED
+    // id shared makes the two disagree: the app claims one identity at runtime
+    // while its own shortcuts were stamped with the other.
+    const buildScript = fs.readFileSync(
+      path.resolve(ROOT, "..", "..", "packaging", "build-desktop.sh"),
+      "utf8"
+    );
+    assert.ok(
+      buildScript.includes("-c.win.appId=com.amazon.kiro.crew.nightly"),
+      "build-desktop.sh must give the nightly channel its own WINDOWS appId, or " +
+        "uninstalling one channel deregisters the other channel's shortcut " +
+        "AppUserModelID and Windows reports that app as relocated"
+    );
+    // It must stay WINDOWS-scoped: appInfo.id prefers the platform-specific
+    // value, so a top-level override would change the macOS bundle id too and
+    // break Squirrel.Mac's designated-requirement check on every installed mac.
+    assert.ok(
+      !buildScript.includes("-c.appId=com.amazon.kiro.crew.nightly"),
+      "the nightly appId override must be win-scoped; a top-level appId would " +
+        "also move the macOS bundle id and strand installed mac updates"
+    );
+    // The runtime id main.js claims for a nightly build must equal the one the
+    // installer stamps, or the shortcuts and the process disagree again.
+    assert.ok(
+      main.includes("com.amazon.kiro.crew.nightly"),
+      "main.js must claim the same nightly AppUserModelID the installer stamps"
+    );
+    // And the shared production id must remain the mac/appId default.
+    assert.equal(electronPkg.build.appId, "com.amazon.kiro.crew");
+  });
 });

--- a/website/electron/test/windows-port.test.js
+++ b/website/electron/test/windows-port.test.js
@@ -1,5 +1,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   parseNetstatListenPids,
   windowsGatewayExecutablePaths,
@@ -361,9 +363,66 @@ test("windowsTaskkill revalidates identity before using force on the PID", async
   });
   assert.deepStrictEqual(invocation, {
     command: TEST_TOOLS.taskkill,
-    args: ["/F", "/PID", "4242"],
+    args: ["/T", "/F", "/PID", "4242"],
     options: { timeout: 2345 },
   });
+});
+
+test("windowsTaskkill reaps the gateway's whole tree, not just the listening PID", () => {
+  // /T IS LOAD-BEARING ON WINDOWS, and its absence is invisible on POSIX.
+  //
+  // The gateway is not a leaf: it spawns detached kiro-cli ACP runtimes, MCP
+  // servers and app servers, and Windows has no process group a single kill can
+  // reach -- taskkill /T is the only way to take the subtree with the parent.
+  // Killing the listener alone frees the PORT (so the recovery probe reports
+  // success) while leaving those children alive and reparented, holding the data
+  // home's locks and the same .local_secret. The respawned gateway then races
+  // orphans from the generation it just replaced.
+  //
+  // The Python side already reached this conclusion: cli_server.py's stop path
+  // routes through platform_compat.kill_process_tree precisely because "a single
+  // -PID kill_pid would orphan them". This is the JS shell honouring the same
+  // invariant, so the two halves of one product stop the same way.
+  //
+  // Asserted against the SOURCE rather than only through the injected execFile
+  // above, so a refactor that reintroduces a single-PID kill on another code
+  // path fails here too.
+  const src = fs.readFileSync(path.join(__dirname, "..", "windows-port.js"), "utf8");
+  assert.match(
+    src,
+    /"\/T",\s*"\/F",\s*"\/PID"/,
+    "windowsTaskkill must pass /T so the gateway's detached children are reaped " +
+      "with it; a single-PID kill frees the port but orphans the subtree"
+  );
+});
+
+test("the SIGKILL launch hint is not offered as macOS-only advice on Windows", () => {
+  // A gateway child that exits with signalCode "SIGKILL" gets a hint pointing at
+  // macOS Gatekeeper and `xattr -cr`. On macOS that is the single most useful
+  // thing to say. On Windows it is never true and actively misleading, because
+  // OUR OWN teardown produces that signalCode: Node maps .kill("SIGTERM") and
+  // .kill("SIGKILL") onto TerminateProcess, so every wedge recovery and every
+  // fallback stop sets it. The launch log is exactly what the unrecoverable-
+  // gateway dialog tells the user to read, so a mac remedy printed on a Windows
+  // box sends bug reports down the wrong path.
+  //
+  // Asserted on the source because main.js requires electron at load time and so
+  // cannot be imported here -- the same idiom windows-titlebar-contract.test.js
+  // uses. The requirement is only that the hint be PLATFORM-GATED; the wording is
+  // free to change.
+  const src = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  const hint = src.split("\n").findIndex((line) => line.includes("xattr -cr"));
+  assert.notStrictEqual(hint, -1, "the Gatekeeper hint should still exist for macOS");
+  const guarded = src
+    .split("\n")
+    .slice(Math.max(0, hint - 4), hint + 1)
+    .join("\n");
+  assert.match(
+    guarded,
+    /IS_MAC|IS_WIN|platform/,
+    "the macOS Gatekeeper/xattr hint must be platform-gated: on Windows our own " +
+      "teardown sets signalCode SIGKILL, so this prints a mac remedy on every stop"
+  );
 });
 
 test("windowsTaskkill refuses a PID reused by an unrelated process", async () => {

--- a/website/electron/windows-port.js
+++ b/website/electron/windows-port.js
@@ -223,10 +223,24 @@ async function windowsTaskkill(
   if (!isTrustedCommand(command)) {
     throw new Error(`Refusing taskkill for pid ${safePid}: process identity changed`);
   }
+  // /T takes the whole subtree, not just the listening PID. The gateway is not a
+  // leaf: it spawns detached kiro-cli ACP runtimes, MCP servers and app servers,
+  // and Windows has no process group a single kill can reach. Killing the parent
+  // alone frees the PORT -- so the caller's verification reports success -- while
+  // those children survive, reparented, still holding the data home's locks and
+  // the same .local_secret, and the respawned gateway then races orphans from the
+  // generation it just replaced. The identity check above still gates on the
+  // PARENT, which is the process whose ownership we can prove; /T then follows the
+  // kernel's own parent links rather than a name match, so it cannot widen the
+  // kill to a process we did not authorise.
+  //
+  // The Python half of the product already settled this: cli_server.py's stop
+  // path uses platform_compat.kill_process_tree ("a single-PID kill_pid would
+  // orphan them"). Same invariant, same reason, both sides.
   await execFileText(
     execFileFn,
     tools.taskkill,
-    ["/F", "/PID", String(safePid)],
+    ["/T", "/F", "/PID", String(safePid)],
     timeoutMs
   );
 }


### PR DESCRIPTION
## Problem

Reported from a real Windows box running both channels side by side: after taking a
nightly update the app failed to restart, and the desktop shortcut reported the app
as **relocated or missing**. Investigating that surfaced three Windows-only defects
on the update/restart path — each invisible on macOS and Linux, which is why the
existing suites were green.

The happy path was never affected. `POST /api/shutdown` lets the gateway reap its own
children.

## 1. A channel uninstall orphans the other channel's shortcuts

Nightly and production share `appId` **on purpose**: Squirrel.Mac validates an update
against the host app's designated requirement, which pins the bundle id, so splitting
it would strand every installed mac app.

On Windows that same id also reaches `${APP_ID}`, which the NSIS template hands to two
registrations that are global *per-id* rather than per-install:

| macro | effect |
|---|---|
| `WinShell::SetLnkAUMI` | stamps the AppUserModelID onto the desktop + Start Menu shortcuts |
| `WinShell::UninstAppUserModelId` | removes that registration outright |

Shared, uninstalling one channel deregisters the AppUserModelID the **other**
channel's shortcuts still carry. The surviving channel's shortcut then resolves to a
dead registration and the shell reports that app as relocated or missing even though
its `.exe` is untouched. Confirmed on the affected machine — both shortcuts carried
the same id:

```
LNK: ...\Desktop\KiroCrew Nightly.lnk   AUMID: 'com.amazon.kiro.crew'
LNK: ...\Desktop\KiroCrew.lnk           AUMID: 'com.amazon.kiro.crew'
```

`main.js` already split the **runtime** id (`app.setAppUserModelId` picks
`com.amazon.kiro.crew.nightly`), so the packaged shortcuts and the running process
disagreed. Fix: give nightly its own `-c.win.appId`. **Win-scoped deliberately** —
`appInfo.id` prefers the platform-specific value, so a top-level `-c.appId` would also
move the macOS bundle id.

The *update* path alone was safe: `nsis.allowToChangeInstallationDirectory` is false,
so that define is never emitted, `setIsTryToKeepShortcuts` always yields `"true"`, and
an update runs the old uninstaller with `--keep-shortcuts`, skipping the block. A real
**uninstall** does not.

## 2. Windows gateway teardown leaks the whole process tree

`stopGatewayGracefully`'s documented `SIGTERM -> SIGKILL` escalation assumes signals.
Node maps **both** names onto `TerminateProcess`, so no handler runs, nothing is
flushed, and the SIGKILL step is unreachable — the SIGTERM already hard-terminated the
pid. Windows had *no* escalation at all.

What survives is every descendant: detached `kiro-cli` ACP runtimes, MCP servers and
app servers, reparented and still holding the data home's locks and the same
`.local_secret`. And because the port frees, `forceStopPort` reports `freed: true`
while those orphans race the replacement gateway.

Both paths that reach a bare kill are fixed:

- **the graceful fallback** — an unreadable `.local_secret`, 403, or timeout.
- **wedge recovery** — which deliberately skips `/api/shutdown` because that endpoint
  runs on the very loop that is frozen. The port sweep cannot cover for either, since
  freeing the port is exactly what stops it from finding an owner.

`windowsTaskkill` also gains the `/T` it was missing.

This is the invariant the Python half already honours — `cli_server.py` routes its stop
through `platform_compat.kill_process_tree` precisely because "a single-PID `kill_pid`
would orphan them".

### Two hazards the tree kill introduces, and how each is bounded

Both would end with the auto-update caller swapping the app's files underneath a
**live** gateway, since the hard timer resolves on schedule either way:

- **It rejects.** `windowsTaskkill` fails closed when its identity probe cannot run or
  the pid was recycled. A swallowed rejection would leave *no* kill attempted —
  strictly worse than what it replaced. Falls back to the single-pid kill.
- **It hangs.** Identity revalidation (PowerShell, then WMIC) precedes taskkill's own
  timeout, so the defaults total 23s against an 18s deadline. The kill is **awaited,
  never pre-empted** — cutting it short would kill the parent alone and orphan exactly
  the descendants it exists to reap — so the *budget* is what shrinks: 3+2+5 = 10s,
  pinned at the call site and CI-asserted to fit.

Losing the descendants is a leak; losing the parent as well is corruption, so the
single-pid kill is an unconditional floor.

## 3. A macOS-only remedy printed on every Windows stop

The `SIGKILL` launch hint points at Gatekeeper and `xattr -cr`. On Windows *our own*
teardown sets that `signalCode`, so it fired on every wedge recovery and fallback
stop — in the very log the unrecoverable-gateway dialog tells the user to read. Now
gated on `IS_MAC`.

## Tests

All TDD — each test was watched failing for the right reason before the fix, and the
two source-asserting invariants were mutation-tested (budget raised / timeout removed)
to confirm they actually fail.

- `packaging.test.js` — nightly carries its own **win-scoped** `appId`; the override is
  NOT top-level (which would move the mac bundle id); the runtime id `main.js` claims
  equals the one the installer stamps.
- `windows-port.test.js` — `windowsTaskkill` passes `/T`; the Gatekeeper hint is
  platform-gated.
- `gateway-stop.test.js` — a rejected tree kill falls back to the pid kill; a hung one
  still resolves and never pre-empts itself; the call site's timeouts fit the deadline;
  wedge recovery is tree-scoped; and **POSIX still takes the graceful SIGTERM path**
  (strictly better there — it flushes sessions/memory/cron before exiting).

## Verification

| Gate | Result |
|---|---|
| `npm test` (electron + website) | 1122 passed, 2 skipped, **0 failed** |
| `npx tsc -b` | exit 0 |
| `flake8` / `isort` | clean (no Python touched) |
| desktop/publish backend suites | 225 passed |
| `docs_lint.py` | all checks passed |
| `check_brand_name.py` | clean |

`scripts/scrub-lint.sh` fails identically on an unmodified `origin/main` checkout
(pre-existing git-history commit authors) — verified by stashing and re-running, so it
is not affected by this change.

## Risk

No behaviour change on macOS or Linux: the tree kill is reachable only on win32, and
POSIX keeps the graceful SIGTERM path.

The `win.appId` split is a **persistent identity**, like `nsis.guid`: it takes effect
for nightly installs from the build that ships it. Existing nightly installs keep the
old AUMID on their current shortcuts until their next install writes new ones.
