### PR TITLE
fix(md-notebook): retry a contended note save without losing an edit

### DIFF
--- a/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
@@ -24,9 +24,11 @@ import base64
 import logging
 import os
 import re
+import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Optional
+from pathlib import Path, PureWindowsPath
+from typing import Any, Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +56,49 @@ TRASH_DIR = ".trash"
 def in_trash(path: str) -> bool:
     """True when a vault-relative path lies inside the local trash folder."""
     return TRASH_DIR in path.replace("\\", "/").split("/")
+
+
+def staged_temp_name(name: str) -> str:
+    """Name for the sibling temp a durable write stages beside *name*."""
+    return f"{name}.{uuid.uuid4().hex}.tmp"
+
+
+#: Basenames of temps a save has staged and not yet consumed. A save registers
+#: its temp for the whole of its transaction, so `status()` can tell the temp
+#: THIS process is mid-publish on from a file that merely looks like one.
+#: Nothing else may hide a path: see the reasoning in `status()`.
+#:
+#: Keyed on the BASENAME, not the full path: the name carries a uuid4 hex, which
+#: is unique on its own, and comparing bare names sidesteps every way two
+#: spellings of the same path can differ (case, 8.3 short names, a symlinked
+#: vault root, separator flavour). A missed match here would silently re-open
+#: the bug the filter exists to close, so the comparison must not depend on
+#: canonicalising two paths built by different call sites.
+_inflight_temps: set[str] = set()
+
+
+@contextmanager
+def inflight_temp(tmp: str | os.PathLike[str]) -> Iterator[None]:
+    """Mark *tmp* as this process's in-flight staged temp for the block's life.
+
+    Registration is the ONLY evidence `status()` accepts for hiding a path.
+    The name shape cannot serve: `<name>.<32 hex>.tmp` is what this module
+    produces, not a shape only this module can produce, so a user file wearing
+    it would be withheld from the user's own repository. Ownership is knowable
+    exactly while the transaction that staged the temp is still running, which
+    is the span this context manager covers.
+    """
+    name = PureWindowsPath(os.fspath(tmp)).name
+    _inflight_temps.add(name)
+    try:
+        yield
+    finally:
+        _inflight_temps.discard(name)
+
+
+def is_inflight_temp(path: str) -> bool:
+    """True when *path* names a temp a save in this process is publishing."""
+    return PureWindowsPath(path).name in _inflight_temps
 
 
 # Seconds before a git invocation is abandoned. Network operations (clone,
@@ -618,14 +663,45 @@ async def status(dir_: str, subfolder: Optional[str] = None) -> list[FileChange]
         if rel:
             changes.append(FileChange(path=rel, kind="added"))
 
-    if prefix:
-        changes = [c for c in changes if c.path.startswith(prefix)]
     # The local trash lives inside the vault, so git sees it. Filtering here
     # keeps a trashed note out of the commit message and out of the notes
     # listing's pending badge; `auto_commit` additionally excludes it from the
     # pathspec, because `add -A` stages from the working tree and never consults
     # this list.
-    return [c for c in changes if not in_trash(c.path)]
+    #
+    # A temp a note save is publishing is likewise not user content, and
+    # committing one is worse than a stray file: it is generated data on the
+    # remote under a note-shaped commit message. Only its ADDITION is dropped.
+    # A temp that reached a commit before this filter existed is tracked, and
+    # its removal must stay committable -- otherwise the app could never clean
+    # up the mess the old behaviour made.
+    #
+    # OWNERSHIP, NOT NAME SHAPE, is what authorizes hiding a file. `<name>.<32
+    # hex>.tmp` is the shape this module PRODUCES; it is not a shape only this
+    # module can produce. A user -- or another tool -- may genuinely create a
+    # file with that name, and an earlier revision of this filter excluded it on
+    # the shape alone. That file then vanished from the pending badge, from the
+    # commit, and from the remote, with nothing to tell anyone it had been
+    # dropped. Silently withholding unknown filesystem content from the user's
+    # own git repository is a worse failure than committing a stray temp.
+    #
+    # So only `is_inflight_temp` may hide a path: a temp THIS process currently
+    # knows it is publishing, registered for the whole stage-and-retry
+    # transaction. Everything else is filesystem content and stays visible.
+    #
+    # The consequence is deliberate: an orphan left behind when a cleanup unlink
+    # lost the race becomes VISIBLE once its transaction ends and ownership can
+    # no longer be evidenced. That is the safe direction to fail. Reaping an
+    # aged orphan is a lifecycle problem with its own answer; a permanent
+    # filename-shape exclusion is not that answer, because it cannot tell an
+    # orphan from a file the user put there.
+    return [
+        c
+        for c in changes
+        if (prefix is None or c.path.startswith(prefix))
+        and not in_trash(c.path)
+        and not (c.kind == "added" and is_inflight_temp(c.path))
+    ]
 
 
 def _commit_message(changes: list[FileChange]) -> str:

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -172,6 +172,13 @@ MTIME_TOLERANCE_MS = 1
 # A real mtime is never negative, so it can't collide with a genuine timestamp.
 _RECREATE_SENTINEL = -1
 
+#: Retry budget for a note save whose rename hit the Windows sharing-violation
+#: window. Mirrors ``atomic_write.replace_with_retry`` (10 x 50ms), whose window
+#: this is; the retry lives here rather than in the rename so each attempt can
+#: re-run the stale-write check first.
+_SAVE_MAX_ATTEMPTS = 10
+_SAVE_BACKOFF_SECONDS = 0.05
+
 # Auto-sync interval bounds, in minutes. These mirror DEFAULT_AUTO_SYNC_MINS /
 # MIN_AUTO_SYNC_MINS / MAX_AUTO_SYNC_MINS in
 # website/src/apps/md-notebook/constants.ts: the picker's range and the
@@ -285,33 +292,99 @@ def _read_vaults_sync() -> list[dict[str, Any]]:
         return []
 
 
-def _atomic_write_text_sync(path: Path, content: str) -> None:
-    """Write via a sibling temp file and rename over the target.
+def _new_staged_note_path(path: Path) -> Path:
+    """Allocate the exact sibling path one note transaction will own."""
+    return path.with_name(git_ops.staged_temp_name(path.name))
 
-    `write_text` truncates first, so a failure partway — a full disk is the
-    realistic one — leaves the note truncated or half-written with no copy of
-    what was there. `os.replace` is atomic within a filesystem, and the temp file
-    is a sibling so it stays on the same one. The `.tmp` suffix keeps it out of
-    the `.md` scan.
+
+def _stage_note_text_sync(tmp: Path, content: str) -> None:
+    """Write *content* to the already-owned *tmp* path and fsync it.
+
+    `write_text` truncates first, so a failure partway -- a full disk is the
+    realistic one -- leaves the note truncated or half-written with no copy of
+    what was there. Staging into a sibling keeps the temp on the same filesystem,
+    so the later rename is atomic, and the `.tmp` suffix keeps it out of the
+    `.md` scan.
+
+    The temp is created ONCE per save and handed back to the caller, which
+    republishes THAT SAME path on every retry. Staging a fresh temp per attempt
+    would leave one orphan behind for each contended attempt whose cleanup unlink
+    also lost the race -- and because the retry ends in a 200, nothing would tell
+    the user to go and look.
+
+    The caller allocates the name and registers it with
+    `git_ops.inflight_temp` BEFORE entering this function. That ordering is part
+    of the contract: `open` makes the untracked file visible immediately, so a
+    concurrent Sync could otherwise discover and commit it while this function
+    was still writing. The caller keeps the registration through publish or
+    cleanup, making ownership cover every instant the temp can exist.
     """
-    tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
-    try:
-        # newline="" disables the platform newline translation that would
-        # otherwise rewrite the note's "\n" as "\r\n" on Windows, so a note's
-        # bytes are identical on every OS.
-        with open(tmp, "w", encoding="utf-8", newline="") as fh:
-            fh.write(content)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
-    except BaseException:
-        # Never leave the temp behind to be mistaken for user content.
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
+    # newline="" disables the platform newline translation that would
+    # otherwise rewrite the note's "\n" as "\r\n" on Windows, so a note's
+    # bytes are identical on every OS.
+    with open(tmp, "w", encoding="utf-8", newline="") as fh:
+        fh.write(content)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def _publish_staged_sync(tmp: Path, path: Path) -> None:
+    """Rename the staged temp over the note. A SINGLE attempt, on purpose.
+
+    Retrying here would be wrong: the save is guarded by an optimistic
+    concurrency check (`baseMtime` -> stat -> 409 ESTALE), and a retry inside the
+    rename extends the window between that check and the publish by the whole
+    retry budget, so an external edit landing in it would be silently
+    overwritten. The retry lives in `_save_note_contents`, which revalidates
+    before each attempt -- and republishes this same temp.
+
+    A successful rename consumes the temp, which is what keeps a 200 from ever
+    coexisting with a surviving temp this save owns.
+    """
+    os.replace(tmp, path)
+
+
+def _discard_staged_sync(tmp: Path) -> None:
+    """Best-effort removal of one EXACT temp this save owns.
+
+    Deliberately not a `glob` over sibling `<note>.*.tmp`: on the guarded path
+    the per-note lock is released across the backoff, so a concurrent save may
+    legitimately own a temp for the same note, and sweeping would destroy it.
+
+    Best-effort is safe to leave best-effort: the handle that refuses a rename
+    commonly refuses this unlink too. While the save is still running the temp
+    is registered with `git_ops.inflight_temp`, so `status()` keeps it out of a
+    commit; once the transaction ends an orphan becomes ordinary visible content
+    rather than a file silently withheld from the user's repository. Tidiness is
+    what is lost here, never correctness.
+    """
+    with contextlib.suppress(OSError):
+        os.unlink(tmp)
+
+
+def _atomic_write_text_sync(path: Path, content: str) -> None:
+    """Stage, publish, and clean up on failure -- the single-attempt whole.
+
+    Kept for callers that write a file with no freshness contract and no retry
+    (the settings store). The note save drives the two halves itself so it can
+    republish one temp across attempts.
+    """
+    tmp = _new_staged_note_path(path)
+    with git_ops.inflight_temp(tmp):
+        try:
+            _stage_note_text_sync(tmp, content)
+            _publish_staged_sync(tmp, path)
+        except BaseException:
+            _discard_staged_sync(tmp)
+            raise
 
 
 def _write_vaults_sync(vaults: list[dict[str, Any]]) -> None:
+    """Replace the vault registry, retrying the Windows rename window.
+
+    Same reason as the note writer above: this file is read back by every
+    later request, so a handle can be open on it when the rename lands.
+    """
     target = _vaults_json()
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_name(f"vaults.json.{uuid.uuid4().hex}.tmp")
@@ -1436,6 +1509,277 @@ async def api_note_read(request: web.Request) -> web.Response:
     )
 
 
+async def _assert_note_is_fresh(
+    abs_path: Path, rel: str, base_mtime: object
+) -> None:
+    """Raise 409 ESTALE if the note changed on disk since the client read it.
+
+    Split out of the save handler so the retry below can re-run it. It must be
+    cheap to repeat and must not mutate anything: it is the freshness half of a
+    check-and-write, and a retry that skipped it would publish against a file it
+    never revalidated.
+    """
+    if isinstance(base_mtime, (int, float)):
+        current: Optional[float] = None
+        try:
+            current = (await asyncio.to_thread(os.stat, abs_path)).st_mtime * 1000
+        except FileNotFoundError:
+            # A supplied baseMtime means the file existed when the client read
+            # it, so its absence now is an external deletion — a conflict, not
+            # a new file. Silently rewriting would resurrect a note the user
+            # deleted in Obsidian or via `git pull`.
+            #
+            # The conflict hands back the -1 sentinel as the new mtime; when
+            # the user chooses "keep mine" the client retries with
+            # baseMtime == -1, which is the one value that means "yes,
+            # recreate it" and falls through to the write below. Without this
+            # escape hatch the retry would hit this same branch forever and
+            # the edit could never be saved.
+            if base_mtime != _RECREATE_SENTINEL:
+                raise ApiError(
+                    "this note was deleted on disk since you opened it",
+                    409,
+                    code="ESTALE",
+                    mtime=_RECREATE_SENTINEL,
+                    disk="",
+                )
+        if current is not None and abs(current - base_mtime) > MTIME_TOLERANCE_MS:
+            # The conflict response hands this content back to the client, so
+            # it goes through the same gate as every other read: containment
+            # inside the vault says nothing about what the vault holds.
+            disk = await read_note_text(abs_path)
+            if disk is None:
+                raise ApiError(f"no such note: {rel}", 404, code="no_such_note")
+            raise ApiError(
+                "this note changed on disk since you opened it",
+                409,
+                code="ESTALE",
+                mtime=current,
+                disk=disk,
+            )
+
+
+async def _observed_note_mtime(abs_path: Path) -> Optional[float]:
+    """The note's current mtime in ms, or None when it does not exist."""
+    try:
+        return (await asyncio.to_thread(os.stat, abs_path)).st_mtime * 1000
+    except FileNotFoundError:
+        return None
+
+
+async def _assert_note_unchanged(
+    abs_path: Path, rel: str, observed: Optional[float]
+) -> None:
+    """Raise 409 ESTALE if the note moved off *observed* since it was sampled.
+
+    The tokenless counterpart to `_assert_note_is_fresh`. A save with no
+    ``baseMtime`` has no client-supplied baseline to revalidate against, so the
+    server takes its OWN: the state the save was about to overwrite, sampled
+    before the first publish attempt.
+
+    The note lock serializes API writers, but it says nothing about an editor
+    writing the file directly -- Obsidian, `git pull`, an external script. That
+    writer lands during the retry backoff, and without this check the next
+    attempt renames over an edit nobody revalidated, answering 200 for a save
+    that destroyed a newer one.
+
+    Only RETRIES consult it. The first attempt is what the caller asked for:
+    overwriting the state sampled here is the save, not a conflict.
+    """
+    current = await _observed_note_mtime(abs_path)
+    if current is None and observed is None:
+        return
+    if (
+        current is not None
+        and observed is not None
+        and abs(current - observed) <= MTIME_TOLERANCE_MS
+    ):
+        return
+    if current is None:
+        # Deleted under us mid-retry. Reported with the same -1 sentinel the
+        # guarded path uses, so the client's "keep mine" retry (baseMtime == -1)
+        # is the one escape hatch on both paths rather than two dialects.
+        raise ApiError(
+            "this note was deleted on disk while your save was retrying",
+            409,
+            code="ESTALE",
+            mtime=_RECREATE_SENTINEL,
+            disk="",
+        )
+    disk = await read_note_text(abs_path)
+    raise ApiError(
+        "this note changed on disk while your save was retrying",
+        409,
+        code="ESTALE",
+        mtime=current,
+        disk=disk if disk is not None else "",
+    )
+
+
+async def _publish_note_once(abs_path: Path, tmp: Path, attempt: int) -> bool:
+    """Publish the staged temp once. True on success, False to retry.
+
+    Takes the temp rather than the content: every attempt republishes the SAME
+    staged file, so a contended save can never leave a trail of orphaned temps
+    behind a 200.
+
+    Terminal failures are raised rather than reported: POSIX re-raises a
+    ``PermissionError`` immediately (there it means the caller genuinely cannot
+    write, and waiting changes nothing), and an exhausted budget propagates the
+    last one.
+    """
+    try:
+        await asyncio.to_thread(_publish_staged_sync, tmp, abs_path)
+        return True
+    except PermissionError:
+        if not platform_compat.IS_WINDOWS:
+            raise
+        if attempt == _SAVE_MAX_ATTEMPTS - 1:
+            raise
+        logger.debug(
+            "md-notebook: note rename contended at %s; retrying (%d/%d)",
+            abs_path,
+            attempt + 1,
+            _SAVE_MAX_ATTEMPTS,
+        )
+        return False
+
+
+async def _save_note_contents(
+    abs_path: Path, rel: str, content: str, base_mtime: object
+) -> None:
+    """Publish *content*, retrying a contended rename without losing a write.
+
+    The rename can fail on Windows with `PermissionError` while another handle is
+    open on the note -- routine for a vault the user also has open in an editor,
+    and for the search indexer and AV scanner. Losing the save there is the user
+    losing what they just typed, so the transient is retried.
+
+    What is retried is the CHECK-AND-WRITE, never the rename alone. Retrying
+    inside the rename would stretch the gap between the freshness check and the
+    publish across the whole backoff, and an edit completing in that gap would be
+    silently overwritten by the next attempt -- exactly what the `baseMtime`
+    guard exists to prevent.
+
+    **The lock policy depends on whether this save carries a freshness token**,
+    because that is what decides whether a writer in the gap can be DETECTED:
+
+    * ``baseMtime`` supplied -- the lock is released across the backoff. Another
+      writer landing in the gap is not a problem to exclude: the next attempt
+      re-runs the check, sees it, and answers 409. Releasing keeps a contended
+      save from blocking an external-conflict resolution behind it.
+
+    * no ``baseMtime`` (the API allows it, and the editor omits it when it has
+      not read an mtime) -- ``_assert_note_is_fresh`` is a no-op, so a writer in
+      the gap is INVISIBLE to every later attempt. Releasing the lock there let a
+      contended save resurrect itself over a later save that had already been
+      acknowledged with 200. The lock is therefore held across the backoff, which
+      preserves exactly the serialization the un-retried code had: a same-note
+      writer waits (at most the retry budget, ~450ms) rather than being
+      overwritten afterwards.
+
+      The lock orders API writers and nothing else, so it is only half the
+      answer. An editor writing the file directly -- Obsidian, ``git pull``, a
+      script -- never takes it, and republishing over that edit is undetectable
+      after the fact. So the tokenless path derives its OWN baseline
+      (``_observed_note_mtime`` before the first attempt) and revalidates
+      against it before every RETRY: the same 409 ESTALE the guarded path
+      answers, from a baseline the server sampled instead of one the client
+      supplied. The first attempt never consults it -- overwriting the sampled
+      state IS the save.
+
+    Holding it is a coroutine suspension, not a blocked event loop, and it is
+    per-note.
+
+    Budget mirrors `atomic_write.replace_with_retry`, whose window this is.
+    """
+    # ONE temp for the whole transaction, on either path. Staged before the
+    # first attempt and republished by every retry, so success consumes it and
+    # any exit path has exactly one file to discard. It carries
+    # `git_ops.staged_temp_name`'s shape for the whole of its life, so a Sync
+    # running during the backoff cannot stage it.
+    #
+    # WHERE it is staged differs, because the two paths serialize differently.
+    if isinstance(base_mtime, (int, float)):
+        # Guarded: the freshness check is what orders these saves, so staging
+        # outside the lock cannot reorder anything -- every attempt revalidates
+        # under the lock before it may publish.
+        #
+        # It runs BEFORE the directory is created, though. A save whose note and
+        # parent were deleted externally is already destined for 409, and
+        # `make_dirs` would put the parent back on the way to refusing: a request
+        # that changes nothing should not resurrect a directory the user removed.
+        # This costs one extra stat on the happy path and weakens nothing -- the
+        # per-attempt check under the lock is still the one that authorizes a
+        # publish.
+        await _assert_note_is_fresh(abs_path, rel, base_mtime)
+        await make_dirs(abs_path.parent)
+        tmp = _new_staged_note_path(abs_path)
+        # Register BEFORE staging: opening the temp is the first instant Sync
+        # can see it. Keep ownership through failure cleanup as well as publish,
+        # so there is no visible gap at either end of the transaction.
+        with git_ops.inflight_temp(tmp):
+            try:
+                await asyncio.to_thread(_stage_note_text_sync, tmp, content)
+                for attempt in range(_SAVE_MAX_ATTEMPTS):
+                    async with _save_lock(str(abs_path)):
+                        await _assert_note_is_fresh(abs_path, rel, base_mtime)
+                        if await _publish_note_once(abs_path, tmp, attempt):
+                            return
+                    # Outside the lock: a writer arriving here is one the next
+                    # attempt's check is meant to notice, so blocking it would
+                    # hide the conflict.
+                    await asyncio.sleep(_SAVE_BACKOFF_SECONDS)
+                return
+            except BaseException:
+                await asyncio.to_thread(_discard_staged_sync, tmp)
+                raise
+
+    # Tokenless: nothing can detect an interleaved writer, so ORDER is the only
+    # guarantee left -- and order has to cover the whole stage-and-publish
+    # transaction, not just the publish. Staging is the slow half (it writes the
+    # entire note), so staging outside the lock let a large save be overtaken:
+    # a later save could take the lock, publish, and answer 200 while the earlier
+    # one was still writing its temp, and the earlier one then published over it.
+    # Both answered 200; the later edit was gone.
+    async with _save_lock(str(abs_path)):
+        await make_dirs(abs_path.parent)
+        tmp = _new_staged_note_path(abs_path)
+        with git_ops.inflight_temp(tmp):
+            try:
+                # Registration precedes the worker-thread open and remains until
+                # cleanup completes, so Sync never sees an unowned temp even if
+                # staging itself is slow or fails partway.
+                await asyncio.to_thread(_stage_note_text_sync, tmp, content)
+                # The server's OWN baseline, standing in for the absent
+                # `baseMtime`: the state this save is about to overwrite.
+                # Sampled after staging (which writes the temp, never the note)
+                # and before the first attempt, so it describes exactly what
+                # attempt 1 would replace.
+                observed = await _observed_note_mtime(abs_path)
+                for attempt in range(_SAVE_MAX_ATTEMPTS):
+                    if attempt:
+                        # A RETRY, so the backoff has already elapsed. The lock
+                        # kept other API writers out of it, but an external
+                        # editor is not subject to the lock -- and republishing
+                        # over its edit is the one thing this path cannot
+                        # detect after the fact.
+                        await _assert_note_unchanged(abs_path, rel, observed)
+                    if await _publish_note_once(abs_path, tmp, attempt):
+                        return
+                    # Still inside the lock: with no token there is nothing to
+                    # detect an interleaved API write with, so ordering has to
+                    # be preserved.
+                    await asyncio.sleep(_SAVE_BACKOFF_SECONDS)
+            except BaseException:
+                # Every non-success exit -- staging failure, an exhausted
+                # budget, a POSIX refusal, cancellation -- discards the one temp
+                # this save owns BEFORE its registration is released. A 200
+                # never reaches here, because its rename consumed the temp.
+                await asyncio.to_thread(_discard_staged_sync, tmp)
+                raise
+
+
 async def api_note_save(request: web.Request) -> web.Response:
     vault = await require_vault(request)
     require_writable(vault)
@@ -1454,52 +1798,7 @@ async def api_note_save(request: web.Request) -> web.Response:
     if await asyncio.to_thread(platform_compat.is_link_or_junction, abs_path):
         raise ApiError("cannot save through a symlink", 400, code="note_is_symlink")
     base_mtime = body.get("baseMtime")
-    # Serialize the check-and-write for this note so two concurrent saves can't
-    # both pass the stale-write guard and silently clobber each other.
-    async with _save_lock(str(abs_path)):
-        # Optimistic concurrency: when the caller passes the mtime it read,
-        # refuse to write if the file changed underneath — otherwise an edit made
-        # outside the app (Obsidian, git pull) would be silently clobbered.
-        if isinstance(base_mtime, (int, float)):
-            current: Optional[float] = None
-            try:
-                current = (await asyncio.to_thread(os.stat, abs_path)).st_mtime * 1000
-            except FileNotFoundError:
-                # A supplied baseMtime means the file existed when the client read
-                # it, so its absence now is an external deletion — a conflict, not
-                # a new file. Silently rewriting would resurrect a note the user
-                # deleted in Obsidian or via `git pull`.
-                #
-                # The conflict hands back the -1 sentinel as the new mtime; when
-                # the user chooses "keep mine" the client retries with
-                # baseMtime == -1, which is the one value that means "yes,
-                # recreate it" and falls through to the write below. Without this
-                # escape hatch the retry would hit this same branch forever and
-                # the edit could never be saved.
-                if base_mtime != _RECREATE_SENTINEL:
-                    raise ApiError(
-                        "this note was deleted on disk since you opened it",
-                        409,
-                        code="ESTALE",
-                        mtime=_RECREATE_SENTINEL,
-                        disk="",
-                    )
-            if current is not None and abs(current - base_mtime) > MTIME_TOLERANCE_MS:
-                # The conflict response hands this content back to the client, so
-                # it goes through the same gate as every other read: containment
-                # inside the vault says nothing about what the vault holds.
-                disk = await read_note_text(abs_path)
-                if disk is None:
-                    raise ApiError(f"no such note: {rel}", 404, code="no_such_note")
-                raise ApiError(
-                    "this note changed on disk since you opened it",
-                    409,
-                    code="ESTALE",
-                    mtime=current,
-                    disk=disk,
-                )
-        await make_dirs(abs_path.parent)
-        await asyncio.to_thread(_atomic_write_text_sync, abs_path, content)
+    await _save_note_contents(abs_path, rel, content, base_mtime)
     mark_self_write(abs_path)
     cache = await get_cache(vault)
     cache["index"].update(

--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -18,6 +18,7 @@ import json
 import os
 import shutil
 import subprocess
+import threading
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -2795,6 +2796,624 @@ async def test_a_failed_save_leaves_the_previous_note_intact(fixtures) -> None:
         assert not (root / "keep.md.tmp").exists()
 
 
+@pytest.mark.asyncio
+async def test_a_contended_rename_does_not_lose_the_save(fixtures) -> None:
+    """A vault is a directory other processes hold open; a save must survive it.
+
+    On Windows ``os.replace`` raises ``PermissionError`` while ANY other handle is
+    open on either path. For a note that is expected rather than exotic: these are
+    Obsidian vaults, so the user's editor is often holding the file, and Windows
+    Search and AV both touch a freshly written one. A bare rename turns that
+    transient into a failed save -- the user loses what they just typed.
+
+    The other half of the contract is pinned by the test below: when the
+    contention coincides with a real external edit, the retry must yield to it
+    instead of publishing. Here nothing else changed the file, so the save is
+    simply completed.
+    """
+    _mod, remote, _seed = fixtures
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        _, read = await client.get("/api/note?path=One.md")
+        target = Path(vault["localPath"]) / "One.md"
+
+        attempts: list[int] = []
+        real_replace = os.replace
+
+        def contended_once(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+            attempts.append(1)
+            if len(attempts) == 1:
+                # WinError 32, the sharing violation this retry exists for --
+                # and no external edit, so the file is unchanged between attempts.
+                raise PermissionError(32, "The process cannot access the file")
+            return real_replace(src, dst, *args, **kwargs)
+
+        with pytest.MonkeyPatch.context() as mp:
+            # The retry is Windows-only and backs off; select that branch on every
+            # platform and zero the wait so it costs no wall clock.
+            mp.setattr(_mod.platform_compat, "IS_WINDOWS", True)
+            mp.setattr(_mod, "_SAVE_BACKOFF_SECONDS", 0.0)
+            mp.setattr(_mod.os, "replace", contended_once)
+            status, body = await client.put(
+                "/api/note",
+                {"path": "One.md", "content": "mine", "baseMtime": read["mtime"]},
+            )
+
+        assert status == 200, f"a transient sharing violation lost the save: {body}"
+        assert target.read_text(encoding="utf-8") == "mine"
+        assert len(attempts) == 2, f"expected one retry, saw {len(attempts)} attempt(s)"
+        assert not list(target.parent.glob("One.md.*.tmp")), "a temp file was left behind"
+
+
+@pytest.mark.asyncio
+async def test_a_contended_save_leaves_no_temp_behind(fixtures) -> None:
+    """A successful save must not leave a generated temp in the vault.
+
+    The cleanup after a refused rename is best-effort: if the same handle that
+    blocked the rename also blocks the unlink, the temp survives. Staging a FRESH
+    temp per attempt then meant a contended save could answer 200 with an orphan
+    ``One.md.<uuid>.tmp`` still sitting in the vault -- and nothing would tell the
+    user to look, because the save reported success.
+
+    That orphan is not inert. A user-initiated Sync stages every change
+    ``status()`` reports; only the unattended autosave is narrowed to ``.md``. So
+    the generated temp reaches a commit, and a push puts it on the remote.
+
+    One temp per save transaction removes the failure mode rather than cleaning
+    up after it: the same staged file is republished by each attempt, so success
+    consumes it.
+    """
+    _mod, remote, _seed = fixtures
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        root = Path(vault["localPath"])
+        target = root / "One.md"
+        _, read = await client.get("/api/note?path=One.md")
+
+        renames: list[str] = []
+        real_replace = os.replace
+        real_unlink = os.unlink
+
+        def contended_once(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+            renames.append(str(src))
+            if len(renames) == 1:
+                raise PermissionError(32, "The process cannot access the file")
+            return real_replace(src, dst, *args, **kwargs)
+
+        def unlink_refused(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # The handle that blocked the rename blocks the cleanup too, which is
+            # the whole reason an orphan can survive.
+            if str(path).endswith(".tmp"):
+                raise PermissionError(32, "The process cannot access the file")
+            return real_unlink(path, *args, **kwargs)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_mod.platform_compat, "IS_WINDOWS", True)
+            mp.setattr(_mod, "_SAVE_BACKOFF_SECONDS", 0.0)
+            mp.setattr(_mod.os, "replace", contended_once)
+            mp.setattr(_mod.os, "unlink", unlink_refused)
+            status, body = await client.put(
+                "/api/note",
+                {"path": "One.md", "content": "mine", "baseMtime": read["mtime"]},
+            )
+
+        assert status == 200, f"the contended save did not succeed: {body}"
+        assert target.read_text(encoding="utf-8") == "mine"
+
+        leftovers = sorted(p.name for p in root.glob("One.md.*.tmp"))
+        assert not leftovers, (
+            "a save answered 200 while leaving generated temp(s) in the vault, "
+            f"which a user Sync would commit: {leftovers}"
+        )
+        # The retry republished the SAME staged file rather than staging another.
+        assert len(set(renames)) == 1, (
+            f"each attempt staged its own temp: {sorted(set(renames))}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_sync_during_the_retry_window_never_commits_the_staged_temp(
+    fixtures,
+) -> None:
+    """A Sync running while a save is between attempts must not commit its temp.
+
+    The save stages content into a sibling temp and renames it over the note. The
+    temp is a real untracked file in the user's vault for the whole of that gap,
+    and a contended rename stretches the gap across the entire retry budget. A
+    user-initiated Sync stages every change ``status()`` reports -- only the
+    unattended autosave is narrowed to ``.md`` -- so in that window a second tab
+    hitting Sync commits a half-published implementation detail and the push puts
+    it on the remote.
+
+    Shortening the window cannot fix this: it is never zero, and the cleanup
+    unlink is best-effort precisely because the handle that refused the rename
+    commonly refuses it too. ``git_ops.status`` therefore recognises the shape
+    ``staged_temp_name`` produces and refuses to report it as an addition.
+
+    Deterministic, never raced: the Sync runs INSIDE the parked backoff, so it is
+    guaranteed to land between attempt 1 and attempt 2, and the vault carries a
+    genuine non-note change so a Sync that silently did nothing cannot pass.
+    """
+    _mod, remote, _seed = fixtures
+    real_asyncio = asyncio
+
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        root = Path(vault["localPath"])
+        target = root / "One.md"
+        before = target.read_text(encoding="utf-8")
+        _, read = await client.get("/api/note?path=One.md")
+
+        # A real user change the whole-scope Sync MUST commit. Without it a Sync
+        # that no-opped would satisfy every assertion below.
+        (root / "attachment.png").write_bytes(bytes([0x89]) + b"PNG")
+
+        parked = asyncio.Event()
+        resume = asyncio.Event()
+        parkings: list[int] = []
+        attempts: list[str] = []
+        real_replace = os.replace
+
+        def contended_once(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+            # Scoped to THIS note's publish. `os` is a shared module object, so
+            # the patch is global: the Sync driven from inside the retry gap runs
+            # git and rebuilds the cache, and those renames must neither absorb
+            # the injected failure nor be counted as attempts.
+            if str(dst).endswith("One.md"):
+                attempts.append(str(src))
+                if len(attempts) == 1:
+                    raise PermissionError(32, "The process cannot access the file")
+            return real_replace(src, dst, *args, **kwargs)
+
+        class _GatedAsyncio:
+            """The real asyncio with the FIRST backoff parked on an event.
+
+            Only the first: the Sync driven from inside that gap runs through the
+            same module reference, and parking its waits too would deadlock the
+            test rather than test anything.
+            """
+
+            async def sleep(self, delay, *args, **kwargs):  # type: ignore[no-untyped-def]
+                parkings.append(1)
+                if len(parkings) == 1:
+                    parked.set()
+                    await resume.wait()
+                    return
+                await real_asyncio.sleep(delay, *args, **kwargs)
+
+            def __getattr__(self, name):  # type: ignore[no-untyped-def]
+                return getattr(real_asyncio, name)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_mod.platform_compat, "IS_WINDOWS", True)
+            mp.setattr(_mod.os, "replace", contended_once)
+            mp.setattr(_mod, "asyncio", _GatedAsyncio())
+
+            save = real_asyncio.create_task(
+                client.put(
+                    "/api/note",
+                    {"path": "One.md", "content": "mine", "baseMtime": read["mtime"]},
+                )
+            )
+            await real_asyncio.wait_for(parked.wait(), timeout=5)
+
+            # The exposure is real and present RIGHT NOW: the temp is on disk and
+            # git reports it as untracked. Asserting it keeps the rest of this
+            # test from passing because nothing was ever staged.
+            staged = [q.name for q in root.glob("One.md.*.tmp")]
+            assert len(staged) == 1, f"expected one staged temp, saw {staged}"
+            porcelain = _git("status", "--porcelain", "--untracked-files=all", cwd=root)
+            assert staged[0] in porcelain, (
+                f"git cannot see the temp, so this proves nothing: {porcelain!r}"
+            )
+
+            # A second tab hits Sync while the first save backs off.
+            sync_status, sync_body = await client.post("/api/sync")
+            assert sync_status == 200, sync_body
+            committed = [c["path"] for c in sync_body["result"]["committed"]]
+
+            resume.set()
+            save_status, save_body = await real_asyncio.wait_for(save, timeout=5)
+
+    assert committed == ["attachment.png"], (
+        f"a Sync inside the retry backoff staged a generated temp: {committed}"
+    )
+    assert staged[0] not in _git("ls-files", cwd=root), "the temp entered local history"
+    assert staged[0] not in _git(
+        "ls-tree", "-r", "--name-only", "HEAD", cwd=Path(remote)
+    ), "the temp was pushed to the remote"
+
+    # The Sync committed against the note as it stood BEFORE the retry finished,
+    # and the save still lands afterwards: the filter costs the save nothing.
+    assert _git("show", "HEAD:One.md", cwd=root) == before.rstrip()
+    assert save_status == 200, f"the contended save was lost: {save_body}"
+    assert target.read_text(encoding="utf-8") == "mine"
+    assert len(attempts) == 2, f"expected one retry, saw {len(attempts)} attempt(s)"
+    # Both attempts republished the one staged temp the Sync just declined to see.
+    assert set(attempts) == {str(root / staged[0])}, f"the temp changed: {attempts}"
+    assert not list(root.glob("One.md.*.tmp")), "a temp survived a successful save"
+
+
+@pytest.mark.asyncio
+async def test_a_sync_while_the_temp_is_still_staging_never_commits_it(
+    fixtures,
+) -> None:
+    """Registration must precede the worker thread creating the temp.
+
+    The retry-window test above begins only after staging returns. A large note
+    exposes an earlier window: ``open`` creates the untracked temp, then the
+    worker can spend arbitrarily long writing and fsyncing it before returning
+    to the coroutine that used to register it. A Sync in that interval could
+    commit a partial implementation detail.
+
+    Deterministic: the staging worker writes the real temp and parks BEFORE it
+    returns. Sync runs while the file is definitely present and the save caller
+    is definitely still awaiting staging.
+    """
+    _mod, remote, _seed = fixtures
+    real_asyncio = asyncio
+
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        root = Path(vault["localPath"])
+        target = root / "One.md"
+        _, read = await client.get("/api/note?path=One.md")
+
+        # Prove this is a real whole-scope Sync, not a no-op that happens to
+        # report no generated temp.
+        (root / "attachment.png").write_bytes(bytes([0x89]) + b"PNG")
+
+        temp_written = threading.Event()
+        release_stage = threading.Event()
+        staged: list[Path] = []
+        real_stage = _mod._stage_note_text_sync
+
+        def parked_stage(tmp, content):  # type: ignore[no-untyped-def]
+            real_stage(tmp, content)
+            staged_path = Path(tmp)
+            # Sync records lastSync through the same generic atomic writer.
+            # Park only this note; delaying settings.json would deadlock the
+            # request that is meant to inspect the note temp.
+            if staged_path.parent == root and staged_path.name.startswith("One.md."):
+                staged.append(staged_path)
+                temp_written.set()
+                if not release_stage.wait(timeout=30):
+                    raise AssertionError("test never released the staging worker")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_mod, "_stage_note_text_sync", parked_stage)
+            save = real_asyncio.create_task(
+                client.put(
+                    "/api/note",
+                    {"path": "One.md", "content": "mine", "baseMtime": read["mtime"]},
+                )
+            )
+
+            save_status = 0
+            save_body: dict[str, Any] = {}
+            try:
+                assert await real_asyncio.to_thread(temp_written.wait, 10), (
+                    "the save never created its staged temp"
+                )
+                assert len(staged) == 1 and staged[0].is_file(), staged
+                porcelain = _git(
+                    "status", "--porcelain", "--untracked-files=all", cwd=root
+                )
+                assert staged[0].name in porcelain, (
+                    "git cannot see the staged temp, so this proves nothing: "
+                    f"{porcelain!r}"
+                )
+
+                sync_status, sync_body = await client.post("/api/sync")
+                assert sync_status == 200, sync_body
+                committed = [c["path"] for c in sync_body["result"]["committed"]]
+            finally:
+                release_stage.set()
+                save_status, save_body = await real_asyncio.wait_for(save, timeout=10)
+
+    assert committed == ["attachment.png"], (
+        f"a Sync while staging committed a generated temp: {committed}"
+    )
+    assert staged[0].name not in _git("ls-files", cwd=root), (
+        "the staging temp entered local history"
+    )
+    assert staged[0].name not in _git(
+        "ls-tree", "-r", "--name-only", "HEAD", cwd=Path(remote)
+    ), "the staging temp was pushed to the remote"
+    assert save_status == 200, f"the parked save failed: {save_body}"
+    assert target.read_text(encoding="utf-8") == "mine"
+    assert not staged[0].exists(), "the temp survived its successful publish"
+
+
+@pytest.mark.asyncio
+async def test_an_external_edit_during_the_retry_window_still_wins(fixtures) -> None:
+    """Retrying a contended save must not defeat the stale-write guard.
+
+    The save is an optimistic check-and-write: the client sends the mtime it
+    read, the server re-stats under the lock, and an external edit since that read is a
+    409 ESTALE rather than a silent overwrite.
+
+    Retrying only the RENAME would stretch the gap between that check and the
+    publish across the whole backoff, so an external edit completing inside the
+    gap would be overwritten by the next attempt — the guard defeated by the very
+    mechanism meant to make saves reliable. The retry therefore re-runs the
+    freshness check before each attempt.
+
+    Ordering is forced, not raced: the external write happens INSIDE the injected
+    rename failure, so it is guaranteed to land after attempt 1 and before
+    attempt 2's re-check.
+    """
+    _mod, remote, _seed = fixtures
+    external = "# One\n\nchanged by another program\n"
+
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        _, read = await client.get("/api/note?path=One.md")
+        target = Path(vault["localPath"]) / "One.md"
+
+        attempts: list[int] = []
+        real_replace = os.replace
+
+        def contended_then_external(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+            attempts.append(1)
+            if len(attempts) == 1:
+                # Another program finishes its write while we are between
+                # attempts. Its mtime is pinned forward rather than slept for:
+                # two writes can share one filesystem tick, which would make the
+                # guard's comparison a coin flip instead of the thing under test.
+                target.write_text(external, encoding="utf-8")
+                future = target.stat().st_mtime + 5
+                os.utime(target, (future, future))
+                raise PermissionError(32, "The process cannot access the file")
+            return real_replace(src, dst, *args, **kwargs)
+
+        from kiro_crew import atomic_write as aw
+
+        with pytest.MonkeyPatch.context() as mp:
+            # Both backoff knobs are zeroed, both with raising=False, so this test
+            # asserts the CONTRACT rather than where the retry happens to live.
+            # That is what makes it a valid negative control: against a build that
+            # retries inside the rename it still runs, and fails because the
+            # external edit was published over -- not because a constant was
+            # missing from the module.
+            mp.setattr(_mod.platform_compat, "IS_WINDOWS", True)
+            mp.setattr(aw.platform_compat, "IS_WINDOWS", True)
+            mp.setattr(_mod, "_SAVE_BACKOFF_SECONDS", 0.0, raising=False)
+            mp.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0.0, raising=False)
+            mp.setattr(_mod.os, "replace", contended_then_external)
+            status, body = await client.put(
+                "/api/note",
+                {"path": "One.md", "content": "mine", "baseMtime": read["mtime"]},
+            )
+
+        assert status == 409, f"the external edit was not detected: {status} {body}"
+        assert body["code"] == "ESTALE"
+        assert target.read_text(encoding="utf-8") == external, (
+            "the retry published over an edit made during its own backoff"
+        )
+        assert "mine" not in target.read_text(encoding="utf-8")
+        # The second attempt must never have REACHED the rename: a re-check that
+        # runs first turns it into the conflict above. A build that retries the
+        # rename alone shows 2 here and has already overwritten the file.
+        assert len(attempts) == 1, (
+            f"a second publish attempt ran without revalidating: {len(attempts)} attempts"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_retrying_save_without_basemtime_cannot_overwrite_a_later_one(
+    fixtures,
+) -> None:
+    """A contended save must not resurrect itself over a save that already won.
+
+    ``baseMtime`` is optional (``saveNote(..., baseMtime?: number)``) and
+    ``_assert_note_is_fresh`` is a no-op without it, so for an unguarded save a
+    writer arriving during the retry backoff is invisible to every later attempt.
+    Releasing the per-note lock across that backoff therefore let an earlier
+    contended save republish over a later one that had already been acknowledged
+    with 200 -- rename order ``['A', 'B', 'A']``, final content ``A``.
+
+    Without a token there is nothing to detect the interleave with, so ordering
+    is preserved instead: the lock is held across the backoff, which is exactly
+    the serialization the un-retried code had.
+
+    Ordering is forced with events and a structural assertion on the lock, never
+    slept for.
+    """
+    _mod, remote, _seed = fixtures
+    real_asyncio = asyncio
+
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        target = Path(vault["localPath"]) / "One.md"
+
+        a_parked = asyncio.Event()
+        release_a = asyncio.Event()
+        renames: list[str] = []
+        real_replace = os.replace
+
+        def one_contention(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+            body = ""
+            try:
+                body = Path(src).read_text(encoding="utf-8")
+            except OSError:
+                pass
+            renames.append(body)
+            if len(renames) == 1:
+                raise PermissionError(32, "The process cannot access the file")
+            return real_replace(src, dst, *args, **kwargs)
+
+        class _GatedAsyncio:
+            """The real asyncio with the retry backoff parked on an event.
+
+            Rebinding the module reference the server holds keeps the
+            substitution to this one call site; every other attribute
+            (``to_thread``, ``Lock``) proxies through untouched.
+            """
+
+            async def sleep(self, _delay, *args, **kwargs):  # type: ignore[no-untyped-def]
+                # Park only the FIRST backoff -- A's -- which is what pins the
+                # ordering. Later backoffs delegate to a real short wait: after A
+                # returns, api_note_save re-reads every note in the vault to
+                # recompute backlinks, OUTSIDE the per-note lock, so B's rename
+                # can hit a genuine Windows sharing violation there. Production
+                # absorbs that with the backoff; collapsing it to zero would burn
+                # B's whole budget inside A's read window and make this test fail
+                # on an artifact of its own instrumentation.
+                if not release_a.is_set():
+                    a_parked.set()
+                    await release_a.wait()
+                    return
+                await real_asyncio.sleep(0.01)
+
+            def __getattr__(self, name):  # type: ignore[no-untyped-def]
+                return getattr(real_asyncio, name)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_mod.platform_compat, "IS_WINDOWS", True)
+            mp.setattr(_mod.os, "replace", one_contention)
+            mp.setattr(_mod, "asyncio", _GatedAsyncio())
+
+            task_a = real_asyncio.create_task(
+                client.put("/api/note", {"path": "One.md", "content": "A"})
+            )
+            await real_asyncio.wait_for(a_parked.wait(), timeout=5)
+
+            # A is mid-retry with no freshness token. The note's lock must still
+            # be held, so a second save cannot slip in behind it.
+            assert _mod._save_lock(str(target)).locked(), (
+                "the per-note lock was released during an unguarded retry"
+            )
+
+            task_b = real_asyncio.create_task(
+                client.put("/api/note", {"path": "One.md", "content": "B"})
+            )
+            # Yield generously rather than sleeping: if B could interleave it
+            # would have completed by now.
+            for _ in range(100):
+                await real_asyncio.sleep(0)
+            assert not task_b.done(), "a later save interleaved into the retry gap"
+
+            release_a.set()
+            status_a, body_a = await real_asyncio.wait_for(task_a, timeout=5)
+            status_b, body_b = await real_asyncio.wait_for(task_b, timeout=5)
+
+        assert status_a == 200, f'the earlier save failed: {body_a}'
+        assert status_b == 200, f'the later save failed: {body_b} renames={renames}'
+        # The invariant is ordering, not a retry count: every A attempt precedes
+        # every B attempt, so the earlier save can never republish after the later
+        # one. An exact count would encode how many times B happened to retry,
+        # which depends on a real collision with A post-save vault read.
+        assert renames == sorted(renames, key=lambda body: body != "A"), (
+            f"an A attempt ran after a B attempt: {renames}"
+        )
+        assert "A" in renames and "B" in renames, f"both saves must publish: {renames}"
+        assert target.read_text(encoding="utf-8") == "B", (
+            "an earlier contended save resurrected itself over a later one"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_tokenless_save_stages_inside_the_note_lock(fixtures) -> None:
+    """Staging is the slow half of the transaction, so it must be serialized too.
+
+    Without a ``baseMtime`` nothing can DETECT an interleaved writer, so order
+    is the only guarantee left -- and order has to cover stage-and-publish, not
+    just publish. Staging writes the entire note, so it is exactly where a large
+    save is slow: with staging outside the lock, a later save could take the
+    lock, publish and answer 200 while the earlier one was still writing its
+    temp, and the earlier one then published over it. Both answered 200 and the
+    later edit was gone.
+
+    No contention is injected here: this is not about a refused rename. The
+    parking point is staging itself, and the assertion is structural -- the
+    note's lock is held while A stages, so B cannot start.
+    """
+    _mod, remote, _seed = fixtures
+    real_asyncio = asyncio
+
+    async with signed_client(_mod) as client:
+        vault = await _clone(client, remote)
+        target = Path(vault["localPath"]) / "One.md"
+
+        a_staging = threading.Event()
+        release_a = threading.Event()
+        staged: list[str] = []
+        real_stage = _mod._stage_note_text_sync
+
+        def parked_stage(tmp, content):  # type: ignore[no-untyped-def]
+            # Runs on a worker thread (`asyncio.to_thread`), so the gate is a
+            # threading.Event, not an asyncio one.
+            staged.append(content)
+            if len(staged) == 1:
+                a_staging.set()
+                release_a.wait(timeout=10)
+            return real_stage(tmp, content)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_mod, "_stage_note_text_sync", parked_stage)
+
+            task_a = real_asyncio.create_task(
+                client.put("/api/note", {"path": "One.md", "content": "A"})
+            )
+            assert await real_asyncio.to_thread(a_staging.wait, 10), (
+                "the first save never reached staging"
+            )
+
+            # The structural claim: A is only STAGING, has published nothing, and
+            # already holds the note's lock.
+            assert _mod._save_lock(str(target)).locked(), (
+                "a tokenless save staged its temp outside the per-note lock"
+            )
+
+            task_b = real_asyncio.create_task(
+                client.put("/api/note", {"path": "One.md", "content": "B"})
+            )
+            # Yield generously rather than sleeping: were the lock free, B would
+            # have staged and published by now.
+            for _ in range(100):
+                await real_asyncio.sleep(0)
+            assert staged == ["A"], f"a later save staged while the earlier one held the lock: {staged}"
+            assert not task_b.done(), "a later save completed while the earlier one was staging"
+
+            release_a.set()
+            status_a, body_a = await real_asyncio.wait_for(task_a, timeout=10)
+            status_b, body_b = await real_asyncio.wait_for(task_b, timeout=10)
+
+    assert status_a == 200, f"the earlier save failed: {body_a}"
+    assert status_b == 200, f"the later save failed: {body_b}"
+    assert staged == ["A", "B"], f"staging order was not preserved: {staged}"
+    assert target.read_text(encoding="utf-8") == "B", (
+        "the earlier save published over the later one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_vault_registry_write_also_retries(fixtures) -> None:
+    """The registry is re-read by every later request, so it has the same window."""
+    from kiro_crew import atomic_write as aw
+
+    server_mod, _remote, _seed = fixtures
+
+    attempts: list[int] = []
+    real_replace = os.replace
+
+    def contended_once(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise PermissionError(32, "The process cannot access the file")
+        return real_replace(src, dst, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(aw.platform_compat, "IS_WINDOWS", True)
+        mp.setattr(aw, "_REPLACE_BACKOFF_SECONDS", 0.0)
+        mp.setattr(aw.os, "replace", contended_once)
+        await asyncio.to_thread(server_mod._write_vaults_sync, [{"id": "v1"}])
+
+    assert json.loads(server_mod._vaults_json().read_text("utf-8")) == [{"id": "v1"}]
+    assert len(attempts) == 2, f"expected one retry, saw {len(attempts)} attempt(s)"
+
+
 # ---------------------------------------------------------------------------
 # Settings store and the server-side auto-sync loop
 # ---------------------------------------------------------------------------
@@ -3450,3 +4069,170 @@ async def test_a_conflicted_manual_sync_reports_no_sync_time(fixtures) -> None:
 
         status, body = await client.get("/api/settings")
         assert body["settings"]["lastSync"] == {}
+
+
+# -- #4899 exact-head review blockers ----------------------------------------
+#
+# `status()` may hide a path on ONE ground: this process currently knows it owns
+# the temp. The name shape is not ownership evidence -- `<name>.<32 hex>.tmp` is
+# what `staged_temp_name` produces, not a shape only it can produce -- so the
+# cases below pin both directions.
+
+NL = chr(10)
+HEX32 = "0123456789abcdef0123456789abcdef"
+
+
+def _seed_vault(tmp_path: Path, *files: str) -> Path:
+    repo = tmp_path / "vault"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    for name in files:
+        (repo / name).write_text("seeded " + name + NL, encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "seed")
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_user_file_in_the_temp_shape_stays_visible(
+    tmp_path: Path,
+) -> None:
+    """A user file NAMED like a staged temp is still the user's file.
+
+    `<name>.<32 hex>.tmp` is the shape this module produces; nothing stops a
+    user or another tool from producing it too. Hiding it on the shape alone
+    withheld real content from the user's own repository -- absent from the
+    pending badge, from the commit, and from the remote, with nothing to say it
+    had been dropped. Withholding unknown filesystem content is a worse failure
+    than committing a stray temp, so shape alone must not hide anything.
+    """
+    repo = _seed_vault(tmp_path, "Report.md")
+    genuine = "Report.md." + HEX32 + ".tmp"
+    (repo / genuine).write_text("a real file the user made" + NL, encoding="utf-8")
+
+    # The origin is untouched: nothing here looks like a rename.
+    assert (repo / "Report.md").exists()
+
+    kinds = {c.path: c.kind for c in await git_ops.status(str(repo))}
+    assert kinds.get(genuine) == "added", (
+        "status() hid a genuine user file because its NAME matched the staged-temp "
+        "shape, so it would never be committed or pushed: %r" % (kinds,)
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_registered_in_flight_temp_is_hidden(tmp_path: Path) -> None:
+    """The one ground for hiding a path: this process owns it right now."""
+    repo = _seed_vault(tmp_path, "Note.md")
+    tmp_name = git_ops.staged_temp_name("Note.md")
+    (repo / tmp_name).write_text("in flight" + NL, encoding="utf-8")
+
+    with git_ops.inflight_temp(repo / tmp_name):
+        paths = {c.path for c in await git_ops.status(str(repo))}
+        assert tmp_name not in paths, (
+            "a temp this process is publishing reached status(): %r" % (paths,)
+        )
+
+    # Ownership ended, so the file is ordinary content again rather than being
+    # withheld forever. An orphan becoming visible is the safe failure direction.
+    paths = {c.path for c in await git_ops.status(str(repo))}
+    assert tmp_name in paths, (
+        "a temp stayed hidden after its transaction ended, so an orphan could "
+        "never be seen or cleaned by the user: %r" % (paths,)
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_rename_into_the_temp_shape_commits_both_halves(
+    tmp_path: Path,
+) -> None:
+    """A tracked file renamed into the temp shape must not lose either half.
+
+    The rename does not arrive as git's `R` record: the renamed file is
+    untracked, so `diff HEAD` reports only the old path as deleted and the new
+    path turns up in `ls-files --others`. Dropping the addition on shape left
+    the deletion standing alone, and the autosave committed the move as a
+    REMOVAL -- the file disappears from the remote while still sitting in the
+    vault under its new name.
+    """
+    repo = _seed_vault(tmp_path, "Note.md")
+    renamed_name = git_ops.staged_temp_name("Note.md")
+    (repo / "Note.md").rename(repo / renamed_name)
+
+    kinds = {c.path: c.kind for c in await git_ops.status(str(repo))}
+    assert kinds.get("Note.md") == "deleted", (
+        "the rename's deleted half vanished from status(): %r" % (kinds,)
+    )
+    assert kinds.get(renamed_name) == "added", (
+        "status() dropped the rename's ADDED half while keeping its deletion, so "
+        "a Sync would commit this move as a removal: %r" % (kinds,)
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_tokenless_retry_refuses_to_overwrite_an_external_edit(
+    fixtures, tmp_path: Path
+) -> None:
+    """A save with no ``baseMtime`` must not republish over an edit made in its gap.
+
+    ``_assert_note_is_fresh`` is a no-op without a client token, and the note
+    lock only serializes API writers -- an editor writing the file directly
+    (Obsidian, ``git pull``, a script) never takes it. So a contended rename that
+    backs off and retries used to rename over whatever landed in the meantime and
+    answer 200, destroying a newer edit with no conflict reported.
+
+    The server therefore samples its OWN baseline before the first attempt and
+    revalidates against it before every retry. Deterministic: the external write
+    is performed from inside the injected backoff, so it is guaranteed to land
+    between attempt 1 and attempt 2.
+    """
+    _mod, _remote, _seed = fixtures
+
+    root = tmp_path / "tokenless-vault"
+    root.mkdir()
+    target = root / "One.md"
+    target.write_text("original" + NL, encoding="utf-8")
+
+    real_replace = os.replace
+    real_sleep = asyncio.sleep
+    attempts: list[str] = []
+
+    def contended_once(src, dst, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if str(dst).endswith("One.md"):
+            attempts.append(str(src))
+            if len(attempts) == 1:
+                raise PermissionError(32, "The process cannot access the file")
+        return real_replace(src, dst, *args, **kwargs)
+
+    async def external_write_during_backoff(delay):  # type: ignore[no-untyped-def]
+        # THE external editor: lands in the retry gap, holds no lock, and leaves
+        # a strictly newer mtime.
+        if attempts:
+            target.write_text("edited in obsidian" + NL, encoding="utf-8")
+            future = time.time() + 5
+            os.utime(target, (future, future))
+        await real_sleep(0)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(os, "replace", contended_once)
+        mp.setattr(_mod.platform_compat, "IS_WINDOWS", True)
+        mp.setattr(_mod.asyncio, "sleep", external_write_during_backoff)
+
+        with pytest.raises(_mod.ApiError) as excinfo:
+            await _mod._save_note_contents(target, "One.md", "my save" + NL, None)
+
+    assert excinfo.value.status == 409, (
+        "a tokenless retry answered %r instead of a conflict" % (excinfo.value.status,)
+    )
+    assert target.read_text(encoding="utf-8") == "edited in obsidian" + NL, (
+        "the tokenless retry republished over an external edit made during its "
+        "backoff -- the edit is gone and the client was never told"
+    )
+    leftovers = sorted(p.name for p in root.glob("One.md.*.tmp"))
+    assert not leftovers, "the refused save left its temp behind: %r" % (leftovers,)


### PR DESCRIPTION
## Problem / Motivation

Saving a note in md-notebook can fail on Windows and lose what the user just typed, while the note keeps its old contents on disk.

`_atomic_write_text_sync` finishes its durable tmp-then-rename write with a bare `os.replace`:

```python
with open(tmp, "w", encoding="utf-8", newline="") as fh:
    fh.write(content)
    fh.flush()
    os.fsync(fh.fileno())
os.replace(tmp, path)          # raises PermissionError under contention
```

On Windows `os.replace` raises `PermissionError` (WinError 32) while **any** other handle is open on either path. There is no retry, so the exception propagates, the `except BaseException` arm removes the temp file, and the save is discarded. `_write_vaults_sync` has the same shape for `vaults.json`.

## Why it matters

This is not the exotic corner it would be for an internal state file. A vault is an **ordinary user directory other processes are expected to hold open**:

- md-notebook vaults are Obsidian vaults — the `obsidian_vault` connector exists precisely so users can point this at a live vault — so the user's editor is frequently holding the file being saved.
- Windows Search indexes `.md` files and AV scans freshly written ones. `replace_with_retry`'s own docstring names exactly these two as its reason for existing.

The shape of the failure is the worst one for a notes app: the write was complete and `fsync`ed, and it is thrown away at the very last step. The user sees a failed save on a note whose old text is still on disk — the data was in hand and then dropped.

## What changed (motivation → approach → change)

**Symptom** — a note save raises `PermissionError` and is lost when another process holds the file.

**Root cause** — the durable write ends in a bare `os.replace`, which on Windows is not a reliable final step; it is the one part of the sequence that fails for reasons unrelated to the caller.

**Change** — retry the note's **check-and-write transaction**.

**Scope correction:** an earlier revision of this description credited this PR with routing the vault registry through `atomic_write.replace_with_retry`. It does not. `_write_vaults_sync` already calls that helper on `origin/main` (`server.py:320`), so that behaviour is inherited, not shipped here. The registry test below is kept as a **preservation** pin, not as evidence of a change.

Retrying the *rename* alone would trade the lost save for something worse. The note save is an optimistic check-and-write: the client sends the mtime it read, the server re-stats under `_save_lock`, and an external edit since that read is a `409 ESTALE` rather than a silent overwrite. A retry inside the rename stretches the gap between that check and the publish across the whole backoff — so an Obsidian write completing inside the gap is overwritten by the next attempt, defeating the guard with the very mechanism meant to make saves reliable.

So `_save_note_contents` re-enters the freshness check on **every** attempt, and the note writer keeps a single-attempt rename. A contended save therefore either publishes against state it just revalidated, or becomes the 409 the external edit has earned.

**The lock policy then depends on whether the save carries a token,** because that is what decides whether a writer in the gap can be *detected*:

- **With `baseMtime`** — release the lock across the backoff. A writer arriving there is one the next attempt's check will see and report, so blocking it would hide the conflict.
- **Without `baseMtime`** — the API permits omitting it (`saveNote(..., baseMtime?: number)`) and the editor does when it has not read an mtime. `_assert_note_is_fresh` is then a no-op, so a writer in the gap is invisible to every later attempt. Releasing the lock there let an earlier contended save republish over a later one already acknowledged with 200. With nothing to detect the interleave, ordering is preserved instead: the lock is **held** across the backoff, which is exactly the serialization the un-retried code had. A same-note writer waits at most the retry budget (~450 ms), as a coroutine suspension rather than a blocked loop.

  **The lock orders API writers and nothing else, so that is only half the answer.** An editor writing the file directly — Obsidian, `git pull`, a script — never takes it, and republishing over that edit is undetectable after the fact. So the tokenless path derives its **own** baseline: `_observed_note_mtime` samples the state the save is about to overwrite before the first attempt, and `_assert_note_unchanged` revalidates against it before every **retry**, answering the same `409 ESTALE` the guarded path answers with the same `-1` recreate sentinel. The first attempt never consults it — overwriting the sampled state *is* the save. The two paths now differ only in where the baseline comes from, not in whether a writer in the gap can be detected.

`_write_vaults_sync` has no such contract (`vaults.json` carries no `baseMtime` and no external editor). It already used `replace_with_retry` before this PR and is untouched by it.

**The tokenless path holds the lock across STAGE-and-publish, not just publish.** Staging writes the whole note, so it is where a large save is slow. With staging outside the lock, a later save could take the lock, publish and answer `200` while the earlier one was still writing its temp — and the earlier one then published over it. Both answered `200`; the later edit was gone. Order is the only guarantee an unguarded save has, so it now covers the whole transaction. The guarded path still stages outside the lock, because there the per-attempt freshness check is what orders saves and it cannot be fooled by a stale temp.

**The guarded path checks freshness before it touches the filesystem.** A save whose note and parent were deleted externally is already destined for `409`, and `make_dirs` would put the parent back on the way to refusing it. The pre-check costs one extra `stat` on the happy path and weakens nothing: the per-attempt check under the lock is still the only thing that authorizes a publish.

**One save owns ONE temp.** Staging a fresh temp per attempt left an orphan for every contended attempt whose cleanup unlink also lost the race — and because the retry ends in 200, nothing told the user to look. The temp is now staged once and republished by each attempt, so a successful rename consumes it, and every non-success exit discards that one exact path. Never a `glob` over sibling `*.tmp` — on the guarded path a concurrent save may legitimately own one.

**A staged temp is unstageable by git, not merely short-lived.** That temp is a real untracked file in the user's vault from the moment it is staged until the rename consumes it, and a user-initiated Sync stages every change `status()` reports — only the unattended autosave is narrowed to `.md`. So a second tab hitting Sync in that gap commits a half-published implementation detail and the push puts it on the remote. A contended rename widens the gap to the whole retry budget, but the gap is never zero even without one, and the cleanup unlink cannot close it: the handle that refuses the rename commonly refuses the unlink too.

Shrinking the window is therefore not a fix. `git_ops.status` is the one choke point — `auto_commit` stages exactly the paths it returns, sync's pending count reads it, and so does the notes listing's badge — so that is where a staged temp is withheld from a commit.

**What authorizes withholding it is OWNERSHIP, not the file's name.** An earlier revision of this PR excluded any addition matching the shape `staged_temp_name` produces (`<name>.<32 hex>.tmp`). That shape is what this module *produces*; it is not a shape only this module *can* produce. A user — or another tool — may genuinely create such a file, and it was then withheld from the user's own repository: absent from the pending badge, from the commit, and from the remote, with nothing to say it had been dropped.

That was a regression this PR introduced, and it was found by falsifying the filter rather than by a reviewer. Measured on three revisions, with a tracked `Report.md` still present beside an untracked `Report.md.<32 hex>.tmp`:

| revision | genuine user `.tmp` |
|---|---|
| `origin/main` `203491d3b` | **visible** (`added`) |
| this PR, before the fix below | hidden |

`is_staged_temp` does not exist on `main`, so this did not come from there — it arrived with this PR's filter, which made it this PR's to fix.

**The fix is a subtraction, not a better heuristic.** Only `is_inflight_temp` may hide a path: a temp *this process currently knows it is publishing*, registered across the whole stage-and-retry transaction (`inflight_temp`, keyed on the uuid4 basename so no two spellings of a path have to agree on case, 8.3 names, a symlinked vault root or separator flavour). `is_staged_temp`, `staged_temp_origin`, the origin-was-deleted pairing and `_STAGED_TEMP_RE` are all gone — keeping a predicate whose docstring asserted the shape was exclusive would leave the misconception in place for the next reader.

This also settles the rename case, which never arrived as git's `R` record anyway: the renamed file is untracked, so `diff HEAD` reports only the old path as deleted and the new path turns up in `ls-files --others`. Both halves are now ordinary content and commit whole, instead of the move being committed as a removal.

**One consequence is deliberate.** An orphan left behind when a cleanup unlink lost the race becomes **visible** once its transaction ends and ownership can no longer be evidenced. That is the safe direction to fail: silently withholding unknown filesystem content from a user's git repository is worse than committing a stray temp. Reaping an aged orphan is a lifecycle problem with its own answer, and a permanent filename-shape exclusion is not that answer — it cannot tell an orphan from a file the user put there.

The freshness check is extracted verbatim into `_assert_note_is_fresh` — including the `-1` recreate-sentinel path — so re-running it costs a `stat` and changes no behaviour on the first attempt.

Three properties:

- **The invariant:** no attempt may publish without revalidating the stale-write contract after the previous sharing violation.
- **The backoff is an `asyncio.sleep`,** suspending the coroutine rather than blocking the gateway loop. Guarded saves release the per-note lock across it; unguarded saves deliberately retain that lock to preserve ordering.
- **POSIX re-raises immediately** — there a `PermissionError` means the caller genuinely cannot write and waiting changes nothing. An exhausted budget propagates. The existing ESTALE payload is reused, not replaced.

**Deliberately out of scope:** `settings.json`, which also writes through `_atomic_write_text_sync` (raised as an advisory concern by First Principles). It carries no freshness contract and no retry, and its behaviour is unchanged here — `_atomic_write_text_sync` is kept as the single-attempt stage/publish/cleanup whole precisely so that caller is untouched. Also out of scope: the trash move in the delete path (`:1545`). It renames the note itself rather than performing a durable tmp-then-rename write, and it already recovers from `OSError` by removing the placeholder it reserved — adding a retry there would change that recovery, which is a separate decision.

Two production files: the note writer, and the `status()` filter that keeps an owned temp out of a commit.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_a_contended_rename_does_not_lose_the_save` | contention with **no** external edit: the save is retried and succeeds (200) |
| `test_an_external_edit_during_the_retry_window_still_wins` | contention **with** an external edit landing between attempts: `409 ESTALE`, the external bytes survive, and no second publish is attempted |
| `test_a_retrying_save_without_basemtime_cannot_overwrite_a_later_one` | with **no** token: a later save cannot interleave into the retry gap, and the earlier save cannot republish over it — publish order `A, A, B`, disk `B` |
| `test_a_contended_save_leaves_no_temp_behind` | a contended save that answers 200 leaves no generated temp in the vault, and each attempt republishes the **same** staged file |
| `test_a_tokenless_save_stages_inside_the_note_lock` | with **no** token: the note's lock is already held while the first save stages, so a later save cannot stage or publish until it finishes — publish order `A, B`, disk `B` |
| `test_the_vault_registry_write_also_retries` | **preservation pin**, not a change: `vaults.json` already retried before this PR |
| `test_a_sync_during_the_retry_window_never_commits_the_staged_temp` | a Sync driven from **inside** the parked backoff commits the user's real change and not the staged temp; the temp never enters local history or the remote, and the contended save still lands afterwards |
| `test_a_rename_into_the_temp_shape_commits_both_halves` | a tracked file renamed into the temp shape keeps **both** halves, so a move is never committed as a removal |
| `test_a_genuine_user_file_in_the_temp_shape_stays_visible` | a user file merely *named* like a staged temp is reported `added`, never withheld from the repository |
| `test_a_registered_in_flight_temp_is_hidden` | the one ground for hiding: registered → hidden; once the transaction ends → visible again, so an orphan can still be seen and cleaned |
| `test_a_tokenless_retry_refuses_to_overwrite_an_external_edit` | with **no** token: an external write landing in the retry gap is answered `409 ESTALE` and its bytes survive, instead of being silently republished over |

They pin **outcomes**, not calls, so they still fail if the retry is removed — a spy-only test would pass against a helper that no longer retries.

The Sync test is deterministic rather than raced: the first `os.replace` is refused and the first backoff parks on an event, so the Sync is guaranteed to land between attempt 1 and attempt 2. The vault carries a genuine non-note change as well, so a Sync that silently no-opped cannot pass, and the temp is asserted present in `git status --porcelain` at that moment so the test cannot pass by never having staged anything. Fail-before with only the `status()` filter reverted:

```
FAILED test_a_sync_during_the_retry_window_never_commits_the_staged_temp
  AssertionError: a Sync inside the retry backoff staged a generated temp:
  ['One.md.129c2e12ef194ee7b37208bd2cb25e05.tmp', 'attachment.png']
```

The concurrency test forces ordering rather than racing it: the external write happens *inside* the injected rename failure, so it is guaranteed to land after attempt 1 and before attempt 2's re-check, and its mtime is pinned forward with `os.utime` because two writes can share one filesystem tick. It also zeroes **both** backoff knobs with `raising=False`, so it asserts the contract independently of where the retry lives — which is what makes it a valid negative control.

The fixture reproduces the real condition rather than a generic error: `PermissionError(32, ...)` — the sharing violation — raised on the first rename only, with the Windows branch selected explicitly so the case runs on every platform, and the backoff zeroed so the retry costs no wall clock.

Fail-before / pass-after on `4cac8222b`, with only `server.py` reverted:

```
=== server.py = origin/main ===
FAILED test_a_contended_rename_does_not_lose_the_save
       - PermissionError: [Errno 32] The process cannot access the file
FAILED test_the_vault_registry_write_also_retries
       - PermissionError: [Errno 32] The process cannot access the file

=== fix applied ===
3 passed
```

And the concurrency test against the **rename-level retry** this PR previously proposed (`649b691`), which is the blocking review's scenario:

```
FAILED test_an_external_edit_during_the_retry_window_still_wins
  AssertionError: the external edit was not detected: 200 {'ok': True, ...}
  assert 200 == 409
```

That build answers **200 OK** and publishes over the external edit. Against this head it is a 409 and the external bytes survive.

The no-token ordering case was proven the same way. Against the previous head `d97cca795`, which released the lock for every save:

```
renames  : ['A', 'B', 'A']
final    : 'A'
AssertionError: an earlier contended save resurrected itself over a later
acknowledged one: disk='A', A=200, B=200
```

Both saves returned 200 and the earlier one won. Against this head the lock is still held at that point, `B` cannot interleave, and the final content is `B`.

The orphan case was proven the same way, against an earlier revision of this PR in which each attempt staged its own temp and the cleanup unlink was also refused:

```
AssertionError: a save answered 200 while leaving generated temp(s) in the
vault, which a user Sync would commit: ['One.md.1974a9e4….tmp']
```

The other four concurrency tests pass against that head, so the new one isolates exactly this defect.

Full `test_md_notebook.py` at head `b36d37fe1`: **203 passed, 10 skipped, 0 failed**. The three adjacent suites that import md-notebook (`test_cse_2026_08_07_fixes.py`, `test_design_tweak_backend.py`, `test_app_proxy_target_ratchet.py`): **327 passed**.

Gates, run at the scope CI uses (`src/kiro_crew test conftest.py xdist_budget.py`): `flake8` clean · `isort` clean · `mypy` clean on both changed modules · `scripts/check_black_formatting.py` (2 files in scope; both are pre-existing baseline entries, so black is not enforced on them and they were not reformatted) · `scripts/check_brand_name.py`.

## Manual verification

N/A — unit coverage sufficient: the defect is entirely in how the rename step handles a `PermissionError`, and the tests drive the production save path end to end, substituting the OS rename failure and — where ordering has to be deterministic — gating the retry backoff on events rather than racing it. The retry policy, the freshness check, the lock discipline, the temp-file cleanup and the final file contents are all production behaviour. Reproducing organically would require a Windows host with a second process holding the note open at the instant of the rename, which cannot be staged in CI; the injected `WinError 32` is that condition's exact observable.

## Related Issues

Fixes #4898.

Same window and same helper as #4331 / #4638 / #4701.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no spec documents md-notebook's write path; the reasoning lives in the md-notebook helper docstrings, updated in this commit
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)









