### PR TITLE
fix(mochi): keep new display overlays hidden

### DIFF
--- a/website/electron/mochi/index.js
+++ b/website/electron/mochi/index.js
@@ -726,7 +726,13 @@ async function reconcileMochiAfterCurrent() {
 }
 
 async function reconcileMochi() {
-  const { openPetWindow, closePetWindow, rearmBlankedOverlays, hasBlankedOverlay } = require("./petOverlays");
+  const {
+    openPetWindow,
+    closePetWindow,
+    rearmBlankedOverlays,
+    hasBlankedOverlay,
+    setPetWindowsHidden,
+  } = require("./petOverlays");
   const {
     closeAvatarWindowFromReconcile,
     setAvatarBaseUrl,
@@ -843,6 +849,7 @@ async function reconcileMochi() {
   // (pet right-click > Avatars, or the dashboard Appearance card). The avatar
   // window is now the Avatars gallery, opened on demand rather than at startup.
   closeAvatarWindowFromReconcile();
+  setPetWindowsHidden(mochiWindowsHidden);
   openPetWindow(mochiPetBaseUrl, mochiPetToken);
   // An overlay stuck on a gateway error page (expired cookie or a transient 5xx)
   // has hidden itself; re-arm it with a token that works for the CURRENT target.

--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -184,6 +184,19 @@ let currentBaseUrl = "";
 let currentToken = "";
 let ipcBound = false;
 let displayListenersBound = false;
+/**
+ * Synchronized hide-all policy; index.js remains authoritative because its
+ * toggle also owns the panel window's visibility.
+ */
+let petWindowsHidden = false;
+
+function canRevealOverlay(win) {
+  return !petWindowsHidden && !overlayBlanked.has(win);
+}
+
+function setPetWindowsHidden(hidden) {
+  petWindowsHidden = Boolean(hidden);
+}
 
 /** @type {{x:number,y:number,w:number,h:number}|null} */
 let petHitbox = null;
@@ -756,11 +769,10 @@ function wireHandshake(win, displayId, pos) {
     };
     send();
     setTimeout(send, 300);
-    // Never reveal an overlay currently hidden on a gateway error page (see the
-    // did-navigate latch): showing it would blanket the display with an
-    // uncloseable page. A healed reload clears the latch and re-fires
-    // did-finish-load, which then shows the pet.
-    if (!overlayBlanked.has(win) && !win.isVisible()) win.showInactive();
+    // Never reveal an overlay while hide-all is active or while it is latched on
+    // a gateway error page. A later restore or healed reload re-fires the shared
+    // reveal policy.
+    if (canRevealOverlay(win) && !win.isVisible()) win.showInactive();
     startHitPoll();
     assertHostStaysInDock();
   });
@@ -927,6 +939,7 @@ function closePetWindow() {
  * screen-saver level can stay above the menu bar even when hidden.
  */
 function hidePetWindow() {
+  petWindowsHidden = true;
   let wasVisible = false;
   for (const win of overlays.values()) {
     if (win.isDestroyed()) continue;
@@ -938,6 +951,7 @@ function hidePetWindow() {
 }
 
 function showPetWindow() {
+  petWindowsHidden = false;
   for (const win of overlays.values()) {
     if (win.isDestroyed()) continue;
     win.setAlwaysOnTop(true, "screen-saver");
@@ -945,7 +959,7 @@ function showPetWindow() {
     // overlay currently hidden on a gateway error page (same guard as the
     // load-finished handler), or CMD+SHIFT+H would bring the uncloseable page
     // back after a persisted auth failure.
-    if (!overlayBlanked.has(win) && !win.isVisible()) win.showInactive();
+    if (canRevealOverlay(win) && !win.isVisible()) win.showInactive();
   }
 }
 
@@ -1029,9 +1043,8 @@ async function transferPetToDisplayById(displayId, localX, localY) {
           resolve(true);
         }, 300);
       });
-      // Do not reveal an overlay hidden on a gateway error page (see the
-      // did-navigate latch); a healed reload clears the latch and shows it.
-      if (!overlayBlanked.has(win) && !win.isVisible()) win.showInactive();
+      // Transfers obey the same hide-all/error-page reveal policy as loads.
+      if (canRevealOverlay(win) && !win.isVisible()) win.showInactive();
     });
   }
 
@@ -1045,6 +1058,7 @@ module.exports = {
   closePetWindow,
   hidePetWindow,
   showPetWindow,
+  setPetWindowsHidden,
   isPetWindowOpen,
   getActiveOverlay,
   getActiveDisplayId,

--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -156,7 +156,9 @@ test("a stale closed handler does not evict the replacement overlay", () => {
 function stubElectronForOpen() {
   const created = [];
   class FakeWebContents {
-    on() {}
+    constructor() { this.listeners = new Map(); }
+    on(event, callback) { this.listeners.set(event, callback); }
+    emit(event, ...args) { this.listeners.get(event)?.(...args); }
     send() {}
     isDestroyed() { return false; }
     isLoading() { return true; }
@@ -166,6 +168,8 @@ function stubElectronForOpen() {
     constructor(opts) {
       this.opts = opts;
       this.webContents = new FakeWebContents();
+      this.visible = false;
+      this.showInactiveCalls = 0;
       created.push(this);
     }
     setFocusable() {}
@@ -182,9 +186,10 @@ function stubElectronForOpen() {
     setAlwaysOnTop() {}
     setBounds(b) { this.bounds = b; }
     loadURL() {}
-    isVisible() { return false; }
+    isVisible() { return this.visible; }
     isDestroyed() { return false; }
-    showInactive() {}
+    showInactive() { this.visible = true; this.showInactiveCalls += 1; }
+    hide() { this.visible = false; }
     close() {}
     on() {}
   }
@@ -196,12 +201,14 @@ function stubElectronForOpen() {
     bounds: { x: 0, y: 0, width: 1440, height: 900 },
     workArea: { x: 0, y: 25, width: 1440, height: 875 },
   };
+  const displays = [DISPLAY];
   // Display listeners are recorded rather than swallowed: whether they are
   // RELEASED on teardown is the contract behind #4673, and an `on() {}` stub
   // cannot see a leak.
   const displayListeners = [];
   return {
     created,
+    displays,
     displayListeners,
     DISPLAY,
     electron: {
@@ -211,7 +218,7 @@ function stubElectronForOpen() {
       shell: { openExternal() {}, showItemInFolder() {} },
       screen: {
         getPrimaryDisplay: () => DISPLAY,
-        getAllDisplays: () => [DISPLAY],
+        getAllDisplays: () => displays,
         getCursorScreenPoint: () => ({ x: 0, y: 0 }),
         on(event, fn) { displayListeners.push({ event, fn }); },
         removeListener(event, fn) {
@@ -337,6 +344,37 @@ test("a display event while the pet is live still follows the new geometry", () 
       DISPLAY.bounds,
       "the live overlay follows the new display bounds",
     );
+  } finally {
+    mod.closePetWindow();
+  }
+});
+
+test("a display added while hide-all is active stays hidden", () => {
+  const { mod, created, displays, displayListeners } = loadPetOverlays();
+  try {
+    mod.openPetWindow("http://localhost:6777", "tok");
+    created[0].webContents.emit("did-finish-load");
+    assert.strictEqual(created[0].isVisible(), true, "the initial overlay is shown");
+
+    mod.hidePetWindow();
+    assert.strictEqual(created[0].isVisible(), false, "hide-all hides the live overlay");
+
+    displays.push({
+      id: 2,
+      bounds: { x: 1440, y: 0, width: 1920, height: 1080 },
+      workArea: { x: 1440, y: 0, width: 1920, height: 1040 },
+    });
+    displayListeners.find((listener) => listener.event === "display-added").fn();
+    assert.strictEqual(created.length, 2, "the new display receives an overlay");
+    created[1].webContents.emit("did-finish-load");
+    assert.strictEqual(
+      created[1].isVisible(),
+      false,
+      "the new overlay must not undo hide-all",
+    );
+
+    mod.showPetWindow();
+    assert.ok(created.every((win) => win.isVisible()), "one restore shows every overlay");
   } finally {
     mod.closePetWindow();
   }
@@ -472,11 +510,16 @@ test("did-navigate delegates to the single navigation handler (no inline retry p
   assert.ok(!idxSrc.includes("setPetReauthProvider"), "index.js must not wire a reauth provider anymore");
 });
 
-test("every showInactive reveal is guarded by the blanked latch", () => {
+test("every showInactive reveal uses the shared hidden/error policy", () => {
   const reveals = fsSrc.match(/win\.showInactive\(\)/g) || [];
-  const guarded = fsSrc.match(/!overlayBlanked\.has\(win\)[\s\S]{0,80}win\.showInactive\(\)/g) || [];
+  const guarded = fsSrc.match(/canRevealOverlay\(win\)[\s\S]{0,80}win\.showInactive\(\)/g) || [];
   assert.ok(reveals.length >= 3, "expected the three overlay reveal sites (handshake, showPetWindow, transfer)");
-  assert.equal(guarded.length, reveals.length, "every showInactive reveal must be latch-guarded");
+  assert.equal(guarded.length, reveals.length, "every showInactive reveal must use the shared policy");
+  assert.match(
+    fsSrc,
+    /return !petWindowsHidden && !overlayBlanked\.has\(win\)/,
+    "the shared policy must preserve hide-all and the error-page latch",
+  );
 });
 
 test("reconcile re-arms with scalar credential values and delivery mode", () => {
@@ -496,4 +539,11 @@ test("reconcile re-arms with scalar credential values and delivery mode", () => 
     "rearm receives scalar token and delivery mode, never the auth record");
   assert.ok(!region.includes('cachedGatewayAuth = { value: "" }'),
     "must NOT clear the credential cache in the rearm path — probe-driven invalidation only, or a persistent non-auth error mints every tick");
+});
+
+test("reconcile synchronizes hide-all before opening overlays", () => {
+  const sync = idxSrc.indexOf("setPetWindowsHidden(mochiWindowsHidden)");
+  const open = idxSrc.indexOf("openPetWindow(mochiPetBaseUrl, mochiPetToken)", sync);
+  assert.ok(sync >= 0, "reconcile must push the authoritative hide-all state down");
+  assert.ok(open > sync, "the reveal policy must be synchronized before overlays open");
 });


### PR DESCRIPTION
## Problem / Motivation

Connecting a display while Mochi is hidden with the hide-all hotkey creates a new overlay whose load handshake calls `showInactive()`. That reveal only honored the gateway error-page latch, so the new overlay appeared even though hide-all remained active.

## Why it matters

Hide-all is the user's immediate way to clear Mochi from every display. Reappearing on a newly connected display breaks that promise and leaves the authoritative flag out of sync, making the next hotkey press take the restore branch instead of hiding the pet.

## What changed (motivation → approach → change)

Kept `mochiWindowsHidden` in `index.js` as the authoritative state because it also governs the panel window, and synchronized that state into `petOverlays.js` before reconciliation opens overlays. The overlay module now applies one shared reveal policy to load handshakes, hide-all restore, and display transfer, preserving both hide-all and the existing error-page latch. The direct hide/show primitives update the synchronized state immediately so display events cannot race the next reconcile tick.

Added a deterministic Electron test that hides the live overlay, emits `display-added`, completes the new overlay handshake, and verifies it stays hidden until one explicit restore. Source guards also pin the shared policy at every reveal site and the reconcile-before-open ordering.

## Tests

- `node --test mochi/test/petOverlays.test.js` (29 passed)
- `npm test` in `website/electron` (1120 tests: 1118 passed, 2 skipped, 0 failed)
- `node --check mochi/petOverlays.js`
- `node --check mochi/index.js`
- `BRAND_BASE_REF=origin/main python scripts/check_brand_name.py`
- `git diff --check`

## Manual verification

Not performed — macOS display hardware is unavailable in this environment. The Electron regression test deterministically exercises the `display-added` and `did-finish-load` sequence with visible-state assertions.

## Screenshots / video

N/A — this changes a visibility state transition rather than visual layout; the macOS interaction is covered by the deterministic main-process regression test.

## Related Issues

Fixes #4930

Related: #4928 addresses display-listener teardown for a destroyed pet; this PR addresses reveal policy for a live but hidden pet and is rebased on its merged change.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
