### PR TITLE
fix(dev-fleet): close stale sync lock race + relay state to remounted UI

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -3477,7 +3477,41 @@ async def _sync() -> dict:
             async with _RUNS_LOCK:
                 run = _RUNS.get(_SYNC_RID)
             if run and run["status"] == "running":
-                return {"ok": False, "error": "sync already running", "run_id": _SYNC_RID}
+                # Guard against a stale "running" status: the worker task may
+                # have exited (process reaped) but the status update has not yet
+                # landed because the event loop has not yielded back to the
+                # worker's finally block.  The correct liveness signal is the
+                # subprocess handle: _ACTIVE_RUNS[rid] is (task, proc), and
+                # proc.returncode is not None means the process has exited even
+                # if the task's finally (cleanup_paths unlinking, status write)
+                # has not completed.  task.done() is strictly LATER than the
+                # status write, so checking it would miss the exact window.
+                active = _ACTIVE_RUNS.get(_SYNC_RID)
+                if active is not None:
+                    _task, proc = active
+                    if proc is None or proc.returncode is None:
+                        # Process still running (or not yet spawned) — genuine.
+                        return {"ok": False, "error": "sync already running", "run_id": _SYNC_RID}
+                    # Process exited but worker hasn't written status yet.
+                    # Wait briefly for the task's finally block to land the
+                    # status write + cleanup, rather than starting a new sync
+                    # while the old worker is still unlinking temp files in the
+                    # same worktree.
+                    try:
+                        await asyncio.wait_for(asyncio.shield(_task), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        # Worker still cleaning up after 2s — refuse the new
+                        # sync to avoid concurrent worktree writes.
+                        return {"ok": False, "error": "sync already running", "run_id": _SYNC_RID}
+                    except Exception:
+                        pass  # task raised during cleanup; safe to proceed
+                # Re-read status after giving the worker a chance to land it.
+                async with _RUNS_LOCK:
+                    run = _RUNS.get(_SYNC_RID)
+                if run and run["status"] == "running":
+                    # Still stale after the wait — reconcile defensively.
+                    run["status"] = "done"
+                    run["exit_code"] = run.get("exit_code") or -1
         return await _sync_start_locked()
 
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1276,12 +1276,22 @@ async def test_worktree_remove_force_must_be_bool():
 # --- sync single-flight (409 on busy) ---
 @pytest.mark.asyncio
 async def test_sync_returns_409_when_already_running():
+    import asyncio
+
     import kiro_crew.apps.builtins.dev_fleet.server as mod
 
-    # Inject a fake running sync
+    # Inject a fake running sync with a live task + process
     mod._SYNC_RID = "fake123"
     async with mod._RUNS_LOCK:
         mod._RUNS["fake123"] = {"status": "running", "exit_code": None, "label": "sync", "output": []}
+
+    # Simulate a genuinely-running process (returncode=None)
+    from unittest.mock import MagicMock
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    never_done = asyncio.get_event_loop().create_future()
+    running_task = asyncio.ensure_future(never_done)
+    mod._ACTIVE_RUNS["fake123"] = (running_task, mock_proc)
 
     try:
         result = await mod._sync()
@@ -1291,6 +1301,9 @@ async def test_sync_returns_409_when_already_running():
         async with mod._RUNS_LOCK:
             del mod._RUNS["fake123"]
         mod._SYNC_RID = None
+        mod._ACTIVE_RUNS.pop("fake123", None)
+        never_done.set_result(None)
+        await running_task
 
 
 # --- redaction ---

--- a/test/test_dev_fleet_server_more_coverage.py
+++ b/test/test_dev_fleet_server_more_coverage.py
@@ -1188,3 +1188,163 @@ async def test_gateway_service_active_false_when_foreground_confined(monkeypatch
     monkeypatch.setattr(mod, "_foreground_backend", lambda: pytest.fail("not eligible"))
 
     assert await mod._gateway_service_active() is False
+
+
+# --- stale sync lock race (issue #4906) ---
+
+
+@pytest.mark.asyncio
+async def test_sync_allows_new_run_when_prior_task_done_but_status_stale(monkeypatch):
+    """When the subprocess has exited (proc.returncode is not None) but _RUNS
+    status is still 'running' (stale due to a lock-acquisition race), _sync()
+    should await the task briefly, then allow a new sync."""
+    import asyncio
+
+    # Simulate a completed task with a process that has already exited
+    done_task = asyncio.ensure_future(asyncio.sleep(0))
+    await done_task  # let it complete
+
+    # Mock a subprocess whose returncode signals exit
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0  # process exited
+
+    old_rid = "stale-run-001"
+    monkeypatch.setattr(mod, "_SYNC_RID", old_rid)
+    monkeypatch.setattr(mod, "_SYNC_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS", {
+        old_rid: {"status": "running", "exit_code": None, "output": []},
+    })
+    # Task done + proc.returncode set — simulates the race window
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {old_rid: (done_task, mock_proc)})
+
+    # _sync_start_locked would normally start a new sync; mock it to confirm
+    # we reach it (rather than getting the 'already running' refusal)
+    new_rid = "new-run-002"
+    monkeypatch.setattr(mod, "_sync_start_locked", AsyncMock(
+        return_value={"ok": True, "run_id": new_rid}
+    ))
+
+    result = await mod._sync()
+    assert result["ok"] is True
+    assert result["run_id"] == new_rid
+
+
+@pytest.mark.asyncio
+async def test_sync_refuses_when_task_genuinely_running(monkeypatch):
+    """When the subprocess is still alive (proc.returncode is None), _sync()
+    should correctly refuse."""
+    import asyncio
+
+    # A task that hasn't completed yet
+    never_done = asyncio.get_event_loop().create_future()
+    running_task = asyncio.ensure_future(never_done)
+
+    # Mock a subprocess still running
+    mock_proc = MagicMock()
+    mock_proc.returncode = None  # process still alive
+
+    old_rid = "active-run-001"
+    monkeypatch.setattr(mod, "_SYNC_RID", old_rid)
+    monkeypatch.setattr(mod, "_SYNC_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS", {
+        old_rid: {"status": "running", "exit_code": None, "output": []},
+    })
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {old_rid: (running_task, mock_proc)})
+
+    result = await mod._sync()
+    assert result["ok"] is False
+    assert "already running" in result["error"]
+    assert result["run_id"] == old_rid
+
+    # Cleanup
+    never_done.set_result(None)
+    await running_task
+
+
+@pytest.mark.asyncio
+async def test_sync_allows_new_run_when_task_absent_from_active_runs(monkeypatch):
+    """When the run is not in _ACTIVE_RUNS at all (task completed and was
+    cleaned up by done_callback), _sync() should allow a new sync."""
+    import asyncio
+
+    old_rid = "gone-run-001"
+    monkeypatch.setattr(mod, "_SYNC_RID", old_rid)
+    monkeypatch.setattr(mod, "_SYNC_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS", {
+        old_rid: {"status": "running", "exit_code": None, "output": []},
+    })
+    # Empty — task was already cleaned up by done_callback
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {})
+
+    monkeypatch.setattr(mod, "_sync_start_locked", AsyncMock(
+        return_value={"ok": True, "run_id": "fresh-run"}
+    ))
+
+    result = await mod._sync()
+    assert result["ok"] is True
+    assert result["run_id"] == "fresh-run"
+
+
+@pytest.mark.asyncio
+async def test_sync_proc_not_yet_spawned_refuses(monkeypatch):
+    """When the active entry has proc=None (subprocess not yet spawned),
+    _sync() should refuse — the sync is genuinely starting up."""
+    import asyncio
+
+    never_done = asyncio.get_event_loop().create_future()
+    running_task = asyncio.ensure_future(never_done)
+
+    old_rid = "spawning-run-001"
+    monkeypatch.setattr(mod, "_SYNC_RID", old_rid)
+    monkeypatch.setattr(mod, "_SYNC_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS", {
+        old_rid: {"status": "running", "exit_code": None, "output": []},
+    })
+    # proc=None means subprocess hasn't been spawned yet
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {old_rid: (running_task, None)})
+
+    result = await mod._sync()
+    assert result["ok"] is False
+    assert "already running" in result["error"]
+
+    # Cleanup
+    never_done.set_result(None)
+    await running_task
+
+
+@pytest.mark.asyncio
+async def test_sync_refuses_when_worker_cleanup_times_out(monkeypatch):
+    """When the process exited but the worker task does not complete within
+    the 2s bounded wait (cleanup is slow), _sync() should refuse rather
+    than starting a concurrent sync against the same worktree."""
+    import asyncio
+
+    # A task that will NOT complete within 2s (simulates slow cleanup)
+    never_done = asyncio.get_event_loop().create_future()
+    slow_task = asyncio.ensure_future(never_done)
+
+    # Mock a subprocess that has exited (returncode set)
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+
+    old_rid = "slow-cleanup-001"
+    monkeypatch.setattr(mod, "_SYNC_RID", old_rid)
+    monkeypatch.setattr(mod, "_SYNC_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS", {
+        old_rid: {"status": "running", "exit_code": None, "output": []},
+    })
+    # Process exited but task won't finish (simulating slow cleanup)
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {old_rid: (slow_task, mock_proc)})
+
+    result = await mod._sync()
+    assert result["ok"] is False
+    assert "already running" in result["error"]
+
+    # Cleanup
+    never_done.set_result(None)
+    await slow_task

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -831,14 +831,40 @@ export default function DevFleetPage() {
     // A poll for this run is already in flight (it outlived a previous mount of
     // this page, which is intended — the build's auto-restart must not be lost
     // to navigation). Starting a second loop here would race it: both would see
-    // `done` and both would fire the restart POST. Skip and let the existing
-    // loop own the run.
-    if (_activeSyncPolls.has(rid)) return
+    // `done` and both would fire the restart POST. Skip — but start a
+    // lightweight state relay so this mount's UI stays updated.
+    if (_activeSyncPolls.has(rid)) {
+      _syncStateRelay(rid, startedAt)
+      return
+    }
     _activeSyncPolls.add(rid)
     try {
       await _pollSyncRunLoop(rid, startedAt)
     } finally {
       _activeSyncPolls.delete(rid)
+    }
+  }
+
+  // Lightweight relay: polls /run to keep THIS mount's syncRun state in sync
+  // while the primary poll (from a prior mount) handles the auto-restart logic.
+  // Exits when the run finishes, the component unmounts, or the run is dismissed.
+  async function _syncStateRelay(rid: string, startedAt: number) {
+    for (let i = 0; i < 900; i++) {
+      await sleep(2000)
+      if (!pollAliveRef.current) return
+      if (cancelledRunsRef.current.has(rid)) return
+      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string } | null = null
+      try { run = await api.get('/run?id=' + rid) } catch { continue }
+      if (!run) continue
+      const t0 = run.started ? run.started * 1000 : startedAt
+      const out = run.output || []
+      const last = [...out].reverse().find((l: string) => l?.trim() && !STEP_MARKER_RE.test(l)) || ''
+      if (run.status === 'done' || run.status === 'timeout') {
+        const okRun = run.exit_code === 0
+        setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last })
+        return
+      }
+      setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, last, stepLabel: run.step_label })
     }
   }
 


### PR DESCRIPTION
## Problem / Motivation

When a user navigates away from the Dev Fleet page during a Pull+Build and returns, clicking "Pull + Build" again intermittently returns "sync already running" even though the previous build completed. Additionally, the build progress stepper sometimes fails to reappear after navigating back — the user sees no indication that a build is still running.

## Why it matters

The user sees "already running" with no way to start a new build, or returns to Dev Fleet with no stepper/progress visible despite an active build. Both erode trust in the build controls and force manual refreshes or waiting.

## What changed (motivation → approach → change)

**Backend race (the "already running" false positive):**
The `_sync()` function checks `_RUNS[_SYNC_RID]["status"] == "running"` to gate new syncs. But there's a sub-second race window: the sync subprocess exits, yet the async `worker()` task's `finally` block has not yet re-acquired `_RUNS_LOCK` to write the terminal status and unlink cleanup paths. During this window, a new sync request reads a stale "running" status and refuses.

Fix: when status says "running", use the subprocess handle as the liveness signal, not the task. `_ACTIVE_RUNS[rid]` is a `(task, proc)` tuple:
- `proc is None` (not yet spawned) or `proc.returncode is None` (still executing) → the sync is genuinely live; refuse with "already running".
- `proc.returncode is not None` (process exited) → the worker is mid-teardown. `await asyncio.wait_for(asyncio.shield(_task), timeout=2.0)` gives its `finally` block time to land the status write and finish unlinking temp files in the same worktree. On `TimeoutError` (cleanup still running after 2s) we **refuse** rather than start a concurrent sync that could overwrite checkout files.

`task.done()` is deliberately NOT used as the signal: it flips true strictly *after* the status write, so it would miss the exact window this fix targets (an inline comment records this). After the bounded wait, the status is re-read under lock and defensively reconciled to "done" if still stale.

**Frontend state relay (the invisible build):**
The sync poll loop (`_pollSyncRunLoop`) deliberately survives component unmount (for auto-restart). A module-level `_activeSyncPolls` Set prevents a remounted component from starting a duplicate poll. But the surviving poll's `setSyncRun` calls target the OLD (unmounted) component's state setter — updates go to the void. The remount's `pollSyncRun` skips due to the dedup guard, so the new component never gets updates.

Fix: when `pollSyncRun` detects an in-flight poll (dedup fires), start a lightweight `_syncStateRelay` that polls `/run` every 2s to mirror state into THIS mount's `setSyncRun`. The relay respects `pollAliveRef` (exits on unmount) and `cancelledRunsRef` (exits on dismiss). The primary poll still owns the auto-restart POST — no double-restart risk.

## Tests

Five backend regression tests cover the `_sync()` liveness gate:

- `test_sync_allows_new_run_when_prior_task_done_but_status_stale` — process exited (`returncode` set), status still stale "running" → bounded wait completes, new sync allowed
- `test_sync_refuses_when_task_genuinely_running` — `proc.returncode is None` → correctly refuses with "already running"
- `test_sync_allows_new_run_when_task_absent_from_active_runs` — run cleaned out of `_ACTIVE_RUNS` → new sync allowed
- `test_sync_proc_not_yet_spawned_refuses` — `proc is None` (subprocess not yet spawned) → refuses (sync is genuinely starting up)
- `test_sync_refuses_when_worker_cleanup_times_out` — process exited but the worker task does not finish within the 2s bounded wait → refuses rather than starting a concurrent sync against the same worktree

The existing `test_sync_returns_409_when_already_running` was updated to configure `_ACTIVE_RUNS` with a live `(task, proc)` tuple so it exercises the new liveness path.

## Manual verification

N/A — the race window is sub-second and timing-dependent. The five tests directly exercise every branch of the liveness gate (genuinely running, not-yet-spawned, process-exited-status-stale, task-absent, slow-cleanup-timeout). The frontend relay is a read-only `/run` poller with no side effects beyond `setSyncRun`.

<!-- no-visual-delta -->
**Why no screenshot:** Both fixes are invisible to the user — the backend race closes a timing gap (no UI change), and the frontend relay keeps an existing stepper alive that was previously going dark (no new component or layout).

Fixes #4906

