### PR TITLE
fix(platform): give owner-only directories inheritable DACLs on Windows

### DIFF
--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -1923,12 +1923,16 @@ incidental. Each was measured on Windows 11:
   is also reachable from config, where a zero or negative budget yields a degenerate
   image and an unbounded one yields a frame far larger than any consumer expects.
 
-  Screenshots are locked down in BOTH layers, because `restrict_to_owner` emits a
-  **non-inheritable** ACE: a directory-only grant leaves each new file with just the
-  inherited SYSTEM / Administrators / Owner-Rights entries and never an owner-only
-  DACL. The directory is created through `platform_compat.make_owner_only_dir` (a
-  bare `mkdir(mode=0o700)` is inert on Windows, where access comes from the DACL) and
-  each frame is tightened as it is written.
+  Screenshots are locked down in BOTH layers. The directory grant is now
+  **inheritable** (`platform_compat.make_owner_only_dir` routes through
+  `restrict_dir_to_owner`, which emits `(OI)(CI)`), so a newly created frame does
+  inherit the owner-only DACL — but inheritance governs only what is CREATED from
+  that point on, and Windows grants Bypass Traverse Checking to Everyone by
+  default, so a frame that already exists keeps its own DACL and stays reachable
+  through the tightened parent. The directory is created through
+  `platform_compat.make_owner_only_dir` (a bare `mkdir(mode=0o700)` is inert on
+  Windows, where access comes from the DACL) and each frame is still tightened as
+  it is written, which is what covers the already-exists case.
 
 - **The `press_key` grammar is a platform-free seam, and both halves canonicalize.**
   `keymap.parse_spec()` returns a `KeySpec` of abstract names, which `tools._perform`

--- a/src/kiro_crew/computer_use/capture_windows.py
+++ b/src/kiro_crew/computer_use/capture_windows.py
@@ -34,11 +34,14 @@ Three Windows-specific findings shape the capture:
 The spool PATH, the ring trim and the owner-only protection are all shared with
 :mod:`capture_macos` (``shots_dir`` resolves through ``tempfile.gettempdir()``,
 already ``%TEMP%`` here). Both layers of that protection are needed on Windows and
-neither substitutes for the other: ``restrict_to_owner`` emits a NON-inheritable
-ACE, so a directory-only grant leaves each new file with just the inherited
-SYSTEM / Administrators / Owner-Rights entries, while a file-only grant leaves the
-directory itself listable. The directory is tightened once per process and each
-frame is tightened as it is written.
+neither substitutes for the other: the directory grant is inheritable
+(``restrict_dir_to_owner`` emits ``(OI)(CI)``) so files created inside inherit the
+owner-only DACL, but inheritance governs only what is CREATED from here on -- a
+frame that already exists keeps its own DACL, and Windows grants Bypass Traverse
+Checking to Everyone by default, so a permissive pre-existing file stays reachable
+through a tightened parent. A file-only grant, conversely, leaves the directory
+itself listable. The directory is tightened once per process and each frame is
+tightened as it is written.
 """
 
 from __future__ import annotations
@@ -387,11 +390,12 @@ def persist_jpeg(raw: bytes) -> str:
 
     The Windows counterpart of ``capture_macos.persist_jpeg``, and it keeps that
     function's per-file ``restrict_to_owner``. The directory ACL is NOT sufficient
-    on its own: ``restrict_to_owner`` emits a non-inheritable ACE (it was written
-    for files), so the directory's owner grant carries no ``(OI)(CI)`` and a new
-    file lands with only the inherited SYSTEM / Administrators / Owner-Rights
-    entries — never an owner-only DACL. A frame can contain anything that was on
-    screen, so the file itself is locked down.
+    on its own even now that it is inheritable: ``make_owner_only_dir`` routes
+    through ``restrict_dir_to_owner``, whose ``(OI)(CI)`` grants cover files
+    CREATED from that point on, but Windows grants Bypass Traverse Checking to
+    Everyone by default, so a frame that already exists keeps its own DACL and
+    stays reachable through the tightened parent. A frame can contain anything
+    that was on screen, so the file itself is locked down.
 
     The spawn is on the capture path, not the observation path: it runs only when a
     screenshot was actually produced, which is already the expensive branch, and

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -833,7 +833,7 @@ def _ensure_auth_staging_parent(home: Path) -> Path:
     if platform_compat.IS_POSIX:
         platform_compat.chmod_safe(str(staging_parent), 0o700)
     else:
-        platform_compat.restrict_to_owner(str(staging_parent))
+        platform_compat.restrict_dir_to_owner(str(staging_parent))
     return staging_parent
 
 
@@ -851,7 +851,7 @@ def _prepare_auth_workspace(
         if platform_compat.IS_POSIX:
             platform_compat.chmod_safe(str(root), 0o700)
         else:
-            platform_compat.restrict_to_owner(str(root))
+            platform_compat.restrict_dir_to_owner(str(root))
         for mapping in _auth_store_mappings(platform_name, home, environ):
             for pattern in mapping.filenames:
                 for source in mapping.source.glob(pattern):

--- a/src/kiro_crew/mcp_gateway/apps.py
+++ b/src/kiro_crew/mcp_gateway/apps.py
@@ -125,7 +125,7 @@ def write_spool(payload: dict) -> str:
         # Fail loud — a record must never exist without owner-only
         # protection; the interception caller's failure-safe path delivers
         # the original tool result with no app render.
-        platform_compat.restrict_to_owner(directory)
+        platform_compat.restrict_dir_to_owner(directory)
 
     spool_id = uuid.uuid4().hex
     record = {

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -2768,6 +2768,22 @@ def unlink_link_or_junction(path: str | os.PathLike) -> None:
 _OWNER_RIGHTS_SID = "*S-1-3-4"
 
 
+# icacls inheritance flags for a DIRECTORY grant: (OI) object-inherit
+# propagates the ACE to files created inside, (CI) container-inherit propagates
+# it to subdirectories. Neither sets (IO), so the ACE also applies to the
+# directory itself and traversal is preserved.
+#
+# Without these flags a grant applies to the named object ALONE. That is
+# correct and complete for a file, and silently wrong for a directory: a file
+# created inside an "owner-only" directory would carry no explicit ACE at all
+# and fall back to whatever the creating process's token grants by default
+# (typically owner + SYSTEM + Administrators) — a default rather than the
+# guarantee the caller asked for. The flags are meaningless on a file, which is
+# why this is a directory-only rights prefix and not something
+# :func:`restrict_to_owner` can pass unconditionally.
+_ICACLS_DIR_INHERIT = "(OI)(CI)"
+
+
 # Success-only memo for _current_user_sid. NOT functools.lru_cache: lru_cache
 # would memoize a *failure* (None) permanently, so one transient whoami
 # timeout at first call (AV scan, system pressure) would poison every later
@@ -3130,9 +3146,16 @@ def make_owner_only_dir(path: str | os.PathLike) -> None:
 
     ``0o700`` and not :func:`restrict_to_owner` on POSIX: that helper applies
     ``0o600``, correct for a secret-bearing file and wrong for a directory,
-    which needs the execute bit to be traversable at all. Windows has no such
-    split (``icacls ... :F`` grants traverse with everything else), and there the
-    DACL is the only carrier of access, so the fail-loud helper is right.
+    which needs the execute bit to be traversable at all. On Windows the split
+    is the inverse of inert: ``restrict_to_owner``'s grants are not inheritable
+    (correct for a file, where the flags mean nothing), so routing a directory
+    through it left every file created inside on the creating token's default
+    DACL. Both platforms therefore go through
+    :func:`restrict_dir_to_owner`, the directory-shaped twin.
+
+    Only newly created children are covered. A file that already exists inside
+    the directory keeps its own DACL — see :func:`restrict_dir_to_owner` for
+    why a tightened parent does not fix one.
 
     Best-effort on the tightening step: the directory is still created, and the
     caller decides whether an un-tightened directory is fatal.
@@ -3140,10 +3163,7 @@ def make_owner_only_dir(path: str | os.PathLike) -> None:
     p = Path(path)
     p.mkdir(parents=True, exist_ok=True, mode=0o700)
     try:
-        if IS_WINDOWS:
-            restrict_to_owner(p)
-        else:
-            p.chmod(0o700)
+        restrict_dir_to_owner(p)
     except OSError:
         logger.warning("could not restrict directory %s to owner-only", p, exc_info=True)
 
@@ -3202,6 +3222,80 @@ def restrict_to_owner(path: str | os.PathLike) -> None:
     if IS_POSIX:
         os.chmod(path, 0o600)
         return
+    # Misuse guard: this helper is FILE-shaped. Its grants carry no (OI)(CI),
+    # so handing it a directory tightens the directory itself and leaves every
+    # file created inside on the creating token's default DACL -- the exact
+    # defect restrict_dir_to_owner exists to close. Warn rather than raise:
+    # the ACE still applies to the named object, so the lockdown is partial
+    # rather than absent, and turning a partial protection into a runtime
+    # OSError would be the worse outcome. The argv tests cannot see this from
+    # the call site, so the check lives here.
+    try:
+        if Path(path).is_dir():
+            # The path is deliberately NOT logged. In this codebase a path can
+            # itself be the secret -- mcp_gateway/apps.py notes that its spool
+            # FILENAMES are live capability tokens -- so naming it here would be
+            # clear-text logging of sensitive information (CodeQL flagged exactly
+            # that). logging already records module/function/lineno, which is
+            # what locates the offending caller.
+            logger.warning(
+                "restrict_to_owner was called on a directory; its grants are not "
+                "inheritable, so files created inside will not be owner-only. "
+                "Use restrict_dir_to_owner for a directory."
+            )
+    except OSError:
+        pass
+    _icacls_owner_only(path, inherit=False)
+
+
+def restrict_dir_to_owner(path: str | os.PathLike) -> None:
+    """Fail-loud owner-only lockdown of a DIRECTORY, inherited by its children.
+
+    The directory twin of :func:`restrict_to_owner`, and separate from it
+    because the two shapes genuinely differ on both platforms:
+
+    POSIX: ``0o700`` rather than ``0o600`` — a directory needs the execute bit
+    to be traversable at all, so the file helper's mode would make the
+    directory useless.
+
+    Windows: the grants carry ``(OI)(CI)`` so they propagate to files and
+    subdirectories created inside. ``restrict_to_owner``'s grants deliberately
+    do not, because those flags are meaningless on a file; applying the
+    file-shaped helper to a directory is what left every file created inside an
+    "owner-only" directory on the creating token's default DACL.
+
+    Note the limit: inheritance governs what gets CREATED from here on. A file
+    that already exists inside the directory keeps its own DACL, and Windows
+    grants *Bypass Traverse Checking* to Everyone by default, so a permissive
+    pre-existing file stays reachable through a tightened parent. Repairing an
+    existing install needs a per-file pass over the known names; this helper is
+    the guarantee for new files, not a retrofit.
+
+    Fail-loud like :func:`restrict_to_owner`: any failure raises ``OSError`` so
+    callers reach their warn-and-continue handlers.
+    """
+    if IS_POSIX:
+        # Semgrep's insecure-file-permissions rule reads 0o700 as "widely
+        # permissive" and recommends 0o644, which is backwards for a DIRECTORY
+        # holding secrets: 0o644 drops owner-execute (making the directory
+        # untraversable) and ADDS world-read -- the exact exposure this helper
+        # exists to close. 0o700 is the restrictive mode here, so the finding is
+        # suppressed on the line below. Same reasoning as cloud/launch_job.py.
+        # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501
+        os.chmod(path, 0o700)
+        return
+    _icacls_owner_only(path, inherit=True)
+
+
+def _icacls_owner_only(path: str | os.PathLike, *, inherit: bool) -> None:
+    """Apply an owner-only DACL to *path* via icacls. Windows-only.
+
+    Shared by :func:`restrict_to_owner` (``inherit=False``, file shape) and
+    :func:`restrict_dir_to_owner` (``inherit=True``, directory shape). The only
+    difference between the two argv forms is the rights prefix, so they are one
+    function: an owner-only DACL that two call paths could drift apart on is
+    the defect this consolidation exists to prevent.
+    """
     icacls = shutil.which("icacls") or r"C:\Windows\System32\icacls.exe"
     # Resolve the invoking user's SID BEFORE building the argv. If whoami is
     # unavailable (missing from PATH under a stripped-down profile, subprocess
@@ -3216,19 +3310,21 @@ def restrict_to_owner(path: str | os.PathLike) -> None:
     user_sid = _current_user_sid()
     if user_sid is None:
         raise OSError(
-            "restrict_to_owner: cannot resolve current user SID via whoami; "
+            f"{'restrict_dir_to_owner' if inherit else 'restrict_to_owner'}: "
+            "cannot resolve current user SID via whoami; "
             "refusing to apply Owner-Rights-only DACL (would lock non-owner "
             f"users out of {path!s} — see _current_user_sid docstring)."
         )
+    rights = f"{_ICACLS_DIR_INHERIT}F" if inherit else "F"
     argv: list[str] = [
         icacls,
         os.fspath(path),
         "/inheritance:r",
         "/grant:r",
-        f"{_OWNER_RIGHTS_SID}:F",
+        f"{_OWNER_RIGHTS_SID}:{rights}",
     ]
     if user_sid != _OWNER_RIGHTS_SID:
-        argv += ["/grant:r", f"{user_sid}:F"]
+        argv += ["/grant:r", f"{user_sid}:{rights}"]
     try:
         r = subprocess.run(
             argv,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,6 +156,11 @@ def _windows_restrict_to_owner_stub(request, monkeypatch):
     call sites that bound the symbol by value (tips.py) are unaffected
     by this module-attr patch -- acceptable: they surface as at most a
     handful of failures, handled individually.
+
+    ``restrict_dir_to_owner`` is stubbed alongside it and must stay that
+    way: it is the directory twin that ``make_owner_only_dir`` routes
+    through, so stubbing only the file helper would leave every test that
+    creates an owner-only directory spawning a real icacls.
     """
     if not platform_compat.IS_WINDOWS or request.module.__name__ in (
         "test_platform_compat",
@@ -164,6 +169,7 @@ def _windows_restrict_to_owner_stub(request, monkeypatch):
         yield
         return
     monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: None)
+    monkeypatch.setattr(platform_compat, "restrict_dir_to_owner", lambda p: None)
     yield
 
 

--- a/test/test_mcp_gateway_oversize.py
+++ b/test/test_mcp_gateway_oversize.py
@@ -148,9 +148,12 @@ class TestSpillToFile:
         """
         if pc.IS_WINDOWS:
             calls: list[str] = []
-            monkeypatch.setattr(
-                pc, "restrict_to_owner", lambda p: calls.append(str(p))
-            )
+            wrong: list[str] = []
+            monkeypatch.setattr(pc, "restrict_dir_to_owner", lambda p: calls.append(str(p)))
+            # The file-shaped helper must NOT be what a directory goes through:
+            # its icacls grants carry no (OI)(CI), so spilled payloads written
+            # into the directory afterwards would not inherit the lockdown.
+            monkeypatch.setattr(pc, "restrict_to_owner", lambda p: wrong.append(str(p)))
         loose = tmp_path / "mcp_spill"
         loose.mkdir(mode=0o755)
 
@@ -165,6 +168,7 @@ class TestSpillToFile:
 
         if pc.IS_WINDOWS:
             assert str(loose) in calls
+            assert str(loose) not in wrong
         else:
             assert loose.stat().st_mode & 0o777 == 0o700
 

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -1656,6 +1656,116 @@ class TestRestrictToOwnerArgvOnLinux:
         # applying a half-configured lockdown.
         assert called == [], f"icacls should not run when SID is unknown: {called}"
 
+    def test_directory_grants_are_inheritable(self, tmp_path, monkeypatch):
+        # The bug this pins: make_owner_only_dir used to delegate to the
+        # FILE-shaped restrict_to_owner, whose grants carry no (OI)(CI). Those
+        # ACEs apply to the directory alone, so a file created inside an
+        # "owner-only" directory got no explicit ACE and fell back to the
+        # creating token's default DACL. No mode assertion can catch this —
+        # NTFS reports 0o666 for any file regardless of its DACL — so the
+        # argv IS the observable, exactly as the file-shape test above.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
+        captured: dict = {}
+
+        def fake_run(argv, **_kw):
+            captured["argv"] = list(argv)
+            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(pc.subprocess, "run", fake_run)
+        d = tmp_path / "secrets-dir"
+        d.mkdir()
+        pc.restrict_dir_to_owner(d)
+        argv = captured["argv"]
+        assert os.fspath(d) in argv
+        assert "/inheritance:r" in argv
+        grants = [argv[i + 1] for i, a in enumerate(argv[:-1]) if a == "/grant:r"]
+        # Both grants must propagate to children, or the directory guarantee
+        # covers nothing created inside it.
+        assert "*S-1-3-4:(OI)(CI)F" in grants, grants
+        assert "*S-1-5-21-1-2-3-1000:(OI)(CI)F" in grants, grants
+
+    def test_file_grants_stay_non_inheritable(self, tmp_path, monkeypatch):
+        # The other half of the split, asserted negatively: (OI)(CI) is
+        # meaningless on a file, so restrict_to_owner must NOT acquire it when
+        # the directory shape does. Without this, "just add (OI)(CI) to
+        # restrict_to_owner" reads as a passing simplification.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
+        captured: dict = {}
+
+        def fake_run(argv, **_kw):
+            captured["argv"] = list(argv)
+            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(pc.subprocess, "run", fake_run)
+        f = tmp_path / "secret.key"
+        f.write_bytes(b"s" * 32)
+        pc.restrict_to_owner(f)
+        grants = [
+            captured["argv"][i + 1]
+            for i, a in enumerate(captured["argv"][:-1])
+            if a == "/grant:r"
+        ]
+        assert grants, captured["argv"]
+        for g in grants:
+            assert "(OI)" not in g and "(CI)" not in g, g
+
+    def test_file_helper_warns_when_handed_a_directory(self, tmp_path, monkeypatch, caplog):
+        # The misuse guard. The argv tests cannot see this from the call site, so
+        # a directory reaching the file-shaped helper has to be caught here --
+        # it tightens the directory but leaves files created inside on the
+        # creating token's default DACL. Warn, not raise: the ACE still applies
+        # to the named object, so the lockdown is partial rather than absent.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
+        )
+        d = tmp_path / "a-directory"
+        d.mkdir()
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc.restrict_to_owner(d)
+        assert any("not inheritable" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    def test_file_helper_stays_quiet_for_a_file(self, tmp_path, monkeypatch, caplog):
+        # The guard must not fire on the helper's actual purpose, or every
+        # secret-file lockdown would emit a spurious warning.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
+        )
+        f = tmp_path / "secret.key"
+        f.write_bytes(b"s" * 32)
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc.restrict_to_owner(f)
+        assert not [r for r in caplog.records if "not inheritable" in r.getMessage()]
+
+    def test_directory_shape_uses_0o700_on_posix(self, tmp_path, monkeypatch):
+        # The POSIX half of the split: 0o700, not the file helper's 0o600 —
+        # a directory without the execute bit is not traversable at all.
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        modes: list[int] = []
+        monkeypatch.setattr(pc.os, "chmod", lambda p, m: modes.append(m))
+        pc.restrict_dir_to_owner(tmp_path)
+        assert modes == [0o700], modes
+
     def test_sid_failure_is_not_cached_success_is(self, monkeypatch):
         # A transient whoami failure (timeout under AV scan, non-zero rc) must
         # NOT be memoized: with lru_cache the first failure poisoned every
@@ -2515,23 +2625,40 @@ class TestMakeOwnerOnlyDir:
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Windows derives access from the DACL, so the mode argument is inert
-        and restrict_to_owner is the only thing that protects the directory."""
+        and the DACL helper is the only thing that protects the directory.
+
+        It must be the DIRECTORY helper. ``restrict_to_owner`` is file-shaped:
+        its grants carry no ``(OI)(CI)``, so routing a directory through it
+        tightened the directory itself and left every file created inside on
+        the creating token's default DACL -- which is why the negative
+        assertion below is the load-bearing half of this test.
+        """
         calls: list[str] = []
+        wrong: list[str] = []
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "restrict_to_owner", lambda p: calls.append(str(p)))
+        monkeypatch.setattr(pc, "restrict_dir_to_owner", lambda p: calls.append(str(p)))
+        monkeypatch.setattr(pc, "restrict_to_owner", lambda p: wrong.append(str(p)))
         target = tmp_path / "win"
         pc.make_owner_only_dir(target)
         assert target.is_dir()
         assert calls == [str(target)]
+        assert wrong == [], "a directory must not go through the file-shaped helper"
 
     def test_directory_still_exists_when_tightening_fails(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Best-effort on the tightening step: the caller decides whether an
-        un-tightened directory is fatal, so creation must not be rolled back."""
+        un-tightened directory is fatal, so creation must not be rolled back.
+
+        Patches the same helper ``make_owner_only_dir`` actually calls -- when
+        this named the file helper instead, the raise never fired and the test
+        passed without exercising the handler at all.
+        """
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(
-            pc, "restrict_to_owner", lambda p: (_ for _ in ()).throw(OSError("nope"))
+            pc,
+            "restrict_dir_to_owner",
+            lambda p: (_ for _ in ()).throw(OSError("nope")),
         )
         target = tmp_path / "partial"
         pc.make_owner_only_dir(target)

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -1779,7 +1779,11 @@ class TestRestrictToOwner:
             raise OSError("no perms")
 
         monkeypatch.setattr(pc, "IS_WINDOWS", False)
-        monkeypatch.setattr(pc.Path, "chmod", _boom)
+        # The POSIX tightening now goes through restrict_dir_to_owner, which
+        # calls os.chmod rather than Path.chmod -- patching the old seam would
+        # intercept nothing, the raise would never fire, and this test would
+        # pass without ever exercising the warn-and-continue handler.
+        monkeypatch.setattr(pc.os, "chmod", _boom)
         with caplog.at_level(logging.WARNING, logger=pc.logger.name):
             pc.make_owner_only_dir(target)
         assert target.is_dir()
@@ -1787,11 +1791,17 @@ class TestRestrictToOwner:
 
     def test_make_owner_only_dir_uses_the_dacl_on_windows(self, monkeypatch, tmp_path):
         called: list[Any] = []
+        wrong: list[Any] = []
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "restrict_to_owner", called.append)
+        # Must be the DIRECTORY helper: restrict_to_owner's grants are
+        # file-shaped (no (OI)(CI)), so files created inside would not inherit
+        # the lockdown.
+        monkeypatch.setattr(pc, "restrict_dir_to_owner", called.append)
+        monkeypatch.setattr(pc, "restrict_to_owner", wrong.append)
         target = tmp_path / "secrets"
         pc.make_owner_only_dir(target)
         assert called and str(called[0]) == str(target)
+        assert wrong == []
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -879,7 +879,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # through the sandbox helper because sandbox imports platform_compat.
         "platform_compat.py::process_owner_uid",
         "platform_compat.py::process_matches",
-        "platform_compat.py::restrict_to_owner",
+        # The single icacls chokepoint shared by restrict_to_owner (file shape)
+        # and restrict_dir_to_owner (directory shape, inheritable grants). Both
+        # public helpers delegate here, so this one entry covers the owner-only
+        # DACL spawn for every caller; neither public name spawns directly.
+        "platform_compat.py::_icacls_owner_only",
         # OS keep-awake helper for the prevent-sleep feature (power.py). FIXED
         # argv — `caffeinate -i -w <pid>` on macOS, `systemd-inhibit
         # --what=idle:sleep --mode=block … /bin/sh -c 'while kill -0 <pid> …'`


### PR DESCRIPTION
## Problem / Motivation

On Windows, a directory created through `make_owner_only_dir` is tightened at
itself but does not govern what is written into it. It delegates its lockdown to
`restrict_to_owner`, which builds:

```
icacls <path> /inheritance:r /grant:r "*S-1-3-4:F" /grant:r "*<user-sid>:F"
```

Those grants carry no `(OI)(CI)`, so the ACEs apply to the named object **alone**.
That is correct and complete for a **file** — which is what `restrict_to_owner`
was written for — but a **directory** routed through it leaves a file created
inside an "owner-only" directory with no explicit ACE at all. It falls back to
whatever the creating process's token grants by default, typically
owner + SYSTEM + Administrators: not world-readable, but a default rather than
the guarantee the caller asked for.

## Why it matters

Ten call sites rely on that guarantee, and every one of them creates a private
directory and then writes secrets into it:

| call site | what lands inside |
|---|---|
| `mcp_gateway/rewriter.py:326`, `:1034` | rewritten MCP env files (credential sidecars) |
| `mcp_gateway/rewriter.py:1044`, `:1233` | settings overlay |
| `mcp_gateway/rewriter.py:1245` | stub servers |
| `mcp_gateway/spill.py:165` | spilled MCP payloads |
| `mcp_gateway/transport.py:522` | the socket path's parent |
| `dashboard/server.py:1382` | unix socket dir (via `subprocess_executor`) |
| `computer_use/capture_windows.py:380` | screenshots of the user's desktop |

The failure is invisible from the code: nothing raises, `icacls` returns 0, and
no mode assertion can detect it because NTFS reports `0o666` for any file
regardless of its DACL. `capture_windows.py:37` already documents the
non-inheritable ACE for its own screenshot pass, so the behaviour was known at
one call site while the other nine assumed the directory covered them.

## What changed (motivation → approach → change)

`(OI)(CI)` cannot simply be added to `restrict_to_owner`: the flags are
meaningless on a file, so the fix has to distinguish the two shapes rather than
widen the existing helper.

The two shapes are now separate public helpers over **one** icacls chokepoint:

- `restrict_to_owner(path)` — file shape, grants stay non-inheritable.
- `restrict_dir_to_owner(path)` — directory shape, grants carry `(OI)(CI)`.
- Both delegate to `_icacls_owner_only(path, *, inherit: bool)`, which differs
  only in the rights prefix (`F` vs `(OI)(CI)F`).

One chokepoint rather than two argv builders, because an owner-only DACL that two
call paths could drift apart on is exactly the defect being fixed here. The SID
resolution, the fail-closed refusal when `whoami` cannot resolve a SID, and the
`OSError` contract are unchanged and now shared.

`make_owner_only_dir` routes to the directory helper on both platforms, which
also folds its POSIX `chmod(0o700)` into the same split — the POSIX half of the
same file/directory distinction (`0o700`, not the file helper's `0o600`, because
a directory needs the execute bit to be traversable).

Neither `(OI)` nor `(CI)` sets `(IO)`, so the ACE still applies to the directory
itself and traversal is preserved.

`restrict_to_owner` also gains a **misuse guard**: it stats its argument and logs
a warning when it is handed a directory. That is the exact mistake the three
converted call sites had made, and it is otherwise silent — nothing raises and
`icacls` returns 0. It warns rather than raises: the ACE it applied is still
correct for the named object, so the lockdown is partial rather than absent, and
turning a partial lockdown into a crash would be the worse trade at every
existing call site. After this PR no caller in `src/` passes a directory to it;
the guard is there to catch the next one, since the shim table in `AGENTS.md`
is what a contributor reads first and the runtime warning is what actually
reaches them.

**Deliberately out of scope.** Inheritance governs what gets *created* from here
on. A file that already exists inside the directory keeps its own DACL, and
Windows grants *Bypass Traverse Checking* to Everyone by default, so a permissive
pre-existing file stays reachable through a tightened parent. Repairing an
existing install needs a per-file pass over the known names, which is the
remaining work on #4543 along with the FTS index and the data-home items — both
of which carry an event-loop design question (a per-file pass inside
`MemoryStore.init()` would put synchronous `icacls` spawns on the dashboard,
gateway and eval loops) that this change does not. This PR is the mechanism those
items need underneath them, not a substitute for them.

## Tests

All in `test/test_platform_compat.py`, and all assert the **argv**, not the mode,
because no mode assertion can catch this class of bug. They monkeypatch
`IS_WINDOWS`/`IS_POSIX` so they execute on the Linux matrix rather than only on a
Windows host.

- `test_directory_grants_are_inheritable` — the directory helper emits
  `*S-1-3-4:(OI)(CI)F` and `*<user-sid>:(OI)(CI)F`.
- `test_file_grants_stay_non_inheritable` — the load-bearing negative: the file
  helper must **not** acquire `(OI)(CI)`, so "just add the flags to
  `restrict_to_owner`" cannot pass this suite.
- `test_directory_shape_uses_0o700_on_posix` — the POSIX half of the split.
- `test_file_helper_warns_when_handed_a_directory` /
  `test_file_helper_stays_quiet_for_a_file` — the misuse guard above: it warns
  when the file helper is handed a directory, stays silent for a file, and (the
  load-bearing half) raises in neither case.
- `TestMakeOwnerOnlyDir::test_uses_the_dacl_helper_on_windows` — updated to
  assert it reaches the directory helper **and** never the file-shaped one.
- `TestMakeOwnerOnlyDir::test_directory_still_exists_when_tightening_fails` —
  updated because it had become **vacuous**: it patched `restrict_to_owner`,
  which `make_owner_only_dir` no longer calls, so the raise never fired and the
  best-effort handler was not being exercised at all.

Two harness changes that are part of the fix, not incidental:

- `test/conftest.py` — the Windows hermeticity stub now no-ops
  `restrict_dir_to_owner` alongside `restrict_to_owner`. Without it every test
  creating an owner-only directory would spawn a real `icacls`.
- `test/test_spawn_audit.py` — the allowlist entry moves from
  `platform_compat.py::restrict_to_owner` to
  `platform_compat.py::_icacls_owner_only`, the function the spawn now lives in.
  `test_benign_allowlist_has_no_stale_entries` fails without this.

## Manual verification

Run on Windows 11 (where the DACL path actually executes) and cross-checked for
the Linux lanes:

- `pytest test/test_platform_compat.py test/test_platform_compat_coverage.py test/test_spawn_audit.py` — 186 passed, 0 failed.
- Caller suites (`test_mcp_gateway_rewriter`, `test_mcp_gateway_transport`, `test_computer_use_capture{,_windows}`, `test_atomic_write_capabilities`, `test_dashboard_server_coverage`) — the only failures are 4 in `test_mcp_gateway_rewriter.py` that are **identical before and after** this commit (verified by stashing): they are pre-existing Windows failures caused by the conftest stub no-opping the helper the assertion looks for.
- `mypy --platform linux src/kiro_crew/` — clean, 1008 source files. Run with the
  CI platform explicitly because native mypy on Windows analyses the wrong branch.
- `flake8` + `isort --check-only` on all four changed files — clean.
- `scripts/check_black_formatting.py` — passed; nothing in scope is unformatted
  outside the 1427-file baseline. The files are pre-existing non-black-clean, so
  they were deliberately **not** reformatted (that would bury the diff); `black --diff`
  confirms none of its proposed hunks touch the added lines.
- `check_brand_name.py`, `check_harness_parity.py`, `check_changelog_history.py`,
  `check_focus_cue.py` — all pass against the base ref.

Not verified by hand: the actual inherited ACE on a child file created inside a
tightened directory. That needs a second local principal to be meaningful, which
this host does not have. The `icacls` syntax is asserted at the argv layer
instead, which is the same boundary the pre-existing
`TestRestrictToOwnerArgvOnLinux` suite chose for the file shape.

## Related Issues

Refs #4543

Deliberately no closing keyword: this PR fixes item 4 of that issue (the
inheritable-grant defect) and leaves items 1–3 open — the FTS index, the
owner-only data home, and the per-file `chmod_safe` sweep, which need the
event-loop ruling the issue is labelled `needs-human` for. Closing #4543 here
would mark that remaining work as done.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to a filesystem permission helper; no
frontend path is touched and nothing renders differently.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, the behaviour contract lives in the helpers' docstrings, which are updated in this diff
- [x] No secrets, credentials, or internal references in the diff

