### PR TITLE
fix(security): judge a stdin-reading interpreter on its program, not its neighbours

### DIFF
--- a/docs/system-specs/modules/ops-mission-control.md
+++ b/docs/system-specs/modules/ops-mission-control.md
@@ -1121,14 +1121,45 @@ defense-in-depth on top of it, not the boundary. Two tests pin both halves: the 
 are denied, and the `chr()`/two-step forms are the acknowledged gap.
 The STDIN forms are the same escape with no operand at all: `python -` and a bare interpreter
 read the program from stdin, so `python - <<'PY' … PY` and `echo '…' | python -` reach the CLI
-with the payload nowhere in argv. When that program text is visible on the command line — a
-heredoc body (later tokens) or a pipe producer (earlier tokens) — the import is matched across
-the whole frame and denied; when it is not (a file redirect, a bare `python -` fed by an unseen
-producer) there is nothing to match and the residual is noted rather than claimed as covered.
-`_python_reads_stdin` is precise (it consumes operand-flags and heredoc tags) so `python
-script.py`, `python -c …`, and `cat kiro_crew_notes.txt | python -` do not trip it, and the
-inline-program scan bails at the interpreter's first positional so the ReDoS-resistance budget
-still holds on spam input. Found in review (GPT 5.6).
+with the payload nowhere in argv. When that program text is visible on the command line the
+import is matched in the tokens that actually CARRY it, and nowhere else in the frame. The
+carriers are enumerated from the shell grammar rather than by example: a heredoc body
+(`<<TAG` / `<<-TAG`), a here-string operand (`<<<WORD`, whose word IS the program), a redirected
+file (`<WORD`), a process substitution (`< <(cmd)`, whose command text spans tokens to its
+closing paren), and a pipe producer. A redirection may appear ANYWHERE in a simple command, the
+program name included, so the whole frame is walked in ONE pass and a redirect glued to a word is
+classified from its first `<` onward — `<<'PY' python -`, `<prog.py python3 -`, `python3<<<'…'`
+and `<<EOF python - … EOF` (marker and body straddling the program name) are all ordinary bash
+reaching the identical mint. Only redirect OPERANDS are yielded, so a neighbouring command's
+ordinary argument is still never program text. `<&N` carries no text on the
+command line and is a stated residual. A heredoc's body ends at the LAST token equal to its
+tag: bash closes a heredoc only on a line holding the delimiter ALONE, and line structure does
+not survive tokenizing, so a body line that merely CONTAINS the word (`# EOF`, an ordinary
+comment) closed it early and left the real payload unscanned. A redirect OPERAND that opens a
+substitution (`$( )`, `<( )`, `${ }`, backticks) is one shell WORD whose text carries
+whitespace, so it too spans tokens — to the LAST matching closer, because `normalize_shell_command`
+strips quoting before this code runs, so a quoted delimiter is indistinguishable from a real one
+and balancing the count is not decidable. `_python_reads_stdin` consumes redirect operands
+through the same helper, so the detector and the carrier scope agree on where an operand ends;
+it also now answers True for `python < prog.py`, which does read its program from that file.
+Scanning the whole frame was a false-positive source: a frame is not split on a newline, so a
+neighbouring command naming the package in a FILE PATH (`isort src/kiro_crew/mcp_core.py`
+followed by any harmless heredoc) read as a mint with no `token` word present (#2660). The pipe
+is detected as a CHARACTER left of or glued into the interpreter token, not as a standalone `|`
+word: the tokenizer splits on whitespace only, so `echo '…'|python -` hands the operator over
+glued to a neighbour and `_program_basename` resolves the program from the last control-operator
+segment. Any pipe to the left qualifies the whole left side — a deliberate over-block, since a
+missed producer is a bypass while an extra token is a visible refusal. When the program text is
+NOT on the command line (a bare `python -` fed by an unseen producer, or a file written earlier
+and then redirected in) there is nothing to match and the residual is noted rather than claimed
+as covered — the same residual the written-then-run script form already has.
+`_python_reads_stdin` is precise (it consumes operand-flags and skips a heredoc's marker, body
+and closing tag, and a here-string's operand, read off the raw token because the operand
+normaliser strips a redirection to the empty string; a heredoc's closing tag ENDS the command,
+so a following `echo ok` is not read as this interpreter's script) so `python script.py`,
+`python -c …`, and `cat kiro_crew_notes.txt | python -`
+do not trip it, and the inline-program scan bails at the interpreter's first positional so the
+ReDoS-resistance budget still holds on spam input. Found in review (GPT 5.6).
 
 **There is deliberately NO migration from `config.json`, and adding one is the trap.** An
 interim revision had `migrate_from_config_if_needed`: on first read, if no keystone file

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -42,7 +42,7 @@ from kiro_crew.vector_memory_constants import _contains_injection
 # off the lightweight import path.
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -3444,6 +3444,220 @@ def _substitution_bodies(text: str) -> "list[str]":
     return bodies
 
 
+def _here_string_payload(raw: str) -> "str | None":
+    """The operand of a HERE-STRING (``<<<WORD``), ``""`` when the word is the next token.
+
+    ``None`` when this is not a here-string.  A here-string feeds its operand to stdin
+    verbatim, so for a stdin-reading interpreter that operand IS the program.
+
+    Kept distinct from :func:`_heredoc_marker` because ``<<<`` also starts with ``<<``:
+    reading it as a heredoc turned the payload into a DELIMITER and dropped it from the
+    search entirely, so ``python - <<<'import kiro_crew'`` went unmatched (caught in
+    review, GPT 5.6).
+    """
+    if not raw.startswith("<<<"):
+        return None
+    return raw[3:]
+
+
+def _heredoc_marker(raw: str) -> "str | None":
+    """The delimiter TAG of a heredoc redirect token.
+
+    Returns the tag for the attached spellings (``<<PY``, ``<<-PY``), ``""`` for a
+    bare ``<<`` whose tag is the NEXT token, and ``None`` when this is not a heredoc --
+    including a here-string (``<<<``), which is :func:`_here_string_payload`'s and must
+    not be mistaken for a heredoc whose tag happens to start with ``<``.
+
+    Read off the RAW token deliberately: ``_normalize_operand`` strips a redirection
+    down to the empty string, which is why the heredoc branch in
+    :func:`_python_reads_stdin` was unreachable -- a bare ``python << 'PY' … PY`` was
+    misread as running a SCRIPT named by the first word of the body (#2660).  Shared
+    by the stdin DETECTOR and the program-text SCOPE so the two cannot disagree about
+    where a heredoc body starts and ends.
+    """
+    if not raw.startswith("<<") or raw.startswith("<<<"):
+        return None
+    return raw[3:] if raw.startswith("<<-") else raw[2:]
+
+
+def _operand_span_end(run: list[str], idx: int, text: str) -> int:
+    """Index just past a redirect OPERAND that continues into later tokens.
+
+    A redirect operand can open a substitution -- ``$( )``, ``<( )``, ``${ }`` or a
+    backtick pair -- whose text carries whitespace, and the tokenizer splits on
+    whitespace only.  So the operand is one shell WORD spread over several tokens, and
+    scanning just the first of them read only ``$(printf`` out of
+    ``<<<$(printf %s "import kiro_crew")`` (caught in review, GPT 5.6).
+
+    Spans to the LAST token carrying a matching closer, not to the first that balances
+    the count.  Balancing is not decidable here: ``normalize_shell_command`` strips
+    quoting BEFORE this runs, so a quoted delimiter (``$(true ')'; printf …)``) is
+    indistinguishable from a real one and a counting walk stopped early, leaving the
+    payload after it unscanned (caught in review, GPT 5.6).  The last closer cannot be
+    undershot that way; it over-yields only when a LATER token happens to carry a closing
+    character, which is the safe direction.
+    """
+    closers = ""
+    if text.count("(") > text.count(")"):
+        closers += ")"
+    if text.count("{") > text.count("}"):
+        closers += "}"
+    if text.count("`") % 2 == 1:
+        closers += "`"
+    if not closers:
+        return idx
+    for j in range(len(run) - 1, idx - 1, -1):
+        if any(c in run[j] for c in closers):
+            return j + 1
+    return len(run)
+
+
+def _stdin_redirect_carriers(tokens: list[str], start: int, stop: int) -> "Iterator[str]":
+    """Program text from the stdin REDIRECTIONS in ``tokens[start:stop]``.
+
+    One walk over a token run, yielding whatever each stdin redirection puts on this
+    interpreter's stdin.  The redirection families, from the shell grammar:
+
+    * ``<<TAG`` / ``<<-TAG`` -- a heredoc; the BODY up to the matching tag is the program.
+      An unterminated one runs to the end of the run, which over-yields, not under.
+    * ``<<<WORD`` -- a here-string; the WORD itself is the program.
+    * ``<WORD`` -- a file whose CONTENT is the program.
+    * ``< <(cmd)`` -- process substitution; the command text is visible and spans tokens
+      up to its closing paren, so it is yielded as a run.
+    * ``<&N`` -- an fd dup, which carries no text at all; a documented residual.
+
+    Walked as a RUN rather than "everything after the interpreter" because a
+    redirection may appear ANYWHERE in a simple command -- BEFORE the program name
+    (``<<'PY' python -``), after it, and GLUED TO IT with no space
+    (``python3<<<'…'``, ``python3<prog.py``), all of which are ordinary bash reaching
+    the same mint (each caught in review, GPT 5.6).  A token that carries a redirect
+    after some other text is therefore classified from its first ``<`` onward: the
+    text before it is the program name or an earlier operand, and the shell reads the
+    rest as the redirection.
+
+    The left-hand run is not split on a newline, so an earlier command's own stdin
+    redirect is yielded too -- the same deliberate over-block the pipe producer has,
+    and for the same reason.
+
+    A heredoc's body ends at the LAST token equal to its tag, not the first.  Bash
+    closes a heredoc only on a line that holds the delimiter ALONE, and line structure
+    does not survive tokenizing -- so a body line that merely CONTAINS the word
+    (``# EOF``, an ordinary Python comment) produced a token equal to the tag and closed
+    the body early, leaving the real payload after it unscanned (caught in review, GPT
+    5.6).  The last occurrence is the delimiter that actually ends it; taking it
+    over-yields only when the tag word recurs in a LATER command, which is the safe
+    direction.
+    """
+    run = tokens[start:stop]
+    idx = 0
+    while idx < len(run):
+        raw = run[idx].strip(_SHELL_WRAPPER_CHARS)
+        if "<" in raw and not raw.startswith("<"):
+            # A redirect GLUED to a preceding word: the shell reads everything from the
+            # first `<` as the redirection, so classify that suffix. Without this the
+            # interpreter's own token was excluded from the walk and
+            # `python3<<<'import kiro_crew'` -- one word, no space -- was never scanned.
+            raw = raw[raw.index("<") :]
+        here = _here_string_payload(raw)
+        if here is not None:
+            # Checked before the heredoc branch, which would otherwise read `<<<payload`
+            # as a tag and drop the payload.
+            idx += 1
+            if not here:  # a bare `<<<` puts its word next
+                if idx >= len(run):
+                    return
+                here = run[idx].strip(_SHELL_WRAPPER_CHARS)
+                yield run[idx]
+                idx += 1
+            else:
+                yield here
+            end = _operand_span_end(run, idx, here)
+            yield from run[idx:end]
+            idx = end
+            continue
+        marker = _heredoc_marker(raw)
+        if marker is not None:
+            # Checked before the plain-redirect branch below, which would otherwise read
+            # the first `<` of `<<` as a stdin redirect.
+            idx += 1
+            if not marker:  # a bare `<<` splits its tag into the next token
+                if idx >= len(run):
+                    return
+                marker = run[idx].strip(_SHELL_WRAPPER_CHARS)
+                idx += 1
+            end = len(run)
+            for j in range(len(run) - 1, idx - 1, -1):
+                if run[j].strip(_SHELL_WRAPPER_CHARS) == marker:
+                    end = j
+                    break
+            yield from run[idx:end]
+            idx = end + 1
+            continue
+        if "<" in raw:
+            target = raw.rsplit("<", 1)[1]
+            if target.startswith("&"):
+                idx += 1  # `<&N` fd dup: nothing on the command line to match
+                continue
+            idx += 1
+            if not target:
+                if idx >= len(run):
+                    return
+                target = run[idx].strip(_SHELL_WRAPPER_CHARS)
+                yield run[idx]
+                idx += 1
+            else:
+                yield target
+            end = _operand_span_end(run, idx, target)
+            yield from run[idx:end]
+            idx = end
+            continue
+        idx += 1
+
+
+def _stdin_program_text(tokens: list[str], i: int) -> "Iterator[str]":
+    """The tokens that can carry the PROGRAM a stdin-reading ``python`` will run.
+
+    ``tokens[i]`` is an interpreter that reads its program from stdin.  The shell can
+    fill that stdin from exactly two families, and this yields those and nothing else:
+
+    * a stdin REDIRECTION -- heredoc body, here-string word, redirected file or process
+      substitution -- anywhere in the command: before the program name, after it, or
+      glued to it (:func:`_stdin_redirect_carriers`).  Walked over the WHOLE frame in ONE
+      pass, not per side of the interpreter: a marker and its body can straddle the
+      program name (``<<EOF python - … EOF``), and splitting the walk lost that
+      association entirely (caught in review, GPT 5.6).  Only REDIRECT OPERANDS are
+      yielded, so a neighbouring command's ordinary argument is still never program text;
+    * a PIPE PRODUCER -- the tokens left of this interpreter, when a pipe feeds it.
+      The pipe is NOT reliably its own token: the tokenizer splits on whitespace only,
+      so ``echo '…'|python -`` glues the operator into a neighbouring word and
+      ``_program_basename`` resolves the program from the LAST control-operator
+      segment.  So the pipe is detected as a CHARACTER anywhere left of, or glued
+      into, the interpreter token, and that token's own leading segment is producer
+      text.  Requiring a standalone ``|`` token missed all four no-space spellings and
+      let the producer's payload through (caught in review, GPT 5.6).
+
+    Both families over-yield on the left: any pipe, or any earlier command's own stdin
+    redirect, qualifies.  That is the safe direction -- a missed carrier is a bypass,
+    an extra token is only a visible refusal (pinned by a test).
+
+    Everything else in the frame is another command's argv.  Scanning THAT was the
+    defect (#2660): a frame is not split on a newline, so an unrelated neighbour that
+    merely names this package in a FILE PATH (``isort src/kiro_crew/mcp_core.py``
+    followed by any ``python - <<'PY' … PY``) made a harmless heredoc read as a
+    credential mint -- with no ``token`` word anywhere in the command.
+
+    Yields lazily so the caller's ``any()`` short-circuits: the cost stays O(frame)
+    per interpreter token, the same bound the frame-wide scan had.
+    """
+    # A PIPE PRODUCER writes this interpreter's stdin, so its argv IS program text.
+    glued_head, pipe_glued, _ = tokens[i].strip(_SHELL_WRAPPER_CHARS).rpartition("|")
+    if pipe_glued or any("|" in t for t in tokens[:i]):
+        yield from tokens[:i]
+        if pipe_glued:
+            yield glued_head
+    yield from _stdin_redirect_carriers(tokens, 0, len(tokens))
+
+
 def _has_self_importing_inline_program(tokens: list[str], i: int) -> bool:
     """True if ``tokens[i]`` is an interpreter given a ``-c`` payload that imports this package.
 
@@ -3461,22 +3675,29 @@ def _has_self_importing_inline_program(tokens: list[str], i: int) -> bool:
     The STDIN forms are the same escape without an operand: ``python -`` (and a bare ``python``
     with no script) read the program from stdin, so a ``python - <<'PY' … PY`` heredoc or an
     ``echo '…' | python -`` pipe reaches the CLI with the payload nowhere in argv. When that
-    program text is visible on the command line — a heredoc body or the left side of a pipe,
-    both of which land as later tokens in this frame — matching the import is the same
-    fail-closed decision as for ``-c``. When it is NOT visible (a file redirect, a bare
-    ``python -`` fed by an unseen producer) there is nothing to match and the gate cannot see
-    it; that residual is noted, not silently claimed as covered.
+    program text is visible on the command line, matching the import is the same fail-closed
+    decision as for ``-c`` — but it is matched only in the tokens that actually CARRY that
+    program (see :func:`_stdin_program_text`), not anywhere in the frame. When it is NOT
+    visible (a bare ``python -`` fed by an unseen producer) there is nothing to match and the
+    gate cannot see it; that residual is noted, not silently claimed as covered.
     """
     if not _PYTHON_PROGRAM_RE.match(_program_basename(tokens[i])):
         return False
     later_tokens = tokens[i + 1 :]
-    # STDIN program: the whole FRAME is the search space, because the program text is not an
-    # operand of this interpreter — it arrives on stdin, which the shell fills from a heredoc
-    # body (later tokens) or a pipe producer (EARLIER tokens, e.g. `echo '…' | python -`). So a
-    # per-position scan is wrong here; match the import anywhere in the frame. `_python_reads_stdin`
-    # is precise so this does not fire for `python script.py`, `python -c …`, or `python -m …`.
+    glued = tokens[i].strip(_SHELL_WRAPPER_CHARS)
+    if "<" in glued:
+        # A redirect GLUED to the program name is still this command's redirect, and the
+        # detector only ever saw the tokens AFTER the interpreter -- so `python<<EOF … EOF`
+        # had no marker in view and its body read as a script path. Hand the suffix over as
+        # its own token (caught in review, GPT 5.6).
+        later_tokens = [glued[glued.index("<") :], *later_tokens]
+    # STDIN program: the text is not an operand of this interpreter — the shell fills stdin from
+    # a heredoc body, a redirected file, or a pipe producer — so the search space is those
+    # carriers rather than this position's operands. `_python_reads_stdin` is precise so this
+    # does not fire for `python script.py`, `python -c …`, or `python -m …`.
     if _python_reads_stdin(later_tokens) and any(
-        _inline_payload_reaches_cli(t.strip(_SHELL_WRAPPER_CHARS)) for t in tokens
+        _inline_payload_reaches_cli(t.strip(_SHELL_WRAPPER_CHARS))
+        for t in _stdin_program_text(tokens, i)
     ):
         return True
     expect_payload = False
@@ -3526,23 +3747,79 @@ def _python_reads_stdin(later_tokens: list[str]) -> bool:
     ``-`` argument; ``-c CODE``, ``-m MOD``, and ``FILE`` all supply the program elsewhere.
     Walks the argument stream the way ``_is_self_module_invocation`` does so the corner cases
     line up: an operand-taking flag consumes its value (``-X dev`` — ``dev`` is not a script),
-    a heredoc redirect (``<<`` and the delimiter tag that follows it) is not an argument, and a
+    a heredoc (the ``<<TAG`` marker, its BODY and the closing tag) is not an argument, and a
     pipe/redirect token ends this command's own arguments.
+
+    The heredoc structure is read off the RAW token via :func:`_heredoc_marker`, because
+    ``_normalize_operand`` strips a redirection to the empty string — which made the heredoc
+    branch here unreachable and had ``python << 'PY' … PY`` (no ``-``) report FALSE, reading
+    the first word of the BODY as a script path (#2660).  A redirect OPERAND is consumed
+    through :func:`_operand_span_end` for the same reason the carrier scan uses it: a
+    substitution operand is one shell WORD over several tokens, and skipping only the first
+    left ``python <<< $(printf …)`` reading ``%s`` as a script path (caught in review, GPT
+    5.6).  The two functions share that helper so the detector and the carrier scope agree
+    on where an operand ends.
     """
     skip_next = False
-    heredoc_tag_next = False
-    for tok in later_tokens:
+    heredoc_tag: str | None = None
+    expect_tag = False
+    idx = 0
+    while idx < len(later_tokens):
+        tok = later_tokens[idx]
+        idx += 1
+        raw = tok.strip(_SHELL_WRAPPER_CHARS)
+        if heredoc_tag is not None:
+            # The body is program text on stdin, not an argument, and its CLOSING TAG
+            # ends this command: the tokenizer drops the newline that follows, so
+            # whatever comes after the tag belongs to the NEXT command. Reading it as
+            # this interpreter's positional made `python <<PY … PY; echo ok` report
+            # "runs a script named echo" and skipped the whole branch, so the heredoc's
+            # payload went unscanned (caught in review, GPT 5.6). The heredoc has
+            # already supplied the program, so the answer here is simply True.
+            if raw == heredoc_tag:
+                return True
+            continue
+        if expect_tag:
+            expect_tag = False
+            heredoc_tag = raw
+            continue
+        here = _here_string_payload(raw)
+        if here is not None:
+            # A here-string supplies the program on stdin exactly as a heredoc does; its
+            # operand is a redirect word, never this interpreter's positional -- and the
+            # WHOLE operand, which a substitution spreads over several tokens.
+            if not here:  # a bare `<<<` puts its word in the next token
+                if idx >= len(later_tokens):
+                    break
+                here = later_tokens[idx].strip(_SHELL_WRAPPER_CHARS)
+                idx += 1
+            idx = _operand_span_end(later_tokens, idx, here)
+            continue
+        marker = _heredoc_marker(raw)
+        if marker is not None:
+            if marker:
+                heredoc_tag = marker
+            else:
+                expect_tag = True  # a bare `<<` splits its tag into the next token
+            continue
+        if "<" in raw:
+            # A stdin REDIRECT and its operand are not this command's arguments either,
+            # and the redirect is what supplies the program: `python < prog.py` reads its
+            # program from that file. The earlier walk stopped at the redirect and then
+            # read the operand as a script path, so `python3 < $(printf …)` answered False.
+            target = raw[raw.index("<") :].rsplit("<", 1)[1]
+            if not target:
+                if idx >= len(later_tokens):
+                    break
+                target = later_tokens[idx].strip(_SHELL_WRAPPER_CHARS)
+                idx += 1
+            idx = _operand_span_end(later_tokens, idx, target)
+            continue
         norm = _normalize_operand(tok).strip("\"'")
-        if heredoc_tag_next:
-            heredoc_tag_next = False
-            continue  # the heredoc delimiter word (`<< 'PY'` → the `PY`)
         if skip_next:
             skip_next = False
             continue  # value consumed by an operand-taking flag (`-X dev`)
         if not norm:
-            continue
-        if norm.startswith("<<"):
-            heredoc_tag_next = norm == "<<"  # a bare `<<` splits its tag into the next token
             continue
         if norm.startswith("<") or norm.startswith("|"):
             break  # a redirect/pipe boundary ends this command's argument list

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -118,8 +118,9 @@ class TestCatalog:
             'python -X dev -c "import kiro_crew.cli"',
             # STDIN forms: `python -` and a bare interpreter read the program from stdin, so a
             # heredoc body or a pipe producer reaches the CLI with nothing in argv. The program
-            # text is visible on the command line (heredoc body → later tokens; pipe source →
-            # earlier tokens), and matching the import there is the same fail-closed call.
+            # text is visible on the command line, and matching the import THERE -- in the
+            # heredoc body, the redirected file, or the pipe producer, and nowhere else in the
+            # frame (see TestStdinProgramTextScoping) -- is the same fail-closed call.
             "python - <<'PY'\nfrom kiro_crew.cli import main; main()\nPY",
             "python3 - <<EOF\nimport kiro_crew.cli\nEOF",
             "echo 'from kiro_crew.cli import main; main()' | python -",
@@ -3147,3 +3148,225 @@ class TestSelfFloorShortCircuit:
         )
         # And the floor's verdict survives the gate: still denied end-to-end.
         assert security._is_credential_mint(cmd)
+
+
+class TestStdinProgramTextScoping:
+    """A stdin-reading interpreter is judged on its PROGRAM, not on its neighbours.
+
+    Regression for #2660.  ``normalize_shell_command`` does not split a frame on a
+    newline, so a multi-line script arrives as ONE token frame.  The stdin branch of
+    ``_has_self_importing_inline_program`` used to search that whole frame for the
+    import name, which made an unrelated neighbour's FILE PATH satisfy the check --
+    a benign ``python - <<'PY' … PY`` in the same script as any command naming a
+    ``kiro_crew`` path read as a credential mint, with no ``token`` word anywhere.
+    """
+
+    # Every one of these is read-only or a formatter run, and none carries the mint
+    # verb.  The product name appears ONLY as a file path handed to another program.
+    BENIGN_NEIGHBOUR = (
+        # The report's own case 2, reduced: format two source files, then edit one
+        # through a heredoc whose payload does not import anything.
+        "isort src/kiro_crew/mcp_core.py\npython3 - <<'PY'\nprint(1)\nPY",
+        # The same shape behind the other two separators a frame preserves.
+        "isort src/kiro_crew/x.py && python3 -",
+        "black src/kiro_crew/security.py; python3 - <<'PY'\nprint(2)\nPY",
+        # Order does not matter: the neighbour may follow the interpreter too.
+        "python3 - <<PY\nprint(1)\nPY\nisort src/kiro_crew/x.py",
+        # A here-string whose payload is harmless, next to a product-named path.
+        "isort src/kiro_crew/x.py\npython3 - <<<'print(1)'",
+        # A substitution operand whose text is harmless, next to a product-named path.
+        "isort src/kiro_crew/x.py\npython3 - <<<$(printf %s 'print(1)')",
+        # A stdin redirect belonging to ANOTHER command, with no interpreter in play.
+        "isort src/kiro_crew/x.py\ncat < notes.txt",
+        # A pipe that does NOT feed this interpreter (it consumes its output).
+        "python3 - <<PY\nprint(1)\nPY\n| grep kiro_crew",
+    )
+
+    # Every way the shell can put a PROGRAM on a simple command's stdin, at every
+    # position it is allowed to appear.  Enumerated from the shell grammar rather than
+    # grown one review round at a time: the first revision covered only the heredoc,
+    # here-string and post-program spellings, and every omission was a real bypass.
+    REAL_STDIN_REACH = (
+        # Heredoc body, in every spelling of the marker.
+        "python3 - <<'PY'\nimport kiro_crew\nPY",
+        "python3 - <<-PY\nimport kiro_crew\nPY",
+        "python3 - << PY\nimport kiro_crew\nPY",
+        "python << 'PY'\nimport kiro_crew\nPY",
+        # An unterminated heredoc runs to the end of the frame (over-block, not under).
+        "python3 - <<PY\nimport kiro_crew\n",
+        # A body LINE that merely CONTAINS the tag word is not a closing delimiter:
+        # bash closes only on a line holding it ALONE, and line structure does not
+        # survive tokenizing, so the body must end at the LAST occurrence of the tag.
+        # `# EOF` is an ordinary Python comment and was enough to close it early.
+        "python3 - <<EOF\n# EOF\nimport kiro_crew\nEOF",
+        "python3 - <<EOF\nx = 1  # EOF\nimport kiro_crew\nEOF",
+        "python3 - <<PY\nprint('PY')\nimport kiro_crew\nPY",
+        # A command AFTER the closing tag is a NEW command, not this interpreter's
+        # script argument -- reading it as one made the detector answer False and
+        # skipped the branch entirely, leaving the heredoc payload unscanned.
+        "python3 <<PY\nimport kiro_crew\nPY\necho ok",
+        "python3 - <<PY\nimport kiro_crew\nPY; echo ok",
+        "python3 - <<PY\nimport kiro_crew\nPY && echo ok",
+        # HERE-STRING: the operand itself is the program on stdin. `<<<` also starts with
+        # `<<`, so reading it as a heredoc made the payload a delimiter and dropped it.
+        "python3 - <<<'import kiro_crew'",
+        "python3 -<<<'import kiro_crew'",
+        "python3 <<<'import kiro_crew'",
+        "python3 - <<< 'import kiro_crew'",
+        "python3 - <<<$'import kiro_crew'",
+        # Pipe producer -- the left side writes this interpreter's stdin.  Every
+        # spacing spelling, because the tokenizer splits on whitespace only, so the
+        # operator glues into a neighbouring word and `|` is often NOT its own token.
+        "echo 'import kiro_crew' | python3 -",
+        "echo 'import kiro_crew'|python3 -",
+        "echo 'import kiro_crew' |python3 -",
+        "echo 'import kiro_crew'| python3 -",
+        "cat src/kiro_crew/cli.py | python3 -",
+        "cat src/kiro_crew/cli.py|python3 -",
+        "printf 'import kiro_crew'|python3",
+        "echo 'import kiro_crew' | python3",
+        # Stdin redirect -- the file's CONTENT becomes the program.
+        "python3 - < src/kiro_crew/cli.py",
+        "python3 -<src/kiro_crew/cli.py",
+        "python3 - 0< src/kiro_crew/cli.py",
+        # Process substitution and command substitution -- the operand is one shell WORD
+        # whose text carries whitespace, so it spans tokens to its closing delimiter.
+        "python3 - < <(echo 'import kiro_crew')",
+        'python3 - <<<$(printf %s "import kiro_crew")',
+        "python3 - <<<`printf %s 'import kiro_crew'`",
+        'python3 - <<<"${x:-import kiro_crew}"',
+        'python3 - < $(printf %s "src/kiro_crew/cli.py")',
+        "python3 - <<<$(cat src/kiro_crew/cli.py)",
+        # A QUOTED delimiter inside the substitution: quoting is stripped before this
+        # code sees the tokens, so balancing the count is not decidable and the operand
+        # must span to the LAST closer.
+        "python3 - <<<$(true ')'; printf %s \"import kiro_crew\")",
+        'python3 - <<<$(echo ")" ; printf %s "import kiro_crew")',
+        # A split operand with NO `-`, where the detector must consume the whole operand
+        # rather than read the substitution's second token as a script path.
+        'python <<< $(printf %s "import kiro_crew")',
+        'python3 <<< $(printf %s "import kiro_crew")',
+        'python3 < $(printf %s "src/kiro_crew/cli.py")',
+        # A redirection may appear ANYWHERE in a simple command, before the program
+        # name included.  These are ordinary bash and reach the identical mint.
+        "<<'PY' python -\nimport kiro_crew\nPY",
+        "<<PY python3 -\nimport kiro_crew\nPY",
+        "<src/kiro_crew/cli.py python3 -",
+        "< src/kiro_crew/cli.py python3 -",
+        "<<<'import kiro_crew' python3 -",
+        # ... a marker and its BODY may straddle the program name, so the carrier walk
+        # cannot be split per side of the interpreter without losing the association.
+        "<<EOF python -\nimport kiro_crew\nEOF",
+        "<<EOF python3 -\nimport kiro_crew\nEOF",
+        "<< EOF python -\nimport kiro_crew\nEOF",
+        # ... including GLUED to the program name with no space at all, which is one
+        # single token: `python3<<<'…'`.  Excluding the interpreter's own token from the
+        # walk is what missed these.
+        'python3<<<"import kiro_crew"',
+        "python3<<<'import kiro_crew'",
+        "python3<src/kiro_crew/cli.py",
+        "python3<<PY\nimport kiro_crew\nPY",
+        "python3<<-PY\nimport kiro_crew\nPY",
+        "python<<<'import kiro_crew'",
+        "python<<EOF\nimport kiro_crew\nEOF",
+        "python3<<EOF\nimport kiro_crew\nEOF",
+    )
+
+    def test_benign_neighbour_no_longer_reads_as_a_mint(self):
+        from kiro_crew import security
+
+        for cmd in self.BENIGN_NEIGHBOUR:
+            assert not security._is_credential_mint(cmd.lower()), f"frame contamination: {cmd!r}"
+            assert security.is_denied(cmd) is None, f"frame contamination: {cmd!r}"
+
+    def test_real_stdin_reach_stays_denied(self):
+        from kiro_crew import security
+
+        for cmd in self.REAL_STDIN_REACH:
+            assert security.is_denied(cmd) is not None, f"stdin reach not blocked: {cmd!r}"
+
+    def test_carriers_are_the_only_search_space(self):
+        """The helper yields program text and nothing else.
+
+        Asserted on the helper directly, so the SCOPE is pinned rather than only its
+        effect on one deny verdict.
+        """
+        from kiro_crew import security
+
+        tokens = security.normalize_shell_command(
+            "isort src/kiro_crew/mcp_core.py\npython3 - <<'PY'\nprint(1)\nPY"
+        )
+        i = tokens.index("python3")
+        assert list(security._stdin_program_text(tokens, i)) == ["print(1)"]
+
+        piped = security.normalize_shell_command("echo 'import kiro_crew' | python3 -")
+        j = piped.index("python3")
+        assert "import kiro_crew" in list(security._stdin_program_text(piped, j))
+
+    def test_bare_interpreter_with_a_heredoc_is_recognised_as_reading_stdin(self):
+        """``python << 'PY' … PY`` (no ``-``) really does read its program from stdin.
+
+        ``_python_reads_stdin`` classified this FALSE: it consulted
+        ``_normalize_operand``, which strips a redirection to the empty string, so its
+        heredoc branch was unreachable and the first word of the BODY read as a script
+        path.  The form was denied anyway, but only by accident -- the closing tag
+        ``PY`` matched ``_PYTHON_PROGRAM_RE`` and the old frame-wide scan then found
+        the import anywhere in the frame.  Once the scan is scoped to real carriers
+        that accident stops covering it, so the detector has to be right.
+        """
+        from kiro_crew import security
+
+        for cmd, expect_stdin in (
+            ("python << 'PY'\nimport kiro_crew\nPY", True),
+            ("python <<PY\nimport kiro_crew\nPY", True),
+            ("python <<-PY\nimport kiro_crew\nPY", True),
+            ("python <<<'import kiro_crew'", True),
+            ("python <<< 'import kiro_crew'", True),
+            ('python <<< $(printf %s "import kiro_crew")', True),
+            ("python < prog.py", True),
+            ("python script.py", False),
+            ("python script.py < input.txt", False),
+            ("python -c 'print(1)'", False),
+            ("python -m kiro_crew gateway", False),
+        ):
+            frame = security.normalize_shell_command(cmd)
+            i = next(
+                k
+                for k, t in enumerate(frame)
+                if security._PYTHON_PROGRAM_RE.match(security._program_basename(t.lower()))
+            )
+            assert security._python_reads_stdin(frame[i + 1 :]) is expect_stdin, cmd
+
+    def test_a_pipe_anywhere_left_is_a_known_over_block(self):
+        """The producer branch over-yields on a pipe that does not feed the interpreter.
+
+        ``a | b; python -`` pipes into ``b``, not into the interpreter, yet the whole
+        left side is still treated as program text.  Pinned as a KNOWN over-block
+        rather than tightened: the alternative -- requiring the pipe to be adjacent --
+        is what let all four no-space spellings through, because the tokenizer glues
+        the operator into a neighbouring word.  A missed producer is a bypass; an extra
+        token is a visible refusal.  If this assertion ever flips, the tightening that
+        did it must be checked against the no-space spellings above.
+        """
+        from kiro_crew import security
+
+        assert security.is_denied("grep kiro_crew src | head; python3 -") is not None
+
+    def test_rule_does_not_fire_on_its_own_pattern_text(self):
+        """Quoting this rule must not trip it.
+
+        ``credential-exfil-kirocrew-token``'s code comment claims this exemption
+        ("a regex LITERAL quoting this very rule ... from reading as a mint"), and
+        #2660 reported the claim failing in practice.  Pin it so discussing,
+        documenting or testing the rule by quoting it stays possible.
+        """
+        from kiro_crew import security
+
+        rule = next(
+            r for r in security.BUILTIN_DENIED_RULES if r.id == "credential-exfil-kirocrew-token"
+        )
+        for cmd in (
+            f'grep -n "{rule.pattern}" notes.txt',
+            f"echo {rule.pattern!r} >> notes.txt",
+        ):
+            assert security.is_denied(cmd) is None, f"rule fires on its own text: {cmd!r}"


### PR DESCRIPTION
## 1. What is the problem?

Two shell deny rules were reported firing on benign read-only commands (#2660). Running each of the four reported cases against unmodified `main` narrows the report considerably:

| reported case | on current main |
| --- | --- |
| 3 (`grep`/`sed` inside site-packages) | already allowed |
| the `#4745` cross-reference (venv-by-path `python -c` reading a `token` JSONL) | already allowed |
| the last comment (quoting the rule's own pattern text) | already allowed |
| 1 (`python -c "import kiro_crew..."`) | denied, and denied BY DESIGN |
| 2 (a formatter run, then an unrelated heredoc) | denied, and this is the bug |
| 4 (`ls ~/.kiro/crew/run`) | denied by a different gate (sensitive-path, not a deny rule) |

An earlier narrowing of the regex tier had already closed three of them. What is left is one real false positive, and it is not in the regex the refusal message quotes -- which is exactly why the report observed that "the effective pattern is broader than the one quoted in the refusal message". The refusal came from the argv-structural floor `_is_credential_mint`, while `is_denied` reported the regex rule's pattern string.

Case 2 reduces to this, with no `token` word anywhere in it:

    isort src/kiro_crew/mcp_core.py
    python3 - <<'PY'
    print(1)
    PY

Change only the path and it is allowed:

    isort src/other/mcp_core.py        # + the identical heredoc -> allowed

## 2. Why this issue matters to the user

`normalize_shell_command` does not split a token frame on a newline, so an entire multi-line script is one frame. The stdin branch of `_has_self_importing_inline_program` searched that whole frame, and the predicate it searched with is `\bkiro_crew\b` -- which a plain FILE PATH satisfies. So in this repository any script that formats, greps, or opens a source file and later runs a heredoc was refused as a credential mint. `&&` and `;` have the same effect, and so does the reverse order.

The report's strongest point is about the workaround, not the annoyance: the identical work completes by moving the payload into a file and running `python3 <file>`, because file CONTENTS are not scanned. The rule displaced the work into a less auditable shape rather than preventing anything.

## 3. How our fix solves it

The stdin form has no operand to inspect -- the shell fills stdin -- so the previous code widened the search to the frame. The carriers are now enumerated from the shell grammar instead, and `_stdin_program_text` yields those and nothing else:

- a heredoc BODY, the tokens after a `<<TAG` / `<<-TAG` marker up to the LAST token equal to the tag;
- a HERE-STRING operand (`<<<WORD`), whose word IS the program -- `_here_string_payload`;
- a stdin REDIRECT target, the file whose CONTENT becomes the program (`python - < prog.py`, `python -<prog.py`);
- a SUBSTITUTION operand -- `$( )`, `<( )`, `${ }` or backticks -- consumed to its last matching closer by `_operand_span_end`, because such an operand is one shell WORD whose text carries whitespace and therefore spans tokens;
- a PIPE PRODUCER, the tokens left of the interpreter when a pipe feeds it.

Three structural facts about the tokenizer decide the shape of that walk, and each one was a real bypass in an earlier revision of this PR:

- A redirection may appear ANYWHERE in a simple command -- before the program name (`<<'PY' python -`), after it, and glued to it with no space (`python3<<<'...'`) -- so a token carrying a redirect after other text is classified from its first `<` onward, and the interpreter's own token is in the walk.
- A heredoc MARKER and its BODY can straddle the program name (`<<EOF python - ... EOF`), so the frame is walked in ONE pass rather than per side of the interpreter. Only redirect OPERANDS are ever yielded, which is what keeps a neighbouring command's ordinary argument out of the search and the reported case 2 allowed.
- The pipe is a CHARACTER, not reliably a token: `normalize_shell_command` splits on whitespace only, so `echo '...'|python -` glues the operator into a neighbouring word while `_program_basename` still resolves the program from the last control-operator segment. The pipe is therefore detected anywhere left of, or glued into, the interpreter token.

Every genuine reach stays denied -- a heredoc body that imports us, a piped producer, `cat src/kiro_crew/cli.py | python -`, a redirected source file, a substitution that prints the payload. `<&N` puts no text on the command line at all and is stated as a residual rather than claimed as covered. The walk yields lazily so the caller's `any()` short-circuits and the cost stays O(frame) per interpreter token, the bound the frame-wide scan already had.

Scoping the scan exposed three defects in the DETECTOR that gates it, all fixed here because the scoped scan stops covering for them:

- `_python_reads_stdin` classified `python << 'PY' ... PY` (no `-`) as NOT reading stdin: it consulted `_normalize_operand`, which strips a redirection to the empty string, so its heredoc branch was unreachable and the first word of the body read as a script path. That form was denied before only by accident -- the closing tag `PY` matches `_PYTHON_PROGRAM_RE`, and the frame-wide scan then found the import from that position.
- A heredoc's closing tag ENDS the command (the tokenizer drops the newline after it), so a trailing `echo ok` was read as this interpreter's script path and the whole branch was skipped.
- A redirect operand was skipped one token at a time, and a marker glued to the program name was invisible because the detector only received the tokens AFTER the interpreter.

Both functions now read the redirect structure off the RAW token through the same helpers (`_heredoc_marker`, `_here_string_payload`, `_operand_span_end`), so the detector and the carrier scope cannot disagree about where an operand or a body ends. One deliberate widening beyond restoring main's verdict: `_python_reads_stdin` now answers True for `python < prog.py`, which does read its program from that file; the benign `python script.py < input.txt` still answers False because the positional is seen first, and both are pinned.

Deliberately NOT in this PR, because each is a security-posture decision rather than a defect:

- Case 1 (`python -c "import kiro_crew..."` is a mint) is intentional fail-closed behaviour: an inline payload can construct the verb itself, so the import is the honest gate. It is also the most ordinary debugging shape in this repository, which is worth revisiting -- separately.
- Case 4: `.kiro/crew/run` is a whole entry in `_SENSITIVE_HOME_DIRS`, so listing it is refused, yet enumerating those filenames is precisely what `run_marker.marker_ports()` does to discover a gateway. What needs protecting is marker CONTENTS, not the listing.
- The report's second half -- a policy block surfacing to the agent as a user cancellation -- is a permission-response limitation, not a string this codebase owns: the deny path answers the ACP permission request with `cancelled`, which has no free-text field. On the dashboard surface `build_refusal_recovery_prompt` already hands the reason back and states in as many words that it was not a user action; it arrives on the next turn, and the surfaces without that mechanism (subagent, Slack, channel, messaging driver) still get nothing.
- One review finding was OVERRIDDEN rather than fixed, disclosed here because it is a known gap this PR does not close: a bare interpreter whose here-string or plain redirect is followed by another command (`python3 <<<"..."; echo ok`) still answers False in the detector. A/B against `main` shows main allows every spelling of it too, so it is pre-existing and closing it is a further deny-side widening; recorded in the local backlog. The heredoc form of that same shape IS denied after this PR, so the detector is now inconsistent across the redirect families, and that inconsistency is what the follow-up should settle.

## 4. What tests we did

`TestStdinProgramTextScoping` in `test/test_denied_commands_security.py`:

- 8 benign neighbour shapes (the report's case 2 reduced, plus the `&&`, `;`, reverse-order, here-string, foreign-redirect and output-pipe variants) assert allowed through both `_is_credential_mint` and `is_denied`;
- 54 real stdin reaches assert still denied, enumerated from the grammar rather than grown one review round at a time -- every heredoc marker spelling, an unterminated heredoc, a trailing command after the closing tag, three tag-impersonation bodies (`# EOF` is an ordinary comment), five here-string spellings, three redirect spellings, six substitution operands, eight pipe-producer spacings, five redirects before the program name, three marker/body straddles and six redirects glued to the program name;
- a pinned known over-block for a pipe that does not feed the interpreter (`a | b; python3 -`);
- the carrier set is asserted on `_stdin_program_text` directly, so the scope is pinned and not merely its effect on one verdict;
- `_python_reads_stdin` is asserted across the bare-heredoc and here-string forms, `python < prog.py`, and the script/`-c`/`-m`/`script.py < input.txt` negatives;
- a ratchet that the rule does not fire on its own pattern text. This one passes on unmodified `main` -- the exemption its code comment claims does hold today -- so it is a guard against regression, not a fix.

Mutation-verified: reverting the `security.py` hunk fails 3 of the new tests (the ones that also pass on `main` are the no-regression guard and that ratchet). Every review round was additionally checked by an A/B harness that loads `origin/main`'s `security.py` alongside this branch's in ONE process and runs both through `is_denied`, which is what separated a regression I had introduced from a gap that predates the PR; it now covers 52 commands agreeing on the intended verdict, 13 the fix must allow and 39 that must stay denied with no regression against main. `test/test_denied_commands_security.py` passes: 501 passed, ReDoS-resistance lane included. `mypy` clean. No rule pattern changed, so the golden manifest is untouched and its parity test passes unchanged. The module spec section describing the old frame-wide behaviour is updated in the same commit.

## 5. Any other suggestions on the work

Three residuals, stated rather than implied.

With the scan scoped, a program written to a file and then fed to stdin (`printf '...' > x.py; python3 - < x.py`) is no longer matched from the earlier `printf`. That is the same write-then-run residual the module already documents as out of a string matcher's reach -- `printf '...' > x.py; python3 x.py` has always been allowed -- so this makes the stdin spelling consistent with the file spelling rather than opening a new class.

Both left-hand families over-yield: any pipe to the LEFT qualifies the whole left side (so `a | b; python3 -` treats `a`'s argv as program text even though the pipe feeds `b`), and an earlier command's own stdin redirect is yielded too. Kept deliberately and pinned by `test_a_pipe_anywhere_left_is_a_known_over_block`, because the precise alternative -- requiring the pipe to be adjacent to the interpreter -- is what let every no-space spelling through in an earlier revision. A missed carrier is a bypass; an extra token is a visible refusal. If someone tightens this later, the no-space spellings are the cases to re-check.

A heredoc body ends at the LAST token equal to its tag, which over-yields when the tag word recurs in a later command. That is the same trade in the other direction: bash closes a heredoc only on a line holding the delimiter ALONE, line structure does not survive tokenizing, and taking the FIRST occurrence let a body line containing the word close it early.

Also worth a separate follow-up, surfaced by this triage rather than fixed here: the refusal message names the REGEX rule's pattern even when the argv-structural floor is what matched. That mismatch is why #2660 was hard to triage -- the report reasonably concluded "the effective pattern is broader than the one quoted". Attributing the floor in the refusal would prevent the next confused report.

Refs #2660
