### PR TITLE
fix(agent): treat a temp-dir checkout as ephemeral for the shared agent home

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -55,6 +55,7 @@ from kiro_crew.config import config_path as _mc_config_path
 from kiro_crew.config.paths import (
     _in_ephemeral_tree,
     _in_linked_git_worktree,
+    _under_system_tmp,
     _valid_override_home,
     isolated_agents_dir,
     kiro_agents_dir,
@@ -2675,7 +2676,52 @@ def _decline_shared_agent_home(*, audit: bool = True) -> Path | None:
     # home and then found no agents). A pod needs no arm here: ``build_pod_env``
     # gives it its own ``KIRO_HOME``, so its target is its own dedicated directory
     # and the private-target exemption above already lets it through.
-    ephemeral = _in_linked_git_worktree(Path(__file__).resolve())
+    #
+    # A checkout under the system temp directory is the third positive signal:
+    # like a linked worktree and a pod, its teardown is a matter of WHEN, not
+    # whether — temp trees are reaped by the OS, by CI, and by the automation
+    # that cloned them (a per-task scratch clone is created and deleted around a
+    # single job). A spec stamped from one names a launcher venv, and possibly a
+    # pinned data home, that stop existing when the tree goes; #4781 documents
+    # both live failure modes (ENOENT-dead managed servers, and empty-credential
+    # ``internal_auth_mismatch`` when the pinned home is recreated empty). This
+    # is checked on the CHECKOUT location (``__file__``), not the data home, so
+    # the offline E2E harness — which runs the REPO checkout on a temp data
+    # home — is unaffected, exactly the regression the note above records.
+    #
+    # An AppImage's runtime mount is carved back OUT of that arm. It sits under
+    # the temp root (``/tmp/.mount_<name>XXXXXX``) and the mount itself is indeed
+    # reaped on exit, but the temp signal's premise — a spec outliving the only
+    # instance that would have written it — inverts here: a DURABLE install (the
+    # ``.AppImage`` file on disk) stands behind the mount and re-runs this on
+    # every start, and because the runtime picks a NEW random mount each launch,
+    # rewriting the spec per start is the only way its managed servers ever
+    # resolve. Declining would freeze the spec on a previous launch's mount path
+    # and ENOENT every managed server — manufacturing #4781's own symptom on a
+    # shipped channel — and on a fresh install would leave no spec at all
+    # (``Mode 'kirocrew' not found``). ``_in_ephemeral_tree`` is the same
+    # AppImage-precise predicate the launcher installer uses; the temp-root rule
+    # it declines is the one being narrowed here, not adopted.
+    #
+    # The temp arm also declines only when there is something to preserve. This
+    # guard's entire remedy is "use the specs that already worked" — the log line
+    # below says exactly that — and with no spec present there are none, so
+    # declining does not protect a shared resource, it just leaves the install
+    # dead (every turn fails with ``Mode 'kirocrew' not found``). #4781's harm is
+    # specifically an OVERWRITE of a working spec, which this still refuses: the
+    # spec is present in every reported instance of it. A spec that exists but is
+    # already stale stays stale, same as under the worktree arm — repairing it is
+    # the durable install's job on its next start, and it rewrites unconditionally.
+    # Deliberately scoped to this arm: the worktree and pod arms predate this fix
+    # and their populations were chosen on their own grounds, so widening them is
+    # a separate decision, not a side effect of adding a third signal.
+    checkout = Path(__file__).resolve()
+    temp_scratch = (
+        _under_system_tmp(checkout)
+        and not _in_ephemeral_tree(checkout)
+        and (target / AGENT_FILENAME).exists()
+    )
+    ephemeral = _in_linked_git_worktree(checkout) or temp_scratch
     if not ephemeral:
         # A GRANT over the shared resource, so it is audited like the denial
         # below: every permission decision about the machine-wide agent home is

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -388,6 +389,62 @@ def _in_ephemeral_tree(path: Path, env: Mapping[str, str] | None = None) -> bool
     # `.mount_` is the AppImage runtime's own prefix, so this does not condemn
     # unrelated temp paths.
     return any(part.startswith(".mount_") for part in path.parts)
+
+
+def _under_system_tmp(path: Path) -> bool:
+    """Whether *path* lives under the system temp directory.
+
+    Ephemerality signal for the shared-agent-home guard
+    (``agent._decline_shared_agent_home``): a CHECKOUT under the temp root is
+    throwaway by construction — the OS reaps it on reboot, CI reaps it per job,
+    and the automation that clones a per-task scratch tree deletes it when the
+    task ends. A machine-wide agent spec stamped from such a checkout outlives
+    it and leaves every managed MCP server pointing at a launcher (and possibly
+    a pinned data home) that no longer exists (#4781).
+
+    Deliberately NOT folded into :func:`_in_ephemeral_tree`. That predicate
+    serves the launcher installer, which rejected a blanket temp-dir rule on
+    its own grounds (see its docstring): a dangling launcher is caught by the
+    interpreter being gone, and declining costs a legitimate temp install its
+    global command. The agent-home guard makes the opposite call because its
+    artifact is shared machine-wide and declining costs nothing durable — the
+    instance simply uses the specs that already worked. It does subtract the one
+    temp resident that is a durable install in disguise: an AppImage's runtime
+    mount, excluded at that call site via :func:`_in_ephemeral_tree`. This
+    predicate stays a plain "is it under the temp root" answer so each caller
+    keeps its own exemptions.
+
+    Compared on RESOLVED paths on both sides, so a symlinked temp root (macOS
+    ``/tmp`` -> ``/private/tmp``, ``/var/folders`` -> ``/private/var/folders``)
+    and a symlink into the tree land in the same namespace.
+
+    TWO roots are answered against, not one. ``tempfile.gettempdir()`` is the
+    root as configured AT CALL TIME (it honours ``$TMPDIR``), matching how the
+    rest of this module treats redirected environments — but on macOS launchd
+    sets ``$TMPDIR`` to a per-user ``/var/folders/.../T``, so ``gettempdir()``
+    alone does NOT contain ``/tmp``, and ``/tmp/<scratch clone>`` — the literal
+    shape #4781 reports — would read as durable there. POSIX ``/tmp`` is
+    therefore checked as well: it is reaped on reboot by contract, so nothing
+    durable lives under it. ``/var/tmp`` deliberately is not: POSIX has it
+    PRESERVED across reboots, which is the opposite claim.
+
+    That literal is added on POSIX ONLY. ``Path("/tmp")`` is drive-RELATIVE on
+    Windows, so ``.resolve()`` anchors it to the current drive and yields
+    ``C:\\tmp`` — a path with none of the reboot-reaped meaning the rule rests on,
+    and one a checkout may legitimately live under. Windows keeps
+    ``gettempdir()`` (``%TEMP%``) as its only root. A root that cannot be
+    resolved is skipped rather than guessed.
+    """
+    roots: list[Path] = []
+    candidates = [tempfile.gettempdir()]
+    if os.name == "posix":
+        candidates.append("/tmp")
+    for candidate in candidates:
+        try:
+            roots.append(Path(candidate).resolve())
+        except (OSError, ValueError):  # pragma: no cover - defensive: unusable root
+            continue
+    return any(path == root or root in path.parents for root in roots)
 
 
 def _in_linked_git_worktree(path: Path) -> bool:

--- a/test/test_agent_home_isolation.py
+++ b/test/test_agent_home_isolation.py
@@ -132,6 +132,23 @@ def test_temp_dir_home_is_still_allowed():
     assert not _is_unsafe_home(Path(tempfile.gettempdir()).resolve())
 
 
+def test_under_system_tmp_answers_on_the_call_time_root():
+    """``_under_system_tmp`` covers the temp root and its subtrees, nothing else.
+
+    The DATA-home predicate above deliberately allows a temp-dir home; this
+    CHECKOUT predicate deliberately condemns a temp-dir checkout. Both answer
+    against ``tempfile.gettempdir()`` as configured at call time.
+    """
+    import tempfile
+
+    from kiro_crew.config.paths import _under_system_tmp
+
+    root = Path(tempfile.gettempdir()).resolve()
+    assert _under_system_tmp(root)
+    assert _under_system_tmp(root / "kc-task-1234" / "repo" / "src")
+    assert not _under_system_tmp(Path("/durable-install/KiroCrew").resolve())
+
+
 # --------------------------------------------------------------------------
 # The worktree decline guard
 # --------------------------------------------------------------------------
@@ -290,16 +307,190 @@ def test_global_kiro_home_in_a_worktree_still_declines(monkeypatch, tmp_path):
     ), "a globally exported KIRO_HOME bypassed the guard"
 
 
-def test_does_not_decline_from_an_ordinary_clone(monkeypatch, tmp_path):
+def test_declines_from_a_clone_under_the_temp_dir(monkeypatch, tmp_path):
+    """A throwaway clone under the system temp dir must not own the shared home.
+
+    The #4781 shape: automation clones the repo into a per-task temp directory,
+    something in that tree reaches ``rebuild_agent_config``, and the machine-wide
+    spec ends up naming a launcher venv (and possibly a pinned data home) that is
+    deleted when the task ends.
+
+    The clone is built under ``tempfile.gettempdir()`` — the root the predicate
+    answers against at call time — NOT under ``tmp_path``: pytest's basetemp is
+    created before the suite redirects the tempfile base, so ``tmp_path`` does
+    not live under the redirected root and would miss the arm under test.
+
+    A spec is planted first because that is the harm: #4781 is an OVERWRITE of a
+    working spec, and the guard's remedy ("use the specs that already worked")
+    only exists when one is there. The empty-home case is the next test.
+    """
+    import tempfile
+
     from kiro_crew import agent
 
     monkeypatch.delenv("KIRO_HOME", raising=False)
-    # No isolated data home either: an ordinary install owns its shared specs.
     monkeypatch.delenv("KIROCREW_HOME", raising=False)
-    clone = tmp_path / "KiroCrew"
-    (clone / "src" / "kiro_crew").mkdir(parents=True)
-    (clone / ".git").mkdir()  # a DIRECTORY -> ordinary clone
-    monkeypatch.setattr(agent, "__file__", str(clone / "src" / "kiro_crew" / "agent.py"))
+    shared = tmp_path / "agents"
+    shared.mkdir()
+    (shared / agent.AGENT_FILENAME).write_text("{}", encoding="utf-8")
+    with tempfile.TemporaryDirectory(prefix="kc-clone-") as scratch_name:
+        clone = Path(scratch_name) / "repo"
+        (clone / "src" / "kiro_crew").mkdir(parents=True)
+        (clone / ".git").mkdir()  # a DIRECTORY -> ordinary clone, not a worktree
+        monkeypatch.setattr(agent, "__file__", str(clone / "src" / "kiro_crew" / "agent.py"))
+        _pretend_target_is_shared(monkeypatch, agent, shared)
+
+        assert (
+            agent._decline_shared_agent_home() is not None
+        ), "a temp-dir clone was allowed to rewrite the shared agent home"
+
+
+def test_does_not_decline_from_a_temp_clone_when_no_spec_exists(monkeypatch, tmp_path):
+    """With an EMPTY shared home the temp arm must write, not decline.
+
+    Declining is only ever a redirect to "the specs that already worked". When
+    there are none, refusing protects nothing and leaves the install with no
+    spec at all -- every turn then fails with ``Mode 'kirocrew' not found``.
+    """
+    import tempfile
+
+    from kiro_crew import agent
+
+    monkeypatch.delenv("KIRO_HOME", raising=False)
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    with tempfile.TemporaryDirectory(prefix="kc-clone-") as scratch_name:
+        clone = Path(scratch_name) / "repo"
+        (clone / "src" / "kiro_crew").mkdir(parents=True)
+        (clone / ".git").mkdir()
+        monkeypatch.setattr(agent, "__file__", str(clone / "src" / "kiro_crew" / "agent.py"))
+        # Target resolves shared but holds no spec -> nothing to preserve.
+        _pretend_target_is_shared(monkeypatch, agent, tmp_path / "agents")
+
+        assert agent._decline_shared_agent_home(audit=False) is None, (
+            "an empty shared agent home was refused its first spec, so the install "
+            "would have no agent to run"
+        )
+
+
+def test_does_not_decline_from_an_appimage_runtime_mount(monkeypatch, tmp_path):
+    """An AppImage lives under the temp root yet must keep writing its specs.
+
+    The runtime unpacks to ``/tmp/.mount_<name>XXXXXX`` and picks a NEW random
+    mount every launch, so the durable ``.AppImage`` behind it can only have
+    working managed servers by rewriting the spec on each start. Declining would
+    freeze the spec on a previous launch's mount and ENOENT every managed server
+    -- #4781's own symptom, manufactured on a shipped channel -- and on a fresh
+    install would leave no spec at all.
+    """
+    import tempfile
+
+    from kiro_crew import agent
+
+    monkeypatch.delenv("KIRO_HOME", raising=False)
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    monkeypatch.delenv("APPDIR", raising=False)  # env-free child: `.mount_` is the signal
+    with tempfile.TemporaryDirectory(prefix="kc-appimage-") as scratch_name:
+        mount = Path(scratch_name) / ".mount_KiroXk3Qm9"
+        (mount / "usr" / "lib" / "kiro_crew").mkdir(parents=True)
+        monkeypatch.setattr(
+            agent, "__file__", str(mount / "usr" / "lib" / "kiro_crew" / "agent.py")
+        )
+        _pretend_target_is_shared(monkeypatch, agent, tmp_path / "agents")
+
+        assert agent._decline_shared_agent_home(audit=False) is None, (
+            "an AppImage runtime mount was refused the shared agent home, so its "
+            "managed servers would stay pinned to a stale mount path"
+        )
+
+
+def test_under_system_tmp_covers_posix_tmp_when_tmpdir_points_elsewhere(monkeypatch, tmp_path):
+    """The macOS shape: ``$TMPDIR`` is per-user, so ``/tmp`` needs its own arm.
+
+    launchd sets ``$TMPDIR`` to ``/var/folders/.../T``, so ``gettempdir()`` does
+    not contain ``/tmp`` there — and ``/tmp/kc-fix-XXXX`` is the literal clone
+    path #4781 reports. Simulated by pointing ``gettempdir()`` away from
+    ``/tmp``, which is what the platform difference amounts to.
+
+    POSIX-only: on Windows ``/tmp`` is a drive-relative path with no reboot-reaped
+    meaning, which is exactly why the predicate documents it as never matching
+    there.
+    """
+    import tempfile as _tempfile
+
+    if sys.platform == "win32":
+        pytest.skip("no POSIX /tmp tree on Windows")
+
+    from kiro_crew.config import paths as paths_mod
+
+    monkeypatch.setattr(_tempfile, "gettempdir", lambda: str(tmp_path / "T"))
+
+    assert paths_mod._under_system_tmp(Path("/tmp/kc-fix-4781/repo/src")) is True
+    # And the configured root still answers, so neither arm shadows the other.
+    assert paths_mod._under_system_tmp(tmp_path / "T" / "scratch") is True
+    assert paths_mod._under_system_tmp(Path("/var/tmp/durable")) is False
+
+
+def test_under_system_tmp_omits_the_posix_literal_off_posix(monkeypatch, tmp_path):
+    """``/tmp`` is drive-relative on Windows, so the literal arm must not apply.
+
+    ``Path("/tmp").resolve()`` anchors to the current drive there (``C:\\tmp``),
+    which carries none of the reboot-reaped meaning the rule rests on and may
+    hold a perfectly durable checkout. Asserted NATIVELY on Windows rather than
+    by simulating ``os.name``: pathlib picks its flavour from that same name, so
+    patching it cannot instantiate a path at all.
+    """
+    import tempfile as _tempfile
+
+    from kiro_crew.config import paths as paths_mod
+
+    if sys.platform != "win32":
+        pytest.skip("the drive-relative resolution being pinned is Windows-only")
+
+    monkeypatch.setattr(_tempfile, "gettempdir", lambda: str(tmp_path / "T"))
+    drive_tmp = Path("/tmp").resolve()
+    if drive_tmp == (tmp_path / "T").resolve() or drive_tmp in (tmp_path / "T").resolve().parents:
+        pytest.skip("this host's %TEMP% is itself under the drive-anchored /tmp")
+
+    assert paths_mod._under_system_tmp(drive_tmp / "kc-fix-4781" / "repo") is False
+    # The configured root is still the one root every platform keeps.
+    assert paths_mod._under_system_tmp(tmp_path / "T" / "scratch") is True
+
+
+def test_under_system_tmp_still_answers_yes_for_an_appimage_mount():
+    """The carve-out belongs to the CALLER, not to the predicate.
+
+    ``_under_system_tmp`` stays a plain "is it under the temp root" answer so a
+    second caller is not silently handed the agent-home guard's exemption.
+
+    The probe path is resolved because the predicate resolves only its ROOTS and
+    documents the caller as resolving the path: on Windows ``gettempdir()``
+    hands back an 8.3 short form (``RUNNER~1``) that is unequal to the long form
+    the root resolves to, so an unresolved probe would miss there and there
+    only.
+    """
+    import tempfile
+
+    from kiro_crew.config.paths import _in_ephemeral_tree, _under_system_tmp
+
+    mount = (Path(tempfile.gettempdir()) / ".mount_KiroXk3Qm9" / "usr" / "lib").resolve()
+    assert _under_system_tmp(mount) is True
+    assert _in_ephemeral_tree(mount, env={}) is True
+
+
+def test_does_not_decline_from_a_durable_clone(monkeypatch, tmp_path):
+    """An ordinary install outside the temp dir still owns its shared specs.
+
+    The path is fabricated (never created) precisely because a real path a test
+    can create lives under the redirected temp root: the guard's predicates are
+    lexical on the resolved path, so existence is not required, and a
+    non-temp, non-worktree location is the durable-install shape.
+    """
+    from kiro_crew import agent
+
+    monkeypatch.delenv("KIRO_HOME", raising=False)
+    monkeypatch.delenv("KIROCREW_HOME", raising=False)
+    durable = Path("/durable-install/KiroCrew/src/kiro_crew/agent.py")
+    monkeypatch.setattr(agent, "__file__", str(durable))
     _pretend_target_is_shared(monkeypatch, agent, tmp_path / "agents")
 
     assert agent._decline_shared_agent_home() is None
@@ -372,10 +563,12 @@ def test_allowed_shared_home_write_is_audited(monkeypatch, tmp_path):
     monkeypatch.delenv("KIRO_HOME", raising=False)
     monkeypatch.delenv("KIROCREW_HOME", raising=False)
     monkeypatch.delenv("KIROCREW_POD", raising=False)
-    clone = tmp_path / "KiroCrew"
-    (clone / "src" / "kiro_crew").mkdir(parents=True)
-    (clone / ".git").mkdir()
-    monkeypatch.setattr(agent, "__file__", str(clone / "src" / "kiro_crew" / "agent.py"))
+    # Fabricated non-temp location: a clone created under tmp_path would now be
+    # (correctly) declined by the temp-dir arm, and this test is about the GRANT
+    # branch. The predicates are lexical on the resolved path, so the file need
+    # not exist.
+    durable = Path("/durable-install/KiroCrew/src/kiro_crew/agent.py")
+    monkeypatch.setattr(agent, "__file__", str(durable))
     _pretend_target_is_shared(monkeypatch, agent, tmp_path / "agents")
 
     assert agent._decline_shared_agent_home() is None


### PR DESCRIPTION
## What is the problem?

`_decline_shared_agent_home` (`src/kiro_crew/agent.py`) exists to stop a throwaway KiroCrew instance from rewriting the machine-wide agent home, because the specs it writes outlive it. Its ephemerality predicate enumerates two positive signals - a linked git worktree and a pod (`KIROCREW_POD`) - so a **throwaway clone** (a fresh `git clone` into a temp directory with its own venv, which automation creates per task and deletes when the task ends) is neither, takes the "ordinary install writing its own shared home" branch, and is allowed to rewrite `<kiro home>/agents/kirocrew.json`.

## Why this issue matters to the user

The poisoned spec outlives the clone and breaks every NEW session on every gateway on the machine, in two observed shapes:

1. `command` names the clone's venv launcher; once the clone is deleted, kiro-cli gets ENOENT and every first-party MCP tool silently disappears, reported only as "A tool with the name '<x>' does not exist".
2. When the writer ran with a `KIROCREW_HOME` override (a test run inside the clone), `env.KIROCREW_HOME` pins a temporary data home; after it is deleted the home is recreated EMPTY on first use, `read_local_secret()` returns an empty string, and every HTTP internal call fails `internal_auth_mismatch` with `received=absent` - `spawn_run`, `learn_add`, `cron_*` all die while in-process tools keep working.

Both self-heal on gateway restart (boot re-runs `rebuild_agent_config`) and recur on the next scratch-clone run, so the failure looks intermittent and resistant to fixing.

## How our fix solves it

Chain from symptom to root cause: empty-credential 403s / vanished tools -> new sessions spawn managed servers from a dead tree -> the machine-wide spec names that tree -> the guard allowed the write because its ephemerality predicate did not recognize a temp-dir clone.

The fix adds the missing positive signal at the guard: a checkout under the system temp directory (`_under_system_tmp`, new in `src/kiro_crew/config/paths.py`) is ephemeral for the same reason a linked worktree and a pod are - its teardown is a matter of when, not whether. Scope decisions:

- Checked on the CHECKOUT location (`__file__`), not the data home, so the offline E2E harness - which runs the repo checkout on a temp data home - keeps writing its own (private-target) specs, exactly the regression the guard's docstring records from an earlier attempt.
- Deliberately NOT folded into `_in_ephemeral_tree`: that predicate serves the launcher installer, which rejected a blanket temp-dir rule on its own grounds (a dangling launcher is caught by `_bin_is_usable`, and declining costs a legitimate temp install its global command). The agent-home guard makes the opposite call because its artifact is machine-wide and declining costs nothing durable - the instance simply uses the specs that already worked.
- Compared on resolved paths against `tempfile.gettempdir()` at call time, so symlinked temp roots (macOS `/private/...`) land in the same namespace.

## What tests we did

- `test_declines_from_a_clone_under_the_temp_dir`: the #4781 shape, mutation-verified (reverting the one-line predicate change makes it fail).
- `test_does_not_decline_from_a_durable_clone`: an ordinary install outside the temp dir still owns its shared specs (replaces the old `test_does_not_decline_from_an_ordinary_clone`, whose clone lived under pytest tmp - the exact shape this fix condemns).
- `test_under_system_tmp_answers_on_the_call_time_root`: direct unit coverage of the new predicate (root, subtree, non-temp).
- `test_allowed_shared_home_write_is_audited` updated to exercise the grant branch from a durable location.
- Full touched-area run green: `test_agent_home_isolation.py`, `test_agent.py`, `test_agent_spec_preflight.py`, `test_kiro_prerequisite.py` (386 passed, 1 skipped). flake8/mypy clean; changed lines black-clean (the file carries pre-existing baseline-listed formatting, left untouched).

## Any other suggestions on the work

- The empty-credential symptom has a second, independent trigger: the test suite's isolation fixture redirects the data home but not the agent-spec home, so a test run from a NON-temp checkout can still write the shared spec. That seam is #4912 and is not addressed here.
- Issue #4781 also lists two hardening directions (spawn-failure legibility / `doctor` flagging dead managed commands, and re-validating the `_KIROCREW_BIN` module cache). Both are independently landable and left out of this minimal guard fix.

Closes #4781
