### PR TITLE
fix(teams): await cancelled handler tasks before close() returns

### DIFF
--- a/src/kiro_crew/teams/client.py
+++ b/src/kiro_crew/teams/client.py
@@ -262,8 +262,11 @@ class TeamsClient:
 
     async def close(self) -> None:
         self._closed = True
-        for task in list(self._handler_tasks):
-            task.cancel()
+        if self._handler_tasks:
+            for task in list(self._handler_tasks):
+                task.cancel()
+            await asyncio.gather(*self._handler_tasks, return_exceptions=True)
+            self._handler_tasks.clear()
         if self._session is not None and not self._session.closed:
             await self._session.close()
             self._session = None

--- a/test/test_teams_client.py
+++ b/test/test_teams_client.py
@@ -464,3 +464,40 @@ class TestOutbound:
             )
             await c.send_message("conv-1", "hi", "https://smba.example.com/")
             assert slept[-1] == expected, f"{headers} -> expected {expected}, got {slept[-1]}"
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_close_awaits_cancelled_handler_before_returning(self) -> None:
+        """Mirrors the Webex/WeCom close() contract: cancel every in-flight
+        handler task and await it before releasing downstream resources, so a
+        handler's ``finally`` has run by the time close() returns."""
+        started = asyncio.Event()
+        cleaned_up = asyncio.Event()
+
+        async def _handler() -> None:
+            started.set()
+            try:
+                await asyncio.Event().wait()  # block until cancelled
+            finally:
+                cleaned_up.set()
+
+        c = TeamsClient(app_id=_APP_ID, app_password="pw")
+        task = asyncio.ensure_future(_handler())
+        c._handler_tasks.add(task)
+        task.add_done_callback(c._handler_tasks.discard)
+        await started.wait()
+
+        await c.close()
+
+        assert cleaned_up.is_set()
+        assert task.done()
+        assert task.cancelled()
+        assert c._handler_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_close_with_no_handlers_still_closes_session(self) -> None:
+        c = TeamsClient(app_id=_APP_ID, app_password="pw")
+        c._session = _FakeSession([])
+        await c.close()
+        assert c._session is None


### PR DESCRIPTION
## Problem / Motivation

`TeamsClient.close()` cancels every in-flight inbound-webhook handler task but never awaits them:

```python
async def close(self) -> None:
    self._closed = True
    for task in list(self._handler_tasks):
        task.cancel()
    if self._session is not None and not self._session.closed:
        await self._session.close()
        self._session = None
```

`on_activity()` fast-acks the Bot Framework webhook with a 200 and runs the actual turn in a background task specifically so a slow turn never times out the POST, so a handler is commonly still alive at gateway shutdown. `task.cancel()` only *schedules* delivery of `CancelledError` into the task; it does not wait for the task to actually unwind, so `close()` can return while a handler's `finally` block is still running.

## Why it matters

Gateway teardown can move on while a Teams turn is still unwinding: its `finally` blocks and any resources it owns run *after* the client lifecycle already says shutdown is complete. If the handler reaches its own outbound cleanup, it also races the already-closed shared `aiohttp.ClientSession`. The un-awaited task can otherwise survive until event-loop teardown and surface as a pending-task or `GeneratorExit` warning.

This is exactly the same shape of bug this repo has already fixed twice on the shutdown side (`AcpSessionProvider.shutdown`, `AcpRuntime.terminate_session`): a cleanup step that isn't sequenced through a lifecycle boundary it should be behind.

## What changed

Teams' `close()` didn't follow the lifecycle contract the repo's other whole-gateway handlers already use. Webex's `close()` (`webex/client.py`) and WeCom's dispatch path both snapshot the handler set, cancel it, `await asyncio.gather(*tasks, return_exceptions=True)`, *then* close the session:

```python
if self._handler_tasks:
    for task in list(self._handler_tasks):
        task.cancel()
    await asyncio.gather(*self._handler_tasks, return_exceptions=True)
    self._handler_tasks.clear()
if self._session is not None and not self._session.closed:
    await self._session.close()
    self._session = None
```

Teams now follows the identical pattern (`src/kiro_crew/teams/client.py::TeamsClient.close`), so the shared session is only closed once every handler has actually stopped, not merely been asked to.

## Tests

Added `TestLifecycle` in `test/test_teams_client.py`:
- `test_close_awaits_cancelled_handler_before_returning` — a handler blocks on an `asyncio.Event`, sets a second event from its `finally`; asserts the second event is set, the task is cancelled/done, and `_handler_tasks` is empty by the time `close()` returns (this reproduces the issue's deterministic repro).
- `test_close_with_no_handlers_still_closes_session` — the empty-handler-set path still closes the session (no regression from the added `if self._handler_tasks:` guard).

`python -m pytest test/test_teams_client.py test/test_teams_dispatch.py test/test_teams_gateway.py test/test_teams_transport.py test/test_teams_wire.py test/test_teams_config.py test/test_teams_renderer.py test/test_teams_dispatch_cov80.py -q` — 96 passed.

`isort`/`flake8`/`mypy` clean on both touched files. (`black --check` currently flags unrelated pre-existing lines in both files under this sandbox's Python 3.13 vs. the repo's Python-3.14-targeted config — reproduces identically on `main` before this change, confirmed via `git stash`; my diff's own lines are untouched by the reformat.)

## Manual verification

N/A — unit coverage sufficient; this is a pure async lifecycle-ordering fix around a mocked handler task, fully exercised by the async unit tests above.

## Related Issues

Fixes #4825.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, `docs/system-specs/modules/messaging.md` documents the shared Layer 1/2/2b abstractions, not per-channel client internals like this handler-task bookkeeping (mirrors how the Webex/WeCom equivalents aren't separately documented either)
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)