### PR TITLE
fix(atomic-write): refuse a redirected parent for secret writes

### DIFF
--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -232,6 +232,187 @@ def read_bytes_with_retry(path: Path | str) -> bytes:
     return target.read_bytes()
 
 
+def _resolved_or_none(path: Path) -> Path | None:
+    """``path.resolve()``, or ``None`` when the platform cannot resolve it.
+
+    A symlink loop or a vanished component ends here. Both exception types are
+    caught on purpose: ``Path.resolve()`` raises ``OSError`` for most failures,
+    but on Python 3.10 a symlink LOOP raises ``RuntimeError`` instead (pathlib
+    only moved that path onto ``os.path.realpath`` in 3.11), and this repo still
+    supports 3.10. Letting that escape would crash the caller -- a Discord
+    resume write, a token store -- where the whole point of this helper is to
+    turn "cannot prove where the write lands" into a refusal.
+
+    Callers treat ``None`` as "cannot prove", which is a refusal on the write
+    path rather than a pass.
+    """
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def _owned_roots() -> tuple[Path, ...]:
+    """The directory roots Kiro Crew itself creates and owns.
+
+    Resolution goes through ``config.paths`` lazily: importing it at module scope
+    would tie this leaf helper to the config package, and calling it at import
+    time would resolve the data home as a side effect of importing a writer.
+    Every entry is best-effort -- a host where one cannot be resolved simply
+    contributes no anchor rather than failing the write. ``kiro_home()`` resolves
+    its override, so it can raise the same ``RuntimeError`` a looped link gives
+    :func:`_resolved_or_none`.
+
+    ``data_home()`` performs start-of-process maintenance (a ``mkdir``, and a
+    recovery-breadcrumb refresh) on the FIRST resolution in a process, so a
+    secret write before ``ensure_data_home()`` can trigger it from here. The
+    ``mkdir`` is subsumed by this write's own ``path.parent.mkdir`` a few lines
+    later; the breadcrumb is a stat plus one small write, once per process.
+    """
+    from kiro_crew.config import paths as config_paths
+
+    roots: list[Path] = []
+    for resolver in (config_paths.data_home, config_paths.legacy_home, config_paths.kiro_home):
+        try:
+            roots.append(Path(resolver()))
+        except (OSError, RuntimeError, ValueError):  # pragma: no cover - defensive
+            continue
+    return tuple(roots)
+
+
+def _link_trust_anchor(parent: Path) -> tuple[Path, tuple[str, ...]] | None:
+    """Split *parent* into (anchor, the names below it), or ``None``.
+
+    The anchor is where "a link here is not ours" starts being true. At or ABOVE
+    it a link is the operator's own deployment choice and must keep working: a
+    symlinked ``$HOME`` (``/home/u -> /local/home/u``) or a data home relocated
+    onto another disk are both supported, and ``config/loader.py`` documents a
+    symlinked ``config.json`` as a normal setup. BELOW the anchor every
+    directory is created by Kiro Crew's own ``mkdir`` calls, so a link there was
+    planted by something else.
+
+    The anchor comes back in *parent*'s own LEXICAL namespace together with the
+    names below it, so ``anchor.joinpath(*names) == parent``. An anchor handed
+    back in the resolved namespace instead would let a link BELOW it satisfy an
+    anchor comparison merely by pointing at the anchor, which is the shape that
+    slipped through the first version of this guard.
+
+    The SHALLOWEST matching depth wins, so a component that maps onto an owned
+    root while a real owned root sits above it in the same chain cannot claim to
+    be the anchor and hide itself from the walk.
+
+    Containment is tried lexically FIRST and only then against the resolved
+    parent. Order matters: for a path lexically inside an owned tree the lexical
+    reading is the truthful one, while its resolved form may have been bent
+    elsewhere by exactly the link this guard looks for. The resolved attempt
+    exists for the other case, a caller naming the tree through an outside alias
+    such as a data home reached by its symlink.
+    """
+    roots = _owned_roots()
+    if not roots:
+        return None
+    lexical = parent if parent.is_absolute() else Path(os.path.abspath(parent))
+    resolved = _resolved_or_none(lexical)
+    for candidate in (lexical, resolved):
+        if candidate is None:
+            continue
+        best: int | None = None
+        for root in roots:
+            if candidate == root or root in candidate.parents:
+                depth = len(candidate.parts) - len(root.parts)
+                if best is None or depth < best:
+                    best = depth
+        if best is None:
+            continue
+        names = lexical.parts[len(lexical.parts) - best :] if best else ()
+        anchor = lexical.parents[best - 1] if best else lexical
+        return anchor, names
+    return None
+
+
+def _refuse_linked_parent(path: Path) -> None:
+    """Refuse to write a secret whose parent chain passes through a link.
+
+    ``mkdir(parents=True)``, ``mkstemp(dir=...)`` and ``os.replace`` all follow
+    every component except the final one, so a symlink (or Windows junction)
+    pre-planted at the destination's parent — or at any ancestor below the
+    trust anchor — silently redirects the whole write: the secret lands under
+    whatever the link points at, outside the sensitive-path fence that is the
+    only real boundary against a same-UID reader, and the caller sees success.
+    Issue #4381 is the class report; a per-caller check was rejected there as
+    whack-a-mole, so the refusal lives in the one helper every secret write
+    already goes through.
+
+    Two checks, because neither alone is sufficient:
+
+    * an ``lstat`` walk over the components BELOW the anchor, which is the only
+      thing that sees a Windows junction (``is_link_or_junction``, since
+      ``islink`` reports False for one);
+    * and the resolved parent must EQUAL the path rebuilt from the resolved
+      anchor and those same names. Containment would not do: a link pointing at
+      another directory INSIDE the owned tree resolves to a contained path and
+      would pass while still landing the secret somewhere the caller never
+      named. Equality also covers a redirect the walk cannot see, such as a
+      reparse point a platform's ``realpath`` follows but ``islink`` misses.
+
+    Only the parent CHAIN is checked. A link at the leaf is not a redirect:
+    ``os.replace`` does not follow the final component, so it replaces the link
+    itself with the new file (verified — the link's target keeps its old
+    contents), which is the same outcome as writing over a regular file.
+
+    lstat-based, so it is not race-free: a link planted between this check and
+    the ``mkstemp`` below still wins. Closing that would need an ``O_NOFOLLOW``
+    descent with a directory handle per component, which ``tempfile`` cannot be
+    driven through. ``memory.py``'s lock-path check states the same limitation
+    for the same reason; refusing a link that is ALREADY there removes the
+    pre-planting shape the report is about, which is the shape an attacker can
+    set up at leisure.
+    """
+    parent = path.parent
+    split = _link_trust_anchor(parent)
+    if split is None:
+        # Outside every directory Kiro Crew creates, a link is indistinguishable
+        # from the operator's own layout, so the walk stops at the first
+        # ancestor that ALREADY exists: everything below that is a directory
+        # this write would create itself, so a link there cannot be ours, while
+        # everything above it is pre-existing layout we do not get to judge (a
+        # symlinked ``/tmp`` on macOS is exactly that).
+        for component in (parent, *parent.parents):
+            _refuse_if_link(path, component)
+            if component.exists():
+                return
+        return
+    anchor, names = split
+    current = anchor
+    for name in names:
+        current = current / name
+        _refuse_if_link(path, current)
+    anchor_resolved = _resolved_or_none(anchor)
+    resolved_parent = _resolved_or_none(parent)
+    if anchor_resolved is None or resolved_parent is None:
+        raise OSError(
+            f"refusing to write {path}: its parent chain cannot be resolved, so "
+            "the write cannot be shown to land where it was named."
+        )
+    expected = anchor_resolved.joinpath(*names)
+    if resolved_parent != expected:
+        raise OSError(
+            f"refusing to write {path}: its parent resolves to {resolved_parent} "
+            f"rather than {expected}, so the write would land somewhere it was "
+            "not named. Replace the redirecting link with a real directory."
+        )
+
+
+def _refuse_if_link(path: Path, component: Path) -> None:
+    """Raise when *component* of *path*'s parent chain is a link or junction."""
+    if platform_compat.is_link_or_junction(component):
+        raise OSError(
+            f"refusing to write {path}: its parent {component} is a symlink or "
+            "junction, so the write would land at the link's target instead. "
+            "Replace the link with a real directory."
+        )
+
+
 def atomic_write(
     path: Path | str,
     content: str | bytes,
@@ -274,7 +455,10 @@ def atomic_write(
     the secret never exists in a world-readable file. It also implies
     ``0o600`` on POSIX, hence the conflict check below: passing a wider
     explicit *mode* alongside it is a caller bug, and narrowing it silently
-    would hide that.
+    would hide that. It further implies :func:`_refuse_linked_parent`: a secret
+    writer must never follow a link, because a pre-planted parent symlink or
+    junction redirects the whole write to a location the caller never named
+    (issue #4381).
 
     *restrict_on_error* selects what happens when that lockdown fails, and only
     means anything alongside ``restrict_to_owner=True``. The default ``"raise"``
@@ -308,6 +492,11 @@ def atomic_write(
     # default after the lockdown has been applied.
     effective_mode = 0o600 if restrict_to_owner else mode
     path = Path(path)
+    if restrict_to_owner:
+        # Before the mkdir: mkdir(parents=True) walks THROUGH a planted link and
+        # would create the missing directories under its target, so checking
+        # after it would find a tree the write itself had already built.
+        _refuse_linked_parent(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
     try:

--- a/test/test_atomic_write_parent_link.py
+++ b/test/test_atomic_write_parent_link.py
@@ -1,0 +1,429 @@
+"""Tests for ``atomic_write``'s parent link/junction refusal (issue #4381).
+
+``mkdir(parents=True)``, ``mkstemp(dir=...)`` and ``os.replace`` follow every
+path component except the final one, so a symlink pre-planted at a secret's
+parent directory redirects the whole write to the link's target while the caller
+sees success. The refusal lives in the shared helper because every
+``restrict_to_owner=True`` caller has the same exposure, and patching them one at
+a time is the whack-a-mole shape the issue rejects.
+
+What must NOT be refused is as load-bearing as what must: a symlinked ``$HOME``
+and a data home relocated onto another disk are supported layouts, and a link at
+or above the trust anchor is the operator's own choice.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kiro_crew import atomic_write as aw
+
+SECRET = "sk-live-DEADBEEF"
+
+# Windows symlink creation needs a privilege the CI account does not have (a
+# junction is the Windows shape, and only for directories); the guard's Windows
+# arm rides on platform_compat.is_link_or_junction, which has its own coverage.
+requires_symlinks = pytest.mark.skipif(
+    not hasattr(os, "symlink") or os.name == "nt",
+    reason="planting a directory symlink requires privileges this platform may withhold",
+)
+
+
+@pytest.fixture
+def owned_home(tmp_path, monkeypatch):
+    """A Kiro Crew data home under *tmp_path*, so the walk has a trust anchor."""
+    home = tmp_path / "datahome"
+    home.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    return home
+
+
+@requires_symlinks
+def test_secret_write_refuses_a_linked_parent(owned_home, tmp_path):
+    """The reported shape: the parent directory is a pre-planted link."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "state")
+
+    with pytest.raises(OSError, match="symlink or junction"):
+        aw.atomic_write(owned_home / "state" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (elsewhere / "token").exists(), "the secret must not land at the link's target"
+
+
+@requires_symlinks
+def test_secret_write_refuses_a_linked_ancestor(owned_home, tmp_path):
+    """A link ABOVE a not-yet-existing parent is the same redirect.
+
+    ``mkdir(parents=True)`` would walk through the link and build the missing
+    directories under its target, so the check has to run before the mkdir and
+    has to look past the immediate parent.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "state")
+
+    with pytest.raises(OSError, match="symlink or junction"):
+        aw.atomic_write(owned_home / "state" / "deep" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (elsewhere / "deep").exists(), "no directory tree may be built under the target"
+
+
+@requires_symlinks
+def test_refusal_names_the_linked_component(owned_home, tmp_path):
+    """The message must name the LINK, not just the destination.
+
+    An operator reading the error has to know which directory to replace, and
+    the destination path alone does not say which component of the chain is the
+    link. The assertion names the component as the subject of the sentence
+    because the destination string contains the link's path as a prefix — a
+    plain substring check would pass even if the component were dropped.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    link = owned_home / "vaults"
+    os.symlink(elsewhere, link)
+
+    with pytest.raises(OSError) as excinfo:
+        aw.atomic_write(link / "sub" / "pat", SECRET, restrict_to_owner=True)
+
+    assert f"{link} is a symlink" in str(excinfo.value)
+
+
+@requires_symlinks
+def test_secret_write_allows_a_symlinked_data_home(tmp_path, monkeypatch):
+    """A data home relocated onto another disk IS a link at the anchor."""
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    linked_home = tmp_path / "datahome"
+    os.symlink(real, linked_home)
+    monkeypatch.setenv("KIROCREW_HOME", str(linked_home))
+
+    target = linked_home / "token"
+    aw.atomic_write(target, SECRET, restrict_to_owner=True)
+
+    assert target.read_text() == SECRET
+
+
+@requires_symlinks
+def test_secret_write_allows_real_subdirs_under_a_symlinked_data_home(tmp_path, monkeypatch):
+    """Only the LINK components matter: real directories below one still write."""
+    real = tmp_path / "elsewhere"
+    (real / "sub").mkdir(parents=True)
+    linked_home = tmp_path / "datahome"
+    os.symlink(real, linked_home)
+    monkeypatch.setenv("KIROCREW_HOME", str(linked_home))
+
+    target = linked_home / "sub" / "token"
+    aw.atomic_write(target, SECRET, restrict_to_owner=True)
+
+    assert target.read_text() == SECRET
+
+
+@requires_symlinks
+def test_non_secret_write_is_unaffected(owned_home, tmp_path):
+    """The guard is scoped to secret writes.
+
+    Widening it to every ``atomic_write`` would change the behaviour of every
+    non-secret persistence site in the repo, which is not what the report is
+    about and is not something a bug fix gets to do.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "state")
+
+    aw.atomic_write(owned_home / "state" / "notes.json", "{}")
+
+    assert (elsewhere / "notes.json").read_text() == "{}"
+
+
+@requires_symlinks
+def test_leaf_link_is_replaced_not_followed(owned_home, tmp_path):
+    """A link at the LEAF is not a redirect, so it must not be refused.
+
+    ``os.replace`` does not follow the final component: it swaps the link itself
+    for the new file, leaving the link's target untouched. Refusing here would
+    reject a write that is already safe.
+    """
+    victim = tmp_path / "elsewhere" / "victim"
+    victim.parent.mkdir()
+    victim.write_text("original")
+    state = owned_home / "state"
+    state.mkdir()
+    os.symlink(victim, state / "token")
+
+    aw.atomic_write(state / "token", SECRET, restrict_to_owner=True)
+
+    assert victim.read_text() == "original", "the link's target must not be overwritten"
+    assert (state / "token").read_text() == SECRET
+    assert not (state / "token").is_symlink()
+
+
+@requires_symlinks
+def test_binary_secret_payload_is_guarded_too(owned_home, tmp_path):
+    """The guard sits ahead of the text/bytes split, so both payloads get it."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "keys")
+
+    with pytest.raises(OSError, match="symlink or junction"):
+        aw.atomic_write(owned_home / "keys" / "hmac", b"\x00\x01\x02", restrict_to_owner=True)
+
+    assert not (elsewhere / "hmac").exists()
+
+
+@requires_symlinks
+def test_warn_policy_does_not_downgrade_the_refusal(owned_home, tmp_path):
+    """``restrict_on_error="warn"`` is about a failed lockdown, not a redirect.
+
+    Two callers pass it because losing their state file is worse than a file
+    another local user can read. Neither accepts writing the secret to a
+    directory it did not name, so the refusal must still raise here — and the
+    callers that swallow ``OSError`` then skip the write, which is fail-closed.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "state")
+
+    with pytest.raises(OSError, match="symlink or junction"):
+        aw.atomic_write(
+            owned_home / "state" / "refresh.json",
+            "{}",
+            restrict_to_owner=True,
+            restrict_on_error="warn",
+        )
+
+    assert not (elsewhere / "refresh.json").exists()
+
+
+@requires_symlinks
+def test_outside_owned_roots_still_refuses_the_planted_chain(tmp_path, monkeypatch):
+    """A destination outside every Kiro Crew root keeps a best-effort check.
+
+    There the walk stops at the first ancestor that already exists, because
+    everything below that is a directory the write would create itself. A link
+    planted at that boundary is still caught.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "datahome"))
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, outside / "state")
+
+    with pytest.raises(OSError, match="symlink or junction"):
+        aw.atomic_write(outside / "state" / "deep" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (elsewhere / "deep").exists()
+
+
+@requires_symlinks
+def test_secret_write_refuses_a_link_pointing_back_into_the_owned_tree(owned_home):
+    """An in-tree alias must be refused, not waved through as "contained".
+
+    A link planted below the anchor whose target is the anchor itself resolves to
+    a path trivially inside the owned tree, so a containment-style check passes
+    it. The write still lands somewhere the caller never named -- at the anchor
+    root, under the leaf's own name, where it can clobber a same-named file.
+    """
+    os.symlink(owned_home, owned_home / "state")
+
+    with pytest.raises(OSError):
+        aw.atomic_write(owned_home / "state" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (owned_home / "token").exists(), "the secret must not land at the anchor root"
+
+
+@requires_symlinks
+def test_secret_write_refuses_an_in_tree_alias_shadowing_a_deeper_link(owned_home, tmp_path):
+    """The refusal must not short-circuit the rest of the chain.
+
+    ``inner`` redirects out of the tree and ``alias`` points back at the anchor.
+    A guard that stopped walking as soon as a component resolved onto the anchor
+    would inspect neither, so both are planted here to pin that every component
+    below the anchor is judged.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "inner")
+    os.symlink(owned_home, owned_home / "alias")
+
+    with pytest.raises(OSError):
+        aw.atomic_write(owned_home / "alias" / "inner" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (elsewhere / "token").exists()
+
+
+@requires_symlinks
+def test_redirect_is_refused_even_when_link_detection_misses_it(owned_home, tmp_path, monkeypatch):
+    """The resolved-path check must stand on its own.
+
+    ``is_link_or_junction`` is the only thing that sees a Windows junction, but a
+    reparse point a platform's ``realpath`` follows while ``islink`` reports
+    False would slip past it. Detection is stubbed out here to leave exactly that
+    gap: the write must still be refused because the parent resolves somewhere
+    other than the path it was named.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    os.symlink(elsewhere, owned_home / "state")
+    monkeypatch.setattr(aw.platform_compat, "is_link_or_junction", lambda _path: False)
+
+    with pytest.raises(OSError, match="rather than"):
+        aw.atomic_write(owned_home / "state" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (elsewhere / "token").exists()
+
+
+def test_unresolvable_parent_chain_is_refused(owned_home, monkeypatch):
+    """Fail closed: a chain that cannot be resolved is not a chain we trust.
+
+    Resolution can fail (a symlink loop, a component vanishing mid-walk). The
+    guard cannot show the write lands where it was named, and a secret write is
+    the wrong place to assume the best.
+    """
+    monkeypatch.setattr(aw, "_resolved_or_none", lambda _path: None)
+
+    with pytest.raises(OSError, match="cannot be resolved"):
+        aw.atomic_write(owned_home / "sub" / "token", SECRET, restrict_to_owner=True)
+
+
+@requires_symlinks
+def test_anchor_split_names_the_shallowest_owned_root(owned_home):
+    """The split must not let a component nominate itself as the anchor.
+
+    ``alias`` resolves onto the data home, so it maps to an owned root at depth
+    zero while the real root sits above it in the same chain. If the split
+    returned that component as the anchor, the names below it would be empty and
+    the walk would inspect nothing -- so the shallowest depth has to win, and
+    the anchor has to come back in the caller's own lexical namespace.
+    """
+    os.symlink(owned_home, owned_home / "alias")
+
+    anchor, names = aw._link_trust_anchor(owned_home / "alias")
+
+    assert names == ("alias",)
+    assert anchor.joinpath(*names) == owned_home / "alias"
+
+
+@requires_symlinks
+def test_in_tree_redirect_is_refused_not_accepted_as_contained(owned_home, monkeypatch):
+    """Containment is not the test -- being where you were named is.
+
+    ``state`` points at a sibling directory INSIDE the owned tree, so the write
+    still lands under the data home and any containment check passes it. The
+    secret is nonetheless in a directory the caller never named, where it can
+    clobber a same-named file. Detection is stubbed out so the resolved-path
+    comparison is the only thing left to answer.
+    """
+    (owned_home / "other").mkdir()
+    os.symlink(owned_home / "other", owned_home / "state")
+    monkeypatch.setattr(aw.platform_compat, "is_link_or_junction", lambda _path: False)
+
+    with pytest.raises(OSError, match="rather than"):
+        aw.atomic_write(owned_home / "state" / "token", SECRET, restrict_to_owner=True)
+
+    assert not (owned_home / "other" / "token").exists()
+
+
+@requires_symlinks
+def test_relocated_data_home_under_the_kiro_home_still_writes(tmp_path, monkeypatch):
+    """The most specific owned root has to win, or relocation breaks.
+
+    The default layout nests two owned roots: the data home ``~/.kiro/crew``
+    sits inside the kiro home ``~/.kiro``. Relocating the data home onto another
+    disk makes ``crew`` itself a link. Anchoring on the OUTER root would put that
+    link below the anchor and refuse a supported layout, so the anchor must be
+    the innermost root containing the destination.
+
+    ``config.paths`` memoises the resolved default home per process, so the
+    caches are cleared alongside ``$HOME`` -- otherwise this test would read
+    whichever home the process resolved first.
+    """
+    from kiro_crew.config import paths as config_paths
+
+    relocated = tmp_path / "another-disk"
+    relocated.mkdir()
+    home = tmp_path / "home"
+    (home / ".kiro").mkdir(parents=True)
+    os.symlink(relocated, home / ".kiro" / "crew")
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(config_paths, "_resolved_home", None)
+    monkeypatch.setattr(config_paths, "_config_dir_memo", None)
+
+    target = home / ".kiro" / "crew" / "sub" / "token"
+    aw.atomic_write(target, SECRET, restrict_to_owner=True)
+
+    assert target.read_text() == SECRET
+    assert (relocated / "sub" / "token").read_text() == SECRET
+
+
+@requires_symlinks
+def test_symlink_loop_is_refused_not_raised_through(owned_home, monkeypatch):
+    """A looped parent must produce the refusal, never the resolver's own error.
+
+    ``Path.resolve()`` reports a symlink loop differently by version: an
+    ``OSError`` on the versions that delegate to ``os.path.realpath``, and a
+    ``RuntimeError`` on Python 3.10, which this repo still supports. Either one
+    escaping would crash the caller instead of refusing the write, and callers
+    that swallow ``OSError`` around their secret write (the refresh-token store,
+    the Discord resume store) would turn a crash into a lost interaction.
+    Detection is stubbed out so the loop reaches the resolver at all.
+    """
+    (owned_home / "a").symlink_to(owned_home / "b")
+    (owned_home / "b").symlink_to(owned_home / "a")
+    monkeypatch.setattr(aw.platform_compat, "is_link_or_junction", lambda _path: False)
+
+    with pytest.raises(OSError):
+        aw.atomic_write(owned_home / "a" / "token", SECRET, restrict_to_owner=True)
+
+
+def test_resolver_turns_a_runtime_error_into_cannot_prove(owned_home, monkeypatch):
+    """Pin the 3.10 loop error explicitly, on every version.
+
+    The test above exercises whichever error the host's ``pathlib`` raises, so on
+    a 3.11+ host it never reaches the ``RuntimeError`` arm. Asserting on the
+    wrapper keeps that arm covered everywhere: it has to report "cannot prove"
+    (``None``), which the guard turns into a refusal, rather than letting the
+    error escape into the caller's secret write.
+    """
+
+    def _boom(self, *args, **kwargs):
+        raise RuntimeError(f"Symlink loop from {self!r}")
+
+    monkeypatch.setattr(aw.Path, "resolve", _boom)
+
+    assert aw._resolved_or_none(owned_home / "sub") is None
+
+
+def test_a_resolver_that_raises_contributes_no_anchor(owned_home, monkeypatch):
+    """A broken root resolver must cost an anchor, never the write.
+
+    ``kiro_home()`` resolves its override, so a looped or hostile ``KIRO_HOME``
+    can raise from inside root collection -- on 3.10 as ``RuntimeError``. The
+    roots are best-effort by design: a resolver that cannot answer drops out and
+    the remaining ones still anchor the walk.
+    """
+    from kiro_crew.config import paths as config_paths
+
+    def _boom():
+        raise RuntimeError("Symlink loop from KIRO_HOME")
+
+    monkeypatch.setattr(config_paths, "kiro_home", _boom)
+    target = owned_home / "sub" / "token"
+
+    aw.atomic_write(target, SECRET, restrict_to_owner=True)
+
+    assert target.read_text() == SECRET
+
+
+def test_plain_secret_write_under_the_data_home_still_works(owned_home):
+    """The guard must not cost the ordinary case anything."""
+    target = owned_home / "sub" / "token"
+
+    aw.atomic_write(target, SECRET, restrict_to_owner=True)
+
+    assert target.read_text() == SECRET


### PR DESCRIPTION
## What is the problem?

`kiro_crew.atomic_write.atomic_write` is the repo's canonical secret writer -- nine production call sites pass `restrict_to_owner=True`. It runs `path.parent.mkdir(parents=True, exist_ok=True)`, then `tempfile.mkstemp(dir=path.parent)`, then `os.replace`, and none of those three follow-safe the parent chain. A symlink (or Windows junction) pre-planted at the destination's parent, or at any ancestor of it, silently redirects the whole write: the secret lands under whatever the link points at and the caller sees success.

Reproduced on unmodified main before any change, in both shapes:

```
A parent-is-link      -> redirected: True | content: sk-live-DEADBEEF
B ancestor-is-link    -> redirected: True | content: sk-live-DEADBEEF   (mkdir walked THROUGH the link)
C leaf-is-link        -> victim overwritten: False                      (a leaf link is not a redirect)
```

GPT 5.6 first raised this on PR #2190 against one caller, where it was rebutted for that caller because both agent write channels to that path are already gated. The class is wider: every `restrict_to_owner=True` site has the same exposure and most of their parent directories are not on the sensitive-path denylist. The issue rejected per-caller patching as whack-a-mole.

## Why this issue matters to the user

The 0600 bits are only half of what protects a secret file. The other half is that it lands in the directory the caller named, inside the sensitive-path fence that is the only real boundary against a same-UID reader. A redirected write puts credentials, HMAC keys, tokens and refresh-token reuse state at an attacker-chosen location outside that fence, with no error anywhere. The planting is something an attacker can set up at leisure, long before the write happens.

## How our fix solves it

Symptom: a secret written through a planted parent link lands at the link's target. Root cause: the three primitives above follow every component except the final one, and the helper never checked the chain. So `atomic_write` now calls `_refuse_linked_parent` when `restrict_to_owner=True`, before the `mkdir` -- after it would be too late, since `mkdir(parents=True)` walks through the link and builds the missing directories under its target.

The guard splits the parent at the **innermost** KiroCrew-owned root containing it (`config.paths.data_home` / `legacy_home` / `kiro_home`), and the anchor is returned in the caller's own lexical namespace together with the names below it:

- **At or above the anchor**, a link is the operator's own layout and still writes: a data home relocated onto another disk, a symlinked `$HOME`, a symlinked `config.json` are all supported setups. The innermost root matters here, because the default layout nests two owned roots (`~/.kiro/crew` inside `~/.kiro`) and anchoring on the outer one would put a relocated `crew` link below the anchor and refuse it.
- **Below the anchor**, every directory is one KiroCrew's own `mkdir` creates, so a link there was planted by something else.
- **Outside every owned root**, the walk stops at the first ancestor that already exists, because everything below that is a directory this write would create itself, while pre-existing layout above it (a symlinked `/tmp` on macOS) is not ours to judge.

Two checks then run, because neither is sufficient alone:

1. an `lstat` walk over the components below the anchor via `platform_compat.is_link_or_junction` -- the only thing that sees a Windows junction, which `os.path.islink` reports as False;
2. the parent must **resolve to exactly** the path rebuilt from the resolved anchor and those same names. Containment would not do: a link aimed at another directory *inside* the owned tree resolves to a contained path and passes any containment test, while still landing the secret in a directory the caller never named, where it can clobber a same-named file. Equality also covers a redirect the walk cannot see, such as a reparse point a platform's `realpath` follows but `islink` misses.

A first revision of this patch anchored the walk on resolved-path equality and broke out of the loop before the link check. A pre-push security review caught that a link pointing back at the anchor then satisfied the break, so it was never link-checked and the rest of the chain was never walked. That is why the anchor is now lexical and the two checks are separate; both shapes are pinned by tests.

Resolution failures fail closed rather than escaping. `Path.resolve()` reports a symlink loop as `OSError` on the versions that delegate to `os.path.realpath` but as `RuntimeError` on Python 3.10, which this repo still supports, so both are caught: a looped parent produces the refusal instead of a `RuntimeError` surfacing inside a caller's secret write. The same applies to root collection, where `kiro_home()` resolves its own override -- a resolver that cannot answer drops out of the anchor set instead of failing the write.

Only the parent chain is checked. A leaf link is not a redirect: `os.replace` does not follow the final component, so it swaps the link itself for the new file and the link's target keeps its old contents. The check is lstat-based and so not race-free -- a link planted between the check and the `mkstemp` still wins, and closing that would need an `O_NOFOLLOW` per-component descent that `tempfile` cannot be driven through. `memory.py`'s lock-path check states the same limitation for the same reason. Refusing a link that is already there removes the pre-planting shape the report is about. Non-secret writes are untouched.

`restrict_on_error="warn"` cannot downgrade this: the refusal raises before `mkstemp`, so the two callers that pass `warn` (`refresh_tokens.py`, `md_notebook/server.py`) skip the write through their own `except OSError` rather than redirect a secret.

## What tests we did

`test/test_atomic_write_parent_link.py` (new, 21 tests), one behaviour each:

- the reported shape (linked parent) and a link above a not-yet-created parent, both refused with nothing created under the target;
- an in-tree alias pointing back at the anchor, and an alias shadowing a deeper out-of-tree link, both refused (the shapes the first revision let through);
- an in-tree redirect to a sibling directory refused with link detection stubbed out, pinning equality rather than containment;
- a redirect refused when `is_link_or_junction` is stubbed to miss it, pinning the resolved-path check on its own;
- a symlink loop refused, the resolver wrapper turning a `RuntimeError` into "cannot prove", and a root resolver that raises dropping out of the anchor set rather than failing the write;
- an unresolvable chain refused, so the guard fails closed;
- a relocated data home under the kiro home still writes, pinning the innermost-root anchor;
- a symlinked data home and real subdirectories below it still write;
- a leaf link replaced with its target untouched; the guard applied to bytes payloads; `restrict_on_error="warn"` still refusing; non-secret writes unaffected; the ordinary write unaffected.

Mutation-verified: 12 mutants, all caught -- guard not called, guard moved after the `mkdir`, walk removed, equality check disabled, equality relaxed to containment, candidate order swapped, outermost root chosen as anchor, fail-closed branch removed, no-anchor walk stripped of its link check, both `RuntimeError` catches narrowed back to `OSError`, and the message dropping the component name. An A/B against the first revision confirms it fails the two alias tests that the current one passes.

Caller-side suites (`browser_cli/token`, `refresh_tokens`, `secrets_vault`, `webhooks_store`, `mcp_gateway_prewarm`, `md_notebook`) and the atomic-write suites pass -- 401 tests over the run before the last two review rounds. `black` (repo baselined gate), `isort`, `flake8`, the brand-name gate and `mypy` are clean on the touched files. Symlink-planting tests skip on Windows, where creating a directory symlink needs a privilege CI lacks.

## Any other suggestions on the work

Scope correction, since the issue's framing invites over-reading this: the refusal closes the exposure for every writer that goes THROUGH `atomic_write`, which is the nine `restrict_to_owner=True` sites. It does not close the class. At least seven hand-rolled secret writers still do their own `mkdir` plus `mkstemp` and never enter the helper, so they keep the exact exposure -- `sel.py` (the HMAC key), `dashboard/token_auth.py`, `dashboard/token_secret.py`, `beacon.py`, `apps/install_receipt.py`, `mcp_gateway/rewriter.py` (the env sidecar holding API keys), `dashboard/handlers/messaging.py`, `dashboard/handlers_system.py`. Migrating them onto the chokepoint is a larger change than this one and belongs in its own issue; naming them here so the gap is on the record rather than implied to be fixed.

One behaviour change worth stating plainly: an operator who relocates a single directory *below* the data home onto another disk with a symlink (say a large state directory) will now get a hard `OSError` on secret writes into that subtree. That is the line the issue asked for, and the message names the offending component so it is actionable, but it is a real change and not only a hardening.

`_owned_roots` also lists `legacy_home` and `kiro_home` even though the nine current callers all land under the data home. That breadth only ever tightens the check below those roots, and it is what makes the innermost-root rule meaningful on a legacy-layout install, so it stays.

Closing the remaining race would need `atomic_write` to stop using `tempfile.mkstemp` and descend with `O_NOFOLLOW` directory handles instead. That is a bigger change to the writer's shape than this fix, and worth its own issue if the pre-planting refusal proves insufficient.

Closes #4381
