### PR TITLE
fix(packaging): route every editable-reinstall site through the dep-only sync

### DIFF
--- a/src/kiro_crew/_bootstrap.py
+++ b/src/kiro_crew/_bootstrap.py
@@ -10,18 +10,26 @@ repair itself. Release installs are unaffected (pip resolves
 
 This module is the console-script entry point
 (``kirocrew = kiro_crew._bootstrap:main``). It imports the real CLI and, on
-``ModuleNotFoundError`` from a source checkout, runs ONE
-``pip install -e <repo>`` and retries the import in-process. A failed import
+``ModuleNotFoundError`` from a source checkout, installs the checkout's
+declared dependencies once and retries the import in-process. A failed import
 is side-effect-free (Python evicts the failing module from ``sys.modules``),
 so the retry needs no re-exec — which also sidesteps the POSIX/Windows
-``execv`` divergence. On Windows the heal itself is skipped — a running
-console launcher cannot be replaced — and the one-line manual fix is printed
-instead, as it is outside a source checkout.
+``execv`` divergence. HOW the install runs is
+:func:`kiro_crew.dep_sync.sync_or_reinstall`'s decision: an editable
+reinstall where pip can replace the console script, and a dependency-only
+install where it cannot — which on Windows is always, since this process was
+launched through the very ``kirocrew.exe`` a reinstall would have to rewrite.
+That is why the heal now runs there instead of printing a manual one-liner: a
+dependency install never touches that wrapper, and a missing dependency is
+precisely what brought us here.
 
 Everything imported here MUST be stdlib: this module runs BEFORE the
-package's dependencies are known to exist. Output MUST stay ASCII-only —
-it prints before ``platform_compat.ensure_utf8_console()`` has run, so
-non-ASCII would UnicodeEncodeError on Windows cp1252 pipes.
+package's dependencies are known to exist. ``kiro_crew.dep_sync`` is the one
+package import it makes, and counts as stdlib for this purpose because it is
+required to stay stdlib-only — it imports nothing else, so it cannot raise the
+very error being healed, and a test asserts that. Output MUST stay
+ASCII-only — it prints before ``platform_compat.ensure_utf8_console()`` has
+run, so non-ASCII would UnicodeEncodeError on Windows cp1252 pipes.
 """
 
 from __future__ import annotations
@@ -31,6 +39,12 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Callable
+
+# Module scope, not function-local: this is the one package import this file can
+# safely make at import time, because dep_sync imports the standard library only
+# (asserted by a test) and so cannot raise the ModuleNotFoundError this file
+# exists to heal. `kiro_crew.__init__` itself imports nothing but asyncio.
+from kiro_crew import dep_sync
 
 _PIP_TIMEOUT_SECS = 300
 
@@ -56,35 +70,40 @@ def _source_checkout_root() -> Path | None:
 
 
 def _self_heal(missing: str) -> bool:
-    """Run ONE ``pip install -e <repo>``; ``True`` when it succeeded.
+    """Bring this venv up to the checkout's declared dependencies. ``True`` on success.
 
-    The argv is fixed and the repo path is derived from this module's own
-    ``__file__`` — never user or agent input. pip's own stderr flows to the
-    console so failures stay diagnosable.
+    The repo path is derived from this module's own ``__file__`` -- never user or
+    agent input -- and the argv is built by :mod:`kiro_crew.dep_sync`, which picks
+    the editable reinstall where it can run and a dependency-only install where it
+    cannot. Windows is the case where it cannot: pip cannot replace the running
+    ``kirocrew.exe`` this very process was launched through, and a reinstall that
+    dies on it has already deleted the editable ``.pth``. Installing only the
+    declared requirements never touches that wrapper, which is why the heal can run
+    there at all -- it is exactly the missing dependency that brought us here.
     """
-    if sys.platform == "win32":
-        # Windows locks a running console launcher, so pip cannot replace
-        # kirocrew.exe from inside a process started by it and the reinstall
-        # fails partway. The manual one-liner works there: the user runs it
-        # from a shell where kirocrew is not running.
-        return False
     root = _source_checkout_root()
     if root is None:
         return False
     print(
         f"kirocrew: missing dependency {missing!r} - your checkout added "
-        "dependencies since the last install. Running one-time "
-        "`pip install -e .` to catch up...",
+        "dependencies since the last install. Installing the declared "
+        "requirements to catch up...",
         file=sys.stderr,
     )
+
+    def _emit(message: str, error: bool) -> None:
+        # This module's output must stay ASCII (see the module docstring): it
+        # prints before ensure_utf8_console(), and these messages carry pip's
+        # output and filesystem paths, neither of which is ASCII by nature.
+        print(message.encode("ascii", "replace").decode("ascii"), file=sys.stderr)
+
     try:
-        proc = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-e", str(root), "--quiet"],
-            timeout=_PIP_TIMEOUT_SECS,
+        rc = dep_sync.sync_or_reinstall(
+            root, Path(sys.executable), _emit, timeout=_PIP_TIMEOUT_SECS
         )
     except (OSError, subprocess.SubprocessError):
         return False
-    return proc.returncode == 0
+    return rc == 0
 
 
 def main() -> None:

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -51,8 +51,8 @@ from typing import Any, Callable
 
 from aiohttp import web
 
-from kiro_crew import frontend, hooks, platform_compat
-from kiro_crew.apps.builtins.dev_fleet import dep_sync, gateway_service
+from kiro_crew import dep_sync, frontend, hooks, platform_compat
+from kiro_crew.apps.builtins.dev_fleet import gateway_service
 from kiro_crew.apps.proxy_auth import raw_request_target
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
@@ -3491,49 +3491,6 @@ def _venv_python(repo: str) -> Path | None:
     return None
 
 
-def _write_locked_console_scripts(venv_python: Path) -> list[str]:
-    """The venv's ``kirocrew`` console scripts that cannot currently be rewritten.
-
-    Windows holds a mandatory lock on a running executable's image, so when the
-    gateway is served BY the very venv pip is about to reinstall into — the
-    ordinary single-checkout setup — pip cannot replace
-    ``Scripts\\kirocrew.exe``, and the reinstall can never succeed.
-
-    That matters well beyond one failed step. pip's uninstall is not atomic: by
-    the time it reaches the locked script it has already renamed the dist-info
-    aside and deleted the editable ``.pth`` that puts ``src`` on ``sys.path``,
-    and it rolls back neither. The venv is left unable to import the package at
-    all, which also kills the console script the gateway is restarted through.
-    The running process survives on already-imported modules, so the damage
-    stays invisible until the next restart fails.
-
-    Probing with an ``r+b`` open is non-destructive and discriminates correctly:
-    a running executable refuses it while every other script in the same
-    directory opens fine. It does not model every way a delete can fail — an
-    opener that permits writes but denies deletes would pass this probe — so a
-    clean result means "no known blocker", not a guarantee. A miss simply leaves
-    the previous behaviour, which is why this is worth doing even though it
-    cannot be exhaustive.
-
-    POSIX returns nothing: an executing binary can be unlinked there, which is
-    why pip has always been able to replace it.
-    """
-    if not platform_compat.IS_WINDOWS:
-        return []
-    locked: list[str] = []
-    for exe in sorted(Path(venv_python).parent.glob("kirocrew*.exe")):
-        try:
-            with exe.open("r+b"):
-                pass
-        except PermissionError:
-            locked.append(str(exe))
-        except OSError:
-            # Unreadable for some other reason. Let pip be the judge rather than
-            # skipping a step that might well have succeeded.
-            continue
-    return locked
-
-
 async def _sync_start_locked() -> dict:
     """Start the sync run. Caller holds _SYNC_LOCK."""
     global _SYNC_RID  # noqa: F824 (assigned below after await)
@@ -3569,15 +3526,17 @@ async def _sync_start_locked() -> dict:
     # Both binary lookups stat the filesystem (`_trusted_bin` walks the trusted
     # dirs; `_toolchain_bin` adds a `shutil.which` over the node bin dirs, which
     # may be NFS-backed). The console-script probe opens files in the target
-    # venv. Resolve them together on the executor so /api/sync cannot stall the
-    # gateway's requests and liveness behind a directory scan.
+    # venv, and the origin probe RUNS that interpreter. Resolve them together on
+    # the executor so /api/sync cannot stall the gateway's requests and liveness
+    # behind a directory scan or a subprocess.
     loop = asyncio.get_running_loop()
-    git_bin, npm_bin, locked_scripts = await loop.run_in_executor(
+    git_bin, npm_bin, locked_scripts, venv_origin = await loop.run_in_executor(
         subprocess_executor(),
         lambda: (
             _trusted_bin("git"),
             _toolchain_bin("npm"),
-            _write_locked_console_scripts(target_py),
+            dep_sync.locked_console_scripts(target_py),
+            dep_sync.installed_package_origin(target_py),
         ),
     )
     if git_bin is None:
@@ -3659,6 +3618,23 @@ async def _sync_start_locked() -> dict:
                   _build_env(with_credentials=True), "Pull")
     merge_step = ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict",
                   _build_env(), "Pull")
+    # The venv must be an install OF this checkout before either install step
+    # runs, and that is true of the reinstall just as much as the substitute.
+    #
+    # `<repo>/.venv` is only where the interpreter was FOUND; it says nothing
+    # about what it is an install of. When it serves a different checkout,
+    # `pip install -e .` silently repoints its editable install at this repo and
+    # the other checkout's gateway becomes this code on its next restart -- the
+    # same hijack the target_py resolution above exists to prevent, arriving by
+    # the other direction. The substitute has always refused this (dep_sync's own
+    # first check); the reinstall branch did not, so the safer path was the only
+    # guarded one. Checking here covers both, on every platform.
+    foreign = dep_sync.venv_not_mapped_to(venv_origin, Path(repo))
+    if foreign:
+        return {"ok": False, "error": (
+            f"refusing to sync: {foreign}. Give this checkout its own editable "
+            "install, or run the sync from the checkout that venv serves."
+        )}
     dep_sync_snapshot: Path | None = None
     if locked_scripts:
         logger.info(

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -17,7 +17,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-from kiro_crew import __version__, platform_compat
+from kiro_crew import __version__, dep_sync, platform_compat
 from kiro_crew.beacon import distribution, is_default_home
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
@@ -1109,15 +1109,19 @@ def _update() -> None:
     # Build the dashboard frontend assets (npm), then reinstall the package.
     build_frontend_sync(Path(proj))
 
-    print("  🔨 pip install -e .")
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-e", ".", "--quiet"],
-        cwd=proj,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(f"  ❌ Install failed:\n{result.stderr.strip()}")
+    # Install the pulled revision into this CLI's own venv. `kirocrew update` is
+    # itself run FROM the console script pip would have to rewrite, so on Windows
+    # the reinstall cannot succeed and dep_sync substitutes a dependency-only sync
+    # (it reports, rather than silently tolerating, a revision that repointed the
+    # script — that is the one case still needing a terminal without kirocrew
+    # running).
+    print("  🔨 Installing the pulled revision…")
+
+    def _emit(message: str, error: bool) -> None:
+        print(f"  {'❌' if error else '•'} {message}")
+
+    rc = dep_sync.sync_or_reinstall(Path(proj), Path(sys.executable), _emit)
+    if rc != 0:
         sys.exit(1)
 
     print("\n✅ Kiro Crew updated!")

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import collections
+import functools
 import json
 import logging
 import os
@@ -17,7 +18,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import __version__ as _local_version
-from kiro_crew import shutdown_event
+from kiro_crew import dep_sync, shutdown_event
 from kiro_crew.changelog import Release, base_version, build_release_list
 from kiro_crew.config.loader import (
     ConfigReadError,
@@ -26,6 +27,7 @@ from kiro_crew.config.loader import (
     update_config_locked,
 )
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.platform.update_capability import (
     CHECK_DEFERRED,
     CHECK_FAILED,
@@ -1030,45 +1032,61 @@ async def _build_frontend(proj: str, state: DashboardState) -> None:
 
 
 async def _venv_pip_install(proj: str, state: DashboardState) -> bool:
-    """Run `pip install -e .` to (re)install the package from source.
+    """Install the pulled revision into this gateway's own venv.
 
     Returns ``True`` on success. On failure, pushes an error to ``state`` and
     returns ``False`` — caller should ``return``.
+
+    Delegates the choice of HOW to :func:`kiro_crew.dep_sync.sync_or_reinstall`:
+    an editable reinstall where it can run, and a dependency-only sync where it
+    cannot. This endpoint is one of the paths that cannot always run it — the
+    gateway it updates is normally started through the very console script pip
+    would have to rewrite, which Windows locks, and a reinstall that dies there
+    has already deleted the editable ``.pth`` and left the venv unable to import
+    the package at all.
+
+    ``dep_sync`` is imported at MODULE level (see its docstring): this runs after
+    the pull, so an import deferred to here would parse the file the incoming
+    revision shipped.
     """
     state.push_update_progress("building", "Installing package (pip)…")
-    install = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "-e",
-        ".",
-        "--quiet",
-        cwd=proj,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.PIPE,
+    loop = asyncio.get_running_loop()
+
+    def _publish(step: str, message: str) -> None:
+        # dep_sync hands pip's output over raw; this is the surface that publishes
+        # it, so redaction and the length cap belong here.
+        message, _ = redact_credentials(message)
+        message, _ = redact_exfiltration_urls(message)
+        if len(message) > 1000:
+            message = message[:1000] + "\n…(truncated)"
+        state.push_update_progress(step, message)
+
+    def _emit(message: str, error: bool) -> None:
+        # Called from the EXECUTOR THREAD, and push_update_progress touches
+        # loop-bound state (the SSE subscriber queues), so it is handed to the
+        # serving loop rather than run here. Doing it inline is the kind of
+        # cross-thread mutation that works until a client is actually connected
+        # and then raises out of a worker thread. Same pattern as the log ring
+        # handler below, which emits from arbitrary logger threads.
+        loop.call_soon_threadsafe(_publish, "error" if error else "building", message)
+
+    rc = await loop.run_in_executor(
+        subprocess_executor(),
+        functools.partial(
+            dep_sync.sync_or_reinstall,
+            Path(proj),
+            Path(sys.executable),
+            _emit,
+            # 600s, not the 120s this endpoint used to put on `pip install -e .`.
+            # The bound now covers a dependency install that may be resolving and
+            # downloading a set this venv has never seen — and building a wheel for
+            # one of them — where 120s is a routine, not an exceptional, overrun.
+            # It is a real bound either way: dep_sync kills the pip child on
+            # expiry rather than letting the step hang on a wedged index.
+            timeout=600,
+        ),
     )
-    try:
-        _, stderr = await asyncio.wait_for(install.communicate(), timeout=120)
-    except asyncio.TimeoutError:
-        try:
-            install.kill()
-        except ProcessLookupError:
-            pass
-        await install.communicate()
-        state.push_update_progress("error", "pip install timed out")
-        return False
-    if install.returncode != 0:
-        raw_err = stderr.decode()
-        raw_err, _ = redact_credentials(raw_err)
-        raw_err, _ = redact_exfiltration_urls(raw_err)
-        # Build wheel / native extension errors often have the actionable message
-        # mid-stderr after a long traceback, so keep up to 1000 chars after redaction.
-        if len(raw_err) > 1000:
-            raw_err = raw_err[:1000] + "\n…(truncated)"
-        state.push_update_progress("error", f"pip install failed: {raw_err}")
-        return False
-    return True
+    return rc == 0
 
 
 async def _restart_gateway(state: DashboardState) -> None:

--- a/src/kiro_crew/dep_sync.py
+++ b/src/kiro_crew/dep_sync.py
@@ -41,6 +41,35 @@ Two things a dependency-only install cannot deliver that a reinstall does, so bo
 are checked rather than left silent: the ``requires-python`` gate pip applies when
 it builds the project, and a rewrite of the console script when the incoming
 revision repoints it.
+
+WHERE THIS LIVES, AND WHAT IT MAY IMPORT
+----------------------------------------
+This module is core rather than app-local because the reinstall it stands in for
+is not a Dev Fleet idea: the same ``pip install -e .`` into the venv serving the
+running gateway is spelled out by the dashboard update handler, the Slack
+gateway's auto-update, ``kirocrew update``, and the console-script bootstrap. Four
+of those five callers are core, so a Dev Fleet home would mean core importing from
+a builtin app.
+
+It imports the standard library ONLY, and that is an invariant a caller depends on
+rather than a stylistic preference. ``kiro_crew._bootstrap`` reaches for this
+module precisely when a declared dependency is missing from the venv -- that is the
+condition it exists to heal -- so a third-party import here would fail in exactly
+the case the module is needed. That is also the concrete argument against deciding
+requirement satisfaction with ``packaging.SpecifierSet``: it is the better parser,
+and adopting it would break the one caller that cannot assume its own
+dependencies are installed. ``tomllib`` is imported through a guarded ``tomli``
+fallback for 3.10 for the same reason -- a missing fallback degrades this module,
+it never breaks the import.
+
+The corollary for callers: import this module BEFORE the step that moves the
+working tree. Every caller merges or resets first, so an import deferred until
+after that point parses the file the incoming revision shipped -- and a revision
+that raises the ``requires-python`` floor and uses newer syntax anywhere would
+then die with a ``SyntaxError`` instead of reaching the floor refusal written for
+exactly that case. An already-imported module is served from
+``sys.modules`` and cannot be re-parsed, which is what makes the refusal
+reachable.
 """
 
 from __future__ import annotations
@@ -51,7 +80,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 try:  # pragma: no cover - exercised by whichever interpreter runs this
     import tomllib as _toml
@@ -60,6 +89,11 @@ except ImportError:  # Python 3.10, which this project still supports
         import tomli as _toml  # type: ignore[no-redef,import-not-found]
     except ImportError:
         _toml = None  # type: ignore[assignment]
+
+#: How a caller receives this module's own messages: ``(message, is_error)``.
+#: Positional rather than keyword so a caller can pass a plain two-argument
+#: function without importing anything from here.
+Emit = Callable[[str, bool], None]
 
 #: Characters that terminate the distribution name at the head of a PEP 508
 #: requirement (version specifier, extras bracket, marker separator, or the
@@ -99,6 +133,56 @@ _PLAIN_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 #: a local file when the file exists, so such a token is refused rather than left
 #: to be disambiguated by the working directory's contents.
 _ARCHIVE_SUFFIXES = (".whl", ".zip", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz")
+
+
+def locked_console_scripts(target_py: Path) -> list[str]:
+    """The venv's ``kirocrew`` console scripts that cannot currently be rewritten.
+
+    This is the probe every caller uses to decide whether a reinstall is even
+    possible, so it lives beside the substitute rather than beside any one caller.
+
+    Windows holds a mandatory lock on a running executable's image, so when the
+    process is served BY the very venv pip is about to reinstall into -- the
+    ordinary single-checkout setup -- pip cannot replace ``Scripts\\kirocrew.exe``,
+    and the reinstall can never succeed.
+
+    That matters well beyond one failed step. pip's uninstall is not atomic: by the
+    time it reaches the locked script it has already renamed the dist-info aside
+    and deleted the editable ``.pth`` that puts ``src`` on ``sys.path``, and it
+    rolls back neither. The venv is left unable to import the package at all, which
+    also kills the console script the gateway is restarted through. The running
+    process survives on already-imported modules, so the damage stays invisible
+    until the next restart fails.
+
+    Probing with an ``r+b`` open is non-destructive and discriminates correctly: a
+    running executable refuses it while every other script in the same directory
+    opens fine. It does not model every way a delete can fail -- an opener that
+    permits writes but denies deletes would pass this probe -- so a clean result
+    means "no known blocker", not a guarantee. A miss simply leaves the previous
+    behaviour, which is why this is worth doing even though it cannot be
+    exhaustive.
+
+    POSIX returns nothing: an executing binary can be unlinked there, which is why
+    pip has always been able to replace it.
+
+    ``sys.platform`` is read directly rather than through the package's platform
+    helper to keep this module's stdlib-only import discipline (see the module
+    docstring) -- ``_bootstrap`` calls into here when an import is already failing.
+    """
+    if sys.platform != "win32":
+        return []
+    locked: list[str] = []
+    for exe in sorted(Path(target_py).parent.glob("kirocrew*.exe")):
+        try:
+            with exe.open("r+b"):
+                pass
+        except PermissionError:
+            locked.append(str(exe))
+        except OSError:
+            # Unreadable for some other reason. Let pip be the judge rather than
+            # skipping a step that might well have succeeded.
+            continue
+    return locked
 
 
 def normalize(name: str) -> str:
@@ -346,18 +430,26 @@ def installed_package_origin(target_py: Path) -> str | None:
     what the installed dependencies will be imported alongside, so it is the thing
     worth checking.
 
-    Returns ``None`` when the package cannot be located at all.
+    Returns ``None`` when the package cannot be located at all -- including when
+    the interpreter itself cannot be run. That case is not theoretical: the caller
+    resolved this path by a filesystem check, and a venv deleted between that check
+    and this probe would otherwise raise ``OSError`` out of a request handler. The
+    callers read ``None`` as "cannot be shown to serve this checkout" and refuse,
+    which is the right answer to an unrunnable interpreter as well.
     """
     probe = (
         "import importlib.util as u, os;"
         "s=u.find_spec('kiro_crew');"
         "print(os.path.abspath(s.origin) if s and s.origin else '')"
     )
-    proc = subprocess.run(
-        [str(target_py), "-c", probe],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            [str(target_py), "-c", probe],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
     if proc.returncode != 0:
         return None
     return proc.stdout.strip() or None
@@ -457,6 +549,19 @@ def _section(toml_text: str, header: str) -> str:
 #: treats a removal like any other disagreement.
 SCRIPT_REMOVED = "removed by the merged revision"
 
+#: Exit code meaning "this stopped before touching the venv". Distinct from 1
+#: because the two demand opposite handling: a caller that reacts to a failed
+#: install by repairing what it can must NOT run that repair after a REFUSED,
+#: since the refusal's whole point is that this venv is not ours to write to.
+#: Every ``_refuse`` path returns it, as does a usage error -- in both cases
+#: nothing was installed.
+#:
+#: An install that RAN and failed returns 1, never pip's own exit code. pip
+#: spends 2 on UNKNOWN_ERROR, so propagating it would announce "nothing was
+#: touched" for a run that may well have changed the venv -- the one reading a
+#: caller must not get wrong. pip's real code is reported in the message.
+REFUSED = 2
+
 
 def console_script_target(repo: Path, script: str) -> str | None:
     """The ``module:attr`` *script* is declared to dispatch to, or ``None``.
@@ -550,32 +655,47 @@ def installed_console_script_target(target_py: Path, script: str) -> str | None:
     return proc.stdout.strip() or None
 
 
-def _refuse(message: str, target_py: Path, repo: Path, remedy: str | None = None) -> int:
+def _print_emit(message: str, error: bool) -> None:
+    """Report to the console -- the shape a subprocess caller reads."""
+    print(message, file=sys.stderr if error else sys.stdout)
+
+
+def _refuse(
+    emit: Emit, message: str, target_py: Path, repo: Path, remedy: str | None = None
+) -> int:
     if remedy is None:
         remedy = (
             "Stop the gateway and finish the sync from a terminal: "
             f'"{target_py}" -m pip install -e "{repo}"'
         )
-    print(
-        f"dep-sync: {message} No dependency was installed. {remedy}",
-        file=sys.stderr,
-    )
-    return 1
+    emit(f"dep-sync: {message} No dependency was installed. {remedy}", True)
+    return REFUSED
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = list(sys.argv[1:] if argv is None else argv)
-    if len(args) != 2:
-        print("usage: dep_sync <repo> <target-python>", file=sys.stderr)
-        return 2
-    repo, target_py = Path(args[0]), Path(args[1])
+def sync(
+    repo: Path, target_py: Path, emit: Emit = _print_emit, timeout: float | None = None
+) -> int:
+    """Install what ``repo`` declares into ``target_py``'s venv. 0 when synced.
 
+    Callers in the same process pass ``emit`` to receive every message they would
+    otherwise have to scrape from a subprocess's streams -- the refusals in
+    particular, each of which names the remedy the operator has to run by hand.
+    pip's own output is captured and handed to ``emit`` too, RAW: it echoes the
+    index URL it resolved against, and an authenticated index carries a credential
+    there, so it must reach the caller that knows where it is about to be published
+    rather than whatever this process's stderr happens to be.
+
+    ``timeout`` bounds the pip invocation. ``None`` leaves it unbounded, which is
+    what the module-run path uses: there the step already runs under the
+    supervision of whatever launched it.
+    """
     # Establish that the venv about to be written to serves THIS checkout before
     # anything is installed. `<repo>/.venv` is where the interpreter was found,
     # which says nothing about what it is an install of.
     foreign = venv_not_mapped_to(installed_package_origin(target_py), repo)
     if foreign:
         return _refuse(
+            emit,
             f"{foreign}.",
             target_py,
             repo,
@@ -589,11 +709,12 @@ def main(argv: list[str] | None = None) -> int:
     # them elsewhere has to stop the step rather than have it install a stale set.
     moved = dependency_authority_moved(repo)
     if moved:
-        return _refuse(f"{moved}, so this step would install a stale set.", target_py, repo)
+        return _refuse(emit, f"{moved}, so this step would install a stale set.", target_py, repo)
 
     specs = declared_requirements(repo)
     if specs is None:
         return _refuse(
+            emit,
             "cannot read install_requires from setup.cfg, so the requirements to "
             "install are unknown.",
             target_py,
@@ -607,6 +728,7 @@ def main(argv: list[str] | None = None) -> int:
         breach = python_floor_breach(floor_spec, version)
         if breach:
             return _refuse(
+                emit,
                 f"the merged revision requires Python {floor_spec} but the target "
                 f"venv runs {version[0]}.{version[1]}.{version[2]}, so its code "
                 "cannot be imported.",
@@ -615,19 +737,21 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     if not specs:
-        print("dep-sync: no requirements declared; nothing to install")
+        emit("dep-sync: no requirements declared; nothing to install", False)
     else:
         rejected = rejected_specs(specs)
         if rejected:
             return _refuse(
+                emit,
                 "the merged revision declares requirements this step will not hand "
                 f"to pip: {'; '.join(rejected)}.",
                 target_py,
                 repo,
             )
-        print(
+        emit(
             f"dep-sync: installing {len(specs)} declared requirements; extras are "
-            "left alone, exactly as a plain `pip install -e .` leaves them"
+            "left alone, exactly as a plain `pip install -e .` leaves them",
+            False,
         )
         # Hand every spec to pip and let it decide: an already-satisfied requirement
         # is a no-op, so this installs what is new and leaves the rest alone without
@@ -636,9 +760,52 @@ def main(argv: list[str] | None = None) -> int:
         # locked console script.
         # `--` ends pip's option parsing, so a declared requirement can never be
         # read as a flag.
-        proc = subprocess.run([str(target_py), "-m", "pip", "install", "--", *specs])
+        #
+        # CAPTURED, not streamed to the inherited stdio. pip echoes the index URL
+        # it resolved against, and an authenticated index carries its credential in
+        # that URL -- inherited stderr on this path is the gateway's own log, so
+        # streaming writes the credential there in the clear. Routing it through
+        # `emit` hands it to the caller that knows where it is about to be
+        # published and is the one redacting it, which is what the reinstall branch
+        # in `sync_or_reinstall` already does. The cost is that a long install stops
+        # being observable line-by-line; that is the right trade against writing a
+        # credential to a log file nobody reviews.
+        try:
+            proc = subprocess.run(
+                [str(target_py), "-m", "pip", "install", "--", *specs],
+                capture_output=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            # NOT _refuse(): that says "No dependency was installed", and a run
+            # killed mid-install may well have installed some of the set. A killed
+            # install is rerunnable and a partial set is this module's already
+            # accepted exposure; an unbounded one hangs the caller instead.
+            emit(
+                f"dep-sync: installing the declared requirements exceeded "
+                f"{timeout}s and was stopped, so the set may be partially "
+                f"installed. Finish the sync from a terminal: "
+                f'"{target_py}" -m pip install -e "{repo}"',
+                True,
+            )
+            return 1
         if proc.returncode != 0:
-            return proc.returncode
+            # Bytes, then an explicit lossy decode, for the same reason as the
+            # reinstall branch: the locale's codec is not guaranteed to decode
+            # pip's output, and `text=True` would raise instead of reporting.
+            detail = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+            emit(
+                f"dep-sync: pip exited {proc.returncode} installing the declared "
+                "requirements" + (f": {detail}" if detail else ""),
+                True,
+            )
+            # 1, NOT pip's own code. pip uses 2 for UNKNOWN_ERROR, which is the
+            # value REFUSED carries, and the two mean opposite things to a caller:
+            # this install RAN and may have changed the venv, so a caller that
+            # repairs after a failure must still repair. Propagating pip's code
+            # would tell it nothing was touched. pip's actual code is in the
+            # message above, where it is diagnostic rather than load-bearing.
+            return 1
 
     # The one thing a dependency-only install cannot deliver: if the merged
     # revision REPOINTED the console script -- or dropped it -- the wrapper on
@@ -658,15 +825,111 @@ def main(argv: list[str] | None = None) -> int:
                 f"script is repointed to {declared} by the merged revision while "
                 f"the installed wrapper still calls {installed}"
             )
-        print(
+        emit(
             f"dep-sync: dependencies are installed, but the {_SCRIPT!r} console "
             f"{disagreement}. That wrapper cannot be "
             f"rewritten while a process is running from it: stop the gateway and run "
             f'"{target_py}" -m pip install -e "{repo}" before restarting.',
-            file=sys.stderr,
+            True,
         )
         return 1
     return 0
+
+
+def sync_or_reinstall(
+    repo: Path,
+    target_py: Path,
+    emit: Emit = _print_emit,
+    timeout: float | None = None,
+) -> int:
+    """Bring ``target_py``'s venv up to date with ``repo``. 0 when it succeeded.
+
+    The one entry point for a caller that wants the editable reinstall wherever it
+    can still run and the dependency-only substitute only where it cannot. The
+    reinstall stays the default deliberately: it is the fuller operation, and it is
+    the one that also rewrites a console script the incoming revision repointed --
+    the single thing the substitute can only report. So this does not replace the
+    reinstall, it stops the reinstall from being attempted in the one case where
+    attempting it does damage: pip's uninstall is not atomic, so a run that dies on
+    the locked script has already deleted the editable ``.pth`` (see
+    :func:`locked_console_scripts`).
+
+    ``timeout`` bounds the pip invocation on EITHER branch. The substitute is not
+    left unbounded on the reasoning that a killed dependency install is worse than
+    a hung one: a killed one is rerunnable, and a partially installed set is
+    already this module's accepted failure mode (see the exposure stated at the top
+    of this file), while an unbounded install on a wedged index hangs the surface
+    that called it with no story at all.
+
+    pip's output is captured and handed to ``emit`` RAW. A caller that publishes it
+    anywhere a user can see -- a dashboard progress feed, a log -- owns redacting
+    it first: pip echoes index URLs, which carry credentials when the operator
+    configured an authenticated index.
+    """
+    # Establish that the venv about to be written to serves THIS checkout BEFORE
+    # the branch, so both paths are covered. `sync()` asks the same question again
+    # on the substitute path, and that duplication is deliberate: `sync()` is also
+    # reached directly (as a module run by path, which is how the Dev Fleet sync
+    # invokes it), so it cannot delegate its own safety to a caller. The cost is
+    # one extra short interpreter probe against an install measured in seconds.
+    #
+    # Without this, the reinstall branch would repeat the exact asymmetry this
+    # change fixes at the Dev Fleet endpoint -- a guarded substitute beside an
+    # unguarded reinstall -- and three of this function's four callers take the
+    # checkout from configuration, so a repointed venv is reachable on all three.
+    foreign = venv_not_mapped_to(installed_package_origin(target_py), repo)
+    if foreign:
+        return _refuse(
+            emit,
+            f"{foreign}.",
+            target_py,
+            repo,
+            remedy=(
+                "Give this checkout its own editable install, or run the update "
+                "from the checkout that venv serves."
+            ),
+        )
+
+    locked = locked_console_scripts(target_py)
+    if locked:
+        emit(
+            f"dep-sync: {', '.join(locked)} locked by a running process; "
+            "substituting a dependency-only sync for the editable reinstall",
+            False,
+        )
+        return sync(repo, target_py, emit, timeout=timeout)
+
+    # `-e <repo>` rather than `-e .` with a cwd: the target is explicit in the argv
+    # instead of implied by the working directory this happens to run in.
+    argv = [str(target_py), "-m", "pip", "install", "-e", str(repo), "--quiet"]
+    try:
+        proc = subprocess.run(argv, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        emit(f"dep-sync: pip install -e timed out after {timeout}s", True)
+        return 1
+    if proc.returncode != 0:
+        # Bytes, then an explicit lossy decode: `text=True` decodes with the
+        # locale's codec, and pip's output is not guaranteed to be in it -- on a
+        # non-UTF-8 console that raises UnicodeDecodeError and loses the error
+        # message that was the point of capturing.
+        detail = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        emit(
+            f"dep-sync: pip install -e exited {proc.returncode}"
+            + (f": {detail}" if detail else ""),
+            True,
+        )
+        # 1, not pip's own code, for the same reason as the substitute branch:
+        # pip's 2 (UNKNOWN_ERROR) is REFUSED's value, and this install ran.
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 2:
+        print("usage: dep_sync <repo> <target-python>", file=sys.stderr)
+        return REFUSED
+    return sync(Path(args[0]), Path(args[1]))
 
 
 if __name__ == "__main__":  # pragma: no cover - module entry point

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -42,7 +42,7 @@ from slack_sdk.socket_mode.websockets import SocketModeClient as WSSocketModeCli
 
 import kiro_crew
 import kiro_crew.crash_guard as crash_guard
-from kiro_crew import beacon, platform_compat, shutdown_event
+from kiro_crew import beacon, dep_sync, platform_compat, shutdown_event
 from kiro_crew.acp.client import AcpError, AcpProcessDied
 from kiro_crew.autonudge import (
     APPROVAL_STALL_REASON,
@@ -7388,31 +7388,50 @@ class GatewayOrchestrator:
 
             if self.dashboard_state:
                 self.dashboard_state.push_update_progress("building", "Rebuilding package…")
-            # pip install -e . picks up new Python deps / entry points.
-            pip_install = await asyncio.create_subprocess_exec(
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "-e",
-                ".",
-                "--quiet",
-                cwd=proj,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            # Install the reset revision's Python deps / entry points. The gateway
+            # is normally started through the console script pip would have to
+            # rewrite, which Windows locks, so dep_sync picks the reinstall only
+            # where it can actually run and substitutes a dependency-only sync
+            # where it cannot — a reinstall that dies on the locked script has
+            # already deleted the editable .pth.
+            pip_messages: list[tuple[str, bool]] = []
+            # The bound lives on the pip subprocess (dep_sync's `timeout`), not on
+            # an `asyncio.wait_for` around the executor. Cancelling a wait_for does
+            # NOT cancel the thread it is waiting on: expiry would report failure
+            # while a live pip kept writing to the venv and permanently occupied a
+            # subprocess_executor thread. Passing the deadline down means the child
+            # is actually killed and the thread is released.
+            pip_rc = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(),
+                functools.partial(
+                    dep_sync.sync_or_reinstall,
+                    Path(proj),
+                    Path(sys.executable),
+                    lambda message, error: pip_messages.append((message, error)),
+                    timeout=600,
+                ),
             )
-            pip_out, pip_err = await asyncio.wait_for(pip_install.communicate(), timeout=400)
-            if pip_install.returncode != 0:
+            if pip_rc != 0:
                 # Same reasoning as the dep-repair path: redact first, cap last.
-                err_text = pip_err.decode(errors="replace")
+                err_text = "; ".join(m for m, _ in pip_messages)
                 err_text, _ = redact_exfiltration_urls(err_text)
                 err_text, _ = redact_credentials(err_text)
                 err_text = err_text[:500]
                 logger.error(
-                    "Auto-update: pip install failed (rc=%d): %s",
-                    pip_install.returncode,
+                    "Auto-update: dependency install failed (rc=%d): %s",
+                    pip_rc,
                     err_text,
                 )
+                if pip_rc == dep_sync.REFUSED:
+                    # REFUSED means the sync stopped BEFORE touching the venv --
+                    # most importantly when that venv serves a different
+                    # checkout. The core-dep repair below would then install into
+                    # exactly the venv the guard just protected, so a refusal ends
+                    # the auto-update here without even repairing: the messages
+                    # above name the remedy, and nothing was changed.
+                    if self.dashboard_state:
+                        self.dashboard_state.push_update_progress("error", err_text)
+                    return
                 if self.dashboard_state:
                     self.dashboard_state.push_update_progress(
                         "building",
@@ -7449,6 +7468,33 @@ class GatewayOrchestrator:
                         fallback.returncode,
                         fb_err.decode(errors="replace")[:300],
                     )
+                # Repair or not, do NOT restart after a sync that did not come back
+                # clean. The tree is already on the new revision (the reset ran
+                # first), and every nonzero result names something the restart
+                # cannot fix by itself:
+                #
+                #   - dependencies still unsatisfied  -> the process this restart
+                #     brings up dies at import and takes the running gateway with
+                #     it, and the repair only covers the CORE deps, not whatever
+                #     the revision actually added.
+                #   - console script repointed or removed by the revision -> the
+                #     wrapper on disk still dispatches to the old target, and no
+                #     dependency install rewrites it. This restart uses
+                #     `-m kiro_crew` so it would survive, but the next restart
+                #     through the service manager runs `kirocrew` and does not.
+                #
+                # Staying up on already-imported modules is strictly better than
+                # either: the operator keeps a working gateway to finish the
+                # install from, and is told so now rather than at the next restart.
+                if self.dashboard_state:
+                    self.dashboard_state.push_update_progress(
+                        "error",
+                        "Update stopped before restart: the dependency sync did "
+                        "not complete cleanly. The gateway is still running on the "
+                        "previously loaded code — finish the install from a "
+                        "terminal, then restart.",
+                    )
+                return
 
             logger.info("Auto-update: rebuild complete, restarting")
             # Re-read version from rebuilt package

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -20,6 +20,22 @@ from kiro_crew import _bootstrap
 # ── Helpers ──
 
 
+def _venv_maps(monkeypatch):
+    """Answer the install path's foreign-venv guard with "it maps".
+
+    ``dep_sync.sync_or_reinstall`` refuses a venv serving a DIFFERENT checkout
+    before it picks a branch, and it answers that by RUNNING the target
+    interpreter — which these tests stub. Without this the guard's refusal would
+    stand in for the outcome each test is actually asserting, and two of them
+    would pass for the wrong reason. The guard itself is covered in
+    test/test_dep_sync.py.
+    """
+    from kiro_crew import dep_sync
+
+    monkeypatch.setattr(dep_sync, "installed_package_origin", lambda target: "<stub>")
+    monkeypatch.setattr(dep_sync, "venv_not_mapped_to", lambda origin, repo: None)
+
+
 def _fail_then_succeed(calls: list[str], sentinel):
     """Import stub failing with ModuleNotFoundError once, then succeeding."""
 
@@ -101,14 +117,38 @@ def test_self_heal_refuses_outside_source_checkout(monkeypatch):
     assert _bootstrap._self_heal("defusedxml") is False
 
 
-def test_self_heal_skips_windows(monkeypatch, tmp_path):
-    """A running console launcher cannot be replaced on Windows -> no heal."""
+def test_self_heal_runs_on_windows_through_the_dependency_only_path(monkeypatch, tmp_path):
+    """Windows heals now. It used to be the one platform that never did.
+
+    The blanket skip was there because pip cannot replace the running
+    ``kirocrew.exe`` — but a dependency install never touches that wrapper, and a
+    missing dependency is the only thing that brings us here. Skipping left the
+    platform whose users hit this most with nothing but a printed one-liner.
+    """
+    from kiro_crew import dep_sync
+
     monkeypatch.setattr(_bootstrap.sys, "platform", "win32")
     monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+    _venv_maps(monkeypatch)
     monkeypatch.setattr(
-        subprocess, "run", lambda *a, **k: pytest.fail("pip must not run")
+        dep_sync, "locked_console_scripts", lambda target: [r"C:\v\Scripts\kirocrew.exe"]
     )
-    assert _bootstrap._self_heal("defusedxml") is False
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: pytest.fail("the reinstall must not run")
+    )
+    seen: dict = {}
+
+    def _fake_sync(repo, target_py, emit=None, timeout=None):
+        seen["repo"] = repo
+        seen["timeout"] = timeout
+        return 0
+
+    monkeypatch.setattr(dep_sync, "sync", _fake_sync)
+    assert _bootstrap._self_heal("defusedxml") is True
+    assert seen["repo"] == tmp_path
+    # The substitute is bounded too — an unbounded dependency install would hang
+    # the console entry point with no way out.
+    assert seen["timeout"] == _bootstrap._PIP_TIMEOUT_SECS
 
 
 def test_retry_invalidates_import_caches(monkeypatch):
@@ -134,16 +174,23 @@ def test_retry_invalidates_import_caches(monkeypatch):
 
 
 def test_self_heal_runs_fixed_pip_argv(monkeypatch, tmp_path):
+    """Where pip CAN rewrite the script, the heal is still the full reinstall."""
+    from kiro_crew import dep_sync
+
     monkeypatch.setattr(_bootstrap.sys, "platform", "linux")  # POSIX heal path
     monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+    _venv_maps(monkeypatch)
+    monkeypatch.setattr(dep_sync, "locked_console_scripts", lambda target: [])
     seen: dict = {}
 
-    def _fake_run(argv, timeout):
+    def _fake_run(argv, **kwargs):
         seen["argv"] = argv
-        seen["timeout"] = timeout
+        seen["timeout"] = kwargs.get("timeout")
 
         class _P:
             returncode = 0
+            stdout = b""
+            stderr = b""
 
         return _P()
 
@@ -154,14 +201,46 @@ def test_self_heal_runs_fixed_pip_argv(monkeypatch, tmp_path):
 
 
 def test_self_heal_reports_pip_failure(monkeypatch, tmp_path):
+    from kiro_crew import dep_sync
+
     monkeypatch.setattr(_bootstrap.sys, "platform", "linux")  # POSIX heal path
     monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+    _venv_maps(monkeypatch)
+    monkeypatch.setattr(dep_sync, "locked_console_scripts", lambda target: [])
 
-    def _fake_run(argv, timeout):
-        raise subprocess.TimeoutExpired(cmd=argv, timeout=timeout)
+    def _fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
     assert _bootstrap._self_heal("defusedxml") is False
+
+
+def test_self_heal_output_stays_ascii(monkeypatch, tmp_path, capsys):
+    """Every line this module prints must survive a cp1252 pipe.
+
+    The heal now relays pip's output and filesystem paths, neither of which is
+    ASCII by nature, and it prints before ensure_utf8_console() has run.
+    """
+    from kiro_crew import dep_sync
+
+    monkeypatch.setattr(_bootstrap.sys, "platform", "linux")
+    monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+    _venv_maps(monkeypatch)
+    monkeypatch.setattr(dep_sync, "locked_console_scripts", lambda target: [])
+
+    def _fake_run(argv, **kwargs):
+        class _P:
+            returncode = 1
+            stdout = b""
+            stderr = "pip a\u00e9choue \u2014 pas de distribution".encode()
+
+        return _P()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert _bootstrap._self_heal("defusedxml") is False
+    err = capsys.readouterr().err
+    assert err  # the failure was reported, not swallowed
+    err.encode("ascii")  # raises UnicodeEncodeError if anything slipped through
 
 
 # ── _source_checkout_root ──

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -458,7 +458,9 @@ class TestUpdateFailures:
             # pip install -e . fails
             if cmd and "pip" in cmd and "install" in cmd:
                 m.returncode = 1
-                m.stderr = "build failed"
+                # BYTES: the install captures without text=True.
+                m.stderr = b"build failed"
+                m.stdout = b""
             return m
 
         with (
@@ -467,6 +469,11 @@ class TestUpdateFailures:
             patch("kiro_crew.cli_server.shutil.which", return_value=None),
             patch("kiro_crew.cli_server.build_frontend_sync"),
             patch("kiro_crew.cli._ensure_node"),
+            # Pin the install route to the reinstall this test is about; the real
+            # probe reads the test interpreter's own Scripts dir, and the origin
+            # guard would otherwise run the stubbed interpreter for its answer.
+            patch("kiro_crew.dep_sync.locked_console_scripts", return_value=[]),
+            patch("kiro_crew.dep_sync.venv_not_mapped_to", return_value=None),
             patch("subprocess.run", side_effect=_side_effect),
         ):
             try:

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -953,7 +953,11 @@ class _GitStub:
         if argv[0] == "kiro-cli":
             return subprocess.CompletedProcess(argv, 0, "", "")
         if "pip" in argv:
-            return subprocess.CompletedProcess(argv, self.rc.get("pip", 0), "", "wheel error")
+            # BYTES, like the real call: the install captures without text=True so
+            # a non-UTF-8 console cannot make pip's own error message undecodable.
+            return subprocess.CompletedProcess(
+                argv, self.rc.get("pip", 0), b"", b"wheel error"
+            )
         return subprocess.CompletedProcess(argv, self.rc.get("setup", 0), "", "")
 
 
@@ -984,6 +988,17 @@ def git_checkout(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_server.shutil, "which", lambda name: None)
     monkeypatch.setattr(cli_server, "build_frontend_sync", lambda p: None)
     monkeypatch.setattr("kiro_crew.cli._ensure_node", lambda *a: None)
+    # Pin the install ROUTE. The real probe reads the test interpreter's own
+    # Scripts dir, so on a Windows dev box running from a checkout these tests
+    # would silently take the dependency-only branch instead of the reinstall
+    # they assert. `kirocrew update`'s own substitute behaviour is covered in
+    # test/test_dep_sync.py.
+    monkeypatch.setattr(cli_server.dep_sync, "locked_console_scripts", lambda target: [])
+    # And the foreign-venv guard, which now runs before either install branch.
+    # Its probe RUNS the target interpreter, which _GitStub intercepts into an
+    # empty answer — read as "cannot be shown to serve this checkout" and refused.
+    # dep_sync's own tests own that guard's behaviour.
+    monkeypatch.setattr(cli_server.dep_sync, "venv_not_mapped_to", lambda origin, repo: None)
     return proj
 
 
@@ -1077,7 +1092,8 @@ class TestUpdateGitPath:
         with pytest.raises(SystemExit) as exc:
             cli_server._update()
         assert exc.value.code == 1
-        assert "Install failed" in capsys.readouterr().out
+        # pip's own reason reaches the console, not just the exit code.
+        assert "wheel error" in capsys.readouterr().out
 
     def test_success_updates_kiro_cli_and_refreshes_agent_config(
         self, monkeypatch, git_checkout, capsys

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -541,13 +541,21 @@ class TestChangelogCache:
 
 
 class TestPipInstallFailureReport:
-    """``_venv_pip_install`` — a long stderr is truncated, not dropped."""
+    """``_venv_pip_install`` — a long message is truncated, not dropped."""
 
     @pytest.mark.asyncio
     async def test_a_huge_stderr_is_truncated_with_a_marker(self, monkeypatch):
+        from kiro_crew import dep_sync
+
         state = MagicMock()
-        proc = _FakeProc(err=("x" * 4000).encode(), returncode=1)
-        _sequence_procs(monkeypatch, [proc])
+
+        def fake_sync(repo, target_py, emit=None, timeout=None):
+            # dep_sync passes pip's captured output through verbatim; the cap is
+            # this endpoint's job because it is the one publishing it.
+            emit("x" * 4000, True)
+            return 1
+
+        monkeypatch.setattr(dep_sync, "sync_or_reinstall", fake_sync)
 
         assert await updates._venv_pip_install("/tmp/proj", state) is False
 

--- a/test/test_dep_sync.py
+++ b/test/test_dep_sync.py
@@ -9,13 +9,17 @@ a repointed console script), and it refuses to write to a venv that serves a
 different checkout.
 """
 
+import ast
+import subprocess
+import sys
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
-from kiro_crew.apps.builtins.dev_fleet import dep_sync
+from kiro_crew import dep_sync
 
 _SETUP_CFG = textwrap.dedent("""
     [options]
@@ -400,6 +404,8 @@ def test_main_hands_every_spec_to_pip_and_stops_on_failure(repo):
         def __init__(self, rc):
             self.returncode = rc
             self.stdout = ""
+            # The pip call captures now, so the failure path decodes stderr.
+            self.stderr = b""
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
@@ -454,7 +460,7 @@ def test_main_refuses_a_declaration_that_names_the_project(repo, capsys):
     ):
         rc = dep_sync.main([str(repo), "py"])
 
-    assert rc == 1
+    assert rc == dep_sync.REFUSED
     assert not sp.run.called
     err = capsys.readouterr().err
     assert "will not hand to pip" in err
@@ -472,7 +478,7 @@ def test_main_refuses_when_the_interpreter_is_below_the_declared_floor(repo, cap
     ):
         rc = dep_sync.main([str(repo), "py"])
 
-    assert rc == 1
+    assert rc == dep_sync.REFUSED
     assert not sp.run.called
     err = capsys.readouterr().err
     assert "3.13" in err
@@ -490,7 +496,7 @@ def test_main_refuses_a_venv_serving_another_checkout(repo, capsys):
     ):
         rc = dep_sync.main([str(repo), "py"])
 
-    assert rc == 1
+    assert rc == dep_sync.REFUSED
     assert not sp.run.called
     err = capsys.readouterr().err
     assert "other" in err
@@ -506,7 +512,7 @@ def test_main_refuses_when_the_requirements_moved_to_pyproject(repo, capsys):
     with patch.object(dep_sync, "subprocess") as sp:
         rc = dep_sync.main([str(repo), "py"])
 
-    assert rc == 1
+    assert rc == dep_sync.REFUSED
     assert not sp.run.called
     assert "stale" in capsys.readouterr().err
 
@@ -592,3 +598,401 @@ def test_main_tolerates_an_unreadable_installed_entry_point(repo):
 def test_main_rejects_a_wrong_argument_count():
     assert dep_sync.main(["only-one"]) == 2
     assert dep_sync.main(["a", "b", "c"]) == 2
+
+
+# --- the probe every caller shares: which install is even possible ------------
+def _make_scripts(tmp_path, *names):
+    """A fake venv Scripts/ dir, returning the interpreter path inside it."""
+    scripts = tmp_path / ".venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    for name in names:
+        (scripts / name).write_bytes(b"MZ")
+    return scripts / "python.exe"
+
+
+def _raise_on(monkeypatch, name, exc):
+    """Make Path.open raise *exc* for the file called *name* only."""
+    real_open = Path.open
+
+    def fake_open(self, *args, **kwargs):
+        if self.name == name:
+            raise exc
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+
+def test_locked_console_scripts_is_a_posix_noop(tmp_path, monkeypatch):
+    """POSIX can unlink an executing binary, so there is nothing to detect."""
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(sys, "platform", "linux")
+    _raise_on(monkeypatch, "kirocrew.exe", PermissionError(13, "in use"))
+
+    assert dep_sync.locked_console_scripts(py) == []
+
+
+def test_locked_console_scripts_flags_a_locked_script(tmp_path, monkeypatch):
+    """The real failure: the exe the gateway is executing cannot be replaced."""
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(sys, "platform", "win32")
+    _raise_on(monkeypatch, "kirocrew.exe", PermissionError(13, "in use"))
+
+    locked = dep_sync.locked_console_scripts(py)
+    assert len(locked) == 1
+    assert locked[0].endswith("kirocrew.exe")
+
+
+def test_locked_console_scripts_passes_a_writable_script(tmp_path, monkeypatch):
+    """A venv the gateway is NOT running from must still get its reinstall."""
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    assert dep_sync.locked_console_scripts(py) == []
+
+
+def test_locked_console_scripts_ignores_unrelated_executables(tmp_path, monkeypatch):
+    """Only the scripts pip would rewrite matter.
+
+    Some other locked exe sharing the Scripts dir must not suppress the
+    reinstall — that would turn an unrelated process into a silent skip.
+    """
+    py = _make_scripts(tmp_path, "kirocrew.exe", "unrelated.exe")
+    monkeypatch.setattr(sys, "platform", "win32")
+    _raise_on(monkeypatch, "unrelated.exe", PermissionError(13, "in use"))
+
+    assert dep_sync.locked_console_scripts(py) == []
+
+
+def test_locked_console_scripts_lets_pip_judge_other_errors(tmp_path, monkeypatch):
+    """An unreadable-for-other-reasons script is not evidence of a lock.
+
+    Skipping on any OSError would suppress installs that would have worked.
+    """
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(sys, "platform", "win32")
+    _raise_on(monkeypatch, "kirocrew.exe", OSError(5, "I/O error"))
+
+    assert dep_sync.locked_console_scripts(py) == []
+
+
+# --- sync_or_reinstall: the reinstall stays the default -----------------------
+def _maps():
+    """Answer the pre-branch foreign-venv guard with "it maps".
+
+    Scoped per test rather than autouse: this module also asserts that the guard
+    REFUSES, and a blanket stub would silence the tests that prove it.
+    """
+    return patch.object(dep_sync, "venv_not_mapped_to", return_value=None)
+
+
+def _origin_stub():
+    """Skip the probe subprocess; the interpreter paths here do not exist."""
+    return patch.object(dep_sync, "installed_package_origin", return_value="<stub>")
+
+
+def test_sync_or_reinstall_prefers_the_reinstall_when_nothing_is_locked(tmp_path):
+    """No lock means no substitute. The reinstall is the fuller operation.
+
+    Only the reinstall also rewrites a console script the incoming revision
+    repointed, so substituting where pip could have run would quietly downgrade
+    every caller on every platform.
+    """
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["timeout"] = kwargs.get("timeout")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    with (
+        _origin_stub(),
+        _maps(),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync, "sync", side_effect=AssertionError("must not substitute")),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.sync_or_reinstall(tmp_path, Path("/venv/bin/python"), timeout=42)
+
+    assert rc == 0
+    assert seen["argv"][1:] == ["-m", "pip", "install", "-e", str(tmp_path), "--quiet"]
+    assert seen["timeout"] == 42
+
+
+def test_sync_or_reinstall_substitutes_when_a_script_is_locked(tmp_path):
+    """A locked script routes to the substitute, and the caller is told why.
+
+    The reinstall must not merely fail here: pip's uninstall is not atomic, so
+    reaching the locked script means the editable .pth is already gone.
+    """
+    messages = []
+
+    with (
+        _origin_stub(),
+        _maps(),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[r"C:\v\kirocrew.exe"]),
+        patch.object(dep_sync, "sync", return_value=0) as sync_mock,
+        patch.object(dep_sync.subprocess, "run", side_effect=AssertionError("must not reinstall")),
+    ):
+        rc = dep_sync.sync_or_reinstall(
+            tmp_path, Path("/venv/bin/python"), lambda m, e: messages.append((m, e))
+        )
+
+    assert rc == 0
+    assert sync_mock.call_count == 1
+    assert any("kirocrew.exe" in m and "dependency-only" in m for m, _ in messages)
+
+
+def test_sync_or_reinstall_guards_the_reinstall_branch_too(tmp_path):
+    """The foreign-venv refusal covers the branch pip can still run.
+
+    Guarding only the substitute would rebuild, inside this shared function, the
+    exact asymmetry it was written to remove: three of its four callers take the
+    checkout from configuration, so a venv serving a DIFFERENT checkout is
+    reachable on all three, and `pip install -e <repo>` against it silently
+    repoints that other checkout's editable install at this repo.
+    """
+    messages = []
+
+    with (
+        patch.object(dep_sync, "installed_package_origin", return_value="/other/src/x.py"),
+        patch.object(
+            dep_sync,
+            "locked_console_scripts",
+            side_effect=AssertionError("must refuse before probing the lock"),
+        ),
+        patch.object(dep_sync.subprocess, "run", side_effect=AssertionError("must not install")),
+    ):
+        rc = dep_sync.sync_or_reinstall(
+            tmp_path, Path("/venv/bin/python"), lambda m, e: messages.append((m, e))
+        )
+
+    assert rc == dep_sync.REFUSED
+    joined = " ".join(m for m, _ in messages)
+    # Not "/other": the message renders a resolved path, so the separator (and on
+    # Windows the drive) is the platform's, not the one written in the stub.
+    assert "other" in joined
+    assert "No dependency was installed" in joined
+
+
+def test_a_refusal_is_a_distinct_exit_code_from_a_failed_attempt():
+    """REFUSED must not be spelled the same as "the install failed".
+
+    A caller that reacts to a failed install by repairing what it can has to be
+    able to tell the two apart: running that repair after a refusal would write
+    into the very venv the refusal was protecting. Pinned as a contract because
+    the Slack auto-update branches on it.
+    """
+    assert dep_sync.REFUSED != 0
+    assert dep_sync.REFUSED != 1
+
+
+@pytest.mark.parametrize("pip_rc", [1, 2, 3, 120])
+def test_an_attempted_install_never_returns_the_refusal_code(tmp_path, pip_rc):
+    """pip's own exit code is NOT propagated, on either branch.
+
+    pip spends 2 on UNKNOWN_ERROR, which is REFUSED's value. Propagating it would
+    tell a caller "nothing was touched" about a run that may have changed the
+    venv — and the Slack auto-update reads exactly that to decide whether to skip
+    its core-dep repair, so the collision would skip the repair of a modified
+    venv. Both branches normalize an attempted failure to 1.
+    """
+    (tmp_path / "setup.cfg").write_text(_SETUP_CFG, encoding="utf-8")
+
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(returncode=pip_rc, stdout=b"", stderr=b"boom")
+
+    # The substitute branch (pip install <specs>).
+    with (
+        _maps(),
+        _origin_stub(),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 12, 0)),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        assert dep_sync.sync(tmp_path, Path("/venv/bin/python"), lambda m, e: None) == 1
+
+    # And the reinstall branch (pip install -e <repo>).
+    with (
+        _maps(),
+        _origin_stub(),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.sync_or_reinstall(tmp_path, Path("/venv/bin/python"), lambda m, e: None)
+    assert rc == 1
+
+
+def test_sync_or_reinstall_reports_a_failed_reinstall_through_emit(tmp_path):
+    """pip's own diagnosis has to reach the caller, not just the exit code.
+
+    Three of the four callers publish this text somewhere a person reads it, and
+    an exit code alone leaves them with nothing to act on.
+    """
+    messages = []
+
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(returncode=1, stdout=b"", stderr=b"no matching distribution")
+
+    with (
+        _origin_stub(),
+        _maps(),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.sync_or_reinstall(
+            tmp_path, Path("/venv/bin/python"), lambda m, e: messages.append((m, e))
+        )
+
+    assert rc == 1
+    assert any(e and "no matching distribution" in m for m, e in messages)
+
+
+def test_sync_or_reinstall_survives_undecodable_pip_output(tmp_path):
+    """pip's stderr is captured as BYTES and decoded leniently.
+
+    `text=True` would decode with the locale's codec, so on a non-UTF-8 console
+    a byte pip emitted would raise UnicodeDecodeError and lose the very message
+    the capture exists to surface.
+    """
+    messages = []
+
+    def fake_run(argv, **kwargs):
+        assert kwargs.get("text") is not True
+        return SimpleNamespace(returncode=1, stdout=b"", stderr=b"\xff\xfe bad bytes")
+
+    with (
+        _origin_stub(),
+        _maps(),
+        patch.object(dep_sync, "locked_console_scripts", return_value=[]),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.sync_or_reinstall(
+            tmp_path, Path("/venv/bin/python"), lambda m, e: messages.append((m, e))
+        )
+
+    assert rc == 1
+    assert any("bad bytes" in m for m, _ in messages)
+
+
+def test_sync_or_reinstall_bounds_both_branches(tmp_path):
+    """``timeout`` reaches the substitute as well as the reinstall.
+
+    Leaving the substitute unbounded was the wrong trade: a killed dependency
+    install is rerunnable and a partial set is already this module's accepted
+    exposure, while an unbounded one hangs the surface that called it — the
+    dashboard endpoint had a hard 120s bound before this refactor and would
+    otherwise have come out of it with none.
+    """
+    with (
+        _origin_stub(),
+        _maps(),
+        patch.object(dep_sync, "locked_console_scripts", return_value=["x.exe"]),
+        patch.object(dep_sync, "sync", return_value=0) as sync_mock,
+    ):
+        dep_sync.sync_or_reinstall(tmp_path, Path("/venv/bin/python"), timeout=7)
+
+    assert sync_mock.call_args.kwargs["timeout"] == 7
+
+
+def test_sync_kills_a_hung_pip_and_says_the_set_may_be_partial(tmp_path):
+    """A timed-out install reports honestly instead of claiming a clean refusal.
+
+    The refusal wording ("No dependency was installed") would be a lie here: pip
+    was killed mid-run, so some of the set may be on disk. The message has to say
+    so, because the operator's next step depends on it.
+    """
+    messages = []
+    (tmp_path / "setup.cfg").write_text(_SETUP_CFG, encoding="utf-8")
+
+    def fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
+
+    with (
+        _maps(),
+        patch.object(dep_sync, "installed_package_origin", return_value="<stub>"),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 12, 0)),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.sync(
+            tmp_path, Path("/venv/bin/python"), lambda m, e: messages.append((m, e)), timeout=5
+        )
+
+    assert rc == 1
+    joined = " ".join(m for m, _ in messages)
+    assert "may be partially installed" in joined
+    assert "No dependency was installed" not in joined
+
+
+def test_installed_package_origin_fails_closed_on_an_unrunnable_interpreter(tmp_path):
+    """An interpreter that cannot be RUN answers None, it does not raise.
+
+    Callers resolve the path by a filesystem check, so a venv deleted between that
+    check and this probe would otherwise raise OSError out of a request handler.
+    None is read as "cannot be shown to serve this checkout", which is the right
+    answer for an interpreter that is not there.
+    """
+    with patch.object(dep_sync.subprocess, "run", side_effect=FileNotFoundError(2, "gone")):
+        assert dep_sync.installed_package_origin(tmp_path / "python") is None
+    # And that answer refuses rather than proceeding.
+    assert dep_sync.venv_not_mapped_to(None, tmp_path) is not None
+
+
+def test_sync_captures_pip_output_instead_of_writing_it_to_stderr(tmp_path, capsys):
+    """pip's output must reach ``emit``, never the inherited stderr.
+
+    pip echoes the index URL it resolved against, and an authenticated index
+    carries its credential there. On the in-process paths the inherited stderr IS
+    the gateway's log, so streaming would write that credential to a file nobody
+    reviews. Handing it to ``emit`` puts it in front of the caller that knows where
+    it is about to be published and is the one redacting it.
+    """
+    messages = []
+    (tmp_path / "setup.cfg").write_text(_SETUP_CFG, encoding="utf-8")
+    secret = "https://user:s3cr3t@index.example.com/simple"
+
+    def fake_run(argv, **kwargs):
+        # Captured, so pip's stream never reaches this process's stderr.
+        assert kwargs.get("capture_output") is True
+        assert kwargs.get("text") is not True
+        return SimpleNamespace(returncode=1, stdout=b"", stderr=f"looking in {secret}".encode())
+
+    with (
+        _maps(),
+        patch.object(dep_sync, "installed_package_origin", return_value="<stub>"),
+        patch.object(dep_sync, "interpreter_version", return_value=(3, 12, 0)),
+        patch.object(dep_sync.subprocess, "run", side_effect=fake_run),
+    ):
+        rc = dep_sync.sync(tmp_path, Path("/venv/bin/python"), lambda m, e: messages.append((m, e)))
+
+    assert rc == 1
+    assert any(secret in m for m, _ in messages), messages
+    # And it did NOT leak to the streams this module was printing to before.
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_module_imports_stdlib_only():
+    """The invariant ``kiro_crew._bootstrap`` depends on, enforced.
+
+    That caller reaches for this module precisely when a declared dependency is
+    missing from the venv, so a third-party import here would fail in exactly the
+    case the module exists to repair. Reading the AST rather than the import graph
+    keeps this honest even when the offending package happens to be installed on
+    the machine running the tests.
+    """
+    tree = ast.parse(Path(dep_sync.__file__).read_text(encoding="utf-8"))
+    roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    # Both names of the TOML ladder are allowed, and neither weakens the check:
+    # `tomllib` IS stdlib, but only from 3.11 — on the 3.10 interpreter this
+    # project still supports it is absent from `sys.stdlib_module_names`, so
+    # deriving the allowance from the running interpreter would make this test
+    # pass or fail on the version that happens to run it. `tomli` is the
+    # third-party fallback for exactly that version. Both imports are guarded, so
+    # a missing one degrades a reader rather than breaking the module.
+    third_party = roots - set(sys.stdlib_module_names) - {"tomllib", "tomli"}
+    assert not third_party, f"dep_sync must import stdlib only; found {sorted(third_party)}"

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -36,6 +36,25 @@ _POSIX_ONLY = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _venv_maps_to_the_synced_checkout():
+    """Answer the sync's foreign-venv guard with "it maps", for tests not about it.
+
+    Both install paths now refuse a venv that serves a DIFFERENT checkout, and
+    answering that question RUNS the target interpreter — which every sync test
+    here points at a path that does not exist. Stubbing both halves keeps an
+    unrelated assertion from turning into an unrunnable-interpreter refusal. The
+    guard's own behaviour is asserted by
+    ``test_sync_refuses_a_venv_that_serves_another_checkout``, which patches it
+    back to a refusal, and the logic behind it lives in ``test/test_dep_sync.py``.
+    """
+    from kiro_crew import dep_sync
+
+    with patch.object(dep_sync, "installed_package_origin", return_value="<stubbed>"), \
+         patch.object(dep_sync, "venv_not_mapped_to", return_value=None):
+        yield
+
+
 # --- worktree porcelain parsing ---
 def test_parse_worktree_porcelain_basic():
     from kiro_crew.apps.builtins.dev_fleet.server import _parse_worktree_porcelain
@@ -890,88 +909,9 @@ async def test_sync_script_emits_step_markers():
 
 
 # --- Windows: a write-locked console script must not be handed to pip ---
-def _make_scripts(tmp_path, *names):
-    """A fake venv Scripts/ dir, returning the interpreter path inside it."""
-    scripts = tmp_path / ".venv" / "Scripts"
-    scripts.mkdir(parents=True)
-    for name in names:
-        (scripts / name).write_bytes(b"MZ")
-    return scripts / "python.exe"
-
-
-def _raise_on(monkeypatch, name, exc):
-    """Make Path.open raise *exc* for the file called *name* only."""
-    real_open = Path.open
-
-    def fake_open(self, *args, **kwargs):
-        if self.name == name:
-            raise exc
-        return real_open(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "open", fake_open)
-
-
-def test_write_locked_console_scripts_is_a_posix_noop(tmp_path, monkeypatch):
-    """POSIX can unlink an executing binary, so there is nothing to detect."""
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
-
-    py = _make_scripts(tmp_path, "kirocrew.exe")
-    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
-    _raise_on(monkeypatch, "kirocrew.exe", PermissionError(13, "in use"))
-
-    assert mod._write_locked_console_scripts(py) == []
-
-
-def test_write_locked_console_scripts_flags_a_locked_script(tmp_path, monkeypatch):
-    """The real failure: the exe the gateway is executing cannot be replaced."""
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
-
-    py = _make_scripts(tmp_path, "kirocrew.exe")
-    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
-    _raise_on(monkeypatch, "kirocrew.exe", PermissionError(13, "in use"))
-
-    locked = mod._write_locked_console_scripts(py)
-    assert len(locked) == 1
-    assert locked[0].endswith("kirocrew.exe")
-
-
-def test_write_locked_console_scripts_passes_a_writable_script(tmp_path, monkeypatch):
-    """A venv the gateway is NOT running from must still get its reinstall."""
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
-
-    py = _make_scripts(tmp_path, "kirocrew.exe")
-    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
-
-    assert mod._write_locked_console_scripts(py) == []
-
-
-def test_write_locked_console_scripts_ignores_unrelated_executables(tmp_path, monkeypatch):
-    """Only the scripts pip would rewrite matter.
-
-    Some other locked exe sharing the Scripts dir must not suppress the
-    reinstall — that would turn an unrelated process into a silent skip.
-    """
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
-
-    py = _make_scripts(tmp_path, "kirocrew.exe", "unrelated.exe")
-    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
-    _raise_on(monkeypatch, "unrelated.exe", PermissionError(13, "in use"))
-
-    assert mod._write_locked_console_scripts(py) == []
-
-
-def test_write_locked_console_scripts_lets_pip_judge_other_errors(tmp_path, monkeypatch):
-    """An unreadable-for-other-reasons script is not evidence of a lock.
-
-    Skipping on any OSError would suppress installs that would have worked.
-    """
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
-
-    py = _make_scripts(tmp_path, "kirocrew.exe")
-    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
-    _raise_on(monkeypatch, "kirocrew.exe", OSError(5, "I/O error"))
-
-    assert mod._write_locked_console_scripts(py) == []
+# The probe itself moved to kiro_crew.dep_sync with the substitute it feeds, and
+# its tests moved with it (test/test_dep_sync.py). What stays here is the sync's
+# use of the result: which install step gets built.
 
 
 def _steps_from_script(script):
@@ -1004,6 +944,9 @@ async def _run_sync(mod, locked):
     ambient makes them pass or fail on whether the HOST running them happens to
     sit in a Kiro Crew checkout. Assertions that quote the repo path must use
     ``_SYNC_REPO`` rather than reading ``mod.MAIN_REPO``.
+
+    The venv-origin guard is answered by the module's autouse fixture; a test
+    about that guard patches it back to a refusal.
     """
     mod._UPSTREAM_REMOTE = "origin"
     mod._SYNC_RID = None
@@ -1011,7 +954,7 @@ async def _run_sync(mod, locked):
          patch.object(mod, "_git", new_callable=AsyncMock, return_value="main"), \
          patch.object(mod, "_venv_python", return_value=Path("/fake/.venv/bin/python")), \
          patch.object(mod, "_trusted_bin", side_effect=lambda n: f"/usr/bin/{n}"), \
-         patch.object(mod, "_write_locked_console_scripts", return_value=locked), \
+         patch.object(mod.dep_sync, "locked_console_scripts", return_value=locked), \
          patch("kiro_crew.apps.builtins.dev_fleet.server.sandboxed_spawn_argv",
                side_effect=lambda cmd, mode, env=None: (cmd, env or {}, None)), \
          patch.object(mod, "_start_run", new_callable=AsyncMock, return_value="run-123") as mock_start:
@@ -1047,7 +990,7 @@ async def test_sync_substitutes_a_dependency_only_install_when_a_script_is_locke
     Windows layout — the ordinary one — with no working Pull+build at all.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
-    from kiro_crew.apps.builtins.dev_fleet import dep_sync
+    from kiro_crew import dep_sync
 
     result, script = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
 
@@ -1086,7 +1029,7 @@ async def test_sync_keeps_the_editable_reinstall_when_nothing_is_locked():
     should.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
-    from kiro_crew.apps.builtins.dev_fleet import dep_sync
+    from kiro_crew import dep_sync
 
     result, script = await _run_sync(mod, [])
 
@@ -1129,6 +1072,39 @@ async def test_sync_runs_every_step_when_nothing_is_locked():
     labels = _steps_from_script(script)
     assert "pip install" in labels
     assert "Pull" in labels
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("locked", [[], [r"C:\repo\.venv\Scripts\kirocrew.exe"]],
+                         ids=["reinstall-branch", "substitute-branch"])
+async def test_sync_refuses_a_venv_that_serves_another_checkout(locked):
+    """The refusal covers BOTH install paths, and refuses before either runs.
+
+    `<repo>/.venv` is only where the interpreter was found; it can be an install
+    of a different checkout, and `pip install -e .` would then silently repoint
+    that editable install at this repo — so the OTHER checkout's gateway becomes
+    this code on its next restart. The dependency-only path has always refused
+    this; the reinstall path did not, which left the safer path as the only
+    guarded one. Parametrized over both branches because that asymmetry is
+    exactly the bug: a fix that only covers the one it was found on is not one.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew import dep_sync
+
+    with patch.object(
+        dep_sync,
+        "venv_not_mapped_to",
+        return_value="the target venv imports this project from /other/checkout",
+    ):
+        result, script = await _run_sync(mod, locked)
+
+    assert result["ok"] is False
+    assert "/other/checkout" in result["error"]
+    # Remedy-first, like every other refusal on this endpoint.
+    assert "own editable install" in result["error"]
+    # Nothing ran: no fetch, no merge, no install. A refusal after the merge
+    # would leave the checkout moved with its dependencies unresolved.
+    assert script is None
 
 
 @pytest.mark.asyncio
@@ -2598,7 +2574,7 @@ async def test_sync_unresolved_git_names_override_not_path(monkeypatch):
          patch.object(mod, "_venv_python",
                       return_value=Path("/fake/.venv/bin/python")), \
          patch.object(mod, "_trusted_bin", side_effect=lambda n: None), \
-         patch.object(mod, "_write_locked_console_scripts", return_value=[]):
+         patch.object(mod.dep_sync, "locked_console_scripts", return_value=[]):
         mod._SYNC_RID = None
         res = await mod._sync()
     assert res["ok"] is False

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from pathlib import Path
@@ -3351,13 +3352,23 @@ class TestAutoApplyUpdateVenvPath:
         with patch("kiro_crew.env.is_toolbox_install", return_value=False):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
                 with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                    with patch.object(
-                        GatewayOrchestrator, "_is_brazil_install", return_value=False
-                    ):
-                        with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
-                            with patch("os.execv", side_effect=OSError("test")):
-                                with patch("shutil.which", return_value=None):
-                                    await orch._auto_apply_update()
+                    with patch(
+                        "kiro_crew.dep_sync.sync_or_reinstall", return_value=0
+                    ) as mock_install:
+                        with patch.object(
+                            GatewayOrchestrator, "_is_brazil_install", return_value=False
+                        ):
+                            with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
+                                with patch("os.execv", side_effect=OSError("test")):
+                                    with patch("shutil.which", return_value=None):
+                                        await orch._auto_apply_update()
+
+        # The install runs through the shared entry point, which picks a reinstall
+        # or a dependency-only sync — the gateway is normally started through the
+        # console script pip would have to rewrite.
+        assert mock_install.call_count == 1
+        assert str(mock_install.call_args[0][0]) == str(Path("/tmp/proj"))
+        assert str(mock_install.call_args[0][1]) == sys.executable
 
         ds.push_update_progress.assert_any_call("pulling", "Fetching latest changes…")
         ds.push_update_progress.assert_any_call("building", "Building frontend…")
@@ -3776,17 +3787,165 @@ class TestAutoApplyUpdateResetPath:
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                with patch(
-                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
-                ) as mock_build:
-                    with patch("os.execv", side_effect=OSError("test")):
-                        with patch("shutil.which", return_value=None):
-                            await orch._auto_apply_update()
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                    ) as mock_build:
+                        with patch("os.execv", side_effect=OSError("test")):
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
 
         # Frontend build+stage runs, and the package is reinstalled.
         mock_build.assert_awaited()
         ds.push_update_progress.assert_any_call("building", "Building frontend…")
         ds.push_update_progress.assert_any_call("building", "Rebuilding package…")
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_skips_the_core_dep_repair_entirely(self):
+        """A REFUSED sync must not be followed by a repair into the same venv.
+
+        REFUSED means the sync stopped before touching anything — most
+        importantly when the venv serves a DIFFERENT checkout. The core-dep
+        repair writes into exactly that venv, so running it after a refusal
+        would perform the mutation the guard exists to prevent, and the restart
+        would then bring up the wrong checkout with changed dependencies.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        call_count = [0]
+
+        async def _fake_exec(*args, **kwargs):
+            call_count[0] += 1
+            spawned.append(args)
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
+            proc.returncode = 1 if call_count[0] == 3 else 0
+            proc.wait = AsyncMock(return_value=proc.returncode)
+            return proc
+
+        from kiro_crew import dep_sync
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.dep_sync.sync_or_reinstall", return_value=dep_sync.REFUSED
+                ):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async",
+                        new_callable=AsyncMock,
+                    ):
+                        with patch("os.execv") as mock_execv:
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        # No pip spawn at all: the repair is what would have written to the venv.
+        assert not any("pip" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+        steps = [c.args[0] for c in ds.push_update_progress.call_args_list]
+        assert "restarting" not in steps
+
+    @pytest.mark.asyncio
+    async def test_no_restart_after_any_unclean_sync_even_when_the_repair_works(self):
+        """A nonzero sync never restarts, even when the core-dep repair succeeds.
+
+        Every nonzero result names something the restart cannot fix on its own.
+        Dependencies may still be unsatisfied — the repair covers only the CORE
+        deps, not whatever the revision actually added. Or the revision repointed
+        the console script, which no dependency install rewrites: this restart uses
+        `-m kiro_crew` and would survive it, but the next restart through the
+        service manager runs `kirocrew` and would not. Staying up on
+        already-imported modules tells the operator now instead of then.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        call_count = [0]
+
+        async def _fake_exec(*args, **kwargs):
+            call_count[0] += 1
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
+            # diff --quiet reports changes; everything else, INCLUDING the
+            # core-dep repair, succeeds.
+            proc.returncode = 1 if call_count[0] == 3 else 0
+            proc.wait = AsyncMock(return_value=proc.returncode)
+            return proc
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                # rc=1, not REFUSED: an install that ran and came back unclean.
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=1):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async",
+                        new_callable=AsyncMock,
+                    ):
+                        with patch("os.execv") as mock_execv:
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        mock_execv.assert_not_called()
+        orch.sessions.close_all.assert_not_called()
+        steps = [c.args[0] for c in ds.push_update_progress.call_args_list]
+        assert "error" in steps
+        assert "restarting" not in steps
+
+    @pytest.mark.asyncio
+    async def test_a_failed_install_with_a_failed_repair_does_not_restart(self):
+        """Restarting into unsatisfied dependencies would kill the gateway.
+
+        The reset already moved the tree to the new revision. If neither the
+        dependency install nor the core-dep repair succeeded, the process this
+        restart brings up is a revision whose dependencies are known to be
+        missing — it dies at import. Staying up on already-imported modules
+        leaves the operator a working gateway to finish the install from.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        call_count = [0]
+
+        async def _fake_exec(*args, **kwargs):
+            call_count[0] += 1
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            if call_count[0] == 1:
+                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
+                proc.returncode = 0
+            elif call_count[0] == 3:
+                proc.returncode = 1  # diff --quiet -> there are changes
+            else:
+                # Everything else, INCLUDING the core-dep repair, fails.
+                proc.communicate = AsyncMock(return_value=(b"", b"boom"))
+                proc.returncode = 0 if call_count[0] in (2, 4, 5) else 1
+            proc.wait = AsyncMock(return_value=proc.returncode)
+            return proc
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=1):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async",
+                        new_callable=AsyncMock,
+                    ):
+                        with patch("os.execv") as mock_execv:
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        mock_execv.assert_not_called()
+        orch.sessions.close_all.assert_not_called()
+        steps = [c.args[0] for c in ds.push_update_progress.call_args_list]
+        assert "error" in steps
+        assert "restarting" not in steps
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -189,13 +189,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # agent-influenced, and the binary is resolved through
         # platform_compat.trusted_system_bin (a vetted absolute path), not PATH.
         "acp/runtime.py::_ps_process_table",
-        # Console-entry self-heal for stale editable installs: ONE fixed
-        # `python -m pip install -e <repo>` argv, no shell. The repo path is
-        # derived from the module's own __file__ (never user/agent input) and
-        # only when setup.cfg + src/kiro_crew exist there. Runs before the
-        # package imports, so it cannot route through sandboxed_spawn_argv —
-        # mirrors dashboard/handlers/updates.py::_venv_pip_install below.
-        "_bootstrap.py::_self_heal",
+        # (_bootstrap.py::_self_heal removed — the console-entry self-heal now
+        # delegates its install to dep_sync.sync_or_reinstall, so the spawn lives
+        # at that key below and an entry here would be stale.)
         # Ops Mission Control ledger-sync tests: fixed `git` argv (init --bare / ls-files)
         # against a per-test tempdir. Nothing here is agent-influenced — the repo path is
         # `tempfile.mkdtemp()` and every argument is a literal in the test file. These are
@@ -605,10 +601,17 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # sync step, which server.py::worker already wrapped through
         # sandboxed_spawn_argv, and a filesystem-scoped wrapper around pip would
         # block the venv writes that are the point of the step.
-        "apps/builtins/dev_fleet/dep_sync.py::interpreter_version",
-        "apps/builtins/dev_fleet/dep_sync.py::installed_console_script_target",
-        "apps/builtins/dev_fleet/dep_sync.py::installed_package_origin",
-        "apps/builtins/dev_fleet/dep_sync.py::main",
+        #
+        # sync_or_reinstall spawns the EDITABLE REINSTALL for the same callers, and
+        # is allowlisted on the same grounds: it is the identical argv those callers
+        # spelled out inline before, with the target read from sys.executable and
+        # the repo from the operator-configured checkout. Sandboxing it now would
+        # refuse a step every platform has always run unsandboxed.
+        "dep_sync.py::interpreter_version",
+        "dep_sync.py::installed_console_script_target",
+        "dep_sync.py::installed_package_origin",
+        "dep_sync.py::sync",
+        "dep_sync.py::sync_or_reinstall",
         # Foreground last-resort restart (Make Live on hosts with no drivable
         # service manager): a detached `kirocrew restart --port <marker port>`,
         # fixed argv whose binary is validated (basenamed kirocrew, absolute,
@@ -804,7 +807,8 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # environment value, never agent input. Read-only version comparison —
         # nothing here writes to the tree.
         "dashboard/handlers/updates.py::_check_git_checkout",
-        "dashboard/handlers/updates.py::_venv_pip_install",
+        # (_venv_pip_install removed — it now delegates the install to
+        # dep_sync.sync_or_reinstall and spawns nothing itself.)
         "dashboard/handlers/updates.py::api_update_apply",
         "dashboard/handlers_system.py::_collect_system_metrics",
         # Split out of _collect_system_metrics above so the whole-machine process

--- a/test/test_update_venv_detection.py
+++ b/test/test_update_venv_detection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -55,106 +56,139 @@ def _track_errors(state):
 
 
 class TestVenvPipInstall:
-    """Tests for the _venv_pip_install helper."""
+    """Tests for the _venv_pip_install helper.
+
+    The helper no longer spawns pip itself — it hands the install to
+    ``dep_sync.sync_or_reinstall``, which picks an editable reinstall or a
+    dependency-only sync depending on whether the console script can be
+    rewritten. These stub that one seam, so they assert what this endpoint owns:
+    the exit code becomes a bool, and every message reaches the progress feed
+    redacted and capped.
+    """
 
     @pytest.mark.asyncio
     async def test_returns_true_on_success(self, monkeypatch, tmp_path) -> None:
         proj = _make_pip_proj(tmp_path)
+        from kiro_crew import dep_sync
         from kiro_crew.dashboard.handlers.updates import _venv_pip_install
 
         state = _make_state(monkeypatch, tmp_path)
+        seen: dict = {}
 
-        async def fake_exec(*args, **kwargs):
-            proc = MagicMock()
-            proc.communicate = AsyncMock(return_value=(b"", b""))
-            proc.returncode = 0
-            return proc
+        def fake_sync(repo, target_py, emit=None, timeout=None):
+            seen["repo"] = repo
+            seen["target"] = target_py
+            return 0
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(dep_sync, "sync_or_reinstall", fake_sync)
         assert await _venv_pip_install(str(proj), state) is True
+        # The venv written to is THIS gateway's own, and the checkout is the one
+        # the endpoint was asked to update — neither is re-derived downstream.
+        assert str(seen["repo"]) == str(proj)
+        assert str(seen["target"]) == sys.executable
 
     @pytest.mark.asyncio
     async def test_returns_false_on_nonzero_exit(self, monkeypatch, tmp_path) -> None:
         proj = _make_pip_proj(tmp_path)
+        from kiro_crew import dep_sync
         from kiro_crew.dashboard.handlers.updates import _venv_pip_install
 
         state = _make_state(monkeypatch, tmp_path)
         errors = _track_errors(state)
 
-        async def fake_exec(*args, **kwargs):
-            proc = MagicMock()
-            proc.communicate = AsyncMock(
-                return_value=(b"", b"ERROR: could not find setup.py")
-            )
-            proc.returncode = 1
-            return proc
+        def fake_sync(repo, target_py, emit=None, timeout=None):
+            emit("dep-sync: pip install -e exited 1: ERROR: could not find setup.py", True)
+            return 1
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(dep_sync, "sync_or_reinstall", fake_sync)
         assert await _venv_pip_install(str(proj), state) is False
-        assert any("pip install failed" in e for e in errors), errors
+        assert any("could not find setup.py" in e for e in errors), errors
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_timeout(self, monkeypatch, tmp_path) -> None:
+    async def test_substitution_notice_is_progress_not_an_error(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A locked script is a route change, not a failure.
+
+        The substitute reports which wrapper was locked; pushing that as an error
+        would surface a red step on a sync that went on to succeed.
+        """
         proj = _make_pip_proj(tmp_path)
+        from kiro_crew import dep_sync
         from kiro_crew.dashboard.handlers.updates import _venv_pip_install
 
         state = _make_state(monkeypatch, tmp_path)
         errors = _track_errors(state)
 
-        async def fake_exec(*args, **kwargs):
-            proc = MagicMock()
-            # First communicate raises TimeoutError; second (after kill) returns.
-            proc.communicate = AsyncMock(
-                side_effect=[asyncio.TimeoutError, (b"", b"")]
-            )
-            proc.kill = MagicMock()
-            proc.returncode = -9
-            return proc
+        def fake_sync(repo, target_py, emit=None, timeout=None):
+            emit(r"dep-sync: C:\v\kirocrew.exe locked; substituting", False)
+            return 0
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
-        assert await _venv_pip_install(str(proj), state) is False
-        assert any("pip install timed out" in e for e in errors), errors
+        monkeypatch.setattr(dep_sync, "sync_or_reinstall", fake_sync)
+        assert await _venv_pip_install(str(proj), state) is True
+        assert not errors, errors
 
     @pytest.mark.asyncio
-    async def test_timeout_swallows_process_lookup_error(self, monkeypatch, tmp_path) -> None:
-        """When the process is already gone, kill() raises ProcessLookupError — handled."""
+    async def test_progress_is_published_on_the_loop_not_the_worker_thread(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """``push_update_progress`` touches loop-bound state, so it must not be
+        called from the executor thread that runs the install.
+
+        The callback is handed to dep_sync and invoked from a worker thread. The
+        SSE subscriber queues it writes to belong to the serving loop, so calling
+        it inline is a cross-thread mutation that works right up until a client is
+        actually connected and then raises out of a thread nobody is awaiting.
+        """
+        import threading
+
         proj = _make_pip_proj(tmp_path)
+        from kiro_crew import dep_sync
         from kiro_crew.dashboard.handlers.updates import _venv_pip_install
 
         state = _make_state(monkeypatch, tmp_path)
-        errors = _track_errors(state)
+        loop_thread = threading.get_ident()
+        seen_threads: list[int] = []
+        original = state.push_update_progress
 
-        async def fake_exec(*args, **kwargs):
-            proc = MagicMock()
-            proc.communicate = AsyncMock(
-                side_effect=[asyncio.TimeoutError, (b"", b"")]
-            )
-            proc.kill = MagicMock(side_effect=ProcessLookupError)
-            proc.returncode = -9
-            return proc
+        def _record(step, detail):
+            seen_threads.append(threading.get_ident())
+            original(step, detail)
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
-        assert await _venv_pip_install(str(proj), state) is False
-        assert any("pip install timed out" in e for e in errors), errors
+        state.push_update_progress = _record
+
+        def fake_sync(repo, target_py, emit=None, timeout=None):
+            # Called on the executor thread — assert that, so the test cannot pass
+            # by accident if the install stops being offloaded.
+            assert threading.get_ident() != loop_thread
+            emit("dep-sync: installing 3 declared requirements", False)
+            return 0
+
+        monkeypatch.setattr(dep_sync, "sync_or_reinstall", fake_sync)
+        assert await _venv_pip_install(str(proj), state) is True
+
+        assert seen_threads, "expected at least one progress push"
+        assert set(seen_threads) == {loop_thread}, seen_threads
 
     @pytest.mark.asyncio
     async def test_stderr_is_redacted(self, monkeypatch, tmp_path) -> None:
-        """Credentials and exfil URLs in pip stderr are redacted before display."""
+        """Credentials and exfil URLs in pip stderr are redacted before display.
+
+        dep_sync hands pip's captured text over RAW — it has no idea where its
+        caller publishes it — so redaction belongs here, at the publishing edge.
+        """
         proj = _make_pip_proj(tmp_path)
+        from kiro_crew import dep_sync
         from kiro_crew.dashboard.handlers.updates import _venv_pip_install
 
         state = _make_state(monkeypatch, tmp_path)
         errors = _track_errors(state)
 
-        async def fake_exec(*args, **kwargs):
-            proc = MagicMock()
-            proc.communicate = AsyncMock(
-                return_value=(b"", b"failed: AKIAIOSFODNN7EXAMPLE token leaked")
-            )
-            proc.returncode = 1
-            return proc
+        def fake_sync(repo, target_py, emit=None, timeout=None):
+            emit("failed: AKIAIOSFODNN7EXAMPLE token leaked", True)
+            return 1
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(dep_sync, "sync_or_reinstall", fake_sync)
         assert await _venv_pip_install(str(proj), state) is False
         # The raw AWS access key id should NOT appear verbatim in the error string.
         assert errors, "expected an error to be reported"


### PR DESCRIPTION
## What

Routes the four remaining editable-reinstall call sites through the
dependency-only sync PR #4541 built, and hoists that module to
`kiro_crew.dep_sync` so core does not import from a builtin app.

| Call site | Before | After |
|---|---|---|
| `dashboard/handlers/updates.py::_venv_pip_install` | `pip install -e .` into the gateway's own venv | `dep_sync.sync_or_reinstall` |
| `slack/gateway.py::_auto_apply_update` | same, inline | `dep_sync.sync_or_reinstall` |
| `cli_server.py::_update` | same, inline | `dep_sync.sync_or_reinstall` |
| `_bootstrap.py::_self_heal` | **returned early on win32 — never healed there** | heals, via the dependency-only path |

Closes #4601.

## Why

An editable install serves source from `src`, so a merged revision is live
without a reinstall; the only thing the reinstall still buys is a dependency the
revision added, and installing a dependency never touches the project's own
console script. Windows locks the running `kirocrew.exe`, so on the ordinary
single-checkout layout the reinstall cannot succeed — and pip's uninstall is not
atomic: by the time it reaches the locked script it has renamed the dist-info
aside and deleted the editable `.pth`, and rolls back neither. The venv is left
unable to import the package at all, and that stays invisible until the next
restart fails.

`_bootstrap` was the sharpest case. The one path whose entire purpose is
repairing a stale editable install skipped itself on the platform that needs it
most, and printed a manual one-liner instead.

## Where the module lives

`dep_sync` moves to `kiro_crew.dep_sync` (a `git mv`, so history follows). Three
of the four new callers are core; a Dev Fleet home would invert the dependency
direction. This was the open maintainer decision on the issue.

It imports the **standard library only**, now enforced by a test that reads the
module's AST. `_bootstrap` calls into it precisely when a declared dependency is
missing, so a third-party import here would fail in the one case the module
exists to repair. That is also the concrete answer to the
`packaging.SpecifierSet` route raised on #4541: it is the better parser, and
adopting it would break the caller that cannot assume its own dependencies are
installed. The `pip install --dry-run --report` route is untouched here and
still worth a separate spike — it makes a reachable index a precondition of a
step whose whole point is working on a machine where the reinstall just failed.

## One entry point

`sync_or_reinstall(repo, target_py, emit, timeout)` picks the path: the editable
reinstall wherever pip can still run it, the substitute where it cannot. The
reinstall stays the **default** deliberately — it is the fuller operation and
the only one that rewrites a repointed console script, so substituting where pip
would have worked would quietly downgrade every caller on every platform.

It refuses a venv serving a **different checkout before it picks a branch**, so
both paths are covered. `sync()` asks the same question again for its own sake:
it is also reached directly, as a module run by path, which is how the Dev Fleet
sync invokes it, so it cannot delegate its safety to a caller. The duplicate
probe costs one short interpreter call against an install measured in seconds.

A refusal exits with `REFUSED`, distinct from an install that was attempted and
failed. The two demand opposite handling: a caller that reacts to a failed
install by repairing what it can must **not** run that repair after a refusal,
since the refusal's whole point is that this venv is not ours to write to.

`timeout` bounds pip on **either** branch. A killed dependency install is
rerunnable and a partial set is already this module's stated exposure, while an
unbounded one hangs the surface that called it.

**pip's output is captured on both branches** and handed to `emit` rather than
streamed to the inherited stdio. pip echoes the index URL it resolved against,
and an authenticated index carries its credential there — on the in-process
paths the inherited stderr is the gateway's own log, so streaming writes that
credential to a file nobody reviews. Routing it through `emit` puts it in front
of the caller that knows where it is about to be published and is the one
redacting it. The cost is line-by-line observability on a long install, which is
the right thing to give up here.

Callers pass `emit` and receive every message they used to scrape from a
subprocess's streams — the refusals in particular, each of which names the
remedy the operator must run by hand. The output arrives **raw**, so the
surfaces that publish it redact and cap it themselves. The dashboard hands it to
the serving loop with `call_soon_threadsafe`: the callback runs on an executor
thread while `push_update_progress` writes loop-bound SSE state, so calling it
inline is a cross-thread mutation that works until a client is actually
connected. `_bootstrap` also folds it to ASCII, since it prints before
`ensure_utf8_console()`.

## Behaviour changes that are not just "route the call sites"

Four, called out because approving the routing means approving these too.

1. **Both install paths now refuse a venv serving a different checkout, on every
   platform.** `<repo>/.venv` is where the interpreter was found, not proof of
   what it is an install of. Against such a venv `pip install -e .` silently
   repoints its editable install at this repo, so that other checkout's gateway
   becomes this code on its next restart. The dependency-only path always
   refused this; the reinstall path did not — the safer path was the only
   guarded one. This is the First Principles finding deferred from #4541.
2. **The Slack auto-update no longer restarts after a dependency sync that did
   not come back clean**, whatever the core-dep repair then did. The reset has
   already moved the tree, and every nonzero result names something a restart
   cannot fix by itself: dependencies still unsatisfied (the repair covers the
   *core* deps, not whatever the revision actually added), or a console script
   the revision repointed, which no dependency install rewrites — this restart
   uses `-m kiro_crew` and would survive that, but the next restart through the
   service manager runs `kirocrew` and would not. The trade is explicit: a
   failed auto-update leaves the gateway on its previously loaded code until the
   operator finishes the install, and the progress feed says exactly that.
   `REFUSED` returns even earlier, before the repair, since that repair would
   write into the very venv the guard just protected.
3. **Install deadlines are raised**: the dashboard endpoint 120s → 600s, the
   Slack auto-update 400s → 600s. The bound now covers a dependency install that
   may resolve, download and build a wheel, where 120s is a routine rather than
   exceptional overrun. Both remain real bounds — pip's child is killed on
   expiry.
4. **The Slack deadline moved onto that child** from an `asyncio.wait_for`
   around the executor. Cancelling a `wait_for` does not cancel the thread it
   waits on, so expiry reported failure while a live pip kept writing to the
   venv and permanently occupied a `subprocess_executor` thread.

Also: `installed_package_origin` no longer raises when the interpreter cannot be
run. Callers resolve that path by a filesystem check, so a venv deleted between
the check and the probe raised `OSError` out of a request handler. It now
answers `None`, which the guard reads as "cannot be shown to serve this
checkout" — a deliberate fail-closed that does collapse "unrunnable" into
"foreign", so a refusal report post-ship is worth looking at here first. Every
surface prints the remedy, so the cost is a manual step, not damage.

## Testing

- `test/test_dep_sync.py` (renamed with the module): the lock probe moves here
  with the code it feeds, plus coverage for `sync_or_reinstall` — reinstall
  preferred when nothing is locked, substitute when something is, the guard
  firing on the reinstall branch (refusing *before* probing the lock, so nothing
  installs), `REFUSED` distinct from a failed attempt, `timeout` reaching both
  branches, a timed-out install reporting "may be partially installed" instead
  of the refusal wording that would claim nothing was installed, pip's output
  reaching `emit` and appearing on neither `stdout` nor `stderr`, undecodable
  pip bytes surviving, the stdlib-only invariant, and the unrunnable
  interpreter.
- `test/test_bootstrap.py`: the `skips_windows` test is **replaced** by one
  asserting Windows heals through the substitute; new tests for the ASCII-only
  output and the bound reaching the substitute.
- `test/test_update_venv_detection.py`: progress is published on the loop
  thread, not the executor thread that runs the install.
- `test/test_slack_gateway.py`: a `REFUSED` sync skips the core-dep repair
  entirely (no pip spawn at all) and does not restart; an unclean sync does not
  restart even when the repair *succeeds*; and neither does one where the repair
  also fails.
- `test/test_dev_fleet_app.py`: the foreign-venv refusal, parametrized over both
  install branches, because that asymmetry was the bug.
- Three suites had tests that mocked `asyncio.create_subprocess_exec` and, after
  the change, **really invoked pip** — including one redaction test that passed
  without exercising redaction at all. All re-pointed at the new seam. Adding
  the pre-branch guard also exposed two tests that had started passing for the
  wrong reason, since the guard's refusal produced the same `False` they were
  asserting.
- `test/test_spawn_audit.py`: allowlist keys follow the module; three entries
  whose functions no longer spawn are removed rather than left to mask a future
  regression at the same key.

Local gates on Windows: isort, flake8, `black --target-version py310` on the two
files whose paths this change adds, and `mypy --platform linux src/kiro_crew/` —
3 pre-existing errors in `wecom/client.py`, byte-identical to `origin/main`.
1034 passed across the nine affected suites; the 12 remaining
`test_dev_fleet_app.py` failures are the documented Windows-only baseline set
(identical names on clean `origin/main`).
