### PR TITLE
fix(desktop): leave macOS fullscreen before hiding the window to the tray

### DIFF
--- a/website/electron/hide-to-tray.js
+++ b/website/electron/hide-to-tray.js
@@ -1,0 +1,182 @@
+"use strict";
+//
+// Pure, injectable helper extracted from main.js so the "never hide a window out
+// of a macOS fullscreen Space" rule is unit-testable without Electron (mirrors
+// blocking-prompt.js / window-state.js / gateway-recovery.js).
+//
+// PROBLEM: on macOS the main window's close button does NOT destroy the window —
+// the app keeps running in the tray, so `close` is preventDefault'ed and the
+// window is hidden instead. Hiding a window that occupies a NATIVE macOS
+// fullscreen Space leaves that Space behind with nothing drawing into it, and
+// three symptoms follow:
+//   - a black full-screen surface the user is left staring at, because the Space
+//     is still mapped but its only window is gone;
+//   - the app still reporting as running (that part is intended tray behaviour,
+//     but next to the black Space it reads as a hang);
+//   - a re-show mapping the window while it is still flagged fullscreen with its
+//     Space destroyed, so it comes back at a degenerate frame — the "very small
+//     window" that only corrects once AppKit re-lays-out after a couple of
+//     focus changes.
+//
+// FIX: leave native fullscreen FIRST, and hide only once macOS has actually torn
+// the Space down. setFullScreen(false) is ASYNCHRONOUS on macOS (there is a
+// ~0.5s Space animation), so the hide has to wait for the `leave-full-screen`
+// event rather than run on the next line — hiding mid-transition reproduces the
+// very bug this avoids.
+//
+// Simple-fullscreen and kiosk are deliberately NOT touched. Neither allocates a
+// Space, so hiding out of them is already clean, and clearing them would
+// silently change the mode the user returns to. This helper is narrower than
+// blocking-prompt.js's exitImmersiveModes() on purpose: that one restores window
+// CHROME so an in-window prompt stays dismissable, which is a different goal.
+//
+// SCOPE: macOS only, for the same reason. Windows and Linux fullscreen is a
+// borderless maximized window with no Space behind it, so hiding out of it is
+// already clean there — and exiting fullscreen on those platforms would be a
+// visible regression, since the window would come back windowed and the geometry
+// listener would persist it as windowed for the next launch too. Off darwin this
+// stays exactly the plain hide it has always been.
+
+// How long to wait for `leave-full-screen` before hiding anyway. Generous
+// relative to the ~0.5s macOS Space animation.
+const DEFAULT_LEAVE_TIMEOUT_MS = 2000;
+
+const isDead = (win) => {
+  try {
+    return typeof win.isDestroyed === "function" && win.isDestroyed();
+  } catch {
+    return true;
+  }
+};
+
+/**
+ * Hide a window to the tray without orphaning a macOS fullscreen Space.
+ *
+ * Best-effort and defensive: every probe is guarded, a destroyed window is a
+ * no-op, and the window is hidden at most once no matter which path gets there
+ * first.
+ *
+ * @param {object} win  A BrowserWindow/BaseWindow-like object. Only the
+ *                      isDestroyed / isFullScreen / setFullScreen / once / off /
+ *                      hide members are used, each optional.
+ * @param {{isMac?:boolean, timeoutMs?:number, setTimeoutFn?:Function, clearTimeoutFn?:Function}} [opts]
+ *                      `isMac` defaults to the real platform; the rest is timer
+ *                      injection for tests.
+ * @returns {{hidden: boolean, deferred: boolean, leftFullScreen: boolean}}
+ *                      `hidden` — hidden synchronously during this call.
+ *                      `deferred` — hide is pending on the fullscreen exit.
+ *                      `leftFullScreen` — setFullScreen(false) was issued.
+ */
+function hideToTray(win, opts = {}) {
+  const result = { hidden: false, deferred: false, leftFullScreen: false };
+  if (!win || isDead(win)) return result;
+
+  const hideNow = () => {
+    // Re-probe: between scheduling and firing, the window may have been
+    // destroyed (a real quit racing the fullscreen animation).
+    if (isDead(win)) return false;
+    try {
+      if (typeof win.hide !== "function") return false;
+      win.hide();
+      return true;
+    } catch {
+      return false; // best effort — never let a hide throw past the caller
+    }
+  };
+
+  // Only macOS puts a fullscreen window in a Space of its own, so only macOS can
+  // orphan one. Everywhere else this must stay the plain hide it was, or a
+  // fullscreen window would reopen windowed on platforms that never had the bug.
+  const isMac = opts.isMac === undefined ? process.platform === "darwin" : !!opts.isMac;
+  if (!isMac) {
+    result.hidden = hideNow();
+    return result;
+  }
+
+  let fullScreen = false;
+  try {
+    fullScreen = typeof win.isFullScreen === "function" && win.isFullScreen();
+  } catch {
+    fullScreen = false;
+  }
+
+  // Common path: a windowed window has no Space to orphan, so hide immediately.
+  const canDefer =
+    fullScreen && typeof win.setFullScreen === "function" && typeof win.once === "function";
+  if (!canDefer) {
+    result.hidden = hideNow();
+    return result;
+  }
+
+  const setTimer = opts.setTimeoutFn || setTimeout;
+  const clearTimer = opts.clearTimeoutFn || clearTimeout;
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_LEAVE_TIMEOUT_MS;
+
+  let settled = false;
+  let timer = null;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    if (timer !== null) {
+      try {
+        clearTimer(timer);
+      } catch {
+        /* best effort */
+      }
+      timer = null;
+    }
+    // `once` only self-removes when it actually FIRES, so if the backstop got
+    // here first the listener would stay armed for the life of the process and
+    // accumulate one per swallowed transition. Harmless individually, but it is
+    // the listener leak that eventually trips MaxListenersExceededWarning.
+    try {
+      const off =
+        typeof win.off === "function"
+          ? win.off
+          : typeof win.removeListener === "function"
+            ? win.removeListener
+            : null;
+      if (off) off.call(win, "leave-full-screen", finish);
+    } catch {
+      /* best effort */
+    }
+    hideNow();
+  };
+
+  try {
+    win.once("leave-full-screen", finish);
+  } catch {
+    // Cannot observe the transition, so a deferred hide would never land.
+    result.hidden = hideNow();
+    return result;
+  }
+
+  // Backstop: if AppKit swallows the transition (a fullscreen animation already
+  // in flight, or the event otherwise never lands) the close button would
+  // silently do nothing at all — a worse outcome than the Space we are avoiding.
+  // Hide anyway once the animation window has comfortably passed.
+  try {
+    timer = setTimer(finish, timeoutMs);
+    // Node/Electron timers keep the event loop alive; a pending hide must never
+    // be the reason the process lingers on a real quit.
+    if (timer && typeof timer.unref === "function") timer.unref();
+  } catch {
+    /* best effort — the leave-full-screen listener is still armed */
+  }
+
+  try {
+    win.setFullScreen(false);
+    result.leftFullScreen = true;
+  } catch {
+    // The exit never started, so nothing will fire the listener. Hide now
+    // rather than leaving the window mapped until the backstop expires.
+    finish();
+    result.hidden = true;
+    return result;
+  }
+
+  result.deferred = true;
+  return result;
+}
+
+module.exports = { hideToTray, DEFAULT_LEAVE_TIMEOUT_MS };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -19,6 +19,7 @@ const { createTokenRetryHandler } = require("./token-retry");
 const { createRendererRecovery } = require("./renderer-recovery");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { exitImmersiveModes } = require("./blocking-prompt");
+const { hideToTray } = require("./hide-to-tray");
 const { shouldRetryLocalTokenMint, tokenMintRetryDelayMs, TOKEN_MINT_MAX_RETRIES } = require("./token-acquire");
 const { createDisplayMediaHandler } = require("./display-media");
 const {
@@ -2118,7 +2119,13 @@ function createWindow() {
   mainWindow.on("close", (e) => {
     if (!isQuitting) {
       e.preventDefault();
-      mainWindow.hide();
+      // Not a quit — hide to the tray. On macOS this MUST leave a native
+      // fullscreen Space first, or the Space is orphaned as a black surface and
+      // the window later re-shows at a degenerate frame (see hide-to-tray.js).
+      // The hide is deferred to `leave-full-screen` in that case; the existing
+      // geometry listener fires on the same event, so the persisted state
+      // truthfully records the window as windowed at its normal bounds.
+      hideToTray(mainWindow);
       return;
     }
     // Real quit — capture the final geometry synchronously before teardown so

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -145,6 +145,7 @@
       "bundle-location.js",
       "gateway-auth-hint.js",
       "blocking-prompt.js",
+      "hide-to-tray.js",
       "gateway-stop.js",
       "gateway-wait.js",
       "sandbox-profile.js",

--- a/website/electron/test/hide-to-tray.test.js
+++ b/website/electron/test/hide-to-tray.test.js
@@ -1,0 +1,265 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { hideToTray, DEFAULT_LEAVE_TIMEOUT_MS } = require("../hide-to-tray");
+
+// Fake BrowserWindow/BaseWindow recording the calls hideToTray makes. Only the
+// members the helper touches are implemented. `once` captures listeners so a
+// test can fire macOS's asynchronous `leave-full-screen` by hand — the real
+// Space animation takes ~0.5s, which is exactly why the helper cannot hide on
+// the next line.
+function makeWin({ fullScreen = false, destroyed = false, throwOnSetFullScreen = false } = {}) {
+  const calls = [];
+  const listeners = new Map();
+  const win = {
+    calls,
+    listeners,
+    isDestroyed: () => destroyed,
+    isFullScreen: () => fullScreen,
+    setFullScreen: (v) => {
+      if (throwOnSetFullScreen) throw new Error("setFullScreen failed");
+      calls.push(["setFullScreen", v]);
+    },
+    once: (event, fn) => {
+      listeners.set(event, fn);
+    },
+    off: (event, fn) => {
+      if (listeners.get(event) === fn) listeners.delete(event);
+    },
+    hide: () => calls.push(["hide"]),
+    // Test-only: pretend macOS finished tearing the Space down.
+    emitLeaveFullScreen() {
+      const fn = listeners.get("leave-full-screen");
+      assert.ok(fn, "expected a leave-full-screen listener to be armed");
+      fn();
+    },
+    destroy() {
+      destroyed = true;
+    },
+  };
+  return win;
+}
+
+// Controllable timer pair so the backstop is asserted without real waiting.
+function makeTimers() {
+  const scheduled = [];
+  return {
+    scheduled,
+    setTimeoutFn: (fn, ms) => {
+      const handle = { fn, ms, cleared: false, unrefed: false, unref() { this.unrefed = true; return this; } };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearTimeoutFn: (handle) => {
+      if (handle) handle.cleared = true;
+    },
+    fire: (i = 0) => scheduled[i].fn(),
+  };
+}
+
+// Every test pins `isMac` rather than inheriting the host platform: the
+// fullscreen behaviour below is macOS-only, and CI runs this suite on Linux and
+// Windows too, where an unpinned test would assert the wrong branch.
+const mac = (extra = {}) => ({ isMac: true, ...extra });
+
+describe("hideToTray", () => {
+  // The common path: closing a windowed window must stay a plain, immediate
+  // hide. A regression here would make the tray close feel laggy for everyone
+  // on every platform, not just the fullscreen case being fixed.
+  it("hides immediately when the window is not fullscreen", () => {
+    const win = makeWin({ fullScreen: false });
+    const result = hideToTray(win, mac());
+    assert.deepEqual(win.calls, [["hide"]]);
+    assert.deepEqual(result, { hidden: true, deferred: false, leftFullScreen: false });
+  });
+
+  // Regression guard for #1000. Hiding a window that owns a native macOS
+  // fullscreen Space orphans the Space as a black surface and leaves the window
+  // flagged fullscreen, so it later re-shows at a degenerate (tiny) frame. The
+  // helper must leave fullscreen and NOT hide yet.
+  it("leaves fullscreen first and does not hide until the Space is torn down", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    const result = hideToTray(win, mac(timers));
+
+    assert.deepEqual(win.calls, [["setFullScreen", false]], "must not hide mid-transition");
+    assert.deepEqual(result, { hidden: false, deferred: true, leftFullScreen: true });
+
+    win.emitLeaveFullScreen();
+    assert.deepEqual(win.calls, [["setFullScreen", false], ["hide"]]);
+  });
+
+  // setFullScreen(false) is async on macOS: hiding on the next line is the bug.
+  // This pins the ORDER, which is the entire fix — an implementation that called
+  // hide() before the event would pass the "eventually hides" assertion above.
+  it("orders the fullscreen exit strictly before the hide", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+    win.emitLeaveFullScreen();
+    assert.deepEqual(win.calls.map(([name]) => name), ["setFullScreen", "hide"]);
+  });
+
+  // Scope guard. Windows/Linux fullscreen is a borderless maximized window with
+  // no Space behind it, so the exit buys nothing there and costs something real:
+  // the window would reopen WINDOWED, and the geometry listener (which persists
+  // on leave-full-screen) would save it as windowed for the next launch too — a
+  // visible regression on two platforms that never had this bug.
+  it("does not touch fullscreen off macOS — a plain hide, as before", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    const result = hideToTray(win, { isMac: false, ...timers });
+
+    assert.deepEqual(win.calls, [["hide"]], "no setFullScreen off darwin");
+    assert.deepEqual(result, { hidden: true, deferred: false, leftFullScreen: false });
+    assert.equal(win.listeners.size, 0, "no listener armed off darwin");
+    assert.equal(timers.scheduled.length, 0, "no backstop timer armed off darwin");
+  });
+
+  // The backstop. If AppKit swallows the transition (an animation already in
+  // flight) the event never lands, and without this the close button would
+  // silently do nothing at all — worse than the orphaned Space.
+  it("hides anyway if leave-full-screen never fires", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+
+    assert.equal(timers.scheduled.length, 1);
+    assert.equal(timers.scheduled[0].ms, DEFAULT_LEAVE_TIMEOUT_MS);
+    assert.deepEqual(win.calls, [["setFullScreen", false]]);
+
+    timers.fire();
+    assert.deepEqual(win.calls, [["setFullScreen", false], ["hide"]]);
+  });
+
+  // `once` only self-removes when it FIRES, so the backstop path would otherwise
+  // leave a listener armed for the life of the process, one per swallowed
+  // transition, until MaxListenersExceededWarning.
+  it("removes the leave-full-screen listener when the backstop wins", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+    assert.equal(win.listeners.size, 1);
+
+    timers.fire();
+    assert.equal(win.listeners.size, 0, "the stale listener must not survive the backstop");
+  });
+
+  // Exactly-once: the event and the backstop race on every real fullscreen
+  // close. A second hide() on an already-hidden window is not merely redundant
+  // — on macOS it can re-order tray/Dock activation state.
+  it("hides exactly once when both the event and the backstop fire", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+
+    const armed = win.listeners.get("leave-full-screen");
+    win.emitLeaveFullScreen();
+    assert.equal(timers.scheduled[0].cleared, true, "the backstop must be cleared on success");
+    timers.fire(); // fire it anyway — a real timer could already be in flight
+    armed(); // and re-enter through the listener the same way a stray event would
+
+    assert.deepEqual(win.calls, [["setFullScreen", false], ["hide"]]);
+  });
+
+  // A pending hide must never be the reason the process lingers on a real quit.
+  it("unrefs the backstop timer", () => {
+    const timers = makeTimers();
+    hideToTray(makeWin({ fullScreen: true }), mac(timers));
+    assert.equal(timers.scheduled[0].unrefed, true);
+  });
+
+  // The quit path destroys the window while the Space animation is still in
+  // flight; hiding a destroyed window throws in Electron.
+  it("does not hide a window destroyed during the fullscreen exit", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+    win.destroy();
+    win.emitLeaveFullScreen();
+    assert.deepEqual(win.calls, [["setFullScreen", false]], "no hide() on a destroyed window");
+  });
+
+  // If the exit cannot even be started, nothing will ever fire the listener, so
+  // falling through to the backstop would leave the window mapped for 2s.
+  it("hides immediately when setFullScreen throws", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true, throwOnSetFullScreen: true });
+    const result = hideToTray(win, mac(timers));
+    assert.deepEqual(win.calls, [["hide"]]);
+    assert.equal(result.hidden, true);
+    assert.equal(result.leftFullScreen, false);
+  });
+
+  // Defensive: BaseWindow variants and test doubles may not expose the
+  // fullscreen API at all. Falling back to a plain hide keeps the tray close
+  // working rather than throwing out of a `close` handler.
+  it("falls back to a plain hide when the fullscreen API is absent", () => {
+    const calls = [];
+    const result = hideToTray({ hide: () => calls.push(["hide"]) }, mac());
+    assert.deepEqual(calls, [["hide"]]);
+    assert.equal(result.hidden, true);
+  });
+
+  it("is a no-op for a destroyed or missing window", () => {
+    const idle = { hidden: false, deferred: false, leftFullScreen: false };
+    const win = makeWin({ fullScreen: true, destroyed: true });
+    assert.deepEqual(hideToTray(win, mac()), idle);
+    assert.deepEqual(win.calls, []);
+    assert.deepEqual(hideToTray(null), idle);
+    assert.deepEqual(hideToTray(undefined), idle);
+  });
+
+  it("never throws when hide() itself throws", () => {
+    const win = {
+      isDestroyed: () => false,
+      isFullScreen: () => false,
+      hide: () => {
+        throw new Error("hide failed");
+      },
+    };
+    assert.equal(hideToTray(win, mac()).hidden, false);
+  });
+
+  // The default must follow the real platform, since main.js passes no options.
+  it("defaults isMac to the host platform", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, timers);
+    if (process.platform === "darwin") {
+      assert.deepEqual(win.calls, [["setFullScreen", false]]);
+    } else {
+      assert.deepEqual(win.calls, [["hide"]]);
+    }
+  });
+});
+
+// The helper above is only a fix if main.js actually routes the tray close
+// through it. A correct helper with the old `mainWindow.hide()` still at the
+// call site passes every test above while the bug is fully intact, so pin the
+// wiring too. Read as TEXT because main.js requires `electron` at load and so
+// cannot be required from this suite — the same idiom windows-titlebar-contract
+// and shell-contract use.
+describe("main.js tray-close wiring", () => {
+  const MAIN_JS = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+
+  it("requires the helper", () => {
+    assert.match(MAIN_JS, /require\("\.\/hide-to-tray"\)/);
+  });
+
+  it("routes the non-quit close through hideToTray, not a bare hide", () => {
+    // The close handler's non-quit branch, up to its `return`.
+    const branch = MAIN_JS.match(
+      /mainWindow\.on\("close"[\s\S]*?if \(!isQuitting\) \{([\s\S]*?)return;/,
+    );
+    assert.ok(branch, "could not locate the close handler's non-quit branch");
+    const body = branch[1];
+    assert.match(body, /hideToTray\(mainWindow\)/);
+    assert.doesNotMatch(
+      body,
+      /mainWindow\.hide\(\)/,
+      "a direct hide() orphans the macOS fullscreen Space — go through hideToTray",
+    );
+  });
+});


### PR DESCRIPTION
## Problem / Motivation

On macOS, closing the app while it is in native full screen leaves the user with a
black full-screen surface. Reopening from the tray brings the window back very
small, and it only returns to a normal size after clicking somewhere else twice.

The cause is in the tray-close path. On macOS the close button does not destroy the
main window — the app keeps running in the tray — so `close` is `preventDefault()`ed
and the window is hidden instead:

```js
mainWindow.on("close", (e) => {
  if (!isQuitting) {
    e.preventDefault();
    mainWindow.hide();      // <- unconditional, even in full screen
    return;
  }
```

That hide ran unconditionally, including while the window occupied a native macOS
full-screen Space. Hiding a window out of a Space leaves the Space mapped with
nothing drawing into it, which is the black surface. The window also stays flagged
full screen while its Space is gone, so the next `show()` maps it at a degenerate
frame — the very small window — which only corrects once AppKit re-lays-out on the
subsequent focus changes.

The "app still shows active" part of the report is intended behaviour, not a bug:
`window-all-closed` deliberately skips `app.quit()` on darwin so the app can live in
the tray. It only reads as a hang next to the black Space.

Worth noting for reviewers who recall `window-state.js`: its header comment
describes symptoms that look identical ("blacked out", "super tiny"), but that fix
lives entirely in `createWindow()` → `sanitizeWindowState()` and only runs on
**relaunch**. The hide/show path in this report never reads persisted state, so it
was not covered.

## Why it matters

Every macOS user who works full screen and closes the window hits it, which is an
ordinary way to use the app rather than an edge case. The failure also looks worse
than it is: a black screen plus an app that still reports as running reads as a
hang, so the natural response is to force-quit — and the recovery (click away
twice) is not discoverable.

## What changed (motivation → approach → change)

Symptom: black Space after a full-screen close, then a tiny window on reopen. Root
cause: hiding a window out of a Space it still owns. So leave native full screen
**first**, and hide only once macOS has actually torn the Space down.

`setFullScreen(false)` is asynchronous on macOS — there is a ~0.5s Space animation —
so the hide has to wait for `leave-full-screen` rather than run on the next line.
Hiding mid-transition reproduces the very bug being fixed.

- **`website/electron/hide-to-tray.js`** (new): `hideToTray(win)` leaves native
  full screen, defers the hide to `leave-full-screen`, and hides immediately on
  every other path. A bounded, `unref()`ed backstop timer hides anyway if that
  event never lands, because a close button that silently does nothing is a worse
  outcome than the Space it avoids. Pure and injectable, so it is unit-testable
  without Electron — the same shape as `blocking-prompt.js` and `window-state.js`.
- **`website/electron/main.js`**: the one non-quit hide call site routes through it.
- **`website/electron/package.json`**: the new module is added to the
  electron-builder `files` allowlist. Without this it works from source and is
  silently **missing from the packaged DMG**; `shell-contract.test.js` enforces it.

Two deliberate scope limits:

- **macOS only.** Windows/Linux full screen is a borderless maximized window with no
  Space behind it, so the exit buys nothing there and would cost something real: the
  window would reopen windowed, and because the existing geometry listener persists
  on `leave-full-screen`, it would be saved as windowed for the next launch too. Off
  darwin this stays exactly the plain hide it has always been.
- **Simple-fullscreen and kiosk are untouched**, for the same reason — neither
  allocates a Space, and clearing them would silently change the mode the user
  returns to. This is intentionally narrower than `blocking-prompt.js`'s
  `exitImmersiveModes()`, which restores window *chrome* for a different goal.

No change to `window-state.js` was needed. The existing `leave-full-screen` geometry
listener (registered at window creation) now fires on a tray close, so the persisted
state truthfully records the window as windowed at its normal bounds.

## Tests

`website/electron/test/hide-to-tray.test.js` (16 cases). The load-bearing ones:

| Test | What it locks in |
|---|---|
| orders the fullscreen exit strictly before the hide | The actual fix. An implementation that called `hide()` before the event would still pass a weaker "eventually hides" assertion |
| does not touch fullscreen off macOS | The scope guard: no `setFullScreen`, no listener, no timer off darwin |
| hides anyway if leave-full-screen never fires | The backstop — a close button must never silently do nothing |
| hides exactly once when both the event and the backstop fire | These race on every real full-screen close |
| removes the leave-full-screen listener when the backstop wins | `once` only self-removes when it fires, so the backstop path would otherwise leak one listener per swallowed transition |
| does not hide a window destroyed during the fullscreen exit | The quit path can destroy the window mid-animation |
| hides immediately when setFullScreen throws | Nothing would ever fire the listener, so waiting would leave the window mapped |
| main.js tray-close wiring (2 cases) | A correct helper that main.js never calls would pass every test above with the bug fully intact |

Every fullscreen case pins `isMac` explicitly rather than inheriting the host, since
this suite also runs on Linux and Windows in CI, where an unpinned test would assert
the wrong branch. The one host-dependent case verifies the production default and
branches its own assertion on `process.platform`.

Mutation-verified rather than assumed — each of these was reverted in turn and the
suite was confirmed to fail:

- call site back to `mainWindow.hide()` → wiring test fails
- platform gate removed → off-darwin test fails
- listener removal disabled → cleanup test fails

Full Electron suite: 1130 pass, 0 fail (`npm test` in `website/electron`).

## Manual verification

Automated coverage coincidentally cannot reach the mechanism here: the defect is in
AppKit's Space lifecycle, which no unit test can observe. On macOS:

1. Open the app and enter native full screen (green button / `Ctrl+Cmd+F`).
2. Click the red close button. **Before:** a black full-screen Space remains.
   **After:** the window leaves full screen, then hides to the tray.
3. Reopen from the tray or the Dock. **Before:** a very small window needing two
   clicks elsewhere to recover. **After:** a normal-size window at its previous
   bounds.
4. Quit and relaunch to confirm the persisted geometry restores windowed and correct.
5. Windows/Linux regression check: full screen, close to tray, reopen — the window
   should still come back **full screen**, exactly as before this change.

No screenshots: the change has no rendered delta in the SPA (the Screenshot Evidence
gate's watched paths are `website/src/{components,pages,apps}` and CSS; this diff is
`website/electron/**`), and the symptom is a Space teardown across an animation that
a still frame cannot show either way. I have deliberately not attached a capture
rather than attach one that does not evidence the precondition.

## Related Issues

Fixes #1000

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the rationale lives in the new module's header comment
- [x] No secrets, credentials, or internal references in the diff
