### PR TITLE
fix(desktop): recover the user's PATH from the launchd domain on macOS

### DIFF
--- a/website/electron/mac-env.js
+++ b/website/electron/mac-env.js
@@ -1,0 +1,173 @@
+// Recover the user's configured PATH on macOS for the bundled Gateway spawn.
+//
+// A GUI-launched .app inherits launchd's minimal environment rather than a
+// login shell's, so `process.env.PATH` is typically just
+// `/usr/bin:/bin:/usr/sbin:/sbin`. Every Gateway descendant — agent shell
+// tools, MCP servers, ACP runtimes — inherits that, so a user-installed CLI
+// living outside the backend's fixed `augmented_path()` list is unresolvable
+// in the app even though the same command works in Terminal (issue #2367).
+//
+// `launchctl setenv PATH ...` writes the launchd USER DOMAIN, which a GUI
+// `.app` does not re-read per launch. That is exactly why "export PATH and
+// relaunch" does not help, and why the domain has to be read explicitly here.
+//
+// Extracted from main.js so it can be unit-tested without Electron: every
+// dependency is injected and the functions are pure apart from the one
+// `execFileSync` call.
+
+// Absolute path, never a bare name: this runs before PATH is trustworthy,
+// which is the whole point of the module.
+const LAUNCHCTL = "/bin/launchctl";
+// Bounds the launchd READ, so a pathological domain value cannot be slurped
+// into memory. Deliberately the only size limit in this module: a merged-PATH
+// cap on top of it would be dead weight (the environment block limit that
+// makes spawn fail with E2BIG is ~1MB, which a read bounded here cannot
+// approach) and actively harmful, because an inherited PATH already larger
+// than the cap would silently suppress every appended entry — turning the fix
+// into a no-op exactly for the users with the most crowded PATH.
+const MAX_LAUNCHD_READ_BYTES = 32 * 1024;
+// `launchctl getenv` is a local IPC round-trip and returns effectively
+// instantly. The timeout exists so a wedged launchd cannot hang the Electron
+// main process indefinitely — not because a slow read is expected.
+const READ_TIMEOUT_MS = 2000;
+
+/**
+ * Read `PATH` from the launchd user domain.
+ *
+ * @param {object} deps
+ * @param {Function} deps.execFileSync - `child_process.execFileSync`
+ * @param {string} [deps.platform] - `process.platform` (defaults to it)
+ * @returns {string|null} The raw value, or `null` on any non-darwin platform,
+ *   any failure, or an unset/empty variable. Callers treat `null` as "nothing
+ *   to merge" and leave the inherited PATH alone.
+ */
+function readLaunchdPath({ execFileSync, platform = process.platform } = {}) {
+  if (platform !== "darwin") return null;
+  try {
+    const out = execFileSync(LAUNCHCTL, ["getenv", "PATH"], {
+      encoding: "utf8",
+      timeout: READ_TIMEOUT_MS,
+      maxBuffer: MAX_LAUNCHD_READ_BYTES,
+      // launchctl writes nothing useful to stderr here, and inheriting the
+      // parent's stdio would interleave it into the app's own log stream.
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const value = typeof out === "string" ? out.trim() : "";
+    return value === "" ? null : value;
+  } catch {
+    // An unset variable exits non-zero, and `launchctl` may be absent or
+    // wedged. None of those are actionable: the inherited PATH is still the
+    // documented behaviour, so degrade silently to it.
+    return null;
+  }
+}
+
+/**
+ * Split a `PATH` string into entries safe to hand to a child process.
+ *
+ * Rejects anything that could change which executable a bare command name
+ * binds to in a way the user did not intend:
+ *
+ * - relative entries, which a child re-resolves against ITS OWN cwd, letting
+ *   a working-directory-relative executable shadow the intended command
+ *   (the same rule `env.py::_validated_bin_dir` applies backend-side);
+ * - entries with a `..` segment, which obscure what directory is really being
+ *   added (matches `validation.js`'s traversal rule for remote paths);
+ * - entries containing NUL or a newline, which indicate a mangled value.
+ *
+ * @param {string|null|undefined} raw - A colon-separated PATH string
+ * @returns {string[]} Accepted entries, in their original order
+ */
+function sanitizePathEntries(raw) {
+  if (typeof raw !== "string" || raw === "") return [];
+  return raw.split(":").filter((entry) => {
+    if (entry === "" || !entry.startsWith("/")) return false;
+    if (entry.includes("\0") || entry.includes("\n") || entry.includes("\r")) return false;
+    return !entry.split("/").includes("..");
+  });
+}
+
+/**
+ * Merge the launchd-domain PATH into the inherited one.
+ *
+ * The inherited value is preserved VERBATIM and the launchd-only entries are
+ * APPENDED. Both halves of that are deliberate:
+ *
+ * - *Appended*, because appending can only make a name resolve that resolved
+ *   nowhere before — which is the reported failure — while prepending would let
+ *   a user-writable directory shadow a system binary that already resolves. It
+ *   mirrors how `env.py::augmented_path` appends the interpreter's own `bin`
+ *   last, "as a pure fallback [that] resolves only names found nowhere else".
+ * - *Verbatim*, because this function must never REMOVE a directory the Gateway
+ *   would otherwise have had. Validation and the byte cap therefore apply only
+ *   to what is being ADDED, exactly as `augmented_path` validates the
+ *   directories it contributes and passes `base_path` through untouched. An odd
+ *   entry already in the inherited PATH (relative, `..`, empty) is left where it
+ *   is: rewriting it would silently stop resolving a command that resolves
+ *   today, and hardening the inherited environment is not this function's job.
+ *
+ * Appended entries are de-duplicated against the inherited ones and against each
+ * other, so the function is idempotent: feeding an already-merged value back in
+ * adds nothing.
+ *
+ * @param {object} args
+ * @param {string} [args.basePath] - The inherited `PATH`, used as-is
+ * @param {string|null} [args.launchdPath] - Value from {@link readLaunchdPath}
+ * @returns {{path: string, added: string[]}} The merged PATH and the entries
+ *   the merge contributed (for logging).
+ */
+function mergeGatewayPath({ basePath = "", launchdPath = null } = {}) {
+  const base = typeof basePath === "string" ? basePath : "";
+  // Split only to compare against — never to rewrite. Empty segments are
+  // excluded from the comparison set so they cannot swallow a real entry.
+  const seen = new Set(base.split(":").filter((entry) => entry !== ""));
+
+  const added = [];
+  for (const entry of sanitizePathEntries(launchdPath)) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    added.push(entry);
+  }
+
+  if (added.length === 0) return { path: base, added };
+  // Always a ":" between the inherited value and the appended tail, even when
+  // the inherited value already ends in one. A trailing ":" is a ZERO-LENGTH
+  // ENTRY, which POSIX defines as the cwd -- so "/usr/bin:" is [/usr/bin, cwd],
+  // and appending to it must yield [/usr/bin, cwd, <new>], i.e. the "::" form.
+  // Collapsing that to a single ":" would DELETE the cwd entry and stop
+  // resolving a command that resolves today, which is exactly the removal this
+  // function exists to prevent. The doubled separator is correct output, not a
+  // formatting bug -- see the test that pins it.
+  return { path: base === "" ? added.join(":") : `${base}:${added.join(":")}`, added };
+}
+
+/**
+ * Compute the `PATH` the bundled Gateway should be spawned with.
+ *
+ * Returns `null` when there is nothing to change — a non-darwin platform, an
+ * unreadable launchd domain, or a domain that contributes no new directory —
+ * so the caller can leave the inherited environment completely untouched
+ * rather than rewriting it to an equal value.
+ *
+ * @param {object} deps
+ * @param {Function} deps.execFileSync - `child_process.execFileSync`
+ * @param {string} [deps.platform] - `process.platform`
+ * @param {string} [deps.basePath] - The inherited `PATH`
+ * @returns {{path: string, added: string[]}|null}
+ */
+function resolveGatewayPath({ execFileSync, platform = process.platform, basePath = "" } = {}) {
+  const launchdPath = readLaunchdPath({ execFileSync, platform });
+  if (launchdPath === null) return null;
+  const merged = mergeGatewayPath({ basePath, launchdPath });
+  return merged.added.length === 0 ? null : merged;
+}
+
+module.exports = {
+  LAUNCHCTL,
+  MAX_LAUNCHD_READ_BYTES,
+  READ_TIMEOUT_MS,
+  readLaunchdPath,
+  sanitizePathEntries,
+  mergeGatewayPath,
+  resolveGatewayPath,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -2,11 +2,12 @@ const { app, BaseWindow, BrowserWindow, WebContentsView, shell, dialog, Tray, Me
 const Store = require("electron-store");
 const fs = require("fs");
 const os = require("os");
-const { spawn, execFile } = require("child_process");
+const { spawn, execFile, execFileSync } = require("child_process");
 const path = require("path");
 const http = require("http");
 
 const { findKirocrewBin } = require("./find-bin");
+const { resolveGatewayPath } = require("./mac-env");
 const {
   findMissingBundleParts,
   describeIncompleteBundle,
@@ -874,6 +875,27 @@ function spawnGateway(resolve) {
         // served on.
         const { KIROCREW_PORT: _ignored, ...cleanEnv } = process.env;
 
+        // macOS: a GUI-launched .app inherits launchd's minimal environment, so
+        // cleanEnv.PATH is typically /usr/bin:/bin:/usr/sbin:/sbin. Recover the
+        // user's configured PATH from the launchd user domain and APPEND the
+        // directories it adds, so agent shell tools and MCP servers can resolve
+        // user-installed CLIs instead of reporting "command not found" for a
+        // binary that works in Terminal (issue #2367). No-op off darwin, when
+        // the domain is unset, or when it adds nothing — in which case
+        // gatewayPath is null and the inherited environment is left untouched.
+        //
+        // This only fixes the environment of a Gateway spawned FROM HERE.
+        // Already-running Gateway/ACP/MCP children keep the environment they
+        // were started with, so changing the domain still needs a Gateway
+        // restart to take effect.
+        const gatewayPath = resolveGatewayPath({
+          execFileSync,
+          basePath: cleanEnv.PATH || "",
+        });
+        if (gatewayPath) {
+          glog(`PATH recovered from launchd domain: +${gatewayPath.added.length} dir(s) appended`);
+        }
+
         // Tee the child's stdout+stderr straight to the launch log via a file
         // descriptor — no JS pipe to drain, no backpressure on a long-running
         // child. This is what surfaces a Python traceback / dylib load error /
@@ -936,6 +958,10 @@ function spawnGateway(resolve) {
           windowsHide: true,
           env: {
             ...cleanEnv,
+            // Overrides the inherited PATH only when the launchd domain
+            // actually contributed a directory (see resolveGatewayPath above);
+            // otherwise this spreads nothing and cleanEnv.PATH stands.
+            ...(gatewayPath ? { PATH: gatewayPath.path } : {}),
             // Windows source layout puts agents/ + skills/ at the repo root
             // (two levels up from electron/), so resolve by markers there.
             // macOS/Linux keep the original one-level-up path unchanged.

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -138,6 +138,7 @@
       "instance-guard.js",
       "context-menu.js",
       "find-bin.js",
+      "mac-env.js",
       "bundle-integrity.js",
       "data-home.js",
       "auto-update.js",

--- a/website/electron/test/mac-env.test.js
+++ b/website/electron/test/mac-env.test.js
@@ -1,0 +1,265 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  LAUNCHCTL,
+  MAX_LAUNCHD_READ_BYTES,
+  READ_TIMEOUT_MS,
+  readLaunchdPath,
+  sanitizePathEntries,
+  mergeGatewayPath,
+  resolveGatewayPath,
+} = require("../mac-env");
+
+// The PATH a GUI-launched .app actually receives on macOS — the whole reason
+// this module exists (issue #2367).
+const GUI_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+// A realistic launchd-domain value: the GUI entries plus user-managed dirs.
+const LAUNCHD_PATH = `/Users/u/.opencode/bin:/Users/u/.cargo/bin:/opt/homebrew/bin:${GUI_PATH}`;
+
+/** execFileSync stub that records its call and returns `out`. */
+const stubExec = (out, calls = []) => {
+  const fn = (file, args, opts) => {
+    calls.push({ file, args, opts });
+    if (out instanceof Error) throw out;
+    return out;
+  };
+  fn.calls = calls;
+  return fn;
+};
+
+describe("readLaunchdPath", () => {
+  it("returns the trimmed launchd value on darwin", () => {
+    const exec = stubExec(`${LAUNCHD_PATH}\n`);
+    assert.equal(readLaunchdPath({ execFileSync: exec, platform: "darwin" }), LAUNCHD_PATH);
+  });
+
+  it("invokes launchctl by absolute path, with a timeout and no inherited stderr", () => {
+    const exec = stubExec("/usr/bin\n");
+    readLaunchdPath({ execFileSync: exec, platform: "darwin" });
+    const [call] = exec.calls;
+    // Absolute: this runs precisely because PATH is not yet trustworthy.
+    assert.equal(call.file, LAUNCHCTL);
+    assert.ok(call.file.startsWith("/"));
+    assert.deepEqual(call.args, ["getenv", "PATH"]);
+    assert.equal(call.opts.timeout, READ_TIMEOUT_MS);
+    // The READ bound is the module's only size limit -- pin it to maxBuffer so
+    // it cannot drift back into being a merged-PATH cap (see the large-inherited
+    // -PATH test for why that shape was removed).
+    assert.equal(call.opts.maxBuffer, MAX_LAUNCHD_READ_BYTES);
+    assert.deepEqual(call.opts.stdio, ["ignore", "pipe", "ignore"]);
+  });
+
+  it("does not shell out at all off darwin", () => {
+    for (const platform of ["win32", "linux"]) {
+      const exec = stubExec(LAUNCHD_PATH);
+      assert.equal(readLaunchdPath({ execFileSync: exec, platform }), null);
+      assert.equal(exec.calls.length, 0, `should not run launchctl on ${platform}`);
+    }
+  });
+
+  it("returns null for an unset or blank variable", () => {
+    // `launchctl getenv` on an unset key prints nothing.
+    assert.equal(readLaunchdPath({ execFileSync: stubExec(""), platform: "darwin" }), null);
+    assert.equal(readLaunchdPath({ execFileSync: stubExec("\n"), platform: "darwin" }), null);
+    assert.equal(readLaunchdPath({ execFileSync: stubExec("   \n"), platform: "darwin" }), null);
+  });
+
+  it("degrades to null when launchctl fails, is missing, or times out", () => {
+    for (const err of [new Error("ENOENT"), Object.assign(new Error("timed out"), { killed: true })]) {
+      assert.equal(readLaunchdPath({ execFileSync: stubExec(err), platform: "darwin" }), null);
+    }
+  });
+});
+
+describe("sanitizePathEntries", () => {
+  it("keeps absolute entries in order", () => {
+    assert.deepEqual(sanitizePathEntries("/usr/bin:/bin"), ["/usr/bin", "/bin"]);
+  });
+
+  it("drops relative entries, which a child re-resolves against its own cwd", () => {
+    assert.deepEqual(sanitizePathEntries("/usr/bin:.:bin:../up:~/bin"), ["/usr/bin"]);
+  });
+
+  it("drops entries containing a .. segment", () => {
+    assert.deepEqual(sanitizePathEntries("/usr/bin:/opt/../etc"), ["/usr/bin"]);
+  });
+
+  it("keeps a directory whose NAME merely starts with dots", () => {
+    // Only a literal ".." SEGMENT is traversal; "..cache" is a real dir name.
+    assert.deepEqual(sanitizePathEntries("/opt/..cache/bin"), ["/opt/..cache/bin"]);
+  });
+
+  it("drops entries with NUL or newlines", () => {
+    assert.deepEqual(sanitizePathEntries("/usr/bin:/a\0b:/c\nd:/e\rf"), ["/usr/bin"]);
+  });
+
+  it("drops empty segments rather than emitting an empty entry", () => {
+    // An empty PATH entry means "cwd" to most resolvers — the exact hazard
+    // the relative-entry rule exists to prevent.
+    assert.deepEqual(sanitizePathEntries("/usr/bin::/bin:"), ["/usr/bin", "/bin"]);
+  });
+
+  it("returns [] for non-strings and empty input", () => {
+    for (const v of ["", null, undefined, 42, {}]) assert.deepEqual(sanitizePathEntries(v), []);
+  });
+});
+
+describe("mergeGatewayPath", () => {
+  it("appends launchd-only entries AFTER the inherited ones", () => {
+    const { path, added } = mergeGatewayPath({ basePath: GUI_PATH, launchdPath: LAUNCHD_PATH });
+    assert.equal(path, `${GUI_PATH}:/Users/u/.opencode/bin:/Users/u/.cargo/bin:/opt/homebrew/bin`);
+    assert.deepEqual(added, ["/Users/u/.opencode/bin", "/Users/u/.cargo/bin", "/opt/homebrew/bin"]);
+  });
+
+  it("never lets a launchd entry shadow a system binary that already resolves", () => {
+    // The security property of appending: /usr/bin stays ahead of a
+    // user-writable directory, so `python3` cannot be rebound by it.
+    const { path } = mergeGatewayPath({
+      basePath: GUI_PATH,
+      launchdPath: "/Users/u/evil/bin:/usr/bin",
+    });
+    assert.ok(path.indexOf("/usr/bin") < path.indexOf("/Users/u/evil/bin"));
+  });
+
+  it("de-duplicates first-wins and is idempotent", () => {
+    const once = mergeGatewayPath({ basePath: GUI_PATH, launchdPath: LAUNCHD_PATH });
+    const twice = mergeGatewayPath({ basePath: once.path, launchdPath: LAUNCHD_PATH });
+    assert.equal(twice.path, once.path);
+    assert.deepEqual(twice.added, [], "a re-merge contributes nothing new");
+  });
+
+  it("reports no additions when launchd matches the inherited PATH", () => {
+    const { path, added } = mergeGatewayPath({ basePath: GUI_PATH, launchdPath: GUI_PATH });
+    assert.equal(path, GUI_PATH);
+    assert.deepEqual(added, []);
+  });
+
+  it("keeps the inherited PATH verbatim, including entries it rejects from launchd", () => {
+    // Validation applies to what is ADDED, never to what was inherited:
+    // rewriting an inherited entry would stop resolving a command that
+    // resolves today. Matches env.py::augmented_path, which validates the
+    // dirs it contributes and passes base_path through untouched.
+    const odd = "/usr/bin:.:/opt/../etc::relative";
+    const { path, added } = mergeGatewayPath({ basePath: odd, launchdPath: "/opt/x/bin:./nope" });
+    assert.ok(path.startsWith(odd), "inherited value must survive byte-for-byte");
+    assert.equal(path, `${odd}:/opt/x/bin`);
+    assert.deepEqual(added, ["/opt/x/bin"], "only the valid launchd entry is appended");
+  });
+
+  it("appends to a very large inherited PATH instead of suppressing the fix", () => {
+    // There is deliberately NO merged-size cap. An earlier revision capped the
+    // MERGED value at 8KB, which meant a user whose inherited PATH already
+    // exceeded that got every launchd entry dropped -- the fix silently doing
+    // nothing for exactly the users with the most crowded PATH. The launchd
+    // READ is bounded instead (MAX_LAUNCHD_READ_BYTES via maxBuffer), which is
+    // the only bound that is load-bearing: the environment-block limit behind
+    // E2BIG is ~1MB and a 32KB read cannot approach it.
+    const filler = [];
+    let bytes = 0;
+    while (bytes < 12 * 1024) {
+      const d = `/opt/f${String(filler.length).padStart(4, "0")}/bin`;
+      filler.push(d);
+      bytes += d.length + 1;
+    }
+    const basePath = filler.join(":");
+    assert.ok(Buffer.byteLength(basePath, "utf8") > 8192, "fixture must exceed the old cap");
+
+    const { path, added } = mergeGatewayPath({ basePath, launchdPath: "/u/x/bin" });
+    assert.deepEqual(added, ["/u/x/bin"], "a large inherited PATH must not suppress the append");
+    assert.ok(path.startsWith(basePath), "the inherited PATH is still preserved whole");
+    assert.equal(path, `${basePath}:/u/x/bin`);
+  });
+
+  it("never drops an inherited entry, whatever its size", () => {
+    const longDir = `/opt/${"L".repeat(4000)}/bin`;
+    const basePath = `/usr/bin:${longDir}`;
+    const { path } = mergeGatewayPath({ basePath, launchdPath: "/u/x/bin" });
+    assert.ok(path.includes(longDir), "a long inherited entry must survive");
+    assert.deepEqual(path.split(":").slice(0, 2), ["/usr/bin", longDir]);
+  });
+
+  it("returns the inherited value unchanged when no launchd entry survives validation", () => {
+    const { path, added } = mergeGatewayPath({ basePath: "relative", launchdPath: "also/relative" });
+    assert.equal(path, "relative", "an invalid inherited value is still passed through");
+    assert.deepEqual(added, []);
+  });
+
+  it("preserves a zero-length inherited entry, even though that yields '::'", () => {
+    // A trailing ":" is a ZERO-LENGTH ENTRY, which POSIX defines as the cwd, so
+    // "/usr/bin:" is [/usr/bin, cwd]. Appending must produce
+    // [/usr/bin, cwd, /opt/x/bin] -- spelled "/usr/bin::/opt/x/bin". Collapsing
+    // it to one ":" would DELETE the cwd entry and stop resolving a command that
+    // resolves today. This test exists because "::" reads like a formatting bug
+    // and a reviewer already proposed "fixing" it.
+    const { path } = mergeGatewayPath({ basePath: "/usr/bin:", launchdPath: "/opt/x/bin" });
+    assert.equal(path, "/usr/bin::/opt/x/bin");
+
+    // Stated as the invariant rather than the spelling: every entry the
+    // inherited value had is still present, at the same index.
+    const before = "/usr/bin:".split(":");
+    const after = path.split(":");
+    assert.deepEqual(after.slice(0, before.length), before, "inherited entries unmoved");
+    assert.deepEqual(after.slice(before.length), ["/opt/x/bin"], "only the new dir is appended");
+  });
+
+  it("preserves a leading zero-length entry too", () => {
+    const { path } = mergeGatewayPath({ basePath: ":/usr/bin", launchdPath: "/opt/x/bin" });
+    assert.equal(path, ":/usr/bin:/opt/x/bin");
+    assert.deepEqual(path.split(":").slice(0, 2), ["", "/usr/bin"]);
+  });
+
+  it("survives an empty inherited PATH", () => {
+    const { path, added } = mergeGatewayPath({ basePath: "", launchdPath: "/opt/x/bin" });
+    assert.equal(path, "/opt/x/bin");
+    assert.deepEqual(added, ["/opt/x/bin"]);
+  });
+});
+
+describe("resolveGatewayPath", () => {
+  it("returns the merged PATH when the launchd domain adds directories", () => {
+    const got = resolveGatewayPath({
+      execFileSync: stubExec(LAUNCHD_PATH),
+      platform: "darwin",
+      basePath: GUI_PATH,
+    });
+    assert.ok(got, "expected a merge result");
+    assert.ok(got.path.includes("/Users/u/.opencode/bin"));
+    assert.equal(got.added.length, 3);
+  });
+
+  it("returns null — leave the environment untouched — when nothing is added", () => {
+    // Same value in the domain as inherited: rewriting PATH to an equal string
+    // would be a pointless environment mutation.
+    assert.equal(
+      resolveGatewayPath({
+        execFileSync: stubExec(GUI_PATH),
+        platform: "darwin",
+        basePath: GUI_PATH,
+      }),
+      null
+    );
+  });
+
+  it("returns null off darwin and when the domain is unreadable", () => {
+    assert.equal(
+      resolveGatewayPath({ execFileSync: stubExec(LAUNCHD_PATH), platform: "linux", basePath: GUI_PATH }),
+      null
+    );
+    assert.equal(
+      resolveGatewayPath({ execFileSync: stubExec(new Error("boom")), platform: "darwin", basePath: GUI_PATH }),
+      null
+    );
+  });
+
+  it("does not drop the inherited PATH when the domain is only partially valid", () => {
+    // A mangled domain must never cost the app the PATH it already had.
+    const got = resolveGatewayPath({
+      execFileSync: stubExec("relative:/opt/good/bin:../bad"),
+      platform: "darwin",
+      basePath: GUI_PATH,
+    });
+    assert.ok(got);
+    assert.ok(got.path.startsWith(GUI_PATH));
+    assert.deepEqual(got.added, ["/opt/good/bin"]);
+  });
+});


### PR DESCRIPTION
## Problem / Motivation

On macOS the desktop app starts with the system-only GUI `PATH` instead of the user's configured command environment. A GUI-launched `.app` inherits launchd's minimal environment, so the Electron shell's `PATH` is typically just:

```
/usr/bin:/bin:/usr/sbin:/sbin
```

`spawnGateway()` passes that environment through verbatim (`website/electron/main.js` derives `cleanEnv` from `process.env` and hands it straight to `spawn`), so the bundled Gateway and every descendant it starts — agent shell tools, MCP servers, ACP runtimes — inherit the incomplete value. The backend re-adds a fixed set of well-known directories in `env.py::augmented_path`, but `_EXTRA_PATH_DIRS` is a six-entry tuple and cannot represent an arbitrary user-configured location.

The user-visible symptom, from #2367: a CLI installed under `~/.opencode/bin` resolves in Terminal but not inside the app.

```console
$ command -v opencode        # inside a Kiro Crew agent tool shell -> no output
$ /Users/<user>/.opencode/bin/opencode --version   # works
```

Exporting the shell `PATH` into the launchd user domain does **not** fix it, which is the useful part of the report: a GUI `.app` does not re-read that domain per launch, so `launchctl getenv PATH` holds the full value while the app process still shows the system-only one.

## Why it matters

Kiro Crew is a developer tool whose whole job is launching user-installed CLIs and MCP servers. Today a tool installed anywhere outside those six directories is unreachable from the app, and the only workarounds are an absolute path in every MCP server spec, a symlink into one of the six, or relaunching the app from a terminal with `open -n --env` on every start. It also produces a misleading failure: the agent reports `command not found` for a binary that is installed and works, so it reads as the tool being broken rather than unresolvable.

## What changed (motivation → approach → change)

Symptom: user-installed CLIs unresolvable in the app. Root cause: the Gateway is spawned with the GUI-minimal environment and nothing in the Electron plane ever consults the launchd user domain (grepping `launchctl` across `website/electron/` matches only `README.md`).

Change: read `PATH` from the launchd user domain immediately before the Gateway spawn and append the directories it contributes. New module `website/electron/mac-env.js`, wired into `spawnGateway()`.

The merge is strictly additive on both axes, and both halves mirror `env.py::augmented_path`:

- **Appended, not prepended.** Appending can only make a name resolve that resolved nowhere before — which is the reported failure — whereas prepending would let a user-writable directory shadow a system binary that already resolves. This matches `augmented_path` appending the interpreter's own `bin` last "as a pure fallback [that] resolves only names found nowhere else".
- **The inherited value is kept verbatim.** Validation applies only to the entries being *added*, so the merge can never *remove* a directory the Gateway would otherwise have had — the same split as `augmented_path`, which validates the directories it contributes and passes `base_path` through untouched. A pre-existing oddity in the inherited `PATH` (relative, `..`, a zero-length entry) is deliberately left alone: rewriting it would stop resolving a command that resolves today, and hardening the inherited environment is out of scope here.

Safety and containment:

- Off darwin the function returns before spawning anything — `launchctl` is never invoked on Windows or Linux.
- `execFileSync` is called with an argv array (no shell), an absolute `/bin/launchctl` (this runs precisely because `PATH` is not yet trustworthy), a 2s timeout, a bounded `maxBuffer`, and `stdio` that discards stderr.
- Any failure — unset variable, missing or wedged `launchctl`, timeout — degrades to `null`, i.e. today's behaviour.
- Added entries must be absolute, free of a `..` segment, and free of NUL/newline. The launchd **read** is bounded at 32 KB (`MAX_LAUNCHD_READ_BYTES`, wired to `maxBuffer` and pinned by a test); the **merged** value is deliberately **not** capped. An earlier revision did cap it at 8 KB, and that cap was removed at the First Principles lane's request: it guarded an `E2BIG` that the read bound already makes unreachable (the environment-block limit is ~1 MB), while an inherited `PATH` already over 8 KB made the fix a silent no-op for exactly the users with the most crowded `PATH`. See the disposition comment on this PR.
- When the domain contributes nothing, `resolveGatewayPath` returns `null` and the spread contributes no key, so `cleanEnv.PATH` is left untouched rather than rewritten to an equal value.

`mac-env.js` is declared in `package.json` `build.files`. Without that the runtime `require("./mac-env")` resolves from source but is absent from the packaged app; the repo's own `test/shell-contract.test.js` catches the omission, and did.

**Scope.** #2367 lists four candidate shapes. This implements only the first. The local-settings surface, the "Refresh environment and restart Gateway" action, and any login-shell import are product-shape decisions still parked at `needs-human` on that issue, and are deliberately not attempted here. Note the inherent limit of shape 1: it fixes the environment of a Gateway spawned *from here*, and already-running Gateway/ACP/MCP children keep the environment they were started with — which is precisely why shape 3 (a graceful restart) is tracked separately.

## Tests

New `website/electron/test/mac-env.test.js`, 27 cases, no external dependencies (`node:test` + `node:assert`):

- `readLaunchdPath`: returns the trimmed domain value; invokes `launchctl` by absolute path with a timeout and non-inherited stderr; **does not spawn anything at all** off darwin; returns `null` for an unset/blank variable and for failure/timeout.
- `sanitizePathEntries`: drops relative, `..`-segment, NUL/newline and empty entries; keeps a directory whose *name* merely starts with dots (`/opt/..cache/bin` is a real path, not traversal).
- `mergeGatewayPath`: appends launchd-only entries after the inherited ones; a launchd entry can never precede `/usr/bin`; de-duplicates and is idempotent; reports no additions when the domain matches what was inherited; and appends to a very large inherited `PATH` rather than suppressing the fix.
- Two regression tests for defects found during local review, both of which pin an invariant rather than a spelling:
  - **appends to a very large inherited PATH instead of suppressing the fix** — first found as a cap loop that used `continue`, so a long inherited directory could be discarded while a shorter launchd directory later in the list still fit; then, once the cap itself was removed, inverted to pin the property that matters: a 12 KB inherited `PATH` must still receive the appended directory. A companion test asserts no inherited entry is ever dropped whatever its size.
  - **preserves a zero-length inherited entry, even though that yields `::`** — a trailing `:` is a zero-length entry, which POSIX defines as the cwd, so `/usr/bin:` is `[/usr/bin, cwd]` and appending must yield `[/usr/bin, cwd, <new>]`. Collapsing that to a single `:` would delete the cwd entry. This test exists because `::` reads like a formatting bug and was proposed for "fixing" during review.
- `resolveGatewayPath`: returns the merge when directories are added; returns `null` on every no-op path (non-darwin, unreadable domain, nothing added); keeps the inherited `PATH` intact when the domain is only partially valid.

Mutation-verified — each mutation is caught by the specific test that owns it, not merely by "some test failing": prepending instead of appending (ordering + shadowing tests), removing the darwin guard (the no-spawn test), accepting relative entries (validation test), and re-running the inherited value through validation (the verbatim test). Two further mutations were run against the revision that still had the merged cap, and both were caught before it was removed.

Full `website/electron` suite: 1140 tests, 1139 pass, 0 fail, 1 skipped.

## Manual verification

N/A — unit coverage sufficient, and honest about one gap.

The launchd read was exercised against the **real** `/bin/launchctl` on a macOS 26.5.2 host: with no `PATH` in the user domain, `readLaunchdPath` returns `null` and `resolveGatewayPath` returns `null`, so the module correctly no-ops and leaves the environment untouched. That run also established that `launchctl getenv` on an unset key exits 0 with empty stdout rather than non-zero — the empty-string path, which the tests cover.

What is **not** covered end-to-end: a real GUI `.app` launch whose Gateway then resolves a user-installed CLI. Reaching `spawnGateway()` on the verifying machine requires the app to spawn its own Gateway, and that host runs the Gateway from a source checkout under a launchd agent with the app reusing it, so the spawn path is not taken. A pod does not help either — a pod's Gateway is started by launchd, not by `main.js`. Rather than fake it, the boundary is stated: the launchd read and the merge are covered by unit tests plus a real-binary check, and the spawn wiring itself is a three-line env spread reviewable by inspection.

## Related Issues

Related: #2367 — implements shape 1 of the four listed there. No completion trailer on purpose: the settings surface and the refresh-and-restart action remain open on that issue, so it must not auto-shut on merge. #3030 owns the complementary backend half (making `augmented_path`'s search path user-extensible) and is unaffected by this change.

<!-- no-visual-delta -->
**Why no screenshot:** Electron main-process only — no rendered surface changes, and the diff touches no path the Screenshot Evidence gate watches (`website/src/{components,pages,apps}` and CSS).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing doc covers the Gateway spawn environment; the rationale lives in the module's own header.
- [x] No secrets, credentials, or internal references in the diff

