### PR TITLE
feat(connections): L1 authorized-grant smoke harness and opt-in lane

### DIFF
--- a/.github/workflows/connections-l1.yml
+++ b/.github/workflows/connections-l1.yml
@@ -1,0 +1,73 @@
+name: Connections L1 Authorized-Grant Smoke
+
+# Scheduled smoke over the Connections providers that ALREADY hold a persisted
+# OAuth grant on the runner: where L0 (connections-l0.yml) checks account-free
+# static metadata, this rung checks a once-consented grant still works live.
+# READ FIRST -- docs/architecture/design-notes/connections-l1-smoke.md: verdict
+# table, runbook, and what a green run does NOT prove (a runtime-custody
+# provider greens as GRANT_HELD, not a proven tool call).
+#
+# OPT-IN BY DESIGN -- inert until the repository variable CONNECTIONS_L1_RUNNER
+# names a self-hosted runner on the box where the grants live: a hosted runner
+# has no grants (every provider SKIPPED -> --min-exercised 1 makes that an
+# explicit `vacuous` failure), and seeding one takes a human at a browser --
+# nothing here initiates consent. Schedule is the ONLY trigger -- a ref-selectable
+# one (workflow_dispatch) lets any writer run a modified branch's workflow on the
+# grant-bearing box. Not a pull_request check either (connections-l0.yml's stated
+# reason). No secrets or writes; the report is an artifact, grants stay on the box.
+
+on:
+  schedule:
+    - cron: "40 7 * * *" # 07:20 is L0's slot; stagger so the two never contend
+
+permissions:
+  contents: read
+
+concurrency:
+  group: connections-l1
+  cancel-in-progress: false # NOT cancel-in-progress: a cancelled run uploads no report
+
+jobs:
+  smoke:
+    name: Smoke providers holding a grant
+    if: vars.CONNECTIONS_L1_RUNNER != '' # empty = no seeded box; skip, never queue
+    runs-on: ${{ vars.CONNECTIONS_L1_RUNNER }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Deliberately no setup-python / setup-uv: this self-hosted box already
+      # runs the gateway and the grants belong to the kiro-cli installed there;
+      # a fresh interpreter would smoke a different environment. So the sweep
+      # runs under the interpreter that OWNS the installed module (bare python3
+      # cannot import it under a pipx/venv install): resolve from the kirocrew
+      # entry point's shebang, fall back to python3, else fail loudly.
+      - name: Run the authorized-grant smoke sweep
+        run: |
+          set -uo pipefail
+          python_bin=""
+          entry="$(command -v kirocrew || true)"
+          shebang="$(sed -n '1s/^#!//p' "$entry" 2>/dev/null || true)"
+          case "$shebang" in
+            /*python*) "$shebang" -c 'import kiro_crew.connections.l1_smoke' 2>/dev/null && python_bin="$shebang" || true ;;
+          esac
+          if [ -z "$python_bin" ] && python3 -c 'import kiro_crew.connections.l1_smoke' 2>/dev/null; then python_bin=python3; fi
+          if [ -z "$python_bin" ]; then
+            echo "::error::no interpreter with kiro_crew.connections.l1_smoke found (checked the kirocrew entry point's shebang, then python3) -- is the installed release older than this module?"
+            exit 1
+          fi
+          "$python_bin" -m kiro_crew.connections.l1_smoke \
+            --report connections-l1-report.json \
+            --min-exercised 1
+
+      # always(): a failing sweep's report is the only record of WHICH provider regressed.
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: connections-l1
+          path: connections-l1-report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/architecture/design-notes/README.md
+++ b/docs/architecture/design-notes/README.md
@@ -11,6 +11,7 @@ grows into a subsystem should become a spec under
 | [session-slack-linking.md](session-slack-linking.md) | How a Slack thread maps onto a Kiro Crew session, and how thread state stays in sync. |
 | [mcp-oauth-ownership.md](mcp-oauth-ownership.md) | Who owns an MCP server's OAuth tokens, and why that ownership is contested. |
 | [connections-status-tiers.md](connections-status-tiers.md) | The authorization axis behind a Connections card: grant-presence status, source-backed connected-since, what Cancel releases, and which mint tiers exist. |
+| [connections-l1-smoke.md](connections-l1-smoke.md) | The Connections launch-gate ladder, and what an automated smoke run over a real stored grant can and cannot prove. |
 | [mcp-entry-provenance.md](mcp-entry-provenance.md) | Which entries in a shared MCP config file a sync may rewrite: the write-authorship marker and its four outcomes. |
 | [mcp-gateway-claim-push.md](mcp-gateway-claim-push.md) | Event-driven caller identity for pooled MCP stubs. |
 | [mcp-gateway-oversize-response.md](mcp-gateway-oversize-response.md) | Handling an MCP tool response that exceeds the gateway read buffer. |

--- a/docs/architecture/design-notes/connections-l1-smoke.md
+++ b/docs/architecture/design-notes/connections-l1-smoke.md
@@ -1,0 +1,98 @@
+# Connections L1: the authorized-grant smoke rung
+
+A visible Connect card is a promise the flow works; each rung of the launch
+ladder asserts something the rung below structurally cannot:
+
+| Rung | Where | Needs an account? | Asserts |
+|---|---|---|---|
+| **L0** | `connections-l0.yml`, nightly, every branch | no | the provider's PUBLIC OAuth metadata still matches the committed `l0_expectations` |
+| **L1** | `connections-l1.yml`, scheduled, opt-in box | yes, one human click per provider, once | a grant that exists still works against the live endpoint |
+| **L2** | manual, at the flag-flip gate | yes | the UI walk-through a human has to actually see (see the Connections manual test SOP) |
+
+L0 never authenticates, so it cannot prove a *connection*; L2 costs a human
+every time. L1 sits between: one consent click, then automated.
+
+## What a green L1 run actually proves
+
+**Kiro Crew holds no token.** kiro-cli owns the OAuth chain and injects the
+bearer inside its own process ([mcp-oauth-ownership.md](mcp-oauth-ownership.md)),
+so an exchange opened from the harness carries no credential for a managed
+provider, and the live endpoint answers with an OAuth challenge -- exactly as it
+answers the dashboard's probe. The verdict vocabulary is built around that fact:
+
+| Verdict | Green? | Established |
+|---|---|---|
+| `PASS` | yes | the exchange ran through `initialize` and `tools/list` non-error, and the registry `smoke_fixture` tool is still advertised. Reachable for an entry that carries its own credential, or an unprotected server |
+| `GRANT_HELD` | yes | the grant is still on disk **and** the endpoint is reachable and still answers a well-formed challenge. Does **not** prove a tool call would succeed |
+| `NEEDS_RECONSENT` | no | a credential this process presented was refused, or an authorization error came back mid-exchange. A human must re-approve |
+| `FAIL` | no | reached and wrong, or unreachable: non-2xx with no challenge, 5xx, timeout, transport error, broken `tools/list`, fixture tool no longer advertised |
+| `SKIPPED` | yes | not a configured MCP server here, no grant for it, or the entry's endpoint does not match the registry `mcp_url`. **L1 never initiates consent** |
+
+Each row also carries `depth` (`tools_list` / `challenge` / `none`), so how far
+the exchange got is never inferred.
+
+### The sweep never calls a tool
+
+It stops at `tools/list`. A `tools/call` issued from here would reach the
+provider outside the governed dispatch path, so a tool an enterprise policy
+denies would be invoked anyway and no SEL event would record it — an unaudited
+side channel is a worse outcome than a narrower verdict. The registry's
+`smoke_fixture` is therefore used for its NAME only (`tools/list` already
+answers whether it is still advertised); exercising it belongs to the ACP-side
+slice below, where kiro-cli's own governed, audited dispatch owns the call.
+
+### Runbook for a failing lane
+
+| Symptom | What it means, what to do |
+|---|---|
+| `vacuous`, every provider `SKIPPED` | No grant is seeded, and seeding IS the one-time consent click: on the box, open Connections and click Connect per provider. Lower `--min-exercised` only if you mean "cover fewer providers" |
+| `NEEDS_RECONSENT` | The grant is spent (expired refresh token, or revoked upstream). A human re-approves on the card |
+| `FAIL` | Usually a provider-side change to its MCP surface: read their changelog before editing our registry |
+| "exceeded its total timeout" | The provider outlasted its whole budget, not one request's. Raise `--timeout` only for a known-slow provider; otherwise treat as `FAIL` -- a session cannot get a tool out of it either |
+
+### The decision that shaped this: a challenge is not a failure
+
+The earlier draft graded every tokenless 401 as `NEEDS_RECONSENT` — but that is
+what a **healthy** authorized provider returns under runtime custody, so the
+lane would sit permanently red, and a lane nobody believes is worse than no
+lane. So the challenge became its own verdict and `NEEDS_RECONSENT` narrowed to
+an attributable rejection. A tokenless `403` with no `WWW-Authenticate` grades
+`FAIL`, not `NEEDS_RECONSENT` — an edge proxy or geo block reads identically,
+and a consent verdict would send a human to re-approve a healthy grant.
+
+### A run that exercised nothing is not green
+
+With no seeded grants every provider is `SKIPPED` and the aggregate would be a
+cheerful `ok` establishing nothing. `--min-exercised N` (the lane passes `1`)
+makes that `vacuous`, nonzero. `GRANT_HELD` counts as exercised; `SKIPPED` not.
+
+## Grant presence is observed, never read
+
+`grant_present` is imported from `connections/mint.py` rather than copied —
+this slice's dedupe obligation, pinned by identity in the tests; the key
+formula and cache-dir resolution are pinned transitively, since it derives
+both internally (a drifted copy grades a live connection `SKIPPED` while the
+card says connected). Presence is a `stat` of the paired
+`{sha256}.token.json` + `{sha256}.registration.json` artifacts and opens
+neither, so no token byte can enter the process, report, or a log line; the
+single-file `{sha256}.json` SSO form is deliberately not consulted, and a test
+fixture makes any *open* of either artifact an outright failure. No SEL read
+audit, unlike mint's `_grant_observed`: that covers a Connect flow acting for a
+remote caller, whereas this is an operator's own CLI, `l0_probe`'s class.
+
+## Known gap: proving a tool actually works
+
+Two boundaries keep this rung short of "a tool call succeeded", and both point
+the same way: kiro-cli holds the bearer, and the governed path owns dispatch
+(enterprise tool policy plus its audit record). Both are answered by having the
+runtime make the call, not by reading its token store or bypassing its gate.
+ACP exposes no tool-invocation surface outside a model turn today, so that
+lands with the ACP-side observation slice; until then `GRANT_HELD` is the
+ceiling for runtime-custody providers and `PASS` means "reachable,
+authenticated, and the pinned tool still advertised".
+
+## Running it by hand
+
+`python3 -m kiro_crew.connections.l1_smoke --report /tmp/l1.json` (under a
+pipx/venv install, use that environment's interpreter). `--min-exercised 1`
+reproduces the lane's gate; `--concurrency`/`--timeout` are in `--help`.

--- a/src/kiro_crew/connections/l1_smoke.py
+++ b/src/kiro_crew/connections/l1_smoke.py
@@ -1,0 +1,663 @@
+"""L1: scheduled smoke run over providers that already hold a persisted grant.
+
+Middle rung of the Connections launch ladder (L0 = the account-free metadata
+probe, L2 = the manual UI gate); the full contract -- verdict table, runbook,
+known gap -- lives in ``docs/architecture/design-notes/connections-l1-smoke.md``.
+Invariants: **Kiro Crew holds no token** (kiro-cli injects the bearer in its own
+process, so a managed provider's healthy reply is an OAuth challenge -- graded
+``GRANT_HELD``, never ``NEEDS_RECONSENT``, reserved for attributable
+rejections); **L1 never initiates consent** (absent grant = ``SKIPPED``); an
+all-skipped sweep is ``vacuous``, not green. Grant presence is observed via
+:func:`~kiro_crew.connections.mint.grant_present` -- paired artifacts stat-ed,
+never opened; one implementation of kiro-cli's key mirror; no SEL read audit,
+an operator CLI in ``l0_probe``'s class. Transport reuses ``mcp_discovery``'s
+reviewed plumbing (private names imported so the challenge rule cannot drift).
+
+The sweep STOPS at ``tools/list`` and never issues ``tools/call``: a call from
+here would reach the provider outside governed dispatch (no policy check, no SEL
+event), so the fixture is checked for ADVERTISEMENT only -- see the design
+note's "The sweep never calls a tool".
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Sequence, TypedDict
+
+import aiohttp
+
+from kiro_crew.connections.mint import grant_present
+from kiro_crew.connections.registry import Provider, get_all_registry_providers
+from kiro_crew.connections.tool_aliases import normalized_endpoint
+from kiro_crew.mcp_discovery import (
+    McpServerInfo,
+    _needs_authorization,
+    list_servers,
+    redact_mcp_error,
+)
+
+__all__ = [
+    "SmokeResult",
+    "build_report",
+    "configured_remote_servers",
+    "grant_present",
+    "main",
+    "run_l1",
+    "smoke_all",
+    "smoke_provider",
+]
+
+DEFAULT_CONCURRENCY = 4
+DEFAULT_TIMEOUT_SECONDS = 20.0
+_REPORT_SCHEMA_VERSION = 1
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+_CLIENT_INFO = {"name": "kirocrew-l1-smoke", "version": "1"}
+_MAX_ERROR_CHARS = 200
+# A JSON-RPC control reply is kilobytes; past this a provider is streaming, not answering.
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+# Whole-run budget derived from the per-request one; bounds a stall-every-leg server.
+_TOTAL_BUDGET_MULTIPLIER = 3
+
+# JSON-RPC error substrings meaning "the grant no longer works": only these grade
+# NEEDS_RECONSENT past initialize, so an outage is never a consent problem.
+_RECONSENT_TOKENS = ("unauthorized", "invalid_token", "invalid_grant", "forbidden")
+
+Verdict = Literal["PASS", "GRANT_HELD", "NEEDS_RECONSENT", "FAIL", "SKIPPED"]
+Depth = Literal["tools_list", "challenge", "none"]
+
+#: Non-failing verdicts: a skip is an unseeded box; a challenge is expected.
+_HEALTHY: frozenset[str] = frozenset({"PASS", "GRANT_HELD", "SKIPPED"})
+_VERDICTS: tuple[Verdict, ...] = ("PASS", "GRANT_HELD", "NEEDS_RECONSENT", "FAIL", "SKIPPED")
+
+
+class SmokeResult(TypedDict):
+    """Machine-readable L1 verdict for one registry provider. ``depth`` says how
+    far the exchange got, so a ``GRANT_HELD`` (stopped at the challenge) is
+    never inferred from the verdict vocabulary alone."""
+
+    slug: str
+    name: str
+    verdict: Verdict
+    depth: Depth
+    installed: bool
+    grant_present: bool
+    credential_presented: bool
+    fixture_tool: str
+    fixture_tool_advertised: bool
+    tools_listed: int
+    errors: list[str]
+    duration_ms: int
+
+
+class _McpChallenge(Exception):
+    """The endpoint is alive and asked to authenticate. Expected, not a fault."""
+
+
+class _McpAuthError(Exception):
+    """A credential this process presented was refused by the provider."""
+
+
+class _McpCallError(Exception):
+    """The exchange reached the provider but did not produce a usable result."""
+
+
+def configured_remote_servers() -> dict[str, McpServerInfo]:
+    """Configured remote MCP servers keyed by name, minus ``disabled`` entries --
+    excluded for the reason ``probe_server`` refuses them: a second entry point
+    must restate the consent gate or become a way around it (SKIPPED, untouched)."""
+    return {
+        server.name: server for server in list_servers() if server.is_remote and not server.disabled
+    }
+
+
+def _presents_credential(headers: dict[str, str]) -> bool:
+    """Whether the server entry carries its own ``Authorization`` header -- the
+    distinction the verdicts turn on: with no credential of our own a 401 is the
+    provider correctly protecting itself; with one, the credential was refused."""
+    return any(key.lower() == "authorization" for key in headers)
+
+
+def _reconsent_error(error: object) -> bool:
+    if not isinstance(error, dict):
+        return False
+    message = str(error.get("message", "")).lower()
+    return any(term in message for term in _RECONSENT_TOKENS)
+
+
+def _result_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """A JSON-RPC ``result``, converting an ``error`` member into an exception."""
+    error = data.get("error")
+    if error is not None:
+        if _reconsent_error(error):
+            raise _McpAuthError(str(error.get("message", "unauthorized")))
+        message = error.get("message", "unknown error") if isinstance(error, dict) else str(error)
+        raise _McpCallError(str(message))
+    result = data.get("result")
+    if not isinstance(result, dict):
+        raise _McpCallError("response carried no result object")
+    return result
+
+
+async def _read_capped(response: aiohttp.ClientResponse) -> dict[str, Any]:
+    """Parse a JSON-RPC reply, refusing a body past ``_MAX_RESPONSE_BYTES``.
+
+    ``mcp_discovery._read_jsonrpc_response`` buffers a whole body, which this
+    harness cannot afford: an OOM kill takes the report with it, and the report is
+    the run's only record of which provider regressed. Accumulating to one byte
+    past the cap is what proves the cap was exceeded. Graded FAIL, never
+    NEEDS_RECONSENT -- an oversized body says nothing about the grant.
+    """
+    raw = b""
+    while len(raw) <= _MAX_RESPONSE_BYTES:
+        # read(n) yields only what is buffered NOW, never n bytes: a chunked or SSE
+        # body arrives across several feeds, so a single read would parse a
+        # truncated prefix and grade a healthy grant FAIL. The request's own
+        # ClientTimeout bounds this loop, and the remainder keeps every n >= 1.
+        chunk = await response.content.read(_MAX_RESPONSE_BYTES + 1 - len(raw))
+        if not chunk:
+            break
+        raw += chunk
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise _McpCallError(f"provider response exceeded {_MAX_RESPONSE_BYTES} bytes")
+    if "text/event-stream" in (response.content_type or ""):
+        last: dict[str, Any] = {}
+        for line in raw.decode("utf-8", "replace").splitlines():
+            if not line.startswith("data:"):
+                continue
+            try:
+                event = json.loads(line[5:].strip())
+            except json.JSONDecodeError:
+                continue  # a partial or non-JSON frame is not the answer
+            if isinstance(event, dict) and "id" in event:
+                last = event
+        return last
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise _McpCallError("provider returned a non-JSON body") from exc
+    if not isinstance(payload, dict):
+        raise _McpCallError("provider returned a non-object JSON-RPC reply")
+    return payload
+
+
+async def _post(
+    session: aiohttp.ClientSession,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    *,
+    timeout_seconds: float,
+) -> tuple[dict[str, Any], str | None]:
+    """POST one JSON-RPC message and return its payload plus any session id.
+
+    A notification carries no ``id`` and no body, so any 2xx is success there
+    (servers answer ``notifications/initialized`` with 202); a request must be
+    answered 200 with a payload. Redirects are not followed: a moved endpoint
+    followed silently would smoke a different server than the registry names.
+    """
+
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    is_notification = body.get("id") is None
+    async with session.post(
+        url, json=body, headers=headers, allow_redirects=False, timeout=timeout
+    ) as response:
+        if _needs_authorization(response.status, response.headers, headers):
+            raise _McpChallenge(f"provider challenged with HTTP {response.status}")
+        if response.status in (401, 403) and _presents_credential(headers):
+            raise _McpAuthError(f"presented credential refused with HTTP {response.status}")
+        # A tokenless 403 with no ``WWW-Authenticate`` is deliberately NOT
+        # claimed here: a refusal this process cannot attribute to the grant
+        # (edge proxy, geo block) falls through to the generic non-2xx FAIL.
+        accepted = 200 <= response.status < 300 if is_notification else response.status == 200
+        if not accepted:
+            raise _McpCallError(f"provider returned HTTP {response.status}, expected 200")
+        session_id = response.headers.get("Mcp-Session-Id")
+        if is_notification:
+            return {}, session_id
+        return await _read_capped(response), session_id
+
+
+async def _connect(
+    session: aiohttp.ClientSession,
+    server: McpServerInfo,
+    *,
+    timeout_seconds: float,
+) -> dict[str, str]:
+    """Run ``initialize`` and return the headers later requests must carry."""
+    headers = {
+        **server.headers,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": _MCP_PROTOCOL_VERSION,
+    }
+    data, session_id = await _post(
+        session,
+        server.url,
+        headers,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": _MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": _CLIENT_INFO,
+            },
+        },
+        timeout_seconds=timeout_seconds,
+    )
+    _result_payload(data)
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    await _post(
+        session,
+        server.url,
+        headers,
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        timeout_seconds=timeout_seconds,
+    )
+    return headers
+
+
+async def _list_tools(
+    session: aiohttp.ClientSession,
+    url: str,
+    headers: dict[str, str],
+    *,
+    timeout_seconds: float,
+) -> list[str]:
+    data, _ = await _post(
+        session,
+        url,
+        headers,
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        timeout_seconds=timeout_seconds,
+    )
+    tools = _result_payload(data).get("tools", [])
+    if not isinstance(tools, list):
+        raise _McpCallError("tools/list did not return a list")
+    return [name for tool in tools if isinstance(tool, dict) and (name := tool.get("name", ""))]
+
+
+def _blank_result(provider: Provider, **overrides: Any) -> SmokeResult:
+    """A result with every field present, so no consumer sees a partial record."""
+    result: SmokeResult = {
+        "slug": provider["slug"],
+        "name": provider["name"],
+        "verdict": "FAIL",
+        "depth": "none",
+        "installed": False,
+        "grant_present": False,
+        "credential_presented": False,
+        "fixture_tool": provider["smoke_fixture"]["tool"],
+        "fixture_tool_advertised": False,
+        "tools_listed": 0,
+        "errors": [],
+        "duration_ms": 0,
+    }
+    result.update(overrides)  # type: ignore[typeddict-item]
+    return result
+
+
+def _redacted_detail(error: BaseException, headers: object) -> str:
+    """Redact THEN truncate, like ``_sanitize_probe_error``: truncating first
+    bisects a reflected credential, and the configured-value scrubber matches
+    whole values only -- the fragment would reach the artifact."""
+    return redact_mcp_error(str(error), headers)[:_MAX_ERROR_CHARS]
+
+
+async def _bounded_stat(fn: Any, *args: Any, timeout: float, **kwargs: Any) -> Any:
+    """Bounded blocking read on a DAEMON thread. Never ``asyncio.to_thread``: a
+    stalled default-executor worker survives ``wait_for`` and is then JOINED by
+    ``asyncio.run``'s shutdown (unbounded on 3.10/3.11), hanging the process
+    after the report is written. A daemon thread is abandonable by design."""
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[Any] = loop.create_future()
+
+    def _worker() -> None:
+        try:
+            payload: tuple[Any, Any] = (future.set_result, fn(*args, **kwargs))
+        except BaseException as error:  # noqa: BLE001 -- relayed to the awaiter
+            payload = (future.set_exception, error)
+        try:
+            loop.call_soon_threadsafe(lambda: future.done() or payload[0](payload[1]))
+        except RuntimeError:
+            pass  # loop closed; the abandoned worker's answer is moot
+
+    threading.Thread(target=_worker, daemon=True, name="l1-bounded-stat").start()
+    return await asyncio.wait_for(future, timeout)
+
+
+async def smoke_provider(
+    session: aiohttp.ClientSession,
+    provider: Provider,
+    server: McpServerInfo | None,
+    *,
+    timeout_seconds: float,
+    cache_dir: Path | None = None,
+) -> SmokeResult:
+    """The L1 verdict for one provider. Never initiates consent."""
+    started = time.monotonic()
+
+    def elapsed() -> int:
+        return round((time.monotonic() - started) * 1000)
+
+    # grant_present's contract: off-loop, bounded, a stalled mount answers as
+    # itself. Past here budget expiry only happens inside the exchange.
+    try:
+        grant = await _bounded_stat(
+            grant_present, provider["mcp_url"], cache_dir=cache_dir, timeout=timeout_seconds
+        )
+    except asyncio.TimeoutError:
+        return _blank_result(
+            provider,
+            verdict="FAIL",
+            installed=server is not None,
+            errors=["grant presence check timed out; is the OAuth cache on a stalled mount?"],
+            duration_ms=elapsed(),
+        )
+    if server is None:
+        return _blank_result(
+            provider,
+            verdict="SKIPPED",
+            grant_present=grant,
+            errors=["provider is not a configured MCP server on this host"],
+            duration_ms=elapsed(),
+        )
+    if normalized_endpoint(server.url) != normalized_endpoint(provider["mcp_url"]):
+        # tool_aliases' rule: identity is proven by endpoint, never by the key.
+        return _blank_result(
+            provider,
+            verdict="SKIPPED",
+            grant_present=grant,
+            errors=["configured server endpoint does not match the registry mcp_url"],
+            duration_ms=elapsed(),
+        )
+    if not grant:
+        return _blank_result(
+            provider,
+            verdict="SKIPPED",
+            installed=True,
+            errors=["no persisted grant on this host; L1 does not initiate consent"],
+            duration_ms=elapsed(),
+        )
+    fixture_tool = provider["smoke_fixture"]["tool"]
+    credentialed = _presents_credential(server.headers)
+    verdict: Verdict = "PASS"
+    depth: Depth = "none"
+    advertised = False
+    tools: list[str] = []
+    errors: list[str] = []
+    try:
+        headers = await _connect(session, server, timeout_seconds=timeout_seconds)
+        tools = await _list_tools(session, server.url, headers, timeout_seconds=timeout_seconds)
+        depth = "tools_list"
+        advertised = fixture_tool in tools
+        if not advertised:
+            raise _McpCallError(f"{fixture_tool} is no longer advertised by the provider")
+    except _McpChallenge as error:
+        # Grant on disk, endpoint alive and still protected -- the GRANT_HELD
+        # rung's whole point; recorded as evidence of WHICH challenge.
+        verdict, depth = "GRANT_HELD", "challenge"
+        errors.append(_redacted_detail(error, server.headers))
+    except _McpAuthError as error:
+        verdict = "NEEDS_RECONSENT"
+        errors.append(_redacted_detail(error, server.headers))
+    except (_McpCallError, aiohttp.ClientError, asyncio.TimeoutError, ValueError) as error:
+        verdict = "FAIL"
+        errors.append(_redacted_detail(error, server.headers) or type(error).__name__)
+    return _blank_result(
+        provider,
+        verdict=verdict,
+        depth=depth,
+        installed=True,
+        grant_present=True,
+        credential_presented=credentialed,
+        fixture_tool_advertised=advertised,
+        tools_listed=len(tools),
+        errors=errors,
+        duration_ms=elapsed(),
+    )
+
+
+async def smoke_all(
+    session: aiohttp.ClientSession,
+    providers: Sequence[Provider],
+    servers: dict[str, McpServerInfo],
+    *,
+    concurrency: int,
+    timeout_seconds: float,
+    cache_dir: Path | None = None,
+) -> list[SmokeResult]:
+    """Smoke every provider with a hard cap on simultaneous exchanges."""
+    semaphore = asyncio.Semaphore(concurrency)
+    total_budget = timeout_seconds * _TOTAL_BUDGET_MULTIPLIER + 1
+
+    async def limited(provider: Provider) -> SmokeResult:
+        async with semaphore:
+            started = time.monotonic()
+            try:
+                return await asyncio.wait_for(
+                    smoke_provider(
+                        session,
+                        provider,
+                        servers.get(provider["slug"]),
+                        timeout_seconds=timeout_seconds,
+                        cache_dir=cache_dir,
+                    ),
+                    timeout=total_budget,
+                )
+            except asyncio.TimeoutError:
+                return _blank_result(
+                    provider,
+                    verdict="FAIL",
+                    installed=provider["slug"] in servers,
+                    # Budget expiry only happens inside the exchange (SKIPPED
+                    # paths synchronous, stat separately bounded): grant proven
+                    # present -- the default False would falsify the field.
+                    grant_present=True,
+                    errors=["provider smoke run exceeded its total timeout"],
+                    duration_ms=round((time.monotonic() - started) * 1000),
+                )
+
+    outcomes = await asyncio.gather(
+        *(limited(provider) for provider in providers), return_exceptions=True
+    )
+    results: list[SmokeResult] = []
+    for provider, outcome in zip(providers, outcomes):
+        if isinstance(outcome, BaseException):
+            if not isinstance(outcome, Exception):
+                raise outcome  # cancellation and exits must still propagate
+            # One provider's stray defect must not erase the other rows.
+            srv = servers.get(provider["slug"])
+            detail = _redacted_detail(outcome, srv.headers if srv else {})
+            results.append(
+                _blank_result(
+                    provider,
+                    verdict="FAIL",
+                    installed=provider["slug"] in servers,
+                    errors=[detail or type(outcome).__name__],
+                )
+            )
+        else:
+            results.append(outcome)
+    return results
+
+
+def build_report(results: Sequence[SmokeResult], *, min_exercised: int = 0) -> dict[str, Any]:
+    """Aggregate verdicts into the report the scheduled lane gates on: skips and
+    challenges never fail the run, and a run exercising fewer than
+    ``min_exercised`` providers is ``vacuous`` and NOT ok."""
+
+    counts = {verdict: 0 for verdict in _VERDICTS}
+    for result in results:
+        counts[result["verdict"]] += 1
+    exercised = len(results) - counts["SKIPPED"]
+    vacuous = exercised < min_exercised
+    return {
+        "schema_version": _REPORT_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "ok": all(result["verdict"] in _HEALTHY for result in results) and not vacuous,
+        "vacuous": vacuous,
+        "min_exercised": min_exercised,
+        "exercised_count": exercised,
+        "provider_count": len(results),
+        "pass_count": counts["PASS"],
+        "grant_held_count": counts["GRANT_HELD"],
+        "needs_reconsent_count": counts["NEEDS_RECONSENT"],
+        "failed_count": counts["FAIL"],
+        "skipped_count": counts["SKIPPED"],
+        "providers": list(results),
+    }
+
+
+async def run_l1(
+    *, concurrency: int, timeout_seconds: float, min_exercised: int = 0
+) -> dict[str, Any]:
+    """Smoke every registry provider that already holds a grant on this host."""
+    providers = get_all_registry_providers()
+    # Off-loop AND bounded, like the grant stat: a stalled home must not wedge us.
+    try:
+        servers = await _bounded_stat(configured_remote_servers, timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        raise RuntimeError(
+            "server inventory read timed out; is the settings home on a stalled mount?"
+        ) from None
+    async with aiohttp.ClientSession() as session:
+        results = await smoke_all(
+            session,
+            providers,
+            servers,
+            concurrency=concurrency,
+            timeout_seconds=timeout_seconds,
+        )
+    return build_report(results, min_exercised=min_exercised)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or more")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke the Connections providers that already hold a grant on this host."
+    )
+    parser.add_argument("--report", type=Path, default=Path("connections-l1-report.json"))
+    parser.add_argument("--concurrency", type=_positive_int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument("--timeout", type=_positive_float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--min-exercised",
+        type=_non_negative_int,
+        default=0,
+        help=(
+            "Fail the run unless at least N providers were non-SKIPPED. The lane passes "
+            "1 so an unseeded box reports vacuous instead of a green proving nothing."
+        ),
+    )
+    return parser
+
+
+def _fatal_report(error: BaseException, *, min_exercised: int) -> dict[str, Any]:
+    """A report for a failure that stopped the sweep before any provider ran --
+    evidence about the HARNESS, not the providers: no per-provider verdicts."""
+    report = build_report([], min_exercised=min_exercised)
+    report["ok"] = False
+    # Redact before report/stdout/artifact; {} engages the site-wide scanners.
+    report["fatal_error"] = redact_mcp_error(f"{type(error).__name__}: {error}", {})
+    return report
+
+
+def _echo(text: str, *, end: str = "\n") -> None:
+    """Echo to stdout with NO power to fail the run. The file is the result; the
+    echo is presentation. A consumer that hangs up (``| head``) breaks the pipe
+    after the report reached disk, and letting that raise reaches :func:`main`'s
+    fallback, which overwrites real verdicts with a contentless fatal report --
+    so every echo site in this module goes through here.
+
+    ``flush=True`` is load-bearing, not tidiness: a pipe is block-buffered, so a
+    report small enough to fit the buffer never reaches the pipe during ``print``
+    and the failure lands instead on the interpreter's shutdown flush, which
+    exits 120 (measured) and fails a run whose report is already good.
+
+    A dead stream is REPLACED rather than repaired. Shutdown flushes whatever
+    ``sys.stdout`` is bound to at the time, so rebinding it is sufficient -- and
+    because that touches no descriptor, the whole class of descriptor bugs
+    (leaking the spare, aliasing ``target``, double-closing it) is
+    unrepresentable here rather than guarded case by case."""
+    try:
+        print(text, end=end, flush=True)
+    except OSError:  # broken pipe, bad fd, full sink -- stdout is gone, disk is not
+        with contextlib.suppress(OSError):
+            sys.stdout = open(os.devnull, "w")  # noqa: SIM115 -- process-lifetime sink
+
+
+def _persist_report(path: Path, report: dict[str, Any]) -> None:
+    """Write and echo the report -- INSIDE the loop on the happy path:
+    ``asyncio.run``'s shutdown can stall joining a leaked worker, so the report
+    must reach disk before that join or it exists only in memory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    path.write_text(rendered, encoding="utf-8")
+    _echo(rendered, end="")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    async def _run_and_persist() -> dict[str, Any]:
+        # Fatal path persists in-loop too -- round 2's trap, one seam over.
+        try:
+            report = await run_l1(
+                concurrency=args.concurrency,
+                timeout_seconds=args.timeout,
+                min_exercised=args.min_exercised,
+            )
+        except Exception as error:  # noqa: BLE001 -- reported, never swallowed
+            report = _fatal_report(error, min_exercised=args.min_exercised)
+        await asyncio.to_thread(_persist_report, args.report, report)
+        return report
+
+    try:
+        report = asyncio.run(_run_and_persist())
+    except Exception as error:  # noqa: BLE001 -- loop setup / persist failures
+        report = _fatal_report(error, min_exercised=args.min_exercised)
+        _persist_report(args.report, report)
+    if report.get("fatal_error"):
+        _echo(f"FATAL: L1 did not run: {report['fatal_error']}")
+    elif report["vacuous"]:
+        _echo(
+            f"VACUOUS: {report['exercised_count']} of {report['provider_count']} providers "
+            f"exercised, {report['min_exercised']} required -- one-time consent click per "
+            "provider; see docs/architecture/design-notes/connections-l1-smoke.md."
+        )
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -938,6 +938,18 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "written into the archive.",
     ),
     (
+        "Connections L1 smoke report",
+        "connections/l1_smoke.py",
+        "The authorized-grant sweep's JSON verdict report: written to disk by "
+        "`_persist_report`, echoed to stdout by `_echo`, and uploaded by the "
+        "nightly lane as a build artifact — so it reaches CI logs and every "
+        "reader of the repository, not just the operator who ran it. The "
+        "credential-bearing part is the provider's own error text, scrubbed by "
+        "`redact_mcp_error` as it enters a verdict row (both site-wide scanners "
+        "plus the configured header-value pass), at the write rather than at a "
+        "read, because the report outlives the process that made it.",
+    ),
+    (
         "Tag definitions (HTTP + auto-tag)",
         "dashboard/chat_tags.py",
         "Tag names supplied by both the POST /api/chat/tags HTTP handler and the "

--- a/test/test_connections_l1_smoke.py
+++ b/test/test_connections_l1_smoke.py
@@ -1,0 +1,860 @@
+"""Hermetic tests for the Connections L1 authorized-grant smoke harness."""
+
+import asyncio
+import builtins
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import threading
+import time
+from copy import deepcopy
+
+import pytest
+
+from kiro_crew.connections import get_provider, l1_smoke, mint
+from kiro_crew.mcp_discovery import McpServerInfo
+
+MCP_URL = "https://mcp.example.com/mcp"
+SESSION_ID = "sess-abc123"
+FIXTURE_TOOL = "list_issues"
+CREDENTIAL = "sk-live-abcdefghijkl"
+FULL_EXCHANGE = ["initialize", "notifications/initialized", "tools/list"]
+
+
+class _FakeStream:
+    """Models aiohttp's reader INCLUDING short reads: ``read(n)`` yields at most
+    ``_CHUNK`` bytes, because the real ``StreamReader.read(n)`` returns only what is
+    buffered at that instant. A fake that always filled the request would hide a
+    caller that reads once and parses a truncated body."""
+
+    _CHUNK = 7
+
+    def __init__(self, raw):
+        self._raw = raw
+
+    async def read(self, n=-1):
+        take = len(self._raw) if n < 0 else min(n, self._CHUNK)
+        chunk, self._raw = self._raw[:take], self._raw[take:]
+        return chunk
+
+
+class FakeResponse:
+    def __init__(self, status=200, payload=None, headers=None, content_type=None, body=None):
+        self.status = status
+        self.headers = headers or {}
+        self.content_type = content_type or "application/json"
+        raw = body if body is not None else ("" if payload is None else json.dumps(payload))
+        self.raw = raw.encode()
+        self.content = _FakeStream(self.raw)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class FakeSession:
+    """Serves queued responses in order and records every request made.
+
+    Headers are snapshotted at send time (the harness reuses one dict across the
+    exchange, so recording by reference would show the final state everywhere).
+    """
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        recorded = dict(kwargs)
+        recorded["headers"] = dict(kwargs.get("headers", {}))
+        self.calls.append((url, recorded))
+        if not self.responses:
+            raise AssertionError("the harness made more requests than the test queued")
+        return self.responses.pop(0)
+
+    @property
+    def methods(self):
+        return [call[1]["json"].get("method") for call in self.calls]
+
+
+@pytest.fixture(autouse=True)
+def forbid_real_http_client(monkeypatch):
+    def fail_if_constructed(*_args, **_kwargs):
+        raise AssertionError("unit tests must not construct a real HTTP client")
+
+    monkeypatch.setattr(l1_smoke.aiohttp, "ClientSession", fail_if_constructed)
+
+
+@pytest.fixture
+def granted(tmp_path):
+    """A cache dir holding the paired grant artifacts for ``MCP_URL``."""
+    key = mint.grant_key(MCP_URL)
+    (tmp_path / f"{key}.token.json").write_text("{}", encoding="utf-8")
+    (tmp_path / f"{key}.registration.json").write_text("{}", encoding="utf-8")
+    return tmp_path
+
+
+def provider(tool=FIXTURE_TOOL, args=None):
+    item = deepcopy(get_provider("linear"))
+    assert item is not None
+    item["name"] = "Example"
+    item["slug"] = "example"
+    item["mcp_url"] = MCP_URL
+    item["smoke_fixture"] = {"tool": tool, "args": {} if args is None else args}
+    return item
+
+
+def server(headers=None):
+    return McpServerInfo(name="example", url=MCP_URL, headers=headers or {})
+
+
+def credentialed_server():
+    return server(headers={"Authorization": f"Bearer {CREDENTIAL}"})
+
+
+def initialize_ok():
+    return FakeResponse(
+        200,
+        {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05"}},
+        headers={"Mcp-Session-Id": SESSION_ID},
+    )
+
+
+def tools_list_ok(tools=(FIXTURE_TOOL, "other_tool")):
+    return FakeResponse(
+        200,
+        {"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": name} for name in tools]}},
+    )
+
+
+def jsonrpc_error(message, request_id=2):
+    return FakeResponse(
+        200, {"jsonrpc": "2.0", "id": request_id, "error": {"code": -32000, "message": message}}
+    )
+
+
+def happy_path():
+    return [initialize_ok(), FakeResponse(202, None), tools_list_ok()]
+
+
+def upto_list(final):
+    """The queue for an exchange that reaches ``tools/list`` and gets ``final``."""
+    return [initialize_ok(), FakeResponse(202, None), final]
+
+
+async def run_one(session, item=None, srv=None, cache_dir=None, timeout=5.0):
+    return await l1_smoke.smoke_provider(
+        session,
+        item if item is not None else provider(),
+        srv if srv is not None else server(),
+        timeout_seconds=timeout,
+        cache_dir=cache_dir,
+    )
+
+
+# Grant presence: one implementation, and it never reads token material
+
+
+def test_grant_helpers_are_mints_and_not_a_local_copy():
+    """N7's dedupe, pinned by identity so a future copy cannot creep back in.
+
+    grant_present internally derives the cache key and resolves the cache dir,
+    so pinning the one symbol this module uses transitively pins all three;
+    test_connections_mint already pins the formula on this function.
+    """
+    assert l1_smoke.grant_present is mint.grant_present
+
+
+@pytest.fixture
+def forbid_token_reads(monkeypatch):
+    """Make ANY attempt to open a kiro-cli OAuth artifact an outright failure."""
+
+    def guard(path):
+        if str(path).endswith((".token.json", ".registration.json")):
+            raise AssertionError(f"token material must never be read: {path}")
+
+    real_open = builtins.open
+
+    def guarded_open(file, *args, **kwargs):
+        guard(file)
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", guarded_open)
+    for method in ("open", "read_text", "read_bytes"):
+        real = getattr(pathlib.Path, method)
+
+        def guarded(self, *args, _real=real, **kwargs):
+            guard(self)
+            return _real(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, method, guarded)
+
+
+def test_grant_detection_never_opens_the_paired_artifacts(granted, forbid_token_reads):
+    assert l1_smoke.grant_present(MCP_URL, cache_dir=granted) is True
+
+
+@pytest.mark.asyncio
+async def test_a_full_pass_run_never_opens_the_paired_artifacts(granted, forbid_token_reads):
+    result = await run_one(FakeSession(happy_path()), cache_dir=granted)
+    assert result["verdict"] == "PASS"
+
+
+def test_the_read_guard_is_active(granted, forbid_token_reads):
+    artifact = granted / f"{mint.grant_key(MCP_URL)}.token.json"
+    with pytest.raises(AssertionError, match="must never be read"):
+        artifact.read_text(encoding="utf-8")
+    with pytest.raises(AssertionError, match="must never be read"):
+        builtins.open(artifact)
+
+
+def test_real_http_client_guard_is_active():
+    with pytest.raises(AssertionError, match="must not construct a real HTTP client"):
+        l1_smoke.aiohttp.ClientSession()
+
+
+def test_cache_dir_defaults_to_the_kiro_cli_oauth_store(tmp_path):
+    assert mint.kiro_oauth_cache_dir(home=tmp_path) == tmp_path / ".aws" / "sso" / "cache"
+
+
+@pytest.mark.asyncio
+async def test_pass_runs_the_exchange_and_binds_every_timeout(granted):
+    session = FakeSession(happy_path())
+    result = await run_one(session, cache_dir=granted, timeout=3.5)
+    assert result["verdict"] == "PASS"
+    assert result["depth"] == "tools_list"
+    assert result["installed"] is True
+    assert result["grant_present"] is True
+    assert result["fixture_tool_advertised"] is True
+    assert result["tools_listed"] == 2
+    assert result["errors"] == []
+    assert session.methods == FULL_EXCHANGE
+    assert all(call[1]["timeout"].total == 3.5 for call in session.calls)
+    assert all(call[1]["allow_redirects"] is False for call in session.calls)
+    assert all(call[0] == MCP_URL for call in session.calls)
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_never_invokes_a_provider_tool(granted):
+    """No tools/call even fully credentialed with the tool advertised -- a call
+    from here would skip governed dispatch and its SEL record."""
+    session = FakeSession(happy_path())
+    result = await run_one(session, srv=credentialed_server(), cache_dir=granted)
+    assert result["verdict"] == "PASS"
+    assert result["fixture_tool_advertised"] is True
+    assert "tools/call" not in session.methods
+
+
+@pytest.mark.asyncio
+async def test_pass_echoes_the_session_id_on_every_later_request(granted):
+    session = FakeSession(happy_path())
+    await run_one(session, cache_dir=granted)
+    ids = [call[1]["headers"].get("Mcp-Session-Id") for call in session.calls]
+    assert ids == [None] + [SESSION_ID] * 2
+    assert session.calls[-1][1]["json"]["method"] == "tools/list"
+
+
+@pytest.mark.asyncio
+async def test_sse_framed_responses_are_parsed_by_the_shared_reader(granted):
+    sse = FakeResponse(
+        200,
+        content_type="text/event-stream",
+        body='data: {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"list_issues"}]}}\n',
+    )
+    session = FakeSession([initialize_ok(), FakeResponse(202, None), sse])
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "PASS"
+    assert result["tools_listed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_provider_body_is_refused_instead_of_buffered(granted, monkeypatch):
+    """A provider that streams instead of answering must not OOM the harness: the
+    report is the run's only record of which provider regressed, so losing the
+    process loses the run. Graded FAIL, never NEEDS_RECONSENT -- an oversized body
+    says nothing about the grant. The cap sits well above the small handshake
+    bodies so ONLY the flooded tools/list leg can trip it."""
+    monkeypatch.setattr(l1_smoke, "_MAX_RESPONSE_BYTES", 4096)
+    flood = tools_list_ok(tools=("x" * 20000,))
+    assert len(flood.raw) > 4096  # else this test would prove nothing
+    session = FakeSession([initialize_ok(), FakeResponse(202, None), flood])
+    result = await run_one(session, cache_dir=granted)
+    assert session.methods == FULL_EXCHANGE  # the handshake survived; the flood is what failed
+    assert result["verdict"] == "FAIL"
+    assert any("exceeded" in e for e in result["errors"])
+    # An unread remainder is the proof the reader stopped at the cap.
+    assert await flood.content.read() != b""
+
+
+@pytest.mark.asyncio
+async def test_a_body_exactly_at_the_cap_still_parses(granted, monkeypatch):
+    """Guards the off-by-one: the reader takes cap+1 bytes to DETECT overflow, so a
+    body sitting exactly on the cap must still be a healthy PASS."""
+    listed = tools_list_ok(tools=(FIXTURE_TOOL,))
+    handshake = initialize_ok()
+    # Pins the cap to this leg; without it a smaller cap would trip the handshake.
+    assert len(handshake.raw) <= len(listed.raw)
+    monkeypatch.setattr(l1_smoke, "_MAX_RESPONSE_BYTES", len(listed.raw))
+    session = FakeSession([handshake, FakeResponse(202, None), listed])
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "PASS"
+    assert result["tools_listed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_multi_feed_body_is_accumulated_not_truncated(granted):
+    """aiohttp's ``read(n)`` returns only the bytes buffered at that instant, so a
+    body split across feeds (chunked encoding, SSE, a large tool list) must be
+    accumulated. Reading once parses a truncated prefix and grades a healthy grant
+    FAIL -- a false red on the scheduled lane. ``_FakeStream`` serves every body in
+    7-byte reads, so the whole suite covers this; this test names the invariant."""
+    session = FakeSession([initialize_ok(), FakeResponse(202, None), tools_list_ok()])
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "PASS"
+    assert result["tools_listed"] == 2
+
+
+# GRANT_HELD: the expected steady state under runtime token custody
+
+
+@pytest.mark.asyncio
+async def test_a_tokenless_401_is_grant_held_not_needs_reconsent(granted):
+    """The regression that matters most: Kiro Crew holds no bearer, so a healthy
+    authorized provider answers with 401 -- grading that NEEDS_RECONSENT would
+    report every working provider as broken, every run."""
+    session = FakeSession([FakeResponse(401, None)])
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "GRANT_HELD"
+    assert result["depth"] == "challenge"
+    assert result["grant_present"] is True
+    assert result["credential_presented"] is False
+    assert result["errors"] == ["provider challenged with HTTP 401"]
+
+
+@pytest.mark.asyncio
+async def test_a_tokenless_403_with_a_challenge_is_grant_held(granted):
+    session = FakeSession(
+        [FakeResponse(403, None, headers={"WWW-Authenticate": 'Bearer resource_metadata="x"'})]
+    )
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "GRANT_HELD"
+
+
+@pytest.mark.asyncio
+async def test_a_tokenless_403_without_a_challenge_is_fail(granted):
+    """Not attributable to the grant (an edge proxy or geo block reads exactly
+    like this), so it must not send a human to re-approve."""
+    session = FakeSession([FakeResponse(403, None)])
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert result["errors"] == ["provider returned HTTP 403, expected 200"]
+
+
+@pytest.mark.asyncio
+async def test_a_grant_held_run_stops_before_listing_tools(granted):
+    session = FakeSession([FakeResponse(401, None)])
+    result = await run_one(session, cache_dir=granted)
+    assert session.methods == ["initialize"]
+    assert result["tools_listed"] == 0
+    assert result["fixture_tool_advertised"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_refused_presented_credential_is_needs_reconsent(granted):
+    session = FakeSession([FakeResponse(401, None)])
+    result = await run_one(session, srv=credentialed_server(), cache_dir=granted)
+    assert result["verdict"] == "NEEDS_RECONSENT"
+    assert result["credential_presented"] is True
+    assert result["errors"] == ["presented credential refused with HTTP 401"]
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_invalid_token_error_is_needs_reconsent(granted):
+    session = FakeSession(upto_list(jsonrpc_error("invalid_token")))
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "NEEDS_RECONSENT"
+    assert result["errors"] == ["invalid_token"]
+
+
+@pytest.mark.asyncio
+async def test_a_mid_exchange_challenge_is_still_grant_held(granted):
+    """A server that admits an unauthenticated ``initialize`` and then challenges
+    at ``tools/list``: still the custody signal -- alive, and demanding a bearer
+    for the actual work. The tool list never arrived, so nothing claims it did."""
+    challenge = FakeResponse(403, None, headers={"WWW-Authenticate": "Bearer"})
+    result = await run_one(FakeSession(upto_list(challenge)), cache_dir=granted)
+    assert result["verdict"] == "GRANT_HELD"
+    assert result["fixture_tool_advertised"] is False
+    assert result["tools_listed"] == 0
+    assert result["depth"] == "challenge"
+
+
+@pytest.mark.asyncio
+async def test_a_missing_fixture_tool_is_fail_and_skips_the_call(granted):
+    session = FakeSession([initialize_ok(), FakeResponse(202, None), tools_list_ok(("other",))])
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert result["fixture_tool_advertised"] is False
+    assert session.methods == ["initialize", "notifications/initialized", "tools/list"]
+    assert f"{FIXTURE_TOOL} is no longer advertised" in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_a_server_error_is_fail_not_a_consent_problem(granted):
+    result = await run_one(FakeSession([FakeResponse(503, None)]), cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert result["errors"] == ["provider returned HTTP 503, expected 200"]
+
+
+@pytest.mark.asyncio
+async def test_a_redirected_endpoint_is_fail(granted):
+    """A moved endpoint must not be followed: it would smoke a different server."""
+    result = await run_one(FakeSession([FakeResponse(307, None)]), cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert "HTTP 307" in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_a_transport_failure_is_fail(granted):
+    class ExplodingSession(FakeSession):
+        def post(self, url, **kwargs):
+            raise asyncio.TimeoutError()
+
+    result = await run_one(ExplodingSession([]), cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert result["errors"] == ["TimeoutError"]
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_tools_list_is_fail(granted):
+    session = FakeSession(
+        [
+            initialize_ok(),
+            FakeResponse(202, None),
+            FakeResponse(200, {"jsonrpc": "2.0", "id": 2, "result": {"tools": "nope"}}),
+        ]
+    )
+    result = await run_one(session, cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert result["errors"] == ["tools/list did not return a list"]
+
+
+@pytest.mark.asyncio
+async def test_a_configured_credential_is_redacted_out_of_every_error(granted):
+    session = FakeSession(upto_list(jsonrpc_error(f"rejected {CREDENTIAL}")))
+    result = await run_one(session, srv=credentialed_server(), cache_dir=granted)
+    assert result["verdict"] == "FAIL"
+    assert CREDENTIAL not in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_a_credential_straddling_the_truncation_boundary_is_still_redacted(granted):
+    """Redact THEN truncate: bisecting first blinds the configured-value scrubber."""
+
+    # A configured value with no generic SHAPE, placed so truncate-first bisects it.
+    secret = "opaque-configured-value-0123456789"
+    half = len(secret) // 2
+    padding = "x" * (l1_smoke._MAX_ERROR_CHARS - len("rejected ") - half)
+    session = FakeSession(upto_list(jsonrpc_error(f"rejected {padding}{secret}")))
+    result = await run_one(
+        session,
+        srv=server(headers={"Authorization": f"Bearer {secret}"}),
+        cache_dir=granted,
+    )
+    assert result["verdict"] == "FAIL"
+    assert secret not in result["errors"][0]
+    assert secret[:half] not in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_the_grant_stat_runs_off_the_loop_and_a_stall_answers_in_bound(granted, monkeypatch):
+    """grant_present's contract: worker thread; a stall answers within its bound."""
+    seen = []
+
+    def stalls(mcp_url, *, cache_dir=None):
+        seen.append(threading.current_thread().name)
+        time.sleep(0.3)
+        return True
+
+    monkeypatch.setattr(l1_smoke, "grant_present", stalls)
+    result = await l1_smoke.smoke_provider(
+        FakeSession([]), provider(), server(), timeout_seconds=0.05, cache_dir=granted
+    )
+    assert seen and all(name != "MainThread" for name in seen)
+    assert result["verdict"] == "FAIL"
+    assert result["grant_present"] is False
+    assert "stalled mount" in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_no_grant_is_skipped_without_touching_the_network(tmp_path):
+    session = FakeSession([])
+    result = await run_one(session, cache_dir=tmp_path)
+    assert result["verdict"] == "SKIPPED"
+    assert result["installed"] is True
+    assert result["grant_present"] is False
+    assert result["errors"] == ["no persisted grant on this host; L1 does not initiate consent"]
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_provider_is_skipped(granted):
+    session = FakeSession([])
+    result = await l1_smoke.smoke_provider(
+        session, provider(), None, timeout_seconds=1, cache_dir=granted
+    )
+    assert result["verdict"] == "SKIPPED"
+    assert result["installed"] is False
+    assert result["grant_present"] is True
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_every_result_carries_the_full_record(granted):
+    """No consumer of the report ever sees a partial row, whatever the verdict."""
+    expected = set(l1_smoke.SmokeResult.__annotations__)
+    skipped = await run_one(FakeSession([]), cache_dir=pathlib.Path("/nonexistent"))
+    passed = await run_one(FakeSession(happy_path()), cache_dir=granted)
+    assert set(skipped) == expected
+    assert set(passed) == expected
+
+
+# Aggregation
+
+
+def result(slug, verdict):
+    return {
+        "slug": slug,
+        "name": slug.title(),
+        "verdict": verdict,
+        "depth": "tools_list" if verdict == "PASS" else "none",
+        "installed": True,
+        "grant_present": verdict != "SKIPPED",
+        "credential_presented": False,
+        "fixture_tool": FIXTURE_TOOL,
+        "fixture_tool_advertised": verdict == "PASS",
+        "tools_listed": 1 if verdict == "PASS" else 0,
+        "errors": [],
+        "duration_ms": 1,
+    }
+
+
+@pytest.mark.parametrize("verdict", ["PASS", "GRANT_HELD", "SKIPPED"])
+def test_healthy_verdicts_keep_the_run_green(verdict):
+    report = l1_smoke.build_report([result("a", "PASS"), result("b", verdict)])
+    assert report["ok"] is True
+    assert report["provider_count"] == 2
+
+
+@pytest.mark.parametrize("verdict", ["NEEDS_RECONSENT", "FAIL"])
+def test_reconsent_and_failure_both_fail_the_run(verdict):
+    assert l1_smoke.build_report([result("a", "PASS"), result("b", verdict)])["ok"] is False
+
+
+def test_the_report_counts_every_verdict_separately():
+    report = l1_smoke.build_report(
+        [result(v.lower(), v) for v in l1_smoke._VERDICTS]  # noqa: SLF001 -- test pin
+    )
+    assert report["pass_count"] == 1
+    assert report["grant_held_count"] == 1
+    assert report["needs_reconsent_count"] == 1
+    assert report["failed_count"] == 1
+    assert report["skipped_count"] == 1
+    assert report["exercised_count"] == 4
+    assert report["schema_version"] == 1
+
+
+def test_an_all_skipped_run_is_ok_when_nothing_was_required():
+    report = l1_smoke.build_report([result("a", "SKIPPED")])
+    assert report["ok"] is True
+    assert report["vacuous"] is False
+
+
+def test_an_all_skipped_run_is_vacuous_when_a_minimum_was_required():
+    """The green-that-proves-nothing guard: an unseeded box must not report ok."""
+    report = l1_smoke.build_report([result("a", "SKIPPED")], min_exercised=1)
+    assert report["vacuous"] is True
+    assert report["ok"] is False
+    assert report["exercised_count"] == 0
+    assert report["min_exercised"] == 1
+
+
+def test_a_challenge_counts_as_exercised_against_the_minimum():
+    """GRANT_HELD is real evidence, so it satisfies the minimum on its own."""
+    report = l1_smoke.build_report([result("a", "GRANT_HELD")], min_exercised=1)
+    assert report["vacuous"] is False
+    assert report["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_smoke_all_caps_provider_concurrency(monkeypatch):
+    active = 0
+    peak = 0
+
+    async def fake_smoke(_session, item, _server, *, timeout_seconds, cache_dir=None):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return result(item["slug"], "PASS")
+
+    monkeypatch.setattr(l1_smoke, "smoke_provider", fake_smoke)
+    results = await l1_smoke.smoke_all(
+        object(), [provider() for _ in range(6)], {}, concurrency=2, timeout_seconds=1
+    )
+    assert len(results) == 6
+    assert peak == 2
+
+
+@pytest.mark.asyncio
+async def test_a_provider_that_outlasts_its_total_budget_is_fail(monkeypatch):
+    async def never_returns(*_args, **_kwargs):
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(l1_smoke, "smoke_provider", never_returns)
+    results = await l1_smoke.smoke_all(
+        object(), [provider()], {}, concurrency=1, timeout_seconds=0.01
+    )
+    assert results[0]["verdict"] == "FAIL"
+    # The budget can only expire inside the exchange, which the grant gates.
+    assert results[0]["grant_present"] is True
+    assert results[0]["errors"] == ["provider smoke run exceeded its total timeout"]
+
+
+@pytest.mark.asyncio
+async def test_one_providers_stray_defect_never_erases_the_other_rows(monkeypatch):
+    """WHICH provider regressed is the report's whole point."""
+
+    async def uneven(_session, item, _server, *, timeout_seconds, cache_dir=None):
+        if item["slug"] == "a":
+            raise TypeError("headers must be a mapping")
+        return result(item["slug"], "PASS")
+
+    monkeypatch.setattr(l1_smoke, "smoke_provider", uneven)
+    first, second = provider(), provider()
+    first["slug"], second["slug"] = "a", "b"
+    results = await l1_smoke.smoke_all(
+        object(), [first, second], {}, concurrency=2, timeout_seconds=1
+    )
+    assert [row["verdict"] for row in results] == ["FAIL", "PASS"]
+    assert results[0]["errors"] == ["headers must be a mapping"]
+
+
+@pytest.mark.asyncio
+async def test_an_entry_under_a_real_slug_but_wrong_endpoint_is_never_smoked(granted):
+    """tool_aliases' rule: identity is proven by endpoint, not the key."""
+    imposter = McpServerInfo(name="example", url="https://elsewhere.example.net/mcp")
+    session = FakeSession([])
+    result = await run_one(session, srv=imposter, cache_dir=granted)
+    assert result["verdict"] == "SKIPPED"
+    assert session.calls == []
+    assert "does not match the registry" in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_inventory_read_fails_within_the_bound(monkeypatch):
+    monkeypatch.setattr(l1_smoke, "configured_remote_servers", lambda: time.sleep(0.3))
+    with pytest.raises(RuntimeError, match="inventory read timed out"):
+        await l1_smoke.run_l1(concurrency=1, timeout_seconds=0.05)
+
+
+def test_a_stalled_stat_never_prevents_process_exit(tmp_path, monkeypatch):
+    """Abandoned daemon worker: shutdown joins nothing, main returns, report on disk."""
+    stall = threading.Event()
+    report_path = tmp_path / "r.json"
+
+    async def leaky_run_l1(**_kwargs):
+        try:
+            await l1_smoke._bounded_stat(stall.wait, timeout=0.05)
+        except asyncio.TimeoutError:
+            pass
+        return l1_smoke.build_report([result("a", "PASS")])
+
+    monkeypatch.setattr(l1_smoke, "run_l1", leaky_run_l1)
+    worker = threading.Thread(
+        target=l1_smoke.main, args=(["--report", str(report_path)],), daemon=True
+    )
+    worker.start()
+    worker.join(timeout=10)
+    try:
+        assert not worker.is_alive()
+        assert report_path.exists()
+    finally:
+        stall.set()
+
+
+def test_the_report_is_written_before_the_loop_joins_leaked_workers(tmp_path, monkeypatch):
+    """A stat thread stalled past its bound must not hold the report hostage."""
+    release = threading.Event()
+    report_path = tmp_path / "r.json"
+
+    async def leaky_run_l1(**_kwargs):
+        asyncio.get_running_loop().run_in_executor(None, release.wait)  # leaked worker
+        return l1_smoke.build_report([result("a", "PASS")])
+
+    monkeypatch.setattr(l1_smoke, "run_l1", leaky_run_l1)
+    worker = threading.Thread(
+        target=l1_smoke.main, args=(["--report", str(report_path)],), daemon=True
+    )
+    worker.start()
+    try:
+        deadline = time.monotonic() + 5
+        while not report_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        # main is still blocked joining the worker, yet the report is on disk.
+        assert worker.is_alive() and report_path.exists()
+    finally:
+        release.set()
+        worker.join(timeout=10)
+
+
+def test_only_remote_servers_are_considered_installed(monkeypatch):
+    monkeypatch.setattr(
+        l1_smoke,
+        "list_servers",
+        lambda: [
+            McpServerInfo(name="example", url=MCP_URL),
+            McpServerInfo(name="local-stdio", command="npx"),
+            McpServerInfo(name="switched-off", url=MCP_URL, disabled=True),
+        ],
+    )
+    assert list(l1_smoke.configured_remote_servers()) == ["example"]
+
+
+def stub_run(monkeypatch, report):
+    async def fake_run_l1(**_kwargs):
+        return report
+
+    monkeypatch.setattr(l1_smoke, "run_l1", fake_run_l1)
+
+
+def test_main_writes_the_machine_report_and_returns_nonzero(tmp_path, monkeypatch):
+    report = l1_smoke.build_report([result("example", "FAIL")])
+    stub_run(monkeypatch, report)
+    report_path = tmp_path / "report.json"
+    assert l1_smoke.main(["--report", str(report_path)]) == 1
+    assert json.loads(report_path.read_text(encoding="utf-8")) == report
+
+
+def test_main_returns_zero_when_every_grant_is_still_healthy(tmp_path, monkeypatch):
+    stub_run(monkeypatch, l1_smoke.build_report([result("a", "GRANT_HELD"), result("b", "PASS")]))
+    assert l1_smoke.main(["--report", str(tmp_path / "report.json")]) == 0
+
+
+def test_main_reports_a_vacuous_run_and_names_the_consent_step(tmp_path, monkeypatch, capsys):
+    stub_run(monkeypatch, l1_smoke.build_report([result("a", "SKIPPED")], min_exercised=1))
+    assert l1_smoke.main(["--report", str(tmp_path / "report.json")]) == 1
+    assert "VACUOUS" in capsys.readouterr().out
+
+
+def test_main_passes_the_minimum_through_to_the_sweep(tmp_path, monkeypatch):
+    seen = {}
+
+    async def fake_run_l1(**kwargs):
+        seen.update(kwargs)
+        return l1_smoke.build_report([])
+
+    monkeypatch.setattr(l1_smoke, "run_l1", fake_run_l1)
+    l1_smoke.main(["--report", str(tmp_path / "r.json"), "--min-exercised", "2"])
+    assert seen["min_exercised"] == 2
+
+
+def test_main_reports_a_fatal_error_instead_of_raising(tmp_path, monkeypatch):
+    async def exploding_run_l1(**_kwargs):
+        raise RuntimeError("registry unreadable")
+
+    monkeypatch.setattr(l1_smoke, "run_l1", exploding_run_l1)
+    report_path = tmp_path / "report.json"
+    assert l1_smoke.main(["--report", str(report_path)]) == 1
+    written = json.loads(report_path.read_text(encoding="utf-8"))
+    assert written["ok"] is False
+    assert written["fatal_error"] == "RuntimeError: registry unreadable"
+    assert written["providers"] == []
+
+
+class _HungUpPipe(io.StringIO):
+    """A consumer that has gone away: every write raises, exactly as writing to a
+    closed pipe does once ``| head`` exits."""
+
+    def write(self, _text):
+        raise BrokenPipeError(32, "Broken pipe")
+
+
+def test_a_hung_up_stdout_never_destroys_a_persisted_report(tmp_path, monkeypatch):
+    """The echo is presentation, the file is the result. A broken pipe must not
+    reach ``main``'s fallback, which would overwrite real verdicts with a
+    contentless fatal report and re-fail on the same dead stream."""
+    report = l1_smoke.build_report([result("a", "GRANT_HELD"), result("b", "PASS")])
+    stub_run(monkeypatch, report)
+    report_path = tmp_path / "report.json"
+    monkeypatch.setattr(sys, "stdout", _HungUpPipe())
+    assert l1_smoke.main(["--report", str(report_path)]) == 0
+    assert json.loads(report_path.read_text(encoding="utf-8")) == report
+
+
+def test_a_hung_up_stdout_still_grades_a_vacuous_run_honestly(tmp_path, monkeypatch):
+    """The FATAL/VACUOUS tail lines share the echo seam -- a dead pipe there must
+    not raise past a report that is already on disk and correctly graded."""
+    report = l1_smoke.build_report([result("a", "SKIPPED")], min_exercised=1)
+    stub_run(monkeypatch, report)
+    report_path = tmp_path / "report.json"
+    monkeypatch.setattr(sys, "stdout", _HungUpPipe())
+    assert l1_smoke.main(["--report", str(report_path)]) == 1
+    assert json.loads(report_path.read_text(encoding="utf-8"))["vacuous"] is True
+
+
+def test_a_small_report_on_a_hung_up_pipe_still_exits_clean():
+    """The BUFFERED case, which needs a real pipe rather than a fake stdout.
+
+    A report small enough to fit the 8 KB block buffer never reaches the pipe
+    during ``print``, so an echo guarded only by ``except OSError`` sees no error
+    and the failure lands on the interpreter's shutdown flush instead -- which
+    exits 120 and fails a run whose report is already correct on disk. Measured
+    at 120 before the in-scope flush; this pins it at 0.
+    """
+    program = (
+        "import time\n"
+        "from kiro_crew.connections.l1_smoke import _echo\n"
+        "time.sleep(0.5)\n"  # let the parent hang up before anything is written
+        '_echo(\'{"ok": true, "providers": []}\')\n'
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", program],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    proc.stdout.close()  # the consumer goes away, exactly as `| head` does
+    try:
+        assert proc.wait(timeout=60) == 0
+    finally:
+        # A hang is the very failure this guards, so never leave the child alive.
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+
+def test_a_dead_stdout_is_replaced_not_repaired(monkeypatch):
+    """The seam swaps the stream instead of touching its descriptor, so a stdout
+    with no usable ``fileno`` needs no special case and a second echo cannot
+    re-fail on the corpse."""
+    dead = _HungUpPipe()
+    monkeypatch.setattr(sys, "stdout", dead)
+    l1_smoke._echo("first")
+    assert sys.stdout is not dead, "the dead stream is still bound"
+    l1_smoke._echo("second")  # must not raise on the replacement
+    sys.stdout.close()
+
+
+@pytest.mark.parametrize("flag", ["--concurrency", "--timeout"])
+def test_nonpositive_tuning_is_rejected(flag):
+    with pytest.raises(SystemExit):
+        l1_smoke.main([flag, "0"])
+
+
+def test_a_negative_minimum_is_rejected():
+    with pytest.raises(SystemExit):
+        l1_smoke.main(["--min-exercised", "-1"])

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -704,6 +704,11 @@ class TestRedactionSinkRegistry:
             "redact_and_truncate",
             "redact_via_context",
             "display_safe",
+            # redact_mcp_error runs redact_exfiltration_urls THEN redact_credentials
+            # (mcp_discovery.py) and then scrubs the exact configured header values
+            # the generic scanners cannot know about — strictly more than either
+            # scanner alone, so a sink using it is fully covered.
+            "redact_mcp_error",
         )
         for label, module, detail in security_posture._REDACTION_SINKS:
             text = (pkg / module).read_text(encoding="utf-8")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -867,6 +867,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # classification as the other ``asyncio.run`` sites in this list.
         "connections/l0_probe.py::_run_record",
         "connections/l0_probe.py::main",
+        # Same classification as l0_probe: a CLI entry point driving an
+        # in-process aiohttp sweep with asyncio.run.
+        "connections/l1_smoke.py::main",
         "cloud/source.py::_git_tracked_files",
         "cloud/source.py::_tracked_tree_is_dirty",
         "cloud/source.py::_use_git_archive",


### PR DESCRIPTION
# Connections N7: L1 authorized-grant smoke harness and opt-in lane

The middle rung of the Connections launch gate. L0 (`connections-l0.yml`, already merged) probes each provider's public OAuth metadata with no account; L2 is the manual UI walk-through at the flag-flip gate. L1 sits between: on a box where a human consented once per provider, a scheduled sweep checks that the grant still works against the live endpoint -- automated from then on.

## The sweep never calls a provider tool

It stops at `tools/list`. A `tools/call` issued from here would reach the provider **outside the governed dispatch path**, so a tool an enterprise policy denies would be invoked anyway and no SEL event would record it -- an unaudited side channel is a worse outcome than a narrower verdict. So the registry `smoke_fixture` is used for its **name only**: `tools/list` already answers whether the pinned tool is still advertised, which is the regression this rung can honestly detect. Exercising the tool belongs with the ACP-side observation slice, where kiro-cli's own governed, audited dispatch owns the call.

## What green actually proves

Kiro Crew holds no token -- kiro-cli owns the OAuth chain and injects the bearer inside its own process. So for a provider in runtime custody, a healthy live endpoint answers this harness with an OAuth challenge. The harness grades that `GRANT_HELD` (grant on disk AND endpoint reachable and still challenging correctly), not `NEEDS_RECONSENT`: the earlier draft graded every tokenless 401 as needs-reconsent, which is exactly what a healthy authorized provider returns, so its PASS was unreachable and the lane would have sat permanently red. `NEEDS_RECONSENT` is narrowed to rejections the process can attribute; an unattributable tokenless 403 grades `FAIL` rather than sending a human to re-approve a grant an edge proxy blocked. An all-skipped sweep reports `vacuous` and exits nonzero instead of a green that proves nothing. `PASS` means reachable, authenticated, and the pinned tool still advertised. Full verdict table and runbook: `docs/architecture/design-notes/connections-l1-smoke.md`.

## What's in the diff

- `src/kiro_crew/connections/l1_smoke.py` -- the harness. Reuses `mcp_discovery`'s reviewed transport (JSON/SSE framing, the challenge classifier, `redact_mcp_error`) and `mint`'s grant helpers (paired-artifact stats, presence only -- no token byte can enter the process; the dedupe is pinned by identity test). Per provider: `initialize` (echoing `Mcp-Session-Id`), `notifications/initialized`, then `tools/list`.
- `.github/workflows/connections-l1.yml` -- scheduled, opt-in lane. Inert until the `CONNECTIONS_L1_RUNNER` repository variable names a self-hosted runner on the box holding the grants; nothing here initiates consent. Pinned action SHAs, `contents: read`, no secrets; the report uploads as an artifact even on failure. The run step resolves the interpreter that owns the installed module from the `kirocrew` entry point's shebang.
- Design note with the verdict table, per-verdict runbook, the governance boundary above, and the known gap (proving a tool works needs the runtime to make the call -- both because it holds the bearer and because it owns dispatch).
- `security_posture.py` / `test_spawn_audit.py` classification entries for the new module.

## Hardening from pre-push review (5 dual-lane rounds)

- **The sweep never invokes a provider tool** (the server GPT round's blocking finding, accepted in full): `_call_fixture` deleted, the `tool_call` depth literal removed, the fixture checked for advertisement only. A test pins the boundary at the path that used to invoke it -- fully credentialed with the tool advertised, and still no `tools/call`.
- Redact-THEN-truncate on every provider-controlled error string (truncating first bisects a reflected credential past the whole-value scrubber); mutation-verified. The fatal path redacts too.
- Disabled MCP entries are excluded -- the consent gate `probe_server` enforces is restated, not bypassed; a switched-off provider grades `SKIPPED`, untouched.
- Endpoint identity gates every exchange: a configured entry whose URL differs from the registry `mcp_url` (a hand-added entry under a real slug) is skipped, never smoked.
- The grant stat and the server-inventory read run off the event loop and bounded, and the report persists inside the loop before `asyncio.run`'s shutdown can join a stalled worker -- an honest FAIL row always reaches disk and the artifact.
- One provider's stray defect folds into its own redacted FAIL row instead of erasing the night's report; cancellation still propagates.
- The total-timeout row carries `grant_present: true`, provable because budget expiry can only occur inside the exchange.

## Tests

52 hermetic tests, no real HTTP client (constructing one fails the test), no token file ever opened (a fixture makes any open an outright failure). Coverage includes the full exchange with per-request timeout binding, every verdict's trigger, SSE framing, session-id echo, redaction including the straddling-boundary case, the never-invoke-a-tool boundary, concurrency cap, total-budget row honesty, stalled-mount bounds, report persistence ordering under a leaked worker, disabled-entry and wrong-endpoint exclusion, vacuous aggregation, and CLI exit codes.

<!-- no-visual-delta -->
**Why no screenshot:** backend CLI harness plus a CI workflow and a design note -- no frontend path is touched and nothing renders in the browser.

Diff is 1,489 additions, single commit on current main. Zero file overlap with the merged Connections status/cancel PR except one row in the design-notes index table.
