### PR TITLE
fix(cron): surface script/command failure reasons to the user

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -379,8 +379,18 @@ class CronJob:
         A job the user paused stays paused: ``user_paused`` is never mutated by
         execution, so it is the discriminator here, and re-enabling THAT is the
         user's action (``enable_job``).
+
+        Also clears the failure-alert dedup fields, and is the ONE owner of that
+        reset. A success means the job recovered, so the next failure must alert
+        fresh rather than be suppressed as a duplicate of the pre-recovery one --
+        and every success path (gate verdict, script, command, the scheduler
+        backstop) routes through here, so putting the reset at any single call
+        site would silence a relapse on the others for up to
+        ``_FAILURE_REMINDER_SECS``.
         """
         self.consecutive_failures = 0
+        self.last_failure_hash = ""
+        self.last_failure_at = 0.0
         if self.auto_paused:
             self.auto_paused = False
             if not self.user_paused:

--- a/src/kiro_crew/docs/cron-and-scheduling.md
+++ b/src/kiro_crew/docs/cron-and-scheduling.md
@@ -252,9 +252,15 @@ command exists to undo.
 
 ## Reliability
 
-- **Failure dedup** — repeated failures with the same error are suppressed
-  after the first Slack notification (dashboard-only after that). Re-alerts
-  after 1 hour or when the error changes. Success clears the failure state.
+- **Failure alerts** — a failed run delivers its REASON to the dashboard bell
+  and (when Slack is configured) to the job's channel or the owner's DM, not
+  only to the gateway log. Covers all three job kinds and a fire-time policy
+  denial, which is otherwise invisible.
+- **Failure dedup** — a repeat of the same reason withholds the Slack DM and
+  marks the bell as suppressed; a different reason alerts in full, and the DM
+  returns after an hour. A `silent: true` job alerts nowhere. Both still count
+  toward auto-pause: dedup silences the DM, never the evidence. Success clears
+  the failure state, so a relapse alerts fresh.
 - **Zombie reaper** — a periodic sweep (60s interval, 30 min deadline)
   force-kills cron jobs whose agent process has become an orphan.
   Prevents resource leaks from stuck jobs.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -210,6 +210,7 @@ from kiro_crew.slack.client import RealSlackClient
 from kiro_crew.slack.format import (
     build_cron_ack_block,
     build_options_blocks,
+    escape_mrkdwn,
     extract_options,
     render_for_slack,
 )
@@ -417,6 +418,10 @@ _EPOCH_RE = re.compile(r"\b\d{10,13}\b")
 _EPOCH_WINDOW_SECS = 300  # strip epoch values within ±5 min of now
 _SUCCESS_REMINDER_SECS = 86400  # post "still succeeding w/ same result" reminder every 24h
 _FAILURE_REMINDER_SECS = 3600  # re-alert still-failing cron every 1h (louder than success dedup)
+# Cap on the failure reason carried into a user-facing alert. Matches the cap
+# _apply_gate_verdict already puts on job.last_error, so the bell and the cron
+# row cannot disagree about how much of a long traceback the user is shown.
+_CRON_FAILURE_DETAIL_CAP = 500
 
 
 # Tool-name prefixes treated as read-only by the --approval reads flag.
@@ -754,9 +759,8 @@ def _apply_gate_verdict(job: CronJob, tally: _GateTally) -> bool:
         return True
     # Clear failure dedup on any success, regardless of whether the success
     # result itself is a dup. A successful run means the job recovered — next
-    # failure should always alert fresh.
-    job.last_failure_hash = ""
-    job.last_failure_at = 0.0
+    # failure should always alert fresh. record_success() owns the reset now, so
+    # every kind's success path gets it rather than only this one.
     job.record_success()
     return False
 
@@ -2510,6 +2514,164 @@ class GatewayOrchestrator:
                         job.name,
                     )
 
+        async def _alert_cron_failure(job: CronJob, detail: str, *, denied: bool = False) -> None:
+            """Tell the user WHY a script/command cron run failed or was denied.
+
+            The script and command paths signal failure by mutating the job
+            (``last_status="error"`` + ``last_error``) and returning normally, so
+            they never reached the message path's failure alert below — the reason
+            existed only in the gateway log and in a dashboard field nobody is
+            watching when the notification they expected simply never arrives. A
+            job whose every run dies on a startup-time ``RuntimeError`` therefore
+            looked idle rather than broken.
+
+            Deliberately NOT a delivery of the run's *result*: this is a bell plus
+            a DM carrying the reason, never an injected turn like
+            :func:`_deliver_script_result`. A job failing on its own schedule must
+            not spend a model turn per failure, and an injected turn is exactly how
+            a failing cron would amplify itself.
+
+            Contract, so the two failure surfaces cannot drift:
+
+            * ``record_failure()`` is NOT called here. Every call site already
+              counted the run (or deliberately did not, for a policy denial), and
+              the counter has one owner per run — see :func:`_apply_gate_verdict`.
+              Callers therefore alert AFTER counting, so ``consecutive_failures``
+              reads true if a future body wants it.
+            * Dedup reuses the SAME ``last_failure_hash`` / ``last_failure_at``
+              fields as the message path. A job is exactly one kind, so the two
+              writers never interleave on one job, and a run that fails
+              identically every minute alerts once per
+              ``_FAILURE_REMINDER_SECS`` instead of once per fire.
+            * Never raises. Every call site is inside an ``except`` block whose
+              exception is the real story; an alert that failed must not replace
+              it. Cancellation still propagates (``CancelledError`` is a
+              ``BaseException``).
+            """
+            try:
+                if job.silent:
+                    # Silent jobs still execute and still count toward auto-pause;
+                    # only the user-facing surfaces are suppressed.
+                    return
+                text = redact(detail or "")
+                text, _ = redact_exfiltration_urls(text)
+                text, _ = redact_credentials(text)
+                text = text.strip()[:_CRON_FAILURE_DETAIL_CAP] or "no reason reported"
+                # job.name is user-controlled and the reason can carry subprocess
+                # output, so both are scrubbed once, ahead of either surface and
+                # of either branch below.
+                label = redact(job.name)
+                label, _ = redact_exfiltration_urls(label)
+                label, _ = redact_credentials(label)
+                mark = "⛔" if denied else "❌"
+                headline = "Blocked by policy" if denied else "Run failed"
+                # Denials and failures hash apart so a policy denial does not read
+                # as a dup of a same-worded crash (and vice versa).
+                fh = _result_hash(f"{'denied' if denied else 'failed'}:{text}")
+                if (
+                    fh == job.last_failure_hash
+                    and time.time() - job.last_failure_at < _FAILURE_REMINDER_SECS
+                ):
+                    logger.info(
+                        "Cron '%s': duplicate failure alert suppressed (%s)",
+                        job.name,
+                        "denied" if denied else "failed",
+                    )
+                    # Same split the message path draws: the LOCAL bell still
+                    # rings (marked suppressed, so a user watching the feed sees
+                    # the job is still down) and only the Slack DM is withheld.
+                    try:
+                        if self.dashboard_state:
+                            self.dashboard_state.notify(
+                                "cron",
+                                f"🔇 Cron: {label} (repeat)",
+                                f"{mark} Still failing (suppressed — same reason):\n{text}",
+                                meta={"job_id": job.id, "failure_hash": fh},
+                            )
+                    except Exception:
+                        logger.debug(
+                            "Dashboard notify failed in cron run-failure suppress path",
+                            exc_info=True,
+                        )
+                    return
+                try:
+                    if self.dashboard_state:
+                        self.dashboard_state.notify(
+                            "cron",
+                            f"Cron: {label}",
+                            f"{mark} {headline}:\n{text}",
+                            meta={"job_id": job.id, "failure_hash": fh},
+                        )
+                except Exception:
+                    logger.debug(
+                        "Dashboard notify failed in cron run-failure alert path", exc_info=True
+                    )
+                slack_failed = False  # real delivery exceptions only
+                if self.slack:
+                    # Name the machine for the same reason the message path does:
+                    # a laptop and a cloud desktop can both run Kiro Crew, and the
+                    # DM is the only place the user learns which one failed.
+                    host = socket.gethostname().split(".")[0]
+                    # Slack PARSES entity markup in a message's text, and both
+                    # halves of this one are attacker-shaped: the job name is
+                    # user-authored and the reason carries subprocess output. A job
+                    # named `<!channel>` would notify every member of the channel
+                    # the moment it failed. Escape at the Slack-facing sink only --
+                    # the dashboard body above is not a mrkdwn sink, and escaping
+                    # there would show a literal `&lt;`.
+                    safe_label = escape_mrkdwn(label)
+                    # Escaping does not neutralize a fence: three backticks inside
+                    # the reason would close this one early and hand the remainder
+                    # to the mrkdwn parser as markup.
+                    safe_text = escape_mrkdwn(text).replace("```", "'''")
+                    msg = (
+                        f"⏰ *Cron: {safe_label}* {mark} "
+                        f"_{headline} on {escape_mrkdwn(host)}_\n```{safe_text}```"
+                    )
+                    msg, _ = redact_exfiltration_urls(msg)
+                    msg, _ = redact_credentials(msg)
+                    try:
+                        channel = job.channel
+                        if not channel and (job.created_by or self._owner_id):
+                            channel = await self._open_dm_with_retry(
+                                job.created_by or self._owner_id, job.name
+                            )
+                        if channel:
+                            await self.slack.post_message(channel, msg)
+                        else:
+                            logger.warning(
+                                "Cron '%s': no channel resolved for run-failure alert", job.name
+                            )
+                    except Exception:
+                        slack_failed = True
+                        logger.error(
+                            "Cron '%s': Slack run-failure alert delivery failed",
+                            job.name,
+                            exc_info=True,
+                        )
+                # Advance dedup only once the reason actually reached someone.
+                # "No channel available" counts as delivered (the bell rang), the
+                # same skip-vs-failure split the message path draws — otherwise a
+                # Slack-less install re-notifies the dashboard on every fire.
+                if not slack_failed:
+                    job.last_failure_hash = fh
+                    job.last_failure_at = time.time()
+                try:
+                    sel().log_tool_invocation(
+                        session_key=f"cron:{job.id}",
+                        tool_name="cron_run_failure_alert",
+                        outcome="denied" if denied else "alerted",
+                        downstream_service="slack" if self.slack else "none",
+                    )
+                except Exception:
+                    logger.debug(
+                        "SEL logging failed in cron run-failure alert path", exc_info=True
+                    )
+            except Exception:
+                logger.warning(
+                    "Cron '%s': run-failure alert failed", job.name, exc_info=True
+                )
+
         async def _cron_callback(job: CronJob) -> str | None:
             # True once ANY prompt has been handed to the provider this
             # invocation. The whole-callback transient retry below is only
@@ -2579,6 +2741,7 @@ class GatewayOrchestrator:
                                 "SEL logging failed in cron command fire-time deny path",
                                 exc_info=True,
                             )
+                        await _alert_cron_failure(job, gate_reason, denied=True)
                         return None
                     cmd_timeout = job.timeout or 300
                     result = await asyncio.wait_for(
@@ -2612,6 +2775,7 @@ class GatewayOrchestrator:
                                 f"non-ok status with no output (status={result.get('status')})"
                             )
                             job.record_failure()
+                            await _alert_cron_failure(job, job.last_error)
                         return None  # no output = no delivery
                     job.set_run_result(redact(output))
                     job.last_error = ""
@@ -2633,6 +2797,10 @@ class GatewayOrchestrator:
                         logger.debug(
                             "SEL logging failed in cron command result path", exc_info=True
                         )
+                    if job.last_status == "error":
+                        # A non-zero exit DOES produce output, and that output is
+                        # the reason — carry it, not just the exit code.
+                        await _alert_cron_failure(job, f"{job.last_error}\n{output}")
                     return job.last_result
                 except asyncio.TimeoutError:
                     job.clear_carried_result()
@@ -2650,6 +2818,7 @@ class GatewayOrchestrator:
                         logger.debug(
                             "SEL logging failed in cron command timeout path", exc_info=True
                         )
+                    await _alert_cron_failure(job, f"command {job.last_error}")
                     return None
                 except Exception as exc:
                     logger.exception("Command cron '%s' failed: %s", job.name, exc)
@@ -2667,6 +2836,7 @@ class GatewayOrchestrator:
                         )
                     except Exception:
                         logger.debug("SEL logging failed in cron command error path", exc_info=True)
+                    await _alert_cron_failure(job, f"{type(exc).__name__}: {exc}")
                     return None
                 finally:
                     self._running_script_ids.discard(job.id)
@@ -2720,6 +2890,7 @@ class GatewayOrchestrator:
                                 "SEL logging failed in cron script fire-time deny path",
                                 exc_info=True,
                             )
+                        await _alert_cron_failure(job, gate_reason, denied=True)
                         return None
                     # Run in sandboxed subprocess via wrap_argv()
                     script_timeout = job.timeout or 30
@@ -2852,6 +3023,7 @@ class GatewayOrchestrator:
                         logger.debug(
                             "SEL logging failed in cron script timeout path", exc_info=True
                         )
+                    await _alert_cron_failure(job, f"script {job.last_error}")
                     return None
                 except Exception as exc:
                     logger.exception("Script cron '%s' failed: %s", job.name, exc)
@@ -2876,6 +3048,11 @@ class GatewayOrchestrator:
                         )
                     except Exception:
                         logger.debug("SEL logging failed in cron script error path", exc_info=True)
+                    # The reason a script cron dies is often environmental (a
+                    # startup RuntimeError, a missing dependency) and identical on
+                    # every fire, so it read as an idle job rather than a broken
+                    # one until this alert carried the reason out.
+                    await _alert_cron_failure(job, f"{type(exc).__name__}: {exc}")
                     return None
                 finally:
                     self._running_script_ids.discard(job.id)
@@ -2907,6 +3084,7 @@ class GatewayOrchestrator:
                     logger.debug(
                         "SEL logging failed in cron message fire-time deny path", exc_info=True
                     )
+                await _alert_cron_failure(job, gate_reason, denied=True)
                 return None
 
             def _cron_extra_env() -> dict[str, str] | None:
@@ -3576,7 +3754,15 @@ class GatewayOrchestrator:
                         alert_title = f"Cron: {job.name}"
                         alert_title, _ = redact_exfiltration_urls(alert_title)
                         alert_title, _ = redact_credentials(alert_title)
-                        self.dashboard_state.notify("cron", alert_title, "❌ Job failed")
+                        # Carry the reason, matching the suppressed-duplicate body
+                        # below: without it the FIRST alert — the one the user
+                        # actually reads — was the least informative of the two.
+                        self.dashboard_state.notify(
+                            "cron",
+                            alert_title,
+                            f"❌ Job failed:\n{exc_summary[:_CRON_FAILURE_DETAIL_CAP]}",
+                            meta={"job_id": job.id, "failure_hash": fh},
+                        )
                 except Exception:
                     logger.debug(
                         "Dashboard notify failed in cron failure alert path", exc_info=True
@@ -3588,17 +3774,35 @@ class GatewayOrchestrator:
                 # credential failure), so the machine name must come from here,
                 # not from inside the cron prompt.
                 host = socket.gethostname().split(".")[0]
+                # Slack PARSES entity markup here, and job.name is user-authored:
+                # a job named `<!channel>` notifies the whole channel on failure.
+                # Same sink and same source as the script/command alert above, so
+                # it gets the same escaping rather than being left as the one
+                # unescaped Slack interpolation of a cron name.
+                safe_name = escape_mrkdwn(job.name)
+                # Carry the reason here too. The dashboard body above and the
+                # script/command DM both do, so leaving this one at "check logs"
+                # made the DM the only failure surface that still withheld what
+                # the caller already knows. Escaped and fence-neutralized for the
+                # same reasons as the script/command alert.
+                safe_reason = escape_mrkdwn(exc_summary[:_CRON_FAILURE_DETAIL_CAP]).replace(
+                    "```", "'''"
+                )
                 if is_dup:
                     # +1: this run's failure is recorded below, after the
                     # awaited Slack attempt, so the display count must include
                     # it explicitly.
                     fail_msg = (
-                        f"⏰ *Cron: {job.name}* ❌ _Job still failing on {host}"
+                        f"⏰ *Cron: {safe_name}* ❌ _Job still failing on {escape_mrkdwn(host)}"
                         f" ({job.consecutive_failures + 1} consecutive failures)"
-                        f" — check logs._"
+                        f" — check logs._\n```{safe_reason}```"
                     )
                 else:
-                    fail_msg = f"⏰ *Cron: {job.name}* ❌ _Job failed on {host} — check logs._"
+                    fail_msg = (
+                        f"⏰ *Cron: {safe_name}* ❌ "
+                        f"_Job failed on {escape_mrkdwn(host)} — check logs._\n"
+                        f"```{safe_reason}```"
+                    )
                 # Never trust interpolated content (job.name is user-controlled):
                 # scrub exfiltration URLs + credentials before it reaches Slack,
                 # mirroring the dashboard alert_title redaction above.

--- a/test/test_cron_run_failure_alert.py
+++ b/test/test_cron_run_failure_alert.py
@@ -1,0 +1,463 @@
+"""A failed script/command cron must tell the user WHY, not only the log.
+
+Regression cover for kirodotdev/KiroCrew#4157: the script and command cron
+branches signal failure by mutating the job and returning normally, so they
+never reached the message path's failure alert. The reason lived in the gateway
+log and in a dashboard field nobody reads while waiting for a notification that
+never comes -- a job dying on the same environmental ``RuntimeError`` every fire
+looked idle rather than broken.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.cron import CronJob, CronSchedule
+from kiro_crew.slack.gateway import _FAILURE_REMINDER_SECS
+
+# The reason from the issue: a startup guard raising before the script body runs.
+CONFLICT = (
+    "data-home conflict: completion marker present at /home/u/.kiro/crew but a "
+    "non-empty legacy home /home/u/.kirocrew also exists"
+)
+
+
+def _make_gw():
+    """A GatewayOrchestrator with only the attributes the cron callback touches."""
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.ctx_builder = MagicMock()
+    gw.slack = MagicMock()
+    gw.slack.post_message = AsyncMock()
+    gw.conv_log = None
+    gw.dashboard_state = MagicMock()
+    gw.dashboard_state.get_slot = MagicMock(return_value=None)
+    gw._owner_id = "U000"
+    gw.subagent_mgr = None
+    gw._cron_injecting = {}
+    gw._running_script_ids = set()
+    gw._no_crons = False
+    gw.cron_svc = MagicMock()
+    gw.cron_svc.remove_job_async = AsyncMock(return_value=True)
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.sessions.set_thread = AsyncMock()
+    gw.sessions.set_channel = AsyncMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.hooks = MagicMock()
+    gw._interactive_approval = MagicMock(return_value="cb")
+    return gw
+
+
+def _script_job(**overrides):
+    defaults = dict(
+        id="sj1",
+        name="monitor-keep-75",
+        message="",
+        schedule=CronSchedule(kind="every", every_secs=60),
+        script="~/.kiro/crew/crons/monitor.py:run",
+        channel="C123",
+    )
+    defaults.update(overrides)
+    return CronJob(**defaults)
+
+
+def _command_job(**overrides):
+    defaults = dict(
+        id="cj1",
+        name="cmd-job",
+        message="",
+        schedule=CronSchedule(kind="every", every_secs=60),
+        command="false",
+        channel="C123",
+    )
+    defaults.update(overrides)
+    return CronJob(**defaults)
+
+
+def _message_job(**overrides):
+    defaults = dict(
+        id="mj1",
+        name="nightly-report",
+        message="go",
+        schedule=CronSchedule(kind="every", every_secs=300),
+        approval_mode="auto",
+        channel="C123",
+    )
+    defaults.update(overrides)
+    return CronJob(**defaults)
+
+
+async def _run_script(gw, job, script_result=None, *, vet_reason=None, side_effect=None):
+    captured = None
+    mock_kw = (
+        {"side_effect": side_effect} if side_effect is not None else {"return_value": script_result}
+    )
+    with (
+        patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+        patch("kiro_crew.slack.gateway.run_script_sandboxed", **mock_kw),
+        patch("kiro_crew.slack.gateway.vet_job_at_fire_time", return_value=vet_reason),
+        patch("kiro_crew.slack.gateway.sel"),
+    ):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured
+            captured = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            svc.remove_job_async = AsyncMock(return_value=True)
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+        await gw._init_cron()
+        assert captured is not None
+        return await captured(job)
+
+
+async def _run_command(gw, job, cmd_result=None, *, vet_reason=None, side_effect=None):
+    captured = None
+    mock_kw = (
+        {"side_effect": side_effect} if side_effect is not None else {"return_value": cmd_result}
+    )
+    gate = (
+        patch("kiro_crew.slack.gateway.vet_job_at_fire_time", return_value=vet_reason)
+        if vet_reason is not None
+        else nullcontext()
+    )
+    with (
+        patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+        patch("kiro_crew.slack.gateway.run_command_sandboxed", **mock_kw),
+        gate,
+        patch("kiro_crew.slack.gateway.sel"),
+    ):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured
+            captured = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            svc.remove_job_async = AsyncMock(return_value=True)
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+        await gw._init_cron()
+        assert captured is not None
+        return await captured(job)
+
+
+async def _run_message_callback_raising(gw, job, exc):
+    """Drive the message (LLM) cron path to its failure alert.
+
+    That path signals failure by RAISING, which is exactly why it had an alert
+    while the script/command paths did not.
+    """
+    captured = None
+
+    async def fake_stream(client, msg, **kwargs):
+        raise exc
+
+    with (
+        patch("kiro_crew.slack.gateway.stream_and_collect", fake_stream),
+        patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+        patch("kiro_crew.slack.gateway.sel"),
+        patch("kiro_crew.slack.gateway.vet_job_at_fire_time", return_value=None),
+    ):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured
+            captured = on_job
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+        await gw._init_cron()
+        assert captured is not None
+        with pytest.raises(type(exc)):
+            await captured(job)
+
+
+def _bodies(gw) -> list[str]:
+    """Every notification body pushed during the run."""
+    return [str(c) for c in gw.dashboard_state.notify.call_args_list]
+
+
+class TestScriptFailureReachesTheUser:
+    @pytest.mark.asyncio
+    async def test_script_error_rings_the_bell_with_the_reason(self) -> None:
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert job.last_status == "error"
+        bodies = _bodies(gw)
+        assert bodies, "a failed script cron must ring the dashboard bell"
+        assert any("data-home conflict" in b for b in bodies), (
+            "the alert must carry the REASON -- a bare 'failed' is what the log "
+            f"already said: {bodies}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_script_error_dms_the_reason(self) -> None:
+        gw = _make_gw()
+        await _run_script(gw, _script_job(), {"status": "error", "error": CONFLICT})
+        gw.slack.post_message.assert_awaited_once()
+        channel, text = gw.slack.post_message.await_args.args
+        assert channel == "C123"
+        assert "data-home conflict" in text
+        assert "monitor-keep-75" in text
+
+    @pytest.mark.asyncio
+    async def test_script_timeout_alerts(self) -> None:
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, side_effect=asyncio.TimeoutError())
+        assert any("timeout" in b for b in _bodies(gw))
+
+    @pytest.mark.asyncio
+    async def test_raising_script_alerts_with_the_exception_type(self) -> None:
+        gw = _make_gw()
+        await _run_script(gw, _script_job(), side_effect=RuntimeError(CONFLICT))
+        bodies = _bodies(gw)
+        assert any("RuntimeError" in b and "data-home conflict" in b for b in bodies)
+
+
+class TestCommandFailureReachesTheUser:
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_carries_the_output(self) -> None:
+        """The output IS the reason for a shell cron -- the exit code alone is not."""
+        gw = _make_gw()
+        job = _command_job()
+        await _run_command(
+            gw, job, {"status": "error", "output": "psql: connection refused", "exit_code": 2}
+        )
+        assert job.last_status == "error"
+        bodies = _bodies(gw)
+        assert any("exit_code=2" in b for b in bodies)
+        assert any("connection refused" in b for b in bodies)
+
+    @pytest.mark.asyncio
+    async def test_non_ok_with_no_output_still_alerts(self) -> None:
+        gw = _make_gw()
+        await _run_command(gw, _command_job(), {"status": "error", "output": "", "exit_code": 1})
+        assert any("no output" in b for b in _bodies(gw))
+
+    @pytest.mark.asyncio
+    async def test_command_timeout_alerts(self) -> None:
+        gw = _make_gw()
+        await _run_command(gw, _command_job(), side_effect=asyncio.TimeoutError())
+        assert any("timeout" in b for b in _bodies(gw))
+
+    @pytest.mark.asyncio
+    async def test_successful_command_does_not_alert(self) -> None:
+        """The alert is failure-only: a healthy job must stay quiet."""
+        gw = _make_gw()
+        job = _command_job()
+        await _run_command(gw, job, {"status": "ok", "output": "42 widgets", "exit_code": 0})
+        assert job.last_status == "ok"
+        gw.slack.post_message.assert_not_awaited()
+        assert not any("Run failed" in b for b in _bodies(gw))
+
+
+class TestFireTimeDenialIsNotSilent:
+    """A policy denial killed every fire with no user-facing signal at all.
+
+    ``fire_time_denied`` only keeps a one-shot job alive; it is not a surface.
+    """
+
+    @pytest.mark.asyncio
+    async def test_script_denial_alerts_as_a_policy_block(self) -> None:
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "ok"}, vet_reason="cron capability disabled")
+        bodies = _bodies(gw)
+        assert any("Blocked by policy" in b for b in bodies), bodies
+        assert any("cron capability disabled" in b for b in bodies)
+
+    @pytest.mark.asyncio
+    async def test_command_denial_alerts(self) -> None:
+        gw = _make_gw()
+        await _run_command(
+            gw,
+            _command_job(),
+            {"status": "ok", "output": "x", "exit_code": 0},
+            vet_reason="cron capability disabled",
+        )
+        assert any("Blocked by policy" in b for b in _bodies(gw))
+
+    @pytest.mark.asyncio
+    async def test_denial_does_not_count_toward_auto_pause(self) -> None:
+        """The alert must not smuggle in the failure count the deny path omits."""
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "ok"}, vet_reason="cron capability disabled")
+        assert job.consecutive_failures == 0
+
+
+class TestAlertNoiseControl:
+    @pytest.mark.asyncio
+    async def test_identical_failure_alerts_once_per_window(self) -> None:
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        # The DM is the noisy surface, so it is the one withheld on a repeat.
+        gw.slack.post_message.assert_awaited_once()
+        # The local bell still rings, marked as a repeat, so a user watching the
+        # feed can see the job is still down.
+        assert any("suppressed" in b for b in _bodies(gw))
+        # Suppression is time-boxed, not permanent.
+        job.last_failure_at -= _FAILURE_REMINDER_SECS + 1
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert gw.slack.post_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_a_different_reason_is_not_suppressed(self) -> None:
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        await _run_script(gw, job, {"status": "error", "error": "disk full"})
+        assert any("disk full" in b for b in _bodies(gw))
+
+    @pytest.mark.asyncio
+    async def test_suppressed_run_still_counts_toward_auto_pause(self) -> None:
+        """Dedup silences the bell, never the auto-pause evidence."""
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert job.consecutive_failures == 2
+
+    @pytest.mark.asyncio
+    async def test_silent_job_alerts_nowhere_but_still_counts(self) -> None:
+        gw = _make_gw()
+        job = _script_job(silent=True)
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        gw.slack.post_message.assert_not_awaited()
+        gw.dashboard_state.notify.assert_not_called()
+        assert job.consecutive_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_a_success_reopens_alerting(self) -> None:
+        """record_success clears the dedup fields, so a relapse alerts fresh."""
+        gw = _make_gw()
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        await _run_script(gw, job, {"status": "ok"})
+        assert job.last_failure_hash == ""
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert gw.slack.post_message.await_count == 2
+
+
+class TestSlackEntityInjection:
+    """Slack PARSES entity markup in a message's text.
+
+    Both halves of the DM are attacker-shaped: the job name is user-authored and
+    the reason carries subprocess output.
+    """
+
+    @pytest.mark.asyncio
+    async def test_broadcast_mention_in_the_job_name_is_escaped(self) -> None:
+        gw = _make_gw()
+        job = _script_job(name="<!channel> nightly")
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        _, text = gw.slack.post_message.await_args.args
+        assert "<!channel>" not in text, "a job name must not reach Slack as a live mention"
+        assert "&lt;!channel&gt;" in text
+
+    @pytest.mark.asyncio
+    async def test_broadcast_mention_in_the_reason_is_escaped(self) -> None:
+        gw = _make_gw()
+        await _run_script(gw, _script_job(), {"status": "error", "error": "boom <!here> boom"})
+        _, text = gw.slack.post_message.await_args.args
+        assert "<!here>" not in text
+        assert "&lt;!here&gt;" in text
+
+    @pytest.mark.asyncio
+    async def test_reason_cannot_escape_the_code_fence(self) -> None:
+        """Escaping alone does not close this hole -- a fence needs neutralizing."""
+        gw = _make_gw()
+        await _run_script(gw, _script_job(), {"status": "error", "error": "a ``` *b* ``` c"})
+        _, text = gw.slack.post_message.await_args.args
+        # Exactly the opening and closing fence this message builds, no more.
+        assert text.count("```") == 2
+
+    @pytest.mark.asyncio
+    async def test_dashboard_body_is_not_escaped(self) -> None:
+        """The bell is not a mrkdwn sink; escaping there shows a literal `&lt;`."""
+        gw = _make_gw()
+        await _run_script(gw, _script_job(), {"status": "error", "error": "boom <!here>"})
+        assert any("<!here>" in b for b in _bodies(gw))
+
+
+class TestMessagePathCarriesTheReasonToo:
+    """The one path that already alerted said only "Job failed" / "check logs".
+
+    Its own suppressed-duplicate body carried the reason, so the alert a user
+    actually reads was the least informative surface of the three.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_alert_bell_carries_the_reason(self) -> None:
+        gw = _make_gw()
+        job = _message_job()
+        await _run_message_callback_raising(gw, job, RuntimeError(CONFLICT))
+        bodies = _bodies(gw)
+        assert any("Job failed" in b for b in bodies)
+        assert any("data-home conflict" in b for b in bodies)
+
+    @pytest.mark.asyncio
+    async def test_first_alert_dm_carries_the_reason(self) -> None:
+        gw = _make_gw()
+        await _run_message_callback_raising(gw, _message_job(), RuntimeError(CONFLICT))
+        _, text = gw.slack.post_message.await_args.args
+        assert "check logs" in text, "the log is still where the full traceback lives"
+        assert "data-home conflict" in text, "but the DM must not withhold the reason itself"
+
+    @pytest.mark.asyncio
+    async def test_dm_reason_is_escaped_and_fence_safe(self) -> None:
+        gw = _make_gw()
+        await _run_message_callback_raising(gw, _message_job(), RuntimeError("<!here> ``` x"))
+        _, text = gw.slack.post_message.await_args.args
+        assert "<!here>" not in text
+        assert text.count("```") == 2
+
+
+class TestAlertNeverBreaksTheRun:
+    @pytest.mark.asyncio
+    async def test_notify_raising_does_not_break_bookkeeping(self) -> None:
+        gw = _make_gw()
+        gw.dashboard_state.notify = MagicMock(side_effect=RuntimeError("bell broke"))
+        job = _script_job()
+        result = await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert result is None
+        assert job.last_status == "error"
+        assert "data-home conflict" in job.last_error
+
+    @pytest.mark.asyncio
+    async def test_slack_failure_leaves_dedup_unadvanced(self) -> None:
+        """An undelivered reason must not be remembered as delivered."""
+        gw = _make_gw()
+        gw.slack.post_message = AsyncMock(side_effect=RuntimeError("slack down"))
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert job.last_failure_hash == ""
+        assert job.last_status == "error"
+
+    @pytest.mark.asyncio
+    async def test_no_slack_configured_still_rings_and_dedups(self) -> None:
+        gw = _make_gw()
+        gw.slack = None
+        job = _script_job()
+        await _run_script(gw, job, {"status": "error", "error": CONFLICT})
+        assert any("data-home conflict" in b for b in _bodies(gw))
+        assert job.last_failure_hash, (
+            "with no Slack the bell is the whole delivery, so dedup must advance "
+            "or every fire re-notifies"
+        )


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; it delivers the cron failure reason through the existing dashboard-bell and Slack-DM surfaces and adds no new or changed UI element.

## Problem / Motivation

When a legacy home directory (`~/.kirocrew`) still exists alongside the new home
(`~/.kiro/crew`), the gateway refuses to run script crons and raises a
`RuntimeError`. On unmodified main the script and command cron branches signal
failure by mutating the job (`last_status = "error"` + `last_error`) and then
returning normally from the callback (`src/kiro_crew/slack/gateway.py:2856-2879`,
origin/main), so they never reach the message path's failure alert. The reason is
written by `logger.exception(...)` to the gateway log and into a dashboard field
nobody is watching -- the user simply never gets the notification they expected.

A job that dies on the same startup `RuntimeError` every fire therefore looks
idle rather than broken. The same silence covers a script/command timeout, a
non-zero exit, and a fire-time policy denial.

## Why it matters

The legacy home is non-empty for entirely innocuous reasons (an old `audit.log`,
`crons/`, or `workspace/` left from before migration), so this hits ordinary
upgraders. Their crons are dead and the only signal is a notification that never
arrives; `kirocrew doctor` surfaces the conflict but only if the user thinks to
run it. Any script or command cron failing for any reason has the same blind
spot, not just the data-home case.

## What changed (motivation -> approach -> change)

Symptom: a failed script/command cron delivers nothing to the user. Root cause:
only the message (LLM) path had a user-facing failure alert; the script and
command paths return normally after recording the error, so the reason stays in
the log. Fix: add a shared `_alert_cron_failure()` helper and wire it into every
script/command failure, timeout, error, and fire-time-deny path.

- It rings the dashboard bell and (when Slack is configured) DMs the job's
  channel or the owner, carrying the actual reason text -- not a bare "failed",
  which is all the log already said.
- It dedups on the same `last_failure_hash` / `last_failure_at` fields the
  message path uses, and draws the same surface split that path draws: a repeat
  of the identical reason within `_FAILURE_REMINDER_SECS` (1h) withholds the
  Slack DM and marks the local bell as a repeat, so a user watching the feed can
  still see the job is down. A different reason alerts in full.
- It never raises (every call site is inside an `except` block whose exception is
  the real story) and never calls `record_failure()` (each call site already
  counts the run, keeping the auto-pause counter single-owner).
- `record_success()` becomes the single owner of the dedup reset. It previously
  lived at the gate-verdict call site only, so once these paths gained dedup a
  script/command job that recovered and then relapsed would have had its fresh
  alert suppressed for up to an hour.
- The message path's failure notification now carries the reason on BOTH its
  surfaces. Its bell said only "Job failed" and its DM only "check logs", while
  its own suppressed-duplicate body already carried the reason -- so the alert a
  user actually reads was the least informative surface of the three. The DM's
  reason gets the same escaping and fence neutralization as the script/command
  one; "check logs" stays, because the log is still where the full traceback
  lives.
- The Slack DM escapes mrkdwn entity markup in both attacker-shaped halves --
  the user-authored job name and the reason, which carries subprocess output.
  Slack parses entities in a message's text, so a job named `<!channel>` would
  have notified every member of the channel the moment it failed. Escaping alone
  does not close the second half: three backticks inside the reason would close
  the code fence early and hand the remainder to the parser as markup, so the
  fence is neutralized too. The pre-existing message-path DM interpolates the
  same job name into the same sink and is escaped in the same commit rather than
  being left as the one unescaped cron name reaching Slack. The dashboard body is
  deliberately NOT escaped -- it is not a mrkdwn sink, and escaping there would
  show a literal `&lt;`.
- `src/kiro_crew/docs/cron-and-scheduling.md` reliability section updated to
  state the alert surfaces and the dedup split, so the shipped doc matches the
  code.

Scope is deliberately the notification plumbing only. The data-home conflict
guard itself, and any "I've seen this, don't block crons" acknowledgment/bypass
policy, are untouched -- that guard prevents split-brain data corruption and
weakening it is a product/safety decision for a maintainer, as the triage routing
on the issue notes. Worth flagging for the maintainer: the conflict guard the
issue reports was since removed from `config/paths.py` by #4761 (the completed
home migration), so the specific `RuntimeError` in the report is no longer
reachable on main. The silence it exposed is not fixed by that removal and is
what this PR closes.

## Tests

New `test/test_cron_run_failure_alert.py` (26 tests), all locking in behaviour
that reverting the production hunks breaks (13 of 19 fail on unmodified main;
the 4 escaping tests were separately mutation-verified -- reverting the two
escape calls fails 3 of them):

- A failed/raising script and a non-zero-exit command ring the bell and DM the
  REASON (the data-home `RuntimeError`, `RuntimeError` type name, `exit_code` +
  output).
- Script and command timeouts alert.
- A successful run alerts nowhere.
- A fire-time policy denial alerts as a policy block and does not count toward
  auto-pause.
- Dedup: an identical reason withholds the DM and marks the bell suppressed, the
  DM returns after the window, a different reason is not suppressed, a
  suppressed run still counts toward auto-pause, and a success re-opens
  alerting.
- A `silent: true` job alerts nowhere but still counts.
- Slack entity injection: a `<!channel>` job name and a `<!here>` reason both
  reach Slack escaped, the reason cannot escape the code fence (exactly two
  fences in the message), and the dashboard body keeps the raw text.
- The message path drives its real raising callback: its bell and its DM both
  carry the reason, and the DM's reason is escaped and fence-safe.
- The alert never breaks the run: a raising bell leaves bookkeeping intact, a
  Slack delivery failure leaves dedup unadvanced (an undelivered reason is not
  remembered as delivered), and a Slack-less install still rings and dedups.

Local gates on the touched files: `flake8` clean, `mypy` clean, black baseline
gate clean, brand-name gate clean, and 429 tests pass across the 11 cron test
files that exercise these paths.

## Manual verification

N/A -- unit coverage exercises every wired call site (failure, timeout, error,
deny) across both job kinds plus the delivery-failure and no-Slack paths through
the real callback, so the behaviour is fully covered without a live gateway.

## Related Issues

Closes #4157
