### PR TITLE
fix(agent): make a stale spec model pin diagnosable and resettable

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -35,9 +35,10 @@ import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, MutableMapping
 
 from kiro_crew import agent_state, platform_compat
+from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.agent_files import (
     AGENT_FILENAME,
 )
@@ -83,6 +84,7 @@ from kiro_crew.sel import (  # circular import: sel imports config which imports
     SecurityEvent,
     sel,
 )
+from kiro_crew.validation import _AGENT_NAME_RE
 
 logger = logging.getLogger(__name__)
 
@@ -2603,6 +2605,204 @@ def migrate_agent_specs() -> int:
     if cleaned:
         logger.info("Cleaned %d kiro agent spec(s) of KiroCrew bookkeeping keys", cleaned)
     return cleaned
+
+
+def clear_model_pin(config: MutableMapping[str, object], name: str) -> None:
+    """Drop *config*'s ``model`` pin and resume tracking the shipped default.
+
+    The in-place half of "return this agent to the default model", shared by
+    every caller that offers it, so the dashboard's Agent Templates editor and
+    the CLI cannot drift on what clearing a model means (the same reason
+    :func:`agent_state.lift_and_strip_bookkeeping` is shared by four writers).
+    The caller persists *config* itself.
+
+    Deliberately the ONLY way a spec's ``model`` becomes managed after install:
+    ownership cannot be inferred from a spec's value, because a model an older
+    build's propagation wrote and one the user typed in by hand are identical on
+    disk. So this is driven by an explicit user action -- clearing the model in
+    the editor, or ``kirocrew agent reset-model`` -- and never by a heuristic
+    running behind the user's back on refresh.
+
+    Ordering is benign in both directions: if the sidecar write lands and the
+    caller's spec write does not, the next refresh resolves the still-pinned
+    spec to the shipped default, which is what the user asked for; if the spec
+    write lands and the sidecar write does not, the pin is gone and the resolver
+    falls through to the global.
+    """
+    config.pop("model", None)
+    agent_state.set_model_managed(name, True)
+
+
+def _read_spec_capped(path: Path) -> dict | None:
+    """Parse an agent spec through the hardened, SIZE-CAPPED read gate.
+
+    ``agent_discovery._read_agent_spec`` is what that module documents as the one
+    reader for both agent scopes: it reads via ``hooks.safe_read_file_bytes``, so
+    a multi-gigabyte "agent config" in a user-writable, tool-shared directory is
+    refused at the cap instead of being slurped into memory, and it also rejects
+    non-UTF-8 bytes, AppleDouble sidecars and JSON that is not an object.
+
+    A thin wrapper rather than a direct call at each site, so the reason the
+    capped reader is used lives in one place.
+    """
+    return _read_agent_spec(path)
+
+
+def _spec_path_is_safe(path: Path, agents_dir: Path) -> bool:
+    """True when *path* is a real file inside *agents_dir*, safe to read and rewrite.
+
+    A spec is read and then written back, so a SYMLINK is refused rather than
+    followed. Following one would read the target and write a modified copy into
+    the agents directory, which launders the contents of a file the reader may
+    not otherwise be allowed to open -- a governance-fenced path, for instance --
+    into a location that is freely readable. (The rewrite itself does not corrupt
+    the target: ``_atomic_json_write`` goes through ``os.replace``, which swaps
+    the link rather than writing through it. The copy-out is the problem.)
+
+    Also refuses a resolved path that leaves the agents directory, and any
+    sensitive path, which is the same fence this module already applies before
+    touching a resolved path elsewhere.
+    """
+    try:
+        if path.is_symlink():
+            return False
+        resolved = path.resolve()
+        if resolved.parent != agents_dir.resolve():
+            return False
+        if is_sensitive_path(str(resolved)):
+            return False
+    except OSError:
+        return False
+    return True
+
+
+def agent_spec_path(name: str) -> Path | None:
+    """Return the user-level kiro spec file for *name*, or ``None`` if absent.
+
+    Prefers ``<agents dir>/<name>.json`` and falls back to a scan for a spec
+    whose ``name`` field matches, mirroring how the dashboard's per-agent
+    handler resolves an agent to a file (a spec's filename and its ``name`` are
+    not required to agree).
+
+    *name* is validated against the shared agent-name grammar BEFORE it reaches
+    the path join, so a caller passing a traversal (``../../something``) gets
+    ``None`` rather than a path outside the agents directory. The check lives
+    here, at the resolver, so every caller inherits it instead of each one
+    remembering: this function returns a path that :func:`reset_agent_model`
+    then WRITES, and the CLI takes the name from a user-supplied ``--agent``.
+    A symlinked or otherwise unsafe candidate is refused for the same reason --
+    see :func:`_spec_path_is_safe`.
+
+    A DECLARED ``name`` wins over a matching filename, which is the order the
+    other two resolvers already use (``_resolve_named_agent_model`` and the
+    dashboard's per-agent handler both test ``data["name"] == agent`` before the
+    stem). Preferring the filename would let ``<name>.json`` that declares a
+    DIFFERENT agent be selected, and since the caller then writes to it, that
+    clears the wrong agent's pin while the requested one stays pinned. The
+    filename is accepted only when no spec declares this name -- see below.
+
+    Raises ``ValueError`` when TWO safe specs declare the same name. The runtime
+    iterates the directory unordered, so which of them is live is undefined, and
+    a writer cannot pick without risking clearing the pin nothing is reading.
+    """
+    if not _AGENT_NAME_RE.match(name or ""):
+        return None
+    agents_dir = kiro_agents_dir_path()
+    if not agents_dir.is_dir():
+        return None
+
+    direct = agents_dir / f"{name}.json"
+    declared_matches: list[Path] = []
+    fallback: Path | None = None
+    for spec_path in sorted(agents_dir.glob("*.json")):
+        if not _spec_path_is_safe(spec_path, agents_dir):
+            continue
+        try:
+            data = _read_spec_capped(spec_path)
+        except (json.JSONDecodeError, OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        declared = data.get("name")
+        if declared == name:
+            declared_matches.append(spec_path)
+        elif spec_path == direct:
+            # Right filename. Accepted as the fallback even when it declares a
+            # DIFFERENT name, because the runtime resolver matches on
+            # `data["name"] == agent OR path.stem == agent` -- so with nothing
+            # declaring this name, the stem match makes THIS file the live spec,
+            # and refusing it would leave a live pin unresettable, which is the
+            # bug this change exists to fix. Only used when no declared match is
+            # found, and a declared match alongside it is the ambiguity the
+            # caller refuses rather than resolves.
+            fallback = spec_path
+    if len(declared_matches) > 1:
+        # Paths are repr'd: a filename in this user-writable, tool-shared
+        # directory is untrusted input, and this message is printed to a terminal.
+        raise ValueError(
+            f"{len(declared_matches)} specs declare the name {name!r}: "
+            f"{', '.join(repr(str(p)) for p in declared_matches)}. The runtime iterates the "
+            f"directory unordered, so which one is live is undefined -- remove or rename "
+            f"one before resetting."
+        )
+    if declared_matches:
+        return declared_matches[0]
+    return fallback
+
+
+def _conflicting_spec_for(name: str, chosen: Path, agents_dir: Path) -> Path | None:
+    """Return a DIFFERENT safe spec whose FILENAME also claims *name*.
+
+    The runtime resolver (``KiroCrewConfig._resolve_named_agent_model``) accepts
+    EITHER a declared-name match or a filename match -- ``data["name"] == agent
+    or path.stem == agent`` -- and iterates ``glob("*.json")``, which is
+    unordered. So when ``<name>.json`` declares a different agent AND another
+    file declares *name*, which of the two the runtime actually uses is
+    UNDEFINED: it is whichever the filesystem yields first.
+
+    A reset cannot pick correctly in that state. Clearing either one can leave
+    the live pin in place and strip the model from a spec nothing is reading, so
+    the caller refuses instead of guessing.
+    """
+    direct = agents_dir / f"{name}.json"
+    if direct == chosen or not direct.is_file():
+        return None
+    if not _spec_path_is_safe(direct, agents_dir):
+        return None
+    return direct
+
+
+def reset_agent_model(name: str) -> tuple[Path, str]:
+    """Clear *name*'s spec model pin on disk; return (spec path, previous model).
+
+    The explicit, narrow counterpart to ``kirocrew setup --clean``, which also
+    resumes default-model tracking but regenerates the whole spec and discards
+    every user customization with it. Raises ``FileNotFoundError`` when the
+    agent has no user-level spec.
+    """
+    spec_path = agent_spec_path(name)
+    if spec_path is None:
+        raise FileNotFoundError(f"no kiro agent spec for {name!r} in {kiro_agents_dir_path()}")
+    conflict = _conflicting_spec_for(name, spec_path, kiro_agents_dir_path())
+    if conflict is not None:
+        raise ValueError(
+            f"two specs claim {name!r}: {str(spec_path)!r} declares it, and {str(conflict)!r} "
+            f"carries the filename. The runtime accepts either, in unordered directory order, "
+            f"so which one is live is undefined -- rename or remove one before resetting."
+        )
+    try:
+        data = _read_spec_capped(spec_path)
+    except (json.JSONDecodeError, OSError, ValueError) as exc:
+        raise FileNotFoundError(f"could not read agent spec {spec_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise FileNotFoundError(f"agent spec {spec_path} is not readable as a JSON object")
+    previous = data.get("model") or ""
+    clear_model_pin(data, name)
+    # Same strip every spec writer runs: kiro-cli validates with
+    # deny_unknown_fields and drops the whole agent on an unknown key.
+    agent_state.lift_and_strip_bookkeeping(data, name)
+    _atomic_json_write(spec_path, data)
+    return spec_path, str(previous)
 
 
 def _decline_shared_agent_home(*, audit: bool = True) -> Path | None:

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2039,6 +2039,19 @@ Examples:
     agent_update.add_argument("--memory-store", help="New memory store name")
     agent_delete = agent_sub.add_parser("delete", help="Delete a Kiro Crew agent")
     agent_delete.add_argument("name", help="Agent name to delete")
+    agent_reset_model = agent_sub.add_parser(
+        "reset-model",
+        help="Clear an agent spec's pinned model so it tracks the shipped default again",
+    )
+    agent_reset_model.add_argument(
+        "--agent",
+        # Literal rather than an import: this parser is built on every CLI
+        # invocation and `agent.py` pulls in config.loader, which is the import
+        # cost the lazy dispatch in main() exists to avoid. Same spelling the
+        # resolver itself compares against in resolve_effective_model.
+        default="kirocrew",
+        help="Kiro agent spec to reset (default: kirocrew)",
+    )
 
     # workspace
     ws_parser = sub.add_parser("workspace", help="Manage workspace definitions")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from kiro_crew import __version__, beacon, platform_compat
+from kiro_crew.agent import reset_agent_model
 from kiro_crew.apps.bridges import (
     deregister_app,
     deregister_app_crons_from_service,
@@ -818,8 +819,50 @@ def _handle_agent(args: argparse.Namespace) -> None:
         cfg.save()
         print(f"Deleted agent: {args.name}")
 
+    elif action == "reset-model":
+        _agent_reset_model(args)
+
     else:
-        print("Usage: kirocrew agent {list|create|update|delete}")
+        print("Usage: kirocrew agent {list|create|update|delete|reset-model}")
+
+
+def _agent_reset_model(args: argparse.Namespace) -> None:
+    """Clear an agent spec's pinned model (``kirocrew agent reset-model``).
+
+    The explicit, narrow way back to the shipped default model. It exists
+    because ownership of a spec's ``model`` cannot be inferred: a value an older
+    build's propagation wrote and one the user typed in by hand are
+    byte-identical on disk, so nothing may reclassify a pin behind the user's
+    back. Before this, the only ways out were the dashboard's Agent Templates
+    editor (clear the model) and ``kirocrew setup --clean``, which also
+    regenerates the whole spec and discards every other customization with it.
+    """
+    name = getattr(args, "agent", None) or "kirocrew"
+    try:
+        spec_path, previous = reset_agent_model(name)
+    except FileNotFoundError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as exc:
+        # Ambiguous: two specs claim the name and the runtime's choice between
+        # them is undefined, so resetting either could strip the wrong one.
+        print(f"❌ {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"❌ Could not write the agent spec: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if previous:
+        # repr on BOTH the model and the path. Neither is trusted input: an
+        # installed app writes specs into the agents directory and a cloned
+        # repository can ship one, so an OSC/ANSI sequence can arrive in the
+        # `model` value AND in the FILENAME -- the declared-name scan returns
+        # whichever file declares the requested name, so its path is attacker-
+        # shaped even though *name* itself is grammar-validated.
+        print(f"✅ Cleared {name}'s pinned model ({previous!r}) in {str(spec_path)!r}")
+    else:
+        print(f"✅ {name} had no pinned model in {str(spec_path)!r}")
+    print("   It now tracks the shipped default; restart the gateway to apply.")
 
 
 def _cron(args: argparse.Namespace) -> None:

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -18,16 +18,26 @@ import urllib.request
 from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
-from kiro_crew import diagnostics, platform_compat, sandbox
+from kiro_crew import agent_state, diagnostics, platform_compat, sandbox
 from kiro_crew._bootstrap import _source_checkout_root
 from kiro_crew.acp import kas_assets, kas_auth
 from kiro_crew.acp.client import KIRO_CLI_BIN
 from kiro_crew.acp.types import ACP_BACKEND_KAS
 from kiro_crew.agent import AGENT_FILENAME
+from kiro_crew.agent_discovery import (
+    _read_agent_spec,
+    project_agent_files,
+    project_agent_name,
+)
 from kiro_crew.agents_janitor import sweep_agents_dir
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import KiroCrewConfig
-from kiro_crew.config.loader import config_dir
+from kiro_crew.config.loader import (
+    config_dir,
+    normalize_agent_model,
+    resolve_agent_bindings,
+    resolve_effective_model,
+)
 from kiro_crew.config.paths import (
     LEGACY_CONFIG_DIR_NAME,
     _valid_override_home,
@@ -75,6 +85,7 @@ from kiro_crew.service import controller as service_controller
 from kiro_crew.service import linux as service_linux
 from kiro_crew.session_pid_sig import signing_health
 from kiro_crew.transcribe import _find_parakeet_mlx, _find_whisper, ensure_ffmpeg_in_path
+from kiro_crew.validation import _AGENT_NAME_RE
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +99,227 @@ KIRO_AGENTS_DIR: Path | None = None
 def _agents_dir() -> Path:
     """Kiro agents directory, honoring the override hook, else the live home."""
     return KIRO_AGENTS_DIR if KIRO_AGENTS_DIR is not None else kiro_agents_dir()
+
+
+def _safe_display(value: object) -> str:
+    """Render a value read off disk so a terminal cannot act on it.
+
+    Agent specs are NOT all trusted input: a cloned repository can ship its own
+    ``<project>/.kiro/agents/*.json``, and an installed app registers specs in
+    the user-level directory, so a ``model`` string (or a configured agent name)
+    can carry OSC/ANSI control sequences. ``repr`` escapes every non-printable
+    character, so the value is shown verbatim-but-inert instead of executing
+    terminal controls or spoofing the surrounding diagnostic lines.
+    """
+    return repr(value)
+
+
+def _doctor_effective_model(cfg: KiroCrewConfig, project_dir: str, issues: list[str]) -> None:
+    """Report which model a new session starts on, and which tier decided it.
+
+    The precedence is real and four tiers deep, and the tier that wins is not
+    visible from any single file, so a surprising model -- the wrong one, or a
+    stale one that outlived the setting that created it -- is otherwise only
+    diagnosable by hand-reading config.json, two agent-spec directories and the
+    sidecar.
+
+    The tiers are listed as DATA and the first non-deferring one is marked, which
+    is ``resolve_effective_model``'s own rule. The marked value is then
+    cross-checked against what that function actually returns and a disagreement
+    is REPORTED rather than hidden, so this report cannot quietly drift into a
+    second, wrong copy of the precedence.
+
+    Read-only: this section never repairs anything, because a spec's ``model``
+    cannot be attributed -- a value an older build's propagation wrote and one
+    the user typed in are identical on disk -- so the repair has to be the
+    user's explicit call (``kirocrew agent reset-model``).
+    """
+    print("\nModel")
+    try:
+        effective = resolve_effective_model(cfg)
+    except Exception as exc:  # noqa: BLE001 -- diagnostics must not crash the report
+        print(f"  effective:   ⚠️  could not resolve ({exc})")
+        issues.append("effective model unresolvable")
+        return
+
+    def _spec_model(path: Path) -> tuple[str, bool]:
+        """Return (normalized model, usable) for a kiro spec file.
+
+        Routed through ``agent_discovery._read_agent_spec``, which the module
+        documents as the ONE reader for both agent scopes so every guard applies
+        uniformly: it goes through the hardened size-capped read gate (a
+        multi-gigabyte "agent config" is refused rather than slurped), and it
+        rejects a symlink whose resolved target is sensitive, non-UTF-8 bytes,
+        AppleDouble sidecars and JSON that is not an object. Hand-rolling those
+        checks here would be a second, weaker copy of a reader that already
+        exists.
+        """
+        data = _read_agent_spec(path)
+        if data is None:
+            # An ABSENT spec is not a fault -- a clean install has none, and the
+            # resolver simply falls through to the bundled default. Only a file
+            # that exists and the hardened reader still refuses is reported.
+            try:
+                exists = path.exists() or path.is_symlink()
+            except OSError:
+                exists = True
+            return "", not exists
+        return normalize_agent_model(data.get("model")), True
+
+    # Deliberately kiro_agents_dir() and not _agents_dir(): this section compares
+    # tiers against what resolve_effective_model returned, so it has to read the
+    # very directory that function reads. Reporting a different directory's spec
+    # beside its verdict is how a report starts contradicting itself.
+    agents_dir = kiro_agents_dir()
+
+    # The DEFAULT alias may bind a kiro agent other than the built-in one, and
+    # the resolver treats those two differently: a non-default bound agent's own
+    # pin is consulted ABOVE the global (tier 2), while the built-in spec is read
+    # only after the global defers (tier 4). Reading kirocrew.json in both cases
+    # would attribute a custom agent's pin to the wrong file and print a reset
+    # command for the wrong agent.
+    try:
+        bindings = resolve_agent_bindings(cfg)
+        override = normalize_agent_model(bindings.model)
+        bound = bindings.kiro_agent or "kirocrew"
+    except Exception:  # noqa: BLE001 -- a broken alias must not kill the report
+        override = ""
+        bound = "kirocrew"
+    # kiro_agent is free text in config.json and this name reaches a path join.
+    # An ABSOLUTE value would make pathlib discard the directory on the left
+    # (`base / "/etc/passwd.json"` is `/etc/passwd.json`), so an unvalidated
+    # binding turns a spec lookup into an arbitrary read. The type check is not
+    # redundant with the grammar: the config loader deliberately KEEPS a
+    # type-mismatched value ("validated by its consumer"), so a hand-edited
+    # non-string reaches here intact and `re.match` would raise TypeError --
+    # aborting the one command a user runs BECAUSE their config is broken.
+    # Anything outside a plain string in the shared grammar is reported and then
+    # treated as unbound.
+    if not isinstance(bound, str) or not _AGENT_NAME_RE.match(bound):
+        print(f"  bound agent: ⚠️  {_safe_display(bound)} is not a valid agent name")
+        issues.append("configured kiro_agent is not a valid agent name")
+        bound = "kirocrew"
+
+    default_spec = agents_dir / AGENT_FILENAME
+    default_model, default_readable = _spec_model(default_spec)
+    if not default_readable:
+        print(f"  user spec:   ⚠️  unreadable ({default_spec})")
+        issues.append("agent spec unreadable")
+
+    bound_model = ""
+    bound_spec: Path | None = None
+    if bound != "kirocrew":
+        bound_spec = agents_dir / f"{bound}.json"
+        # Read through the resolver's own accessor: it matches on the spec's
+        # ``name`` field as well as the filename, which a bare path join misses.
+        try:
+            bound_model = normalize_agent_model(cfg._resolve_named_agent_model(bound))
+        except Exception:  # noqa: BLE001
+            bound_model = ""
+
+    # Labelled in resolve_effective_model's own order. Tier 2 is present only
+    # when it applies, so the list never shows a tier the resolver skipped.
+    tiers: list[tuple[str, str]] = [("agent override", override)]
+    if bound != "kirocrew":
+        tiers.append((f"bound agent pin ({_safe_display(bound)})", bound_model))
+    tiers.append(("global agent.model", normalize_agent_model(cfg.agent.model)))
+    tiers.append(("default spec pin", default_model))
+
+    decided_by = next((label for label, value in tiers if value), "bundled defaults.json")
+    if any(value for _, value in tiers):
+        decided_value = next(value for _, value in tiers if value)
+    elif default_readable:
+        # Nothing pinned anything, so the bundled default answered and the
+        # resolver's value is legitimately ours.
+        decided_value = effective
+    else:
+        # A spec read was REFUSED, so the resolver may have followed a link this
+        # report would not. Adopting its answer here would hide exactly that.
+        decided_value = ""
+
+    print(f"  effective:   {_safe_display(effective) if effective else 'auto (backend picks)'}")
+    print(f"  decided by:  {decided_by}")
+    for label, value in tiers:
+        print(f"    {label + ':':<26} {_safe_display(value) if value else '(defers)'}")
+    print(f"  spec file:   {_safe_display(str(default_spec))}")
+    if bound_spec is not None:
+        print(f"  bound spec:  {_safe_display(str(bound_spec))}")
+
+    # Self-check: the marked tier must be what the resolver actually returned.
+    if decided_value != effective:
+        if not default_readable:
+            # Not drift. The resolver reads the spec through its own path, which
+            # FOLLOWS a symlink, while this report refuses to; so it can resolve
+            # a value this section declined to attribute. Say that, rather than
+            # accusing the tier list of being stale.
+            print(
+                "  ⚠️  the resolver read a spec this report refused to follow, so the "
+                "deciding tier above is not attributed"
+            )
+        else:
+            print(
+                f"  ⚠️  this report says {decided_value!r} but the resolver returned "
+                f"{effective!r} — the precedence shown here is out of date"
+            )
+            issues.append("doctor model precedence disagrees with the resolver")
+
+    # Which spec is actually deciding, so the tracking state and the repair below
+    # describe THAT agent rather than always the built-in one.
+    if decided_by.startswith("bound agent pin"):
+        pinned_agent, pinned_value = bound, bound_model
+    elif decided_by == "default spec pin":
+        pinned_agent, pinned_value = "kirocrew", default_model
+    else:
+        pinned_agent, pinned_value = bound, ""
+
+    try:
+        managed = agent_state.get_model_managed(pinned_agent)
+    except Exception:  # noqa: BLE001 -- an unreadable sidecar is not fatal here
+        managed = None
+    if managed is None:
+        tracking = "not recorded"
+    else:
+        tracking = "shipped default" if managed else "frozen (explicit pick)"
+    print(f"  tracking:    {tracking} ({_safe_display(pinned_agent)})")
+
+    # kiro-cli resolves --agent against <project>/.kiro/agents FIRST, with no
+    # upward walk, and Kiro Crew's own resolver never reads that directory. So a
+    # project-local spec can decide what actually RUNS while every Kiro Crew
+    # surface reports something else -- worth naming even though it is rare.
+    # *project_dir* is the caller's already-resolved value (env, else the saved
+    # project_dir file), so this agrees with the Project section above.
+    if project_dir:
+        # Resolved the way kiro-cli itself resolves --agent, via the existing
+        # helper: the DECLARED name wins and the filename is only the fallback,
+        # so a project spec that declares this agent under some other filename is
+        # still found. Checking `<bound>.json` alone missed exactly that and
+        # under-reported the shadow.
+        proj_spec = next(
+            (p for p in project_agent_files(project_dir) if project_agent_name(p) == bound),
+            None,
+        )
+        if proj_spec is not None:
+            proj_model, proj_usable = _spec_model(proj_spec)
+            shown = (
+                _safe_display(proj_model)
+                if proj_model
+                else ("(unreadable)" if not proj_usable else "(no model)")
+            )
+            print(f"  project spec: ⚠️  {_safe_display(str(proj_spec))} -> {shown}")
+            print("                kiro-cli loads this one first; not read above")
+            issues.append("project-local agent spec shadows the user-level one")
+
+    if pinned_value:
+        # pinned_agent is either the literal "kirocrew" or a configured kiro
+        # agent name; the flag form is only emitted for a name that matched a
+        # spec file on disk, so it is a real agent rather than free text.
+        # The name is escaped like every other value read out of config: a
+        # control-bearing kiro_agent would otherwise reach the terminal on the
+        # one line the user is most likely to copy and run.
+        flag = "" if pinned_agent == "kirocrew" else f" --agent {_safe_display(pinned_agent)}"
+        global_shown = _safe_display(cfg.agent.model) if cfg.agent.model else "unset"
+        print(f"  ⚠️  the spec pin decides because the global is {global_shown}")
+        print(f"      Fix: kirocrew agent reset-model{flag}   (clears the pin, tracks the default)")
 
 
 def _os_fix_hint(mac: str, linux: str, windows: str | None = None) -> str:
@@ -1646,6 +1878,12 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
         if not _has_slack:
             print("  auth:        ⚠️  Slack not configured — token generation unavailable")
             issues.append("dashboard auth: remote bind without Slack")
+
+    # ── Effective model (+ which tier decided it) ──
+    # After Configuration, deliberately: that section prints the global
+    # agent.model, and the whole point here is that the global is not
+    # necessarily what a new session gets.
+    _doctor_effective_model(cfg, proj, issues)
 
     # ── Data Home (+ leftover legacy home) ──
     _doctor_data_home()

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -17,7 +17,13 @@ from aiohttp import web
 
 from kiro_crew import agent_state, model_registry
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
-from kiro_crew.agent import AGENT_FILENAME, get_shipped_tools, install_agent, kiro_agents_dir_path
+from kiro_crew.agent import (
+    AGENT_FILENAME,
+    clear_model_pin,
+    get_shipped_tools,
+    install_agent,
+    kiro_agents_dir_path,
+)
 from kiro_crew.agent_discovery import (
     clear_list_agents_cache,
     list_agents,
@@ -1401,10 +1407,12 @@ async def api_agent_detail(request: web.Request) -> web.Response:
                             # provider id at the config.loader factory boundary.
                             data["model"] = patch_body["model"] or None
                             if data["model"] is None:
-                                data.pop("model", None)
                                 # Cleared/auto: resume tracking the shipped
                                 # default (re-synced by _refresh_dynamic_fields).
-                                agent_state.set_model_managed(agent_name, True)
+                                # Shared with `kirocrew agent reset-model` so the
+                                # two surfaces cannot disagree on what clearing a
+                                # model means.
+                                clear_model_pin(data, agent_name)
                             else:
                                 # Explicit pick: freeze it against default bumps.
                                 agent_state.set_model_managed(agent_name, False)

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -4709,6 +4710,115 @@ class TestRefreshDynamicFieldsSyncsConfigModel:
         assert config["model"] == "claude-sonnet-4.6"
 
 
+class TestResetAgentModel:
+    """The explicit way back to the shipped default (#2559).
+
+    Ownership of a spec's ``model`` cannot be inferred -- a value an older
+    build's propagation wrote and one the user typed in are identical on disk --
+    so the reset is a user action, and these tests pin that it clears BOTH halves
+    of the state (the spec pin and the sidecar flag) and never guesses.
+    """
+
+    def _spec(self, tmp_path: Path, stem: str, body: dict) -> Path:
+        spec = tmp_path / f"{stem}.json"
+        spec.write_text(json.dumps(body), encoding="utf-8")
+        return spec
+
+    def test_clear_model_pin_drops_the_pin_and_resumes_tracking(self):
+        from kiro_crew.agent import clear_model_pin
+
+        config = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        clear_model_pin(config, "kirocrew")
+        assert "model" not in config
+        assert agent_state.get_model_managed("kirocrew") is True
+
+    def test_clear_model_pin_is_idempotent_with_no_pin(self):
+        from kiro_crew.agent import clear_model_pin
+
+        config: dict = {"name": "kirocrew"}
+        clear_model_pin(config, "kirocrew")
+        assert "model" not in config
+        assert agent_state.get_model_managed("kirocrew") is True
+
+    def test_reset_writes_the_spec_and_reports_the_previous_model(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        self._spec(tmp_path, "kirocrew", {"name": "kirocrew", "model": "claude-opus-4.8"})
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+
+        spec_path, previous = agent_mod.reset_agent_model("kirocrew")
+
+        assert previous == "claude-opus-4.8"
+        assert json.loads(spec_path.read_text(encoding="utf-8")) == {"name": "kirocrew"}
+        assert agent_state.get_model_managed("kirocrew") is True
+
+    def test_reset_overrides_an_explicit_freeze(self, tmp_path: Path, monkeypatch):
+        """A frozen editor pick is the user's own answer, and asking for a reset
+        is a NEWER answer from the same user -- so it wins."""
+        import kiro_crew.agent as agent_mod
+
+        agent_state.set_model_managed("kirocrew", False)
+        self._spec(tmp_path, "kirocrew", {"name": "kirocrew", "model": "claude-haiku-4.5"})
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+
+        agent_mod.reset_agent_model("kirocrew")
+        assert agent_state.get_model_managed("kirocrew") is True
+
+    def test_reset_never_writes_bookkeeping_into_the_spec(self, tmp_path: Path, monkeypatch):
+        """kiro-cli validates specs with deny_unknown_fields and drops the whole
+        agent on an unknown key, so a stray sidecar key must be lifted out."""
+        import kiro_crew.agent as agent_mod
+
+        self._spec(
+            tmp_path,
+            "kirocrew",
+            {"name": "kirocrew", "model": "claude-opus-4.8", "cc_model": "claude-sonnet-4.6"},
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+
+        spec_path, _ = agent_mod.reset_agent_model("kirocrew")
+        written = json.loads(spec_path.read_text(encoding="utf-8"))
+        assert "cc_model" not in written and "model_managed" not in written
+        assert agent_state.get_cc_model("kirocrew") == "claude-sonnet-4.6"
+
+    def test_reset_resolves_a_spec_whose_filename_differs_from_its_name(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        self._spec(tmp_path, "some-file", {"name": "custom-agent", "model": "claude-haiku-4.5"})
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+
+        spec_path, previous = agent_mod.reset_agent_model("custom-agent")
+        assert spec_path.name == "some-file.json"
+        assert previous == "claude-haiku-4.5"
+
+    def test_reset_refuses_an_agent_with_no_spec(self, tmp_path: Path, monkeypatch):
+        import kiro_crew.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: tmp_path)
+        with pytest.raises(FileNotFoundError):
+            agent_mod.reset_agent_model("kirocrew")
+        # Nothing was claimed on a failed reset.
+        assert agent_state.get_model_managed("kirocrew") is None
+
+    def test_refresh_still_leaves_an_unrecorded_spec_alone(self, tmp_path: Path):
+        """The counterpart contract: with no sidecar entry the refresh must not
+        reclassify a pin on its own. Inferring ownership from the value is what
+        makes the explicit reset necessary rather than optional."""
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        mc = tmp_path / "config.json"
+        mc.write_text(json.dumps({"agent": {"model": "auto"}}), encoding="utf-8")
+        config = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            _refresh_dynamic_fields(config)
+        assert config["model"] == "claude-opus-4.8"
+        assert agent_state.get_model_managed("kirocrew") is None
+
+
 # ── ensure_agent_materialized (self-heal for kiro-cli "Mode not found") ──
 
 
@@ -4770,3 +4880,387 @@ def test_ensure_agent_materialized_swallows_errors(tmp_path, monkeypatch):
 
     managed = Path(agent_mod.AGENT_FILENAME).stem
     assert agent_mod.ensure_agent_materialized(managed) is False
+
+
+class TestAgentSpecPathRejectsTraversal:
+    """``agent_spec_path`` validates the name BEFORE the path join (#4911 review).
+
+    The path it returns is one ``reset_agent_model`` then WRITES, and the CLI
+    takes the name from a user-supplied ``--agent``, so a traversal would rewrite
+    an arbitrary JSON file and strip its ``model`` key. The guard lives at the
+    resolver so every caller inherits it.
+    """
+
+    def test_traversal_is_refused_and_the_outside_file_is_untouched(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        outsider = tmp_path / "victim.json"
+        original = json.dumps({"model": "claude-opus-4.8", "keep": 1})
+        outsider.write_text(original, encoding="utf-8")
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        assert agent_mod.agent_spec_path("../victim") is None
+        with pytest.raises(FileNotFoundError):
+            agent_mod.reset_agent_model("../victim")
+        assert outsider.read_text(encoding="utf-8") == original
+
+    @pytest.mark.parametrize(
+        "name",
+        ["../victim", "a/b", "..", "", "with space", "sub/../../x", "tab\tname"],
+    )
+    def test_names_outside_the_grammar_are_refused(self, tmp_path: Path, monkeypatch, name):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+        assert agent_mod.agent_spec_path(name) is None
+
+    def test_a_valid_name_still_resolves(self, tmp_path: Path, monkeypatch):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "my-agent_2.json").write_text(
+            json.dumps({"name": "my-agent_2"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+        assert agent_mod.agent_spec_path("my-agent_2") == agents / "my-agent_2.json"
+
+
+class TestSpecPathRefusesSymlinks:
+    """A spec is read and then written back, so a symlink is refused, not followed.
+
+    Following one copies the target's contents into the agents directory, which
+    launders a file the reader may not otherwise be allowed to open into a freely
+    readable location (#4911 review).
+    """
+
+    def test_a_symlinked_spec_is_refused_and_the_target_is_not_copied(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        secret = tmp_path / "protected.json"
+        secret.write_text(json.dumps({"model": "leaked", "secret": "s"}), encoding="utf-8")
+        link = agents / "kirocrew.json"
+        link.symlink_to(secret)
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        assert agent_mod.agent_spec_path("kirocrew") is None
+        with pytest.raises(FileNotFoundError):
+            agent_mod.reset_agent_model("kirocrew")
+        # The link is intact and nothing was copied into the agents directory.
+        assert link.is_symlink()
+        assert json.loads(secret.read_text(encoding="utf-8"))["secret"] == "s"
+
+    def test_the_name_scan_also_skips_a_symlink(self, tmp_path: Path, monkeypatch):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        outside = tmp_path / "outside.json"
+        outside.write_text(json.dumps({"name": "wanted", "model": "x"}), encoding="utf-8")
+        (agents / "some-file.json").symlink_to(outside)
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        assert agent_mod.agent_spec_path("wanted") is None
+
+    def test_a_plain_spec_is_still_accepted(self, tmp_path: Path, monkeypatch):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "kirocrew.json").write_text(json.dumps({"name": "kirocrew"}), encoding="utf-8")
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        assert agent_mod.agent_spec_path("kirocrew") == agents / "kirocrew.json"
+
+
+class TestSpecPathPrefersTheDeclaredName:
+    """A declared ``name`` wins over a matching filename (#4911 review).
+
+    The caller WRITES to the path this returns, so selecting ``<name>.json``
+    when that file declares a different agent clears the wrong agent's pin and
+    leaves the requested one pinned. Matches the order the repo's other two
+    resolvers already use.
+    """
+
+    def _dir(self, tmp_path: Path, monkeypatch) -> Path:
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+        return agents
+
+    def test_a_filename_declaring_another_agent_is_not_selected(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The resolver prefers the declared name. (The WRITE path additionally
+        refuses this state outright -- see TestResetRefusesAnAmbiguousName --
+        because the runtime's choice between the two files is undefined.)"""
+        import kiro_crew.agent as agent_mod
+
+        agents = self._dir(tmp_path, monkeypatch)
+        (agents / "foo.json").write_text(
+            json.dumps({"name": "bar", "model": "bar-model"}), encoding="utf-8"
+        )
+        (agents / "elsewhere.json").write_text(
+            json.dumps({"name": "foo", "model": "foo-model"}), encoding="utf-8"
+        )
+
+        assert agent_mod.agent_spec_path("foo") == agents / "elsewhere.json"
+
+    def test_a_mismatched_filename_is_used_when_nothing_declares_the_name(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """`foo.json` declaring `bar`, with nothing declaring `foo`: the runtime
+        matches it by STEM, so it is the live spec for `--agent foo` and refusing
+        it would leave a live pin unresettable (#4911 review)."""
+        import kiro_crew.agent as agent_mod
+
+        agents = self._dir(tmp_path, monkeypatch)
+        (agents / "foo.json").write_text(
+            json.dumps({"name": "bar", "model": "m"}), encoding="utf-8"
+        )
+
+        assert agent_mod.agent_spec_path("foo") == agents / "foo.json"
+        spec_path, previous = agent_mod.reset_agent_model("foo")
+        assert spec_path.name == "foo.json"
+        assert previous == "m"
+
+    def test_the_filename_is_accepted_when_it_declares_no_name(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        agents = self._dir(tmp_path, monkeypatch)
+        (agents / "foo.json").write_text(json.dumps({"model": "m"}), encoding="utf-8")
+        assert agent_mod.agent_spec_path("foo") == agents / "foo.json"
+
+    def test_the_filename_is_accepted_when_it_declares_the_same_name(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        agents = self._dir(tmp_path, monkeypatch)
+        (agents / "foo.json").write_text(json.dumps({"name": "foo"}), encoding="utf-8")
+        assert agent_mod.agent_spec_path("foo") == agents / "foo.json"
+
+
+class TestResetRefusesAnAmbiguousName:
+    """Two specs claiming one name is refused, not guessed (#4911 review).
+
+    The runtime resolver accepts EITHER a declared-name match or a filename
+    match and iterates an unordered glob, so which of the two is live is
+    undefined. Clearing either could leave the live pin in place and strip the
+    model from a spec nothing reads.
+    """
+
+    def test_a_declared_match_plus_a_filename_match_is_refused(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "foo.json").write_text(
+            json.dumps({"name": "bar", "model": "bar-model"}), encoding="utf-8"
+        )
+        (agents / "elsewhere.json").write_text(
+            json.dumps({"name": "foo", "model": "foo-model"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        with pytest.raises(ValueError) as exc:
+            agent_mod.reset_agent_model("foo")
+        assert "undefined" in str(exc.value)
+        # NEITHER file was touched.
+        assert json.loads((agents / "foo.json").read_text(encoding="utf-8"))["model"] == (
+            "bar-model"
+        )
+        assert json.loads((agents / "elsewhere.json").read_text(encoding="utf-8"))["model"] == (
+            "foo-model"
+        )
+        assert agent_mod.agent_state.get_model_managed("foo") is None
+
+    def test_an_unambiguous_declared_match_still_resets(self, tmp_path: Path, monkeypatch):
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "elsewhere.json").write_text(
+            json.dumps({"name": "foo", "model": "foo-model"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        spec_path, previous = agent_mod.reset_agent_model("foo")
+        assert spec_path.name == "elsewhere.json"
+        assert previous == "foo-model"
+
+    def test_two_specs_declaring_the_same_name_is_refused(self, tmp_path: Path, monkeypatch):
+        """Same undefined-liveness argument as the filename collision: the
+        runtime iterates unordered, so a writer cannot pick (#4911 review)."""
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "a.json").write_text(
+            json.dumps({"name": "dup", "model": "a-model"}), encoding="utf-8"
+        )
+        (agents / "b.json").write_text(
+            json.dumps({"name": "dup", "model": "b-model"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        with pytest.raises(ValueError) as exc:
+            agent_mod.agent_spec_path("dup")
+        assert "undefined" in str(exc.value)
+
+        with pytest.raises(ValueError):
+            agent_mod.reset_agent_model("dup")
+        # Neither model was cleared.
+        assert json.loads((agents / "a.json").read_text(encoding="utf-8"))["model"] == "a-model"
+        assert json.loads((agents / "b.json").read_text(encoding="utf-8"))["model"] == "b-model"
+        assert agent_mod.agent_state.get_model_managed("dup") is None
+
+
+class TestSpecReadsAreSizeCapped:
+    """Spec reads go through the hardened, size-capped gate (#4911 review).
+
+    The agents directory is user-writable and shared with other tools, so an
+    oversized file there must be refused rather than slurped into memory. Uses a
+    LOWERED cap instead of a real 50 MB fixture -- writing 50 MB in a test is not
+    acceptable, and the property under test is "the cap is consulted", not its
+    value. Verified against the real 50 MB cap once by hand before landing.
+    """
+
+    def test_an_oversized_spec_is_refused_by_resolver_and_reset(self, tmp_path: Path, monkeypatch):
+        import kiro_crew.agent as agent_mod
+        from kiro_crew import hooks
+
+        monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "kirocrew.json").write_text(
+            json.dumps({"name": "kirocrew", "model": "m", "pad": "x" * 1024}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        assert agent_mod.agent_spec_path("kirocrew") is None
+        with pytest.raises(FileNotFoundError):
+            agent_mod.reset_agent_model("kirocrew")
+
+    def test_a_normal_sized_spec_under_the_same_cap_still_resets(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The A-side of the cap test: proves the refusal above is the SIZE, not
+        the lowered cap breaking every read."""
+        import kiro_crew.agent as agent_mod
+        from kiro_crew import hooks
+
+        monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "kirocrew.json").write_text(
+            json.dumps({"name": "kirocrew", "model": "claude-opus-4.8"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        _, previous = agent_mod.reset_agent_model("kirocrew")
+        assert previous == "claude-opus-4.8"
+
+
+class TestResetOutputEscapesUntrustedPaths:
+    """A spec FILENAME is untrusted input too (#4911 review).
+
+    The declared-name scan returns whichever file declares the requested name, so
+    its path is attacker-shaped even though the requested name is
+    grammar-validated. Every line that prints one -- success, no-pin, and the
+    ambiguity refusal -- must escape it.
+
+    The hostile path is INJECTED rather than created on disk: control bytes are
+    illegal in a Windows filename, so building the fixture would make these
+    assertions Windows-only-skipped, and the property under test is "the printer
+    escapes what it is handed", not "the filesystem accepts odd names". Keeping
+    the assertion platform-independent follows the conftest rule of probing or
+    injecting rather than blanket-skipping a platform.
+    """
+
+    HOSTILE = "/tmp/agents/evil\x1b[2J.json"
+
+    def test_the_success_line_escapes_the_path(self, monkeypatch, capsys):
+        import kiro_crew.cli_commands as cli_commands
+
+        monkeypatch.setattr(
+            cli_commands,
+            "reset_agent_model",
+            lambda name: (Path(self.HOSTILE), "claude-opus-4.8"),
+        )
+
+        cli_commands._agent_reset_model(argparse.Namespace(agent="kirocrew"))
+
+        out = capsys.readouterr().out
+        assert "Cleared" in out
+        assert "\x1b" not in out, "raw escape from a spec filename reached the terminal"
+        assert "\\x1b" in out, "the path is still shown, just escaped"
+
+    def test_the_no_pin_line_escapes_the_path(self, monkeypatch, capsys):
+        import kiro_crew.cli_commands as cli_commands
+
+        monkeypatch.setattr(
+            cli_commands, "reset_agent_model", lambda name: (Path(self.HOSTILE), "")
+        )
+
+        cli_commands._agent_reset_model(argparse.Namespace(agent="kirocrew"))
+
+        out = capsys.readouterr().out
+        assert "had no pinned model" in out
+        assert "\x1b" not in out
+        assert "\\x1b" in out
+
+    def test_the_ambiguity_refusal_escapes_both_paths(self, tmp_path: Path, monkeypatch):
+        """The refusal message names two paths; both come off disk."""
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "kirocrew.json").write_text(
+            json.dumps({"name": "other"}), encoding="utf-8"
+        )
+        (agents / "elsewhere.json").write_text(
+            json.dumps({"name": "kirocrew"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+        # Inject the hostile path as the CONFLICTING file, portably.
+        monkeypatch.setattr(
+            agent_mod, "_conflicting_spec_for", lambda n, c, d: Path(self.HOSTILE)
+        )
+
+        with pytest.raises(ValueError) as exc:
+            agent_mod.reset_agent_model("kirocrew")
+        assert "\x1b" not in str(exc.value)
+        assert "\\x1b" in str(exc.value)
+
+    def test_the_duplicate_name_refusal_escapes_paths(self, tmp_path: Path, monkeypatch):
+        """The other refusal builds its message from a list of real spec paths."""
+        import kiro_crew.agent as agent_mod
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "a.json").write_text(json.dumps({"name": "dup"}), encoding="utf-8")
+        (agents / "b.json").write_text(json.dumps({"name": "dup"}), encoding="utf-8")
+        monkeypatch.setattr(agent_mod, "kiro_agents_dir_path", lambda: agents)
+
+        with pytest.raises(ValueError) as exc:
+            agent_mod.agent_spec_path("dup")
+        # Both paths are repr'd, so a control byte in either could not execute.
+        assert "'" in str(exc.value), "paths are quoted (repr), not raw"
+        assert "a.json" in str(exc.value) and "b.json" in str(exc.value)

--- a/test/test_cli_agent.py
+++ b/test/test_cli_agent.py
@@ -168,3 +168,91 @@ class TestAgentDelete:
         assert exc_info.value.code != 0
         err = capsys.readouterr().err
         assert "cannot delete default agent" in err
+
+
+class TestAgentResetModel:
+    """``kirocrew agent reset-model`` -- the explicit way back to the default.
+
+    Goes through ``main()`` rather than calling the handler directly: the verb
+    lives on the SAME ``agent`` subparser group as list/create/update/delete, and
+    a second group registered under the same name raises
+    ``conflicting subparser: agent`` at parser-build time, which breaks the whole
+    CLI while a handler-level test still passes. Routing through main() is what
+    pins the wiring.
+    """
+
+    def _isolated_spec(self, tmp_path: Path, monkeypatch, model: str | None) -> Path:
+        """Install a kiro spec in a throwaway agents dir, via the override hook.
+
+        Uses ``agent.KIRO_AGENTS_DIR`` rather than ``KIRO_HOME``: that hook is
+        what ``kiro_agents_dir_path`` consults FIRST, so it short-circuits before
+        the env-based resolver and is the seam the suite's own agent-spec
+        isolation is built on. Setting only ``KIRO_HOME`` would be ignored here.
+        The containment assert makes a lapse fail loudly rather than write into a
+        real agents directory.
+        """
+        import kiro_crew.agent as agent_mod
+
+        agents_dir = tmp_path / "kiro-agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(agent_mod, "KIRO_AGENTS_DIR", agents_dir)
+        resolved = agent_mod.kiro_agents_dir_path()
+        assert resolved.is_relative_to(tmp_path), f"{resolved} escaped {tmp_path}"
+        body: dict = {"name": "kirocrew", "tools": ["fs_read"]}
+        if model is not None:
+            body["model"] = model
+        spec = agents_dir / "kirocrew.json"
+        spec.write_text(json.dumps(body), encoding="utf-8")
+        return spec
+
+    def test_reset_clears_the_pin_and_keeps_the_rest_of_the_spec(
+        self, tmp_path: Path, monkeypatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from kiro_crew import agent_state
+
+        spec = self._isolated_spec(tmp_path, monkeypatch, "claude-opus-4.8")
+
+        with unittest.mock.patch("sys.argv", ["kirocrew", "agent", "reset-model"]):
+            main()
+
+        written = json.loads(spec.read_text(encoding="utf-8"))
+        assert "model" not in written
+        assert written["tools"] == ["fs_read"], "reset must not regenerate the whole spec"
+        assert agent_state.get_model_managed("kirocrew") is True
+        out = capsys.readouterr().out
+        assert "claude-opus-4.8" in out, "the cleared value is reported so it can be re-pinned"
+
+    def test_reset_reports_a_spec_that_had_no_pin(
+        self, tmp_path: Path, monkeypatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._isolated_spec(tmp_path, monkeypatch, None)
+
+        with unittest.mock.patch("sys.argv", ["kirocrew", "agent", "reset-model"]):
+            main()
+
+        assert "had no pinned model" in capsys.readouterr().out
+
+    def test_reset_exits_nonzero_for_an_unknown_agent(self, tmp_path: Path, monkeypatch) -> None:
+        self._isolated_spec(tmp_path, monkeypatch, "claude-opus-4.8")
+
+        with unittest.mock.patch(
+            "sys.argv", ["kirocrew", "agent", "reset-model", "--agent", "nope"]
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 1
+
+    def test_the_existing_agent_verbs_still_route(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Ratchet for the conflicting-subparser class: adding reset-model must
+        not shadow or displace the group's original verbs."""
+        cfg_path = _write_config(tmp_path, _base_config())
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+            unittest.mock.patch("sys.argv", ["kirocrew", "agent", "list"]),
+        ):
+            main()
+
+        assert "KIRO_AGENT" in capsys.readouterr().out

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -7,8 +7,11 @@ command on Linux where there is no brew.
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
+
+import pytest
 
 from kiro_crew import cli_doctor
 
@@ -1158,3 +1161,400 @@ class TestCliInstallerResidue:
         assert "4.0 MiB" in out
         assert "≥" not in out
         assert "4+" not in out
+
+
+class TestEffectiveModelSection:
+    """`kirocrew doctor`'s Model section (#2559).
+
+    The four-tier model precedence is not visible from any single file, so a
+    stale spec pin that outlived the setting which created it is otherwise only
+    diagnosable by hand-reading config.json, two agent-spec directories and the
+    sidecar. This section names the winning tier and, when a pin is deciding,
+    the exact command that clears it.
+
+    ISOLATION: the section reads the directory the RESOLVER reads, and that
+    resolver is ``kiro_home()``, which the suite's autouse fixtures deliberately
+    do NOT pin (see the note in the rootdir conftest) -- it resolves the real
+    machine-wide ``~/.kiro``. So every test here sets ``KIRO_HOME`` itself, and
+    ``_agents_dir`` asserts the resolved path really is under tmp before writing
+    a byte. Without that guard these tests overwrite the operator's live agent
+    spec.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_kiro_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro-home"))
+        self._tmp = tmp_path
+
+    def _agents_dir(self) -> Path:
+        from kiro_crew.config.paths import kiro_agents_dir
+
+        agents_dir = kiro_agents_dir()
+        # Fail loudly rather than write into a real home if the override lapses.
+        assert self._tmp in agents_dir.parents or agents_dir.is_relative_to(self._tmp), (
+            f"KIRO_HOME isolation failed: {agents_dir} is outside {self._tmp}"
+        )
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        return agents_dir
+
+    def _cfg(self, global_model: str):
+        from kiro_crew.config import KiroCrewConfig
+
+        cfg = KiroCrewConfig()
+        cfg.agent.model = global_model
+        return cfg
+
+    def _install_spec(self, model: str | None) -> Path:
+        from kiro_crew.agent import AGENT_FILENAME
+
+        body: dict = {"name": "kirocrew"}
+        if model is not None:
+            body["model"] = model
+        spec = self._agents_dir() / AGENT_FILENAME
+        spec.write_text(json.dumps(body), encoding="utf-8")
+        return spec
+
+    def test_spec_pin_decides_when_the_global_defers(self, capsys) -> None:
+        """The reported symptom: the global says auto, so the spec pin decides
+        and the report says so instead of leaving the user to work it out."""
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+
+        out = capsys.readouterr().out
+        assert "effective:   'claude-opus-4.8'" in out
+        assert "decided by:  default spec pin" in out
+        assert "kirocrew agent reset-model" in out
+        # Advisory, not a setup failure: the state is legal and may be wanted.
+        assert issues == []
+
+    def test_explicit_global_outranks_the_spec_pin(self, capsys) -> None:
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("claude-haiku-4.5"), "", issues)
+
+        out = capsys.readouterr().out
+        assert "effective:   'claude-haiku-4.5'" in out
+        assert "decided by:  global agent.model" in out
+        # No pin is deciding, so no repair is offered.
+        assert "reset-model" not in out
+        assert issues == []
+
+    def test_report_and_resolver_agreement_is_asserted(self, capsys) -> None:
+        """The self-check must stay silent while the two agree -- if this line
+        ever fires it means the tier list drifted from the resolver."""
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+        assert "out of date" not in capsys.readouterr().out
+        assert issues == []
+
+    def test_tracking_state_is_reported(self, capsys) -> None:
+        from kiro_crew import agent_state
+
+        agent_state.set_model_managed("kirocrew", False)
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+        assert "tracking:    frozen (explicit pick)" in capsys.readouterr().out
+
+    def test_unrecorded_tracking_is_named(self, capsys) -> None:
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+        assert "tracking:    not recorded" in capsys.readouterr().out
+
+    def test_unreadable_spec_is_reported_not_swallowed(self, capsys) -> None:
+        from kiro_crew.agent import AGENT_FILENAME
+
+        (self._agents_dir() / AGENT_FILENAME).write_text("{ not json", encoding="utf-8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+        assert "unreadable" in capsys.readouterr().out
+        assert issues == ["agent spec unreadable"]
+
+    def test_project_local_spec_is_flagged_as_shadowing(self, capsys) -> None:
+        """kiro-cli resolves <project>/.kiro/agents FIRST and Kiro Crew's own
+        resolver never reads it, so that file can decide what actually runs while
+        every Kiro Crew surface reports something else."""
+        from kiro_crew.agent import AGENT_FILENAME
+
+        self._install_spec(None)
+        project = self._tmp / "proj"
+        (project / ".kiro" / "agents").mkdir(parents=True)
+        (project / ".kiro" / "agents" / AGENT_FILENAME).write_text(
+            json.dumps({"name": "kirocrew", "model": "claude-opus-4.8"}), encoding="utf-8"
+        )
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), str(project), issues)
+
+        out = capsys.readouterr().out
+        assert "project spec" in out
+        assert "claude-opus-4.8" in out
+        assert "kiro-cli loads this one first" in out
+        assert issues == ["project-local agent spec shadows the user-level one"]
+
+    def test_no_project_dir_prints_no_project_line(self, capsys) -> None:
+        self._install_spec(None)
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+        assert "project spec" not in capsys.readouterr().out
+        assert issues == []
+
+    def _bind_custom_agent(self, cfg, name: str):
+        """Point the default alias at a non-built-in kiro agent."""
+        from kiro_crew.config.loader import KiroCrewAgentConfig
+
+        cfg.default_agent = "default"
+        cfg.agents["default"] = KiroCrewAgentConfig(kiro_agent=name)
+        return cfg
+
+    def test_a_bound_custom_agent_is_attributed_to_its_own_spec(self, capsys) -> None:
+        """The default alias may bind a kiro agent other than the built-in one,
+        and the resolver consults THAT spec's pin above the global (tier 2).
+        Reading kirocrew.json in both cases attributed the pin to the wrong file
+        and printed a reset command for the wrong agent (#4911 review)."""
+        self._install_spec(None)
+        agents_dir = self._agents_dir()
+        (agents_dir / "custom-agent.json").write_text(
+            json.dumps({"name": "custom-agent", "model": "claude-opus-4.8"}), encoding="utf-8"
+        )
+        cfg = self._bind_custom_agent(self._cfg("auto"), "custom-agent")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(cfg, "", issues)
+
+        out = capsys.readouterr().out
+        assert "effective:   'claude-opus-4.8'" in out
+        assert "decided by:  bound agent pin ('custom-agent')" in out
+        # The repair must name the agent that actually holds the pin.
+        assert "kirocrew agent reset-model --agent 'custom-agent'" in out
+        # And the tier the resolver skipped for the built-in agent is shown here.
+        assert "bound agent pin ('custom-agent'):" in out
+        assert "out of date" not in out, "report must agree with the resolver"
+        assert issues == []
+
+    def test_the_builtin_agent_shows_no_bound_tier(self, capsys) -> None:
+        """Tier 2 is skipped for the built-in agent, so the list must not show
+        a tier the resolver never consulted."""
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+
+        out = capsys.readouterr().out
+        assert "bound agent pin" not in out
+        assert "decided by:  default spec pin" in out
+        assert "kirocrew agent reset-model" in out
+        assert "--agent" not in out, "the built-in agent needs no --agent flag"
+
+    def test_tracking_names_the_agent_it_describes(self, capsys) -> None:
+        from kiro_crew import agent_state
+
+        self._install_spec(None)
+        agents_dir = self._agents_dir()
+        (agents_dir / "custom-agent.json").write_text(
+            json.dumps({"name": "custom-agent", "model": "claude-opus-4.8"}), encoding="utf-8"
+        )
+        agent_state.set_model_managed("custom-agent", False)
+        cfg = self._bind_custom_agent(self._cfg("auto"), "custom-agent")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(cfg, "", issues)
+        assert "tracking:    frozen (explicit pick) ('custom-agent')" in capsys.readouterr().out
+
+    def test_project_spec_check_follows_the_bound_agent(self, capsys) -> None:
+        """kiro-cli dispatches the BOUND agent, so that is the filename whose
+        project-local copy can shadow the user-level spec."""
+        self._install_spec(None)
+        agents_dir = self._agents_dir()
+        (agents_dir / "custom-agent.json").write_text(
+            json.dumps({"name": "custom-agent"}), encoding="utf-8"
+        )
+        project = self._tmp / "proj"
+        (project / ".kiro" / "agents").mkdir(parents=True)
+        (project / ".kiro" / "agents" / "custom-agent.json").write_text(
+            json.dumps({"name": "custom-agent", "model": "claude-haiku-4.5"}), encoding="utf-8"
+        )
+        cfg = self._bind_custom_agent(self._cfg("auto"), "custom-agent")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(cfg, str(project), issues)
+
+        out = capsys.readouterr().out
+        assert "custom-agent.json' -> 'claude-haiku-4.5'" in out
+        assert issues == ["project-local agent spec shadows the user-level one"]
+
+    def test_control_sequences_in_a_spec_model_are_escaped(self, capsys) -> None:
+        """An agent spec is not always trusted input -- an installed app writes
+        one and a cloned repository can ship a project-local one -- so an
+        OSC/ANSI sequence in `model` must reach the terminal inert rather than
+        executing controls or spoofing the surrounding diagnostic lines."""
+        hostile = "claude-opus-4.8\x1b]0;pwned\x07\x1b[2K"
+        self._install_spec(hostile)
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, "raw escape reached the terminal"
+        assert "\x07" not in out
+        assert "\\x1b" in out, "the value is still shown, just escaped"
+
+    def test_control_sequences_in_a_project_spec_are_escaped(self, capsys) -> None:
+        from kiro_crew.agent import AGENT_FILENAME
+
+        self._install_spec(None)
+        project = self._tmp / "proj"
+        (project / ".kiro" / "agents").mkdir(parents=True)
+        (project / ".kiro" / "agents" / AGENT_FILENAME).write_text(
+            json.dumps({"name": "kirocrew", "model": "x\x1b[31mred"}), encoding="utf-8"
+        )
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), str(project), issues)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "\\x1b" in out
+
+    def test_control_sequences_in_the_global_are_escaped(self, capsys) -> None:
+        self._install_spec("claude-opus-4.8")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto\x1b[2J"), "", issues)
+
+        assert "\x1b" not in capsys.readouterr().out
+
+    def test_a_symlink_to_a_sensitive_target_is_refused(self, monkeypatch, capsys) -> None:
+        """The doctor read goes through agent_discovery's hardened reader, which
+        refuses a symlink whose RESOLVED target is sensitive (the documented
+        `evil.json -> ~/.aws/credentials` case) and caps the read size. Routing
+        through that one reader instead of hand-rolling the checks is the point
+        (#4911 review); a benign link is followed exactly as the resolver follows
+        it, so the report cannot disagree with what will actually run."""
+        from kiro_crew import agent_discovery
+        from kiro_crew.agent import AGENT_FILENAME
+
+        agents_dir = self._agents_dir()
+        target = self._tmp / "protected.json"
+        target.write_text(json.dumps({"model": "leaked-value"}), encoding="utf-8")
+        (agents_dir / AGENT_FILENAME).symlink_to(target)
+        monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(target) in str(p))
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+
+        out = capsys.readouterr().out
+        # The report refuses to ATTRIBUTE the refused spec ...
+        assert "unreadable" in out
+        assert issues == ["agent spec unreadable"]
+        assert "(defers)" in out.split("default spec pin:", 1)[1].splitlines()[0]
+        # ... and explains the gap instead of accusing its own tier list of being
+        # stale. `effective` may still carry the value: the RESOLVER reads the
+        # spec through its own path, which follows the link, and hiding what will
+        # actually run would make the report lie. That resolver-side following is
+        # pre-existing and main-owned; noted as a follow-up, not changed here.
+        assert "refused to follow" in out
+        assert "out of date" not in out
+
+    def test_an_absent_spec_is_not_reported_as_a_fault(self, capsys) -> None:
+        """A clean install has no spec and the resolver just falls through, so
+        absence must not raise an issue."""
+        self._agents_dir()  # exists, but empty
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "", issues)
+
+        assert "unreadable" not in capsys.readouterr().out
+        assert issues == []
+
+    def test_an_absolute_kiro_agent_binding_cannot_escape_the_agent_dir(self, capsys) -> None:
+        """`kiro_agent` is free text in config.json and reaches a path join, and
+        pathlib DISCARDS the left side when the right is absolute -- so an
+        unvalidated binding would turn a spec lookup into an arbitrary read
+        (#4911 review)."""
+        self._install_spec(None)
+        secret = self._tmp / "protected.json"
+        secret.write_text(json.dumps({"model": "leaked-value"}), encoding="utf-8")
+        cfg = self._bind_custom_agent(self._cfg("auto"), str(secret)[:-5])
+        project = self._tmp / "proj"
+        (project / ".kiro" / "agents").mkdir(parents=True)
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(cfg, str(project), issues)
+
+        out = capsys.readouterr().out
+        assert "leaked-value" not in out
+        assert "not a valid agent name" in out
+        assert "configured kiro_agent is not a valid agent name" in issues
+
+    def test_a_control_bearing_binding_is_escaped_and_refused(self, capsys) -> None:
+        self._install_spec(None)
+        cfg = self._bind_custom_agent(self._cfg("auto"), "evil\x1b[2Jname")
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(cfg, "", issues)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "not a valid agent name" in out
+
+    def test_a_control_bearing_project_filename_is_escaped(self, monkeypatch, capsys) -> None:
+        """A cloned repository can TRACK a filename containing control bytes, so
+        the path itself is untrusted input on this line (#4911 review).
+
+        The hostile path is INJECTED rather than created: control bytes are
+        illegal in a Windows filename, so building it on disk would make this
+        assertion Windows-only-skipped, and what is under test is that the
+        printer escapes what it is handed.
+        """
+        hostile = Path("/tmp/proj/.kiro/agents/kirocrew\x1b[2J.json")
+        self._install_spec(None)
+        real_reader = cli_doctor._read_agent_spec
+        monkeypatch.setattr(cli_doctor, "project_agent_files", lambda d: [hostile])
+        monkeypatch.setattr(cli_doctor, "project_agent_name", lambda p: "kirocrew")
+        # Only the injected path is faked; the user-level spec still goes through
+        # the real reader so the report's own self-check is not disturbed.
+        monkeypatch.setattr(
+            cli_doctor,
+            "_read_agent_spec",
+            lambda p: {"model": "m"} if p == hostile else real_reader(p),
+        )
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(self._cfg("auto"), "/tmp/proj", issues)
+
+        out = capsys.readouterr().out
+        # Not vacuous: the shadow line must actually be reached.
+        assert "project spec" in out
+        assert issues == ["project-local agent spec shadows the user-level one"]
+        assert "\x1b" not in out, "raw escape from a tracked filename reached the terminal"
+        assert "\\x1b" in out, "the path is still shown, just escaped"
+
+    def test_a_non_string_kiro_agent_does_not_crash_the_report(self, capsys) -> None:
+        """The config loader deliberately KEEPS a type-mismatched value ("validated
+        by its consumer"), so a hand-edited non-string reaches this section intact
+        and a bare `re.match` would raise TypeError -- aborting the one command a
+        user runs BECAUSE their config is broken (#4911 review)."""
+        self._install_spec("claude-opus-4.8")
+        cfg = self._bind_custom_agent(self._cfg("auto"), "placeholder")
+        cfg.agents["default"].kiro_agent = 12345  # type: ignore[assignment]
+        issues: list[str] = []
+
+        cli_doctor._doctor_effective_model(cfg, "", issues)
+
+        out = capsys.readouterr().out
+        assert "not a valid agent name" in out
+        assert "configured kiro_agent is not a valid agent name" in issues
+        # It degrades to the built-in agent and still produces the report.
+        assert "effective:" in out
+        assert "tracking:" in out


### PR DESCRIPTION
## What is the problem?

An agent spec's `model` outranks the global `agent.model` in `resolve_effective_model`, and the managed re-sync in `_refresh_dynamic_fields` deliberately skips a spec whose `agent_model_state.json` entry is absent. A spec pinned by an older build therefore keeps that pin, and:

- nothing in the product surfaces that it is happening, so the state is only diagnosable by hand-reading `config.json`, two agent-spec directories and the sidecar;
- clearing `agent_model_state.json` -- the obvious response to a stuck model -- removes the one branch that could ever have reset it, turning a recoverable state into a permanent one.

## Why this issue matters to the user

Every level of configuration reads `auto` and new sessions still open on a concrete model. The pre-#1423 shipped default bills at a 2.2x credit multiplier against `auto`'s 1.0x on every turn, so the user pays a premium for a model they believe they turned off, with no signal that the setting was ignored and no way to undo it short of `kirocrew setup --clean`, which regenerates the whole spec and discards every other customization with it.

## How our fix solves it

**Symptom:** the global says `auto`, the spec pin decides, and nothing says so.

**Root cause:** the precedence is four tiers deep and invisible, and the only in-product reset lives inside one dashboard editor.

**What this does NOT do, deliberately.** An earlier revision inferred ownership of a spec's `model` -- from the value matching a previously shipped default, and from the global propagation having replaced a different value -- and reclassified the pin as managed. That is unsound and it is gone: a value an older build's propagation wrote and one the user typed in by hand are **byte-identical on disk**, so any such rule silently overwrites a deliberate pick. `claude-opus-4.8` is still a live model in `model_registry.py`, so this is not a dead-pin cleanup either. The refresh keeps its hands off; what was actually missing is added instead.

**1. `kirocrew doctor` gains a Model section.** Actual output:

```
Model
  effective:   'claude-opus-4.8'
  decided by:  default spec pin
    agent override:            (defers)
    global agent.model:        (defers)
    default spec pin:          'claude-opus-4.8'
  spec file:   '/home/<user>/.kiro/agents/kirocrew.json'
  tracking:    not recorded ('kirocrew')
  !  the spec pin decides because the global is 'auto'
     Fix: kirocrew agent reset-model   (clears the pin, tracks the default)
```

The tiers are listed as data and the first non-deferring one is marked, which is `resolve_effective_model`'s own rule. That marked value is then **cross-checked against what the resolver actually returns**, and a disagreement is reported rather than hidden, so this report cannot quietly drift into a second, wrong copy of the precedence. It reads the directory the resolver reads, for the same reason.

A **bound agent pin** tier appears when the default alias binds a kiro agent other than the built-in one: the resolver consults that spec's pin ABOVE the global (tier 2) while the built-in spec is read only after the global defers (tier 4), so reading `kirocrew.json` in both cases attributed a custom agent's pin to the wrong file and printed a reset command for the wrong agent.

It also reports the tracking state (`shipped default` / `frozen (explicit pick)` / `not recorded`) with the agent it describes, and flags a project-local `<project>/.kiro/agents` spec: kiro-cli resolves that directory FIRST with no upward walk, and this project's resolver never reads it, so such a file can decide what actually runs while every other surface reports something else.

**2. `kirocrew agent reset-model [--agent NAME]`** clears the pin and resumes tracking, on the existing `agent` subcommand group. It shares one `clear_model_pin` helper with the dashboard's Agent Templates editor, so the two surfaces cannot disagree on what clearing a model means -- the same reason `lift_and_strip_bookkeeping` is shared by four spec writers. It preserves the rest of the spec (the narrow counterpart to `setup --clean`), lifts stray sidecar keys so kiro-cli's `deny_unknown_fields` still accepts the file, reports the value it cleared so it can be re-pinned, and resolves a spec whose filename differs from its `name`.

Ordering is benign in both directions: a sidecar-only write leaves a still-pinned spec that the next refresh resolves to the shipped default (what the user asked for); a spec-only write leaves no pin and the resolver falls through to the global.

## Hardening (please review as security work, not as test additions)

Both new surfaces read and print data from `~/.kiro/agents` and `config.json`, and neither is fully trusted input: an installed app writes specs there, a cloned repository can ship a project-local one, and `kiro_agent` is free text. Nine review rounds drove the untrusted-input class to four chokepoints:

- **`_AGENT_NAME_RE` before any path join.** `agent_spec_path` validates the agent name at the resolver, so `--agent ../../something` returns `None` instead of a path outside the agents directory -- the returned path is one `reset_agent_model` then WRITES. The same grammar now also gates the configured `kiro_agent` binding in `cli_doctor`, because pathlib DISCARDS the left operand when the right is absolute (`base / "/etc/passwd.json"` is `/etc/passwd.json`), which turned an absolute binding into an arbitrary read.
- **`_spec_path_is_safe` on the write path.** A symlinked spec is refused rather than followed: following one reads the target and writes a modified copy into the agents directory, laundering a file the reader may not otherwise be allowed to open into a freely readable location. It also refuses a resolved path that leaves the agents directory, and any `is_sensitive_path`. (`os.replace` swaps the link rather than writing through it, so a target is never corrupted; the copy-out was the problem.)
- **`_read_spec_capped`, the size-capped read.** Both spec reads go through `agent_discovery._read_agent_spec`, which that module documents as the one reader for both agent scopes: it reads via `hooks.safe_read_file_bytes`, so an oversized "agent config" in this user-writable, tool-shared directory is refused at the 50 MB cap instead of being slurped into memory. Verified against the real cap, not asserted: a 52,432,941-byte spec makes the resolver return `None` and the reset refuse, while a normal spec still resets. The doctor read uses the same reader, which is also why it inherits that reader's symlink POLICY (a benign link is followed, a sensitive target refused) -- correct there, since the resolver follows the link anyway and hiding what will actually run would make the report lie.
- **`_safe_display` on every printed value AND path.** Model values, agent names and spec paths are all rendered through `repr`, so an OSC/ANSI sequence in a `model` field, a `kiro_agent` value, or a **tracked filename** in a cloned repository reaches the terminal inert instead of executing controls or spoofing the surrounding diagnostic lines.

Plus one correctness refusal in the same family: **`agent_spec_path` raises `ValueError` when two specs claim one name.** The runtime resolver accepts either a declared-name match or a filename match and iterates an unordered glob, so which of them is live is undefined; a writer that picks either can strip the pin nothing is reading. It refuses with both paths named instead of guessing.

## What tests we did

**9 new test classes, 51 test functions, 57 collected cases** (one is parametrized over 7 rejected name forms), all passing -- 316 in the three touched files:

- `TestResetAgentModel` (9) and `TestAgentResetModel` (4, routed through `main()`) -- the helper clears both halves of the state and is idempotent; the reset preserves the rest of the spec, reports the previous model, overrides an explicit freeze, never writes bookkeeping into the spec, resolves a filename/`name` mismatch, refuses an agent with no spec without claiming anything; plus the counterpart contract that the refresh still leaves an unrecorded spec alone, and a ratchet that the `agent` group's original verbs still route.
- `TestAgentSpecPathRejectsTraversal` (9), `TestSpecPathRefusesSymlinks` (3), `TestSpecPathPrefersTheDeclaredName` (4), `TestResetRefusesAnAmbiguousName` (3), `TestSpecReadsAreSizeCapped` (2), `TestResetOutputEscapesUntrustedPaths` (4) -- one class per hardening chokepoint above, each asserting the untouched-victim side too (the outside file keeps its bytes, neither ambiguous spec is modified, no tracking flag is claimed on a refusal).
- `TestEffectiveModelSection` (19) -- which tier decides and the fix command it prints, an explicit global outranking a pin, the resolver self-check staying silent while the two agree, tracking states, an unreadable spec reported not swallowed, the bound-custom-agent attribution, the project-local shadow, and escaping for a hostile model value, global, agent name and filename.

Mutation-verified, each hunk independently load-bearing: flipping `clear_model_pin`'s stamp fails 5 tests, flattening `_safe_display` fails 3, skipping the bound-agent tier fails 1, dropping the name-grammar guard fails the traversal test.

**A real wiring bug was caught by an end-to-end smoke, not by the unit tests.** The first revision registered its own `agent` subparser; one already exists at `cli.py:2023`, and argparse raised `conflicting subparser: agent` at parser-build time -- which breaks the ENTIRE CLI while handler-level tests still pass. The verb now lives on the existing group and a test pins that class.

Gates: baselined black, isort, flake8 over `src/kiro_crew test conftest.py xdist_budget.py`, `mypy src/kiro_crew/` (1008 files) and the brand gate all reproduce green locally. Both CLI surfaces re-verified end-to-end against a throwaway `KIRO_HOME`.

## Any other suggestions on the work

1. **The value-based migration is a product decision, not a code gap.** Delivering #1423's default-model migration to installs with no sidecar entry requires inferring intent from a value. If that is wanted, the honest shape is a prompt ("your agent is pinned to X by an older build -- switch to auto?"), not a silent rewrite on refresh.
2. **The resolver reads specs without the hardened gate.** `config/loader._resolve_agent_model` uses a plain `read_text` -- no size cap, symlinks followed. Untouched here because it is main-owned and on the execution path; filed as #4962. This is why `effective:` can show a value the report declines to attribute, and the report says so rather than pretending otherwise.
3. **The global propagation ignores a frozen pick.** The `agent.model` branch overwrites a spec's `model` regardless of `model_managed`, so an explicit `False` does not actually protect a value from an explicit global. Pre-existing, untouched.
4. **Agent-spec test isolation is now shared, and this branch adopts it.** When this PR opened, the suite pinned `KIROCREW_HOME` per test but deliberately not `KIRO_HOME`, so a test touching `kiro_agents_dir()` wrote into the operator's live agent specs unless it isolated itself. `main` has since landed exactly the shared fixture that was wanted, pinning the agents dir through the `KIRO_AGENTS_DIR` override hooks. Rebasing onto it surfaced that this branch's CLI tests were isolating the older way: the hook is consulted BEFORE the env resolver, so a test setting only `KIRO_HOME` is ignored. Those tests now set `agent.KIRO_AGENTS_DIR`, which is the seam that fixture is built on, and keep the tmp-containment assert.

Closes #2559
