### PR TITLE
refactor(instances): share the SSH/SSM builders and fix a false comment

### DIFF
--- a/src/kiro_crew/instances/diagnostics.py
+++ b/src/kiro_crew/instances/diagnostics.py
@@ -22,6 +22,7 @@ import logging
 from dataclasses import dataclass, field
 
 from kiro_crew.cloud import ssm as cloud_ssm
+from kiro_crew.instances.token_mint import _build_ssh_argv
 from kiro_crew.instances.validation import (
     SshValidationError,
     SsmValidationError,
@@ -102,6 +103,33 @@ class DiagnosisResult:
         return {"code": self.code, "ok": self.ok, "reason": self.reason, "probes": self.probes}
 
 
+def _remote_status_probe_command(remote_port: int) -> str:
+    """Remote shell snippet that reports whether the dashboard answers.
+
+    Prints the HTTP status ``curl`` saw, which is what both transports' rung 2
+    interprets: any status (including an auth gate like 401/403/404) means
+    something is listening, while ``000`` — or no output at all, e.g. a remote
+    with no ``curl`` — means nothing is bound there.
+    """
+    return (
+        f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 "
+        f"http://{_LOOPBACK}:{int(remote_port)}/api/status"
+    )
+
+
+def _dashboard_is_listening(output: str | None) -> bool:
+    """Interpret rung 2's remote ``curl`` output — see :func:`_remote_status_probe_command`.
+
+    ``None`` is the SSH rung's "the ssh invocation itself failed" and is False,
+    same as the no-output case; the SSM rung passes the invocation's stdout, so
+    a remote whose ``curl`` never ran reaches here as an empty string.
+    """
+    if output is None:
+        return False
+    code = output.strip().strip("'\"")
+    return bool(code) and code != "000"
+
+
 async def _probe_ssh(
     ssh_host: str, connect_timeout_secs: float = _DEFAULT_PROBE_CONNECT_TIMEOUT_SECS
 ) -> bool:
@@ -116,17 +144,7 @@ async def _probe_ssh(
     2s margin past the ssh-side timeout for auth + running ``true`` after
     connect succeeds.
     """
-    argv = [
-        "ssh",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        f"ConnectTimeout={max(1, round(connect_timeout_secs))}",
-        "-o",
-        "AddressFamily=inet",
-        ssh_host,
-        "true",
-    ]
+    argv = _build_ssh_argv(ssh_host, "true", connect_timeout_secs=connect_timeout_secs)
     return await _run_ok(argv, connect_timeout_secs + 2.0)
 
 
@@ -145,26 +163,12 @@ async def _probe_remote_dashboard(
     leaves a 5s margin past the ssh-side timeout, matching the remote
     ``curl --max-time 5`` this runs after connect succeeds.
     """
-    remote_cmd = (
-        f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 "
-        f"http://{_LOOPBACK}:{int(remote_port)}/api/status"
-    )
-    argv = [
-        "ssh",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        f"ConnectTimeout={max(1, round(connect_timeout_secs))}",
-        "-o",
-        "AddressFamily=inet",
+    argv = _build_ssh_argv(
         ssh_host,
-        remote_cmd,
-    ]
-    out = await _run_stdout(argv, connect_timeout_secs + 5.0)
-    if out is None:
-        return False
-    code = out.strip().strip("'\"")
-    return bool(code) and code != "000"
+        _remote_status_probe_command(remote_port),
+        connect_timeout_secs=connect_timeout_secs,
+    )
+    return _dashboard_is_listening(await _run_stdout(argv, connect_timeout_secs + 5.0))
 
 
 async def _probe_local_forward(local_port: int) -> bool:
@@ -298,15 +302,13 @@ async def _probe_remote_dashboard_ssm(
 ) -> bool:
     """Return True if the remote dashboard answers on its loopback port, via SSM.
 
-    Runs the same ``curl`` check as the SSH rung but dispatches it with SSM
-    ``send-command`` instead of ``ssh``. Any HTTP status (incl. an auth gate like
-    401/403/404) means something is listening; ``000``/empty means nothing is
-    bound there.
+    Runs the same ``curl`` check as the SSH rung (the one
+    :func:`_remote_status_probe_command` builds) but dispatches it with SSM
+    ``send-command`` instead of ``ssh``.
     """
-    remote_cmd = (
-        f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 "
-        f"http://{_LOOPBACK}:{int(remote_port)}/api/status"
-    )
+    # Built outside the try so a malformed port raises rather than being folded
+    # into the "no answer" verdict below.
+    remote_cmd = _remote_status_probe_command(remote_port)
     try:
         result = await asyncio.wait_for(
             asyncio.to_thread(
@@ -322,8 +324,7 @@ async def _probe_remote_dashboard_ssm(
         )
     except Exception:  # timeout, AWSError, dispatch failure — treat as no answer
         return False
-    code = (result.stdout or "").strip().strip("'\"")
-    return bool(code) and code != "000"
+    return _dashboard_is_listening(result.stdout or "")
 
 
 async def diagnose_instance_ssm(

--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -283,6 +283,18 @@ class _RegistryDoc:
     last_active_id: str = ""
 
 
+def _find(doc: _RegistryDoc, instance_id: str) -> Instance | None:
+    """Return the record in *doc* with *instance_id*, or ``None`` if absent.
+
+    Hands back the live object out of ``doc.instances`` (not a copy), so a caller
+    holding the lock can mutate it in place and persist *doc*.
+    """
+    for inst in doc.instances:
+        if inst.id == instance_id:
+            return inst
+    return None
+
+
 class InstancesRegistry:
     """CRUD over ``instances.json`` with atomic writes and a process lock.
 
@@ -349,10 +361,7 @@ class InstancesRegistry:
     def get(self, instance_id: str) -> Instance | None:
         """Return the instance with *instance_id*, or ``None`` if absent."""
         with self._lock:
-            for inst in self._read().instances:
-                if inst.id == instance_id:
-                    return inst
-            return None
+            return _find(self._read(), instance_id)
 
     def get_last_active(self) -> Instance | None:
         """Return the last-active instance to auto-revive on startup."""
@@ -360,10 +369,7 @@ class InstancesRegistry:
             doc = self._read()
             if not doc.last_active_id:
                 return None
-            for inst in doc.instances:
-                if inst.id == doc.last_active_id:
-                    return inst
-            return None
+            return _find(doc, doc.last_active_id)
 
     # ── write API ────────────────────────────────────────────────────────
 
@@ -471,11 +477,7 @@ class InstancesRegistry:
             validate_ttl(str(changes["ttl"]))
         with self._lock:
             doc = self._read()
-            target: Instance | None = None
-            for inst in doc.instances:
-                if inst.id == instance_id:
-                    target = inst
-                    break
+            target = _find(doc, instance_id)
             if target is None:
                 raise InstanceNotFoundError(f"no instance with id {instance_id!r}")
             for key, value in changes.items():
@@ -505,14 +507,11 @@ class InstancesRegistry:
         """Set the ``was_connected`` hint (no-op if the instance is gone)."""
         with self._lock:
             doc = self._read()
-            changed = False
-            for inst in doc.instances:
-                if inst.id == instance_id:
-                    inst.was_connected = bool(value)
-                    changed = True
-                    break
-            if changed:
-                self._write(doc)
+            inst = _find(doc, instance_id)
+            if inst is None:
+                return
+            inst.was_connected = bool(value)
+            self._write(doc)
 
     def set_last_active(self, instance_id: str) -> None:
         """Mark *instance_id* as the one to auto-revive on next startup.
@@ -522,7 +521,7 @@ class InstancesRegistry:
         """
         with self._lock:
             doc = self._read()
-            if not any(i.id == instance_id for i in doc.instances):
+            if _find(doc, instance_id) is None:
                 raise InstanceNotFoundError(f"no instance with id {instance_id!r}")
             doc.last_active_id = instance_id
             self._write(doc)

--- a/src/kiro_crew/instances/run_marker.py
+++ b/src/kiro_crew/instances/run_marker.py
@@ -80,6 +80,27 @@ def _run_dir() -> Path:
     return d
 
 
+def _read_sidecar(port: int, suffix: str) -> str:
+    """Stripped contents of ``run/gateway-<port><suffix>``, or ``""``.
+
+    Read-only on purpose: it composes the path itself instead of calling
+    :func:`marker_path` / :func:`pid_path` / :func:`secret_path`, because those
+    go through :func:`_run_dir` and would MATERIALISE ``run/`` — a client command
+    that merely looks for a gateway must not create the run dir. (``config_dir()``
+    still resolves, and creates, the data home itself.) An unreadable or absent
+    file is indistinguishable from an empty one here; each reader decides what
+    "" means for its own value.
+    """
+    try:
+        return (
+            (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{suffix}")
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+    except (OSError, ValueError):
+        return ""
+
+
 def marker_path(port: int) -> Path:
     """Path of the run-marker for a gateway serving *port*."""
     return _run_dir() / f"{_MARKER_PREFIX}{int(port)}{_MARKER_SUFFIX}"
@@ -123,13 +144,7 @@ def read_secret(port: int) -> str:
     proof the recorded gateway still owns the port; that remains
     ``port_resolution._gateway_owns_port``'s job.
     """
-    try:
-        raw = (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{_SECRET_SUFFIX}").read_text(
-            encoding="utf-8"
-        )
-    except (OSError, ValueError):
-        return ""
-    return raw.strip()
+    return _read_sidecar(port, _SECRET_SUFFIX)
 
 
 def read_pid(port: int) -> int | None:
@@ -145,13 +160,7 @@ def read_pid(port: int) -> int | None:
 
     Read-only: never creates ``run/``.
     """
-    try:
-        raw = (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{_PID_SUFFIX}").read_text(
-            encoding="utf-8"
-        )
-    except (OSError, ValueError):
-        return None
-    raw = raw.strip()
+    raw = _read_sidecar(port, _PID_SUFFIX)
     if not raw.isdigit():
         return None
     pid = int(raw)
@@ -173,14 +182,7 @@ def read_launcher(port: int) -> str | None:
     Read-only: never creates ``run/`` (unlike :func:`marker_path`, whose
     ``_run_dir`` materialises the directory).
     """
-    try:
-        raw = (config_dir() / "run" / f"{_MARKER_PREFIX}{int(port)}{_MARKER_SUFFIX}").read_text(
-            encoding="utf-8"
-        )
-    except (OSError, ValueError):
-        return None
-    raw = raw.strip()
-    return raw or None
+    return _read_sidecar(port, _MARKER_SUFFIX) or None
 
 
 def marker_ports() -> list[int]:

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -473,27 +473,36 @@ class _SshTunnel:
         """
         deadline = time.monotonic() + self._connect_timeout
         while time.monotonic() < deadline:
-            proc = self._proc
-            if proc is not None and proc.returncode is not None:
-                await self._capture_stderr()
-                self.status.state = TunnelState.ERROR
-                self.status.error = self._exit_error(proc.returncode)
+            if await self._failed_on_child_exit():
                 return False
             if await self._port_reachable():
                 # A reachable port is NOT proof THIS child bound it: a lingering
                 # tunnel or orphaned ssh can answer while our child already lost
                 # the bind race (ExitOnForwardFailure -> exit 255). Confirm our
                 # child is still alive before declaring the tunnel ready.
-                proc = self._proc
-                if proc is not None and proc.returncode is not None:
-                    await self._capture_stderr()
-                    self.status.state = TunnelState.ERROR
-                    self.status.error = self._exit_error(proc.returncode)
+                if await self._failed_on_child_exit():
                     return False
                 return True
             await asyncio.sleep(_READY_POLL_INTERVAL_SECS)
         self.status.error = f"timed out after {self._connect_timeout}s waiting for forward"
         return False
+
+    async def _failed_on_child_exit(self) -> bool:
+        """Record an already-exited child as an ERROR status; True if it exited.
+
+        ``self._proc`` is re-read on every call rather than passed in, because
+        each caller looks across an await during which the child can have exited.
+        Returns False when there is no child at all — a racing ``stop()`` clears
+        ``self._proc`` — so that teardown is left to the readiness timeout rather
+        than reported as an exit with a returncode nobody captured.
+        """
+        proc = self._proc
+        if proc is None or proc.returncode is None:
+            return False
+        await self._capture_stderr()
+        self.status.state = TunnelState.ERROR
+        self.status.error = self._exit_error(proc.returncode)
+        return True
 
     async def _port_reachable(self) -> bool:
         """Return True if something accepts a TCP connect on the local forward."""
@@ -2015,12 +2024,15 @@ class SshTunnelManager:
         try:
             while True:
                 await asyncio.sleep(delay)
-                refreshed = await self._refresh_token_once(instance_id)
-                if not refreshed:
-                    # instance gone, or transient mint failure — recompute delay
-                    # from the (possibly unchanged) ttl and try again next cycle.
-                    if instance_id not in self._tunnels:
-                        return
+                # A failed re-mint is only terminal once the instance is no longer
+                # connected (dropped from _tunnels); a transient mint failure
+                # retries on the next cycle at the same interval, since `delay` is
+                # derived from the ttl once, before the loop, and never re-derived.
+                if (
+                    not await self._refresh_token_once(instance_id)
+                    and instance_id not in self._tunnels
+                ):
+                    return
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # never let the refresh loop crash silently

--- a/src/kiro_crew/instances/ssm_token_mint.py
+++ b/src/kiro_crew/instances/ssm_token_mint.py
@@ -29,12 +29,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 
 from kiro_crew.cloud import ssm as cloud_ssm
-from kiro_crew.instances.constants import DEFAULT_SSM_MINT_TIMEOUT_SECS, TTL_PATTERN
+from kiro_crew.instances.constants import DEFAULT_SSM_MINT_TIMEOUT_SECS
+
+# The subcommand builder and the ttl/port bounds are SHARED with the SSH
+# transport on purpose: both transports hand the same string to the same remote
+# shell, so a second copy of either could only ever drift into a weaker bound.
 from kiro_crew.instances.token_mint import (
     TokenMintError,
+    _token_subcommand,
+    _validate_port,
+    _validate_ttl,
     build_remote_command,
     parse_token_from_stdout,
 )
@@ -56,21 +62,8 @@ logger = logging.getLogger(__name__)
 # ``instances.mint_timeout_secs`` wins for both transports.
 _DEFAULT_MINT_TIMEOUT_SECS = DEFAULT_SSM_MINT_TIMEOUT_SECS
 
-# Same ttl shape token_mint.py accepts (kept local rather than importing a
-# "private" helper cross-module — see module docstring).
-_TTL_RE = re.compile(TTL_PATTERN)
-
 # How much of a failing remote's stdout/stderr to carry in an error message.
 _OUTPUT_TAIL_CHARS = 300
-
-
-def _validate_ttl(ttl: str) -> str:
-    if not _TTL_RE.match(ttl):
-        raise TokenMintError(
-            f"invalid ttl {ttl!r}: expected a positive integer with 'h' or 'm' "
-            "suffix (e.g. '20h', '30m')"
-        )
-    return ttl
 
 
 def _redacted_tail(text: str, limit: int = _OUTPUT_TAIL_CHARS) -> str:
@@ -87,18 +80,6 @@ def _redacted_tail(text: str, limit: int = _OUTPUT_TAIL_CHARS) -> str:
         return ""
     safe = redact_exfiltration_urls(redact_credentials(text)[0])[0]
     return safe.strip()[-limit:]
-
-
-def _validate_port(port: int | None) -> int | None:
-    if port is None:
-        return None
-    try:
-        p = int(port)
-    except (TypeError, ValueError) as e:
-        raise TokenMintError(f"invalid port {port!r}: not an integer") from e
-    if not (1 <= p <= 65535):
-        raise TokenMintError(f"invalid port {p}: out of range 1-65535")
-    return p
 
 
 async def mint_remote_token_ssm(
@@ -129,14 +110,9 @@ async def mint_remote_token_ssm(
     port = _validate_port(remote_port)
     embed_port = _validate_port(embed_parent_port)
 
-    subcommand = "token"
-    if ttl:
-        subcommand += f" --ttl {ttl}"
-    if port:
-        subcommand += f" --port {port}"
-    if embed_port:
-        subcommand += f" --embed-parent-port {embed_port}"
-    remote_command = build_remote_command(remote_bin, subcommand, marker_port=port)
+    remote_command = build_remote_command(
+        remote_bin, _token_subcommand(ttl, port, embed_port), marker_port=port
+    )
 
     # False positive (below): the message mentions "token" (this function's job)
     # but the interpolated values are the SSM target id and the ttl — never the

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -2968,12 +2968,22 @@ class TestDiagnostics:
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
         assert asyncio.run(diag._probe_ssh("cd-1", connect_timeout_secs=42.0)) is True
         assert "ConnectTimeout=42" in captured["argv"]
+        # Both probes share token_mint._build_ssh_argv with the mint, so the two
+        # options a probe cannot work without are pinned HERE too: without
+        # BatchMode a probe hangs on an interactive prompt instead of reporting
+        # unreachable, and without AddressFamily=inet it can resolve ::1 and miss
+        # the IPv4 loopback forward. A mint-motivated edit to the shared builder
+        # would otherwise change the ladder with no signal on this side.
+        assert "BatchMode=yes" in captured["argv"]
+        assert "AddressFamily=inet" in captured["argv"]
 
         assert (
             asyncio.run(diag._probe_remote_dashboard("cd-1", 7777, connect_timeout_secs=42.0))
             is True
         )
         assert "ConnectTimeout=42" in captured["argv"]
+        assert "BatchMode=yes" in captured["argv"]
+        assert "AddressFamily=inet" in captured["argv"]
 
     def test_probe_local_forward(self):
         from kiro_crew.instances import diagnostics as diag


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change under `src/kiro_crew/instances/`; nothing
in `website/` is touched and no rendered surface changes.

## Problem / Motivation

`src/kiro_crew/instances/` carries the same logic in more than one place, and one
comment describes behaviour the code does not have:

- The SSH and SSM transports are deliberately two front ends over one set of
  builders, but the SSM mint had re-implemented three of them: its own `--ttl` /
  `--port` / `--embed-parent-port` subcommand assembly, its own `_validate_ttl`,
  and its own `_validate_port` — byte-identical to `token_mint`'s, error messages
  included. `docs/system-specs/modules/instances.md` already names
  `token_mint.py`'s validators as *the* bounds on the remote command's variable
  parts, so the copies made the spec imprecise rather than wrong.
- `diagnostics.py` hand-built the `ssh -o BatchMode=yes -o ConnectTimeout=… -o
  AddressFamily=inet` argv twice, with a comment noting it "matches
  `token_mint._build_ssh_argv`" — the helper it could have called — and built the
  remote `curl`-the-dashboard command twice, once per transport, with the rung's
  `000`-means-nothing-bound rule spelled out in one copy and not the other.
- `registry.py` open-coded the same find-by-id linear scan four times, once with a
  `changed` bool that only existed to remember whether the scan had hit.
- `run_marker.py` had three copies of "read `run/gateway-<port><suffix>` without
  creating `run/`", the last clause of which is load-bearing (a client command
  that merely looks for a gateway must materialise no state) and was restated in
  each docstring.
- `_wait_until_ready` had the same four-line "the child already exited → record an
  ERROR status" block twice.
- `_token_refresh_loop`'s comment claimed a failed re-mint would "recompute delay
  from the (possibly unchanged) ttl". Nothing recomputes the delay; the loop keeps
  sleeping the interval it computed once.

## Why it matters

Duplicated validation is the shape that drifts: the next change to the ttl bound
or the ssh probe argv has to be found in two places, and a miss is invisible
because both copies still pass their own tests. The false comment is worse than a
stale one — a reader trusting it would look for the recompute that is not there,
and a future change might "restore" a behaviour the loop never had.

## What changed (motivation → approach → change)

Behaviour-preserving only: no control flow, no error text, no argv, no persisted
shape changes. Each rewrite routes an existing duplicate through the copy that
already exists in this package, or lifts a repeated block into one named helper.

- **`ssm_token_mint.py`** — build the `token` subcommand with `token_mint`'s
  `_token_subcommand`, and validate ttl/port with `token_mint`'s `_validate_ttl` /
  `_validate_port` (same strings, same `TokenMintError` messages, same order,
  still before the remote command is built). Drops the local copies plus the now
  unused `re` / `TTL_PATTERN` imports. Cross-module private sharing inside
  `kiro_crew.instances` is the existing convention here — `ssh_tunnel_manager`
  already imports `port_allocator._is_port_free` and `registry._UNALLOCATED_PORT`.
- **`diagnostics.py`** — both ssh probes call `token_mint._build_ssh_argv` (the
  argv it produces is byte-identical to the lists it replaces); the remote status
  probe command and its `000`-means-nothing-bound interpretation each become one
  helper shared by the SSH and SSM rungs.
- **`registry.py`** — one module-level `_find(doc, instance_id)` replaces four
  scans; `set_was_connected` loses its `changed` flag and `update` its
  `target = None` prelude.
- **`run_marker.py`** — one `_read_sidecar(port, suffix)` replaces three identical
  reads and carries the never-materialise-`run/` rationale once. `read_pid` /
  `read_launcher` / `read_secret` keep their own return contracts.
- **`ssh_tunnel_manager.py`** — `_failed_on_child_exit()` replaces the twice-copied
  child-exit block (it re-reads `self._proc` per call, which is what the second
  copy existed for); `_token_refresh_loop` flattens its nested `if` and its comment
  now states what the loop does.

### Pre-review before opening

Five read-only reviewers ran over the finished diff, each with a distinct lens
(AUTOSDE blocking rules, behaviour preservation hunk-by-hunk, import/patch
semantics, the security controls and boot path, comment accuracy). Three returned
no findings; the behaviour reviewer confirmed all 20 hunks equivalent. What they
did surface, and what came of it:

- **Fixed — a statement moved into a `try`.** `_probe_remote_dashboard_ssm` built
  the curl command inside the `try`, so an `int(remote_port)` failure would have
  been folded into the "no answer" verdict instead of propagating. Hoisted back
  out; the exception boundary is now exactly the pre-change one. (Unreachable
  today — `Instance.validate()` guarantees an int — but it was a real narrowing.)
- **Fixed — the shared argv is now pinned on the probe path.** Routing both probes
  through `token_mint._build_ssh_argv` means a mint-motivated edit to that builder
  reaches the diagnosis ladder. The diagnostics test asserted only
  `ConnectTimeout`, so it now also pins `BatchMode=yes` and `AddressFamily=inet`
  — the two options a probe cannot work without (one hangs on a prompt, the other
  can resolve `::1` and miss the IPv4 forward).
- **Fixed — four comment-accuracy corrections**, all in text this diff writes: the
  dropped "or no output at all" clause on the status rung (load-bearing on the SSM
  path, which reads stdout without consulting the exit code); `_read_sidecar`'s
  over-broad "creates no state" (`config_dir()` does create the data home);
  `_failed_on_child_exit`'s unreachable "or been replaced" plus its undocumented
  no-child arm; and `_token_refresh_loop`'s "the ttl has not moved", which could
  be read as a recompute that does not happen.
- **Fixed — the reversed stance is recorded.** The deleted comment said the ttl
  shape was "kept local rather than importing a private helper cross-module". A
  note at the import now states the opposite stance and why.
- **Refuted — "call the public `build_remote_token_command` instead of importing
  three private names."** It is line-for-line equivalent to the sequence here, but
  it validates ttl and ports *together*, inside itself. This function validates
  the ttl **first**, before the SSM target/profile/region, so adopting it would
  change which error an input with both a bad ttl and a bad target raises
  (`TokenMintError` → `SsmValidationError`). That is a behaviour change, which is
  the one thing this PR may not make. Left as-is; the stance note above covers the
  reviewer's underlying concern.

Deliberately NOT touched, so the diff stays a readability change:

- `validation.py` — an injection guard. A verbose explicit guard stays verbose,
  including the belt-and-braces leading-`-` check that `validate_ssh_host` applies
  to both the whole host and each segment.
- `PortAllocator` / `SshTunnelManager._reserved_ports` — the connect path mirrors
  the remote port, so the allocator is currently unreached from the manager.
  Removing it would change the `base_port` constructor kwarg's meaning, and
  #3648 is actively re-wiring exactly that path.
- `send_session_bundle` / `search_sessions_remote` — the deepest nesting in the
  module. Flattening them means reshaping a credential-retry state machine; that
  is not a mechanical rewrite and belongs in its own change.

## Tests

Two assertions added to the existing
`TestDiagnostics::test_probes_honor_connect_timeout_secs`, pinning `BatchMode=yes`
and `AddressFamily=inet` on the diagnosis ladder's argv now that it shares
`_build_ssh_argv` with the mint (see Pre-review above). No other new tests: this
change adds no behaviour to lock in, and the existing suites already pin every
rewritten path — `TestTokenMint` / `TestTokenMintGeneric` (the
mint subcommand, the ttl/port validation errors, the ssh argv), `TestRegistry` /
`TestSsmRegistry`, `TestRunMarker` / `TestRunMarkerDiscovery`, `TestDiagnostics` /
`TestSsmDiagnostics` (both diagnosis ladders), `TestSshTunnelArgvCompression` and
the ssh/ssm exit classifiers, and `TestSelfHealRefreshRestart` for the refresh
loop. 1,070 tests across the module's own files
and every downstream consumer of the changed modules pass unchanged:

```
test/test_instances.py test/test_instances_search_federation.py
test/test_instance_credential_pairing.py test/test_ssh_tunnel_manager_cov80.py
test/test_apps_instances_loop_offload.py test/test_cli.py test/test_cloud_connect.py
test/test_cloud_launch_job.py test/test_dashboard_server_coverage.py
test/test_governance_self_protection.py test/test_lazy_data_home_paths.py
test/test_mcp_api_port_resolution.py test/test_runtime_home_write_paths.py
test/test_session_transfer.py test/test_spawn_audit.py test/test_tailnet_cli.py
test/test_installer_distro.py test/test_security_posture.py
→ 1112 passed, 2 skipped
```

Gates, all green on the Python 3.12 CI-parity venv: `flake8`, `isort
--check-only`, `mypy src/kiro_crew` (1008 files), `black --check` on every touched
file outside the baseline, `check_brand_name.py`, `check_harness_parity.py`,
`docs_lint.py --test`, `docs-lint.sh`, `check_per_file_coverage.py --test`,
`verify_vendor_manifest.py`, `scrub-lint.sh --no-history`.

## Manual verification

N/A — unit coverage sufficient. Every hunk is a provable no-op (identical argv,
identical strings, identical branch order), so there is no runtime behaviour a
manual pass could observe that the suites do not already assert.

## Related Issues

no linked issue: a readability sweep of one module, not a reported defect.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass; no new functionality, so only the two argv assertions above
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented behaviour changed
- [x] No secrets, credentials, or internal references in the diff
