### PR TITLE
fix(mcp): say which directories were searched when a command is not found

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -59,7 +59,13 @@ from kiro_crew.config.paths import (
     isolated_agents_dir,
     kiro_agents_dir,
 )
-from kiro_crew.env import emit_env, spec_env_path, spec_path_key
+from kiro_crew.env import (
+    dedup_path,
+    describe_search_path,
+    emit_env,
+    spec_env_path,
+    spec_path_key,
+)
 from kiro_crew.mcp_cleanup import purge_deleted_proxy_from_config
 from kiro_crew.mcp_provenance import without_marker
 from kiro_crew.mcp_utils import kiro_oauth_wire_entry, mcp_server_alias
@@ -3105,8 +3111,13 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     # spec from the other sources before dropping it, in priority order
     # (kirocrew > kiro-global > provider-global).  This prevents one source's
     # unresolvable command from killing a server another source can resolve.
-    def _resolve_command(cmd: str, env: dict | None) -> str | None:
-        """Resolve an MCP command to an absolute path, or None if not found.
+    def _resolve_command(cmd: str, env: dict | None) -> tuple[str | None, str]:
+        """Resolve an MCP command to an absolute path, plus the path searched.
+
+        Returns ``(resolved_or_None, search_path)``. The second element is what
+        lets the drop warning name the directories actually consulted; it is ""
+        when no PATH search happened (empty command, or an absolute command
+        accepted directly).
 
         Accepts an absolute path directly when the file exists and is
         executable — shutil.which can fail inside user-namespace sandboxes
@@ -3124,18 +3135,21 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         fallback for pip-generated wrappers like ``kirocrew``.
         """
         if not cmd:
-            return None
+            return None, ""
         if os.path.isabs(cmd) and os.path.isfile(cmd) and os.access(cmd, os.X_OK):
-            return cmd
+            return cmd, ""
         # Case-insensitive PATH key: a Windows-authored spec says "Path", and
         # resolving against a DIFFERENT path than the emitted spec carries would
         # reopen the probe/session split from the other side.
         _env = env or {}
         _key = spec_path_key(_env)
         _declared = _env.get(_key, "") if _key else ""
-        return shutil.which(
-            cmd, path=spec_env_path(_declared if isinstance(_declared, str) else "")
-        )
+        _search = spec_env_path(_declared if isinstance(_declared, str) else "")
+        # The search path is returned, not recomputed by the caller: a candidate
+        # that declares its own ``env.PATH`` is searched against a DIFFERENT path
+        # than one that does not, so a caller reporting ``spec_env_path("")``
+        # would name directories that were never searched.
+        return shutil.which(cmd, path=_search), _search
 
     valid_servers: dict[str, Any] = {}
     # The store is keyed by its own RAW name, but ``name`` below iterates the
@@ -3232,12 +3246,15 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         resolved: str | None = None
         chosen: dict = spec
         tried: list[str] = []
+        searched: list[str] = []
         had_any_command = False
         for label, cand in candidates:
             cmd = cand.get("command", "")
             if cmd:
                 had_any_command = True
-            r = _resolve_command(cmd, cand.get("env"))
+            r, cand_search = _resolve_command(cmd, cand.get("env"))
+            if cand_search:
+                searched.append(cand_search)
             tried.append(f"{label}={cmd or '<none>'}{' -> ok' if r else ''}")
             if r:
                 resolved = r
@@ -3275,10 +3292,19 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             # that was defined but couldn't be resolved.
             logger.warning("Dropping MCP server %r: no command", name)
         else:
+            # The searched directories belong in the WARNING, not only at DEBUG:
+            # a default-level reader is exactly who needs to tell "installed
+            # somewhere this path does not cover" from "not installed at all".
+            # Built from the paths the candidates were ACTUALLY searched against
+            # and deduped -- a candidate declaring its own env.PATH is searched
+            # against a different path, so recomputing one here would name
+            # directories that were never consulted. The candidate list stays at
+            # DEBUG: that is about which spec won, not about why none resolved.
             logger.warning(
-                "Dropping MCP server %r: command not found: %s",
+                "Dropping MCP server %r: command not found: %s — %s",
                 name,
                 spec.get("command", ""),
+                describe_search_path(dedup_path(os.pathsep.join(searched))),
             )
             logger.debug("MCP %r resolution failed; tried %s", name, "; ".join(tried))
     config["mcpServers"] = valid_servers

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -508,6 +508,34 @@ def augmented_path(base_path: str = "") -> str:
     return os.pathsep.join(parts)
 
 
+#: How many directories :func:`describe_search_path` names before truncating.
+#: The effective search path carries a bin dir per installed Node version, so an
+#: unbounded dump would push the actionable first entries out of a log reader's
+#: view.
+_SEARCH_PATH_REPORT_LIMIT = 40
+
+
+def describe_search_path(path: str) -> str:
+    """Render *path* as a human-readable list of searched directories.
+
+    ``command not found: <name>`` never said WHERE it looked, so a reader could
+    not tell "this install directory is not covered by the search path" from
+    "this binary is not installed" -- two different problems with two different
+    fixes -- without reading the source. Every caller formats the search path
+    through here so the two failures read differently everywhere they are
+    reported.
+
+    Truncated at :data:`_SEARCH_PATH_REPORT_LIMIT`; the count is always stated,
+    so a truncated tail is visible rather than silent.
+    """
+    dirs = [d for d in path.split(os.pathsep) if d]
+    if not dirs:
+        return "searched no directories (empty PATH)"
+    shown = dirs[:_SEARCH_PATH_REPORT_LIMIT]
+    suffix = f" (+{len(dirs) - len(shown)} more)" if len(dirs) > len(shown) else ""
+    return f"searched {len(dirs)} directories: {', '.join(shown)}{suffix}"
+
+
 def dedup_path(path: str) -> str:
     """Drop repeated entries from a ``PATH`` string, keeping the first of each.
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -33,6 +33,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.env import (
     denied_spec_env_keys,
+    describe_search_path,
     emit_env,
     sanitize_spec_env,
     spec_env_path,
@@ -116,16 +117,40 @@ _PROBE_TTL_SECS = 1800
 _unresolvable_warned: set[tuple[str, str]] = set()
 
 
-def _warn_unresolvable_once(name: str, command: str) -> None:
-    """WARNING on first sight of an unresolvable command, DEBUG thereafter."""
+def _unresolved_error(command: str, search_path: str = "") -> str:
+    """The dashboard-facing string for a command that resolved nowhere.
+
+    Names the count of directories searched, because ``command not found`` alone
+    does not distinguish the two causes a reader can act on: the binary is not
+    installed, or it is installed somewhere the search path does not cover. The
+    full directory list goes to the log (:func:`_warn_unresolvable_once`) rather
+    than here -- this string renders in a fixed-width dashboard cell.
+    """
+    if not search_path:
+        return f"command not found: {command}"
+    count = len([d for d in search_path.split(os.pathsep) if d])
+    return (
+        f"command not found: {command} — not in any of the {count} directories "
+        "searched (see the gateway log for the list)"
+    )
+
+
+def _warn_unresolvable_once(name: str, command: str, search_path: str = "") -> None:
+    """WARNING on first sight of an unresolvable command, DEBUG thereafter.
+
+    *search_path* is the PATH actually searched; naming its directories is what
+    lets a reader tell "this install location is not covered" from "this binary
+    does not exist" without reading the source.
+    """
     key = (name, command)
+    searched = f" ({describe_search_path(search_path)})" if search_path else ""
     if key in _unresolvable_warned:
         logger.debug(
             "MCP probe [%s]: command still not found: %s (already reported)", name, command
         )
         return
     _unresolvable_warned.add(key)
-    logger.warning("MCP probe failed [%s]: command not found: %s", name, command)
+    logger.warning("MCP probe failed [%s]: command not found: %s%s", name, command, searched)
 
 
 #: Servers whose probe has already reported a missing sandbox backend. Keyed by
@@ -1520,6 +1545,10 @@ async def probe_server(
         return server
 
     server.status = "probing"
+    # The PATH the spawn will actually search, bound before the try so the
+    # FileNotFoundError handler can name the searched directories regardless of
+    # how far the attempt got.
+    effective_path = ""
     # Stamped at probe START so the early error returns below (which skip the
     # cache) still carry an honest "when": the probe DID run at this time.
     # _cache_probe overwrites it with completion time on the paths it covers.
@@ -1556,11 +1585,12 @@ async def probe_server(
         )
 
         # Resolve command to absolute path using the merged env PATH
-        resolved = shutil.which(server.command, path=env.get("PATH"))
+        effective_path = env.get("PATH") or ""
+        resolved = shutil.which(server.command, path=effective_path)
         if not resolved:
             server.status = "error"
-            server.error = f"command not found: {server.command}"
-            _warn_unresolvable_once(server.name, server.command)
+            server.error = _unresolved_error(server.command, effective_path)
+            _warn_unresolvable_once(server.name, server.command, effective_path)
             return server
 
         # The command resolved, so forget any prior "not found" report — keyed on
@@ -1765,8 +1795,10 @@ async def probe_server(
         )
     except FileNotFoundError:
         server.status = "error"
-        server.error = f"command not found: {server.command}"
-        _warn_unresolvable_once(server.name, server.command)
+        server.error = _unresolved_error(server.command, effective_path)
+        # ``effective_path`` was bound before the try, so it is always safe to
+        # read here even if the failure preceded PATH resolution.
+        _warn_unresolvable_once(server.name, server.command, effective_path)
     except SandboxUnavailableError as exc:
         # The PROBE could not run — this says nothing about the server, and the
         # two must not be reported alike. Ahead of the generic clause, which would

--- a/test/test_unresolved_command_message.py
+++ b/test/test_unresolved_command_message.py
@@ -1,0 +1,103 @@
+"""``command not found`` must say WHERE it looked (part of #3030).
+
+Both the dashboard probe and the agent config rebuild reported an unresolvable
+MCP command as a bare ``command not found: <name>``, and the searched
+directories existed only at DEBUG. A reader could not tell "this binary is not
+installed" from "it is installed somewhere the search path does not cover" --
+two different problems with two different fixes -- without reading the source.
+
+Path fixtures are built through :func:`_abs` and ``os.pathsep`` rather than
+written as POSIX literals: on Windows ``os.pathsep`` is ``;`` and ``normpath``
+returns backslashes, so a hardcoded ``"/usr/bin:/bin"`` is ONE entry there and
+would silently assert something different.
+"""
+
+from __future__ import annotations
+
+import os
+
+from kiro_crew import env as env_mod
+from kiro_crew.env import describe_search_path
+
+
+def _abs(*parts: str) -> str:
+    root = "C:\\" if os.name == "nt" else "/"
+    return os.path.normpath(os.path.join(root, *parts))
+
+
+USR_BIN = _abs("usr", "bin")
+BIN = _abs("bin")
+BASE_PATH = os.pathsep.join([USR_BIN, BIN])
+
+
+# ── describe_search_path ──────────────────────────────────────────────────────
+
+
+def test_names_the_directories_and_the_count():
+    out = describe_search_path(BASE_PATH)
+    assert USR_BIN in out and BIN in out
+    assert "2" in out  # states how many were searched
+
+
+def test_truncates_but_states_the_total():
+    limit = env_mod._SEARCH_PATH_REPORT_LIMIT
+    total = limit + 20
+    many = os.pathsep.join(_abs(f"d{i}") for i in range(total))
+    out = describe_search_path(many)
+    assert f"searched {total} directories" in out
+    assert f"+{total - limit} more" in out
+    assert _abs(f"d{total - 1}") not in out
+
+
+def test_handles_an_empty_path():
+    assert "empty PATH" in describe_search_path("")
+
+
+def test_ignores_empty_entries():
+    """A trailing or doubled separator must not be counted as a directory."""
+    padded = os.pathsep.join(["", USR_BIN, "", BIN, ""])
+    assert "searched 2 directories" in describe_search_path(padded)
+
+
+# ── the dashboard-facing string ───────────────────────────────────────────────
+
+
+def test_probe_error_states_how_many_directories_were_searched():
+    from kiro_crew.mcp_discovery import _unresolved_error
+
+    msg = _unresolved_error("vendor-mcp", BASE_PATH)
+    assert "command not found: vendor-mcp" in msg  # prefix preserved for callers
+    assert "2 directories" in msg
+
+
+def test_probe_error_without_a_search_path_is_unchanged():
+    """No search happened, so claim nothing about directories."""
+    from kiro_crew.mcp_discovery import _unresolved_error
+
+    assert _unresolved_error("vendor-mcp") == "command not found: vendor-mcp"
+
+
+# ── the operator-facing log line ──────────────────────────────────────────────
+
+
+def test_probe_warning_lists_the_searched_directories(caplog):
+    from kiro_crew import mcp_discovery
+
+    mcp_discovery._unresolvable_warned.clear()
+    with caplog.at_level("WARNING"):
+        mcp_discovery._warn_unresolvable_once("srv", "ghost", BASE_PATH)
+    assert USR_BIN in caplog.text
+    assert "ghost" in caplog.text
+
+
+def test_probe_warning_repeats_are_still_demoted(caplog):
+    """The once-only ledger must survive the added argument."""
+    from kiro_crew import mcp_discovery
+
+    mcp_discovery._unresolvable_warned.clear()
+    with caplog.at_level("WARNING"):
+        mcp_discovery._warn_unresolvable_once("srv", "ghost", BASE_PATH)
+        assert "command not found" in caplog.text  # first sighting warns
+        caplog.clear()
+        mcp_discovery._warn_unresolvable_once("srv", "ghost", BASE_PATH)
+        assert "command not found" not in caplog.text  # repeat demoted to DEBUG


### PR DESCRIPTION
## 1. What is the problem?

Both surfaces that report an unresolvable MCP server command said only `command not found: <name>`:

- the dashboard probe (`mcp_discovery.probe_server`), in the string the UI shows;
- the agent config rebuild, in the WARNING it logs when it drops a server.

Neither said what was searched. `agent.py` already computed the candidate list but logged it at DEBUG, and the searched *directories* were nowhere at all. So a reader could not distinguish two different problems that need two different fixes: the binary is not installed, or it is installed in a directory the search path does not cover.

That search path is not obvious from the outside. `env.augmented_path()` composes six built-in directories, a bin dir per installed Node version manager, the inherited `PATH`, and the running interpreter's own bin dir. Whether a given install location is in there is not something a user can reason about without reading the source.

This is the message half of #3030, which reported both a missing capability and this message defect. It does not close that issue -- see section 5.

## 2. Why this issue matters to the user

The failure is silent about its own cause at exactly the moment a user is trying to fix it. `~/.deno/bin`, `~/.bun/bin`, `~/go/bin` and a corporate-managed install root are all outside the built-in list, and a gateway launched from systemd or launchd does not inherit a login shell's `PATH`. In that situation the server shows as an error and is dropped from the generated config, and the message sends the user to reinstall a binary that is already installed.

## 3. How our fix solves it

`env.describe_search_path(path)` renders a search path as a human-readable directory list, truncated at 40 entries with the total always stated. Truncation matters because the effective path carries a bin dir per installed Node version, and an unbounded dump would push the actionable first entries out of a log reader's view; stating the count keeps a truncated tail visible rather than silent.

Three report sites use it:

- `mcp_discovery._warn_unresolvable_once` logs the directory list. It keeps its once-per-`(server, command)` ledger, so a config carried between machines still does not repeat the warning forever -- a test pins that the repeat is still demoted to DEBUG.
- `mcp_discovery._unresolved_error` builds the dashboard string. It states how many directories were searched and points at the log for the list, rather than embedding 20+ paths in a fixed-width cell.
- `agent.py`'s drop warning promotes the directory list from DEBUG to WARNING, since a default-level reader is exactly who needs it.

The directories reported are the ones **actually** searched. `_resolve_command` now returns `(resolved, search_path)` instead of just the resolution, because a candidate that declares its own `env.PATH` is searched against a different path than one that does not -- recomputing a default at the report site would name directories that were never consulted. The drop warning reports the deduped union of the paths the candidates were really searched against.

Two things deliberately unchanged: the `command not found: <cmd>` prefix stays, so existing callers and assertions still match; and a failure where no PATH search happened at all (empty command, or an absolute command accepted directly) reports exactly as before rather than claiming a directory count it does not have.

## 4. What tests we did

New `test/test_unresolved_command_message.py`, 8 tests: the directory list and count; truncation stating the total; an empty path; empty/doubled separators not counted as directories; the dashboard string with and without a search path; the probe warning naming the directories; and the once-only ledger still demoting repeats.

Mutation-verified at all three report sites -- dropping the searched dirs from the probe warning, dropping the count from the dashboard string, and dropping the truncation notice each fail a test.

Path fixtures are built through a helper and `os.pathsep` rather than POSIX literals: on Windows `os.pathsep` is `;` and `normpath` returns backslashes, so a hardcoded `"/usr/bin:/bin"` is one entry there and would silently assert something different.

Targeted runs green: `test_unresolved_command_message`, `test_env`, `test_mcp_*`, `test_agent*` -- 3687 passed, 16 skipped. `black` / `flake8` / `isort` / `mypy` clean on the touched files.

## 5. Any other suggestions on the work

**This is deliberately half of #3030, so it says `Refs` rather than `Closes`.** The other half -- a user-extensible search path (`agent.extra_path_dirs`) -- was implemented and withdrawn, because it cannot be made revocable in this pipeline as it stands. The rebuild persists BOTH its resolution results into the agent config (`merged["command"] = resolved`, and the expanded `PATH` via `emit_env`), and `install_agent` reads that config back as a source to "preserve user customizations". A persisted value is then indistinguishable from one the user authored, so clearing the setting does not revoke it -- the resolved absolute command keeps executing, and a persisted `PATH` entry returns as a *declared* entry, which ranks first. Verified from three directions (the agent config, the create-only `~/.kiro/settings/mcp.json`, and the resolved command itself).

So the prerequisite is provenance on persisted managed fields, so a rebuild re-derives them instead of re-consuming them. That is worth its own issue and would make the config key a small addition afterwards. Until then the supported answer for an out-of-list install directory is a per-spec `env.PATH`, which already works.

**Unrelated finding worth its own issue.** While checking the trust surface of that withdrawn key: `config.json` and `config.local.json` are in `_WRITE_PROTECTED_HOME_PATHS`, so the file-edit tool is gated, but they are absent from `_WRITE_PROTECTED_BASH_LEAVES`, and a probe confirms `is_sensitive_bash_command` allows a shell redirect into the crew `config.json` while correctly denying the paired `playwright-cli-config.json`. The comment at `hooks.py:587` asserts the opposite ("Bash writes ... are blocked separately"). Nothing in this PR depends on it.

Refs #3030
