### PR TITLE
feat(doctor): detect agent specs with dead command/args/env paths

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1503,6 +1503,7 @@ _AGENT_SPEC_HOOKS: tuple[tuple[str, str], ...] = (
     ("kiro_crew.agent_discovery", "_KIRO_AGENTS_DIR"),
     ("kiro_crew.apps.bridges", "KIRO_AGENTS_DIR"),
     ("kiro_crew.cli_doctor", "KIRO_AGENTS_DIR"),
+    ("kiro_crew.doctor_deadpath", "KIRO_AGENTS_DIR"),
 )
 
 #: Modules that WRITE through a bound ``config.paths.kiro_agents_dir`` name, which no

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -44,6 +44,7 @@ from kiro_crew.dashboard.origin import (
     machine_hostname,
     parse_dashboard_url,
 )
+from kiro_crew.doctor_deadpath import doctor_dead_paths
 from kiro_crew.embeddings import (
     _LIB_PATH_ENV,
     _load_llama_class,
@@ -1630,6 +1631,20 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── kiro-cli installer residue (silent unless residue is on disk) ──
     _doctor_cli_installer_residue(issues)
+
+    # ── Agent Spec Paths (dead command/args/env paths) ──
+    # Own module + single call so a sibling sweep wiring into doctor rebases
+    # trivially. Walks EVERY spec in the agents dir (not just kirocrew.json),
+    # so it runs unconditionally rather than under the agent_path guard below.
+    # Pass doctor's OWN resolved agents dir so the scan — and any managed repair
+    # it triggers — operate on the same directory doctor is inspecting, never a
+    # re-resolved live home while doctor is pointed elsewhere.
+    #
+    # BEFORE the MCP probe, deliberately: the managed repair rewrites a spec
+    # whose command went dead, and the probe should observe the repaired spec.
+    # Ordered the other way round, the probe records the stale command as a
+    # failure first and a successful repair still exits nonzero.
+    doctor_dead_paths(issues, agents_dir=_agents_dir())
 
     # ── MCP Tools ──
     print("\nMCP Tools")

--- a/src/kiro_crew/doctor_deadpath.py
+++ b/src/kiro_crew/doctor_deadpath.py
@@ -1,0 +1,472 @@
+"""Doctor check: agent specs whose command/args/env paths no longer exist.
+
+Agent spec JSONs in the shared kiro agents dir rot. A spec's ``mcpServers``
+entry can point at paths that stop existing — a removed venv, a reaped
+temporary checkout, a relocated tool. The symptom is silent and expensive:
+every new session selecting that agent starts with its first-party MCP servers
+dead (spawn fails on a nonexistent command), or resolves secrets against a dead
+data home and surfaces ``internal_auth_mismatch``. Nothing names the dead path.
+
+This module walks every agent spec JSON in :func:`kiro_agents_dir_path` and
+stats every absolute ``command`` path, absolute path-like arg, and absolute
+path-like env value:
+
+* **Managed specs** (the ones ``install_agent`` / ``rebuild_agent_config`` own,
+  i.e. :data:`~kiro_crew.agent_files.OWNED_KIRO_AGENT_FILES`) with dead paths are
+  repaired automatically via the existing rebuild path, then re-verified.
+* **Foreign specs** (other tools' agents sharing the directory) are report-only,
+  naming the spec file, the server name, and the dead path. Kiro Crew never
+  rewrites what it does not own.
+* **Malformed / unreadable spec JSON** is reported, never crashing the whole
+  check (fail-open per file).
+
+Kept deliberately self-contained — one module, one public entry point
+(:func:`check_dead_paths`) plus a thin doctor renderer
+(:func:`doctor_dead_paths`) — so the doctor wiring is a single call and a
+sibling change wiring another sweep into doctor rebases trivially.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kiro_crew.agent_files import OWNED_KIRO_AGENT_FILES
+from kiro_crew.config.paths import kiro_agents_dir
+
+logger = logging.getLogger(__name__)
+
+# Import-time override hook mirroring ``agent.KIRO_AGENTS_DIR`` /
+# ``cli_doctor.KIRO_AGENTS_DIR``: ``None`` means "resolve from the live data
+# home"; tests patch this attribute directly. Never captured at import — a
+# frozen path would defeat KIRO_HOME resolution and test isolation.
+KIRO_AGENTS_DIR: Path | None = None
+
+
+def kiro_agents_dir_path() -> Path:
+    """Kiro agents directory, honoring the override hook, else the live home.
+
+    Resolved live via :func:`kiro_crew.config.paths.kiro_agents_dir`, which
+    honors ``KIRO_HOME``. ``config.paths`` is a stdlib-only leaf module, so it
+    is imported at module scope (no config-plane import cost, no cycle).
+    """
+    if KIRO_AGENTS_DIR is not None:
+        return KIRO_AGENTS_DIR
+    return kiro_agents_dir()
+
+
+@dataclass
+class DeadPath:
+    """One dead absolute path found inside an agent spec.
+
+    ``where`` names the location within the spec (e.g. ``command``, ``args[0]``,
+    ``env[KIROCREW_HOME]``) so a report points at exactly what to fix.
+    """
+
+    spec: str  # spec filename (e.g. "kirocrew.json")
+    server: str  # mcpServers entry name, or "" when outside mcpServers
+    where: str  # location within the entry (command / args[i] / env[KEY])
+    path: str  # the dead absolute path
+
+
+@dataclass
+class SpecResult:
+    """Per-spec outcome of the dead-path walk."""
+
+    spec: str
+    managed: bool
+    dead: list[DeadPath] = field(default_factory=list)
+    # Set when the file could not be read or parsed as a JSON object. The walk
+    # is fail-open per file: an unreadable spec is reported, never fatal.
+    unreadable: str | None = None
+    # Set on a managed spec after a repair attempt: True if the rebuild cleared
+    # every dead path, False if any survived. None when no repair was attempted.
+    repaired: bool | None = None
+
+
+@dataclass
+class DeadPathReport:
+    """Aggregate result across every spec in the agents dir."""
+
+    results: list[SpecResult] = field(default_factory=list)
+
+    @property
+    def foreign_dead(self) -> list[SpecResult]:
+        return [r for r in self.results if not r.managed and r.dead]
+
+    @property
+    def managed_dead(self) -> list[SpecResult]:
+        return [r for r in self.results if r.managed and r.dead]
+
+    @property
+    def unreadable(self) -> list[SpecResult]:
+        return [r for r in self.results if r.unreadable]
+
+    @property
+    def repair_failed(self) -> list[SpecResult]:
+        return [r for r in self.results if r.managed and r.repaired is False]
+
+    @property
+    def has_findings(self) -> bool:
+        """Whether anything worth surfacing was found.
+
+        A managed spec that was repaired AND re-verified clean is NOT a finding
+        — the repair is the whole point, and reporting a self-healed spec as a
+        problem would make doctor exit nonzero on a state it just fixed.
+        """
+        return bool(self.foreign_dead or self.unreadable or self.repair_failed)
+
+
+def _sanitize_for_terminal(value: str) -> str:
+    """Neutralize control characters in an untrusted, spec-derived string.
+
+    Spec files (foreign ones especially) are untrusted content. Their strings —
+    server names, paths, and the raw JSON error text that lands in the
+    ``unreadable`` reason — are printed to the operator's terminal by ``kirocrew
+    doctor``. A path or server name carrying ANSI/OSC escape bytes would let a
+    hostile spec drive the terminal (retitle the window, rewrite earlier output,
+    inject a pasteable command) the moment doctor renders it. Replace every C0
+    control (except tab) and the C1/DEL range with a visible ``\\xNN`` token so
+    the value is still readable but inert. ESC in particular can no longer open
+    a control sequence.
+    """
+    out: list[str] = []
+    for ch in value:
+        codepoint = ord(ch)
+        if ch == "\t" or (0x20 <= codepoint <= 0x7E) or codepoint >= 0xA0:
+            out.append(ch)
+        else:
+            out.append(f"\\x{codepoint:02x}")
+    return "".join(out)
+
+
+def _colon_scan_rejects(value: str) -> bool:
+    """Whether *value* looks like a POSIX ``PATH``-style colon-joined list.
+
+    A colon flanked by a path separator (``/``), or a trailing colon, is the
+    list-separator shape (``/usr/bin:/bin``). A lone drive-letter colon
+    (``C:\\Users\\...``) has no adjacent ``/`` and is NOT rejected here, so a
+    real Windows path is left alone. Split out from
+    :func:`_looks_like_single_absolute_path` so the list-detection can be tested
+    without depending on the platform-specific ``os.path.isabs``.
+    """
+    if "/" not in value:
+        return False
+    for i, ch in enumerate(value):
+        if ch != ":":
+            continue
+        if i == 1 and value[0].isalpha() and i + 1 < len(value) and value[i + 1] in ("/", "\\"):
+            # Drive-letter colon (``C:/x`` or ``C:\x``) — a Windows path, not
+            # a list separator, even though a ``/`` follows it.
+            continue
+        before = value[i - 1] if i > 0 else ""
+        after = value[i + 1] if i + 1 < len(value) else ""
+        if before == "/" or after == "/" or after == "":
+            return True
+    return False
+
+
+def _looks_like_single_absolute_path(value: str) -> bool:
+    """Whether *value* looks like exactly ONE absolute path.
+
+    Colon-joined values like ``PATH`` (``/usr/bin:/bin``) are NOT single paths
+    and must not be stat-ed as one — that is the explicit false-positive to
+    avoid. The Windows list separator ``;`` is rejected for the same reason. A
+    Windows drive path (``C:\\Users\\...``) legitimately contains a colon, so
+    the colon test is scoped to the POSIX list-separator shape (see
+    :func:`_colon_scan_rejects`), leaving a bare drive-letter colon alone.
+
+    Only absolute paths are considered: a bare token, a URL, a flag, or a
+    relative value is not something whose absence on THIS host is meaningful.
+    """
+    if not value or not os.path.isabs(value):
+        return False
+    # Windows PATH-style list — never a single path.
+    if ";" in value:
+        return False
+    # POSIX PATH-style list.
+    if _colon_scan_rejects(value):
+        return False
+    # A newline-joined blob is not one path either.
+    if "\n" in value:
+        return False
+    return True
+
+
+def _path_is_dead(value: str) -> bool:
+    """Whether an absolute path no longer exists on disk (a stat check).
+
+    ``os.path.exists`` follows symlinks, so a live symlink to a live target
+    reads present and a dangling one reads dead — both correct for "would this
+    command/arg/env still resolve".
+    """
+    try:
+        return not os.path.exists(value)
+    except OSError:
+        # A path so malformed the OS refuses to stat it is, for our purpose,
+        # unusable — report it as dead rather than crashing the walk.
+        return True
+
+
+#: Env KEY substrings that mark an entry's VALUE as potentially secret.
+#: Display-redaction only, biased toward redacting: the locator (``env[KEY]``)
+#: still names the entry, so a redacted report stays fully actionable, while a
+#: missed redaction prints a live secret into terminal output that routinely
+#: gets pasted into bug reports. A slash-prefixed token value can pass the
+#: single-absolute-path shape test, so the VALUE shape alone cannot be trusted.
+_CREDENTIAL_KEY_MARKERS: tuple[str, ...] = (
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "CREDENTIAL",
+    "APIKEY",
+    "API_KEY",
+    "AUTH",
+    "PRIVATE",
+)
+
+_REDACTED_VALUE = "<redacted: credential-shaped key>"
+
+
+def _credential_shaped_key(key: str) -> bool:
+    upper = key.upper()
+    return any(marker in upper for marker in _CREDENTIAL_KEY_MARKERS)
+
+
+def _walk_server_paths(server: str, entry: dict) -> list[DeadPath]:
+    """Collect dead absolute paths from one ``mcpServers`` entry."""
+    dead: list[DeadPath] = []
+
+    command = entry.get("command")
+    if isinstance(command, str) and os.path.isabs(command) and _path_is_dead(command):
+        dead.append(DeadPath(spec="", server=server, where="command", path=command))
+
+    args = entry.get("args")
+    if isinstance(args, list):
+        for i, arg in enumerate(args):
+            if (
+                isinstance(arg, str)
+                and _looks_like_single_absolute_path(arg)
+                and _path_is_dead(arg)
+            ):
+                dead.append(DeadPath(spec="", server=server, where=f"args[{i}]", path=arg))
+
+    env = entry.get("env")
+    if isinstance(env, dict):
+        for key, val in env.items():
+            if (
+                isinstance(val, str)
+                and _looks_like_single_absolute_path(val)
+                and _path_is_dead(val)
+            ):
+                # Redacted at RECORD CREATION, not at print time, so every
+                # consumer (section prints, the issues summary doctor joins
+                # into its final line) is safe by construction. The re-verify
+                # pass only checks presence, never compares path text.
+                shown = _REDACTED_VALUE if _credential_shaped_key(str(key)) else val
+                dead.append(DeadPath(spec="", server=server, where=f"env[{key}]", path=shown))
+
+    return dead
+
+
+def _walk_spec(spec_path: Path) -> tuple[list[DeadPath], str | None]:
+    """Read one spec file and collect its dead paths (fail-open per file).
+
+    Returns ``(dead_paths, unreadable_reason)``. An unreadable / non-object /
+    malformed spec yields ``([], reason)`` rather than raising, so one bad file
+    never aborts the whole check.
+    """
+    try:
+        raw = spec_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], f"unreadable ({exc.strerror or exc})"
+    except UnicodeError as exc:
+        # A non-UTF-8 / binary file dropped into the agents dir decodes with a
+        # UnicodeDecodeError (a UnicodeError, NOT an OSError) — catch it here so
+        # one such file is reported as unreadable rather than aborting the whole
+        # walk, keeping the check fail-open per file.
+        return [], f"not valid UTF-8 ({exc})"
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return [], f"malformed JSON ({exc})"
+    if not isinstance(data, dict):
+        return [], "top-level JSON is not an object"
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        return [], None
+
+    dead: list[DeadPath] = []
+    for server, entry in servers.items():
+        if not isinstance(entry, dict):
+            continue
+        for dp in _walk_server_paths(str(server), entry):
+            dp.spec = spec_path.name
+            dead.append(dp)
+    return dead, None
+
+
+def _default_repair() -> None:
+    """Repair managed specs by rewriting them from the current install.
+
+    Delegates to the existing authoritative rebuild path
+    (:func:`kiro_crew.agent.rebuild_agent_config`), which re-resolves every
+    managed server's command/args/env against this install and drops any server
+    whose command no longer resolves. Imported lazily to keep this module's
+    import graph light and to avoid an import cycle (``agent`` imports the config
+    plane this module also reaches).
+    """
+    from kiro_crew.agent import rebuild_agent_config
+
+    rebuild_agent_config()
+
+
+def _report_only() -> None:
+    """No-op repair: the pass records findings without rewriting anything."""
+
+
+def check_dead_paths(*, agents_dir: Path | None = None, repair=_default_repair) -> DeadPathReport:
+    """Walk every agent spec and report (and repair managed) dead paths.
+
+    Args:
+        agents_dir: The agents directory to scan. Defaults to
+            :func:`kiro_agents_dir_path`. Callers that resolve the agents dir
+            themselves (notably ``kirocrew doctor``, which has its OWN override
+            hook) MUST pass their resolved directory so the scan and any repair
+            operate on the SAME directory the caller is inspecting — otherwise
+            the scan could stat the live ``~/.kiro/agents`` while the caller is
+            pointed elsewhere, and a dead managed path would trigger a rebuild
+            against specs the caller never meant to touch.
+        repair: Zero-arg callable invoked once, only when a managed spec has a
+            dead path, to rewrite the managed specs from the current install.
+            Defaults to :func:`_default_repair`. Injectable so tests can drive
+            the repair + re-verify contract without a full rebuild, and so a
+            caller can pass a no-op to get a report-only pass.
+
+    Returns:
+        A :class:`DeadPathReport`. Managed specs that had dead paths are
+        re-walked after the repair; ``SpecResult.repaired`` records whether the
+        rebuild cleared them.
+    """
+    report = DeadPathReport()
+    ambient = kiro_agents_dir_path()
+    if agents_dir is None:
+        agents_dir = ambient
+    elif repair is _default_repair and agents_dir.resolve() != ambient.resolve():
+        # The caller redirected the SCAN but kept the default repair, and the
+        # default repair (rebuild_agent_config) writes wherever the AMBIENT
+        # environment resolves -- not the scanned directory. Running it here
+        # would judge specs in one directory and rewrite specs in another
+        # (e.g. a test scanning a fixture dir triggering a rebuild of the
+        # operator's real specs). Degrade to report-only; a caller that wants
+        # repair on a redirected directory must inject a repair bound to it.
+        repair = _report_only
+    if not agents_dir.is_dir():
+        return report
+
+    managed_names = set(OWNED_KIRO_AGENT_FILES)
+    managed_needs_repair = False
+
+    for spec_path in sorted(agents_dir.glob("*.json")):
+        managed = spec_path.name in managed_names
+        dead, unreadable = _walk_spec(spec_path)
+        result = SpecResult(spec=spec_path.name, managed=managed, dead=dead, unreadable=unreadable)
+        report.results.append(result)
+        if managed and dead:
+            managed_needs_repair = True
+
+    if not managed_needs_repair:
+        return report
+
+    # Repair once for the whole managed set (rebuild rewrites every managed
+    # spec), then re-verify each managed spec that had dead paths.
+    try:
+        repair()
+    except Exception:
+        logger.warning("dead-path repair via rebuild failed", exc_info=True)
+        # Leave repaired=None on the affected specs — the re-verify below still
+        # runs and will record whether anything changed on disk regardless.
+
+    for result in report.results:
+        if not (result.managed and result.dead):
+            continue
+        dead_after, unreadable_after = _walk_spec(agents_dir / result.spec)
+        result.repaired = not dead_after and unreadable_after is None
+        if not result.repaired:
+            # Surface what survived so a stuck repair is still diagnosable.
+            result.dead = dead_after
+            result.unreadable = unreadable_after
+
+    return report
+
+
+def doctor_dead_paths(issues: list[str], *, agents_dir: Path | None = None) -> None:
+    """Render the ``Agent Spec Paths`` section of ``kirocrew doctor``.
+
+    Managed specs with dead paths are repaired in place; a repaired-and-clean
+    spec is reported as auto-fixed and is NOT counted as an issue. Foreign specs
+    are report-only (naming the spec, server, and dead path). Malformed /
+    unreadable specs are reported. Anything that is a real, unresolved finding —
+    a foreign dead path, an unreadable spec, or a repair that did not take — is
+    appended to *issues* so ``kirocrew doctor`` exits nonzero and the failure
+    class is diagnosable in one step.
+
+    Args:
+        issues: doctor's exit-code channel; real findings are appended here.
+        agents_dir: The agents directory doctor is inspecting. Passed straight
+            through to :func:`check_dead_paths` so the scan (and any repair) run
+            against the SAME directory the rest of doctor uses, honoring doctor's
+            own agent-dir override rather than re-resolving the live home. When
+            ``None`` the check resolves the live agents dir itself.
+
+    Best-effort: a failure inside the walk must not abort the whole doctor run,
+    whose job is to diagnose exactly this kind of breakage.
+    """
+    print("\nAgent Spec Paths")
+    try:
+        report = check_dead_paths(agents_dir=agents_dir)
+    except Exception as exc:  # noqa: BLE001 — doctor must survive a broken walk
+        print(f"  paths:       ⚠️  could not check ({exc})")
+        return
+
+    if not report.results:
+        print("  paths:       ⏹ no agent specs found")
+        return
+
+    for result in report.managed_dead:
+        spec = _sanitize_for_terminal(result.spec)
+        if result.repaired:
+            print(f"  {spec}: ✅ dead paths repaired from the current install")
+        else:
+            print(f"  {spec}: ❌ managed spec has dead paths the rebuild did not clear")
+            for dp in result.dead:
+                loc = f"{dp.server}.{dp.where}" if dp.server else dp.where
+                print(f"      {_sanitize_for_terminal(loc)}: {_sanitize_for_terminal(dp.path)}")
+            if result.unreadable:
+                print(f"      (re-read failed: {_sanitize_for_terminal(result.unreadable)})")
+            issues.append(f"agent spec dead paths: {spec}")
+
+    for result in report.foreign_dead:
+        spec = _sanitize_for_terminal(result.spec)
+        print(f"  {spec}: ⚠️  foreign spec has dead paths (not repaired — not ours)")
+        for dp in result.dead:
+            loc = f"{dp.server}.{dp.where}" if dp.server else dp.where
+            print(f"      {_sanitize_for_terminal(loc)}: {_sanitize_for_terminal(dp.path)}")
+        issues.append(f"foreign agent spec dead paths: {spec}")
+
+    for result in report.unreadable:
+        # A managed spec whose re-read failed is already reported above.
+        if result.managed and result.dead:
+            continue
+        print(
+            f"  {_sanitize_for_terminal(result.spec)}: ⚠️  {_sanitize_for_terminal(result.unreadable or '')}"
+        )
+        issues.append(f"unreadable agent spec: {_sanitize_for_terminal(result.spec)}")
+
+    if not report.has_findings and not report.managed_dead:
+        print("  paths:       ✅ all agent spec paths resolve")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -75,7 +75,11 @@ def _healthy_agent_file(path: Path) -> None:
         allowed=refs,
         servers={
             name: {
-                "command": "/usr/local/bin/kirocrew",
+                # sys.executable, not a literal like /usr/local/bin/kirocrew:
+                # doctor's dead-path scan stats every absolute command for real
+                # (no shutil.which stub covers it), so the fixture's "healthy"
+                # spec must name a binary that actually exists on the runner.
+                "command": sys.executable,
                 # The subcommand is the server name minus the "kirocrew-" prefix
                 # ("kirocrew-core" -> "mcp-core"), matching the real invocation.
                 "args": [f"mcp-{name.split('-', 1)[1]}"],

--- a/test/test_doctor_deadpath.py
+++ b/test/test_doctor_deadpath.py
@@ -1,0 +1,439 @@
+"""Tests for the doctor dead-path check (kiro_crew.doctor_deadpath).
+
+Covers the four scenarios the check must get right, on fabricated spec dirs
+under ``tmp_path`` (never the real agents dir):
+
+* a MANAGED spec with a dead path is repaired via the rebuild path and
+  re-verified;
+* a FOREIGN spec with a dead path is report-only and never rewritten;
+* a colon-joined PATH-like env value is NOT treated as a single path
+  (no false positive);
+* malformed / unreadable spec JSON is tolerated (fail-open per file), never
+  crashing the whole check.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import doctor_deadpath as dp
+from kiro_crew.agent_files import AGENT_FILENAME
+
+
+@pytest.fixture
+def agents_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Point the check at a fabricated agents dir under tmp_path."""
+    d = tmp_path / "agents"
+    d.mkdir()
+    monkeypatch.setattr(dp, "KIRO_AGENTS_DIR", d)
+    return d
+
+
+def _write_spec(agents_dir: Path, name: str, servers: dict) -> Path:
+    path = agents_dir / name
+    path.write_text(json.dumps({"name": name[:-5], "mcpServers": servers}), encoding="utf-8")
+    return path
+
+
+# ── the absolute-single-path heuristic ────────────────────────────────────────
+
+
+class TestLooksLikeSinglePath:
+    def test_absolute_path_is_one(self) -> None:
+        assert dp._looks_like_single_absolute_path("/opt/tool/bin/x") is True
+
+    def test_relative_is_not(self) -> None:
+        assert dp._looks_like_single_absolute_path("tool/bin/x") is False
+
+    def test_bare_token_is_not(self) -> None:
+        assert dp._looks_like_single_absolute_path("kirocrew") is False
+
+    def test_posix_path_list_is_not_a_single_path(self) -> None:
+        # The explicit false-positive to avoid: a colon-joined PATH.
+        assert dp._looks_like_single_absolute_path("/usr/local/bin:/usr/bin:/bin") is False
+
+    def test_windows_path_list_is_not_a_single_path(self) -> None:
+        assert dp._looks_like_single_absolute_path(r"C:\a;C:\b") is False
+
+    def test_windows_drive_path_not_mistaken_for_posix_list(self) -> None:
+        # The colon-list rejection is scoped to the POSIX list-separator shape
+        # (a colon flanked by ``/``). A lone drive-letter colon has no adjacent
+        # ``/`` so the colon scan must not reject it. (On a POSIX runner the
+        # value is not ``os.path.isabs`` and so returns False at the abs guard;
+        # this asserts the colon scan itself does not add a rejection.)
+        assert dp._colon_scan_rejects(r"C:\Users\me\tool.exe") is False
+        assert dp._colon_scan_rejects("/usr/bin:/bin") is True
+
+    def test_forward_slash_drive_path_not_mistaken_for_posix_list(self) -> None:
+        # ``C:/Users/x`` carries a ``/`` right after the drive colon, which the
+        # flanked-colon shape would otherwise read as a list separator. The
+        # drive-letter exemption (colon at index 1 after a letter, followed by
+        # a separator) keeps it a single path; every other flanked colon still
+        # rejects.
+        assert dp._colon_scan_rejects("C:/Users/me/tool.exe") is False
+        assert dp._colon_scan_rejects("/opt/a:/opt/b") is True
+
+    def test_credential_shaped_env_key_value_is_redacted(self, agents_dir: Path) -> None:
+        # A secret VALUE can pass the single-absolute-path shape test (a
+        # slash-prefixed token), and doctor output routinely gets pasted into
+        # bug reports -- so an env entry under a credential-shaped KEY must
+        # never surface its value. The locator (env[KEY]) still names the
+        # entry, so the report stays actionable.
+        secret = "/" + "s3cr3t-b64-blob-that-does-not-exist"
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {"srv": {"command": str(agents_dir / "gone"), "env": {"API_TOKEN": secret}}},
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        result = next(r for r in report.results if r.spec == "foreign.json")
+        env_hits = [d for d in result.dead if d.where == "env[API_TOKEN]"]
+        assert env_hits, "credential-keyed dead entry must still be reported"
+        assert secret not in env_hits[0].path
+        assert env_hits[0].path == dp._REDACTED_VALUE
+        # A non-credential key keeps its real value (actionability).
+        plain_hits = [d for d in result.dead if d.where == "command"]
+        assert plain_hits and str(agents_dir / "gone") == plain_hits[0].path
+
+    def test_empty_is_not(self) -> None:
+        assert dp._looks_like_single_absolute_path("") is False
+
+
+# ── managed-repair ─────────────────────────────────────────────────────────────
+
+
+class TestDefaultRepairDirGuard:
+    """The DEFAULT repair (rebuild_agent_config) writes wherever the AMBIENT
+    environment resolves, not the scanned directory. When a caller redirects
+    the scan but keeps the default repair, the pass must degrade to
+    report-only rather than judge one directory and rewrite another."""
+
+    def test_redirected_scan_with_default_repair_is_report_only(
+        self, agents_dir: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        calls: list[bool] = []
+        monkeypatch.setattr(
+            "kiro_crew.agent.rebuild_agent_config", lambda *a, **k: calls.append(True)
+        )
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        _write_spec(other, AGENT_FILENAME, {"srv": {"command": str(other / "gone")}})
+
+        report = dp.check_dead_paths(agents_dir=other)
+
+        assert calls == []  # the ambient rebuild never ran
+        assert any(r.managed and r.dead for r in report.results)  # still reported
+
+    def test_ambient_dir_with_default_repair_still_repairs(
+        self, agents_dir: Path, monkeypatch
+    ) -> None:
+        calls: list[bool] = []
+        monkeypatch.setattr(
+            "kiro_crew.agent.rebuild_agent_config", lambda *a, **k: calls.append(True)
+        )
+        _write_spec(agents_dir, AGENT_FILENAME, {"srv": {"command": str(agents_dir / "gone")}})
+
+        dp.check_dead_paths(agents_dir=agents_dir)
+
+        assert calls == [True]  # same directory: the default repair runs
+
+
+class TestManagedRepair:
+    def test_managed_spec_dead_path_is_repaired_and_reverified(self, agents_dir: Path) -> None:
+        dead = str(agents_dir / "gone" / "python")  # does not exist
+        live = str(agents_dir)  # exists
+        spec = _write_spec(
+            agents_dir, AGENT_FILENAME, {"kirocrew-core": {"command": dead, "args": []}}
+        )
+
+        def fake_repair() -> None:
+            # Simulate rebuild rewriting the managed spec to a live command.
+            spec.write_text(
+                json.dumps({"mcpServers": {"kirocrew-core": {"command": live}}}),
+                encoding="utf-8",
+            )
+
+        report = dp.check_dead_paths(repair=fake_repair)
+
+        managed = report.managed_dead
+        # After a clean repair the spec is no longer counted as dead...
+        assert managed == [] or all(r.repaired for r in managed)
+        result = next(r for r in report.results if r.spec == AGENT_FILENAME)
+        assert result.managed is True
+        assert result.repaired is True
+        assert report.has_findings is False
+
+    def test_managed_spec_repair_that_does_not_take_is_a_finding(self, agents_dir: Path) -> None:
+        dead = str(agents_dir / "gone" / "python")
+        _write_spec(agents_dir, AGENT_FILENAME, {"kirocrew-core": {"command": dead}})
+
+        def noop_repair() -> None:
+            pass  # repair fails to clear the dead path
+
+        report = dp.check_dead_paths(repair=noop_repair)
+
+        result = next(r for r in report.results if r.spec == AGENT_FILENAME)
+        assert result.repaired is False
+        assert report.repair_failed == [result]
+        assert report.has_findings is True
+
+    def test_repair_is_only_invoked_when_a_managed_spec_is_dead(self, agents_dir: Path) -> None:
+        live = str(agents_dir)
+        _write_spec(agents_dir, AGENT_FILENAME, {"kirocrew-core": {"command": live}})
+        calls = {"n": 0}
+
+        def counting_repair() -> None:
+            calls["n"] += 1
+
+        dp.check_dead_paths(repair=counting_repair)
+        assert calls["n"] == 0
+
+
+# ── foreign-report-only ──────────────────────────────────────────────────────
+
+
+class TestForeignReportOnly:
+    def test_foreign_spec_dead_path_reported_not_repaired(self, agents_dir: Path) -> None:
+        dead = str(agents_dir / "reaped-venv" / "bin" / "server")
+        spec = _write_spec(agents_dir, "some-other-tool.json", {"their-server": {"command": dead}})
+        before = spec.read_text(encoding="utf-8")
+
+        def boom_repair() -> None:  # must never be called for a foreign-only dir
+            raise AssertionError("repair must not run for a foreign spec")
+
+        report = dp.check_dead_paths(repair=boom_repair)
+
+        foreign = report.foreign_dead
+        assert len(foreign) == 1
+        assert foreign[0].spec == "some-other-tool.json"
+        assert foreign[0].dead[0].server == "their-server"
+        assert foreign[0].dead[0].path == dead
+        # The foreign spec is left byte-for-byte untouched.
+        assert spec.read_text(encoding="utf-8") == before
+        assert report.has_findings is True
+
+
+# ── PATH-like value ignored ──────────────────────────────────────────────────
+
+
+class TestPathListIgnored:
+    def test_colon_joined_env_value_is_not_flagged(self, agents_dir: Path) -> None:
+        # A PATH env value listing several dirs must not be treated as one path
+        # even though each component may be absent.
+        _write_spec(
+            agents_dir,
+            AGENT_FILENAME,
+            {
+                "kirocrew-core": {
+                    "command": str(agents_dir),  # live command
+                    "env": {"PATH": "/nonexistent/a:/nonexistent/b:/bin"},
+                }
+            },
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        result = next(r for r in report.results if r.spec == AGENT_FILENAME)
+        assert result.dead == []
+        assert report.has_findings is False
+
+    def test_single_absolute_env_value_that_is_dead_is_flagged(self, agents_dir: Path) -> None:
+        dead_home = str(agents_dir / "dead-data-home")
+        _write_spec(
+            agents_dir,
+            "foreign.json",
+            {
+                "srv": {
+                    "command": str(agents_dir),
+                    "env": {"KIROCREW_HOME": dead_home},
+                }
+            },
+        )
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        foreign = report.foreign_dead
+        assert len(foreign) == 1
+        assert foreign[0].dead[0].where == "env[KIROCREW_HOME]"
+        assert foreign[0].dead[0].path == dead_home
+
+
+# ── malformed JSON tolerated ─────────────────────────────────────────────────
+
+
+class TestMalformedTolerated:
+    def test_malformed_json_is_reported_not_fatal(self, agents_dir: Path) -> None:
+        (agents_dir / "broken.json").write_text("{ not json", encoding="utf-8")
+        # A healthy foreign spec alongside proves the walk continues past the
+        # broken one.
+        _write_spec(agents_dir, "ok.json", {"srv": {"command": str(agents_dir)}})
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        unreadable = report.unreadable
+        assert [r.spec for r in unreadable] == ["broken.json"]
+        assert unreadable[0].unreadable and "malformed JSON" in unreadable[0].unreadable
+        assert report.has_findings is True
+        # The healthy spec was still walked.
+        assert any(r.spec == "ok.json" for r in report.results)
+
+    def test_non_object_json_is_reported(self, agents_dir: Path) -> None:
+        (agents_dir / "list.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        result = next(r for r in report.results if r.spec == "list.json")
+        assert result.unreadable == "top-level JSON is not an object"
+
+    def test_non_utf8_spec_is_reported_not_fatal(self, agents_dir: Path) -> None:
+        # A binary / non-UTF-8 file decodes with a UnicodeDecodeError (NOT an
+        # OSError); it must be a per-file unreadable result, and the walk must
+        # continue to the healthy spec beside it.
+        (agents_dir / "binary.json").write_bytes(b"\xff\xfe\x00\x01 not utf-8")
+        _write_spec(agents_dir, "ok.json", {"srv": {"command": str(agents_dir)}})
+
+        report = dp.check_dead_paths(repair=lambda: None)
+
+        result = next(r for r in report.results if r.spec == "binary.json")
+        assert result.unreadable and "UTF-8" in result.unreadable
+        assert any(r.spec == "ok.json" for r in report.results)
+
+    def test_missing_agents_dir_returns_empty(self, monkeypatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(dp, "KIRO_AGENTS_DIR", tmp_path / "nope")
+        report = dp.check_dead_paths(repair=lambda: None)
+        assert report.results == []
+        assert report.has_findings is False
+
+
+# ── doctor renderer wiring ───────────────────────────────────────────────────
+
+
+class TestDoctorRenderer:
+    def test_foreign_dead_path_appends_issue_and_prints(
+        self, agents_dir: Path, capsys, monkeypatch
+    ) -> None:
+        dead = str(agents_dir / "gone" / "server")
+        _write_spec(agents_dir, "foreign.json", {"srv": {"command": dead}})
+        # Never repair (there are no managed specs anyway).
+        monkeypatch.setattr(dp, "_default_repair", lambda: None)
+
+        issues: list[str] = []
+        dp.doctor_dead_paths(issues)
+
+        out = capsys.readouterr().out
+        assert "Agent Spec Paths" in out
+        assert "foreign.json" in out
+        assert dead in out
+        assert any("foreign" in i for i in issues)
+
+    def test_clean_dir_prints_ok_and_no_issue(self, agents_dir: Path, capsys) -> None:
+        _write_spec(agents_dir, "foreign.json", {"srv": {"command": str(agents_dir)}})
+        issues: list[str] = []
+        dp.doctor_dead_paths(issues)
+        out = capsys.readouterr().out
+        assert "all agent spec paths resolve" in out
+        assert issues == []
+
+    def test_terminal_escape_bytes_are_neutralized(self, agents_dir: Path, capsys) -> None:
+        # A foreign spec is untrusted content: an ESC/OSC sequence in a dead
+        # path must not reach the terminal verbatim.
+        dead = str(agents_dir / "gone") + "\x1b]0;pwned\x07\x1b[31m"
+        _write_spec(agents_dir, "evil.json", {"srv": {"command": dead}})
+
+        issues: list[str] = []
+        dp.doctor_dead_paths(issues)
+
+        out = capsys.readouterr().out
+        assert "\x1b" not in out  # no raw ESC reaches the terminal
+        assert "\x07" not in out  # no raw BEL either
+        assert "\\x1b" in out  # rendered as a visible, inert token
+        assert any("evil.json" in i for i in issues)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="NTFS refuses control bytes in filenames at creation (EINVAL), "
+        "so the hostile-FILENAME shape this pins is POSIX-only; the sanitizer "
+        "itself is platform-neutral and covered by the tests above.",
+    )
+    def test_issue_entries_are_sanitized_too(self, agents_dir: Path, capsys) -> None:
+        # The FILENAME itself can carry control bytes, and every issues entry
+        # is later joined into doctor's final "Fix these issues" summary line,
+        # which prints -- so the issues channel must be as inert as the direct
+        # prints. Covers all three append sites: foreign-dead, unreadable, and
+        # managed-not-cleared.
+        evil_name = "ev\x1bil.json"
+        _write_spec(agents_dir, evil_name, {"srv": {"command": str(agents_dir / "gone")}})
+        (agents_dir / "bro\x07ken.json").write_text("{not json", encoding="utf-8")
+
+        issues: list[str] = []
+        dp.doctor_dead_paths(issues)
+        capsys.readouterr()
+
+        assert issues, "expected findings"
+        joined = " | ".join(issues)
+        assert "\x1b" not in joined and "\x07" not in joined
+        assert "\\x1b" in joined  # visible token survives for diagnosability
+
+    def test_sanitizer_keeps_ordinary_text(self) -> None:
+        assert dp._sanitize_for_terminal("/opt/tool/bin/x") == "/opt/tool/bin/x"
+        assert dp._sanitize_for_terminal("a\tb") == "a\tb"  # tab is kept
+        assert dp._sanitize_for_terminal("x\x1by") == "x\\x1by"
+
+
+class TestExplicitAgentsDir:
+    """The scan and repair must operate on the caller's resolved dir.
+
+    Regression guard: doctor has its OWN agent-dir override, so if the check
+    re-resolved the live home instead of honoring the dir doctor passes, a dead
+    managed path could trigger a rebuild against specs doctor never meant to
+    touch.
+    """
+
+    def test_check_scans_the_passed_dir_not_the_module_default(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        # Module default points at an EMPTY dir; the explicit arg points at the
+        # dir that actually holds a dead-path spec.
+        empty = tmp_path / "module-default"
+        empty.mkdir()
+        monkeypatch.setattr(dp, "KIRO_AGENTS_DIR", empty)
+        target = tmp_path / "doctor-dir"
+        target.mkdir()
+        dead = str(target / "gone" / "server")
+        (target / "foreign.json").write_text(
+            json.dumps({"mcpServers": {"srv": {"command": dead}}}), encoding="utf-8"
+        )
+
+        # Passing the module default would find nothing; the explicit dir finds
+        # the dead path.
+        assert dp.check_dead_paths(agents_dir=empty, repair=lambda: None).results == []
+        report = dp.check_dead_paths(agents_dir=target, repair=lambda: None)
+        assert [r.spec for r in report.foreign_dead] == ["foreign.json"]
+
+    def test_doctor_forwards_agents_dir(self, monkeypatch, tmp_path: Path, capsys) -> None:
+        # If doctor_dead_paths ignored its agents_dir and used the module
+        # default (empty), it would report "no agent specs"; forwarding the arg
+        # makes it see the dead path in the passed dir.
+        empty = tmp_path / "module-default"
+        empty.mkdir()
+        monkeypatch.setattr(dp, "KIRO_AGENTS_DIR", empty)
+        target = tmp_path / "doctor-dir"
+        target.mkdir()
+        dead = str(target / "gone" / "server")
+        (target / "foreign.json").write_text(
+            json.dumps({"mcpServers": {"srv": {"command": dead}}}), encoding="utf-8"
+        )
+
+        issues: list[str] = []
+        dp.doctor_dead_paths(issues, agents_dir=target)
+
+        out = capsys.readouterr().out
+        assert "foreign.json" in out
+        assert dead in out
+        assert any("foreign" in i for i in issues)

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -264,6 +264,7 @@ class TestTheAgentSpecSeamRatchet:
         ("kiro_crew/agent_discovery.py", "kiro_agents_dir"): "covered by its own hook",
         ("kiro_crew/apps/bridges.py", "kiro_agents_dir"): "covered by its own hook",
         ("kiro_crew/cli_doctor.py", "kiro_agents_dir"): "covered by its own hook",
+        ("kiro_crew/doctor_deadpath.py", "kiro_agents_dir"): "covered by its own hook",
         # Read-only consumers: see the note above this table.
         ("kiro_crew/config/loader.py", "kiro_agents_dir"): "read-only consumer",
         ("kiro_crew/context.py", "kiro_agents_dir"): "read-only consumer",


### PR DESCRIPTION
## What is the problem?

Agent spec JSONs in the shared kiro agents dir rot. A spec's `mcpServers` entry can point at paths that stop existing: a removed venv, a reaped temporary checkout, a relocated tool. The symptom is silent and expensive. Every new session selecting that agent starts with its first-party MCP servers dead (spawn fails on a nonexistent command), or resolves secrets against a dead data home and surfaces `internal_auth_mismatch`. Nothing names the dead path, so the failure class is invisible until someone reads a per-session kiro-cli log.

## Why this issue matters to the user

The write-side fixes (#4781 / #4912) stopped ephemeral writers from ever embedding these paths, but specs poisoned before those fixes, or by writers outside this repo, stay broken on disk. A user in that state loses `spawn_run`, `cron_add`, `learn_add` and the rest of their first-party tooling on every session with no diagnosable cause, and `kirocrew doctor` reports healthy. This makes the breakage self-diagnosing in one step.

## How our fix solves it

A new doctor check (`kiro_crew.doctor_deadpath`) walks every agent spec JSON in `config.paths.kiro_agents_dir()` (which honors `KIRO_HOME`) and stats every absolute `command` path, absolute path-like arg, and absolute path-like env value:

- **Managed specs** (the ones `install_agent` / `rebuild_agent_config` own, i.e. `OWNED_KIRO_AGENT_FILES`) with dead paths are repaired automatically via the existing `rebuild_agent_config` path, then re-verified. A repaired-and-clean spec is reported as auto-fixed and is not counted as an issue.
- **Foreign specs** (other tools' agents sharing the directory) are report-only, naming the spec file, server name, and dead path. KiroCrew never rewrites what it does not own.
- **Malformed / unreadable spec JSON** is reported, never crashing the whole check (fail-open per file).
- Real findings (a foreign dead path, an unreadable spec, or a repair that did not take) are appended to doctor's `issues` list, so `kirocrew doctor` exits nonzero and the failure class surfaces in one step.

Colon-joined values like `PATH` (`/usr/bin:/bin`) are not treated as single paths, so they never false-positive; only a value that looks like ONE absolute path is stat-ed. The check lives in its own module with a single wiring call in `_doctor()`, so the sibling janitor-sweep change (#4950) that also wires into doctor rebases trivially.

## What tests we did

New `test/test_doctor_deadpath.py` (18 tests) on fabricated spec dirs under `tmp_path` (never the real agents dir), covering the required scenarios:

- managed-repair: a managed spec with a dead command is repaired via the injected rebuild path and re-verified clean; a repair that does not take is recorded as a finding; repair is only invoked when a managed spec is actually dead;
- foreign-report-only: a foreign spec's dead path is reported and the file is left byte-for-byte untouched (the repair callable is asserted never to run);
- PATH-like value ignored: a colon-joined `PATH` env value is not flagged, while a single absolute dead env value (e.g. a dead `KIROCREW_HOME`) is;
- malformed JSON tolerated: a broken spec is reported and the walk continues past it; a non-object top-level JSON is reported; a missing agents dir returns empty;
- doctor renderer wiring: a foreign dead path prints the section and appends an issue; a clean dir prints OK and appends nothing.

The new file passes (18/18), the existing `test/test_cli_doctor.py` still passes (79/79) after the import + wiring change, and both new files are black- and flake8-clean.

## Any other suggestions

The repair currently runs one full `rebuild_agent_config()` when any managed spec is dead, which is the authoritative path but broad; a future refinement could scope the rewrite to the affected spec. The check is also positioned to share a single "Agent Spec Paths" section with the #4950 janitor sweep once both land.

Closes #4949
