### PR TITLE
refactor(dashboard): reuse canonical chunk fold

### DIFF
--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1663,14 +1663,12 @@ def _collapse_wire_rows(messages: list[dict]) -> list[dict]:
     rather than messages, and a bound taken before this reduction is spent on
     rows the response will not contain.
 
-    Runs of ``chunk`` fold into one ``chunk`` row; ``done`` rows drop. Both are
-    output-equivalent to leaving them for :func:`_prepare_messages`, which
-    reads nothing from a ``chunk`` row but its ``content``, accumulates a run
-    into one output row, and skips ``done`` WITHOUT flushing that accumulator
-    -- so dropping a terminator here, rather than letting it split a run, is
-    what matches its behaviour. No redaction is applied and no other role is
-    rewritten, which is what lets this run ahead of a slice without changing
-    what the slice renders as.
+    Runs of ``chunk`` fold into one ``chunk`` row; ``done`` rows drop. This is
+    the canonical first pass for :func:`_prepare_messages`, so dropping a
+    terminator here rather than letting it split a run defines the render
+    behaviour too. No redaction is applied and no other role is rewritten,
+    which is what lets this run ahead of a slice without changing what the
+    slice renders as.
 
     Input dicts are never mutated: a merged row is a fresh dict, because these
     rows are shared with the live window the event loop appends to.
@@ -1705,55 +1703,53 @@ def _collapse_wire_rows(messages: list[dict]) -> list[dict]:
 def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
     """Prepare messages for API response."""
     out: list[dict] = []
-    chunk_text = ""
-    for m in messages:
+    for m in _collapse_wire_rows(messages):
         role = m.get("role", "")
         if role == "chunk":
-            chunk_text += m.get("content", "")
-        elif role == "done":
-            continue
-        else:
-            if chunk_text:
-                redacted_chunk, _ = redact_exfiltration_urls(chunk_text)
-                redacted_chunk, _ = redact_credentials(redacted_chunk)
-                out.append({"role": "streaming", "content": redacted_chunk, "cls": "msg msg-a"})
-                chunk_text = ""
             text = m.get("content", "")
-            # Gate is `!= "user"`, NOT `not in ("user", "system")`. This is the
-            # display-time redaction boundary for everything the slot detail
-            # endpoint returns — including the frozen-prefix lines read straight
-            # off disk — so it must cover every non-user role. The load path does
-            # not redact on load, and `system` content is written to disk
-            # unredacted (see _build_message_entry's gate), so excluding it here
-            # would emit raw stored bytes.
-            # User-authored content stays raw: the user typed it and is the only
-            # one who sees it back.
-            if role != "user" and text:
+            if text:
                 text, _ = redact_exfiltration_urls(text)
                 text, _ = redact_credentials(text)
-                m = {**m, "content": text}
-            msg_out = dict(m)
-            if msg_out.get("variants"):
-                # Snapshot for the same reason as _redact_meta — this runs in a
-                # worker thread (slot-detail render offload) while the event
-                # loop may still be appending variants to the live list.
-                msg_out["variants"] = [
-                    {**v, "content": redact_credentials(redact_exfiltration_urls(v.get("content", ""))[0])[0]}
-                    for v in list(msg_out["variants"]) if isinstance(v, dict)
-                ]
-            meta = parse_cls_meta(m.get("cls", ""))
-            if meta is not None:
-                msg_out["meta"] = _redact_meta_for_role(role, meta)
-            elif isinstance(msg_out.get("meta"), dict):
-                # Redact the STORED meta too. Without this branch the stored dict
-                # passes through by reference (dict(m) is shallow), so it would
-                # reach the client exactly as loaded. This is the only guard on
-                # meta for the slot-detail response (the load path does not
-                # redact meta).
-                msg_out["meta"] = _redact_meta_for_role(role, msg_out["meta"])
-            out.append(msg_out)
-    if chunk_text:
-        redacted_chunk, _ = redact_exfiltration_urls(chunk_text)
-        redacted_chunk, _ = redact_credentials(redacted_chunk)
-        out.append({"role": "streaming", "content": redacted_chunk, "cls": "msg msg-a"})
+                out.append({"role": "streaming", "content": text, "cls": "msg msg-a"})
+            continue
+        text = m.get("content", "")
+        # Gate is `!= "user"`, NOT `not in ("user", "system")`. This is the
+        # display-time redaction boundary for everything the slot detail
+        # endpoint returns — including the frozen-prefix lines read straight
+        # off disk — so it must cover every non-user role. The load path does
+        # not redact on load, and `system` content is written to disk
+        # unredacted (see _build_message_entry's gate), so excluding it here
+        # would emit raw stored bytes.
+        # User-authored content stays raw: the user typed it and is the only
+        # one who sees it back.
+        if role != "user" and text:
+            text, _ = redact_exfiltration_urls(text)
+            text, _ = redact_credentials(text)
+            m = {**m, "content": text}
+        msg_out = dict(m)
+        if msg_out.get("variants"):
+            # Snapshot for the same reason as _redact_meta — this runs in a
+            # worker thread (slot-detail render offload) while the event
+            # loop may still be appending variants to the live list.
+            msg_out["variants"] = [
+                {
+                    **v,
+                    "content": redact_credentials(
+                        redact_exfiltration_urls(v.get("content", ""))[0]
+                    )[0],
+                }
+                for v in list(msg_out["variants"])
+                if isinstance(v, dict)
+            ]
+        meta = parse_cls_meta(m.get("cls", ""))
+        if meta is not None:
+            msg_out["meta"] = _redact_meta_for_role(role, meta)
+        elif isinstance(msg_out.get("meta"), dict):
+            # Redact the STORED meta too. Without this branch the stored dict
+            # passes through by reference (dict(m) is shallow), so it would
+            # reach the client exactly as loaded. This is the only guard on
+            # meta for the slot-detail response (the load path does not
+            # redact meta).
+            msg_out["meta"] = _redact_meta_for_role(role, msg_out["meta"])
+        out.append(msg_out)
     return out

--- a/test/test_chat_utils.py
+++ b/test/test_chat_utils.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+import kiro_crew.dashboard.chat_utils as chat_utils
 from kiro_crew.dashboard.chat_utils import (
     _extract_bash_command,
     _history_key_for,
@@ -126,6 +127,26 @@ class TestRemoveQueuedById:
 
 
 class TestPrepareMessages:
+    def test_reuses_canonical_wire_row_collapse(self, monkeypatch):
+        messages = [
+            {"role": "chunk", "content": "hel"},
+            {"role": "done", "content": ""},
+            {"role": "chunk", "content": "lo"},
+        ]
+        calls = []
+        collapse = chat_utils._collapse_wire_rows
+
+        def record_collapse(rows):
+            calls.append(rows)
+            return collapse(rows)
+
+        monkeypatch.setattr(chat_utils, "_collapse_wire_rows", record_collapse)
+
+        result = _prepare_messages(messages, running=True)
+
+        assert calls == [messages]
+        assert result == [{"role": "streaming", "content": "hello", "cls": "msg msg-a"}]
+
     def test_strips_done(self):
         msgs = [{"role": "user", "content": "hi"}, {"role": "done", "content": ""}]
         result = _prepare_messages(msgs, running=False)


### PR DESCRIPTION
## Problem / Motivation

The dashboard has two independent spellings of the same wire-row folding semantics. Bounded history reads use _collapse_wire_rows, while _prepare_messages separately accumulates chunk rows and skips done rows. A future change to only one path can make pagination count different messages from the render path.

## Why it matters

If the two implementations drift, a bounded response can disagree with what the dashboard displays, reintroducing truncated or miscounted history pages. Keeping one canonical fold removes that maintenance hazard from every history response.

## What changed (motivation → approach → change)

Route _prepare_messages through _collapse_wire_rows before redaction and rendering. Each collapsed chunk row is then emitted directly as one redacted streaming row, so the duplicate accumulator and both of its flush sites are removed. Empty chunks, done rows, redaction, input immutability, and all non-wire roles retain their existing behavior.

A focused regression test patches the canonical helper and proves that _prepare_messages uses it, while also pinning the load-bearing rule that a done row does not split a chunk run.

## Tests

- test/test_chat_utils.py: 35 passed serially and 35 passed with two xdist workers
- test/test_slot_detail_inflight_tail.py: 13 passed
- test/test_display_time_redaction.py: 24 passed
- focused test/test_dashboard_chat.py selection: 6 passed
- Black baseline gate, isort, and flake8 passed for the changed files

## Manual verification

N/A — this is a behavior-preserving backend refactor covered by unit and dashboard integration tests.

## Related Issues

Fixes #4665

## Checklist

- [x] Single commit with a Conventional Commits title (feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->