### PR TITLE
fix(env): let a user extend the MCP binary search path

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -59,7 +59,13 @@ from kiro_crew.config.paths import (
     isolated_agents_dir,
     kiro_agents_dir,
 )
-from kiro_crew.env import emit_env, spec_env_path, spec_path_key
+from kiro_crew.env import (
+    dedup_path,
+    describe_search_path,
+    emit_env,
+    spec_env_path,
+    spec_path_key,
+)
 from kiro_crew.mcp_cleanup import purge_deleted_proxy_from_config
 from kiro_crew.mcp_provenance import without_marker
 from kiro_crew.mcp_utils import kiro_oauth_wire_entry, mcp_server_alias
@@ -3105,8 +3111,13 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     # spec from the other sources before dropping it, in priority order
     # (kirocrew > kiro-global > provider-global).  This prevents one source's
     # unresolvable command from killing a server another source can resolve.
-    def _resolve_command(cmd: str, env: dict | None) -> str | None:
-        """Resolve an MCP command to an absolute path, or None if not found.
+    def _resolve_command(cmd: str, env: dict | None) -> tuple[str | None, str]:
+        """Resolve an MCP command to an absolute path, plus the path searched.
+
+        Returns ``(resolved_or_None, search_path)``. The second element is what
+        lets the drop warning name the directories actually consulted; it is ""
+        when no PATH search happened (empty command, or an absolute command
+        accepted directly).
 
         Accepts an absolute path directly when the file exists and is
         executable — shutil.which can fail inside user-namespace sandboxes
@@ -3124,18 +3135,21 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         fallback for pip-generated wrappers like ``kirocrew``.
         """
         if not cmd:
-            return None
+            return None, ""
         if os.path.isabs(cmd) and os.path.isfile(cmd) and os.access(cmd, os.X_OK):
-            return cmd
+            return cmd, ""
         # Case-insensitive PATH key: a Windows-authored spec says "Path", and
         # resolving against a DIFFERENT path than the emitted spec carries would
         # reopen the probe/session split from the other side.
         _env = env or {}
         _key = spec_path_key(_env)
         _declared = _env.get(_key, "") if _key else ""
-        return shutil.which(
-            cmd, path=spec_env_path(_declared if isinstance(_declared, str) else "")
-        )
+        _search = spec_env_path(_declared if isinstance(_declared, str) else "")
+        # The search path is returned, not recomputed by the caller: a candidate
+        # that declares its own ``env.PATH`` is searched against a DIFFERENT path
+        # than one that does not, so a caller reporting ``spec_env_path("")``
+        # would name directories that were never searched.
+        return shutil.which(cmd, path=_search), _search
 
     valid_servers: dict[str, Any] = {}
     # The store is keyed by its own RAW name, but ``name`` below iterates the
@@ -3232,12 +3246,15 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         resolved: str | None = None
         chosen: dict = spec
         tried: list[str] = []
+        searched: list[str] = []
         had_any_command = False
         for label, cand in candidates:
             cmd = cand.get("command", "")
             if cmd:
                 had_any_command = True
-            r = _resolve_command(cmd, cand.get("env"))
+            r, cand_search = _resolve_command(cmd, cand.get("env"))
+            if cand_search:
+                searched.append(cand_search)
             tried.append(f"{label}={cmd or '<none>'}{' -> ok' if r else ''}")
             if r:
                 resolved = r
@@ -3275,10 +3292,21 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             # that was defined but couldn't be resolved.
             logger.warning("Dropping MCP server %r: no command", name)
         else:
+            # The searched directories belong in the WARNING, not only at DEBUG:
+            # a default-level reader is exactly who needs to tell "installed
+            # somewhere this path does not cover" (add agent.extra_path_dirs)
+            # from "not installed" (install it). Built from the paths the
+            # candidates were ACTUALLY searched against and deduped -- a
+            # candidate declaring its own env.PATH is searched against a
+            # different path, so recomputing one here would name directories
+            # that were never consulted. The candidate list stays at DEBUG:
+            # that is about which spec won, not about why none resolved.
             logger.warning(
-                "Dropping MCP server %r: command not found: %s",
+                "Dropping MCP server %r: command not found: %s — %s. "
+                "If it is installed, add its directory to agent.extra_path_dirs.",
                 name,
                 spec.get("command", ""),
+                describe_search_path(dedup_path(os.pathsep.join(searched))),
             )
             logger.debug("MCP %r resolution failed; tried %s", name, "; ".join(tried))
     config["mcpServers"] = valid_servers

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1692,6 +1692,23 @@ class AgentConfig:
             "Values support ~ expansion. Empty list disables cwd overrides.",
         ),
     )
+    extra_path_dirs: list[str] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Extra PATH Directories",
+            "Additional directories to search for MCP server binaries, for "
+            "installs outside the built-in list (~/.deno/bin, ~/.bun/bin, "
+            "~/go/bin, a corporate install root). Values support ~ expansion and "
+            "must be absolute. RESOLUTION ONLY: it decides which executable a "
+            "command name binds to, and is never written into a launched "
+            "server's PATH, so a launcher that shells out to a SIBLING in the "
+            "same directory still needs its own env.PATH on the spec. Not "
+            "applied to the agent's own shell commands or the harness. Searched "
+            "AFTER the inherited PATH, so an entry can only resolve a command "
+            "that resolves nowhere else -- it can never shadow a system binary. "
+            "Empty list is a no-op. Takes effect on gateway restart.",
+        ),
+    )
     max_channels: int = field(
         default=1,
         metadata=_meta("Max Channels", "Maximum concurrent agent channels (1-5)."),
@@ -6275,6 +6292,16 @@ class KiroCrewConfig:
                     [r for r in _roots if isinstance(r, str)]
                     if isinstance(_roots := agent_data.get("subagent_cwd_allowed_roots"), list)
                     else list(DEFAULT_CWD_ALLOWED_ROOTS)
+                ),
+                # Empty on anything malformed, NOT a built-in fallback: unlike
+                # subagent_cwd_allowed_roots this key has no shipped default, so
+                # the safe reading of a broken value is "the user declared
+                # nothing" — which leaves resolution exactly as it was before the
+                # key existed.
+                extra_path_dirs=(
+                    [d for d in _extra_dirs if isinstance(d, str)]
+                    if isinstance(_extra_dirs := agent_data.get("extra_path_dirs"), list)
+                    else []
                 ),
                 log_level=(
                     lvl.upper()

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -191,6 +191,113 @@ def _validated_bin_dir(val: str) -> str | None:
     return val
 
 
+def _raw_extra_path_dirs() -> list:
+    """Read ``agent.extra_path_dirs`` from disk without loading the whole config.
+
+    Deliberately NOT ``KiroCrewConfig.load()``. That call validates the entire
+    document against the JSON schema, builds the full dataclass tree, and can
+    perform a write-back migration — and :func:`spec_env_path` is reached from
+    the asynchronous MCP probe, so a schema validation and a possible config
+    WRITE would land on the gateway event loop. This reads the one key: two
+    small reads and a ``json.loads``, no validation, no write.
+
+    Honours the ``config.local.json`` overlay with the same precedence
+    ``KiroCrewConfig.load()`` gives it (local wins), so the two spellings of
+    the key cannot disagree.
+    """
+    # Function-local because a module-level import would close a real cycle:
+    # config.loader imports mcp_gateway.rewriter (loader.py:117), which imports
+    # this module for spec_env_path/spec_path_key (rewriter.py:40). env must stay
+    # importable below loader.
+    from kiro_crew.config.loader import config_local_path, config_path
+
+    value: list = []
+    for path in (config_path(), config_local_path()):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        agent = raw.get("agent")
+        if not isinstance(agent, dict) or "extra_path_dirs" not in agent:
+            continue
+        # PRESENCE wins, which is what the loader's overlay does: a local file
+        # naming the key REPLACES the base value. A malformed override therefore
+        # replaces it with NOTHING rather than silently preserving the base --
+        # writing ``"extra_path_dirs": null`` in the local file is a way to turn
+        # the setting off, and preserving the base there would leave a directory
+        # active that the user believes they revoked.
+        found = agent["extra_path_dirs"]
+        value = found if isinstance(found, list) else []
+    return value
+
+
+@functools.lru_cache(maxsize=4)
+def _configured_extra_path_dirs(home: str) -> tuple[str, ...]:
+    """User-declared MCP binary directories from ``agent.extra_path_dirs``.
+
+    ``_EXTRA_PATH_DIRS`` is a fixed list, so a gateway that does not inherit a
+    login shell's ``PATH`` cannot resolve an MCP binary installed anywhere else
+    (``~/.deno/bin``, ``~/.bun/bin``, ``~/go/bin``, a corporate-managed install
+    root). This is the supported escape hatch. Consumed only by
+    :func:`spec_env_path` — see the comment there for why not
+    :func:`augmented_path`.
+
+    Deliberately CONFIG-FILE ONLY, with no environment-variable equivalent: an
+    env var is readable and writable by any lower-trust parent process, whereas
+    the config file is at least covered by the file-edit gate. For the same
+    reason entries expand ``~`` but NOT ``$VAR`` — ``expandvars`` would reopen
+    the env-var route through the back door.
+
+    Entries are validated, never probed: :func:`_validated_bin_dir` rejects
+    relative, empty, ``NUL``-bearing, and separator-smuggling values, but a
+    directory that does not exist is left on the search path rather than
+    stat-ed away. That matches ``subagent_cwd_allowed_roots`` (also never
+    probed on load) and keeps resolution free of per-entry I/O.
+
+    Read once per process and cached, the same discipline
+    :func:`_node_all_bin_dirs` already applies to the filesystem glob inside
+    :func:`augmented_path`: an edit is not visible until the gateway restarts.
+    That is not a compromise — an already-spawned child keeps the ``PATH`` it
+    was given regardless. Call ``_configured_extra_path_dirs.cache_clear()`` to
+    re-read without a restart.
+    """
+    try:
+        raw = _raw_extra_path_dirs()
+    except Exception:
+        # A missing, unreadable, or invalid config must not make an MCP binary
+        # unresolvable that resolved before this feature existed — fall back to
+        # the built-in list alone.
+        logger.debug("agent.extra_path_dirs unavailable; using built-in dirs only", exc_info=True)
+        return ()
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        candidate = entry.strip()
+        if candidate == "~":
+            candidate = home
+        elif candidate.startswith("~"):
+            candidate = os.path.join(home, candidate[1:].lstrip("/\\"))
+        validated = _validated_bin_dir(os.path.normpath(candidate) if candidate else "")
+        if validated is None:
+            logger.warning(
+                "agent.extra_path_dirs: ignoring %r — entries must be a single "
+                "absolute directory (~ is expanded; $VAR is not)",
+                entry,
+            )
+            continue
+        key = os.path.normcase(validated)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(validated)
+    return tuple(out)
+
+
 def _marker_node_bin_dir() -> str | None:
     """Read the node bin dir recorded by ``ensure-node.sh``, or ``None``."""
     try:
@@ -489,6 +596,10 @@ def augmented_path(base_path: str = "") -> str:
     agent's own ``python``/``pip`` shell calls) to the gateway's venv
     interpreter. As a pure fallback it resolves only names found nowhere
     else — exactly the console-script-wrapper case.
+
+    A user extends the search with ``agent.extra_path_dirs``
+    (:func:`_configured_extra_path_dirs`), whose entries land after
+    *base_path* — see the comment at the append site for why last.
     """
     home = os.path.expanduser("~")
     mise_data = mise_data_dir(home)
@@ -506,6 +617,34 @@ def augmented_path(base_path: str = "") -> str:
     parts = extra + ([base_path] if base_path else [])
     parts.append(str(Path(sys.executable).parent))
     return os.pathsep.join(parts)
+
+
+#: How many directories :func:`describe_search_path` names before truncating.
+#: The effective search path can carry a bin dir per installed Node version, and
+#: an unbounded dump would push the actionable first entries out of a log
+#: reader's view.
+_SEARCH_PATH_REPORT_LIMIT = 40
+
+
+def describe_search_path(path: str) -> str:
+    """Render *path* as a human-readable list of searched directories.
+
+    ``command not found: <name>`` never said WHERE it looked, so a user could
+    not tell "your install directory is not on the built-in list" (fixable with
+    ``agent.extra_path_dirs``) from "your binary is not installed" (fixable by
+    installing it) without reading the source. Every caller formats the search
+    path through here so the two failures read differently everywhere they are
+    reported.
+
+    Truncated at :data:`_SEARCH_PATH_REPORT_LIMIT`; the count is always stated,
+    so a truncated tail is visible rather than silent.
+    """
+    dirs = [d for d in path.split(os.pathsep) if d]
+    if not dirs:
+        return "searched no directories (empty PATH)"
+    shown = dirs[:_SEARCH_PATH_REPORT_LIMIT]
+    suffix = f" (+{len(dirs) - len(shown)} more)" if len(dirs) > len(shown) else ""
+    return f"searched {len(dirs)} directories: {', '.join(shown)}{suffix}"
 
 
 def dedup_path(path: str) -> str:
@@ -559,7 +698,7 @@ def _spec_path_entries(env_path: str) -> list[str]:
     return out
 
 
-def spec_env_path(env_path: str) -> str:
+def spec_env_path(env_path: str, *, include_extra_dirs: bool = True) -> str:
     """Expand an MCP spec's ``env.PATH`` into the PATH its child actually needs.
 
     A spec's ``env`` is applied per key by whatever spawns the server, so
@@ -613,6 +752,40 @@ def spec_env_path(env_path: str) -> str:
         logger.debug("ignoring non-string MCP spec PATH: %s", type(env_path).__name__)
         env_path = ""
     parts = [*_spec_path_entries(env_path), augmented_path(os.environ.get("PATH", ""))]
+    # ``agent.extra_path_dirs`` is appended HERE and not inside
+    # :func:`augmented_path`, deliberately. That function is the search path for
+    # things other than an MCP server: ``kiro_cli.find_kiro_cli_candidates``
+    # locates the ACP HARNESS through it, and acp/client, acp/runtime,
+    # browser_cli and the agents handler build child environments from it. A
+    # config key added so an MCP server binary can be found has no business
+    # deciding which harness executable runs -- the config file is writable
+    # outside the file-edit gate, so feeding harness selection from it would let
+    # a planted binary be chosen as the harness. Appending at this level keeps
+    # the key to MCP spec resolution only, which is the whole of what #3030
+    # asks for: the dashboard probe (mcp_discovery), the agent config rebuild's
+    # command resolver (agent.py), and the gateway rewriter all route here.
+    #
+    # Scoped this way the key grants no capability the config file did not
+    # already have: a writer who can add this key can equally add an
+    # ``mcpServers`` entry naming an absolute command.
+    #
+    # LAST, so the entries rank below the spec's own PATH, the inherited PATH
+    # and the built-in list. The reported gap is that the binary resolves
+    # NOWHERE, so last place already closes it, and this makes the change a
+    # strict addition: no command name that resolves today can be rebound, and a
+    # user-writable directory cannot shadow a system binary. Granting override
+    # precedence is a separate trust decision this key does not settle.
+    #
+    # ``include_extra_dirs=False`` is for a caller writing a DURABLE file that is
+    # also a rebuild SOURCE (``~/.kiro/settings/mcp.json``, written create-only
+    # and read back by ``agent.install_agent``). Baking the configured dirs into
+    # one of those would make the setting irrevocable: clearing the config could
+    # not remove them, and on the next rebuild they would come back as a
+    # DECLARED PATH, which ranks FIRST -- inverting the lowest-precedence
+    # property above. A revocable setting must never be persisted into an
+    # irrevocable file.
+    if include_extra_dirs:
+        parts.extend(_configured_extra_path_dirs(os.path.expanduser("~")))
     return dedup_path(os.pathsep.join(filter(None, parts)))
 
 
@@ -773,7 +946,25 @@ def emit_env(env: dict) -> dict:
         # spelling included, so the config error stays visible.
         return dict(env)
     out = {k: v for k, v in env.items() if not (isinstance(k, str) and k.upper() == "PATH")}
-    out["PATH"] = spec_env_path(path)
+    # include_extra_dirs=False on EVERY emission, deliberately. An emitted PATH is
+    # persisted into files that are read-modify-write sources on the next rebuild
+    # -- the agent config above all (``install_agent`` loads the existing one to
+    # "preserve user customizations"), and the create-only
+    # ``~/.kiro/settings/mcp.json``. A value written there is indistinguishable
+    # next time from one the user authored, so baking a REVOCABLE setting into it
+    # makes the setting permanent: clearing ``agent.extra_path_dirs`` could not
+    # remove the directory, and it would return as a DECLARED entry, which ranks
+    # FIRST -- inverting the lowest-precedence property the key relies on.
+    #
+    # So the key stays RESOLUTION-ONLY: it decides what a command name binds to,
+    # and never what a child's PATH contains. Consequence, disclosed rather than
+    # hidden: a launcher in a configured directory that shells out to a SIBLING in
+    # that same directory still fails, because the child does not inherit it. That
+    # case has a supported answer today -- declare ``env.PATH`` on the spec --
+    # whereas an irrevocable setting has none. Emitting for the child needs
+    # provenance on emitted PATH values (so a rebuild re-derives instead of
+    # re-consuming), which is a change to this pipeline, not to this key.
+    out["PATH"] = spec_env_path(path, include_extra_dirs=False)
     return out
 
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -33,6 +33,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.env import (
     denied_spec_env_keys,
+    describe_search_path,
     emit_env,
     sanitize_spec_env,
     spec_env_path,
@@ -116,16 +117,37 @@ _PROBE_TTL_SECS = 1800
 _unresolvable_warned: set[tuple[str, str]] = set()
 
 
-def _warn_unresolvable_once(name: str, command: str) -> None:
-    """WARNING on first sight of an unresolvable command, DEBUG thereafter."""
+def _unresolved_error(command: str) -> str:
+    """The dashboard-facing string for a command that resolved nowhere.
+
+    Names the remedy, because ``command not found`` alone does not distinguish
+    the two causes a user can act on: the binary is not installed, or it is
+    installed in a directory the search path does not cover. The full directory
+    list goes to the log (:func:`_warn_unresolvable_once`) rather than here —
+    this string renders in a fixed-width dashboard cell.
+    """
+    return (
+        f"command not found: {command} — not in any searched directory. "
+        "If it is installed, add its directory to agent.extra_path_dirs."
+    )
+
+
+def _warn_unresolvable_once(name: str, command: str, search_path: str = "") -> None:
+    """WARNING on first sight of an unresolvable command, DEBUG thereafter.
+
+    *search_path* is the PATH actually searched; naming its directories is what
+    lets a reader tell "this install location is not covered" from "this binary
+    does not exist" without reading the source.
+    """
     key = (name, command)
+    searched = f" ({describe_search_path(search_path)})" if search_path else ""
     if key in _unresolvable_warned:
         logger.debug(
             "MCP probe [%s]: command still not found: %s (already reported)", name, command
         )
         return
     _unresolvable_warned.add(key)
-    logger.warning("MCP probe failed [%s]: command not found: %s", name, command)
+    logger.warning("MCP probe failed [%s]: command not found: %s%s", name, command, searched)
 
 
 #: Servers whose probe has already reported a missing sandbox backend. Keyed by
@@ -1520,6 +1542,10 @@ async def probe_server(
         return server
 
     server.status = "probing"
+    # The PATH the spawn will actually search, bound before the try so the
+    # FileNotFoundError handler can name the searched directories regardless of
+    # how far the attempt got.
+    effective_path = ""
     # Stamped at probe START so the early error returns below (which skip the
     # cache) still carry an honest "when": the probe DID run at this time.
     # _cache_probe overwrites it with completion time on the paths it covers.
@@ -1556,12 +1582,26 @@ async def probe_server(
         )
 
         # Resolve command to absolute path using the merged env PATH
-        resolved = shutil.which(server.command, path=env.get("PATH"))
+        effective_path = env.get("PATH") or ""
+        resolved = shutil.which(server.command, path=effective_path)
         if not resolved:
             server.status = "error"
-            server.error = f"command not found: {server.command}"
-            _warn_unresolvable_once(server.name, server.command)
+            server.error = _unresolved_error(server.command)
+            _warn_unresolvable_once(server.name, server.command, effective_path)
             return server
+
+        # ``agent.extra_path_dirs`` is RESOLUTION-ONLY: it may decide which
+        # executable the command name binds to (above), but it must not reach the
+        # spawned child, because the emitted session config carries no such entry
+        # (see env.emit_env). Handing the probe child a WIDER PATH than a session
+        # child gets is the "probes healthy, fails in a session" divergence this
+        # module exists to close -- a launcher needing a sibling from that
+        # directory would pass here and die under kiro-cli. So rebuild the spawn
+        # PATH without the extra dirs now that resolution is done; the command is
+        # already absolute, so nothing that resolved is lost.
+        env["PATH"] = spec_env_path(
+            _declared_path if isinstance(_declared_path, str) else "", include_extra_dirs=False
+        )
 
         # The command resolved, so forget any prior "not found" report — keyed on
         # resolvability, NOT on handshake health. Clearing this at the end of the
@@ -1765,8 +1805,10 @@ async def probe_server(
         )
     except FileNotFoundError:
         server.status = "error"
-        server.error = f"command not found: {server.command}"
-        _warn_unresolvable_once(server.name, server.command)
+        server.error = _unresolved_error(server.command)
+        # ``effective_path`` was bound before the try, so it is always safe to
+        # read here even if the failure preceded PATH resolution.
+        _warn_unresolvable_once(server.name, server.command, effective_path)
     except SandboxUnavailableError as exc:
         # The PROBE could not run — this says nothing about the server, and the
         # two must not be reported alike. Ahead of the generic clause, which would
@@ -2070,7 +2112,13 @@ def _envs_agree(agent_env: dict, source_env: dict) -> bool:
     for key, val in source_env.items():
         current = agent_env.get(key)
         if key == "PATH" and val:
-            if current == val or current == spec_env_path(val):
+            # include_extra_dirs=False to match what ``emit_env`` actually
+            # STORED. Recomputing with the default (True) would append
+            # ``agent.extra_path_dirs`` to the comparison value while the stored
+            # config carries none, so any server declaring its own env.PATH would
+            # look changed on every pass -- an endless rebuild + audit entry,
+            # which is the re-sync this guard exists to prevent.
+            if current == val or current == spec_env_path(val, include_extra_dirs=False):
                 continue
             return False
         if current != val:

--- a/test/test_config_schema.py
+++ b/test/test_config_schema.py
@@ -606,6 +606,7 @@ class TestFieldTypeResolution:
         ("slack.reactions", "object"),
         ("slack.trusted_bot_ids", "array"),
         ("agent.subagent_cwd_allowed_roots", "array"),
+        ("agent.extra_path_dirs", "array"),
         ("memory.semantic_keys", "array"),
         ("slack_channels", "object"),
         ("session.timeout_secs", "integer"),

--- a/test/test_extra_path_dirs.py
+++ b/test/test_extra_path_dirs.py
@@ -1,0 +1,417 @@
+"""``agent.extra_path_dirs`` — the user-extensible MCP binary search path (#3030).
+
+``_EXTRA_PATH_DIRS`` is a fixed tuple, so before this key a gateway that did not
+inherit a login shell's ``PATH`` could not resolve an MCP binary installed
+anywhere else, with no supported way to fix it.
+
+The key is RESOLUTION-ONLY: it decides what a bare command name binds to, and
+never what a launched child's ``PATH`` contains. These tests pin the capability
+and the four properties that make it safe:
+
+* it reaches MCP spec resolution ONLY, never the shared ``augmented_path()``
+  that locates the ACP harness (the config file is writable outside the
+  file-edit gate, so harness selection must not be fed from it);
+* it is never EMITTED into a config file, because every such file is a
+  read-modify-write source on the next rebuild -- persisting a revocable
+  setting there would make it permanent, and it would return as a *declared*
+  entry, which ranks first;
+* entries land at the lowest precedence, so nothing that resolves today can be
+  rebound;
+* a malformed or absent value is a strict no-op.
+
+Path fixtures are built through :func:`_abs` and ``os.pathsep`` rather than
+written as POSIX literals: on Windows ``os.pathsep`` is ``;`` (so a colon is not
+separator-smuggling), ``ntpath.isabs("/opt/x")`` is True, and ``normpath``
+returns backslashes -- a hardcoded ``"/opt/a:/opt/b"`` would silently test
+something different there.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import env as env_mod
+from kiro_crew.env import augmented_path, describe_search_path, emit_env, spec_env_path
+
+
+def _abs(*parts: str) -> str:
+    """A platform-correct absolute directory, normalized as the code normalizes."""
+    root = "C:\\" if os.name == "nt" else "/"
+    return os.path.normpath(os.path.join(root, *parts))
+
+
+VENDOR = _abs("opt", "vendor", "mcp", "bin")
+OK = _abs("opt", "ok", "bin")
+ONE = _abs("opt", "one", "bin")
+TWO = _abs("opt", "two", "bin")
+USR_BIN = _abs("usr", "bin")
+BIN = _abs("bin")
+BASE_PATH = os.pathsep.join([USR_BIN, BIN])
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """The helper is cached for the process, so every test must start cold."""
+    env_mod._configured_extra_path_dirs.cache_clear()
+    yield
+    env_mod._configured_extra_path_dirs.cache_clear()
+
+
+def _configure(monkeypatch, value):
+    """Point the on-disk read at *value* without touching a real config file."""
+    monkeypatch.setattr(env_mod, "_raw_extra_path_dirs", lambda: value)
+
+
+def _entries(path: str) -> list[str]:
+    return [p for p in path.split(os.pathsep) if p]
+
+
+# ── the capability ────────────────────────────────────────────────────────────
+
+
+def test_configured_dir_becomes_searchable(monkeypatch):
+    """The reported gap: a binary outside the built-in list must resolve."""
+    _configure(monkeypatch, [VENDOR])
+    assert VENDOR in _entries(spec_env_path(""))
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="a shebang script is not PATHEXT-executable on Windows; the ordering "
+    "and isolation properties below cover this platform",
+)
+def test_a_binary_only_in_a_configured_dir_is_found(monkeypatch, tmp_path):
+    """End to end through ``shutil.which``, not just string membership."""
+    bindir = tmp_path / "vendorbin"
+    bindir.mkdir()
+    tool = bindir / "vendor-mcp-server"
+    tool.write_text("#!/bin/sh\nexit 0\n")
+    tool.chmod(0o755)
+
+    assert shutil.which("vendor-mcp-server", path=BASE_PATH) is None
+    _configure(monkeypatch, [str(bindir)])
+    assert shutil.which("vendor-mcp-server", path=spec_env_path("")) == str(tool)
+
+
+def test_a_spec_declared_path_still_wins(monkeypatch, tmp_path):
+    """The key must not disturb a spec that pins its own PATH first."""
+    _configure(monkeypatch, [VENDOR])
+    entries = _entries(spec_env_path(str(tmp_path)))
+    assert entries[0] == str(tmp_path)
+    assert entries.index(str(tmp_path)) < entries.index(VENDOR)
+
+
+# ── resolution-only: never persisted into a config file ───────────────────────
+
+
+def test_emitted_env_never_carries_configured_dirs(monkeypatch):
+    """The key must not reach ANY emitted config.
+
+    Every file ``emit_env`` feeds is a read-modify-write source on the next
+    rebuild -- ``install_agent`` loads the existing agent config to "preserve
+    user customizations", and ``~/.kiro/settings/mcp.json`` is written
+    create-only and read back. A configured dir persisted there could not be
+    removed by clearing the config, and would return as a DECLARED entry, which
+    ranks FIRST -- inverting the lowest-precedence property below.
+    """
+    _configure(monkeypatch, [VENDOR])
+    out = emit_env({"PATH": OK})
+    assert OK in _entries(out["PATH"])  # the declaration survives
+    assert VENDOR not in _entries(out["PATH"])  # the revocable setting does not
+
+
+def test_emission_stays_env_less_for_an_env_less_spec(monkeypatch):
+    """Resolution-only means no spec gains an env it did not have."""
+    _configure(monkeypatch, [VENDOR])
+    assert emit_env({}) == {}
+    assert emit_env({"TOKEN": "t"}) == {"TOKEN": "t"}
+
+
+def test_clearing_the_key_fully_revokes(monkeypatch):
+    """Nothing persisted, so re-expansion after removal cannot resurrect it."""
+    _configure(monkeypatch, [VENDOR])
+    persisted = emit_env({"PATH": OK})["PATH"]
+    env_mod._configured_extra_path_dirs.cache_clear()
+    _configure(monkeypatch, [])
+    assert VENDOR not in _entries(spec_env_path(persisted))
+
+
+def test_probe_spawn_path_matches_the_session(monkeypatch):
+    """The probe child must not get a WIDER PATH than a session child.
+
+    Resolution may use the configured dirs; the spawn must not, or a launcher
+    needing a sibling from that directory passes the probe and dies in a session.
+    """
+    _configure(monkeypatch, [VENDOR])
+    session_path = emit_env({"PATH": OK})["PATH"]
+    probe_spawn_path = spec_env_path(OK, include_extra_dirs=False)
+    assert probe_spawn_path == session_path
+    assert VENDOR not in _entries(probe_spawn_path)
+
+
+# ── the security property: harness resolution must NOT see this key ───────────
+
+
+def test_shared_augmented_path_never_carries_configured_dirs(monkeypatch):
+    """Regression pin for the escalation this key must not open.
+
+    ``kiro_cli.known_kiro_cli_dirs`` locates the ACP HARNESS through
+    ``augmented_path()``, and acp/client, acp/runtime, browser_cli and the
+    agents handler build child environments from it. The config file is
+    writable outside the file-edit gate, so a configured directory reaching
+    this function would let a planted binary be selected as the harness.
+    """
+    _configure(monkeypatch, [VENDOR])
+    assert VENDOR not in _entries(augmented_path(BASE_PATH))
+    assert VENDOR not in _entries(augmented_path(""))
+
+
+def test_kiro_cli_candidate_dirs_never_carry_configured_dirs(monkeypatch):
+    """The same property asserted at the harness resolver itself."""
+    from kiro_crew.kiro_cli import known_kiro_cli_dirs
+
+    _configure(monkeypatch, [VENDOR])
+    dirs = known_kiro_cli_dirs(
+        "linux", Path(os.path.expanduser("~")), {"PATH": BASE_PATH}, include_inherited_path=True
+    )
+    assert VENDOR not in dirs
+
+
+# ── the precedence property ───────────────────────────────────────────────────
+
+
+def test_entries_rank_below_the_inherited_path(monkeypatch):
+    """Strict addition: a user dir can never shadow a name PATH already resolves."""
+    monkeypatch.setenv("PATH", BASE_PATH)
+    _configure(monkeypatch, [VENDOR])
+    entries = _entries(spec_env_path(""))
+    assert entries.index(USR_BIN) < entries.index(VENDOR)
+    assert entries.index(BIN) < entries.index(VENDOR)
+
+
+def test_entries_rank_below_the_builtin_dirs(monkeypatch):
+    _configure(monkeypatch, [VENDOR])
+    entries = _entries(spec_env_path(""))
+    home_local = os.path.join(os.path.expanduser("~"), ".local", "bin")
+    if home_local in entries:  # built-ins are host-shaped; assert only when present
+        assert entries.index(home_local) < entries.index(VENDOR)
+
+
+def test_entries_rank_below_the_interpreter_fallback(monkeypatch):
+    """Last of all: the key resolves only what nothing else can."""
+    _configure(monkeypatch, [VENDOR])
+    entries = _entries(spec_env_path(""))
+    interp = str(Path(sys.executable).parent)
+    if interp in entries:
+        assert entries.index(interp) < entries.index(VENDOR)
+    assert entries[-1] == VENDOR
+
+
+def test_empty_config_is_byte_identical_to_no_key(monkeypatch):
+    """An empty list must be a strict no-op, not a reordering."""
+    _configure(monkeypatch, [])
+    with_empty = spec_env_path("")
+    env_mod._configured_extra_path_dirs.cache_clear()
+    _configure(monkeypatch, [])
+    assert with_empty == spec_env_path("")
+
+
+def test_unreadable_config_does_not_break_resolution(monkeypatch):
+    """A config that raises must not make a previously-resolvable binary vanish."""
+
+    def _boom():
+        raise RuntimeError("config on fire")
+
+    monkeypatch.setattr(env_mod, "_raw_extra_path_dirs", _boom)
+    monkeypatch.setenv("PATH", BASE_PATH)
+    assert USR_BIN in _entries(spec_env_path(""))  # built, no exception escaped
+
+
+# ── reading the key off disk ──────────────────────────────────────────────────
+
+
+def test_reads_the_key_from_config_json(monkeypatch, tmp_path):
+    """Covers the real on-disk read, not just the patched helper."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"agent": {"extra_path_dirs": ["/opt/from/base"]}}))
+    missing = tmp_path / "config.local.json"
+    # Patch the SOURCE module: _raw_extra_path_dirs re-imports these inside its
+    # body, so patching a copy held elsewhere would be silently ignored.
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg)
+    monkeypatch.setattr("kiro_crew.config.loader.config_local_path", lambda: missing)
+    assert env_mod._raw_extra_path_dirs() == ["/opt/from/base"]
+
+
+def test_local_overlay_wins(monkeypatch, tmp_path):
+    """Same precedence ``KiroCrewConfig.load()`` gives the overlay."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"agent": {"extra_path_dirs": ["/opt/from/base"]}}))
+    local = tmp_path / "config.local.json"
+    local.write_text(json.dumps({"agent": {"extra_path_dirs": ["/opt/from/local"]}}))
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg)
+    monkeypatch.setattr("kiro_crew.config.loader.config_local_path", lambda: local)
+    assert env_mod._raw_extra_path_dirs() == ["/opt/from/local"]
+
+
+def test_absent_and_malformed_files_yield_empty(monkeypatch, tmp_path):
+    bad = tmp_path / "config.json"
+    bad.write_text("{ not json")
+    missing = tmp_path / "nope.json"
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: bad)
+    monkeypatch.setattr("kiro_crew.config.loader.config_local_path", lambda: missing)
+    assert env_mod._raw_extra_path_dirs() == []
+
+
+def test_read_never_writes_the_config(monkeypatch, tmp_path):
+    """The read must not migrate or rewrite config -- it runs on the event loop."""
+    cfg = tmp_path / "config.json"
+    body = json.dumps({"agent": {"extra_path_dirs": ["/opt/x/bin"]}})
+    cfg.write_text(body)
+    before = cfg.stat().st_mtime_ns
+    missing = tmp_path / "nope.json"
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg)
+    monkeypatch.setattr("kiro_crew.config.loader.config_local_path", lambda: missing)
+    env_mod._raw_extra_path_dirs()
+    assert cfg.read_text() == body
+    assert cfg.stat().st_mtime_ns == before
+
+
+def test_local_null_override_revokes_the_base_value(monkeypatch, tmp_path):
+    """Presence wins: a malformed local override must not preserve the base.
+
+    ``"extra_path_dirs": null`` in the local file is how a user turns the setting
+    off; preserving the base value there would leave a directory active that they
+    believe they revoked.
+    """
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"agent": {"extra_path_dirs": ["/opt/from/base"]}}))
+    local = tmp_path / "config.local.json"
+    local.write_text(json.dumps({"agent": {"extra_path_dirs": None}}))
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg)
+    monkeypatch.setattr("kiro_crew.config.loader.config_local_path", lambda: local)
+    assert env_mod._raw_extra_path_dirs() == []
+
+
+def test_local_file_without_the_key_keeps_the_base_value(monkeypatch, tmp_path):
+    """Absence is not an override -- only a PRESENT key replaces."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"agent": {"extra_path_dirs": ["/opt/from/base"]}}))
+    local = tmp_path / "config.local.json"
+    local.write_text(json.dumps({"agent": {"bot_name": "x"}}))
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg)
+    monkeypatch.setattr("kiro_crew.config.loader.config_local_path", lambda: local)
+    assert env_mod._raw_extra_path_dirs() == ["/opt/from/base"]
+
+
+def test_resync_guard_compares_against_what_was_emitted(monkeypatch):
+    """``_envs_agree`` must not recompute with the extra dirs.
+
+    ``emit_env`` stores a PATH without them, so recomputing with them makes any
+    server declaring its own env.PATH look changed on every pass -- an endless
+    rebuild plus an audit entry, the re-sync the guard exists to prevent.
+    """
+    from kiro_crew.mcp_discovery import _envs_agree
+
+    _configure(monkeypatch, [VENDOR])
+    stored = emit_env({"PATH": OK})["PATH"]
+    assert VENDOR not in _entries(stored)
+    # The guard must consider the stored value in agreement with its source.
+    assert _envs_agree({"PATH": stored}, {"PATH": OK}) is True
+
+
+# ── entry validation ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        os.path.join("relative", "bin"),  # re-resolved against the CHILD's cwd
+        "",
+        "   ",
+        os.pathsep.join([_abs("opt", "a"), _abs("opt", "b")]),  # separator smuggling
+        _abs("opt", "\0bin"),
+    ],
+)
+def test_invalid_entries_are_rejected(monkeypatch, bad):
+    _configure(monkeypatch, [bad])
+    assert env_mod._configured_extra_path_dirs(os.path.expanduser("~")) == ()
+
+
+def test_non_string_entries_are_skipped(monkeypatch):
+    _configure(monkeypatch, [5, None, {"a": 1}, OK])
+    assert env_mod._configured_extra_path_dirs(os.path.expanduser("~")) == (OK,)
+
+
+def test_tilde_is_expanded(monkeypatch):
+    _configure(monkeypatch, ["~/.deno/bin"])
+    home = os.path.expanduser("~")
+    assert env_mod._configured_extra_path_dirs(home) == (
+        os.path.normpath(os.path.join(home, ".deno", "bin")),
+    )
+
+
+def test_dollar_vars_are_not_expanded(monkeypatch):
+    """``$VAR`` must NOT expand -- that would reopen the env-var route this key
+    declines, letting a lower-trust parent process inject a directory."""
+    monkeypatch.setenv("EVIL_DIR", os.path.join("tmp", "evil"))
+    _configure(monkeypatch, [os.path.join("$EVIL_DIR", "bin")])
+    assert env_mod._configured_extra_path_dirs(os.path.expanduser("~")) == ()
+
+
+def test_duplicates_collapse(monkeypatch):
+    _configure(monkeypatch, [OK, OK, os.path.join(OK, ".", "")])
+    assert env_mod._configured_extra_path_dirs(os.path.expanduser("~")) == (OK,)
+
+
+def test_order_among_configured_entries_is_preserved(monkeypatch):
+    _configure(monkeypatch, [ONE, TWO])
+    entries = _entries(spec_env_path(""))
+    assert entries.index(ONE) < entries.index(TWO)
+
+
+# ── the message half of #3030 ─────────────────────────────────────────────────
+
+
+def test_describe_search_path_names_the_directories():
+    out = describe_search_path(BASE_PATH)
+    assert USR_BIN in out and BIN in out
+    assert "2" in out  # states how many were searched
+
+
+def test_describe_search_path_truncates_but_states_the_total():
+    limit = env_mod._SEARCH_PATH_REPORT_LIMIT
+    total = limit + 20
+    many = os.pathsep.join(_abs(f"d{i}") for i in range(total))
+    out = describe_search_path(many)
+    assert f"searched {total} directories" in out
+    assert f"+{total - limit} more" in out
+    assert _abs(f"d{total - 1}") not in out
+
+
+def test_describe_search_path_handles_empty():
+    assert "empty PATH" in describe_search_path("")
+
+
+def test_probe_error_points_at_the_remedy():
+    """The dashboard string must distinguish 'not installed' from 'not covered'."""
+    from kiro_crew.mcp_discovery import _unresolved_error
+
+    msg = _unresolved_error("vendor-mcp")
+    assert "command not found: vendor-mcp" in msg  # prefix preserved for callers
+    assert "agent.extra_path_dirs" in msg
+
+
+def test_probe_warning_lists_the_searched_directories(caplog):
+    from kiro_crew import mcp_discovery
+
+    mcp_discovery._unresolvable_warned.clear()
+    with caplog.at_level("WARNING"):
+        mcp_discovery._warn_unresolvable_once("srv", "ghost", BASE_PATH)
+    assert USR_BIN in caplog.text
+    assert "ghost" in caplog.text


### PR DESCRIPTION
## 1. What is the problem?

`_EXTRA_PATH_DIRS` in `src/kiro_crew/env.py` is a fixed six-entry tuple, and nothing exposed a way for a user to add to it. It feeds `augmented_path()`, the single executable search path shared by nine call sites, including the dashboard probe (`mcp_discovery.py`) and the agent config rebuild's command resolver (`agent.py`).

So a gateway that does not inherit a login shell's `PATH` -- systemd, launchd, or any detached launch -- cannot resolve an MCP binary installed in any other directory. The only workarounds were a symlink into one of the six directories or an absolute path in every server spec.

To be precise about the gap, since the issue's framing overstates it slightly: a spec-declared `env.PATH` (expanded by `spec_env_path`) *does* already make an out-of-list directory searchable for one server. What was missing is a setting that applies once instead of being repeated into every spec.

Separately, `command not found: <name>` never said what was searched, so a user could not tell "my install directory is not on the built-in list" from "my binary is not installed" -- two different problems with two different fixes, reported identically.

## 2. Why this issue matters to the user

Any install location outside those six is unreachable: `~/.deno/bin`, `~/.bun/bin`, `~/.cargo/bin`, `~/go/bin`, or a corporate-managed install root. The server shows as an error in the dashboard and is silently dropped from the generated agent config, with a message that does not say why.

Related but distinct: #2367 asks for the same capability from the macOS side, where the GUI `PATH` is not inherited at all. Its proposed fixes all sit in the Electron plane and do not help a headless install, so that issue keeps its own scope and is not closed by this.

## 3. How our fix solves it

`agent.extra_path_dirs`, a `list[str]` of `~`-expanding absolute directories, appended inside `spec_env_path()`.

**Resolution only.** The key decides which executable a bare command name binds to. It is never written into a launched server's `PATH`. That boundary is the load-bearing design decision, and it is forced by how this pipeline persists config: every file `emit_env` feeds is a read-modify-write source on the next rebuild -- `install_agent` loads the existing agent config to "preserve user customizations" (`agent.py:3001`), and `~/.kiro/settings/mcp.json` is written create-only and read back as `shared_mcp` (`agent.py:3055`). A value written into either is indistinguishable next time from one the user authored. So emitting a *revocable* setting there would make it *permanent*: clearing the config could not remove the directory, and it would return as a **declared** entry, which ranks first -- inverting the precedence property below. A test pins that clearing the key fully revokes.

**The consequence, disclosed rather than hidden:** a launcher in a configured directory that shells out to a *sibling* in that same directory still fails, because the child does not inherit the directory. That case has a supported answer today -- declare `env.PATH` on the spec -- and the config field's own description says so. Closing it properly needs provenance on emitted `PATH` values so a rebuild re-derives instead of re-consuming; that is a change to this pipeline, not to this key, and it is called out in section 5.

**Not `augmented_path()`.** That function also locates the ACP harness (`kiro_cli.known_kiro_cli_dirs`) and builds child environments for `acp/client`, `acp/runtime` and `browser_cli`. The config file is writable outside the file-edit gate, so a key added to find an MCP server binary must not decide which harness executable runs. Two tests assert configured directories never appear in `augmented_path()` or in the harness candidate list.

**Config key, no environment variable.** An env var is readable and writable by any lower-trust parent process. For the same reason entries expand `~` but not `$VAR` -- `expandvars` would reopen the env-var route through the back door. This matches the `agent.subagent_cwd_allowed_roots` precedent: config-file only, no settings UI.

**Entries rank last.** The reported gap is that the binary resolves *nowhere*, so last place already closes it -- and doing it this way makes the change a strict addition: no command name that resolves today can be rebound, so a user-writable directory cannot shadow a system binary. Granting override precedence is a separate trust decision this key does not settle.

**No `KiroCrewConfig.load()` on the resolution path.** That call validates the whole document against the JSON schema, builds the full dataclass tree, and can perform a write-back migration -- and `spec_env_path()` is reached from the asynchronous MCP probe, so it would put schema validation and a possible config *write* on the gateway event loop. `_raw_extra_path_dirs()` reads just that key, honouring the `config.local.json` overlay with the same precedence, and is cached once per process (the same discipline `_node_all_bin_dirs` already applies to the glob in `augmented_path()`). A missing, unreadable, or malformed value yields an empty tuple.

For the message half, `describe_search_path()` renders the searched directories for the probe warning and the `agent.py` drop path, which previously logged this only at DEBUG. The directories reported are the ones *actually* searched: `_resolve_command` returns the path it used, because a candidate declaring its own `env.PATH` is searched against a different path than one that does not.

## 4. What tests we did

New `test/test_extra_path_dirs.py`, 37 tests: the capability end-to-end through `shutil.which`; resolution-only (no emitted config carries the directories, an env-less spec stays env-less, clearing the key fully revokes); harness isolation asserted at both `augmented_path()` and `known_kiro_cli_dirs`; precedence (below the spec's own PATH, the inherited PATH, the built-ins, and last overall); empty/malformed config byte-identical to no key; the on-disk read including the local overlay, a malformed file, and a check that the read does not rewrite the config; entry validation (relative, empty, separator-smuggling, `NUL`, non-string); `~` expanded and `$VAR` not; dedup; order preservation; and the message sites.

Path fixtures are built through a helper and `os.pathsep` rather than POSIX literals -- on Windows `os.pathsep` is `;`, so a hardcoded `"/opt/a:/opt/b"` was not testing separator-smuggling at all.

Targeted runs green: the whole MCP-config-emission surface (`test_mcp_*`, `test_agent*`, `test_app_*`, `test_env`, `test_config_schema`, `test_config_loader`, `test_handlers_mcp_coverage`) -- 5076 passed, 29 skipped. `black` / `flake8` / `isort` / `mypy` clean on the touched files.

`test_config_schema.py` gained the `agent.extra_path_dirs` -> `array` row so the field cannot silently degrade to `"string"`.

## 5. Any other suggestions on the work

**Emitted `PATH` values have no provenance, and that is the real blocker for the child-PATH half.** Because the agent config and the global `mcp.json` are both read-modify-write sources, an expanded `PATH` written into either is treated as user-authored on the next rebuild. This is pre-existing and independently observable: a user who declares `env.PATH` today and later narrows it finds the old expansion still in effect. Until emitted values are marked so a rebuild re-derives them, no setting that widens the search path can safely be persisted. Worth its own issue, and it is the prerequisite for extending this key to the child's `PATH`.

**`config.json` is not write-protected on the shell path, and a comment says it is.** `config.json` and `config.local.json` are in `_WRITE_PROTECTED_HOME_PATHS` (so the file-edit tool is gated) but absent from `_WRITE_PROTECTED_BASH_LEAVES`, and a probe confirms `is_sensitive_bash_command` allows a shell redirect into the crew `config.json` while correctly denying the paired `playwright-cli-config.json`. The comment at `hooks.py:587` asserts the opposite. This PR does not depend on closing that gap -- the key is resolution-only and reaches nothing the config file could not already reach -- but it is why the harness-isolation property above is asserted by test rather than argued from the gate.

**`config-baseline.json` is deliberately not regenerated.** Its test generates into a `tmp_path` and asserts the file was created; it never compares against the checked-in copy. Regenerating showed that copy is already stale by roughly 40 fields from earlier merges (`acp_backend`, `tool_search_min_pct`, the `sandbox` default, others), so refreshing it here would bury a one-field change under ~940 lines of unrelated drift.

Closes #3030
