### PR TITLE
fix(dashboard): read the agent tool policy off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -10,7 +10,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from kiro_crew.providers.base import LLMProvider  # noqa: F811
@@ -1605,6 +1605,30 @@ def _service_wait_ping(
         state.push_slots_update()
 
 
+def _read_managed_tool_policy_sync(agent_path: Path) -> dict[str, Any] | None:
+    """Read one agent's ``managedToolPolicy`` from disk. Blocking.
+
+    Split out so the whole filesystem transaction -- the existence probe, the
+    read and the JSON parse -- crosses to a worker as ONE unit. Offloading only
+    the read would leave the ``stat`` and the parse on the gateway's single event
+    loop, which is the same defect in a smaller form.
+
+    ``None`` means "no policy to report", and is deliberately distinct from an
+    empty dict. The caller answers ``{}`` for both, but only a dict is an agent
+    whose config was read and understood, which is what its SEL ``ok`` record
+    attests -- an unreadable or malformed file is not an agent with no policy.
+    Collapsing the two would start logging success for files this never parsed.
+    """
+    try:
+        if not agent_path.is_file():
+            return None
+        config = json.loads(agent_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    policy = config.get("managedToolPolicy", {})
+    return policy if isinstance(policy, dict) else None
+
+
 async def api_session_tool_policy(request: web.Request) -> web.Response:
     """GET /api/session-tool-policy — return managedToolPolicy for the
     calling session's agent.
@@ -1672,18 +1696,15 @@ async def api_session_tool_policy(request: web.Request) -> web.Response:
         )
         return web.json_response({"error": "invalid agent name"}, status=400)
 
-    # Read agent config from disk
+    # Read agent config from disk, OFF the event loop. A managed MCP server
+    # calls this to filter its tool list, so it runs on ordinary request traffic
+    # rather than at startup: the stat, the read and the parse would otherwise
+    # execute on the single loop every gateway request shares.
     agent_path = kiro_agents_dir() / f"{agent_name}.json"
-    if not agent_path.is_file():
-        return web.json_response({})
-
-    try:
-        config = json.loads(agent_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return web.json_response({})
-
-    policy = config.get("managedToolPolicy", {})
-    if not isinstance(policy, dict):
+    policy = await asyncio.to_thread(_read_managed_tool_policy_sync, agent_path)
+    if policy is None:
+        # Missing, unreadable, malformed, or a non-dict policy: answer the same
+        # empty policy as before and, as before, do not log it as a success.
         return web.json_response({})
 
     _sel().log_api_access(

--- a/test/test_session_tool_policy_off_loop.py
+++ b/test/test_session_tool_policy_off_loop.py
@@ -1,0 +1,185 @@
+"""``api_session_tool_policy`` must not read the agent config on the gateway loop.
+
+A managed MCP server (kirocrew-core, kirocrew-cron) calls this endpoint to filter
+its tool list per agent, so it runs on ordinary request traffic. The handler
+resolved the agent's config file inline::
+
+    if not agent_path.is_file():        # stat
+    config = json.loads(agent_path.read_text(...))   # read + parse
+
+all three on the single event loop every other gateway request shares.
+
+The proof below is thread identity at the real filesystem seam -- ``read_text``
+itself -- not an assertion that ``asyncio.to_thread`` was called. A spy on the
+offload would keep passing if the call were later moved back inline behind some
+other wrapper; the thread the read actually runs on cannot be faked.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.handlers import sessions as sessions_mod
+
+AGENT = "reviewer"
+
+
+def _state(agent: str = AGENT) -> MagicMock:
+    """A state whose session key resolves straight to *agent*."""
+    state = MagicMock()
+    slot = MagicMock()
+    slot.agent = agent
+    state.get_slot = MagicMock(return_value=slot)
+    # Agent already resolved from the slot, so the session-manager fallback in
+    # the handler must not be consulted.
+    state.sessions = None
+    return state
+
+
+def _request(state: MagicMock) -> MagicMock:
+    request = MagicMock()
+    request.headers = {"X-Session-Key": f"dashboard:{AGENT}-slot"}
+    request.app = {"state": state}
+    return request
+
+
+def _body(response: Any) -> Any:
+    return json.loads(response.body.decode("utf-8"))
+
+
+async def _call(monkeypatch: pytest.MonkeyPatch, agents_dir: Path) -> Any:
+    monkeypatch.setattr(sessions_mod, "kiro_agents_dir", lambda: agents_dir)
+    monkeypatch.setattr(sessions_mod, "_sel", lambda: MagicMock())
+    return await sessions_mod.api_session_tool_policy(_request(_state()))
+
+
+@pytest.mark.asyncio
+async def test_the_agent_config_read_runs_off_the_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The thread that reads and parses the agent config is not the loop's."""
+    (tmp_path / f"{AGENT}.json").write_text(
+        json.dumps({"managedToolPolicy": {"exclude": ["shell"]}}), encoding="utf-8"
+    )
+
+    read_threads: list[int] = []
+    real_read_text = Path.read_text
+
+    def recording_read_text(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        read_threads.append(threading.get_ident())
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", recording_read_text)
+
+    loop_thread = threading.get_ident()
+    response = await _call(monkeypatch, tmp_path)
+
+    assert _body(response) == {"exclude": ["shell"]}
+    assert read_threads, "the agent config was never read"
+    assert loop_thread not in read_threads, (
+        "the agent config was read on the event-loop thread: the stat, the read "
+        "and the JSON parse all block every other request on that loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_missing_agent_config_is_an_empty_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Behaviour preserved: no file for this agent answers an empty policy."""
+    response = await _call(monkeypatch, tmp_path)
+    assert response.status == 200
+    assert _body(response) == {}
+
+
+@pytest.mark.asyncio
+async def test_an_unparseable_agent_config_is_an_empty_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Behaviour preserved: malformed JSON answers {} rather than raising.
+
+    The endpoint is deny-by-default about IDENTITY (an unresolved session is a
+    400/404), but permissive about a policy it cannot read: an unreadable file
+    must not take the MCP server's tool listing down.
+    """
+    (tmp_path / f"{AGENT}.json").write_text("{ not json", encoding="utf-8")
+    response = await _call(monkeypatch, tmp_path)
+    assert response.status == 200
+    assert _body(response) == {}
+
+
+@pytest.mark.asyncio
+async def test_a_non_dict_policy_is_an_empty_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Behaviour preserved: a policy of the wrong shape is not handed through."""
+    (tmp_path / f"{AGENT}.json").write_text(
+        json.dumps({"managedToolPolicy": ["exclude"]}), encoding="utf-8"
+    )
+    response = await _call(monkeypatch, tmp_path)
+    assert _body(response) == {}
+
+
+@pytest.mark.asyncio
+async def test_an_agent_without_a_policy_key_is_reported_as_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``{}`` from a READ config is not the same as ``{}`` from an unread one.
+
+    Both answer an empty policy, but only the former is an agent whose config was
+    parsed and understood -- which is what the handler's SEL ``ok`` record
+    attests. Collapsing the two would start logging success for files that were
+    never read, so the split is pinned here.
+    """
+    (tmp_path / f"{AGENT}.json").write_text(json.dumps({"name": AGENT}), encoding="utf-8")
+
+    sel = MagicMock()
+    monkeypatch.setattr(sessions_mod, "kiro_agents_dir", lambda: tmp_path)
+    monkeypatch.setattr(sessions_mod, "_sel", lambda: sel)
+    response = await sessions_mod.api_session_tool_policy(_request(_state()))
+
+    assert _body(response) == {}
+    assert sel.log_api_access.called, "a config that WAS read should log its ok"
+    assert sel.log_api_access.call_args.kwargs["outcome"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_an_unread_config_is_not_logged_as_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of the split: a missing file logs no success."""
+    sel = MagicMock()
+    monkeypatch.setattr(sessions_mod, "kiro_agents_dir", lambda: tmp_path)
+    monkeypatch.setattr(sessions_mod, "_sel", lambda: sel)
+    response = await sessions_mod.api_session_tool_policy(_request(_state()))
+
+    assert _body(response) == {}
+    assert not sel.log_api_access.called, "an unread config must not report ok"
+
+
+@pytest.mark.asyncio
+async def test_a_traversing_agent_name_is_still_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The path-traversal guard runs before any filesystem work, as before."""
+    monkeypatch.setattr(sessions_mod, "kiro_agents_dir", lambda: tmp_path)
+    monkeypatch.setattr(sessions_mod, "_sel", lambda: MagicMock())
+    response = await sessions_mod.api_session_tool_policy(_request(_state("../../etc/passwd")))
+    assert response.status == 400
+    assert _body(response)["error"] == "invalid agent name"
+
+
+@pytest.mark.asyncio
+async def test_a_missing_session_key_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deny-by-default on identity is unchanged."""
+    monkeypatch.setattr(sessions_mod, "_sel", lambda: MagicMock())
+    request = _request(_state())
+    request.headers = {}
+    response = await sessions_mod.api_session_tool_policy(request)
+    assert response.status == 400


### PR DESCRIPTION
## Problem / Motivation

`GET /api/session-tool-policy` resolves the calling session's agent config **on the gateway event loop**. `api_session_tool_policy` does the whole filesystem transaction inline:

```python
agent_path = kiro_agents_dir() / f"{agent_name}.json"
if not agent_path.is_file():                                    # stat
    return web.json_response({})

try:
    config = json.loads(agent_path.read_text(encoding="utf-8"))  # read + parse
except (OSError, json.JSONDecodeError):
    return web.json_response({})
```

A stat, a read and a JSON parse, none of them offloaded, on the single loop every other gateway request shares.

## Why it matters

This is not a startup path. Managed MCP servers (kirocrew-core, kirocrew-cron) call this endpoint to filter their tool lists per agent — `docs/architecture/mcp.md` lists it as a gateway round-trip on the MCP path — so it runs on ordinary request traffic.

The directory it reads is a real user directory (`<kiro home>/agents`), not a cache, so its reads are exactly as slow as that filesystem is: a network home, a cold page cache, or a Windows indexer or AV holding the file each turn a "cheap" read into loop time that every other request waits behind. Nothing about the call site bounds that cost.

The repo already treats this as a defect class of its own (`no-blocking-call-on-event-loop`), with the same correction landed at other call sites — #4118, #3803, #4550.

## What changed (motivation → approach → change)

**Symptom** — an MCP tool-list filter request performs blocking filesystem work on the gateway loop.

**Root cause** — the existence probe, the read and the parse are written inline in an `async def`, so they execute on whatever thread the coroutine is running on, which is the loop's.

**Change** — extract the three into one sync helper and invoke it through `asyncio.to_thread`:

```python
policy = await asyncio.to_thread(_read_managed_tool_policy_sync, agent_path)
if policy is None:
    return web.json_response({})
```

**The whole transaction moves, not just the read.** Offloading `read_text` alone would leave the `stat` and the `json.loads` on the loop — the same defect in a smaller form, and a thread-identity test would then prove the fix incomplete rather than prove it correct.

**`None` is deliberately distinct from `{}`.** The helper answers `None` for every case that already returned an empty policy *without* an audit record — missing file, `OSError`, malformed JSON, non-dict policy — and a dict for a config that was read and understood. That split is load-bearing: a policy of `{}` because the key is absent is an agent whose config **was** parsed, which is what the SEL `ok` record attests, while an unreadable file is not. Folding the two together would start logging success for files that were never read. Two tests pin both halves.

**Not moved:** `kiro_agents_dir()` stays on the loop — it is `kiro_home() / "agents"`, pure path arithmetic with no I/O, and moving it would be style rather than a fix. The path-traversal guard still runs before any filesystem work, exactly as before.

One production file; no route, contract, or response-shape change.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_the_agent_config_read_runs_off_the_event_loop` | the thread performing the read is not the loop's |
| `test_a_missing_agent_config_is_an_empty_policy` | missing file → `{}` |
| `test_an_unparseable_agent_config_is_an_empty_policy` | malformed JSON → `{}`, not a raise |
| `test_a_non_dict_policy_is_an_empty_policy` | wrong-shaped policy → `{}` |
| `test_an_agent_without_a_policy_key_is_reported_as_read` | a parsed config with no policy key still logs SEL `ok` |
| `test_an_unread_config_is_not_logged_as_ok` | an unread config logs no success |
| `test_a_traversing_agent_name_is_still_refused` | the path-traversal guard precedes any filesystem work |
| `test_a_missing_session_key_is_refused` | deny-by-default on identity is unchanged |

The proof is **thread identity at the real filesystem seam** — `Path.read_text` itself — not an assertion that `asyncio.to_thread` was called. A spy on the offload would keep passing if the call were later moved back inline behind another wrapper; the thread the read actually runs on cannot be faked. Same shape as the accepted proof in #4118.

Fail-before / pass-after on `c940485dc`, with only `sessions.py` reverted:

```
=== sessions.py = origin/main ===
FAILED test_the_agent_config_read_runs_off_the_event_loop
  AssertionError: the agent config was read on the event-loop thread: the stat,
  the read and the JSON parse all block every other request on that loop
1 failed, 7 passed

=== fix applied ===
8 passed
```

The seven behavioural tests pass on **both** sides, which is the point: they demonstrate that observable behaviour is preserved rather than merely re-stated.

`test_session_tool_policy_off_loop.py` + `test_mcp_shared_cache.py` + `test_mcp_call_site_auth_coverage.py`: **36 passed**.

Gates: `flake8` · `isort` · `scripts/check_black_formatting.py` · `scripts/check_brand_name.py`.

## Manual verification

N/A — unit coverage sufficient: the change is entirely about which thread performs the filesystem work, and the test measures that directly on the production handler with only the seam instrumented. Observing it in a running gateway would mean timing loop stalls under a slow filesystem, which is precisely the non-deterministic evidence the thread-identity assertion replaces.

## Related Issues

Fixes #4945.

Same defect class as #4118, #3803 and #4550.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: `docs/architecture/mcp.md` documents this endpoint's *contract* (it returns the session's `managedToolPolicy.exclude`), which is unchanged; only the thread the read runs on differs
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
