### PR TITLE
fix(packaging): declare macOS local-network intent so the LAN prompt appears

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -679,6 +679,62 @@ tccutil reset Microphone com.amazon.kiro.crew
 This is also why distributing the signed + notarized DMG matters (above): a
 stable identity is what keeps grants sticky instead of silently orphaning them.
 
+### Local network access needs a USAGE STRING, and no entitlement exists for it
+
+macOS 15 (Sequoia) added local-network privacy for **every** app, sandboxed or
+not. The mic's lesson does not transfer: there is no `device.*` entitlement to
+add here, and adding one of the neighbouring network keys makes things worse.
+This resource is TCC-only, and `NSLocalNetworkUsageDescription` is the entire
+declaration.
+
+> **Symptom:** an agent's shell command connects fine to the default gateway
+> (`192.168.x.1`) and to any public host, but every **other** LAN address — a NAS,
+> an IoT device, another dev box — fails **instantly** with errno 65
+> (`EHOSTUNREACH`, "No route to host") in ~0.000s rather than timing out. `ping`
+> and ARP to the same host succeed, so it reads as a routing fault. There is no
+> Kiro Crew row under System Settings › Privacy & Security › Local Network, and
+> `tccutil reset LocalNetwork com.amazon.kiro.crew` fails because no TCC record
+> exists to reset.
+
+The gateway-works / everything-else-fails split is the signature of the TCC gate,
+not of the network. With no declared intent macOS creates no
+`kTCCServiceLocalNetwork` record, so there is no prompt to answer and no toggle to
+flip — the same dead end as the mic, reached by a different mechanism.
+
+Three neighbouring keys look like the fix and are **not**:
+
+- `com.apple.developer.networking.multicast` covers multicast and broadcast,
+  requires an Apple-granted provisioning profile, and breaks signing when
+  requested unprovisioned. Plain unicast LAN access does not need it.
+- `com.apple.security.network.client` only means anything under **App Sandbox**,
+  which this bundle does not use.
+- `NSAllowsLocalNetworking` (which the bundle already carries) is an **App
+  Transport Security** key that relaxes HTTPS requirements for local hostnames.
+  It has nothing to do with the TCC gate — an easy one to mistake for a fix,
+  since it is already present in a bundle that cannot reach the LAN.
+
+`website/electron/test/packaging.test.js` pins both directions: the usage string
+must be declared with real copy, and neither entitlement may appear in either
+signing lane.
+
+#### Why the CLI gateway is not affected the same way
+
+Apple exempts several launch contexts from local-network privacy: daemons started
+by `launchd`, anything running as root, and **command-line tools run from Terminal
+or over SSH, including every child process they spawn**. So a gateway started with
+`kirocrew gateway` from a terminal reaches the LAN normally, while the same agent
+command run under the desktop app is gated by the app bundle's TCC record. That
+asymmetry is a useful triage question ("how did you start the gateway?") and a
+usable workaround, not evidence that the app is fine.
+
+One caveat worth knowing before concluding the usage string alone fixed it: agent
+shell commands are wrapped by `sandbox_exec_argv` in `src/kiro_crew/sandbox.py`,
+which `exec`s the target through `/usr/bin/sandbox-exec` and replaces the process
+image. The Seatbelt profile itself is `(allow default)` plus filesystem denies and
+carries **no** network rules, so the sandbox does not block sockets — but whether
+TCC's responsible-process attribution still lands on the app bundle across that
+`exec` has to be confirmed on a real macOS 15 host rather than reasoned about.
+
 ## Remote tunnel mode
 
 The desktop app can also connect to a gateway running on a **remote** host (e.g.

--- a/docs/build/signing-runbook.md
+++ b/docs/build/signing-runbook.md
@@ -155,6 +155,16 @@ makes the microphone work for voice input and streaming STT; without it the mic 
 refused with **no prompt at all** and no System Settings toggle to fix it. Camera
 is deliberately absent, because `permission-handler.js` denies video.
 
+Not every protected resource works that way, so do not generalize the mic rule.
+**Local network access has no entitlement** — on macOS 15 it is gated by TCC alone
+and declared solely by `NSLocalNetworkUsageDescription` in
+`website/electron/package.json`'s `build.mac.extendInfo`, which both lanes inherit
+from the same built bundle. Requesting
+`com.apple.developer.networking.multicast` to "fix" LAN access breaks signing
+unless Apple has provisioned it, and `com.apple.security.network.client` is an
+App-Sandbox key this bundle has no use for. `packaging.test.js` asserts both stay
+out of both files.
+
 ## Supply-chain ordering inside the jobs
 
 Two orderings in the workflow are deliberate and must be preserved:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -43,7 +43,8 @@
       "x64ArchFiles": "{**/backend-dist/**,**/backend-dist/**/.*/**}",
       "extendInfo": {
         "CFBundleDisplayName": "Kiro Crew",
-        "NSMicrophoneUsageDescription": "Kiro Crew uses the microphone for voice input and dictation in chat. Audio is captured only while you hold or toggle the mic button."
+        "NSMicrophoneUsageDescription": "Kiro Crew uses the microphone for voice input and dictation in chat. Audio is captured only while you hold or toggle the mic button.",
+        "NSLocalNetworkUsageDescription": "Kiro Crew connects to devices on your local network so agent commands can reach your own servers, NAS, containers, and dev machines. Only the addresses a command names are contacted."
       }
     },
     "afterSign": "scripts/notarize.js",

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -193,6 +193,66 @@ describe("first-download installer design contract", () => {
 });
 
 
+// Shared by the microphone and local-network describes below: both need to read
+// the two entitlements plists as parsed key->value maps rather than as text.
+// Hoisted to module scope so the two blocks cannot drift into slightly different
+// parsers and disagree about what a file actually grants.
+
+/**
+ * Strip XML comments, repeatedly, until the text stops changing.
+ *
+ * One pass is not enough: removing an outer `<!-- … -->` can splice together
+ * text that forms a NEW `<!--`, so a single replace can leave a comment
+ * opener behind. Looping to a fixed point (then asserting nothing is left)
+ * is what makes "this key is real, not commented-out prose" trustworthy.
+ */
+function stripComments(xml) {
+  let out = xml;
+  for (let i = 0; i < 20; i += 1) {
+    const next = out.replace(/<!--[\s\S]*?-->/g, "");
+    if (next === out) return next;
+    out = next;
+  }
+  return out;
+}
+
+/**
+ * Parse an entitlements plist into a plain { key: value } map.
+ *
+ * Deliberately a scanner rather than a built-from-a-string RegExp: composing
+ * a pattern out of a key name means hand-rolling escaping, which is easy to
+ * get subtly wrong (CodeQL flags exactly that), and a text match cannot tell
+ * a genuine <dict> entry from one mentioned in a comment. Walking the tags
+ * gives an exact key->value answer with no escaping in the picture at all.
+ * Booleans are all these files hold; anything else is reported as its raw tag.
+ */
+function parseEntitlements(xml) {
+  const body = stripComments(xml);
+  assert.equal(body.includes("<!--"), false, "unterminated XML comment");
+  const out = {};
+  const tag = /<key>([\s\S]*?)<\/key>\s*(<[^>]+>)/g;
+  let m;
+  while ((m = tag.exec(body)) !== null) {
+    const name = m[1].trim();
+    const value = m[2].replace(/\s|\//g, "");
+    out[name] = value === "<true>" ? true : value === "<false>" ? false : m[2];
+  }
+  return { entitlements: out, body };
+}
+
+// There are TWO signing lanes reading TWO different files (electron-builder
+// locally, the enterprise signing service for release), so an entitlement
+// present in one and absent from the other still ships a broken bundle on that
+// lane. Every entitlement assertion below runs against both.
+const ENTITLEMENT_LANES = {
+  "electron-builder (build/entitlements.mac.plist)": path.join(
+    ROOT, "build", "entitlements.mac.plist"
+  ),
+  "signing service (packaging/signing/Entitlements.entitlements)": path.resolve(
+    ROOT, "..", "..", "packaging", "signing", "Entitlements.entitlements"
+  ),
+};
+
 // Under the hardened runtime, an Info.plist usage string does NOT grant a
 // protected resource — the matching `device.*` entitlement does. With
 // audio-input missing, the runtime refused the microphone BEFORE macOS (TCC) was
@@ -205,58 +265,7 @@ describe("macOS microphone entitlement (both signing lanes)", () => {
   const MIC = "com.apple.security.device.audio-input";
   const CAMERA = "com.apple.security.device.camera";
 
-  /**
-   * Strip XML comments, repeatedly, until the text stops changing.
-   *
-   * One pass is not enough: removing an outer `<!-- … -->` can splice together
-   * text that forms a NEW `<!--`, so a single replace can leave a comment
-   * opener behind. Looping to a fixed point (then asserting nothing is left)
-   * is what makes "this key is real, not commented-out prose" trustworthy.
-   */
-  function stripComments(xml) {
-    let out = xml;
-    for (let i = 0; i < 20; i += 1) {
-      const next = out.replace(/<!--[\s\S]*?-->/g, "");
-      if (next === out) return next;
-      out = next;
-    }
-    return out;
-  }
-
-  /**
-   * Parse an entitlements plist into a plain { key: value } map.
-   *
-   * Deliberately a scanner rather than a built-from-a-string RegExp: composing
-   * a pattern out of a key name means hand-rolling escaping, which is easy to
-   * get subtly wrong (CodeQL flags exactly that), and a text match cannot tell
-   * a genuine <dict> entry from one mentioned in a comment. Walking the tags
-   * gives an exact key->value answer with no escaping in the picture at all.
-   * Booleans are all these files hold; anything else is reported as its raw tag.
-   */
-  function parseEntitlements(xml) {
-    const body = stripComments(xml);
-    assert.equal(body.includes("<!--"), false, "unterminated XML comment");
-    const out = {};
-    const tag = /<key>([\s\S]*?)<\/key>\s*(<[^>]+>)/g;
-    let m;
-    while ((m = tag.exec(body)) !== null) {
-      const name = m[1].trim();
-      const value = m[2].replace(/\s|\//g, "");
-      out[name] = value === "<true>" ? true : value === "<false>" ? false : m[2];
-    }
-    return { entitlements: out, body };
-  }
-
-  const LANES = {
-    "electron-builder (build/entitlements.mac.plist)": path.join(
-      ROOT, "build", "entitlements.mac.plist"
-    ),
-    "signing service (packaging/signing/Entitlements.entitlements)": path.resolve(
-      ROOT, "..", "..", "packaging", "signing", "Entitlements.entitlements"
-    ),
-  };
-
-  for (const [lane, file] of Object.entries(LANES)) {
+  for (const [lane, file] of Object.entries(ENTITLEMENT_LANES)) {
     it(`grants the microphone in the ${lane} lane`, () => {
       const { entitlements } = parseEntitlements(fs.readFileSync(file, "utf8"));
       assert.equal(
@@ -336,6 +345,85 @@ describe("macOS microphone entitlement (both signing lanes)", () => {
       "must be real prompt copy explaining WHY the mic is used, not empty/placeholder"
     );
   });
+});
+
+// macOS 15 (Sequoia) gates local-network access behind TCC for EVERY app, not
+// just sandboxed ones. An app that declares no local-network intent gets no
+// prompt and no row in Privacy & Security -> Local Network, so there is nothing
+// for the user to allow and `tccutil reset LocalNetwork <bundle-id>` fails with
+// no record to reset. In that state unicast connections from the app's process
+// subtree to non-gateway RFC1918 addresses fail INSTANTLY with EHOSTUNREACH,
+// which reads as a routing fault rather than a denied permission. That was the
+// shipped state: extendInfo declared the microphone and nothing else.
+//
+// This is the same failure SHAPE as the dead microphone above — capability
+// refused, no prompt, no toggle — but NOT the same mechanism, and the difference
+// is the whole point of these tests. Local network on a non-sandboxed
+// hardened-runtime app is TCC-only: the Info.plist usage string is the entire
+// declaration, and there is no entitlement to add. Two neighbouring keys look
+// like they would help and must stay OUT:
+//
+//   * the multicast entitlement is for multicast/broadcast, needs an
+//     Apple-granted provisioning profile, and signing with it unprovisioned
+//     fails outright;
+//   * the App-Sandbox network-client entitlement only means anything under App
+//     Sandbox, which this app does not use — shipping it implies a sandbox the
+//     bundle is not built for.
+//
+// So the assertions run in both directions: the usage string must be present,
+// and neither cargo-culted entitlement may appear in either signing lane.
+describe("macOS local network privacy declaration", () => {
+  const MULTICAST = "com.apple.developer.networking.multicast";
+  const SANDBOX_NETWORK_CLIENT = "com.apple.security.network.client";
+
+  it("declares local-network intent with real prompt copy", () => {
+    // Without this key macOS shows no prompt and creates no TCC record, which
+    // is precisely the state where the user cannot grant access even though the
+    // System Settings pane exists. As with the mic, assert the VALUE: macOS
+    // refuses an empty purpose string, so a present-but-blank key ships the bug.
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+    const usage = (pkg.build.mac.extendInfo || {}).NSLocalNetworkUsageDescription;
+    assert.equal(
+      typeof usage,
+      "string",
+      "NSLocalNetworkUsageDescription must be declared, or LAN access is denied " +
+        "with no prompt and no Privacy & Security row to flip"
+    );
+    assert.ok(
+      usage.trim().length >= 20,
+      "must be real prompt copy explaining WHY the local network is used"
+    );
+    // Electron's own bundled Info.plist carries generic boilerplate of the form
+    // "This app needs access to …" for keys nobody wrote copy for. Shipping that
+    // as a user-facing security prompt is the failure this guards.
+    assert.equal(
+      /this app needs access to/i.test(usage),
+      false,
+      "must not ship Electron's generic boilerplate as the prompt copy"
+    );
+  });
+
+  for (const [lane, file] of Object.entries(ENTITLEMENT_LANES)) {
+    it(`adds no local-network entitlement in the ${lane} lane`, () => {
+      // Checked as parsed keys, not substrings: the comments in these files and
+      // in this test MENTION both names to explain why they are absent, and a
+      // substring test would fail on the very prose documenting the rule.
+      const { entitlements } = parseEntitlements(fs.readFileSync(file, "utf8"));
+      assert.notEqual(
+        entitlements[MULTICAST],
+        true,
+        `${file} must not request ${MULTICAST} — it needs an Apple-granted ` +
+          "provisioning profile and breaks signing when unprovisioned; plain " +
+          "unicast LAN access does not need it"
+      );
+      assert.notEqual(
+        entitlements[SANDBOX_NETWORK_CLIENT],
+        true,
+        `${file} must not request ${SANDBOX_NETWORK_CLIENT} — it is an ` +
+          "App-Sandbox key and this bundle is not sandboxed"
+      );
+    });
+  }
 });
 
 describe("uninstall data preservation contract", () => {


### PR DESCRIPTION
Fixes the packaging half of #4374.

## The problem

macOS 15 (Sequoia) gates local-network access behind TCC for **every** app, sandboxed or not. `KiroCrew.app` declared no local-network intent anywhere:

```console
$ codesign -d --entitlements - --xml /Applications/KiroCrew.app | plutil -p -
{
  "com.apple.security.automation.apple-events" => true
  "com.apple.security.cs.allow-jit" => true
  "com.apple.security.cs.allow-unsigned-executable-memory" => true
  "com.apple.security.cs.disable-library-validation" => true
  "com.apple.security.device.audio-input" => true
}
```

…and `build.mac.extendInfo` carried only `NSMicrophoneUsageDescription`. With no declared intent macOS creates no `kTCCServiceLocalNetwork` record, so there is no prompt to answer and no row under System Settings › Privacy & Security › Local Network to switch on — and `tccutil reset LocalNetwork com.amazon.kiro.crew` fails because there is nothing to reset.

The reported symptom follows from exactly that: the default gateway and public hosts are reachable, every other RFC1918 address fails **instantly** with errno 65 (`EHOSTUNREACH`) in ~0.000s, and `ping`/ARP to the same host succeed. The gateway-works / everything-else-fails split is the signature of the TCC gate, not of the network.

The agent sandbox is **not** involved: the Seatbelt profile in `src/kiro_crew/sandbox.py` is `(allow default)` plus filesystem denies and carries no network rules at all. Worth stating because it is the obvious wrong suspect.

## The change

Declare `NSLocalNetworkUsageDescription` with real prompt copy, and **add no entitlement**. The issue title proposes a "Local Network entitlement"; no such thing exists for a non-sandboxed hardened-runtime app, and the two keys that look like they would help must stay out:

| Key | Why not |
|---|---|
| `com.apple.developer.networking.multicast` | Multicast/broadcast only; needs an Apple-granted provisioning profile and **breaks signing** when requested unprovisioned. Plain unicast LAN access does not need it. |
| `com.apple.security.network.client` | App-Sandbox key; this bundle is not sandboxed, so shipping it implies a sandbox it is not built for. |

`NSAllowsLocalNetworking`, already present in the bundle, is an App Transport Security key (HTTPS relaxation for local hostnames) and has no bearing on the TCC gate — easy to mistake for a fix, since it is already there in a bundle that cannot reach the LAN.

This is the same failure *shape* as the dead-microphone bug (capability refused, no prompt, no toggle) but deliberately **not** the same remedy, and the tests encode that difference so the mic precedent is not cargo-culted onto a TCC-only resource.

## Tests

`packaging.test.js` pins both directions, and both assertions were mutation-verified:

| Mutation | Result |
|---|---|
| Remove `NSLocalNetworkUsageDescription` | ✖ `declares local-network intent with real prompt copy` |
| Add the multicast entitlement to `build/entitlements.mac.plist` | ✖ `adds no local-network entitlement in the electron-builder … lane` |

The usage-string test also rejects empty copy (macOS refuses a blank purpose string, so a present-but-blank key would ship the bug) and rejects Electron's generic `"This app needs access to …"` boilerplate — the bundle already carries that boilerplate for camera and Bluetooth, so the guard is grounded, not hypothetical.

The plist parser and the two-lane table are hoisted to module scope so the microphone and local-network blocks cannot drift into slightly different parsers and disagree about what a file grants. No behavioural change to the existing mic assertions.

Verification on this branch:

- `npm test` in `website/electron` — **1117 pass, 0 fail, 1 skipped** (29 in `packaging.test.js`)
- `scripts/docs-lint.sh` — 216 files, all checks passed
- `scripts/scrub-lint.sh` — content checks clean (the git-history check fails identically on `origin/main`; it is about local commit authorship, unrelated to this change)
- `BRAND_BASE_REF=origin/main scripts/check_brand_name.py` — clean

No screenshot or recording is attached: the change is a signing/Info.plist declaration, and the state it fixes only becomes visible on a real macOS 15 host after a signed rebuild. A capture from this machine would show an ordinary screen without the precondition and would mislead rather than inform.

## What this does NOT close, and why the issue should stay open

The declaration is **necessary**; whether it is **sufficient** needs an on-device check I cannot do from here, for two reasons worth a maintainer's attention:

1. **TCC attribution across `exec`.** Agent shell commands are wrapped by `sandbox_exec_argv` (`src/kiro_crew/sandbox.py`), which `exec`s the target through `/usr/bin/sandbox-exec` and replaces the process image. Whether TCC's responsible-process attribution still lands on the app bundle across that `exec` has to be measured, not reasoned about. If it does not, the prompt will appear for the app while the agent's own commands stay blocked, and a first-run local-network touch from the Electron main process would be the follow-up.

2. **The reporter's launch path is ambiguous.** The install method is "Desktop app" but repro step 2 says `kirocrew gateway`. Apple exempts command-line tools run from Terminal or over SSH **and every child process they spawn**, so a terminal-started gateway should reach the LAN normally. That asymmetry is both a triage question and a workaround for the reporter in the meantime, and it is now documented.

Both are written up in `docs/build/desktop-app.md` rather than left in a PR comment, alongside the `NSAllowsLocalNetworking` false lead and the launch-context exemptions — the pieces that cost the most to rediscover. `docs/build/signing-runbook.md` gets the shorter companion note, since it is the file that documents the entitlements lanes and is where someone would otherwise generalize the microphone rule to this resource.
