### PR TITLE
fix(mochi): release the pet overlay's display listeners on teardown

### DIFF
--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -767,12 +767,58 @@ function wireHandshake(win, displayId, pos) {
 }
 
 /**
+ * The display events that make the overlay set stale.
+ *
+ * Named once so binding and unbinding cannot drift apart: an event added to the
+ * bind side but forgotten on the unbind side is the exact shape of the leak
+ * below.
+ */
+const DISPLAY_EVENTS = ["display-added", "display-removed", "display-metrics-changed"];
+
+/**
+ * Bind the display listeners, once per live pet.
+ *
+ * Paired with `unbindDisplayListeners` in `closePetWindow`. The pairing is the
+ * whole point: this used to be a ONE-WAY latch that was never released, so the
+ * handler outlived every teardown and kept rebuilding overlays for a pet that
+ * was no longer supposed to exist.
+ */
+function bindDisplayListeners() {
+  if (displayListenersBound) return;
+  displayListenersBound = true;
+  for (const event of DISPLAY_EVENTS) screen.on(event, onDisplayChange);
+}
+
+/**
+ * Release the display listeners on teardown.
+ *
+ * Without this, a disabled Mochi still flashed its pet back onto the desktop
+ * (#4673): macOS fires `display-metrics-changed` on a space switch and on wake
+ * from sleep, the leaked handler found an empty overlay map, rebuilt one overlay
+ * per display and `wireHandshake` revealed them — visible until the host's next
+ * 5s reconcile tick tore them down again.
+ */
+function unbindDisplayListeners() {
+  if (!displayListenersBound) return;
+  displayListenersBound = false;
+  for (const event of DISPLAY_EVENTS) screen.removeListener(event, onDisplayChange);
+}
+
+/**
  * Rebuild overlays when displays are added, removed or rearranged.
  *
  * Upstream's version contains a duplicated `if (isHidden)` block (a copy/paste
  * slip); it is ported once here.
  */
 function onDisplayChange() {
+  // No live overlay means there is no pet on screen, so there is nothing to
+  // rebuild — REBUILDING would CREATE one, which is the opposite of what a
+  // torn-down pet wants. Belt to `unbindDisplayListeners`' braces: the unbind
+  // stops the event arriving at all, and this makes the handler itself correct
+  // for an event already dispatched when teardown ran, and for any future
+  // caller that binds without checking.
+  if (overlays.size === 0) return;
+
   const newDisplays = screen.getAllDisplays();
   const newIds = new Set(newDisplays.map((d) => d.id));
 
@@ -851,17 +897,16 @@ function openPetWindow(baseUrl, token = "") {
     wireHandshake(win, d.id, startPos);
   }
 
-  if (!displayListenersBound) {
-    displayListenersBound = true;
-    screen.on("display-added", onDisplayChange);
-    screen.on("display-removed", onDisplayChange);
-    screen.on("display-metrics-changed", onDisplayChange);
-  }
+  bindDisplayListeners();
 
   return getActiveOverlay();
 }
 
 function closePetWindow() {
+  // FIRST, before any window closes: a `close()` can synchronously reshape the
+  // display arrangement (an overlay leaving a space), and a listener still bound
+  // at that moment would re-enter this module mid-teardown.
+  unbindDisplayListeners();
   stopHitPoll();
   stopDragPolling();
   for (const win of [...overlays.values()]) {

--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -180,6 +180,7 @@ function stubElectronForOpen() {
     // actually asserted instead of merely not crashing.
     setContentProtection(on) { this.contentProtection = on; }
     setAlwaysOnTop() {}
+    setBounds(b) { this.bounds = b; }
     loadURL() {}
     isVisible() { return false; }
     isDestroyed() { return false; }
@@ -187,9 +188,22 @@ function stubElectronForOpen() {
     close() {}
     on() {}
   }
-  const DISPLAY = { id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 } };
+  // `workArea` is not optional on a real Electron Display, and getAllDisplayInfo
+  // reads it whenever the arrangement changes — a bounds-only double throws
+  // there instead of exercising the handler.
+  const DISPLAY = {
+    id: 1,
+    bounds: { x: 0, y: 0, width: 1440, height: 900 },
+    workArea: { x: 0, y: 25, width: 1440, height: 875 },
+  };
+  // Display listeners are recorded rather than swallowed: whether they are
+  // RELEASED on teardown is the contract behind #4673, and an `on() {}` stub
+  // cannot see a leak.
+  const displayListeners = [];
   return {
     created,
+    displayListeners,
+    DISPLAY,
     electron: {
       app: { on() {}, setActivationPolicy() {}, dock: { show() {} } },
       BrowserWindow: FakeWindow,
@@ -199,7 +213,11 @@ function stubElectronForOpen() {
         getPrimaryDisplay: () => DISPLAY,
         getAllDisplays: () => [DISPLAY],
         getCursorScreenPoint: () => ({ x: 0, y: 0 }),
-        on() {},
+        on(event, fn) { displayListeners.push({ event, fn }); },
+        removeListener(event, fn) {
+          const at = displayListeners.findIndex((l) => l.event === event && l.fn === fn);
+          if (at >= 0) displayListeners.splice(at, 1);
+        },
       },
     },
   };
@@ -243,6 +261,82 @@ test("the pet overlay is a non-activating panel on macOS only", () => {
       // "panel" is not a legal `type` off macOS; the option must be omitted.
       assert.strictEqual(type, undefined);
     }
+  } finally {
+    mod.closePetWindow();
+  }
+});
+
+// ── Display-listener lifecycle (#4673) ─────────────────────────────────────
+// openPetWindow watches the display arrangement so the overlay set can follow
+// it. That subscription used to sit behind a one-way latch and was never
+// released, so it outlived every teardown: macOS fires
+// display-metrics-changed on a space switch and on wake from sleep, the leaked
+// handler saw an empty overlay map, rebuilt one overlay per display and
+// wireHandshake revealed them — the pet flashed back onto the desktop of a user
+// who had DISABLED Mochi, until the host's next 5s reconcile tick closed it
+// again. Nothing on that path consults the enabled state, so the fix is
+// lifecycle symmetry here, not an async probe on the redraw path.
+
+test("closePetWindow releases the display listeners openPetWindow bound", () => {
+  const { mod, displayListeners } = loadPetOverlays();
+  try {
+    mod.openPetWindow("http://localhost:6777", "tok");
+    assert.deepStrictEqual(
+      displayListeners.map((l) => l.event).sort(),
+      ["display-added", "display-metrics-changed", "display-removed"],
+      "all three arrangement events are watched while a pet is live",
+    );
+
+    mod.closePetWindow();
+    assert.deepStrictEqual(displayListeners, [], "teardown must release every one");
+
+    // The latch is RESET, not merely unset: a re-enable re-arms exactly once, so
+    // an enable/disable cycle can neither leak a handler nor double-fire one.
+    mod.openPetWindow("http://localhost:6777", "tok");
+    assert.strictEqual(displayListeners.length, 3, "a re-open re-arms once, not twice");
+  } finally {
+    mod.closePetWindow();
+  }
+});
+
+test("a display event after teardown does not flash the pet back on screen", () => {
+  const { mod, created, displayListeners } = loadPetOverlays();
+  try {
+    mod.openPetWindow("http://localhost:6777", "tok");
+    assert.strictEqual(created.length, 1, "one overlay for the single display");
+    const metrics = displayListeners.find((l) => l.event === "display-metrics-changed");
+    assert.ok(metrics, "the handler under test must be registered while live");
+
+    mod.closePetWindow();
+    // Exactly what the leak did: deliver the event to the handler that was
+    // registered. It must now build nothing — the guard holds even for an event
+    // already dispatched when teardown ran.
+    metrics.fn();
+    assert.strictEqual(created.length, 1, "no overlay may be created for a torn-down pet");
+    assert.strictEqual(mod.isPetWindowOpen(), false, "and the pet stays gone");
+  } finally {
+    mod.closePetWindow();
+  }
+});
+
+test("a display event while the pet is live still follows the new geometry", () => {
+  // The guard must not be over-broad: a resolution or arrangement change with a
+  // LIVE pet still has to resize its overlay, which is the behaviour the
+  // listeners exist for.
+  const { mod, created, displayListeners, DISPLAY } = loadPetOverlays();
+  try {
+    mod.openPetWindow("http://localhost:6777", "tok");
+    const metrics = displayListeners.find((l) => l.event === "display-metrics-changed");
+    DISPLAY.bounds = { x: 0, y: 0, width: 1280, height: 800 };
+    DISPLAY.workArea = { x: 0, y: 25, width: 1280, height: 775 };
+
+    metrics.fn();
+    assert.strictEqual(created.length, 1, "an existing display reuses its overlay");
+    assert.deepStrictEqual(
+      created[0].bounds,
+      DISPLAY.bounds,
+      "the live overlay follows the new display bounds",
+    );
   } finally {
     mod.closePetWindow();
   }


### PR DESCRIPTION
## Problem / Motivation

On macOS, the Mochi floating pet briefly flashes back onto the desktop of a user who has **disabled** the Mochi app — on every space switch and every wake from sleep. Reported in #4673, where the flash was observed exactly at those moments.

## Why it matters

Disabling an app is the user's instruction that it should stop being on screen. An always-on-top, full-display overlay that reappears anyway — repeatedly, on an interaction as routine as switching spaces — reads as the disable switch not working. The only workaround found in the issue was hand-editing the Electron shell's own state file, and it does not actually address the cause (see below), so the flash returns after the next enable/disable cycle.

## What changed (motivation → approach → change)

**Symptom → cause.** `openPetWindow` subscribes to the display arrangement so the overlay set can follow it, and it did so behind a **one-way latch**:

```js
if (!displayListenersBound) {
  displayListenersBound = true;
  screen.on("display-added", onDisplayChange);
  screen.on("display-removed", onDisplayChange);
  screen.on("display-metrics-changed", onDisplayChange);
}
```

`closePetWindow` never released those listeners and never reset the latch, so the handler **outlived every teardown**. macOS fires `display-metrics-changed` on a space switch and on wake from sleep; the leaked `onDisplayChange` then found an empty `overlays` map, took its "displays that appeared" branch for every display, and `wireHandshake`'s `did-finish-load` called `showInactive()`. Nothing on that path consults the enabled state, so the overlays stayed on screen until the host's next reconcile tick (`MOCHI_PET_RECONCILE_MS = 5000`) reached the `state === "disabled"` teardown branch and closed them again. That gap is the visible flash.

**Approach — lifecycle symmetry, not an enabled-state probe on the redraw path.** The obvious-looking fix, "check the enabled flag before showing on redraw", is the wrong shape: the reconcile loop's enabled state is deliberately **tri-state** (`enabled` / `disabled` / `unknown`, where unknown means *change nothing*), and an `await` on the redraw path would race that. The question the redraw path actually needs answered is not "is Mochi enabled" but "is there a pet on screen at all" — which is synchronous local state this module already owns.

**Change.**

- `DISPLAY_EVENTS` names the three events once, so the bind and unbind sides cannot drift apart (an event added to one and forgotten on the other is the exact shape of this bug).
- `bindDisplayListeners()` / `unbindDisplayListeners()` replace the latch with a symmetric pair. The unbind **resets** the latch rather than merely leaving it set, so a re-enable re-arms exactly once.
- `closePetWindow` calls the unbind **first**, before any `close()`: closing a full-display overlay can itself reshape the arrangement, and a listener still bound at that moment would re-enter this module mid-teardown.
- `onDisplayChange` early-returns on `overlays.size === 0`. This is the belt to the unbind's braces — it keeps the handler correct for an event already dispatched when teardown ran, and for any future caller that binds without checking.

Behaviour for a **live** pet is unchanged: a resolution or arrangement change still resizes its overlays, which is locked in by a test below.

Present since Mochi shipped as a builtin (#1258). No test touched the display events, so the leak was invisible to CI.

## Tests

All three are in `website/electron/mochi/test/petOverlays.test.js`. The existing `stubElectronForOpen` double now **records** display listeners instead of swallowing them with `on() {}` — an `on() {}` stub cannot observe a leak — and its display gained the `workArea` a real Electron `Display` always has (`getAllDisplayInfo` reads it on every arrangement change).

- **`closePetWindow releases the display listeners openPetWindow bound`** — all three events are watched while a pet is live, none remain after teardown, and a re-open re-arms exactly once (the latch is reset, not leaked, so an enable/disable cycle can neither leak nor double-fire a handler).
- **`a display event after teardown does not flash the pet back on screen`** — the regression itself: deliver `display-metrics-changed` to the handler that was registered, after `closePetWindow`, and assert no overlay is created and `isPetWindowOpen()` stays false.
- **`a display event while the pet is live still follows the new geometry`** — the guard is not over-broad: with a live pet, a resolution change still reaches the existing overlay's `setBounds` and creates no duplicate.

**Mutation-proven.** Reverting only the production hunks (keeping the tests) fails exactly the first two — 25 pass / 2 fail. The third passes either way by design; it exists to catch an over-broad guard, not the leak. Full Electron shell suite with the fix: **1117 pass / 0 fail**.

## Manual verification

N/A — unit coverage sufficient. The trigger is a real macOS display event (`display-metrics-changed` on a space switch or wake), which is what the tests deliver to the registered handler directly; there is no additional signal a hand-run would produce that the assertions do not already pin.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the rendered delta is the *absence* of an overlay that should never have appeared, on a disabled app. There is no UI state to capture — a correct build shows an unchanged desktop, which is indistinguishable in a still frame from a build that simply had not fired the event yet. `website/electron/**` is the Electron main process and renders no dashboard surface.

## Related Issues

Fixes #4673

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes; the reasoning lives in the code comments at the bind/unbind pair and the guard
- [x] No secrets, credentials, or internal references in the diff
