### PR TITLE
feat(registry): diagnose credential-posture clone failures instead of bare 'git clone failed'

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -3659,10 +3659,13 @@ async def _git_clone_or_pull(
             return {
                 "ok": False,
                 "name": dest.name,
-                "error": "unreadable_clone_origin",
-                "message": (
+                # Human sentence in `error`, machine slug in `code`: the App
+                # Store install banner renders `result.error` and never
+                # `result.message`, so the slug must not sit in `error`.
+                "code": "unreadable_clone_origin",
+                "error": (
                     "The existing checkout's origin remote is unreadable. "
-                    "Remove or fix it manually and retry the install."
+                    f"Remove or fix it manually at {dest} and retry the install."
                 ),
             }
         if existing_origin != git_url:
@@ -3679,10 +3682,11 @@ async def _git_clone_or_pull(
                 return {
                     "ok": False,
                     "name": dest.name,
-                    "error": "stale_clone_not_removed",
-                    "message": (
+                    "code": "stale_clone_not_removed",
+                    "error": (
                         "A checkout of a different repository is present and could not be "
-                        "moved aside. Remove it manually and retry the install."
+                        f"moved aside (a file at {dest} may be locked or in use). "
+                        "Remove it manually and retry the install."
                     ),
                 }
 
@@ -3854,6 +3858,27 @@ async def _git_clone_or_pull(
             raise
         if proc.returncode != 0:
             await asyncio.to_thread(platform_compat.rmtree_force, dest)
+            if index_originated:
+                # The clone ran credential-free (anonymous_git_env + strict
+                # sandbox) because the repo URL came from an external registry
+                # index whose repo differs from the registry URL, so owner
+                # credentials were withheld (confused-deputy defense). A
+                # private sibling repo therefore fails to clone. Tell the owner
+                # the cause and the remedy instead of a bare "git clone failed".
+                # Human sentence in `error`, machine slug in `code`: the install
+                # banner renders `result.error`, never `result.message`.
+                return {
+                    "ok": False,
+                    "name": dest.name,
+                    "code": "git_clone_failed_no_credentials",
+                    "error": (
+                        "Git clone failed (cloned without credentials because "
+                        "this app's repo URL differs from the registry URL, so "
+                        "owner credentials are withheld). Private app repos must "
+                        "live inside the registry repo — see the monorepo layout "
+                        "in docs/app-kit/publishing-guide.md."
+                    ),
+                }
             return {"ok": False, "name": dest.name, "error": "git clone failed"}
         clone_succeeded = True
         return None
@@ -5080,7 +5105,10 @@ async def install_from_registry(
             # Retain moved-aside checkouts so the user can recover local
             # edits; they will be swept after _STALE_CHECKOUT_RETENTION_DAYS.
             for _stale in build_result.get("_pending_stale_cleanup") or []:
-                log_lines.append(f"Previous checkout retained at: {_stale}")
+                log_lines.append(
+                    f"Previous checkout retained at: {_stale} "
+                    f"(removed automatically after {_STALE_CHECKOUT_RETENTION_DAYS} days)"
+                )
                 logger.info("Retained stale checkout: %s", _stale)
             if official_entry:
                 install_receipt.dispatch(
@@ -5137,7 +5165,10 @@ async def install_from_registry(
             # Retain moved-aside checkouts so the user can recover local
             # edits; they will be swept after _STALE_CHECKOUT_RETENTION_DAYS.
             for _stale in build_result.get("_pending_stale_cleanup") or []:
-                log_lines.append(f"Previous checkout retained at: {_stale}")
+                log_lines.append(
+                    f"Previous checkout retained at: {_stale} "
+                    f"(removed automatically after {_STALE_CHECKOUT_RETENTION_DAYS} days)"
+                )
                 logger.info("Retained stale checkout: %s", _stale)
             if official_entry:
                 # Detached best-effort telemetry runs only after durable success.

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -2196,7 +2196,7 @@ async def handle_blob_proxy(request: web.Request) -> web.Response:
     if not repo or not file_path:
         return web.json_response({"error": "repo and path required"}, status=400)
     if not _is_safe_repo_identifier(repo):
-        return web.json_response({"error": "invalid repo name"}, status=400)
+        return web.json_response({"error": "invalid repo URL or name"}, status=400)
     if not _SAFE_PATH_RE.match(file_path):
         return web.json_response({"error": "invalid path characters"}, status=400)
     if not _SAFE_REF_RE.match(ref):
@@ -2625,7 +2625,7 @@ async def handle_registries(request: web.Request) -> web.Response:
         # vetted full git URL. Reuse the blob-proxy validator, which rejects
         # shell metacharacters / traversal and owner/repo shorthand.
         if not _is_safe_repo_identifier(repo):
-            return _deny(f"invalid repo name: {repo!r}", f"repo={repo}")
+            return _deny(f"invalid repo URL or name: {repo!r}", f"repo={repo}")
         if repo in _blocked_repos:
             return _deny(
                 f"{repo!r} is the core registry — no need to add it", f"blocked_repo={repo}"

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -2438,7 +2438,7 @@ class TestStaleCloneDeletionFailsClosed:
 
         # Fails closed with an error dict...
         assert err is not None and not err["ok"]
-        assert err["error"] == "stale_clone_not_removed"
+        assert err["code"] == "stale_clone_not_removed"
         # ...and never pulls or clones over the surviving stale checkout.
         assert not any(c[:2] == ["git", "pull"] for c in captured["calls"])
         assert not any(c[:2] == ["git", "clone"] for c in captured["calls"])
@@ -2650,7 +2650,7 @@ class TestOriginMismatchDeleteOrder:
         # Must return stale_clone_not_removed error.
         assert err is not None
         assert err["ok"] is False
-        assert err["error"] == "stale_clone_not_removed"
+        assert err["code"] == "stale_clone_not_removed"
         # The original clone is UNTOUCHED — no data loss.
         assert (dest / "intact.txt").exists()
         assert (dest / "intact.txt").read_text() == "do not touch"
@@ -3014,10 +3014,11 @@ class TestUnreadableOriginAbort:
                 index_originated=False,
             )
 
-        # Must return the unreadable_clone_origin error.
+        # Must return the unreadable_clone_origin error (slug in `code`,
+        # human sentence in `error` — the install banner renders `error`).
         assert err is not None
         assert err["ok"] is False
-        assert err["error"] == "unreadable_clone_origin"
+        assert err["code"] == "unreadable_clone_origin"
         # Dest is UNTOUCHED — no rename, no rmtree, no re-clone.
         assert (dest / "local-edits.txt").exists()
         assert (dest / "local-edits.txt").read_text() == "precious work"
@@ -4439,3 +4440,117 @@ class TestManifestBranchGate:
         assert result is not None
         assert result.get("stale") is not True
         assert result.get("version") == "2.0.0"
+
+
+class TestCloneFailureDiagnostics:
+    """A failed clone must tell an index-originated installer WHY: the clone
+    ran credential-free because the repo URL differs from the registry URL, so
+    a private sibling repo cannot be read. Owner-designated installs keep the
+    ambient identity, so their failure must NOT carry the misleading hint.
+
+    The human sentence lives in ``error`` and the machine slug in ``code``: the
+    App Store install banner renders ``result.error`` and never
+    ``result.message`` (AppDetailPage.tsx), so a slug in ``error`` would be
+    shown to the user verbatim.
+    """
+
+    @staticmethod
+    def _fake_wrap_argv(argv, mode="standard"):
+        return list(argv), None
+
+    class _FailProc:
+        returncode = 128  # git clone failure
+
+        async def communicate(self):
+            return (b"fatal: could not read Username (no credentials)", None)
+
+    @pytest.mark.asyncio
+    async def test_index_originated_failure_explains_credential_posture(self, tmp_path):
+        """index_originated=True + failed fresh clone → error carries the
+        credential-posture explanation and the monorepo-recipe pointer; the
+        machine slug is in ``code``."""
+        import kiro_crew.apps.registry as reg
+
+        git_url = "https://forge.example.com/owner/private-sibling.git"
+        dest = tmp_path / "app-sources" / "myapp"
+
+        async def _fake_create_subprocess(*args, **kwargs):
+            # Fresh clone: dest is created by git, then git exits nonzero.
+            dest.mkdir(parents=True, exist_ok=True)
+            return self._FailProc()
+
+        log_lines: list[str] = []
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=self._fake_wrap_argv),
+            patch("kiro_crew.apps.registry.cgroup_scope_argv", side_effect=lambda a: a),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_create_subprocess,
+            ),
+        ):
+            err = await reg._git_clone_or_pull(
+                git_url,
+                "main",
+                dest,
+                log_lines,
+                index_originated=True,
+            )
+
+        assert err is not None
+        assert err["ok"] is False
+        # Machine-stable slug is in `code`, NOT `error`.
+        assert err["code"] == "git_clone_failed_no_credentials"
+        human = err["error"]
+        # The human text must NOT be the bare slug (which the banner would show).
+        assert human != "git_clone_failed_no_credentials"
+        assert human != "git clone failed"
+        # It explains the cause (credential-free / withheld) and the remedy.
+        low = human.lower()
+        assert "credential" in low
+        assert "registry" in low
+        assert "docs/app-kit/publishing-guide.md" in human
+        # No secret/identity material: only the owner's own registry/repo posture
+        # is referenced, never the git URL, a token, or ssh identity.
+        assert git_url not in human
+        assert "ssh" not in low
+        assert "token" not in low
+
+    @pytest.mark.asyncio
+    async def test_owner_designated_failure_has_no_misleading_hint(self, tmp_path):
+        """index_originated=False + failed fresh clone → the bare
+        ``git clone failed`` error, with NO credential-posture hint (the clone
+        kept the ambient identity, so the hint would be wrong)."""
+        import kiro_crew.apps.registry as reg
+
+        git_url = "https://forge.example.com/owner/app.git"
+        dest = tmp_path / "app-sources" / "myapp"
+
+        async def _fake_create_subprocess(*args, **kwargs):
+            dest.mkdir(parents=True, exist_ok=True)
+            return self._FailProc()
+
+        log_lines: list[str] = []
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=self._fake_wrap_argv),
+            patch("kiro_crew.apps.registry.cgroup_scope_argv", side_effect=lambda a: a),
+            patch(
+                "kiro_crew.apps.registry.create_subprocess_limited",
+                side_effect=_fake_create_subprocess,
+            ),
+        ):
+            err = await reg._git_clone_or_pull(
+                git_url,
+                "main",
+                dest,
+                log_lines,
+                index_originated=False,
+            )
+
+        assert err is not None
+        assert err["ok"] is False
+        # Unchanged bare failure — no credential-posture code, no hint.
+        assert err["error"] == "git clone failed"
+        assert "code" not in err
+        assert "credential" not in err["error"].lower()

--- a/test/test_registries_api.py
+++ b/test/test_registries_api.py
@@ -379,7 +379,22 @@ class TestPutRegistriesValidation:
                 json={"registries": [{"repo": "../evil"}]},
             )
             assert resp.status == 400
-            assert "invalid repo name" in (await resp.json())["error"]
+            # The rejection covers full ssh/https URLs too, so the wording says
+            # "URL or name" rather than the misleading name-only phrasing.
+            assert "invalid repo URL or name" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_repo_url(self, tmp_path, monkeypatch):
+        """A malformed full URL is rejected with the URL-or-name wording (the
+        input is a URL, so a bare "invalid repo name" banner would read wrong)."""
+        _setup_env(tmp_path, monkeypatch)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.put(
+                "/api/apps/registries",
+                json={"registries": [{"repo": "ssh://git@evil host/repo.git"}]},
+            )
+            assert resp.status == 400
+            assert "invalid repo URL or name" in (await resp.json())["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_repo_with_spaces(self, tmp_path, monkeypatch):
@@ -564,7 +579,7 @@ class TestPutRegistriesUrls:
                 json={"registries": [{"repo": "acme/apps"}]},
             )
             assert resp.status == 400
-            assert "invalid repo name" in (await resp.json())["error"]
+            assert "invalid repo URL or name" in (await resp.json())["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_shell_metachar_junk(self, tmp_path, monkeypatch):
@@ -575,7 +590,7 @@ class TestPutRegistriesUrls:
                 json={"registries": [{"repo": "https://github.com/a/b;rm -rf /"}]},
             )
             assert resp.status == 400
-            assert "invalid repo name" in (await resp.json())["error"]
+            assert "invalid repo URL or name" in (await resp.json())["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_plaintext_http_url(self, tmp_path, monkeypatch):
@@ -589,7 +604,7 @@ class TestPutRegistriesUrls:
                 json={"registries": [{"repo": "http://github.com/acme/apps"}]},
             )
             assert resp.status == 400
-            assert "invalid repo name" in (await resp.json())["error"]
+            assert "invalid repo URL or name" in (await resp.json())["error"]
 
     @pytest.mark.asyncio
     async def test_blocked_repo_still_blocked(self, tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Diagnose credential-posture clone failures instead of bare 'git clone failed'**

## Changes and rationale

### Diagnose credential-posture clone failures instead of bare 'git clone failed'
**Tests:** test/test_external_registry.py: index-originated clone failure → error dict carries the credential-posture explanation; owner-designated (non-index) clone failure → message unchanged (no misleading hint). Remember: never assert raw git argv — cgroup_scope_argv wraps argv on Linux. test/test_registries_api.py: invalid repo input → 400 body says "invalid…
**Review focus:** backend, security boundaries, documentation and public behavior

## Review map

| Change | Primary files |
|---|---|
| Diagnose credential-posture clone failures instead of bare 'git clone failed' | `src/kiro_crew/apps/registry.py`<br>`src/kiro_crew/apps/routes.py`<br>`test/test_external_registry.py`<br>`test/test_registries_api.py` |

## Commits
- [`8672fb4`](https://github.com/kirodotdev/KiroCrew/pull/4939/commits/8672fb48aef229163f9512e3939ed0affb41bd39) feat(registry): diagnose credential-posture clone failures instead of…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (4 files, +179/-18)</summary>

- `src/kiro_crew/apps/registry.py` (+39/-8)
- `src/kiro_crew/apps/routes.py` (+2/-2)
- `test/test_external_registry.py` (+119/-4)
- `test/test_registries_api.py` (+19/-4)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->