### PR TITLE
fix(security): stop a name-based auto-approve from honouring a shadowed program name

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from kiro_crew import mcp_apps_render, model_registry, session_directive
+from kiro_crew import mcp_apps_render, model_registry, platform_compat, session_directive
 from kiro_crew.acp.client import (
     AcpAuthRequired,
     AcpError,
@@ -199,6 +199,7 @@ from kiro_crew.messaging.link import (
 from kiro_crew.messaging.renderer import chunk_for_transport
 from kiro_crew.metrics.events import TURN_TIMEOUT_CAUSE, emit_counter
 from kiro_crew.metrics.provider import get_recorder
+from kiro_crew.name_grant import Refusal, name_grant_refusal, pin_human_approval
 from kiro_crew.platform import redact_via_context
 from kiro_crew.providers.acp import is_claude_backend
 from kiro_crew.providers.base import (
@@ -2233,6 +2234,87 @@ def _session_principal(session_key: str) -> str:
     if parsed is None or parsed.chat_type != CHAT_TYPE_DIRECT or len(parsed.scope) != 1:
         return ""
     return parsed.scope[0]
+
+
+async def _name_grant_refusal_off_loop(command: str) -> Refusal | None:
+    """The ONE place this module's tiers reach the name-grant check.
+
+    It resolves names against ``PATH`` and digests the file behind each one, so
+    it runs on a worker thread: the gateway's loop must not stat a stalled
+    network mount or read a large binary. Every tier goes through here rather
+    than calling ``asyncio.to_thread`` itself, so there is a single place to
+    reason about (and, for the rung tests, a single place to stub -- three tiers
+    each spawning their own thread is what crashed the Windows xdist workers).
+
+    Windows is answered ON the loop, because there the verdict needs no
+    filesystem access at all: the check declines every name-based grant outright
+    (neither ``cmd.exe`` search order nor POSIX-mode tokenization is modelled),
+    so the thread would do nothing but hand back a constant. Paying a hop for it
+    is not merely waste -- the worker can outlive a caller's event loop, which is
+    what crashes an xdist worker rather than merely failing its test.
+    """
+
+    if not command:
+        return None
+    if platform_compat.IS_WINDOWS:
+        return name_grant_refusal(command)
+    return await asyncio.to_thread(name_grant_refusal, command)
+
+
+async def _name_grant_refusal_for(event: object) -> Refusal | None:
+    """Why a shell *event* may not be auto-approved by program NAME, or ``None``.
+
+    Every auto-approve tier is a statement about a PROGRAM, and the shell
+    resolves the name itself afterwards through a ``PATH`` that legitimately
+    leads with directories the agent can write.
+
+    This lives here rather than inside ``HookManager.on_tool_call``, which is
+    synchronous and called ON the loop. The hook layer decides its own tiers and
+    this downgrades an auto-approve it granted, so a refusal costs one
+    interactive prompt and never blocks.
+
+    ``None`` for a non-shell tool or an unrecoverable command: there is no
+    program name to vouch for, and those tiers are unchanged.
+    """
+
+    if not getattr(event, "is_shell", False):
+        return None
+    command = getattr(event, "shell_command", None)
+    if not command:
+        return None
+    return await _name_grant_refusal_off_loop(command)
+
+
+def _audit_name_grant_refusal(
+    *, session_key: str, slot: Any, event: Any, refusal: Refusal, tier: str
+) -> None:
+    """Record that a name-based auto-approve was DECLINED, and on which tier.
+
+    Declining is a security decision, so it belongs in the audit log beside the
+    approvals and denials. Without it the log shows a command arriving at the
+    interactive card and never says that a grant was withheld, or why.
+
+    The CODE, never the ``detail``: the detail names the program and the resolved
+    paths, and an audit sink is exactly where that becomes a disclosure. Both
+    ``code`` and ``log_text`` are constants read out of a module table.
+
+    Not ``critical=True``. That flag is for audit-or-deny, where a caller must
+    refuse rather than run something unaudited. Nothing runs unaudited here:
+    declining sends the request to the approval card, and the human's own answer
+    is audited in turn.
+    """
+
+    sel().log_tool_invocation(
+        session_key=session_key,
+        agent=slot.agent or "kirocrew",
+        source="dashboard",
+        tool_name=_redact_display_text(event.title),
+        tool_kind=getattr(event, "tool_kind", ""),
+        outcome="auto_approve_declined",
+        request_id=event.request_id,
+        error=refusal.log_text,
+        metadata={"reason": "name_grant", "code": refusal.code, "tier": tier},
+    )
 
 
 def _resolve_channel_target(
@@ -6667,6 +6749,37 @@ async def _run_chat(
                             )
                             tool_result = ToolHookResult(action=TOOL_ALLOW)
                     if tool_result.action == TOOL_AUTO_APPROVE:
+                        # The hook layer granted this by NAME (its
+                        # `auto_approve_tools` globs, or the read-only allowlist).
+                        # Ask off-loop whether the names still identify the
+                        # programs they appear to name; a shadowed, agent-tree or
+                        # unidentified resolution falls through to the interactive
+                        # card instead. Done HERE rather than inside the hook
+                        # because the answer needs filesystem work that its
+                        # synchronous, loop-bound method must not perform.
+                        _hook_shim = await _name_grant_refusal_for(event)
+                        if _hook_shim is not None:
+                            logger.warning(
+                                "declining a hook auto-approve: %s; the request "
+                                "falls through to interactive approval",
+                                _hook_shim.log_text,
+                            )
+                            _audit_name_grant_refusal(
+                                session_key=session_key,
+                                slot=slot,
+                                event=event,
+                                refusal=_hook_shim,
+                                tier="hook_auto_approve",
+                            )
+                            slot.append(
+                                "system",
+                                "🛡️ Auto-approve not applied — "
+                                f"{_redact_display_text(_hook_shim.detail)}. "
+                                "Approve this command explicitly.",
+                                "msg msg-info",
+                            )
+                            tool_result = ToolHookResult(action=TOOL_ALLOW)
+                    if tool_result.action == TOOL_AUTO_APPROVE:
                         try:
                             validated_tool = _validate_tool_name(
                                 event.title, is_shell=event.is_shell
@@ -6863,6 +6976,41 @@ async def _run_chat(
                         if _tp_command
                         else None
                     )
+                    if matched and event.is_shell and _tp_command:
+                        # The user granted a PROGRAM NAME. Do not honour it when
+                        # that name no longer identifies the program it appears
+                        # to name — the shell resolves it again, through a PATH
+                        # that can lead with directories the agent writes.
+                        # Declining costs one interactive prompt; the command is
+                        # neither blocked nor rewritten.
+                        #
+                        # `is_shell` is tested explicitly because `_tp_command`
+                        # is non-empty for a non-shell grant too, where it is a
+                        # canonical `mcp-trust:v1:...` identity rather than a
+                        # command. There is no program name to vouch for there,
+                        # so that tier stays unchanged.
+                        _tp_shim = await _name_grant_refusal_off_loop(_tp_command)
+                        if _tp_shim:
+                            # The CODE, not the detail and not the pattern: both
+                            # are derived from user/agent input, and a log sink is
+                            # where that becomes a disclosure. The detail still
+                            # reaches the person, on the card below.
+                            logger.warning("trusted pattern not applied: %s", _tp_shim.log_text)
+                            _audit_name_grant_refusal(
+                                session_key=session_key,
+                                slot=slot,
+                                event=event,
+                                refusal=_tp_shim,
+                                tier="trusted_pattern",
+                            )
+                            slot.append(
+                                "system",
+                                "🛡️ Trusted pattern not applied — "
+                                f"{_redact_display_text(_tp_shim.detail)}. "
+                                "Approve this command explicitly.",
+                                "msg msg-info",
+                            )
+                            matched = None
                     if matched:
                         try:
                             validated_tool = _validate_tool_name(
@@ -6932,7 +7080,19 @@ async def _run_chat(
                     and cmd
                     and not _child_low_fidelity
                 ):
-                    if is_read_only_bash(cmd):
+                    _tr_shim = (
+                        await _name_grant_refusal_off_loop(cmd) if is_read_only_bash(cmd) else None
+                    )
+                    if _tr_shim is not None:
+                        logger.warning("trust-reads not applied: %s", _tr_shim.log_text)
+                        _audit_name_grant_refusal(
+                            session_key=session_key,
+                            slot=slot,
+                            event=event,
+                            refusal=_tr_shim,
+                            tier="trust_reads",
+                        )
+                    if is_read_only_bash(cmd) and _tr_shim is None:
                         try:
                             validated_tool = _validate_tool_name(
                                 event.title, is_shell=event.is_shell
@@ -7416,6 +7576,31 @@ async def _run_chat(
                             metadata={"reason": "interactive"},
                         )
                     else:
+                        # BEFORE approve_tool, not after: the approval response
+                        # is what starts execution, so a file swapped in that
+                        # window would be the one pinned -- recording a file the
+                        # human never saw. Off-loop because it digests the file.
+                        #
+                        # Scope kept to `cmd`, the command the tiers above already
+                        # extracted. Round 18 widened this to fall back to
+                        # `event.shell_command` so a structured approval of a
+                        # non-system program stopped re-prompting; round 20 called
+                        # the wider form an undisclosed persistent grant, and
+                        # between "prompts once more than it needs to" and "records
+                        # an identity from a surface the human may not read as
+                        # durable", the extra prompt is the safe side. The narrower
+                        # form is the one that ships.
+                        #
+                        # `is_shell` is tested explicitly (round 21) because
+                        # `extract_bash_command` reads a `command` key out of ANY
+                        # structured input and falls back to the raw string, so a
+                        # NON-shell MCP call carrying `{"command": "gh ..."}` would
+                        # otherwise mint a witness for the shell program `gh` --
+                        # a durable grant from an approval that was never about
+                        # running `gh` at all. Same reason the trusted-pattern tier
+                        # above tests it.
+                        if event.is_shell and cmd:
+                            await asyncio.to_thread(pin_human_approval, cmd)
                         await client.approve_tool(event.request_id)
                         _approved_title = _redact_display_text(event.title)
                         slot.append(

--- a/src/kiro_crew/dashboard/terminal_commands.py
+++ b/src/kiro_crew/dashboard/terminal_commands.py
@@ -93,7 +93,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 
-from kiro_crew import platform_compat
+from kiro_crew import name_grant, platform_compat
 from kiro_crew.executors import discovery_executor
 from kiro_crew.hooks import validate_file_path
 from kiro_crew.sandbox import (
@@ -357,28 +357,13 @@ _ADMIN_WRITE_GIDS: frozenset[int] = frozenset({80} if platform_compat.IS_MACOS e
 #: write the project — which includes the agent — so resolving a command name to
 #: it would let a planted file run with gateway privileges the moment the user
 #: types that command's name.
-_PROJECT_LOCAL_SEGMENTS = frozenset({
-    ".venv", "venv", ".virtualenv", "virtualenv", "node_modules", ".tox", ".nox",
-    "vendor", ".direnv", "target", "build", "dist", ".git",
-})
+#:
+#: Owned by :mod:`kiro_crew.name_grant`, which asks the same question of an
+#: auto-approved command's program names. One definition, so the two answers
+#: cannot drift apart.
+_PROJECT_LOCAL_SEGMENTS = name_grant.PROJECT_LOCAL_SEGMENTS
 
-
-def _is_project_local(entry: str) -> bool:
-    """Whether a PATH entry belongs to a project tree rather than an install.
-
-    Segment-wise, not substring: ``/opt/venv-tools/bin`` is an installed prefix
-    that merely CONTAINS the text, while ``/home/u/proj/.venv/bin`` genuinely is
-    project-local.
-
-    Both separators are honoured regardless of host. ``os.sep`` alone would make
-    this silently useless for POSIX-shaped input on Windows (and vice versa) —
-    and a security filter that quietly stops matching is worse than one that is
-    absent, because the tests that cover it keep passing on the host that wrote
-    them. `_resolve` is reachable on either platform (only ``_run_probe`` is
-    POSIX-gated), so the check must not depend on which one it runs from.
-    """
-    parts = entry.replace("\\", "/").split("/")
-    return any(part in _PROJECT_LOCAL_SEGMENTS for part in parts)
+_is_project_local = name_grant.is_project_local
 
 
 def _own_uid() -> int | None:

--- a/src/kiro_crew/name_grant.py
+++ b/src/kiro_crew/name_grant.py
@@ -1,0 +1,1248 @@
+"""Whether a NAME-based approval may be honoured for a shell command line.
+
+Every auto-approve tier that decides from a program NAME -- a session-trusted
+pattern (``head *``), a configured ``auto_approve_tools`` glob, the read-only
+allowlist -- is making a statement about a PROGRAM. The shell then performs its
+own ``PATH`` lookup, and a gateway's ``PATH`` legitimately leads with
+directories the agent itself can write (a worktree venv's ``bin``, mise shims,
+``~/.local/bin``). A file the agent planted at ``~/.local/bin/head`` therefore
+wins the lookup over ``/usr/bin/head``, and a grant made because the command
+"is just ``head``" runs it.
+
+:func:`name_grant_refusal` answers the one question those tiers need: does the
+name still identify the program it appears to name? A refusal does NOT block the
+command and does NOT rewrite it -- the request falls through to the ordinary
+interactive approval card, where the human decides on this specific command.
+That is the whole point: the tier's job is to skip a prompt the user has already
+answered in general, and a shadowed name is a case the user has not answered.
+
+Three shapes are refused, and nothing else:
+
+* **A shadowing resolution.** The name resolves somewhere other than the
+  same-named program in the trusted system directories
+  (:func:`platform_compat.trusted_system_bin`). ``head`` found at
+  ``~/.local/bin/head`` while ``/usr/bin/head`` exists is the reported attack.
+* **A resolution inside a tree the agent writes** -- the project checkout, the
+  LLM workspace root (:func:`github_runner.agent_writable_roots`), or a
+  project-local tool directory (``.venv/bin``, ``node_modules/.bin``). No
+  shadowing is needed for this one to be suspicious: it is the same class
+  ``github_runner.validate_provider_executable`` and the terminal panel's
+  command probe already refuse.
+* **A name no approval has identified.** The two rules above cannot help a name
+  the system directories do not carry -- ``gh``, ``node``, ``kirocrew``, a
+  version manager's ``python`` -- because such a program legitimately lives
+  where the user installed it, which is also where the agent can write. For
+  those the tiers require a WITNESS: a human answering an approval card has seen
+  the command and said yes, and that moment records the file's identity
+  (:func:`pin_human_approval`). A grant naming the program is then honoured only
+  while the same file answers to the name. No pin means refuse -- pinning on
+  first SIGHT would bless whatever is there the first time a tier looks, and a
+  tier looks precisely when it is about to auto-approve without asking anyone.
+
+A command carrying a construct whose programs cannot be enumerated -- a
+substitution inside quotes, a backtick, a process substitution -- is refused
+whole, and so is a program token the shell expands (``$CMD``). Seeing part of a
+command's program set is not a basis for vouching for the command.
+
+What this deliberately does NOT do, stated plainly so the boundary is not
+mistaken for a stronger one:
+
+* It does not make a decision BINDING on the exec. The check runs when the
+  approval is decided and the shell resolves again when it runs, so a second
+  agent writing the shim in that window still wins. Closing that needs the
+  child's ``PATH`` to stop leading with agent-writable directories, which
+  changes the execution environment of every command the agent runs and is a
+  separate change with its own compatibility surface (upstream issue #4438
+  names it).
+* It does not decide that a user-owned directory is untrustworthy. A program
+  the user installed into ``~/.local/bin`` is theirs, and refusing it outright
+  would leave the auto-approve tiers dead on the most common developer host --
+  an unused code path, not a security win. It is admitted on a human's say-so
+  and only while it stays the same file, which costs one approval card per
+  program (and one more after an upgrade) rather than the whole tier.
+* It says nothing about full-trust or YOLO mode, which approve everything by
+  construction and are not name-based grants.
+* The witness is recorded on the dashboard's approval card. Another surface's
+  approval does not pin, so a non-system program there keeps prompting -- more
+  prompts, never fewer, which is the safe direction to be incomplete in.
+
+Resolution runs against the same ``PATH`` value the spawn code hands the
+child (:func:`env.augmented_path`), not this process's own ``PATH``: the child's
+is a superset with the version-manager directories PREPENDED, so resolving
+against ours would answer for a search order the command will not use.
+
+Cost is a ``which`` walk plus a handful of ``stat`` calls per decision, on the
+same order as ``trusted_system_bin``'s own lookup, and it runs on the event loop
+where the approval is decided. Building the search path is safe there because
+:func:`env.augmented_path` is string work over a glob that
+``env._node_all_bin_dirs`` caches for the process lifetime, and that cache is
+already warm: the same call builds the ``PATH`` handed to the agent process at
+session start, long before any tool approval.
+
+The verdict itself is deliberately uncached: a cached "trusted" answer is a
+substitution window, and this must reflect the filesystem as it is when the tier
+decides.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import shlex
+import shutil
+import stat
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+
+from kiro_crew import platform_compat
+from kiro_crew.env import augmented_path
+from kiro_crew.github_runner import agent_writable_roots
+
+logger = logging.getLogger(__name__)
+
+#: Path segments that mark a directory as PROJECT-LOCAL tooling rather than an
+#: installed program. A binary under one of these is writable by whatever can
+#: write the project -- which includes the agent -- so a name that resolves into
+#: one is not a name a grant can vouch for.
+PROJECT_LOCAL_SEGMENTS = frozenset(
+    {
+        ".venv",
+        "venv",
+        ".virtualenv",
+        "virtualenv",
+        "node_modules",
+        ".tox",
+        ".nox",
+        "vendor",
+        ".direnv",
+        "target",
+        "build",
+        "dist",
+        ".git",
+    }
+)
+
+#: Tokens after which the NEXT word is a program name rather than an operand.
+#: Redirects are deliberately absent: what follows them is a file, and treating
+#: it as a program would resolve an operand.
+_COMMAND_STARTERS = frozenset({"|", "||", "&&", ";", ";;", "&", "|&", "(", ")", "\n"})
+
+#: Redirection operators, EXACTLY. ``shlex`` groups a run of punctuation into one
+#: token, so a composite like ``;(`` or ``;>`` arrives whole -- and a membership
+#: test against these two sets is what makes such a token unrecognized instead of
+#: silently skipped. ``head x;(payload)`` used to yield only ``head``.
+_REDIRECT_OPERATORS = frozenset(
+    {"<", ">", ">>", "<<", "<<<", "<&", ">&", "<>", ">|", "&>", "&>>", ">>&"}
+)
+
+#: Every character ``shlex`` may hand back as punctuation with
+#: ``punctuation_chars=True``. A token made only of these is an operator, and if
+#: it is not one of the two sets above it is grammar this walk does not model.
+_PUNCTUATION = "();<>|&"
+
+
+#: Constructs that RUN a program in a position this tokenizer cannot enumerate.
+#: ``shlex`` in POSIX mode consumes quotes, so a substitution inside double
+#: quotes (``echo "$(head x)"``) collapses into one ordinary token and its inner
+#: program disappears from the walk entirely. Refusing the whole command line is
+#: the only honest answer: the tier cannot vouch for a program it cannot see.
+_UNENUMERABLE = ("$(", "`", "<(", ">(")
+
+#: Characters that make a PROGRAM token something other than a literal name --
+#: the shell expands them, so what runs is decided after this check reads it.
+_EXPANDING_CHARS = ("$", "`", "*", "?", "[")
+
+#: ``(program name, directory) -> identity`` for the first file each name
+#: resolved to. See :func:`_pin_refusal`; bounded so a long-lived gateway cannot
+#: accumulate an entry per name it has ever seen.
+_PINS: "OrderedDict[tuple[str, str], tuple]" = OrderedDict()
+_PIN_LIMIT = 512
+
+#: Guards :data:`_PINS`. Every check runs on a worker thread (the tiers call
+#: through ``asyncio.to_thread``), so read-compare-touch has to be one critical
+#: section: otherwise a concurrent insert can evict the key a check is holding.
+_PIN_LOCK = threading.Lock()
+
+# ── Refusal reasons ──
+#
+# Each refusal carries a CODE as well as its human detail, because the detail is
+# built from the command line and from resolved paths: logging it is a dataflow
+# from tool input into a log sink, which CodeQL's
+# `py/clear-text-logging-sensitive-data` query reports at high severity (and it
+# is right to -- a resolved path discloses more than the user typed). Callers log
+# ``Refusal.log_text``, which reads a constant OUT of a table below; that severs
+# the flow in a way the analysis can verify, where returning the caller's own
+# string after checking it would not.
+
+UNENUMERABLE = "unenumerable_construct"
+UNTOKENIZABLE = "untokenizable"
+EXPANDED = "expanded_program_token"
+RELATIVE_PATH = "relative_path_program"
+AGENT_TREE = "agent_writable_tree"
+SHADOWED = "shadows_system_program"
+IDENTITY_CHANGED = "identity_changed"
+UNWITNESSED = "no_approval_identified_this_file"
+DISPATCHER = "program_dispatches_another"
+AMBIGUOUS_PATH = "search_path_has_a_relative_entry"
+WINDOWS_UNMODELLED = "windows_lookup_not_modelled"
+UNINSPECTABLE = "uninspectable"
+UNKNOWN_COMMAND = "unresolved_command_word"
+AMBIGUOUS_ENV = "inherited_env_can_redefine_programs"
+
+_REFUSAL_LOG_TEXT = {
+    UNENUMERABLE: "the command carries a construct whose programs cannot be enumerated",
+    UNTOKENIZABLE: "the command line could not be tokenized, or uses shell grammar "
+    "this check does not model",
+    EXPANDED: "a program token is expanded by the shell",
+    RELATIVE_PATH: "a program is named by relative path",
+    AGENT_TREE: "a program resolves inside a tree the agent can write",
+    SHADOWED: "a program name shadows the system program of that name",
+    IDENTITY_CHANGED: "a program name resolves to a different file than an approval identified",
+    UNWITNESSED: "a non-system program has no file identified by an approval",
+    DISPATCHER: "a program runs another program named in its arguments",
+    AMBIGUOUS_PATH: "the search path contains an empty or relative entry",
+    WINDOWS_UNMODELLED: "Windows tokenization and shell lookup are not modelled",
+    UNINSPECTABLE: "a program could not be inspected",
+    UNKNOWN_COMMAND: "a command word resolves to no program and is not a known inert builtin",
+    AMBIGUOUS_ENV: "the inherited environment can redefine a program name as a shell function",
+}
+
+
+@dataclass(frozen=True)
+class Refusal:
+    """Why a name-based auto-approve must not be honoured.
+
+    ``detail`` names the program and the paths involved and is meant for the
+    person deciding at the approval card. ``log_text`` is the constant to log --
+    see the note above on why the two are separate.
+    """
+
+    code: str
+    detail: str
+
+    @property
+    def log_text(self) -> str:
+        return _REFUSAL_LOG_TEXT.get(self.code, "a program name could not be vouched for")
+
+
+#: Shell RESERVED WORDS and grouping tokens. This walk models one grammar --
+#: simple commands joined by pipes, ``&&``/``||``/``;`` and subshells -- and a
+#: reserved word means the command is using grammar it does NOT model, where the
+#: real program hides behind a syntax word: in ``head x | { evil; }`` a walk that
+#: reads ``{`` as the program never sees ``evil``. Meeting one in a command
+#: position refuses the whole line rather than vouching for what it could see.
+#:
+#: ``test`` and ``[`` are absent on purpose: those are real programs, not
+#: grammar. ``time`` and ``!`` are here because they PREFIX a command, which is
+#: the same hiding shape.
+_RESERVED_WORDS = frozenset(
+    {
+        "{",
+        "}",
+        "!",
+        "time",
+        "if",
+        "then",
+        "elif",
+        "else",
+        "fi",
+        "for",
+        "while",
+        "until",
+        "do",
+        "done",
+        "case",
+        "esac",
+        "select",
+        "function",
+        "coproc",
+        "[[",
+        "]]",
+    }
+)
+
+
+def _is_redirect(token: str) -> bool:
+    """Whether a token is EXACTLY a redirection operator.
+
+    Exact membership, not "contains ``<`` or ``>``": ``shlex`` groups a run of
+    punctuation into one token, so a composite such as ``;>`` both separates
+    commands and redirects, and consuming it as a plain redirect would swallow
+    the program that follows it.
+    """
+
+    return token in _REDIRECT_OPERATORS
+
+
+def is_project_local(entry: str) -> bool:
+    """Whether a path belongs to a project tree rather than an install.
+
+    Segment-wise, not substring: ``/opt/venv-tools/bin`` is an installed prefix
+    that merely CONTAINS the text, while ``/home/u/proj/.venv/bin`` genuinely is
+    project-local.
+
+    Both separators are honoured regardless of host. ``os.sep`` alone would make
+    this silently useless for POSIX-shaped input on Windows (and vice versa),
+    and a security filter that quietly stops matching is worse than one that is
+    absent, because the tests covering it keep passing on the host that wrote
+    them.
+    """
+
+    parts = entry.replace("\\", "/").split("/")
+    return any(part in PROJECT_LOCAL_SEGMENTS for part in parts)
+
+
+def _path_is_ambiguous() -> bool:
+    """Whether the agent's ``PATH`` contains an entry this check cannot resolve.
+
+    An empty entry (``PATH=/usr/bin:``) and a relative one (``PATH=.:...``) both
+    mean "the current directory", and the two processes disagree about which
+    directory that is: the check runs in the gateway's, the command runs in the
+    session's. Dropping such entries is not enough -- it makes the check resolve
+    ``head`` to ``/usr/bin/head`` and vouch for it while the child, which still
+    has the entry, runs a planted ``./head`` from its own directory. Since
+    neither keeping nor dropping the entry can answer the question, a ``PATH``
+    carrying one refuses every name-based auto-approve outright.
+    """
+
+    raw = augmented_path(os.environ.get("PATH", ""))
+    return any(not entry or not os.path.isabs(entry) for entry in raw.split(os.pathsep))
+
+
+def _agent_search_path() -> str:
+    """The ``PATH`` a spawned agent command searches, absolute entries only.
+
+    Only ever consulted once :func:`_path_is_ambiguous` has answered ``False``,
+    so the filter here is belt-and-braces rather than the guarantee.
+    """
+
+    raw = augmented_path(os.environ.get("PATH", ""))
+    return os.pathsep.join(
+        entry for entry in raw.split(os.pathsep) if entry and os.path.isabs(entry)
+    )
+
+
+def _agent_writable_roots() -> tuple[str, ...] | None:
+    """Trees the agent itself writes, or ``None`` when that cannot be decided.
+
+    ``None`` is fail-closed at every caller ("assume the path IS inside one"):
+    a filter that silently dropped a root it could not resolve would admit
+    exactly the trees it exists to refuse.
+
+    Read live rather than cached, because a session can retarget its project
+    directory between two tool calls.
+    """
+
+    try:
+        return tuple(os.path.normcase(str(root)) for root in agent_writable_roots())
+    except Exception:
+        logger.warning(
+            "agent-writable roots unavailable; refusing to honour a name-based "
+            "grant until they can be resolved",
+            exc_info=True,
+        )
+        return None
+
+
+def _within(path: str, roots: tuple[str, ...] | None) -> bool:
+    """Whether *path* sits inside one of *roots*, refusing when *roots* is None.
+
+    Compared against ``root + os.sep`` rather than by bare prefix, so a sibling
+    that merely starts with the same characters (``…/workspace-other`` next to
+    ``…/workspace``) is outside.
+    """
+
+    if roots is None:
+        return True
+    real = os.path.normcase(path)
+    return any(real == root or real.startswith(root + os.sep) for root in roots)
+
+
+def program_names(command: str) -> list[str] | None:
+    """Program tokens of *command*, or ``None`` when it cannot be tokenized.
+
+    Every command position is collected -- each stage of a pipeline, each side
+    of ``&&``/``||``/``;``, each LINE, and the inside of a subshell -- so a grant
+    cannot be honoured on the strength of its first word alone.
+
+    Lines are split before tokenizing because ``shlex`` treats a newline as
+    ordinary whitespace: in ``head file\\npayload`` it would hand back
+    ``['head', 'file', 'payload']``, leaving ``payload`` in operand position and
+    invisible. A newline inside quotes makes its line's quoting unbalanced, which
+    tokenizes to ``None`` and refuses -- the safe direction.
+
+    A ``VAR=value`` prefix keeps the position open: it assigns into the
+    command's environment, and the program is the token after it.
+
+    ``None`` (unbalanced quotes, an unterminated construct, grammar this walk
+    does not model) means the program set could not be established, which callers
+    treat as a refusal rather than as "no programs found".
+    """
+
+    names: list[str] = []
+    for line in command.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        if not line.strip():
+            continue
+        found = _program_names_line(line)
+        if found is None:
+            return None
+        names.extend(found)
+    return names
+
+
+def _program_names_line(command: str) -> list[str] | None:
+    """:func:`program_names` for a single line."""
+
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    # `shlex` DISCARDS THE REST OF THE LINE AFTER `#` BY DEFAULT. Bash does not:
+    # `#` only opens a comment at the start of a word, so `head file#x; cat secret`
+    # runs BOTH commands, while the default lexer handed this walk `['head',
+    # 'file']` and the `cat` was never checked at all. Measured, not assumed --
+    # bash prints both halves. Turning commenters off is what makes the token
+    # stream describe the command bash will actually run; a genuine trailing
+    # comment then arrives as an ordinary operand, which is harmless here because
+    # only command POSITIONS are inspected.
+    lexer.commenters = ""
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return None
+    names: list[str] = []
+    expect_program = True
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if not token:
+            continue
+        if token in _COMMAND_STARTERS:
+            expect_program = True
+            continue
+        # A REDIRECT may appear anywhere in a simple command, INCLUDING BEFORE
+        # the program: `2>/dev/null head x` runs `head`. So consume the operator
+        # and the file it names, and leave the command position as it was.
+        # Closing the position here would make `head` invisible; opening it would
+        # judge the FILE in `head x > out`. `2>` and `2>&1` arrive as a digit
+        # token followed by the operator, so that fd prefix is consumed too.
+        if _is_redirect(token):
+            index += 1  # its target, if any
+            continue
+        if token.isdigit() and index < len(tokens) and _is_redirect(tokens[index]):
+            index += 2  # the operator and its target
+            continue
+        if all(ch in _PUNCTUATION for ch in token):
+            # Punctuation that is neither a starter nor a redirect: `shlex` groups
+            # a run of it into one token, so `;(` and `;>out` arrive whole and
+            # match no operator. Skipping such a token loses the command it
+            # introduces, so report "unknown" instead.
+            return None
+        if not expect_program:
+            continue
+        if token in _RESERVED_WORDS:
+            # Grammar this walk does not model. The program is elsewhere in a
+            # shape it cannot follow, so report "unknown" rather than the subset
+            # it managed to see.
+            return None
+        # `VAR=value cmd` assigns into the environment; the program follows it.
+        # Only a STRICT `NAME=` prefix is skipped, and only for a variable that
+        # does not decide what runs. Anything else carrying `=` in a command
+        # position -- `PATH+=:.`, `A[0]=x`, a quoted oddity -- is a state change
+        # this walk cannot evaluate, and skipping it would leave the program that
+        # follows unchecked, so the line is refused.
+        if "=" in token:
+            head = token.split("=", 1)[0]
+            if _decides_execution(head) or not _ASSIGN_NAME_RE.fullmatch(head):
+                return None
+            continue
+        names.append(token)
+        expect_program = False
+    return names
+
+
+#: Programs whose JOB is to run another program named in their arguments. The
+#: walk sees ``env head file`` as the single program ``env`` with two operands, so
+#: it would vouch for ``/usr/bin/env`` while ``head`` is resolved from ``PATH`` at
+#: exec time -- the same substitution the shebang chain closes, reached through
+#: argv instead. Each one has its own flag grammar (``env -i -u X CMD``,
+#: ``timeout -s KILL 5 CMD``, ``xargs -I{} CMD``), so rather than model them the
+#: walk refuses: a grant naming a dispatcher cannot identify what it dispatches.
+_DISPATCHERS = frozenset(
+    {
+        # Command SHELLS. `sh -c 'head file'` runs an arbitrary command string, so
+        # vouching for `/bin/sh` says nothing about what executes. Scoped out in
+        # round 9 and asked for in round 12: a grant naming a shell is a grant to
+        # run anything, which is a decision for the approval card, not for a name
+        # check. Interpreters that take CODE (`python3 -c`) are deliberately NOT
+        # here -- the read-only tier already restricts them through its own
+        # denied-programs list, and listing them would refuse `python3 --version`,
+        # which that tier grants on purpose.
+        "sh",
+        "bash",
+        "dash",
+        "zsh",
+        "ksh",
+        "csh",
+        "tcsh",
+        "ash",
+        "fish",
+        "busybox",
+        "cmd",
+        "cmd.exe",
+        "powershell",
+        "powershell.exe",
+        "pwsh",
+        "pwsh.exe",
+        # Shell BUILTINS that CHANGE HOW A LATER NAME RESOLVES. `export
+        # PATH=/agent/bin:$PATH && head file` re-points the lookup for every
+        # command after it, and `hash`/`alias` re-point one name directly -- so
+        # the resolution this check performs describes the PREVIOUS state, not
+        # the one the later command will use. They cannot be evaluated by
+        # resolving a name, so a line carrying one is refused. (A bare
+        # `PATH=... cmd` PREFIX is caught separately by `_EXEC_ENV_VARS`.)
+        "export",
+        "hash",
+        "alias",
+        "unalias",
+        "declare",
+        "typeset",
+        "readonly",
+        "local",
+        "set",
+        "shopt",
+        # Builtins that WRITE A VARIABLE from their arguments, so they can set
+        # `PATH` without an assignment token: `printf -v PATH /writable; payload`
+        # leaves the walk checking `payload` against the previous search path.
+        "printf",
+        "read",
+        "mapfile",
+        "readarray",
+        "getopts",
+        "let",
+        # Shell BUILTINS that hand off to a program named in their arguments.
+        # These are the sharpest case because `shutil.which` cannot see them at
+        # all: an unresolvable name is otherwise treated as "nothing to shadow,
+        # nothing to vouch for", so `exec head file` passed while `head` was
+        # resolved from PATH at exec time and never inspected.
+        "exec",
+        "eval",
+        "builtin",
+        "source",
+        ".",
+        # External wrappers whose whole job is to run something else.
+        "env",
+        "nohup",
+        "nice",
+        "ionice",
+        "chrt",
+        "stdbuf",
+        "unbuffer",
+        "setsid",
+        "timeout",
+        "xargs",
+        "command",
+        "watch",
+        "parallel",
+        "sudo",
+        "doas",
+        "su",
+        "runuser",
+        "pkexec",
+        "systemd-run",
+        "script",
+        "strace",
+        "ltrace",
+    }
+)
+
+
+#: Environment variables that, when INHERITED (not written in the command line),
+#: make bash run code before the named program and can define a shell FUNCTION
+#: that shadows it. `BASH_ENV=/writable/rc` holding `head() { payload; }` means
+#: `bash -c 'head file'` runs the function, while this check resolves the name to
+#: `/usr/bin/head` and calls it a trusted system program.
+#:
+#: This is the same threat as the command-line `BASH_ENV=...` prefix that
+#: `_EXEC_ENV_VARS` already refuses, arriving through the process environment
+#: instead. Neither is visible in the command line, so the check reads its own
+#: environment -- the one a child shell inherits by default.
+_ENV_PRELOAD_VARS = ("BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS")
+
+
+#: An EXPORTED SHELL FUNCTION, which shadows a program name directly rather than
+#: via a file bash is told to source. Bash exports `head() { payload; }` as an
+#: environment entry and re-imports it in the child, so `bash -c 'head file'`
+#: runs the function while this check resolves the name to `/usr/bin/head` and
+#: calls it a trusted system program -- the same unsoundness as
+#: :data:`_ENV_PRELOAD_VARS`, needing no writable file at all.
+#:
+#: The key is matched on its `BASH_FUNC_` PREFIX alone, deliberately: the suffix
+#: has been spelled `()` and `%%` by different bash versions, and pinning a
+#: spelling would hand the bypass back on any build that picks another one.
+#:
+#: The value form is matched too, for the pre-2014 spelling where the key is the
+#: bare function name and only the `() {` value marks it. Supported bash no
+#: longer imports that, so this is belt-and-braces rather than the live vector.
+_BASH_FUNC_KEY_PREFIX = "BASH_FUNC_"
+_BASH_FUNC_VALUE_PREFIX = "() {"
+
+
+def _inherited_preload() -> str | None:
+    """The inherited variable that makes a name-based grant unsound, if any."""
+
+    for var in _ENV_PRELOAD_VARS:
+        if os.environ.get(var):
+            return var
+    for key, value in os.environ.items():
+        if key.startswith(_BASH_FUNC_KEY_PREFIX) or value.startswith(_BASH_FUNC_VALUE_PREFIX):
+            # The FAMILY, not the key: the key embeds an attacker-chosen function
+            # name and this string reaches a log sink and the dashboard card.
+            return f"{_BASH_FUNC_KEY_PREFIX}*"
+    return None
+
+
+#: Shell builtins that resolve to NO file and are still allowed, because they can
+#: neither run a program named in their arguments nor change how a later name
+#: resolves. Anything not here that fails to resolve is refused -- see the
+#: `not found` branch in :func:`_program_refusal` for why the default is refuse.
+#:
+#: Deliberately NOT here, and each for a measured reason: `time` and `command`
+#: run a program named in their arguments; `trap` and `enable` install code that
+#: runs later (`trap 'payload' DEBUG` before every command, `enable -f` loading a
+#: shared object as a builtin); `:` is here because it is a true no-op, while
+#: `eval`/`exec`/`source`/`.` are the sharpest dispatchers there are.
+_INERT_BUILTINS = frozenset(
+    {
+        ":",
+        "cd",
+        "echo",
+        "pwd",
+        "true",
+        "false",
+        "test",
+        "[",
+        "wait",
+    }
+)
+
+#: A STRICT shell assignment name. Anything else carrying `=` in a command
+#: position is not a plain `NAME=value` prefix and is refused rather than skipped.
+_ASSIGN_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+#: Environment variables whose value in a COMMAND POSITION decides which file
+#: runs, or what code runs inside it. `PATH=/writable/bin head file` re-points
+#: the very lookup this module vouches for, and the loader variables inject code
+#: into whatever does run, so a command carrying one cannot be answered for by
+#: resolving its program name. An ordinary assignment (`FOO=bar head x`) is left
+#: alone: it changes the program's inputs, not its identity.
+_EXEC_ENV_VARS = frozenset(
+    {
+        "PATH",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FRAMEWORK_PATH",
+        "BASH_ENV",
+        "ENV",
+        "SHELL",
+        "IFS",
+        # A TOOL that runs a helper command named by its environment. The base
+        # program is genuinely the trusted system one, so resolving its name
+        # answers nothing about what executes: `GIT_SSH_COMMAND=/writable/evil
+        # git fetch ssh://x` vouches for `/usr/bin/git` and runs the planted
+        # file. Same shape as `LD_PRELOAD`, reached through a tool's own config.
+        "GIT_SSH_COMMAND",
+        "GIT_SSH",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_PAGER",
+        "GIT_EDITOR",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        # An INTERPRETER told to load extra code before the script it was given.
+        # `PYTHONPATH=/writable python3 x` with a planted `sitecustomize.py`, or
+        # `NODE_OPTIONS=--require=/writable/evil node x`, both run attacker code
+        # inside a program this check called trusted.
+        "NODE_OPTIONS",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "PYTHONHOME",
+        "PERL5OPT",
+        "PERL5LIB",
+        "PERLLIB",
+        "RUBYOPT",
+        "RUBYLIB",
+        "GEM_PATH",
+        "GEM_HOME",
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
+        "CLASSPATH",
+    }
+)
+
+#: Assignment-name FAMILIES that decide what code runs. Named as families rather
+#: than as more exact spellings because this is the shape that kept recurring:
+#: every round found one more interpreter or tool with its own way of being told
+#: to load code, and an exact list can only ever be as complete as the last
+#: person to think about it. A loader prefix (``LD_*``, ``DYLD_*``) and the
+#: option/search-path suffixes cover the families themselves.
+#:
+#: Over-refusing is the safe direction and its cost is bounded: an assignment
+#: like ``PYTHONUNBUFFERED=1`` or ``MY_CONFIG_PATH=/x`` costs ONE approval
+#: prompt, because a refusal here never blocks and never rewrites the command.
+_EXEC_ENV_PREFIXES = ("LD_", "DYLD_")
+_EXEC_ENV_SUFFIXES = ("_OPTIONS", "OPT", "PATH", "LIB", "_PRELOAD")
+
+
+def _decides_execution(head: str) -> bool:
+    """Whether assigning *head* decides WHAT runs, not merely a program's inputs."""
+
+    return (
+        head in _EXEC_ENV_VARS
+        or head.startswith(_EXEC_ENV_PREFIXES)
+        or head.endswith(_EXEC_ENV_SUFFIXES)
+    )
+
+
+#: Returned by :func:`_shebang_interpreter` for an ``env`` shebang carrying more
+#: than one bare name. A sentinel rather than ``None`` or a guess: ``None`` means
+#: "no shebang, nothing to follow" and would ALLOW the command, and guessing the
+#: interpreter validates the wrong file while vouching for the right one. Not a
+#: possible filename, so it cannot collide with a real interpreter.
+_COMPLEX_ENV_SHEBANG = "\x00complex-env-shebang"
+
+#: How deep an interpreter chain is followed. A shebang normally names an ELF
+#: binary, so one step ends it; two allows for a wrapper script in between.
+_INTERPRETER_DEPTH = 2
+
+
+def _shebang_interpreter(real: str) -> str | None:
+    """The interpreter a script hands itself to, or ``None`` for a binary.
+
+    Pinning a SCRIPT binds its bytes, and its bytes may say
+    ``#!/usr/bin/env node`` -- which resolves ``node`` from ``PATH`` at exec time,
+    exactly the lookup this module exists to distrust. The script can stay
+    byte-identical while the program that actually runs is replaced underneath
+    it, so the interpreter has to face the same questions the script did.
+
+    Returns the interpreter as written: an absolute path (``/bin/sh``) or a bare
+    name when the shebang goes through ``env``. Flags are skipped, so
+    ``#!/usr/bin/env -S node --flag`` yields ``node``. ``None`` means there is no
+    shebang to follow -- a binary, or a file whose first bytes are not ``#!``.
+    """
+
+    if not _is_regular_file(real):
+        # Same reason the digest refuses one: opening a FIFO here would block a
+        # worker thread in the kernel forever.
+        return None
+    try:
+        with open(real, "rb") as handle:
+            first = handle.readline(256)
+    except (OSError, ValueError):
+        return None
+    if not first.startswith(b"#!"):
+        return None
+    try:
+        tokens = first[2:].decode("utf-8", "replace").strip().split()
+    except ValueError:  # pragma: no cover - decode with errors= cannot raise
+        return None
+    if not tokens:
+        return None
+    interpreter = tokens[0]
+    if os.path.basename(interpreter) in ("env", "env.exe"):
+        # The `env` BINARY is what the kernel runs, so it decides what executes
+        # no matter which name follows it. Reading the name and forgetting the
+        # path would validate `node` while `#!~/.local/bin/env node` runs a
+        # planted `env` -- and because a pin binds the SCRIPT's bytes, the script
+        # keeps matching while the file behind its shebang is swapped. So the
+        # path is held to the same standard as any other program: it must BE the
+        # system `env`, not merely be spelled like it.
+        try:
+            real_env = os.path.realpath(interpreter)
+        except (OSError, ValueError):
+            return _COMPLEX_ENV_SHEBANG
+        if not _is_trusted_system_file(os.path.basename(interpreter), real_env):
+            return _COMPLEX_ENV_SHEBANG
+        # ONLY the bare `#!/usr/bin/env NAME` form is read. `env`'s options take
+        # operands (`-u VAR`, `-S 'cmd args'`, `--chdir=DIR`), so picking the
+        # first non-flag token mistakes `VAR` for the interpreter -- which is
+        # worse than not answering, because it validates the wrong file and
+        # vouches for the command. Anything more complex than one bare name is
+        # refused by returning a token that cannot resolve.
+        rest = tokens[1:]
+        if len(rest) == 1 and not rest[0].startswith("-") and "=" not in rest[0]:
+            return rest[0]
+        return _COMPLEX_ENV_SHEBANG
+    return interpreter
+
+
+#: Read size for the identity digest. The WHOLE file is digested -- this is only
+#: the chunk size. An earlier version capped the digest at 1 MiB and hashed a
+#: large file's head and tail, which left a middle-only rewrite of a big binary
+#: undetected when it also preserved the size and landed inside one ctime tick.
+#: Refusing large files instead would have been worse: `node`, `gh` and `docker`
+#: are all above any sane cap, and they are exactly what people grant.
+_DIGEST_CHUNK = 1 << 20
+
+
+def _is_regular_file(real: str) -> bool:
+    """Whether *real* is a REGULAR file, so reading it cannot block forever.
+
+    A FIFO passes every test that matters to a ``PATH`` lookup -- it exists, it
+    can carry the execute bit, it is not a directory -- so ``shutil.which``
+    returns it and the digest below would ``open()`` it ``O_RDONLY``, which blocks
+    in the kernel until a writer appears. On a worker thread that is permanent:
+    an outer timeout can cancel the await but cannot free a syscall-blocked
+    thread, so repeating it drains the shared executor and stalls every other
+    session's approvals. A character or block device is the same shape. Only a
+    regular file is read.
+    """
+
+    try:
+        return stat.S_ISREG(os.stat(real).st_mode)
+    except (OSError, ValueError):
+        return False
+
+
+def _content_digest(real: str, size: int) -> str | None:
+    """A digest of ALL of *real*'s bytes, with the size mixed in.
+
+    Metadata alone cannot answer "is this the same program": ``mtime`` and
+    ``size`` are both under the writer's control (a same-size rewrite followed by
+    ``os.utime`` restores the pair exactly), and while ``st_ctime_ns`` is
+    kernel-set and unrestorable, its clock has a tick -- a rewrite inside the
+    same tick as the pin leaves it equal, measured on both tmpfs and xfs. So the
+    digest is what actually decides, and the metadata rides along to catch the
+    cheap cases first.
+
+    The whole file, not a window: hashing only the head and tail left a
+    middle-only rewrite of a large binary undetected when it preserved the size
+    and landed in one ctime tick. The cost is read bandwidth on an auto-approve
+    decision -- for a ~100 MB interpreter roughly a quarter second, page-cached
+    after the first pass, and always on a worker thread, never the event loop.
+    Only a NON-system program reaches here (a system-resolved one is identified
+    by its own directory), so the ordinary read-only allowlist never pays it.
+    """
+
+    if not _is_regular_file(real):
+        return None
+    try:
+        digest = hashlib.sha256()
+        digest.update(str(size).encode())
+        with open(real, "rb") as handle:
+            while True:
+                chunk = handle.read(_DIGEST_CHUNK)
+                if not chunk:
+                    break
+                digest.update(chunk)
+        return digest.hexdigest()
+    except (OSError, ValueError):
+        return None
+
+
+def _identity(real: str) -> tuple | None:
+    """A value that changes whenever the file behind a name changes.
+
+    Content first (:func:`_content_digest`), with the metadata that a writer
+    cannot restore -- inode, device, and the kernel-set ``st_ctime_ns`` -- as
+    corroboration. ``mtime`` and ``size`` are included for completeness but are
+    NOT what the guarantee rests on: both are forgeable by the same-uid process
+    this pin exists to catch.
+    """
+
+    try:
+        st = os.stat(real)
+    except (OSError, ValueError):
+        return None
+    digest = _content_digest(real, st.st_size)
+    if digest is None:
+        # Unreadable, or not a regular file at all (a planted FIFO resolves like
+        # a program but cannot be identified as one). Either way there is nothing
+        # to pin, and the caller turns this into a refusal.
+        return None
+    return (
+        real,
+        digest,
+        st.st_mtime_ns,
+        st.st_ctime_ns,
+        st.st_size,
+        st.st_ino,
+        st.st_dev,
+    )
+
+
+def _pin_refusal(name: str, found: str, real: str, witness: bool) -> Refusal | None:
+    """Vouch for a non-system program only on the file a HUMAN approved.
+
+    The shadowing rule cannot help a name the trusted system directories do not
+    carry -- ``gh``, ``node``, ``kirocrew``, a version manager's ``python``.
+    Those live where the user installed them, which is also where the agent can
+    write, so the name alone says nothing about the file.
+
+    Refusing them outright is not a trade worth taking: it would leave the trust
+    tiers dead for most of what a developer actually grants, and a "Trust all gh
+    commands" button that never takes effect pushes people to blanket trust. What
+    the tiers can require instead is a WITNESS. A human answering an approval
+    card has seen the command and said yes to it, so that moment records the
+    file's identity (:func:`pin_human_approval`); afterwards a grant naming it is
+    honoured only while the same file answers to the name.
+
+    That ordering is the point. Pinning on first SIGHT would bless whatever is
+    there the first time a tier looks -- and a tier looks precisely when it is
+    about to auto-approve without asking anyone, so a file planted before that
+    moment would pin itself. No pin therefore means refuse, not adopt.
+
+    Keyed by ``(name, directory)``, so two projects that ship a same-named tool
+    do not invalidate each other; only a swap in place is a mismatch.
+
+    A mismatch does NOT re-pin from a check -- re-pinning there would mean "one
+    prompt, then trusted", and this code cannot see whether the human answered
+    that prompt with yes. The next human approval re-pins, which is how an
+    upgraded tool becomes auto-approvable again.
+
+    Bounded LRU: a long-lived gateway must not accumulate an entry per name it
+    has ever seen.
+    """
+
+    identity = _identity(real)
+    if identity is None:
+        return Refusal(UNINSPECTABLE, f"{name} could not be inspected")
+    key = (name, os.path.normcase(os.path.dirname(found)))
+    # The read, the comparison and the LRU touch are one decision, and this runs
+    # on a worker thread per approval -- several at once across sessions. Without
+    # the lock a concurrent insert can evict the key between `get` and
+    # `move_to_end`, and that `KeyError` would surface as an aborted turn rather
+    # than as a refusal. The digest above is deliberately OUTSIDE the lock: it
+    # does I/O, and holding a mutex across a file read would serialize every
+    # session's approvals behind the slowest disk.
+    with _PIN_LOCK:
+        pinned = _PINS.get(key)
+        if witness:
+            # A human just approved this command: record what they approved, and
+            # replace a stale entry (an upgraded tool) with it.
+            _PINS[key] = identity
+            _PINS.move_to_end(key)
+            if len(_PINS) > _PIN_LIMIT:
+                _PINS.popitem(last=False)
+            return None
+        if pinned is None:
+            return Refusal(
+                UNWITNESSED,
+                f"{name} at {found} is not a system program and no approval has "
+                "identified this file, so a grant naming it cannot be honoured yet",
+            )
+        if pinned != identity:
+            return Refusal(
+                IDENTITY_CHANGED,
+                f"{name} at {found} is not the file an approval identified earlier, "
+                "so a grant made about it no longer identifies it",
+            )
+        try:
+            _PINS.move_to_end(key)
+        except KeyError:
+            # The lock makes this unreachable through the module's own paths, and
+            # it is caught anyway: this sits on the approval path, where an
+            # exception aborts the user's turn while a refusal only costs a
+            # prompt. The verdict does not depend on the touch -- the identity
+            # comparison above already succeeded -- but the safe answer when the
+            # pin has vanished is that nothing identifies this file.
+            return Refusal(
+                UNWITNESSED,
+                f"{name} at {found} lost its recorded identity, so a grant naming "
+                "it cannot be honoured until an approval identifies it again",
+            )
+    return None
+
+
+def _program_refusal(
+    name: str, witness: bool = False, depth: int = 0, as_interpreter: bool = False
+) -> Refusal | None:
+    """Why a name-based grant must not be honoured for *name*, else ``None``.
+
+    ``as_interpreter`` marks the recursive step that judges a script's shebang
+    target, and it SKIPS the dispatcher rule. That rule exists because the
+    program to run is named in ARGUMENTS this check cannot identify; for a
+    shebang the program to run is the pinned script itself, whose bytes were
+    verified. So `sh -c 'head file'` on a command line is refused, while
+    `#!/bin/sh` atop a script whose identity is pinned is not.
+    """
+
+    if any(ch in name for ch in _EXPANDING_CHARS):
+        # `$CMD arg`, `./*.sh`: the shell decides what this names after this
+        # check has read it, so no grant can identify the program.
+        return Refusal(EXPANDED, f"{name} is expanded by the shell rather than naming a program")
+    if not as_interpreter and os.path.basename(name) in _DISPATCHERS:
+        return Refusal(
+            DISPATCHER,
+            f"{name} runs a program named in its own arguments, which this check "
+            "cannot identify from the command line",
+        )
+    if "/" in name or (os.sep != "/" and os.sep in name) or (os.altsep and os.altsep in name):
+        if not os.path.isabs(name):
+            # A relative program is resolved against the command's working
+            # directory, which the approval never saw, so no name-based grant
+            # can identify what it will run.
+            return Refusal(
+                RELATIVE_PATH,
+                f"{name} names a program by relative path, which the grant cannot identify",
+            )
+        try:
+            real = os.path.realpath(name)
+        except (OSError, ValueError):
+            return Refusal(UNINSPECTABLE, f"{name} could not be resolved")
+        roots = _agent_writable_roots()
+        if is_project_local(name) or _within(name, roots) or _within(real, roots):
+            return Refusal(AGENT_TREE, f"{name} resolves inside a tree the agent can write")
+        if _is_trusted_system_file(os.path.basename(name), real):
+            # Spelling the system program's own path out is still the system
+            # program; it needs no witness.
+            return _interpreter_refusal(name, real, witness, depth)
+        dispatched = _dispatcher_target_refusal(name, real, as_interpreter)
+        if dispatched is not None:
+            return dispatched
+        pinned = _pin_refusal(name, name, real, witness)
+        if pinned is not None:
+            return pinned
+        return _interpreter_refusal(name, real, witness, depth)
+
+    found = shutil.which(name, path=_agent_search_path())
+    if not found:
+        # NOTHING ON THE SEARCH PATH ANSWERS TO THIS NAME, SO IT IS A SHELL
+        # BUILTIN (or a typo), AND IT IS REFUSED UNLESS PROVABLY INERT.
+        #
+        # This branch used to allow every unresolved name, reasoning that there
+        # was no shadowed program and so nothing to vouch for. That reasoning is
+        # wrong, and it generated a review finding per round for four rounds:
+        # `exec`, then `export`, then `set`, then `printf -v`, then `trap
+        # 'payload' DEBUG`. A builtin does not need to SHADOW a program to decide
+        # what runs -- it IS the mechanism, and `shutil.which` cannot see it at
+        # all. Bash has around seventy builtins, so enumerating the dangerous
+        # ones was never going to converge; the ALLOWLIST below is the whole
+        # inversion, and it is short because very few builtins can neither run a
+        # program nor change how a later name resolves.
+        #
+        # The cost is that an unknown command word now prompts instead of being
+        # waved through: a shell function or alias from the user's rc file, and a
+        # typo (which would have failed anyway). That is the correct direction for
+        # a check whose entire job is to say which file will run.
+        if os.path.basename(name) in _INERT_BUILTINS:
+            return None
+        return Refusal(
+            UNKNOWN_COMMAND,
+            f"{name} is not a program on the search path, so it is a shell "
+            "builtin this check cannot identify or vouch for",
+        )
+    try:
+        real = os.path.realpath(found)
+    except (OSError, ValueError):
+        return Refusal(UNINSPECTABLE, f"{name} could not be resolved")
+    # `is_project_local` reads the location the name was FOUND in, never the
+    # symlink target: a real system install can legitimately resolve THROUGH a
+    # segment on that list (`/usr/bin/npm` -> `…/node_modules/npm/bin/npm-cli.js`),
+    # and judging the target would refuse it. Where the target LEADS is covered
+    # by the agent-writable roots below, which compare whole paths instead of
+    # guessing from a segment name.
+    roots = _agent_writable_roots()
+    if is_project_local(found) or _within(found, roots) or _within(real, roots):
+        return Refusal(AGENT_TREE, f"{name} resolves inside a tree the agent can write ({found})")
+    system = platform_compat.trusted_system_bin(name)
+    if system is not None:
+        if not _is_trusted_system_file(name, real):
+            return Refusal(
+                SHADOWED,
+                f"{name} resolves to {found}, which shadows the system program at {system}",
+            )
+        # The system program itself. The name identifies it by construction, so
+        # no witness is needed -- this is what keeps coreutils and the read-only
+        # allowlist working with no approval history at all.
+        return _interpreter_refusal(name, real, witness, depth)
+    dispatched = _dispatcher_target_refusal(name, real, as_interpreter)
+    if dispatched is not None:
+        return dispatched
+    pinned = _pin_refusal(name, found, real, witness)
+    if pinned is not None:
+        return pinned
+    return _interpreter_refusal(name, real, witness, depth)
+
+
+def _dispatcher_target_refusal(name: str, real: str, as_interpreter: bool) -> Refusal | None:
+    """Refuse a name whose RESOLVED file is a dispatcher, however it is spelled.
+
+    The check above this one reads the name as WRITTEN, so it catches `env foo`
+    and misses an alias for it: an agent plants `runner -> /usr/bin/env`, a human
+    approves `runner` once and pins it, and every later `runner <payload>` is
+    auto-approved while `env` runs the payload. The dispatcher rule is about the
+    FILE's behaviour, so it has to be asked of the file.
+
+    Deliberately reached only AFTER the trusted-system branch. On a BusyBox
+    install every coreutils name resolves to `/bin/busybox`, which is a
+    dispatcher by basename; those names are already recognised as the system
+    program they are, so asking this question later leaves them alone and still
+    catches a planted alias, which is never a trusted system file.
+    """
+
+    if as_interpreter:
+        # A shebang's interpreter runs the pinned script, not a program named in
+        # a command line, which is the distinction the caller already draws.
+        return None
+    if os.path.basename(real) not in _DISPATCHERS:
+        return None
+    return Refusal(
+        DISPATCHER,
+        f"{name} resolves to a program that runs whatever its arguments name, "
+        "which this check cannot identify from the command line",
+    )
+
+
+def _interpreter_refusal(name: str, real: str, witness: bool, depth: int) -> Refusal | None:
+    """Apply the same questions to the interpreter *real* hands itself to.
+
+    Measured on a stock host, the read-only allowlist's own programs are binaries
+    except ``egrep`` and ``fgrep``, which are scripts naming ``sh`` by ABSOLUTE
+    path -- a trusted system file, so their chain ends immediately and needs no
+    witness.
+    """
+
+    if depth >= _INTERPRETER_DEPTH:
+        return Refusal(
+            UNTOKENIZABLE,
+            f"{name} chains through more interpreters than this check follows",
+        )
+    interpreter = _shebang_interpreter(real)
+    if interpreter is None:
+        return None
+    if interpreter == _COMPLEX_ENV_SHEBANG:
+        return Refusal(
+            UNENUMERABLE,
+            f"{name} hands itself to `env` with options, so which interpreter runs "
+            "cannot be read off the shebang line",
+        )
+    return _program_refusal(interpreter, witness=witness, depth=depth + 1, as_interpreter=True)
+
+
+def _is_trusted_system_file(name: str, real: str) -> bool:
+    """Whether *real* IS the trusted system program called *name*."""
+
+    system = platform_compat.trusted_system_bin(name)
+    if system is None:
+        return False
+    try:
+        return os.path.normcase(os.path.realpath(system)) == os.path.normcase(real)
+    except (OSError, ValueError):
+        return False
+
+
+def pin_human_approval(command: str) -> None:
+    """Record the programs in a command a HUMAN just approved.
+
+    This is what makes a later name-based grant honourable for a program the
+    trusted system directories do not carry: the person saw this command on the
+    approval card and said yes, so the file behind each of its program names is
+    the file their decision was about. :func:`_pin_refusal` refuses such a name
+    until this has run, and refuses it again once a DIFFERENT file answers to it.
+
+    Call it only on a genuine human answer -- never from an auto-approve path,
+    which is the very thing the pin exists to constrain. Failures are swallowed:
+    a missing pin costs one prompt, and an approval must not fail because a
+    program could not be stat-ed.
+    """
+
+    try:
+        for name in program_names(command) or []:
+            _program_refusal(name, witness=True)
+    except Exception:
+        logger.debug("could not record approved program identities", exc_info=True)
+
+
+def name_grant_refusal(command: str) -> Refusal | None:
+    """Why *command* may not be auto-approved by NAME, or ``None`` when it may.
+
+    The result is a diagnostic, not a denial: the caller falls through to
+    interactive approval, so a refusal costs one prompt and never blocks the
+    command. Log ``Refusal.log_text`` (a constant) and show ``Refusal.detail``
+    to the person deciding.
+
+    CALL THIS OFF THE EVENT LOOP. It resolves names against ``PATH`` and digests
+    the file behind each one, so a stalled network mount or a large binary would
+    stall the gateway. The tiers reach it through ``asyncio.to_thread``; there is
+    deliberately no cheaper on-loop mode, because a mode that cannot read a file
+    cannot answer the question and would only look like it had.
+
+    An empty command returns ``None`` -- there is no name to vouch for, and the
+    tiers that call this have already established they have a command.
+    """
+
+    if not command.strip():
+        return None
+    if platform_compat.IS_WINDOWS:
+        # FAIL CLOSED ON WINDOWS, for two reasons that compound.
+        #
+        # Tokenization: POSIX mode reads a backslash as an ESCAPE, so
+        # `C:\workspace\tool.exe` arrives as `C:workspacetool.exe`. That is no
+        # longer a path, so the path-form branch never runs; it is a bare name
+        # that resolves nowhere, and an unresolvable name is otherwise ALLOWED
+        # ("nothing to shadow" -- the branch that lets `cd /tmp && ls` work).
+        #
+        # Resolution: `cmd.exe` searches the CURRENT DIRECTORY before `PATH`,
+        # which POSIX shells do not. The directory it searches is the session's,
+        # while this check runs in the gateway's, so a planted `find.exe` in the
+        # session's work directory wins a lookup this code cannot even see. Add
+        # `PATHEXT` and the search order is a second set of semantics to model.
+        #
+        # Neither is a name the check can identify, so it identifies none of them:
+        # on Windows a name-based auto-approve is declined and the request goes to
+        # the approval card. That is a functional cost -- Windows users lose
+        # auto-approve for shell commands entirely -- and it is the honest state
+        # given that this module's own tests are POSIX-only. Modelling the child's
+        # working directory and the shell's search order is the fix, and it is its
+        # own change with its own tests.
+        return Refusal(
+            WINDOWS_UNMODELLED,
+            "on Windows this check cannot identify which file a program name "
+            "runs: the tokenizer cannot preserve a backslash path, and the shell "
+            "searches the command's own directory before the search path",
+        )
+    if _path_is_ambiguous():
+        return Refusal(
+            AMBIGUOUS_PATH,
+            "the agent's search path contains an empty or relative entry, so which "
+            "file a program name resolves to depends on a working directory this "
+            "check cannot see",
+        )
+    preload = _inherited_preload()
+    if preload is not None:
+        # The environment this process passes to a child shell can redefine any
+        # program name as a shell function, so resolving the name says nothing
+        # about what will run. Refusing every name grant while that is set is the
+        # honest answer; it costs auto-approve for a session whose environment
+        # carries one of these, which is rare and already unusual.
+        return Refusal(
+            AMBIGUOUS_ENV,
+            f"{preload} is set in the inherited environment, so a shell function "
+            "can replace any program this check resolves",
+        )
+    for construct in _UNENUMERABLE:
+        if construct in command:
+            # A substitution runs a program in a position the tokenizer cannot
+            # reach (POSIX quote handling swallows `"$(head x)"` whole), so the
+            # command's program set is not knowable here. Refuse rather than
+            # vouch for the part that happens to be visible.
+            return Refusal(
+                UNENUMERABLE,
+                f"the command line contains {construct!r}, whose programs cannot be enumerated",
+            )
+    names = program_names(command)
+    if names is None:
+        return Refusal(
+            UNTOKENIZABLE,
+            "the command line could not be reduced to a known set of program names",
+        )
+    for name in names:
+        refusal = _program_refusal(name)
+        if refusal is not None:
+            return refusal
+    return None

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from chat_test_helpers import _make_ready_kiro_prerequisite
 
+from kiro_crew import name_grant
 from kiro_crew.acp.types import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
@@ -2429,6 +2430,114 @@ class TestRunChatRecoveryLadders:
 
 
 class TestRunChatAutoApproveRungs:
+    @pytest.fixture(autouse=True)
+    def _vouch_for_the_program(self):
+        """Let these tests exercise the RUNG, not the host's program layout.
+
+        Each rung now re-judges its own auto-approve by asking whether the
+        command's program names still identify the programs they name
+        (``name_grant``), which resolves against the real ``PATH`` and reads the
+        file behind each name. That made these tests depend on the machine: they
+        use ``ls -la``, which passes on Linux because ``ls`` lives in a trusted
+        system directory and FAILS on Windows, where there is no such ``ls`` --
+        so the rung declined, `approve_tool` was never called, and the assertions
+        below broke on one platform only. The thread hop the real check needs also
+        outlives these tests' event loop and crashed the xdist worker.
+
+        Stubbing it keeps each test measuring what its name claims -- does the
+        rung approve, reject, and render -- while the check itself is covered
+        directly in ``test/test_name_grant.py``. It patches the ONE off-loop
+        entry point every rung goes through; patching only the event-shaped
+        wrapper left two rungs spawning real threads, which is why the Windows
+        workers kept crashing after the first attempt at this.
+        """
+
+        with patch.object(
+            chat_runner, "_name_grant_refusal_off_loop", new=AsyncMock(return_value=None)
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_a_non_shell_approval_mints_no_shell_witness(self, tmp_path):
+        """GPT 5.6 round-22: a non-shell approval must not pin a shell program.
+
+        `extract_bash_command` reads a `command` key out of ANY structured input,
+        so a non-shell MCP call carrying `{"command": "gh ..."}` would otherwise
+        record a durable identity for `gh` from an approval that was never about
+        running `gh`.
+        """
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(
+            client,
+            [
+                _permission(
+                    title="Looking up the record",
+                    tool_input='{"command": "gh repo view"}',
+                    tool_kind="other",
+                    is_shell=False,
+                    tool_name="read_record",
+                    mcp_server_name="records:primary",
+                ),
+                _complete(),
+            ],
+        )
+
+        def _allow_once_when_registered():
+            future = slot._approval_futures.get("req-cov-1")
+            if future is not None and not future.done():
+                future.set_result("approved")
+
+        state.push_slots_update.side_effect = _allow_once_when_registered
+        with patch.object(chat_runner, "pin_human_approval") as pin:
+            await _drive(state, slot)
+
+        # The branch really was reached -- otherwise the assertion below would
+        # pass for the wrong reason, which is exactly how a guard like this gets
+        # a test that cannot fail.
+        client.approve_tool.assert_awaited_once_with("req-cov-1")
+        pin.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_declined_name_grant_is_audited(self, tmp_path):
+        """GPT 5.6 round-19: declining a grant is a security decision, so it is logged.
+
+        Without this the audit trail shows a command arriving at the interactive
+        card and never says a name grant was withheld, or why.
+        """
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._trust_reads = True
+        _set_stream(
+            client,
+            [_permission(title="Running: ls -la", tool_input='{"command": "ls -la"}'), _complete()],
+        )
+        refusal = name_grant.Refusal(name_grant.SHADOWED, "ls resolves to /writable/ls")
+        slot._empty_response_retries = 2
+        with (
+            patch.object(chat_runner, "sel") as mock_sel,
+            patch.object(
+                chat_runner, "_name_grant_refusal_off_loop", new=AsyncMock(return_value=refusal)
+            ),
+            patch.object(chat_runner, "tool_approval_timeout_secs", return_value=0.0),
+        ):
+            audit = MagicMock()
+            mock_sel.return_value = audit
+            await chat_runner._run_chat(state, slot, "hello")
+        await _settle(slot)
+
+        declined = [
+            c.kwargs
+            for c in audit.log_tool_invocation.call_args_list
+            if c.kwargs.get("outcome") == "auto_approve_declined"
+        ]
+        assert declined, audit.log_tool_invocation.call_args_list
+        assert declined[0]["metadata"]["code"] == name_grant.SHADOWED
+        assert declined[0]["metadata"]["tier"] == "trust_reads"
+        # The CODE, never the detail: the detail names resolved paths, and an
+        # audit sink is exactly where that becomes a disclosure.
+        assert "/writable/ls" not in json.dumps(declined[0], default=str)
+
     @pytest.mark.asyncio
     async def test_non_shell_trust_matches_cached_server_tool_identity(self, tmp_path):
         state, client = _runner_state(tmp_path)

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -1495,7 +1495,20 @@ class TestDenyRowTitleRedaction:
         state, client = _make_state(tmp_path)
         slot = _make_slot()
         slot._trust_reads = True
-        with patch("kiro_crew.dashboard.chat_runner.sel") as mock_sel:
+        # The name-grant check is stubbed to "no refusal" so this test keeps
+        # measuring what its name claims -- that the trust-reads DENY row and its
+        # SEL record are redacted -- rather than the host's PATH semantics. It
+        # reaches the tier with `ls`, which resolves to a trusted system program on
+        # POSIX but does not exist on Windows, where the check therefore declines
+        # the tier outright, the request falls through to the interactive card, and
+        # the `trust_reads` deny asserted below never happens. Patching the ONE
+        # off-loop entry point every tier goes through is the same seam
+        # `test_chat_runner_coverage.py` uses; the check itself is covered directly
+        # in `test/test_name_grant.py`.
+        _no_refusal = patch.object(
+            chat_runner, "_name_grant_refusal_off_loop", new=AsyncMock(return_value=None)
+        )
+        with patch("kiro_crew.dashboard.chat_runner.sel") as mock_sel, _no_refusal:
             audit = MagicMock()
             mock_sel.return_value = audit
             await _drive_deny_turn(

--- a/test/test_host_service_guard.py
+++ b/test/test_host_service_guard.py
@@ -98,6 +98,12 @@ _DELIBERATELY_UNGUARDED = {
     # behind them — a detector of `doas`, not a spawn of it. `doas systemctl
     # restart` is still caught on the inner `systemctl` token.
     "doas": "privilege prefix; the wrapped command carries the action",
+    # The polkit equivalent, and excluded for the identical reason. Its only
+    # appearance in src/ is as a MEMBER of `name_grant._DISPATCHERS`, the table
+    # that refuses to vouch for a program which runs another program named in
+    # its arguments -- a detector of `pkexec`, not a spawn of it. `pkexec
+    # systemctl restart` is still caught on the inner `systemctl` token.
+    "pkexec": "privilege prefix; the wrapped command carries the action",
 }
 
 

--- a/test/test_name_grant.py
+++ b/test/test_name_grant.py
@@ -1,0 +1,1232 @@
+"""A name-based auto-approve must not be honoured for a shadowed program name.
+
+Upstream issue #4438: trust grants and the read-only allowlist authorize a
+command by program NAME, while the shell resolves that name afterwards through a
+``PATH`` that can lead with directories the agent itself writes. These tests pin
+both halves -- the decision function and the tiers wired to it.
+
+Every test that resolves a name builds its own ``PATH`` and its own stand-in for
+the trusted system directories, so no assertion depends on what the host has
+installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import pytest
+
+from kiro_crew import name_grant, platform_compat
+from kiro_crew.hooks import TOOL_AUTO_APPROVE, HookManager, HooksConfig
+
+pytestmark = pytest.mark.skipif(
+    platform_compat.IS_WINDOWS,
+    reason="resolution fixtures rely on the POSIX execute bit and a ':'-joined PATH",
+)
+
+
+def _program(directory, name: str) -> str:
+    """Create an executable *name* in *directory* and return its path.
+
+    Written as a BINARY (no shebang), because that is what the programs this
+    module vouches for actually are -- ``/usr/bin/head`` is ELF, not a script.
+    A test that needs an interpreter chain writes its own shebang file, so the
+    chain is exercised where it is the subject rather than everywhere by
+    accident.
+    """
+
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_bytes(b"\x7fELF\x02\x01\x01\x00 not a real binary\n")
+    path.chmod(0o700)
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def _clear_pins():
+    """Each test starts with no pinned identities.
+
+    The pin store is process-wide by design (a file's identity is not a property
+    of one session), so tests must not inherit each other's observations.
+    """
+
+    name_grant._PINS.clear()
+    yield
+    name_grant._PINS.clear()
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch):
+    """A hermetic search path plus a stand-in for the system bin directories.
+
+    Returns the tuple ``(system_dir, user_dir)``: ``user_dir`` comes FIRST on the
+    search path, which is the ordering the issue reports on a real host.
+    """
+
+    system_dir = tmp_path / "usr" / "bin"
+    user_dir = tmp_path / "home" / ".local" / "bin"
+    system_dir.mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        name_grant,
+        "_agent_search_path",
+        lambda: os.pathsep.join([str(user_dir), str(system_dir)]),
+    )
+
+    def fake_system_bin(name: str) -> str | None:
+        candidate = system_dir / name
+        return str(candidate) if candidate.is_file() else None
+
+    monkeypatch.setattr(platform_compat, "trusted_system_bin", fake_system_bin)
+    # No project checkout / workspace root unless a test declares one.
+    monkeypatch.setattr(name_grant, "_agent_writable_roots", lambda: ())
+    # The fixture's search path is absolute by construction; pin the ambiguity
+    # answer so no assertion here depends on the host's own PATH (a runner with
+    # an empty entry would otherwise refuse every command for the right reason
+    # and fail every test for the wrong one).
+    monkeypatch.setattr(name_grant, "_path_is_ambiguous", lambda: False)
+    return system_dir, user_dir
+
+
+class TestProgramNames:
+    """Every command position is collected, and only command positions."""
+
+    def test_pipeline_and_chain_positions(self):
+        assert name_grant.program_names("cat a | grep x | wc -l") == ["cat", "grep", "wc"]
+        assert name_grant.program_names("cd /tmp && ls") == ["cd", "ls"]
+        assert name_grant.program_names("a; b || c") == ["a", "b", "c"]
+
+    def test_environment_prefix_keeps_the_position_open(self):
+        assert name_grant.program_names("FOO=bar head x") == ["head"]
+        assert name_grant.program_names("A=1 B=2 grep x") == ["grep"]
+
+    @pytest.mark.parametrize(
+        "assignment",
+        ["PATH=/writable/bin", "LD_PRELOAD=/tmp/eve.so", "BASH_ENV=/tmp/rc", "IFS=x"],
+    )
+    def test_execution_affecting_assignment_refuses(self, assignment):
+        # GPT 5.6 round-10: `PATH=/writable/bin head file` decides which `head`
+        # runs, and the loader variables decide what code runs inside it. The walk
+        # used to skip every assignment and vouch for the system `head`.
+        assert name_grant.program_names(f"{assignment} head file") is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # A TOOL pointed at a helper command by its environment.
+            "GIT_SSH_COMMAND=/writable/evil git fetch ssh://x",
+            "GIT_EXTERNAL_DIFF=/writable/evil git diff",
+            # An INTERPRETER told to load extra code first.
+            "PYTHONPATH=/writable python3 x",
+            "NODE_OPTIONS=--require=/writable/evil node x",
+            "PERL5OPT=-Mevil perl x",
+            "RUBYOPT=-revil ruby x",
+            "JAVA_TOOL_OPTIONS=-javaagent:/writable/e.jar java X",
+            # The FAMILIES, not just the spellings above: a name this list never
+            # enumerates is still refused when it is shaped like one of them.
+            "SOMETOOL_OPTIONS=--load=/writable/evil head file",
+            "WHATEVERLIB=/writable head file",
+            "LD_SOMETHING_NEW=/writable head file",
+        ],
+    )
+    def test_code_injecting_assignment_refuses(self, command):
+        # Opus 4.8 round-18. The base program really is the trusted system one,
+        # so resolving its name answers nothing: `GIT_SSH_COMMAND=/writable/evil
+        # git fetch` vouched for `/usr/bin/git` and ran the planted file. Same
+        # shape as `LD_PRELOAD`, arriving through a tool's or interpreter's own
+        # configuration. Matched as FAMILIES because each round found one more
+        # interpreter with its own spelling, so an exact list is only ever as
+        # complete as the last person to think about it.
+        assert name_grant.program_names(command) is None
+
+    @pytest.mark.parametrize(
+        "command",
+        ["FOO=bar head x", "A=1 B=2 head x", "MY_TOKEN=abc head x"],
+    )
+    def test_an_ordinary_assignment_is_still_skipped(self, command):
+        # The other side of the rule: an assignment that changes a program's
+        # INPUTS is not a statement about what runs, so it must not cost a prompt.
+        assert name_grant.program_names(command) == ["head"]
+
+    @pytest.mark.parametrize(
+        "token",
+        ["PATH+=:.", "PATH+=:/writable", "A[0]=x", "=bare"],
+    )
+    def test_non_plain_assignment_token_refuses(self, token):
+        # GPT 5.6 round-14: only a strict `NAME=value` prefix is a benign
+        # assignment. A compound (`PATH+=:.`) or an array element is a state
+        # change this walk cannot evaluate, and skipping it left the program after
+        # it unchecked.
+        assert name_grant.program_names(f"{token} payload") is None
+
+    def test_a_benign_assignment_prefix_still_walks(self):
+        assert name_grant.program_names("FOO=bar head x") == ["head"]
+
+    def test_redirect_target_is_not_a_program(self):
+        # `>` is punctuation but does NOT open a command position: what follows
+        # is a file. Judging it would resolve an operand.
+        assert name_grant.program_names("head x > /tmp/out") == ["head"]
+        assert name_grant.program_names("head x 2>&1") == ["head"]
+
+    def test_leading_redirect_does_not_hide_the_program(self):
+        # GPT 5.6's round-2 finding: a redirect may PRECEDE the program, and the
+        # fd prefix arrives as its own token, so a position-closing rule made the
+        # real program invisible.
+        assert name_grant.program_names("2>/dev/null head README.md") == ["head"]
+        assert name_grant.program_names("2>&1 head x") == ["head"]
+        assert name_grant.program_names(">out head x") == ["head"]
+        assert name_grant.program_names("cat a | 2>/dev/null grep x") == ["cat", "grep"]
+
+    def test_substitution_inner_program_is_collected(self):
+        assert name_grant.program_names("echo $(head x)") == ["echo", "head"]
+
+    def test_quoted_separator_is_not_a_position(self):
+        assert name_grant.program_names("echo 'a && b'") == ["echo"]
+
+    def test_untokenizable_is_none_not_empty(self):
+        # None means "argv could not be established", which the caller refuses.
+        # An empty list would read as "no programs found" and be honoured.
+        assert name_grant.program_names("head 'unbalanced") is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "head x | { evil; }",  # GPT 5.6 round-3: `{` read as the program
+            "if true; then evil; fi",
+            "for f in a b; do evil; done",
+            "while true; do evil; done",
+            "! evil",
+            "time evil",
+            "case x in a) evil;; esac",
+        ],
+    )
+    def test_unmodelled_grammar_is_none(self, command):
+        # This walk models simple commands joined by pipes, `&&`/`||`/`;` and
+        # subshells. A reserved word means the real program hides behind a syntax
+        # word, so the answer is "unknown", never the subset it could see.
+        assert name_grant.program_names(command) is None
+
+    def test_newline_is_a_command_separator(self):
+        # GPT 5.6 round-4: shlex treats a newline as ordinary whitespace, so
+        # `head file\npayload` handed back ['head', 'file', 'payload'] and the
+        # second command sat in operand position, invisible.
+        assert name_grant.program_names("head file\npayload") == ["head", "payload"]
+        assert name_grant.program_names("head a\r\ngrep b\rwc c") == ["head", "grep", "wc"]
+
+    def test_newline_inside_quotes_refuses(self):
+        # Splitting a quoted newline leaves that line unbalanced, which is the
+        # safe direction: refuse rather than mis-read.
+        assert name_grant.program_names("grep 'a\nb' file") is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "head x;(payload)",  # GPT 5.6 round-5: `;(` arrives as ONE token
+            "head x&&(payload)",
+            "head x|(payload)",
+            "head x;>out payload",
+        ],
+    )
+    def test_composite_operator_is_refused(self, command):
+        # `shlex` groups a run of punctuation into one token, so these matched no
+        # operator and were skipped -- losing the command they introduce.
+        assert name_grant.program_names(command) is None
+
+    def test_spaced_forms_of_those_still_walk(self):
+        assert name_grant.program_names("head x; (payload)") == ["head", "payload"]
+        assert name_grant.program_names("head x && (payload)") == ["head", "payload"]
+
+    def test_subshell_is_still_walked(self):
+        # `(` opens a command position, so a subshell needs no refusal.
+        assert name_grant.program_names("head x && (grep y)") == ["head", "grep"]
+
+
+class TestLoopSafety:
+    """The check does filesystem work, so it must only ever run off the loop."""
+
+    def test_the_dashboard_downgrade_helper_runs_it_in_a_thread(self):
+        # Every rung reaches this check through ONE off-loop entry point, and
+        # that entry point is what hands it to a worker thread. Pinning both
+        # facts here is what keeps a future edit from calling it straight from
+        # the loop -- the shape GPT flagged when the hook layer did exactly that.
+        import inspect
+
+        from kiro_crew.dashboard import chat_runner
+
+        entry = chat_runner._name_grant_refusal_off_loop
+        assert inspect.iscoroutinefunction(entry)
+        assert "asyncio.to_thread(name_grant_refusal" in inspect.getsource(entry)
+        # And no rung may spawn its own thread instead of using it.
+        runner_source = inspect.getsource(chat_runner)
+        assert runner_source.count("asyncio.to_thread(name_grant_refusal") == 1
+
+    def test_the_loop_bound_hook_no_longer_resolves_anything(self):
+        # `HookManager.on_tool_call` is synchronous and called on the loop, so it
+        # must not reach this module at all: not `shutil.which`, not a digest.
+        import inspect
+
+        from kiro_crew import hooks
+
+        source = inspect.getsource(hooks.HookManager.on_tool_call)
+        assert "name_grant" not in source
+
+
+class TestShadowedResolution:
+    """The reported attack and the cases that must stay auto-approvable."""
+
+    def test_system_program_is_honoured(self, world):
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head -5 /etc/hosts") is None
+
+    def test_planted_shim_that_shadows_a_system_program_is_refused(self, world):
+        system_dir, user_dir = world
+        _program(system_dir, "head")
+        shim = _program(user_dir, "head")
+        refusal = name_grant.name_grant_refusal("head -5 /etc/hosts")
+        assert refusal is not None
+        assert refusal.code == name_grant.SHADOWED
+        assert shim in refusal.detail
+        assert str(system_dir / "head") in refusal.detail
+
+    def test_shim_in_a_later_pipeline_stage_is_refused(self, world):
+        system_dir, user_dir = world
+        _program(system_dir, "cat")
+        _program(system_dir, "grep")
+        _program(user_dir, "grep")
+        assert name_grant.name_grant_refusal("cat a | grep x") is not None
+
+    def test_user_installed_program_with_no_system_twin_shadows_nothing(self, world):
+        # `gh`, `node`, `kirocrew`: nothing in the system directories answers to
+        # the name, so the shadowing rule has no opinion. Such a name is gated by
+        # the witnessed pin instead (see TestIdentityPin) -- here the point is
+        # only that it is not refused AS A SHADOW.
+        _, user_dir = world
+        _program(user_dir, "gh")
+        refusal = name_grant.name_grant_refusal("gh pr view 1")
+        assert refusal is not None
+        assert refusal.code != name_grant.SHADOWED
+
+    def test_unresolvable_name_is_honoured(self, world):
+        # A shell builtin (`cd`) resolves nowhere. There is no shadowed program,
+        # and refusing every builtin would break `cd /tmp && ls`.
+        system_dir, _ = world
+        _program(system_dir, "ls")
+        assert name_grant.name_grant_refusal("cd /tmp && ls") is None
+
+    def test_symlink_to_the_same_system_file_is_honoured(self, world):
+        # Distros ship `/usr/bin/head` -> a multi-call binary, and a second
+        # spelling of the SAME file is not a substitution.
+        system_dir, user_dir = world
+        real = _program(system_dir, "head")
+        (user_dir / "head").symlink_to(real)
+        assert name_grant.name_grant_refusal("head x") is None
+
+    def test_untokenizable_command_is_refused(self, world):
+        assert name_grant.name_grant_refusal("head 'unbalanced") is not None
+
+    def test_empty_command_is_not_refused(self, world):
+        assert name_grant.name_grant_refusal("   ") is None
+
+
+class TestAgentWritableTrees:
+    """A resolution inside a tree the agent writes needs no shadowing."""
+
+    def test_resolution_inside_the_project_checkout_is_refused(self, world, tmp_path, monkeypatch):
+        system_dir, _ = world
+        _program(system_dir, "head")
+        checkout = tmp_path / "checkout"
+        planted = _program(checkout / "bin", "tool")
+        monkeypatch.setattr(
+            name_grant,
+            "_agent_search_path",
+            lambda: os.pathsep.join([str(checkout / "bin"), str(system_dir)]),
+        )
+        monkeypatch.setattr(
+            name_grant, "_agent_writable_roots", lambda: (os.path.normcase(str(checkout)),)
+        )
+        refusal = name_grant.name_grant_refusal("tool --list")
+        assert refusal is not None
+        assert refusal.code == name_grant.AGENT_TREE
+        assert planted in refusal.detail
+
+    def test_project_local_tool_directory_is_refused(self, world, tmp_path, monkeypatch):
+        system_dir, _ = world
+        venv_bin = tmp_path / "proj" / ".venv" / "bin"
+        _program(venv_bin, "tool")
+        monkeypatch.setattr(
+            name_grant,
+            "_agent_search_path",
+            lambda: os.pathsep.join([str(venv_bin), str(system_dir)]),
+        )
+        assert name_grant.name_grant_refusal("tool --list") is not None
+
+    def test_system_install_resolving_through_a_project_segment_is_honoured(
+        self, world, tmp_path, monkeypatch
+    ):
+        # `/usr/bin/npm` -> `…/node_modules/npm/bin/npm-cli.js`. The segment list
+        # describes where a name was FOUND, so judging the symlink TARGET would
+        # refuse a stock install. Regression guard for that false positive.
+        system_dir, _ = world
+        target = _program(tmp_path / "usr" / "lib" / "node_modules" / "npm" / "bin", "npm-cli.js")
+        (system_dir / "npm").symlink_to(target)
+        assert name_grant.name_grant_refusal("npm run build") is None
+
+    def test_roots_lookup_failure_fails_closed(self, world, monkeypatch):
+        system_dir, _ = world
+        _program(system_dir, "head")
+        monkeypatch.setattr(name_grant, "_agent_writable_roots", lambda: None)
+        assert name_grant.name_grant_refusal("head x") is not None
+
+
+class TestPathFormPrograms:
+    """A program named by path, not by name."""
+
+    def test_relative_path_is_refused(self, world):
+        assert name_grant.name_grant_refusal("./gradlew build") is not None
+
+    def test_absolute_path_outside_the_agent_trees_is_honoured(self, world):
+        system_dir, _ = world
+        head = _program(system_dir, "head")
+        assert name_grant.name_grant_refusal(f"{head} -5 /etc/hosts") is None
+
+    def test_absolute_path_inside_an_agent_tree_is_refused(self, world, tmp_path, monkeypatch):
+        checkout = tmp_path / "checkout"
+        planted = _program(checkout / "bin", "payload")
+        monkeypatch.setattr(
+            name_grant, "_agent_writable_roots", lambda: (os.path.normcase(str(checkout)),)
+        )
+        assert name_grant.name_grant_refusal(f"{planted} --help") is not None
+
+    def test_a_nul_bearing_path_refuses_instead_of_raising(
+        self, world
+    ):  # GPT 5.6 round-18. A NUL byte makes the filesystem calls raise
+        # ValueError, NOT OSError -- `shlex` hands the token through intact, so
+        # an OSError-only guard let it escape and abort the whole chat turn with
+        # an error card in place of the approval. This module's contract is that
+        # it RETURNS a refusal and never raises at its callers, so every
+        # inspection site fails closed on both.
+        refusal = name_grant.name_grant_refusal("/tmp/a\x00b --version")
+        assert refusal is not None
+        assert refusal.code == name_grant.UNINSPECTABLE
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "head /tmp/a\x00b",  # a NUL in an OPERAND, not the program
+            "/tmp/a\x00b",  # the program alone, no arguments
+            "head file; /tmp/a\x00b",  # a second command position
+        ],
+    )
+    def test_a_nul_byte_never_raises_from_any_position(self, world, command):
+        # The contract is total: whatever a caller passes, this returns a verdict.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        name_grant.name_grant_refusal(command)
+        name_grant.program_names(command)
+
+    def test_an_alias_for_a_dispatcher_is_refused(self, world, monkeypatch):
+        # GPT 5.6 round-19. The dispatcher rule read the name as WRITTEN, so an
+        # ALIAS for one slipped past it: plant `runner -> env`, have a human
+        # approve `runner` once (which pins it), and every later
+        # `runner <payload>` auto-approves while `env` runs the payload. The rule
+        # is about the FILE's behaviour, so it is now asked of the resolved file.
+        system_dir, user_dir = world
+        env = _program(system_dir, "env")
+        alias = user_dir / "runner"
+        alias.symlink_to(env)
+        # Pin it the way a human approval would, so the pin cannot be what
+        # refuses this -- the dispatcher rule has to be what does.
+        name_grant.pin_human_approval("runner --version")
+        refusal = name_grant.name_grant_refusal("runner /writable/payload")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    def test_an_absolute_alias_for_a_dispatcher_is_refused(self, world):
+        # The same bypass spelled as a path rather than found on the search path.
+        system_dir, user_dir = world
+        env = _program(system_dir, "env")
+        alias = user_dir / "runner2"
+        alias.symlink_to(env)
+        name_grant.pin_human_approval(f"{alias} --version")
+        refusal = name_grant.name_grant_refusal(f"{alias} /writable/payload")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    def test_a_system_program_resolving_to_a_dispatcher_is_still_honoured(self, world):
+        # The BusyBox shape, and the reason the new question is asked AFTER the
+        # trusted-system branch: there every coreutils name resolves to
+        # `/bin/busybox`, a dispatcher by basename. Those names ARE the system
+        # program they claim to be, so they must not start costing a prompt.
+        system_dir, _ = world
+        busybox = _program(system_dir, "busybox")
+        head = system_dir / "head"
+        head.symlink_to(busybox)
+        assert name_grant.name_grant_refusal("head file") is None
+
+
+class TestUnenumerableConstructs:
+    """Seeing part of a command's program set is not a basis for vouching."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "$(head x)"',  # POSIX quote handling swallows the substitution
+            "echo $(head x)",
+            'echo "`head x`"',
+            "echo `head x`",
+            "cat <(head x)",
+            "diff <(head a) <(head b)",
+        ],
+    )
+    def test_substitutions_are_refused(self, world, command):
+        system_dir, _ = world
+        _program(system_dir, "echo")
+        _program(system_dir, "cat")
+        _program(system_dir, "diff")
+        assert name_grant.name_grant_refusal(command) is not None
+
+    def test_expanded_program_token_is_refused(self, world):
+        assert name_grant.name_grant_refusal("$CMD --version") is not None
+        assert name_grant.name_grant_refusal("./*.sh") is not None
+
+
+class TestNonRegularFiles:
+    """A program name that resolves to something unreadable must never be read."""
+
+    def test_a_planted_fifo_is_refused_without_opening_it(self, world):
+        # Opus 4.8: a FIFO passes every test a PATH lookup applies -- it exists,
+        # it carries the execute bit, it is not a directory -- so `which` returns
+        # it and the digest would open() it O_RDONLY, blocking in the kernel until
+        # a writer appears. On a worker thread that leak is permanent, and
+        # repeating it drains the shared executor, stalling every other session's
+        # approvals. The test would HANG rather than fail if the guard regressed,
+        # so it is also its own canary.
+        _, user_dir = world
+        fifo = user_dir / "gh"
+        os.mkfifo(fifo, 0o700)
+        refusal = name_grant.name_grant_refusal("gh pr view 1")
+        assert refusal is not None
+        assert refusal.code == name_grant.UNINSPECTABLE
+
+    def test_a_fifo_interpreter_is_refused_without_opening_it(self, world):
+        _, user_dir = world
+        fifo = user_dir / "myrunner"
+        os.mkfifo(fifo, 0o700)
+        script = user_dir / "tool"
+        script.write_text(f"#!{fifo}\n")
+        script.chmod(0o700)
+        name_grant.pin_human_approval("tool run")
+        refusal = name_grant.name_grant_refusal("tool run")
+        assert refusal is not None
+
+    def test_the_regular_file_predicate_rejects_a_fifo(self, world):
+        _, user_dir = world
+        fifo = user_dir / "pipe"
+        os.mkfifo(fifo)
+        assert name_grant._is_regular_file(str(fifo)) is False
+        plain = _program(user_dir, "plain")
+        assert name_grant._is_regular_file(plain) is True
+
+
+class TestIdentityPin:
+    """A non-system program is vouched for only on the file a human approved."""
+
+    def test_unwitnessed_program_is_refused(self, world):
+        # GPT 5.6's round-2 finding: pinning on first SIGHT would bless whatever
+        # is there when a tier first looks -- and a tier looks precisely when it
+        # is about to auto-approve without asking anyone.
+        _, user_dir = world
+        _program(user_dir, "gh")
+        refusal = name_grant.name_grant_refusal("gh pr view 1")
+        assert refusal is not None
+        assert refusal.code == name_grant.UNWITNESSED
+
+    def test_human_approval_makes_it_auto_approvable(self, world):
+        _, user_dir = world
+        _program(user_dir, "gh")
+        name_grant.pin_human_approval("gh pr view 1")
+        assert name_grant.name_grant_refusal("gh pr view 1") is None
+        assert name_grant.name_grant_refusal("gh pr view 2") is None
+
+    def test_replaced_binary_with_no_system_twin_is_refused(self, world):
+        # `gh` has no `/usr/bin/gh`, so the shadowing rule cannot see a
+        # substitution. The witnessed pin can.
+        _, user_dir = world
+        _program(user_dir, "gh")
+        name_grant.pin_human_approval("gh pr view 1")
+        assert name_grant.name_grant_refusal("gh pr view 1") is None
+        (user_dir / "gh").write_text("#!/bin/sh\necho pwned\n")
+        (user_dir / "gh").chmod(0o700)
+        refusal = name_grant.name_grant_refusal("gh pr view 1")
+        assert refusal is not None
+        assert refusal.code == name_grant.IDENTITY_CHANGED
+        assert "gh" in refusal.detail
+
+    def test_mismatch_does_not_re_pin_from_a_check(self, world):
+        # Re-pinning on a check would mean "one prompt, then trusted" -- and this
+        # code cannot see whether the human said yes to that prompt. Only a real
+        # approval re-pins.
+        _, user_dir = world
+        _program(user_dir, "gh")
+        name_grant.pin_human_approval("gh pr view 1")
+        (user_dir / "gh").write_text("#!/bin/sh\necho pwned\n")
+        (user_dir / "gh").chmod(0o700)
+        assert name_grant.name_grant_refusal("gh pr view 1") is not None
+        assert name_grant.name_grant_refusal("gh pr view 1") is not None
+        name_grant.pin_human_approval("gh pr view 1")
+        assert name_grant.name_grant_refusal("gh pr view 1") is None
+
+    def test_system_program_needs_no_witness(self, world):
+        # What keeps coreutils and the read-only allowlist working with no
+        # approval history at all.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head x") is None
+
+    def test_absolute_system_path_needs_no_witness(self, world):
+        system_dir, _ = world
+        head = _program(system_dir, "head")
+        assert name_grant.name_grant_refusal(f"{head} x") is None
+
+    def test_same_name_in_two_directories_is_independent(self, world, tmp_path, monkeypatch):
+        # Two projects shipping a same-named tool must not invalidate each other:
+        # only a swap IN PLACE is a mismatch.
+        system_dir, user_dir = world
+        _program(user_dir, "toolx")
+        name_grant.pin_human_approval("toolx run")
+        assert name_grant.name_grant_refusal("toolx run") is None
+        other = tmp_path / "other" / "bin"
+        _program(other, "toolx")
+        monkeypatch.setattr(
+            name_grant,
+            "_agent_search_path",
+            lambda: os.pathsep.join([str(other), str(system_dir)]),
+        )
+        # A different directory is a different pin, so it starts unwitnessed
+        # rather than inheriting the other one's approval.
+        refusal = name_grant.name_grant_refusal("toolx run")
+        assert refusal is not None and refusal.code == name_grant.UNWITNESSED
+        name_grant.pin_human_approval("toolx run")
+        assert name_grant.name_grant_refusal("toolx run") is None
+
+    def test_same_size_rewrite_with_restored_mtime_is_refused(self, world):
+        # GPT 5.6 round-3: mtime and size are both under the writer's control, so
+        # a same-size in-place rewrite plus os.utime restores them exactly. No
+        # sleep here on purpose -- the rewrite lands inside the same ctime tick as
+        # the pin, so the metadata alone (including the kernel-set ctime) is
+        # identical and only the content digest can tell them apart.
+        _, user_dir = world
+        gh = user_dir / "gh"
+        gh.write_text("#!/bin/sh\nexit 0\n")
+        gh.chmod(0o700)
+        before = gh.stat()
+        name_grant.pin_human_approval("gh pr view 1")
+        assert name_grant.name_grant_refusal("gh pr view 1") is None
+        gh.write_text("#!/bin/sh\nexit 9\n")  # byte-for-byte same length
+        os.utime(gh, ns=(before.st_atime_ns, before.st_mtime_ns))
+        after = gh.stat()
+        assert after.st_size == before.st_size
+        assert after.st_mtime_ns == before.st_mtime_ns
+        assert after.st_ino == before.st_ino
+        refusal = name_grant.name_grant_refusal("gh pr view 1")
+        assert refusal is not None
+        assert refusal.code == name_grant.IDENTITY_CHANGED
+
+    def test_a_large_file_is_digested_whole_including_its_middle(self, world):
+        # GPT 5.6 round-14: an earlier version hashed only a large file's head and
+        # tail, so a MIDDLE-only rewrite that preserved the size and landed in one
+        # ctime tick kept the identity equal. Refusing large files instead would
+        # have killed witnessing for `node`, `gh` and `docker`, so the digest now
+        # covers every byte.
+        _, user_dir = world
+        big = user_dir / "toolbig"
+        payload = bytearray(b"A" * (3 * name_grant._DIGEST_CHUNK))
+        big.write_bytes(bytes(payload))
+        big.chmod(0o700)
+        before = big.stat()
+        name_grant.pin_human_approval("toolbig run")
+        assert name_grant.name_grant_refusal("toolbig run") is None
+        middle = len(payload) // 2
+        payload[middle : middle + 8] = b"BBBBBBBB"  # same size, changed MIDDLE
+        big.write_bytes(bytes(payload))
+        os.utime(big, ns=(before.st_atime_ns, before.st_mtime_ns))
+        assert big.stat().st_size == before.st_size
+        refusal = name_grant.name_grant_refusal("toolbig run")
+        assert refusal is not None
+        assert refusal.code == name_grant.IDENTITY_CHANGED
+
+    def test_lost_pin_during_the_touch_refuses_instead_of_raising(self, world, monkeypatch):
+        # GPT 5.6 round-5: a concurrent insert can evict the key between the read
+        # and the LRU touch. `_PIN_LOCK` makes that unreachable through this
+        # module's own paths, so the race cannot be reproduced by timing -- this
+        # injects the failure directly, because what matters is the consequence:
+        # on the approval path an exception aborts the user's turn, a refusal
+        # costs a prompt.
+        _, user_dir = world
+        _program(user_dir, "gh")
+        name_grant.pin_human_approval("gh pr view 1")
+        assert name_grant.name_grant_refusal("gh pr view 1") is None
+
+        class Evicting(type(name_grant._PINS)):  # type: ignore[misc]
+            def move_to_end(self, key, last=True):  # noqa: D102
+                raise KeyError(key)
+
+        monkeypatch.setattr(name_grant, "_PINS", Evicting(name_grant._PINS))
+        refusal = name_grant.name_grant_refusal("gh pr view 1")
+        assert refusal is not None
+        assert refusal.code == name_grant.UNWITNESSED
+
+    def test_concurrent_checks_and_pins_do_not_raise(self, world):
+        # Contention smoke test: many checks against a store being churned below
+        # the eviction threshold. It does not reproduce the eviction window (the
+        # lock closes it), so the test above is what pins the consequence.
+        import threading
+
+        _, user_dir = world
+        _program(user_dir, "gh")
+        name_grant.pin_human_approval("gh pr view 1")
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def check() -> None:
+            try:
+                while not stop.is_set():
+                    name_grant.name_grant_refusal("gh pr view 1")
+            except BaseException as exc:  # noqa: BLE001 - the point is to catch any
+                errors.append(exc)
+
+        def churn() -> None:
+            try:
+                index = 0
+                while not stop.is_set():
+                    name_grant.pin_human_approval(f"filler{index}")
+                    index += 1
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=check), threading.Thread(target=churn)]
+        # A small store makes eviction certain rather than theoretical.
+        original_limit = name_grant._PIN_LIMIT
+        name_grant._PIN_LIMIT = 4
+        try:
+            for thread in threads:
+                thread.start()
+            time.sleep(0.4)
+            stop.set()
+            for thread in threads:
+                thread.join(timeout=5)
+        finally:
+            name_grant._PIN_LIMIT = original_limit
+        assert not errors, errors
+
+    def test_pin_store_is_bounded(self, world):
+        _, user_dir = world
+        _program(user_dir, "gh")
+        for index in range(name_grant._PIN_LIMIT + 20):
+            name_grant.pin_human_approval(f"synthetic{index}")
+        name_grant.pin_human_approval("gh pr view 1")
+        assert len(name_grant._PINS) <= name_grant._PIN_LIMIT
+        assert name_grant.name_grant_refusal("gh pr view 1") is None
+
+
+class TestLogSafety:
+    """A refusal's log text must not carry the command line or a resolved path."""
+
+    def test_log_text_is_a_module_constant(self, world):
+        system_dir, user_dir = world
+        _program(system_dir, "head")
+        shim = _program(user_dir, "head")
+        refusal = name_grant.name_grant_refusal("head /etc/hosts")
+        assert refusal is not None
+        assert refusal.log_text in name_grant._REFUSAL_LOG_TEXT.values()
+        # The path IS in the detail (the person deciding needs it) and must NOT
+        # be in the text that reaches a log sink.
+        assert shim in refusal.detail
+        assert shim not in refusal.log_text
+        assert "/etc/hosts" not in refusal.log_text
+
+    def test_every_code_has_log_text(self):
+        codes = {
+            name_grant.UNENUMERABLE,
+            name_grant.UNTOKENIZABLE,
+            name_grant.EXPANDED,
+            name_grant.RELATIVE_PATH,
+            name_grant.AGENT_TREE,
+            name_grant.SHADOWED,
+            name_grant.IDENTITY_CHANGED,
+            name_grant.UNWITNESSED,
+            name_grant.DISPATCHER,
+            name_grant.AMBIGUOUS_PATH,
+            name_grant.WINDOWS_UNMODELLED,
+            name_grant.UNINSPECTABLE,
+            name_grant.UNKNOWN_COMMAND,
+            name_grant.AMBIGUOUS_ENV,
+        }
+        assert codes == set(name_grant._REFUSAL_LOG_TEXT)
+
+
+class TestSearchPath:
+    """What the check resolves against must be what the child will search."""
+
+    def test_relative_entry_refuses_everything(self, world, monkeypatch):
+        # GPT 5.6 round-8, correcting round-6: dropping `.` from the search path
+        # is not enough. The CHILD still has it, so the check would resolve
+        # `/usr/bin/head` and vouch while the child ran a planted `./head` from
+        # its own directory. Neither keeping nor dropping the entry answers the
+        # question, so a PATH carrying one refuses outright.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        # Override the fixture's pin: this test is about the ambiguous case.
+        monkeypatch.setattr(name_grant, "_path_is_ambiguous", lambda: True)
+        refusal = name_grant.name_grant_refusal("head x")
+        assert refusal is not None
+        assert refusal.code == name_grant.AMBIGUOUS_PATH
+
+    def test_ambiguity_is_detected_from_the_real_path(self, monkeypatch):
+        monkeypatch.setenv("PATH", os.pathsep.join([".", "/usr/bin"]))
+        assert name_grant._path_is_ambiguous() is True
+        monkeypatch.setenv("PATH", os.pathsep.join(["/usr/bin", ""]))
+        assert name_grant._path_is_ambiguous() is True
+        monkeypatch.setenv("PATH", os.pathsep.join(["/usr/bin", "/bin"]))
+        assert name_grant._path_is_ambiguous() is False
+
+    def test_only_absolute_entries_are_searched(self, monkeypatch):
+        monkeypatch.setenv("PATH", os.pathsep.join([".", "relative/bin", "/usr/bin"]))
+        entries = name_grant._agent_search_path().split(os.pathsep)
+        assert all(os.path.isabs(entry) for entry in entries)
+
+
+class TestDispatchers:
+    """A program that runs another program named in its arguments."""
+
+    @pytest.mark.parametrize("wrapper", ["env", "sudo", "nohup", "timeout", "xargs", "command"])
+    def test_dispatcher_is_refused(self, world, wrapper):
+        # GPT 5.6 round-8: `env head file` is ONE program with two operands as far
+        # as the walk can tell, so it would vouch for `/usr/bin/env` while `head`
+        # is resolved from PATH at exec time.
+        system_dir, _ = world
+        _program(system_dir, wrapper)
+        _program(system_dir, "head")
+        refusal = name_grant.name_grant_refusal(f"{wrapper} head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    @pytest.mark.parametrize("builtin", ["exec", "eval", "builtin", "source", "."])
+    def test_dispatching_builtin_is_refused(self, world, builtin):
+        # GPT 5.6 round-9: a builtin is invisible to `which`, and an unresolvable
+        # name is otherwise "nothing to shadow, nothing to vouch for" -- so
+        # `exec head file` passed while `head` came from PATH at exec time. No
+        # program file is created for these on purpose: not being resolvable is
+        # the whole point.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        refusal = name_grant.name_grant_refusal(f"{builtin} head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    def test_absolute_dispatcher_is_refused_too(self, world):
+        system_dir, _ = world
+        env = _program(system_dir, "env")
+        refusal = name_grant.name_grant_refusal(f"{env} head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    @pytest.mark.parametrize("shell", ["sh", "bash", "zsh", "dash", "fish"])
+    def test_command_shell_is_refused(self, world, shell):
+        # GPT 5.6 round-12: `sh -c 'head file'` runs an arbitrary command string,
+        # so vouching for `/bin/sh` says nothing about what executes. Scoped out in
+        # round 9 and asked for here; a grant naming a shell is a grant to run
+        # anything, which belongs on the approval card.
+        system_dir, _ = world
+        _program(system_dir, shell)
+        refusal = name_grant.name_grant_refusal(f"{shell} -c 'head file'")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    @pytest.mark.parametrize("builtin", ["export", "hash", "alias", "declare", "set"])
+    def test_resolution_mutating_builtin_is_refused(self, world, builtin):
+        # GPT 5.6 round-13: `export PATH=/agent/bin:$PATH && head file` re-points
+        # the lookup for every command after it, so the resolution this check
+        # performs describes the PREVIOUS state. `hash` and `alias` re-point one
+        # name directly. No program file is created: like the dispatching
+        # builtins, not being resolvable is the point.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        refusal = name_grant.name_grant_refusal(f"{builtin} PATH=/agent/bin && head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    @pytest.mark.parametrize("builtin", ["printf", "read", "mapfile", "let"])
+    def test_variable_writing_builtin_is_refused(self, world, builtin):
+        # GPT 5.6 round-14: `printf -v PATH /writable; payload` sets PATH with no
+        # assignment token at all, so the walk checked `payload` against the
+        # previous search path.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        refusal = name_grant.name_grant_refusal(f"{builtin} -v PATH /writable; head file")
+        assert refusal is not None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "trap 'payload' DEBUG; head file",
+            "enable -f /writable/evil.so head; head file",
+        ],
+    )
+    def test_code_installing_builtin_is_refused(self, world, command):
+        # GPT 5.6 round-15. `trap` installs a body that runs before every later
+        # command; `enable -f` loads a shared object AS a builtin. Neither is a
+        # file on the search path, so `shutil.which` cannot see either one.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        refusal = name_grant.name_grant_refusal(command)
+        assert refusal is not None
+        assert refusal.code == name_grant.UNKNOWN_COMMAND
+
+    def test_a_hash_inside_a_word_does_not_hide_a_later_command(self, world):
+        # GPT 5.6 round-16, and the sharpest finding on this PR because it is the
+        # PR's own thesis turned against it. `shlex` discards the rest of the line
+        # after `#`; bash does NOT (a `#` only opens a comment at the start of a
+        # word). Measured: `bash -c 'echo A file#x; echo B ran'` prints BOTH
+        # halves, while the default lexer handed this walk ['head', 'file'] and
+        # the second command was never checked.
+        system_dir, user_dir = world
+        _program(system_dir, "head")
+        _program(system_dir, "cat")
+        _program(user_dir, "cat")  # the shadowing plant
+        names = name_grant.program_names("head file#x; cat secret")
+        assert names == ["head", "cat"]
+        refusal = name_grant.name_grant_refusal("head file#x; cat secret")
+        assert refusal is not None
+        assert refusal.code == name_grant.SHADOWED
+
+    def test_a_trailing_comment_is_still_harmless(self, world):
+        # Turning commenters off means a real comment arrives as an operand. That
+        # is fine: only command POSITIONS are inspected.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.program_names("head file # a note") == ["head"]
+
+    @pytest.mark.parametrize("var", ["BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS"])
+    def test_inherited_preload_variable_refuses(self, world, var, monkeypatch):
+        # GPT 5.6 round-16. `BASH_ENV=/writable/rc` holding `head() { payload; }`
+        # means `bash -c 'head file'` runs the FUNCTION, while the name still
+        # resolves to /usr/bin/head. Same threat as the command-line prefix
+        # `_EXEC_ENV_VARS` already refuses, arriving through the environment.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head file") is None
+        monkeypatch.setenv(var, "/writable/rc")
+        refusal = name_grant.name_grant_refusal("head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.AMBIGUOUS_ENV
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "BASH_FUNC_head%%",  # bash >= 4.3, the live spelling
+            "BASH_FUNC_head()",  # the interim post-Shellshock spelling
+            "BASH_FUNC_anything%%",  # a function that shadows nothing in THIS command
+        ],
+    )
+    def test_an_exported_shell_function_refuses(self, world, key, monkeypatch):
+        # GPT 5.6 round-17. An exported function shadows the name with no writable
+        # file anywhere: bash re-imports `BASH_FUNC_head%%` in the child, so
+        # `head file` runs the payload while the name still resolves to
+        # /usr/bin/head. Matched on the `BASH_FUNC_` PREFIX so a build that spells
+        # the suffix differently cannot hand the bypass back -- which is why the
+        # third case, naming a function this command never mentions, refuses too.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head file") is None
+        monkeypatch.setenv(key, "() { payload; }")
+        refusal = name_grant.name_grant_refusal("head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.AMBIGUOUS_ENV
+
+    def test_a_legacy_bare_name_function_export_refuses(self, world, monkeypatch):
+        # The pre-2014 spelling: the key is the bare function name and only the
+        # `() {` value marks it as a function. Supported bash no longer imports
+        # this, so it is belt-and-braces -- but the value form costs one check.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head file") is None
+        monkeypatch.setenv("head", "() { payload; }")
+        refusal = name_grant.name_grant_refusal("head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.AMBIGUOUS_ENV
+
+    @pytest.mark.parametrize("builtin", ["compgen", "pushd", "popd", "bind", "caller", "disown"])
+    def test_an_unenumerated_builtin_is_refused_by_default(self, world, builtin):
+        # THE POINT OF THE INVERSION, and the reason this class is closed rather
+        # than four rounds of patching. None of these names appears anywhere in
+        # the module: they refuse because an unresolved command word is refused BY
+        # DEFAULT, not because someone thought of them. A future bash builtin is
+        # covered the same way.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert builtin not in name_grant._DISPATCHERS
+        refusal = name_grant.name_grant_refusal(f"{builtin} x; head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.UNKNOWN_COMMAND
+
+    @pytest.mark.parametrize("command", ["cd /tmp && ls", "echo hi", ": && ls", "pwd"])
+    def test_inert_builtins_are_still_allowed(self, world, command):
+        # The inversion refuses by default, so the allowlist is what keeps the
+        # ordinary read-only tier working. `cd /tmp && ls` is the case that made
+        # the original "unresolvable means nothing to shadow" branch look right.
+        system_dir, _ = world
+        for name in ("ls", "pwd"):
+            _program(system_dir, name)
+        assert name_grant.name_grant_refusal(command) is None
+
+    def test_an_ordinary_program_is_unaffected(self, world):
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head file") is None
+
+
+class TestInterpreterChain:
+    """A pinned script binds its bytes; its interpreter must face the same rules."""
+
+    def test_env_shebang_interpreter_is_checked(self, world):
+        # GPT 5.6 round-6: `#!/usr/bin/env node` resolves `node` from PATH at exec
+        # time, so the script can stay byte-identical while the program that
+        # actually runs is replaced underneath it.
+        system_dir, user_dir = world
+        script = user_dir / "tool"
+        # The env path must be the fixture's OWN system env, not a literal
+        # `/usr/bin/env`: the shebang's env binary is now held to the same
+        # standard as any program (round 21), and a host path would make this
+        # test depend on the runner's filesystem, which the fixture exists to
+        # avoid.
+        system_env = _program(system_dir, "env")
+        script.write_text(f"#!{system_env} node\n")
+        script.chmod(0o700)
+        _program(user_dir, "node")
+        name_grant.pin_human_approval("tool run")
+        assert name_grant.name_grant_refusal("tool run") is None
+        # Replace only the INTERPRETER; the script is untouched.
+        (user_dir / "node").write_text("#!/bin/sh\necho pwned\n")
+        (user_dir / "node").chmod(0o700)
+        refusal = name_grant.name_grant_refusal("tool run")
+        assert refusal is not None
+        assert refusal.code == name_grant.IDENTITY_CHANGED
+
+    def test_shadowed_interpreter_is_refused(self, world):
+        system_dir, user_dir = world
+        _program(system_dir, "python3")
+        _program(user_dir, "python3")  # shim shadowing the system interpreter
+        script = user_dir / "tool"
+        system_env = _program(system_dir, "env")
+        script.write_text(f"#!{system_env} python3\n")
+        script.chmod(0o700)
+        name_grant.pin_human_approval("tool run")
+        refusal = name_grant.name_grant_refusal("tool run")
+        assert refusal is not None
+        assert refusal.code == name_grant.SHADOWED
+
+    def test_complex_env_shebang_is_refused(self, world):
+        # GPT 5.6 round-10: `env`'s options take operands, so picking the first
+        # non-flag token read `UNUSED` as the interpreter -- validating the wrong
+        # file while vouching for the command. Only the bare one-name form is read.
+        system_dir, user_dir = world
+        _program(user_dir, "node")
+        system_env = _program(system_dir, "env")
+        for line in (
+            f"#!{system_env} -S -u UNUSED node",
+            f"#!{system_env} -i node",
+            f"#!{system_env} FOO=bar node",
+        ):
+            script = user_dir / "tool"
+            script.write_text(f"{line}\n")
+            script.chmod(0o700)
+            name_grant.pin_human_approval("tool run")
+            refusal = name_grant.name_grant_refusal("tool run")
+            assert refusal is not None, line
+            assert refusal.code == name_grant.UNENUMERABLE, line
+
+    def test_a_shebang_env_that_is_not_the_system_env_is_refused(self, world):
+        # GPT 5.6 round-21. `env` was matched by BASENAME, so the path was read
+        # for the name after it and then forgotten -- `#!<planted>/env node`
+        # validated `node` while the planted `env` is what the kernel actually
+        # runs. A pin binds the SCRIPT's bytes, so the script keeps matching
+        # while the file behind its shebang is swapped underneath it. The env
+        # binary now has to BE the system one, not merely be spelled like it.
+        system_dir, user_dir = world
+        _program(system_dir, "node")
+        planted_env = _program(user_dir, "env")
+        script = user_dir / "tool"
+        script.write_text(f"#!{planted_env} node\n")
+        script.chmod(0o700)
+        name_grant.pin_human_approval("tool run")
+        refusal = name_grant.name_grant_refusal("tool run")
+        assert refusal is not None
+        assert refusal.code == name_grant.UNENUMERABLE
+
+    def test_the_system_env_shebang_is_still_honoured(self, world):
+        # The other side: tightening the env path must not refuse the ordinary
+        # `#!<system>/env node` form, which is what real scripts carry.
+        system_dir, user_dir = world
+        _program(system_dir, "node")
+        system_env = _program(system_dir, "env")
+        script = user_dir / "tool"
+        script.write_text(f"#!{system_env} node\n")
+        script.chmod(0o700)
+        name_grant.pin_human_approval("tool run")
+        assert name_grant.name_grant_refusal("tool run") is None
+
+    def test_shell_shebang_is_not_treated_as_a_dispatcher(self, world):
+        # The distinction the `as_interpreter` step exists for: `sh -c '...'` on a
+        # command line names its program in arguments this check cannot read, but
+        # `#!/bin/sh` atop a script whose BYTES are pinned runs that script. Adding
+        # shells to the dispatcher table without this would have refused every
+        # shell script -- an over-refusal, caught by three existing tests.
+        system_dir, user_dir = world
+        _program(system_dir, "sh")
+        script = user_dir / "tool"
+        script.write_text(f"#!{system_dir / 'sh'}\necho hi\n")
+        script.chmod(0o700)
+        name_grant.pin_human_approval("tool run")
+        assert name_grant.name_grant_refusal("tool run") is None
+
+    def test_absolute_system_interpreter_is_fine(self, world):
+        system_dir, user_dir = world
+        _program(system_dir, "sh")
+        script = user_dir / "tool"
+        script.write_text(f"#!{system_dir / 'sh'}\n")
+        script.chmod(0o700)
+        name_grant.pin_human_approval("tool run")
+        assert name_grant.name_grant_refusal("tool run") is None
+
+    def test_interpreter_inside_an_agent_tree_is_refused(self, world, tmp_path, monkeypatch):
+        _, user_dir = world
+        checkout = tmp_path / "checkout"
+        planted = _program(checkout / "bin", "myrunner")
+        script = user_dir / "tool"
+        script.write_text(f"#!{planted}\n")
+        script.chmod(0o700)
+        monkeypatch.setattr(
+            name_grant, "_agent_writable_roots", lambda: (os.path.normcase(str(checkout)),)
+        )
+        name_grant.pin_human_approval("tool run")
+        refusal = name_grant.name_grant_refusal("tool run")
+        assert refusal is not None
+        assert refusal.code == name_grant.AGENT_TREE
+
+    def test_loop_bound_callers_cannot_reach_the_shebang_read(self):
+        # The shebang read is one more reason the check may not run on the loop;
+        # `TestLoopSafety` pins that the only in-gateway caller is off-loop.
+        assert name_grant._shebang_interpreter("/nonexistent/program") is None
+
+
+class TestDowngradePath:
+    """A hook-granted shell auto-approve is re-judged off-loop and can be downgraded."""
+
+    @staticmethod
+    def _event(command: str | None, is_shell: bool = True):
+        class _Event:
+            pass
+
+        event = _Event()
+        event.is_shell = is_shell  # type: ignore[attr-defined]
+        event.shell_command = command  # type: ignore[attr-defined]
+        return event
+
+    def test_clean_name_is_not_downgraded(self, world):
+        system_dir, _ = world
+        _program(system_dir, "head")
+        from kiro_crew.dashboard.chat_runner import _name_grant_refusal_for
+
+        assert asyncio.run(_name_grant_refusal_for(self._event("head x"))) is None
+
+    def test_shadowed_name_is_downgraded(self, world):
+        system_dir, user_dir = world
+        _program(system_dir, "head")
+        _program(user_dir, "head")
+        from kiro_crew.dashboard.chat_runner import _name_grant_refusal_for
+
+        refusal = asyncio.run(_name_grant_refusal_for(self._event("head x")))
+        assert refusal is not None
+        assert refusal.code == name_grant.SHADOWED
+
+    def test_non_shell_and_commandless_events_are_left_alone(self, world):
+        from kiro_crew.dashboard.chat_runner import _name_grant_refusal_for
+
+        assert asyncio.run(_name_grant_refusal_for(self._event("head x", is_shell=False))) is None
+        assert asyncio.run(_name_grant_refusal_for(self._event(None))) is None
+
+
+class TestWindowsPaths:
+    """A path this tokenizer cannot preserve must not become a silent pass.
+
+    Runs on POSIX by patching the platform flag, because the module-level skip
+    keeps the rest of this file off Windows: the fixtures rely on the POSIX
+    execute bit. That skip is why this gap existed at all, and it is stated in
+    the PR rather than papered over.
+    """
+
+    def test_windows_refuses_every_name(self, world, monkeypatch):
+        # GPT 5.6 rounds 11 and 12, compounding: POSIX tokenization destroys a
+        # backslash path (leaving a bare name that resolves nowhere, which is
+        # ALLOWED), and `cmd.exe` searches the command's own directory before
+        # PATH -- a directory this check, running in the gateway's, cannot see.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        monkeypatch.setattr(name_grant.platform_compat, "IS_WINDOWS", True)
+        for command in (r"C:\workspace\tool.exe run", "head file", "find ."):
+            refusal = name_grant.name_grant_refusal(command)
+            assert refusal is not None, command
+            assert refusal.code == name_grant.WINDOWS_UNMODELLED, command
+
+    def test_the_tokenizer_really_does_destroy_it(self):
+        # Half the premise, pinned: if this stops being true the refusal can
+        # narrow to the lookup-order half alone.
+        assert name_grant.program_names(r"C:\workspace\tool.exe run") == ["C:workspacetool.exe"]
+
+    def test_posix_backslash_is_left_alone(self, world):
+        # On POSIX a backslash IS an escape, and the program name survives, so
+        # these must keep working.
+        system_dir, _ = world
+        _program(system_dir, "grep")
+        _program(system_dir, "find")
+        assert name_grant.name_grant_refusal(r"grep '\d+' file") is None
+        assert name_grant.name_grant_refusal(r"find . -name \*.py") is None
+
+
+class TestHookTierIsUntouched:
+    """The hook layer keeps its own behaviour; the name check is not in it."""
+
+    def test_read_only_tier_still_auto_approves(self, world):
+        result = HookManager().on_tool_call("list", command="ls -la", is_shell=True)
+        assert result.action == TOOL_AUTO_APPROVE
+
+    def test_shadowed_name_is_no_longer_the_hook_layer_s_business(self, world):
+        # It grants; the async caller re-judges and downgrades. Pinning this stops
+        # a future edit from quietly reintroducing filesystem work on the loop.
+        system_dir, user_dir = world
+        _program(system_dir, "ls")
+        _program(user_dir, "ls")
+        result = HookManager().on_tool_call("list", command="ls -la", is_shell=True)
+        assert result.action == TOOL_AUTO_APPROVE
+
+    def test_non_shell_tools_are_untouched(self, world):
+        cfg = HooksConfig(auto_approve_tools=["ReadFile"])
+        assert HookManager(cfg).on_tool_call("ReadFile").action == TOOL_AUTO_APPROVE
+
+    def test_non_system_program_is_granted_here_and_judged_by_the_caller(self, world):
+        # The hook layer no longer defers a non-system program: it grants, and the
+        # async caller decides. `TestDowngradePath` is where the decision is
+        # pinned; this only records that the hook layer stopped doing filesystem
+        # work of its own.
+        _, user_dir = world
+        _program(user_dir, "gh")
+        cfg = HooksConfig(auto_approve_tools=["Running: gh *"])
+        result = HookManager(cfg).on_tool_call(
+            "Running: gh pr view 1", command="gh pr view 1", is_shell=True
+        )
+        assert result.action == TOOL_AUTO_APPROVE


### PR DESCRIPTION
## 1. What is the problem?

A trust grant, a configured `auto_approve_tools` glob and the read-only allowlist all authorize a command by its program **name**. The shell then performs its own `PATH` lookup, and a gateway's `PATH` legitimately leads with directories the agent itself can write (a worktree venv's `bin`, mise shims, `~/.local/bin`).

So a file the agent plants at `~/.local/bin/head` wins the lookup over `/usr/bin/head`, and an approval granted because the command "is just `head`" executes whatever the agent last wrote there. The repo already documents this threat in `trusted_system_bin`'s docstring, but that primitive only protects callers that **spawn** a resolved absolute path; it has no reach into the approval path.

## 2. Why this issue matters to the user

A grant is meant to be a statement about a program's behaviour. When the name does not identify the binary, the grant conveys authority the user never intended: writing a file is cheap for an agent and executing one is gated, and a name-based grant is exactly the bridge between the two. The user clicked "trust all `head` commands" having seen a paging utility, not an arbitrary program that keeps running unprompted for the rest of the session.

## 3. How our fix solves it -- from symptom to root cause

Symptom: a grant for `head` runs a planted shim.
Mechanism: the grant names a program; the lookup that picks the file happens later, in the shell, over a search path whose leading entries the agent can write.
Root cause: no tier ever asks whether the name still identifies the program it appears to name.

New `src/kiro_crew/name_grant.py` answers that question for a command line. **It runs in the dashboard's chat runner, off the event loop** -- that surface and no other, which is a deliberate scope stated in full under "Known costs" below and tracked in #6361 -- at three points:

- a hook-granted shell auto-approve (the operator's `auto_approve_tools` globs, and the read-only allowlist) is re-judged and downgraded to the interactive card when the check refuses;
- the session-trusted-pattern tier consults it before honouring a matched pattern;
- the `trust_reads` tier consults it before honouring a read-only classification.

`hooks.py` is deliberately **unchanged** (byte-identical to main). `HookManager.on_tool_call` is synchronous and called on the gateway's event loop, and this check resolves names against `PATH` and digests the file behind each one -- work that must not run there. A test pins that its source never mentions this module, so the work cannot creep back onto the loop.

A refusal never blocks and never rewrites a command. It returns `allow()`, so the request falls through to the ordinary approval card: the tier stops skipping a prompt the user has not answered for this program.

**What the check asks.** A name is honoured only when it still identifies its program:

- it must not SHADOW the same-named program in the trusted system directories (`~/.local/bin/head` over `/usr/bin/head` is the reported attack);
- it must not resolve inside a tree the agent writes -- the project checkout, the workspace root, or a project-local tool directory (`.venv/bin`, `node_modules/.bin`);
- if it is NOT a system program (`gh`, `node`, `kirocrew`, a version manager's `python`), a human approval must have identified the file, and it must still be that file. Approving a command records each of its programs by identity: a SHA-256 of the bytes (capped at 1 MiB, head and tail above that) plus size, inode, device and the kernel-set `st_ctime_ns`. Metadata alone is forgeable by the writer this pin exists to catch -- a same-size rewrite plus `os.utime` restores mtime and size exactly -- so the content digest is what decides. Pinning on first SIGHT would be worthless, because a tier looks precisely when it is about to auto-approve without asking anyone;
- a script's INTERPRETER faces the same questions. `#!/usr/bin/env node` resolves `node` from `PATH` at exec time, so a pinned script can stay byte-identical while the program that runs is replaced underneath it.

**What the check refuses outright**, because the command line does not identify its programs at all: substitutions and backticks (`shlex` swallows `"$(head x)"` whole); shell grammar it does not model (`{ }`, `if`, `for`, `while`, `case`, `!`, `time`); composite operators (`;(`, `;>`); a shell-expanded program token (`$CMD`); a relative program path; a command-position assignment to a variable that decides what runs (`PATH=`, `LD_PRELOAD=`, `BASH_ENV=`, `IFS=`, the `DYLD_*` family); a dispatcher that runs a program named in its arguments (`env`, `sudo`, `timeout`, `xargs`, `exec`, `eval`, `source`, and their kin); an `env` shebang carrying options, whose interpreter cannot be read off the line; and any `PATH` containing an empty or relative entry, since which file such an entry names depends on a working directory this check cannot see.

Program names are collected from every command position -- each pipeline stage, both sides of `&&`/`||`/`;`, each line, and inside a subshell.

Each refusal carries a **code** as well as a human detail, and callers log only the code: the detail names resolved paths, and logging it is a dataflow from tool input into a log sink that CodeQL reports at high severity. `Refusal.log_text` reads a constant out of a module table, the same severing pattern `spine/keeper.py` and `cli_bench.py` use.

**Known costs, and one named residual.**

- A version manager whose shim shadows a system program (`python3` behind a mise shim while `/usr/bin/python3` exists) costs one prompt per command instead of a silent auto-approve. Coreutils and `git` read verbs -- the read-only allowlist's day-to-day traffic -- are unaffected.
- A non-system program costs one approval card before name grants work for it, and one more after an upgrade changes its identity.
- A `PATH` with `.` on it disables name-based auto-approve entirely until it is cleaned up.
- **Residual: non-dashboard surfaces are not covered, and this is one of four.** The same hook-granted `TOOL_AUTO_APPROVE` is honoured with no name check at `task_executor.py:393`, `subagent.py:6249` and `messaging/dispatch.py:295`, so Slack, Discord, Telegram, subagents, the taskrunner, `llm_helpers` and the auto-improvement spine still honour a name-based grant exactly as they did before this PR. Nothing regresses there and no prompts are added -- but the reported attack remains open on those surfaces, and since the adversary is the agent itself it picks the surface, so the unwatched ones are the cheaper target rather than the rarer one. Covering them is a design change, not a port: `dispatch.py`'s `_tool_gate` is synchronous and loop-bound while this check must resolve `PATH` and digest a file off the loop -- the same constraint that keeps `hooks.py` byte-identical here -- and the shared entry point would have to be promoted out of `chat_runner` first. **Tracked in #6361**, with the three sites and a suggested shape. This PR does not claim to fix them.
- The check is not binding on the exec: it runs when the approval is decided and the shell resolves again when it runs, so a second concurrent agent writing the shim inside that window still wins. Closing that needs the child's `PATH` to stop leading with agent-writable directories, which is what #4438 asks for and is not attempted here.

One consolidation rides along: the project-local segment policy lived in `dashboard/terminal_commands.py` and is now owned by `name_grant` and imported there, so the two answers to the same question cannot drift.

## 4. What tests we did

`test/test_name_grant.py`, 158 tests. Every resolution is built against a hermetic search path and a stand-in for the trusted system directories, and the fixture pins the search-path ambiguity answer, so no assertion depends on the host's own `PATH` or installed programs.

Covered: the reported attack and its pipeline variants; a clean system program, a builtin that resolves nowhere, and a second symlink spelling of the same file still auto-approving; a non-system program refused until an approval identifies it, honoured after, refused once a different file answers to the name, and re-honoured after the next approval; a same-size rewrite with mtime restored inside the same ctime tick; an above-cap file changed at its head; project-checkout and `.venv/bin` resolutions; a stock install resolving THROUGH a `node_modules` segment still honoured; interpreter chains, including a shadowed interpreter, an agent-tree interpreter, and an `env` shebang with options; every tokenizer shape listed in section 3; the pin surviving concurrent churn, and a lost pin refusing instead of raising; log text never carrying a path; and the downgrade helper being a coroutine that hands the check to a thread.

Mutation-verified: 21 mutants, 20 killed. The one that is not is removing the pin store's lock, which no timing test can kill -- stated rather than papered over. Its consequence is covered instead by a deterministic test that injects the `KeyError` and asserts a refusal.

Also run: `test_hooks.py`, `test_chat_runner_coverage.py`, `test_terminal_commands.py`, `test_dashboard_approval.py`, `test_chat_hooks.py`, `test_denied_commands_hooks.py`. black / isort / flake8 / mypy clean on the changed files.

Two later rounds, after a rebase onto current main:

- **An exported shell function** (`BASH_FUNC_head%%`) shadows a name directly, with no writable file anywhere: bash re-imports it in the child, so `head file` runs the payload while the check resolves `/usr/bin/head` and vouches for it. Refused now on the `BASH_FUNC_` prefix rather than a `%%` suffix, because the suffix has been spelled `()` and `%%` by different bash versions and pinning one hands the bypass back; the legacy bare-name spelling is caught by its `() {` value. Four cases pin it, all mutation-verified red.
- **The Windows verdict is answered on the loop**, not through `asyncio.to_thread`. The check already declines every name grant on Windows at its first branch without touching the filesystem, so the worker returned a constant -- and a hop that buys nothing is still a hop. Identical verdict on every platform; the hop remains where there is real filesystem work.
- **A code-injecting assignment prefix is refused** (Opus round-18). `_EXEC_ENV_VARS` caught `PATH` and the loader family but not a tool or interpreter told to load code by its environment, so `GIT_SSH_COMMAND=/writable/evil git fetch ssh://x` vouched for `/usr/bin/git` and ran the planted file -- and `PYTHONPATH`, `NODE_OPTIONS`, `PERL5OPT`, `RUBYOPT` and `JAVA_TOOL_OPTIONS` are the same shape. Refused as FAMILIES (a `LD_*`/`DYLD_*` prefix, an `_OPTIONS`/`OPT`/`PATH`/`LIB`/`_PRELOAD` suffix) rather than as more exact spellings, because every round found one more interpreter with its own way of being told to load code and an exact list is only as complete as the last person to think about it. Over-refusing is the safe direction and costs one prompt; an ordinary `FOO=bar head x` is still skipped, which a test pins.
- **A NUL byte in a path refuses instead of aborting the turn** (GPT round-18). `realpath`, `stat` and `open` raise `ValueError`, not `OSError`, on an embedded null, and `shlex` hands the token through intact -- so an `OSError`-only guard let it escape this module and replace the approval card with an error card. All seven inspection sites now fail closed on both, and four cases pin it (including a NUL in an operand and in a second command position).
- **A Windows-specific test premise was corrected.** `test_dashboard_approval.py`'s trust-reads deny test drives the tier with `ls`, which is a trusted system program on POSIX and absent on Windows -- where the check declines the tier, the request falls through to the interactive card, and the `trust_reads` deny it asserts never happens (an xdist worker death rather than a plain failure). It now stubs the one off-loop entry point, the same seam `test_chat_runner_coverage.py` uses, so it measures redaction rather than host `PATH` semantics.
- **The pin stays scoped to the extracted command** (GPT rounds 18 and 20). Round 18 asked for a fallback to `event.shell_command` so a structured approval of a non-system program stopped re-prompting; round 20 called that wider form an undisclosed persistent identity grant. Between one extra prompt and recording an identity from a surface the human may not read as durable, the extra prompt is the safe side, so the fallback is withdrawn and the narrower form ships.
- **A vouched-for program can still exec another by name.** `egrep`'s whole body is `exec grep -E "$@"`, so a planted `grep` is reached one hop after this check has vouched for `egrep`. This is the "not binding on the exec" residual above rather than a separate defect, and it is not script-specific -- `strings /usr/bin/git` and `man` both surface `PATH`-resolved helper names, so refusing scripts would narrow the surface without ending the class. **Tracked in #6438**, where the durable fix is #4438's `PATH`-sanitization half.

## 5. Any other suggestions on the work

This PR went through twenty review rounds, and the great majority of findings were all one shape: a shell command line can hide the program it runs, and each round found another way. Every one was real and fixed; **none were overridden**. The result is correct but the surface is a twelve-reason denylist over a hand-rolled tokenizer.

My recommendation, for this PR or a follow-up: invert the rule. Accept only a plain `program args [| program args]*` line whose program tokens are bare words, and refuse everything else. That replaces the accumulating list with one rule, costs a prompt for command shapes that are rare in practice, and ends the class rather than enumerating it. I have not done it unilaterally mid-review because it changes what users see on ordinary commands.

Two siblings are tracked separately in #4921, because the shadowing rule is the wrong question for them: the read-only tier's `<name> --help` usage probe takes an AGENT-chosen name, and the browser-CLI tier's presence-as-consent binary lives in an agent-writable npm global directory.

Refs #4438


