### PR TITLE
fix(acp): bound KAS auth answer tasks

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -513,6 +513,18 @@ true notifications (method, no id) broadcast. The routed case — an unknown
 request **with** a `sessionId` — still gets its single per-session reply from
 that session's dispatch loop (`server_request_unknown`).
 
+**KAS auth callbacks are retained and bounded off-loop answers.**
+`_kiro/auth/getAccessToken` is connection-scoped and may shell out before writing
+its response, so the reader schedules it without blocking stdout demux but keeps
+a strong reference in `_answer_tasks`. It shares `_max_answer_tasks` with other
+off-loop answers because every path ultimately contends for the same stdin; a
+separate token cap would allow the combined resource total to exceed the bound.
+The done callback removes completed tasks. At capacity, the reader uses the same
+bounded discrimination wait as permission answers: one completion admits the
+callback, while no progress within the bound marks the runtime dead so pending
+waiters resolve explicitly. Server-to-client requests never take the notification
+counted-drop path, because that would leave the remote requester unanswered.
+
 **Unroutable frames are counted, not logged per frame.** The reader drops any
 frame it cannot route; the drop itself is correct and unchanged, but logging one
 `DEBUG` line per dropped frame is a log-retention hazard on a multiplexed

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -742,12 +742,13 @@ class AcpRuntime:
         # Volume bound for in-flight auto-answer tasks. Each task can block
         # on stdin drain() against a backend that floods permission frames
         # while never reading its stdin — unbounded, that grows the task set
-        # until the gateway OOMs. Awaiting inline on the reader instead
+        # until the gateway OOMs. Awaiting an answer inline on the reader
         # would hand the same hostile backend a demux freeze for every
-        # session, so the bound treats overflow as a dead pipe (see
-        # _spawn_answer_task).
+        # session, so the bound treats a capacity timeout as a dead pipe
+        # (see _wait_for_answer_capacity).
         self._max_answer_tasks: int = 128
-        # Bounded discrimination wait at the cap (see _spawn_answer_task):
+        # Bounded discrimination wait at the cap (see
+        # _wait_for_answer_capacity):
         # small enough that a wedged pipe is condemned promptly, large enough
         # that a responsive backend's in-flight answers can complete.
         self._answer_cap_wait_secs: float = 5.0
@@ -1339,6 +1340,78 @@ class AcpRuntime:
             next(iter(self._session_queues)) if len(self._session_queues) == 1 else None
         )
 
+    async def _wait_for_answer_capacity(
+        self,
+        msg: JsonRpcMessage,
+        *,
+        request_kind: str,
+        session_id: str = "",
+        audit_reason: str | None = None,
+    ) -> bool:
+        """Wait briefly for shared answer capacity or condemn a wedged pipe.
+
+        Server-to-client requests require a response, so overflowing answers
+        cannot take the notification counted-drop path. A responsive backend
+        may fill the set with already-buffered requests before completed-task
+        callbacks run; one completion admits the current request. No
+        completion within the bound means writes are wedged, so marking the
+        runtime dead resolves every pending wait instead of leaving the remote
+        requester unanswered indefinitely.
+        """
+        def _deny() -> bool:
+            """Refuse admission, recording the decision first.
+
+            A refusal that reaches a caller which had already been admitted to
+            wait must leave a SEL record, or a permission decision that denied a
+            real tool invocation is indistinguishable from one never made.
+            """
+            if audit_reason is not None:
+                self._audit_denied_off_loop(msg, session_id, audit_reason)
+            return False
+
+        # Deliberately NOT audited: on an already-dead runtime a flooding
+        # backend's frames are gated out here, and auditing each one would grow
+        # audit tasks without bound — the very failure the cap prevents.
+        if self._dead:
+            return False
+        if len(self._answer_tasks) < self._max_answer_tasks:
+            return True
+
+        done, _pending = await asyncio.wait(
+            set(self._answer_tasks),
+            timeout=self._answer_cap_wait_secs,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if done:
+            # asyncio schedules task callbacks separately from waking waiters.
+            # Remove completed entries here so admitting the replacement never
+            # transiently exceeds the shared cap; the callbacks remain an
+            # idempotent cleanup backstop.
+            self._answer_tasks.difference_update(done)
+            if self._dead:
+                # A concurrent waiter condemned the runtime while this one was
+                # parked: capacity freed but admission still fails, so this
+                # refusal owes an audit like any other.
+                return _deny()
+            return True
+
+        logger.error(
+            "answer-task cap (%d) reached at %s request id=%s%s and no "
+            "in-flight answer completed in %gs — backend is flooding frames "
+            "while not reading stdin; marking runtime dead so every pending "
+            "wait resolves",
+            self._max_answer_tasks,
+            request_kind,
+            msg.id,
+            f" for session {session_id}" if session_id else "",
+            self._answer_cap_wait_secs,
+        )
+        # Audit before condemning the runtime, so the record for this decision
+        # cannot race the wait-resolution _mark_dead triggers.
+        refusal = _deny()
+        self._mark_dead(f"{request_kind}-answer task cap reached (backend not reading)")
+        return refusal
+
     async def _spawn_answer_task(
         self,
         msg: JsonRpcMessage,
@@ -1352,59 +1425,18 @@ class AcpRuntime:
         ``drain()`` against a backend that is not reading — awaiting inline
         would freeze the shared reader (every session's demux) on one hostile
         or wedged backend. Bounded because each blocked task is retained in
-        ``_audit_tasks``: a backend that floods permission frames while never
+        ``_answer_tasks``: a backend that floods permission frames while never
         reading stdin would otherwise grow that set until the gateway OOMs.
-        Past the cap the frame takes the counted-drop path instead — the
-        flooding backend hangs on its own unanswered request; well-behaved
-        backends (a handful of concurrent in-flight answers at most) never
-        come near the cap.
+        At capacity the shared admission wait either observes progress or
+        marks the runtime dead so the requester cannot remain unanswered.
         """
-        if self._dead:
-            # Already dead (this cap fired, or any other death path): the
-            # teardown has resolved/poisoned every wait, and no answer can be
-            # written to a dead pipe. Without this gate the still-draining
-            # reader would re-take the cap branch for every remaining flood
-            # frame and enqueue one audit task each — the same unbounded
-            # growth the cap exists to stop, rebuilt out of audits.
+        if not await self._wait_for_answer_capacity(
+            msg,
+            request_kind="permission",
+            session_id=session_id,
+            audit_reason="answer_task_cap_runtime_dead",
+        ):
             return
-        if len(self._answer_tasks) >= self._max_answer_tasks:
-            # At the cap, DISCRIMINATE before condemning: a burst of frames
-            # already buffered lets readline() return without suspending, so
-            # a RESPONSIVE backend can hit this branch before its (fast)
-            # answers had any loop time to complete. Give the in-flight set
-            # a bounded chance to make progress — if even one answer
-            # completes, the pipe is alive and this request proceeds; only
-            # when nothing completes (writes genuinely wedged on drain())
-            # is the runtime condemned.
-            done, _pending = await asyncio.wait(
-                set(self._answer_tasks),
-                timeout=self._answer_cap_wait_secs,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if not done:
-                # 128 blocked writes and none completed in 5s = the backend
-                # is provably not reading its stdin. Not a shed-and-forget:
-                # SEL-audit the denial (every permission decision leaves a
-                # record) and mark the runtime dead — teardown resolves
-                # every pending oneshot, so the requester does NOT hang, and
-                # the task set stops growing. Counts ONLY answer tasks
-                # (never SEL audits) so audit bursts cannot trip this.
-                logger.error(
-                    "answer-task cap (%d) reached at permission request id=%s "
-                    "for session %s and no in-flight answer completed in 5s — "
-                    "backend is flooding frames while not reading stdin; "
-                    "marking runtime dead so every pending wait resolves",
-                    self._max_answer_tasks,
-                    msg.id,
-                    session_id,
-                )
-                self._audit_denied_off_loop(
-                    msg, session_id, "answer_task_cap_runtime_dead"
-                )
-                self._mark_dead(
-                    "permission-answer task cap reached (backend not reading)"
-                )
-                return
         _t = asyncio.ensure_future(
             self._answer_unroutable_permission(msg, session_id, reason=reason)
         )
@@ -1783,7 +1815,23 @@ class AcpRuntime:
                     and msg.error is None
                     and msg.is_method(METHOD_KAS_AUTH_GET_ACCESS_TOKEN)
                 ):
-                    asyncio.ensure_future(self._answer_get_access_token(msg.id))
+                    # Token resolution can outlive a reader-loop tick and the
+                    # eventual stdin write can block. Retain it in the same
+                    # bounded set as other off-loop answers: a separate token
+                    # cap would let their combined total exceed the real
+                    # resource ceiling. Because this is a request, capacity
+                    # uses the same bounded progress-or-dead admission as
+                    # permission answers; counted-drop is only valid for
+                    # notifications that do not require a response.
+                    if not await self._wait_for_answer_capacity(
+                        msg, request_kind="KAS auth"
+                    ):
+                        continue
+                    answer_task = asyncio.ensure_future(
+                        self._answer_get_access_token(msg.id)
+                    )
+                    self._answer_tasks.add(answer_task)
+                    answer_task.add_done_callback(self._answer_tasks.discard)
                     continue
 
                 # Route notifications by sessionId

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -47,6 +47,7 @@ from kiro_crew.acp.types import (
     EVENT_TEXT_CHUNK,
     JSONRPC_METHOD_NOT_FOUND,
     METHOD_COMMANDS_EXECUTE,
+    METHOD_KAS_AUTH_GET_ACCESS_TOKEN,
     METHOD_MCP_OAUTH_REQUEST,
     METHOD_SESSION_LOAD,
     METHOD_SESSION_NEW,
@@ -338,6 +339,65 @@ async def test_ownerless_request_answered_once_not_broadcast():
 
 
 @pytest.mark.asyncio
+async def test_kas_auth_waits_for_shared_answer_capacity_then_answers():
+    """A temporary full cap delays, rather than drops, the next KAS answer."""
+    rt, reader, _ = _make_runtime()
+    rt._max_answer_tasks = 1
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    second_capacity_check = asyncio.Event()
+    release_first = asyncio.Event()
+    release_second = asyncio.Event()
+    capacity_checks = 0
+
+    async def blocked_answer(request_id: int | str) -> None:
+        if request_id == 1:
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+            await release_second.wait()
+
+    wait_for_capacity = rt._wait_for_answer_capacity
+
+    async def observed_capacity(*args, **kwargs) -> bool:
+        nonlocal capacity_checks
+        capacity_checks += 1
+        if capacity_checks == 2:
+            second_capacity_check.set()
+        return await wait_for_capacity(*args, **kwargs)
+
+    rt._answer_get_access_token = blocked_answer  # type: ignore[method-assign]
+    rt._wait_for_answer_capacity = observed_capacity  # type: ignore[method-assign]
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"id": 1, "method": METHOD_KAS_AUTH_GET_ACCESS_TOKEN})
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        assert len(rt._answer_tasks) == 1
+
+        _feed(reader, {"id": 2, "method": METHOD_KAS_AUTH_GET_ACCESS_TOKEN})
+        await asyncio.wait_for(second_capacity_check.wait(), timeout=1.0)
+        assert not second_started.is_set()
+
+        release_first.set()
+        await asyncio.wait_for(second_started.wait(), timeout=1.0)
+        assert len(rt._answer_tasks) == 1
+        assert sum(rt._dropped_frames.values()) == 0
+
+        retained = next(iter(rt._answer_tasks))
+        discarded = asyncio.Event()
+        retained.add_done_callback(lambda _task: discarded.set())
+        release_second.set()
+        await asyncio.wait_for(discarded.wait(), timeout=1.0)
+        assert rt._answer_tasks == set()
+    finally:
+        release_first.set()
+        release_second.set()
+        await asyncio.gather(*rt._answer_tasks, return_exceptions=True)
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
 async def test_ownerless_response_with_null_result_is_not_answered():
     """An id-carrying frame with NO method is a response, not a request.
 
@@ -358,6 +418,50 @@ async def test_ownerless_response_with_null_result_is_not_answered():
         ]
         assert not [r for r in replies if r.get("id") == 77]
     finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_kas_auth_cap_timeout_marks_runtime_dead_without_growth():
+    """A wedged shared cap fails the runtime instead of losing a KAS request."""
+    rt, reader, _ = _make_runtime()
+    rt._max_answer_tasks = 1
+    rt._answer_cap_wait_secs = 0.0
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    marked_dead = asyncio.Event()
+    dead_reasons: list[str] = []
+
+    async def blocked_answer(request_id: int | str) -> None:
+        if request_id == 1:
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+
+    def mark_dead(reason: str) -> None:
+        dead_reasons.append(reason)
+        rt._dead = True
+        marked_dead.set()
+
+    rt._answer_get_access_token = blocked_answer  # type: ignore[method-assign]
+    rt._mark_dead = mark_dead  # type: ignore[method-assign]
+    task = await _start_reader(rt)
+    try:
+        _feed(reader, {"id": 1, "method": METHOD_KAS_AUTH_GET_ACCESS_TOKEN})
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+
+        _feed(reader, {"id": 2, "method": METHOD_KAS_AUTH_GET_ACCESS_TOKEN})
+        await asyncio.wait_for(marked_dead.wait(), timeout=1.0)
+
+        assert not second_started.is_set()
+        assert len(rt._answer_tasks) == 1
+        assert sum(rt._dropped_frames.values()) == 0
+        assert dead_reasons and "KAS auth" in dead_reasons[0]
+    finally:
+        release_first.set()
+        await asyncio.gather(*rt._answer_tasks, return_exceptions=True)
         await _stop_reader(task)
 
 
@@ -6650,6 +6754,57 @@ async def test_answer_task_cap_marks_dead_instead_of_growing_unbounded():
     assert audited == ["answer_task_cap_runtime_dead"]
     _never.set()
     await _asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_capacity_freed_but_runtime_died_still_audits_the_refusal():
+    """A waiter parked at the cap can be woken by a completing answer AND find
+    the runtime condemned by a concurrent waiter in the same moment. Capacity
+    was freed, so this is not the timeout path, but admission still fails — and
+    a refused permission decision must leave a SEL record either way."""
+    rt, _, _ = _make_runtime()
+    rt._max_answer_tasks = 1
+
+    import asyncio as _asyncio
+
+    audited: list[str] = []
+    rt._audit_denied_off_loop = (  # type: ignore[method-assign]
+        lambda msg, session_id, reason, title=None: audited.append(reason)
+    )
+
+    release = _asyncio.Event()
+
+    async def _held() -> None:
+        await release.wait()
+
+    holder = _asyncio.ensure_future(_held())
+    rt._answer_tasks.add(holder)
+
+    frame = JsonRpcMessage.from_dict(
+        {
+            "jsonrpc": "2.0",
+            "id": 907,
+            "method": "session/request_permission",
+            "params": {"sessionId": "child-x", "options": []},
+        }
+    )
+
+    async def _condemn_then_release() -> None:
+        await _asyncio.sleep(0)
+        rt._dead = True  # a sibling waiter's _mark_dead lands first
+        release.set()
+
+    condemner = _asyncio.ensure_future(_condemn_then_release())
+    admitted = await rt._wait_for_answer_capacity(
+        frame,
+        request_kind="permission",
+        session_id="child-x",
+        audit_reason="answer_task_cap_runtime_dead",
+    )
+    await condemner
+
+    assert admitted is False
+    assert audited == ["answer_task_cap_runtime_dead"], "the refusal must be audited"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

`AcpRuntime._reader_loop` launched KAS `_kiro/auth/getAccessToken` answers with a bare `asyncio.ensure_future()`. The runtime did not retain those tasks, and a backend that emitted callbacks faster than token resolution or stdin writes completed could grow unbounded ownerless work.

## Why it matters

The callback may shell out before writing its response and the final stdin drain can block. Losing the task reference can interrupt authentication mid-flight; allowing an unlimited callback flood can exhaust the gateway process. Because these frames are server-to-client requests, silently dropping one also leaves the requester waiting for an answer that will never arrive.

## What changed (motivation → approach → change)

KAS callbacks need to stay off the reader loop, but bare tasks were neither retained nor bounded. The runtime now retains them in the existing `_answer_tasks` set and shares the existing `_max_answer_tasks` total budget used by other off-loop answers. A shared `_wait_for_answer_capacity()` admission path handles a full cap: it waits for bounded progress, admits the request when one answer completes, and marks the runtime dead when no answer completes before the timeout so all pending waits resolve. KAS server-to-client requests are not sent through the notification counted-drop path. Completed tasks use the existing done-callback discard shape. A separate token cap was intentionally avoided because all answer paths ultimately contend for the same stdin. This remains on current `main` and does not copy or modify PR #4880's ownerless-request implementation.

## Tests

- Deterministic regression: at a cap of one, the second KAS request waits, then executes after the first answer releases capacity, with no counted drop
- Deterministic regression: when capacity never releases, the bounded wait marks the runtime dead without starting the second answer, growing the task set, or recording a counted drop
- `pytest -n 0 test/test_acp_runtime.py -q`: 232 passed, 1 skipped
- `pytest -n 4 --dist loadgroup --max-worker-restart=2 test/test_acp_runtime.py -q`: 232 passed, 1 skipped
- staged-snapshot `isort --check-only` and `flake8`
- `scripts/check_black_formatting.py`
- `scripts/docs_lint.py`

## Manual verification

Confirmed temporary saturation delays rather than loses the second KAS request; releasing the first answer admits the second and its done callback empties `_answer_tasks`. With no progress before the configured timeout, the runtime becomes dead, the second answer never starts, the retained set stays bounded, and the drop counter remains unchanged.

## Related Issues

Closes #4884

Related: #4880

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
