### PR TITLE
feat(agents): add age-based janitor for orphaned temps and stale backups

### DIFF
--- a/src/kiro_crew/agents_janitor.py
+++ b/src/kiro_crew/agents_janitor.py
@@ -1,0 +1,320 @@
+"""Age-based janitor for the shared kiro agents directory.
+
+The kiro agents directory (:func:`kiro_crew.config.paths.kiro_agents_dir`) is
+rewritten continuously by several independent writers — this project's spec
+rebuild plus other tools that install agents there. Every writer uses
+write-temp-then-rename, and a crash or a race between the write and the rename
+strands the temp file forever. Backups written beside the live spec accumulate
+the same way. Nothing removes any of it, so the directory only grows and every
+consumer that globs it pays for the junk.
+
+This module sweeps only the recognized, unambiguously-dead name shapes, and only
+when they are old enough that no in-flight operation could still own them:
+
+* orphaned atomic-write temps ``<base>.json.<digits>.tmp`` (foreign writers) and
+  ``tmp<alnum>.tmp`` (this project's own ``mkstemp`` residue) — swept at 24h;
+* aged backups ``*.bak-<digits>`` and ``*.json.bak.<digits>`` — OPT-IN
+  (``sweep_backups=True``) and swept at a much longer 14-day window. Kiro Crew
+  authors no backups in this directory, so every backup a sweep would remove
+  belongs to a foreign writer whose retention policy is not ours to decide; and
+  a backup exists precisely to outlive its write, so the millisecond "garbage by
+  construction" argument that justifies 24h for a temp does not apply. The
+  wired-in callers therefore leave backups alone unless
+  ``agent.sweep_agents_backups`` is enabled.
+
+Conservative by construction — an in-flight atomic replace completes in
+milliseconds, so a recognized temp older than the 24h threshold is garbage. The
+sweep is deliberately narrow and fail-open:
+
+* it matches ONLY the exact name shapes above (never a live ``*.json`` spec, and
+  never a foreign file whose name does not match);
+* it never touches directories;
+* it never follows symlinks — every entry is inspected with :func:`os.lstat`,
+  and a symlink (even one whose name matches) is skipped, so the sweep can only
+  ever unlink a real regular file inside the agents directory itself;
+* it removes only regular files whose mtime is at least the threshold old;
+* every deletion is logged with the filename and the file's age;
+* a failure on any one entry (unreadable, vanished mid-sweep, permission
+  denied) is tolerated and the sweep continues.
+
+It is intentionally isolated in its own module with a small, side-effect-free
+surface so it can be wired into ``kirocrew doctor`` and gateway boot in one or
+two lines each. The same write-temp-then-rename residue exists in other
+data-home directories too; the agents directory is swept first because it is the
+*shared*, foreign-writer directory that grows fastest, and a general residue
+sweep across the other single-writer directories is left as follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import stat
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Minimum age before a recognized atomic-write TEMP is considered garbage. An
+#: atomic replace finishes in milliseconds, so 24h is orders of magnitude beyond
+#: any legitimate lifetime for a ``.tmp`` orphan.
+DEFAULT_TEMP_MAX_AGE_SECONDS = 24 * 60 * 60
+
+#: Minimum age before a recognized BACKUP is swept. Backups are deliberately
+#: longer-lived than temps: a ``*.bak-<digits>`` / ``*.json.bak.<digits>`` exists
+#: precisely to outlive the write that produced it, so it can be used to recover
+#: a bad spec. Deleting one after only 24h would remove a recovery artifact — and
+#: ``kirocrew doctor``, the command you run *when something is broken*, is one of
+#: the sweep triggers — so backups get a much longer window (14 days). The
+#: "garbage by construction" argument that justifies 24h for temps does not
+#: apply to backups, so they are aged separately.
+DEFAULT_BACKUP_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
+
+#: Recognized non-live TEMP shapes, anchored so a match is the WHOLE filename.
+#:
+#: * ``<base>.json.<digits>.tmp`` — an orphaned atomic-write temp from a foreign
+#:   writer. The digits are the writer's disambiguator (a pid, an epoch, a
+#:   counter); requiring at least one digit between ``.json.`` and ``.tmp`` is
+#:   what distinguishes a stranded temp from a legitimately-named file ending in
+#:   ``.tmp``.
+#: * ``tmp<alnum>.tmp`` — Kiro Crew's OWN atomic-write residue. ``agent.py``'s
+#:   ``_atomic_json_write`` calls ``tempfile.mkstemp(suffix=".tmp")``, which
+#:   emits ``tmp`` + random alphanumerics + ``.tmp`` (never the dotted
+#:   ``.json.<digits>.tmp`` shape), so without this pattern the project's own
+#:   crash residue would never be reclaimed. The ``tmp`` prefix + ``.tmp``
+#:   suffix + a non-empty random middle is exactly mkstemp's contract, which is
+#:   narrow enough not to sweep an arbitrarily-named foreign file.
+#:
+#: A live spec is ``<name>.json`` with no trailing temp suffix and never matches,
+#: which is the core safety property.
+_TEMP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^.+\.json\.\d+\.tmp$"),
+    re.compile(r"^tmp[A-Za-z0-9_]+\.tmp$"),
+)
+
+#: Recognized BACKUP shapes, anchored to the whole filename.
+#:
+#: * ``<base>.bak-<digits>`` — an epoch-suffixed backup.
+#: * ``<base>.json.bak.<digits>`` — the other backup shape seen in the wild.
+_BACKUP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^.+\.bak-\d+$"),
+    re.compile(r"^.+\.json\.bak\.\d+$"),
+)
+
+
+def _classify_junk_name(name: str) -> str | None:
+    """Return ``"temp"``/``"backup"`` if *name* is a recognized dead shape, else ``None``.
+
+    Name-only classification — it never touches the filesystem, so it cannot be
+    a live ``*.json`` spec (none of the anchored patterns match a bare ``.json``)
+    and it never depends on TOCTOU-sensitive state. Which class a name falls into
+    selects the age threshold applied to it.
+    """
+    if any(pattern.match(name) for pattern in _TEMP_PATTERNS):
+        return "temp"
+    if any(pattern.match(name) for pattern in _BACKUP_PATTERNS):
+        return "backup"
+    return None
+
+
+@dataclass
+class SweepResult:
+    """Outcome of one sweep, for logging / doctor reporting.
+
+    ``removed`` and ``freed_bytes`` count files unlinked (or, under ``dry_run``,
+    that would be unlinked). ``removed_names`` keeps their basenames so a caller
+    can render them without re-listing the directory.
+    """
+
+    removed: int = 0
+    freed_bytes: int = 0
+    removed_names: list[str] = field(default_factory=list)
+
+
+def _unlink_if_still_stale(
+    target: Path,
+    seen: os.stat_result,
+    threshold: float,
+    reference: float,
+) -> bool:
+    """Unlink *target* only if it is still the same aged regular file we scanned.
+
+    Closes the recreate-same-pathname race: between the directory scan and this
+    call a writer can crash-strand a NEW temp at the same pathname (a foreign
+    ``<base>.json.<digits>.tmp`` whose pid/counter was reused), and a blind
+    ``os.unlink(target)`` would then delete that fresh in-flight file and lose
+    the writer's spec write. So re-``lstat`` the path immediately before
+    unlinking and refuse unless the entry is byte-for-byte the one we judged:
+
+    * same inode identity (``st_dev`` + ``st_ino``) — the file was not replaced;
+    * a regular file, not a symlink — nothing was swapped for a link;
+    * unchanged mtime and size — it was not rewritten in place;
+    * still at least *threshold* old — belt-and-suspenders on the age.
+
+    Returns ``True`` when the file was unlinked, ``False`` when it was skipped
+    (changed, vanished, or unreadable) — never raises, so the sweep stays
+    fail-open.
+    """
+    try:
+        now_info = os.lstat(target)
+    except OSError:
+        # Vanished between scan and re-stat (another writer cleaned it up), or
+        # unreadable. Nothing to delete; not an error we must surface.
+        logger.debug("agents janitor: %r gone before re-stat; skipping", target.name)
+        return False
+
+    if (
+        now_info.st_dev != seen.st_dev
+        or now_info.st_ino != seen.st_ino
+        or now_info.st_mtime != seen.st_mtime
+        or now_info.st_size != seen.st_size
+        or stat.S_ISLNK(now_info.st_mode)
+        or not stat.S_ISREG(now_info.st_mode)
+        or (reference - now_info.st_mtime) < threshold
+    ):
+        # The path no longer holds the aged garbage we classified — a writer
+        # recreated or refreshed it. Leave the current occupant alone.
+        logger.debug("agents janitor: %r changed before delete; skipping", target.name)
+        return False
+
+    try:
+        os.unlink(target)
+    except OSError:
+        # Per-file failure is tolerated: another writer may have removed it, or
+        # permissions may forbid it. Never abort the whole sweep.
+        logger.debug("agents janitor: could not remove %r; skipping", target.name, exc_info=True)
+        return False
+    return True
+
+
+def sweep_agents_dir(
+    agents_dir: Path | str,
+    *,
+    now: float | None = None,
+    sweep_backups: bool = False,
+    dry_run: bool = False,
+) -> SweepResult:
+    """Remove aged orphaned atomic-write temps and stale backups in *agents_dir*.
+
+    Deletes only entries whose *name* matches a recognized temp/backup shape
+    (see :data:`_TEMP_PATTERNS` / :data:`_BACKUP_PATTERNS`) AND that are regular
+    files (not symlinks, not directories) old enough for their class:
+    :data:`DEFAULT_TEMP_MAX_AGE_SECONDS` for temps,
+    :data:`DEFAULT_BACKUP_MAX_AGE_SECONDS` for backups. Temps and backups are
+    aged separately because a backup exists to outlive its write, so the
+    millisecond "garbage by construction" argument that justifies a 24h temp
+    threshold does not apply to it. Everything else — live ``*.json`` specs,
+    foreign files, directories, symlinks, and anything younger than its
+    threshold — is left untouched.
+
+    Fail-open throughout: a missing directory, an unreadable entry, or a file
+    that vanishes mid-sweep is tolerated and never raises. Returns a
+    :class:`SweepResult` so callers can log or report what happened.
+
+    :param now: reference time (epoch seconds) for age computation; defaults to
+        :func:`time.time`. Exposed for deterministic tests.
+    :param sweep_backups: when false (the default), only temps are swept and
+        recognized backups are left entirely alone. Kiro Crew authors no
+        ``*.bak-<digits>`` / ``*.json.bak.<digits>`` files in this directory, so
+        every backup a sweep would remove belongs to a foreign writer whose
+        retention policy is not ours to decide; the default therefore reaps only
+        the atomic-write temps, which carry the bulk of the growth at near-zero
+        risk. The wired-in callers pass ``agent.sweep_agents_backups`` (also off
+        by default), so an operator must opt in twice-over before a foreign
+        backup is ever touched.
+    :param dry_run: when true, identify eligible files and populate
+        ``removed`` / ``freed_bytes`` / ``removed_names`` exactly as a real
+        sweep would, but never unlink anything. Lets a read-only caller (e.g.
+        ``kirocrew doctor``) REPORT what a sweep would reclaim without mutating
+        the directory — deletion is left to the fire-and-forget boot sweep.
+    """
+    result = SweepResult()
+    reference = time.time() if now is None else now
+    directory = Path(agents_dir)
+
+    try:
+        entries = list(os.scandir(directory))
+    except FileNotFoundError:
+        # A fresh install / ephemeral instance may not have the directory yet.
+        return result
+    except OSError:
+        # Unreadable directory — fail open, sweep nothing.
+        logger.debug("agents janitor: could not list %s; skipping sweep", directory, exc_info=True)
+        return result
+
+    for entry in entries:
+        name = entry.name
+        kind = _classify_junk_name(name)
+        if kind is None:
+            # Not a recognized shape — includes every live ``*.json`` spec and
+            # any foreign file with an unrecognized name.
+            continue
+        if kind == "backup" and not sweep_backups:
+            # Backups belong to foreign writers here — skip unless opted in.
+            continue
+
+        try:
+            # os.lstat on the entry PATH, deliberately NOT
+            # ``entry.stat(follow_symlinks=False)``: the delete-time recheck
+            # (:func:`_unlink_if_still_stale`) compares this snapshot against a
+            # fresh ``os.lstat`` by inode identity, and on Windows ``scandir``'s
+            # cached stat carries ``st_ino == st_dev == 0`` while ``os.lstat``
+            # returns the real identifiers — the comparison then NEVER matches
+            # and the sweep silently refuses every removal. One syscall family
+            # on both sides keeps the identity check meaningful everywhere.
+            # (lstat, never stat: it must NOT follow a symlink. A symlink whose
+            # name happens to match a recognized shape is skipped entirely, so
+            # the sweep can only ever unlink a real regular file inside the
+            # agents directory — never a link target elsewhere.)
+            info = os.lstat(entry.path)
+        except OSError:
+            # Raced with a delete, or unreadable — tolerate and move on. The
+            # filename is rendered with ``%r`` so an attacker-controlled name
+            # (this directory is shared with foreign writers) cannot smuggle a
+            # terminal-control sequence through the log.
+            logger.debug("agents janitor: could not stat %r; skipping", name, exc_info=True)
+            continue
+
+        mode = info.st_mode
+        if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+            # Symlinks (even matching-named ones) and non-regular entries
+            # (directories, sockets, fifos) are never candidates.
+            continue
+
+        threshold = (
+            DEFAULT_TEMP_MAX_AGE_SECONDS if kind == "temp" else DEFAULT_BACKUP_MAX_AGE_SECONDS
+        )
+        age = reference - info.st_mtime
+        if age < threshold:
+            # A genuinely in-flight temp, or a backup still inside its retention
+            # window — leave it.
+            continue
+
+        if not dry_run:
+            if not _unlink_if_still_stale(directory / name, info, threshold, reference):
+                # The entry changed between the scan and the delete — recreated,
+                # replaced, or refreshed by a writer — so the file at this path
+                # is no longer the aged garbage we classified. Skip it: this is
+                # the guard against the recreate-same-pathname race where a boot
+                # sweep could otherwise unlink a writer's brand-new temp and lose
+                # its spec write.
+                continue
+
+        result.removed += 1
+        result.freed_bytes += info.st_size
+        result.removed_names.append(name)
+        # ``%r`` on the name: foreign writers control these filenames, so a raw
+        # ``%s`` would let a crafted name inject a terminal-control sequence into
+        # a log stream an operator later views in a terminal.
+        logger.info(
+            "agents janitor: %s %r (%s, age %.1fh, %d bytes)",
+            "would remove" if dry_run else "removed",
+            name,
+            kind,
+            age / 3600.0,
+            info.st_size,
+        )
+
+    return result

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -24,6 +24,7 @@ from kiro_crew.acp import kas_assets, kas_auth
 from kiro_crew.acp.client import KIRO_CLI_BIN
 from kiro_crew.acp.types import ACP_BACKEND_KAS
 from kiro_crew.agent import AGENT_FILENAME
+from kiro_crew.agents_janitor import sweep_agents_dir
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import config_dir
@@ -1374,6 +1375,42 @@ def _kas_engine_flag_supported(kiro_bin: str) -> bool:
     return kas_assets.KAS_ENGINE_FLAG in (proc.stdout or "") + (proc.stderr or "")
 
 
+def _doctor_agents_janitor(issues: list[str], sweep_backups: bool) -> None:
+    """Report aged orphaned atomic-write temps and stale backups in the agents dir.
+
+    The shared kiro agents directory accumulates ``<base>.json.<digits>.tmp``
+    orphans and ``*.bak-<digits>`` / ``*.json.bak.<digits>`` backups from the
+    several independent writers that install agents there; nothing else removes
+    them. ``kirocrew doctor`` REPORTS what a sweep would reclaim but never
+    deletes anything itself (``dry_run=True``) — a diagnostic you run *because
+    something broke* must not silently unlink files, including recovery backups,
+    in the same invocation. Actual deletion is left to the fire-and-forget boot
+    sweep, and the report mirrors that sweep's scope: backups are only counted
+    when ``agent.sweep_agents_backups`` is enabled (*sweep_backups*), since Kiro
+    Crew authors none of them and the boot sweep leaves foreign backups alone by
+    default. Advisory only (never appended to ``issues``): reclaimable junk is
+    housekeeping, not a setup fault, and the scan is fail-open so it can never
+    abort the run.
+    """
+    del issues  # advisory-only diagnostic; keeps the call-site signature uniform
+    print("\nAgents Directory")
+    agents_dir = _agents_dir()
+    result = sweep_agents_dir(agents_dir, dry_run=True, sweep_backups=sweep_backups)
+    if result.removed:
+        mib = result.freed_bytes / 1048576
+        print(
+            f"  janitor:     🧹 {result.removed} stale temp/backup file(s) "
+            f"reclaimable ({mib:.1f} MiB) — the gateway sweeps these on boot"
+        )
+        for name in result.removed_names:
+            # ``!r`` on the name: this directory is shared with foreign writers,
+            # so a crafted filename could otherwise smuggle a terminal-control
+            # (ANSI/OSC) escape sequence straight to the operator's terminal.
+            print(f"{_INDENT}- {name!r}")
+    else:
+        print("  janitor:     ✅ no stale temp/backup files to reclaim")
+
+
 def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False) -> None:
     """Verify KiroCrew setup — check dependencies, config, credentials, connectivity.
 
@@ -1613,6 +1650,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     _doctor_data_home()
     _doctor_path_launcher()
     _doctor_trust_root()
+
+    # ── Agents dir janitor (orphaned atomic-write temps + stale backups) ──
+    _doctor_agents_janitor(issues, cfg.agent.sweep_agents_backups)
 
     # ── KAS backend (only when selected) ──
     _doctor_kas(issues)

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1309,6 +1309,20 @@ class AgentConfig:
         default="",
         metadata=_meta("Default Agent", "Default agent name for new sessions."),
     )
+    sweep_agents_backups: bool = field(
+        default=False,
+        metadata=_meta(
+            "Sweep foreign agent backups",
+            "When true, the agents-directory janitor also deletes aged backup "
+            "files (*.bak-<digits> / *.json.bak.<digits>, older than 14 days) "
+            "from the shared kiro agents directory. OFF by default: Kiro Crew "
+            "does not author those backups, so every one it would delete belongs "
+            "to another tool whose retention policy is not ours to decide. The "
+            "orphaned atomic-write TEMP sweep (24h) always runs and reclaims most "
+            "of the growth at near-zero risk; enable this only if you also want "
+            "foreign backups in that directory reaped.",
+        ),
+    )
     sandbox: str = field(
         default="auto",
         metadata=_meta(
@@ -6202,6 +6216,9 @@ class KiroCrewConfig:
                 mcp_registry_mode=_safe_bool(agent_data.get("mcp_registry_mode", False), False),
                 acp_backend=_normalize_acp_backend(agent_data.get("acp_backend")),
                 default_agent=agent_data.get("default_agent", ""),
+                sweep_agents_backups=_safe_bool(
+                    agent_data.get("sweep_agents_backups", False), False
+                ),
                 sandbox=agent_data.get("sandbox", "auto"),
                 sandbox_allow_no_isolation=bool(
                     agent_data.get("sandbox_allow_no_isolation", False)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -44,6 +44,7 @@ import kiro_crew
 import kiro_crew.crash_guard as crash_guard
 from kiro_crew import beacon, dep_sync, platform_compat, shutdown_event
 from kiro_crew.acp.client import AcpError, AcpProcessDied
+from kiro_crew.agents_janitor import sweep_agents_dir
 from kiro_crew.autonudge import (
     APPROVAL_STALL_REASON,
     AutoNudgeService,
@@ -9264,6 +9265,10 @@ class GatewayOrchestrator:
 # be garbage-collected mid-flight.
 _SLICE_LIMITS_TASK: "asyncio.Task[None] | None" = None
 
+# Strong ref to the fire-and-forget agents-dir janitor sweep launched at boot
+# (the loop holds tasks weakly, so without this it could be GC'd mid-flight).
+_AGENTS_JANITOR_TASK: "asyncio.Task[None] | None" = None
+
 
 async def run_gateway(
     cfg: KiroCrewConfig,
@@ -9312,6 +9317,43 @@ async def run_gateway(
 
         _SLICE_LIMITS_TASK = asyncio.create_task(
             _apply_slice_limits(), name="agents-slice-limits"
+        )
+
+    # ── Agents-dir janitor (fire-and-forget) ──
+    # Sweep aged orphaned atomic-write temps + stale backups from the shared
+    # kiro agents directory (see kiro_crew.agents_janitor). Scheduled as a
+    # contained background task and never awaited, so a slow or failing sweep
+    # cannot delay dashboard binding or crash boot: the coroutine offloads the
+    # blocking filesystem work to a thread and swallows every error. The module
+    # global keeps a strong reference (the loop holds tasks weakly). Skipped in
+    # test_mode so the offline E2E gate never touches the developer's real
+    # agents dir.
+    global _AGENTS_JANITOR_TASK
+    if not test_mode:
+
+        async def _run_agents_janitor() -> None:
+            try:
+
+                def _sweep_in_thread() -> None:
+                    # kiro_agents_dir() resolved INSIDE the worker thread, not
+                    # in this coroutine body: the resolver walks env +
+                    # Path.home() + .resolve(), which is blocking filesystem
+                    # work — on an unavailable network home it can stall
+                    # indefinitely, and this coroutine runs on the event loop
+                    # during boot, between bind and serve.
+                    sweep_agents_dir(
+                        kiro_agents_dir(),
+                        sweep_backups=cfg.agent.sweep_agents_backups,
+                    )
+
+                await asyncio.to_thread(_sweep_in_thread)
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "agents-dir janitor sweep failed at boot", exc_info=True
+                )
+
+        _AGENTS_JANITOR_TASK = asyncio.create_task(
+            _run_agents_janitor(), name="agents-dir-janitor"
         )
 
     # ── Anonymous usage beacon (at most one HTTP GET per day) ──

--- a/test/test_agents_janitor.py
+++ b/test/test_agents_janitor.py
@@ -1,0 +1,353 @@
+"""Tests for the age-based agents-directory janitor.
+
+Covers the hard safety contract in :mod:`kiro_crew.agents_janitor`:
+
+* an aged orphaned atomic-write temp is removed (foreign shape and this
+  project's own ``mkstemp`` residue);
+* a fresh temp (younger than the threshold) is kept;
+* a live ``*.json`` spec is never touched;
+* an aged foreign file with an unrecognized name is never touched;
+* a symlink whose name matches a recognized shape is skipped (never followed);
+* an unreadable / vanished entry is tolerated (fail-open);
+* backups are aged on their own, longer retention window and are opt-in (Kiro
+  Crew authors none of them, so they belong to foreign writers).
+
+All filesystem work is under ``tmp_path`` — the sweep never runs against a real
+agents directory here.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.agents_janitor import (
+    DEFAULT_BACKUP_MAX_AGE_SECONDS,
+    DEFAULT_TEMP_MAX_AGE_SECONDS,
+    SweepResult,
+    _classify_junk_name,
+    sweep_agents_dir,
+)
+
+# A fixed reference clock keeps every age assertion deterministic.
+_NOW = 1_000_000_000.0
+# Older than the temp threshold but younger than the backup threshold — proves
+# the two classes are aged independently.
+_OLD_TEMP = _NOW - (DEFAULT_TEMP_MAX_AGE_SECONDS + 3600)
+_OLD_BACKUP = _NOW - (DEFAULT_BACKUP_MAX_AGE_SECONDS + 3600)
+_FRESH = _NOW - 60  # one minute old — an in-flight temp
+
+
+def _touch(path: Path, *, mtime: float, content: str = "{}") -> Path:
+    path.write_text(content, encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+# ── name-shape classification (pure, no filesystem) ──
+
+
+@pytest.mark.parametrize(
+    "name,kind",
+    [
+        ("build-agent.json.12345.tmp", "temp"),
+        ("kiro.json.1.tmp", "temp"),
+        ("tmpA1b2C3d4.tmp", "temp"),  # this project's own mkstemp residue
+        ("tmp0.tmp", "temp"),
+        ("spec.bak-1700000000", "backup"),
+        ("spec.json.bak.42", "backup"),
+    ],
+)
+def test_classifies_junk_shapes(name: str, kind: str) -> None:
+    assert _classify_junk_name(name) == kind
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "build-agent.json",  # live spec — the core safety case
+        "kiro.json",
+        "notes.txt",
+        "agent.json.tmp",  # no digits between .json. and .tmp
+        "agent.tmp",  # not a recognized temp shape
+        "tmp.tmp",  # mkstemp always has a non-empty random middle
+        "agent.bak-",  # no digits
+        "agent.json.bak.",  # no digits
+        "agent.json.bak",  # missing the trailing .<digits>
+    ],
+)
+def test_rejects_non_junk_shapes(name: str) -> None:
+    assert _classify_junk_name(name) is None
+
+
+# ── sweep behaviour ──
+
+
+def test_removes_aged_orphan_temp(tmp_path: Path) -> None:
+    orphan = _touch(tmp_path / "build-agent.json.98765.tmp", mtime=_OLD_TEMP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert not orphan.exists()
+    assert result.removed == 1
+    assert orphan.name in result.removed_names
+
+
+def test_sweep_survives_zeroed_dirent_identity(tmp_path: Path, monkeypatch) -> None:
+    """Windows regression guard, runnable on any platform.
+
+    On Windows, ``os.scandir``'s cached stat reports ``st_ino == st_dev == 0``
+    while ``os.lstat`` returns the real identifiers. The delete-time recheck
+    (``_unlink_if_still_stale``) compares by inode identity, so a scan that
+    takes its snapshot from ``entry.stat()`` can never match the recheck there
+    and the sweep silently refuses every removal. The scan must therefore
+    snapshot via ``os.lstat`` — this shim makes ``entry.stat()`` return zeroed
+    identity everywhere, so a regression back to ``entry.stat()`` fails here,
+    not only on the Windows runner.
+
+    The shim is installed on the MODULE UNDER TEST's ``os`` binding only
+    (``agents_janitor.os``), never on the global ``os`` module: pytest's own
+    tmp-path/residue machinery walks directories with ``with os.scandir(...)``
+    during teardown, and a globally patched scandir handed it a fake that broke
+    on Windows while passing on Linux.
+    """
+    import kiro_crew.agents_janitor as aj
+
+    orphan = _touch(tmp_path / "build-agent.json.98765.tmp", mtime=_OLD_TEMP)
+
+    class _ZeroIdentityEntry:
+        def __init__(self, entry: "os.DirEntry[str]") -> None:
+            self.name = entry.name
+            self.path = entry.path
+            self._entry = entry
+
+        def stat(self, follow_symlinks: bool = True) -> os.stat_result:
+            info = self._entry.stat(follow_symlinks=follow_symlinks)
+            values = list(info)
+            values[1] = 0  # st_ino, as on Windows scandir
+            values[2] = 0  # st_dev, as on Windows scandir
+            return os.stat_result(tuple(values))
+
+    class _OsShim:
+        """Delegates everything to the real ``os`` except ``scandir``, whose
+        entries carry zeroed cached-stat identity — the exact Windows
+        contract. ``os.lstat`` stays real, so the fixed scan (snapshotting via
+        ``os.lstat``) sees true identity and removal proceeds; a regression to
+        ``entry.stat()`` reads zeros and refuses."""
+
+        def __getattr__(self, name: str):
+            return getattr(os, name)
+
+        def scandir(self, path):
+            with os.scandir(path) as it:
+                return [_ZeroIdentityEntry(e) for e in it]
+
+    monkeypatch.setattr(aj, "os", _OsShim())
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert not orphan.exists()
+    assert result.removed == 1
+
+
+def test_removes_aged_own_mkstemp_residue(tmp_path: Path) -> None:
+    # Kiro Crew's own _atomic_json_write leaves tmp<random>.tmp on a crash.
+    residue = _touch(tmp_path / "tmpA1b2C3d4.tmp", mtime=_OLD_TEMP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert not residue.exists()
+    assert result.removed == 1
+
+
+def test_removes_aged_backups_when_opted_in(tmp_path: Path) -> None:
+    # Backups are only swept when explicitly enabled.
+    bak_epoch = _touch(tmp_path / "spec.bak-1700000000", mtime=_OLD_BACKUP)
+    bak_json = _touch(tmp_path / "spec.json.bak.7", mtime=_OLD_BACKUP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW, sweep_backups=True)
+
+    assert not bak_epoch.exists()
+    assert not bak_json.exists()
+    assert result.removed == 2
+
+
+def test_backups_left_alone_when_gated_off(tmp_path: Path) -> None:
+    # sweep_backups=False (what the wired-in callers pass by default from
+    # agent.sweep_agents_backups): foreign backups are never touched, even when
+    # well past the backup window, because their retention is not Kiro Crew's to
+    # decide. This is the ownership-boundary guarantee.
+    bak_epoch = _touch(tmp_path / "spec.bak-1700000000", mtime=_OLD_BACKUP)
+    bak_json = _touch(tmp_path / "spec.json.bak.7", mtime=_OLD_BACKUP)
+    # A temp is still swept in the same call — only the backup class is gated.
+    temp = _touch(tmp_path / "build-agent.json.5.tmp", mtime=_OLD_TEMP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW, sweep_backups=False)
+
+    assert bak_epoch.exists()
+    assert bak_json.exists()
+    assert not temp.exists()
+    assert result.removed == 1
+    assert result.removed_names == [temp.name]
+
+
+def test_keeps_fresh_temp(tmp_path: Path) -> None:
+    fresh = _touch(tmp_path / "build-agent.json.11111.tmp", mtime=_FRESH)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert fresh.exists()  # an in-flight atomic replace must survive
+    assert result.removed == 0
+
+
+def test_keeps_backup_within_retention_window(tmp_path: Path) -> None:
+    # A backup older than the TEMP threshold but younger than the BACKUP
+    # threshold is a recovery artifact still inside its window — keep it even
+    # when backups are opted in. This is the case Design Review flagged: a backup
+    # must not be swept at 24h.
+    recent_backup = _touch(tmp_path / "spec.json.bak.9", mtime=_OLD_TEMP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW, sweep_backups=True)
+
+    assert recent_backup.exists()
+    assert result.removed == 0
+
+
+def test_leaves_live_json_spec_untouched(tmp_path: Path) -> None:
+    # Even an OLD live spec is not junk: it does not match any recognized shape.
+    spec = _touch(tmp_path / "build-agent.json", mtime=_OLD_BACKUP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW, sweep_backups=True)
+
+    assert spec.exists()
+    assert result.removed == 0
+
+
+def test_leaves_aged_foreign_unrecognized_file(tmp_path: Path) -> None:
+    # An old file whose name is not a recognized temp/backup shape is left be,
+    # no matter how old it is.
+    foreign = _touch(tmp_path / "some-other-tool.leftover", mtime=_OLD_BACKUP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW, sweep_backups=True)
+
+    assert foreign.exists()
+    assert result.removed == 0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation is privileged on Windows")
+def test_skips_symlink_with_matching_name(tmp_path: Path) -> None:
+    # A symlink whose NAME matches a recognized shape must be skipped entirely,
+    # and its target must never be followed or removed.
+    target = _touch(tmp_path / "real-target.txt", mtime=_OLD_BACKUP)
+    link = tmp_path / "build-agent.json.55555.tmp"
+    link.symlink_to(target)
+    # Age the link itself past the threshold (utime the link, not the target).
+    os.utime(link, (_OLD_TEMP, _OLD_TEMP), follow_symlinks=False)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert link.is_symlink()  # link untouched
+    assert target.exists()  # target never followed / removed
+    assert result.removed == 0
+
+
+def test_tolerates_unreadable_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A stat/unlink failure on one entry must not abort the sweep: the good
+    # entry is still removed, the bad one is tolerated (fail-open).
+    good = _touch(tmp_path / "good.json.222.tmp", mtime=_OLD_TEMP)
+    bad = _touch(tmp_path / "bad.json.333.tmp", mtime=_OLD_TEMP)
+
+    real_unlink = os.unlink
+
+    def flaky_unlink(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if os.path.basename(os.fspath(path)) == bad.name:
+            raise PermissionError("simulated unreadable/locked entry")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "unlink", flaky_unlink)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert not good.exists()  # sweep continued past the failure
+    assert bad.exists()  # the failing entry was tolerated, left in place
+    assert result.removed == 1
+
+
+def test_missing_directory_is_fail_open(tmp_path: Path) -> None:
+    result = sweep_agents_dir(tmp_path / "does-not-exist", now=_NOW)
+    assert isinstance(result, SweepResult)
+    assert result.removed == 0
+
+
+def test_never_touches_directories(tmp_path: Path) -> None:
+    # A directory whose name matches a recognized shape is never removed.
+    d = tmp_path / "weird.json.999.tmp"
+    d.mkdir()
+    os.utime(d, (_OLD_TEMP, _OLD_TEMP))
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert d.is_dir()
+    assert result.removed == 0
+
+
+def test_temp_age_boundary_is_exact(tmp_path: Path) -> None:
+    # Exactly at the threshold is eligible (age >= max_age); just under is not.
+    at = _touch(tmp_path / "at.json.1.tmp", mtime=_NOW - DEFAULT_TEMP_MAX_AGE_SECONDS)
+    under = _touch(tmp_path / "under.json.2.tmp", mtime=_NOW - DEFAULT_TEMP_MAX_AGE_SECONDS + 1)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert not at.exists()
+    assert under.exists()
+    assert result.removed == 1
+
+
+def test_recreated_pathname_race_is_not_deleted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The recreate-same-pathname race: an aged temp is scanned, then a writer
+    # replaces that exact pathname with a FRESH file before the unlink. The
+    # janitor must detect the change (inode/mtime) and refuse to delete the new
+    # occupant, so a live in-flight spec write is never lost.
+    orphan = _touch(tmp_path / "build-agent.json.7.tmp", mtime=_OLD_TEMP)
+
+    real_lstat = os.lstat
+    swapped = {"done": False}
+
+    def racing_lstat(path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        # On the re-stat immediately before unlink, simulate a writer having
+        # replaced the file with a fresh one (new inode + current mtime).
+        info = real_lstat(path, *args, **kwargs)
+        if not swapped["done"] and os.path.basename(os.fspath(path)) == orphan.name:
+            swapped["done"] = True
+            orphan.unlink()
+            _touch(orphan, mtime=_NOW, content="{FRESH}")
+            return real_lstat(path, *args, **kwargs)
+        return info
+
+    monkeypatch.setattr(os, "lstat", racing_lstat)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW)
+
+    assert orphan.exists()  # the freshly-recreated file survives
+    assert orphan.read_text(encoding="utf-8") == "{FRESH}"
+    assert result.removed == 0
+
+
+def test_dry_run_reports_without_deleting(tmp_path: Path) -> None:
+    # dry_run identifies eligible files and populates the result exactly as a
+    # real sweep would, but unlinks nothing — this is the doctor report path.
+    orphan = _touch(tmp_path / "build-agent.json.42.tmp", mtime=_OLD_TEMP)
+    backup = _touch(tmp_path / "spec.json.bak.3", mtime=_OLD_BACKUP)
+
+    result = sweep_agents_dir(tmp_path, now=_NOW, dry_run=True, sweep_backups=True)
+
+    assert orphan.exists()  # nothing deleted
+    assert backup.exists()
+    assert result.removed == 2  # but both are reported as reclaimable
+    assert set(result.removed_names) == {orphan.name, backup.name}
+    assert result.freed_bytes > 0


### PR DESCRIPTION
## Problem / Motivation

The shared kiro agents directory is rewritten continuously by several
independent writers - this project's spec rebuild, plus other tools that install
agents there. Every writer uses write-temp-then-rename, and a crash or a race
between the write and the rename strands the temp file forever. Backups written
beside the live spec accumulate the same way.

Observed live in one directory listing: three orphaned
`<name>.json.<digits>.tmp` files aged 2-7 days from more than one writer,
`*.bak-<epoch>` backups weeks old, and stale non-spec leftovers months old.
Nothing ever removes any of it, so the directory only grows.

## Why it matters

The directory only ever grows, and every consumer that globs it pays for the
junk on every read - the spec rebuild, agent resolution, and the diagnostics
that list it. Left unbounded this is a slow, silent disk leak and a steadily
rising per-glob cost that no existing code path reclaims.

## What changed (motivation -> approach -> change)

An in-flight atomic replace completes in milliseconds, so any recognized *temp*
older than 24h is garbage by construction - that observation is what makes a
safe, unattended sweep possible. The approach is a deliberately narrow,
fail-open, age-based sweep rather than a broad "clean the directory" pass, so it
can never touch a live spec.

- New leaf module `kiro_crew/agents_janitor.py` with `sweep_agents_dir()`. It
  removes only entries whose **name** matches an exact recognized shape, and
  that are **regular files** (via `os.lstat`, so symlinks are never followed and
  are skipped even when their name matches), **not directories**, and old enough
  for their class. Two recognized classes with **separate** age thresholds:
  - **Temps (24h):** `<base>.json.<digits>.tmp` (foreign writers) and
    `tmp<alnum>.tmp` (this project's own `tempfile.mkstemp(suffix=".tmp")`
    residue from `agent._atomic_json_write`, which never takes the dotted
    shape).
  - **Backups (14 days, opt-in):** `*.bak-<digits>` and `*.json.bak.<digits>`.
    These are recovery artifacts that outlive their write, so the millisecond
    "garbage by construction" argument does not apply; they get a much longer
    window. Kiro Crew authors no backups in this directory, so every backup a
    sweep would remove belongs to a foreign writer whose retention policy is not
    ours to decide -- backup sweeping is therefore gated behind the new
    `agent.sweep_agents_backups` config key (default OFF). The temp sweep alone
    reclaims the bulk of the growth at near-zero risk.
  Every deletion is logged with the filename and age; every per-file failure
  (unreadable, vanished mid-sweep, permission denied) is tolerated and the sweep
  continues. A live `*.json` spec matches no pattern, so it is structurally
  impossible to remove one.
- Wired into **gateway boot** as a fire-and-forget task that offloads the
  filesystem work to a thread, is never awaited (so it cannot delay dashboard
  binding), swallows every error (so it cannot crash boot), and is skipped in
  `test_mode`. The wiring mirrors the existing `_SLICE_LIMITS_TASK` boot pattern.
- Wired into **`kirocrew doctor`** as a **report-only** section (`dry_run=True`):
  doctor lists what a sweep would reclaim but never deletes anything itself, so a
  diagnostic you run *because something broke* cannot silently unlink files
  (including recovery backups) in the same invocation. Actual deletion is left to
  the boot sweep.

The same write-temp-then-rename residue exists in other single-writer data-home
directories too; the agents directory is swept first because it is the *shared*,
foreign-writer directory that grows fastest, and a broader residue sweep is left
as a follow-up.

## Tests

`test/test_agents_janitor.py` (all under `tmp_path`, deterministic clock):

- aged orphan temp removed; aged own `mkstemp` residue (`tmp<alnum>.tmp`)
  removed; aged backups (both shapes) removed;
- fresh temp (< 24h) kept - an in-flight atomic replace survives;
- a backup older than 24h but within its 14-day window is kept (recovery
  artifact retained);
- live `*.json` spec untouched even when old; aged foreign file with an
  unrecognized name untouched;
- symlink whose name matches a recognized shape is skipped and its target never
  followed or removed;
- an unreadable/failing entry is tolerated (fail-open) while the good entry is
  still removed;
- `dry_run=True` reports reclaimable files without deleting them (the doctor
  path);
- plus: missing directory is fail-open, directories are never removed, the temp
  age boundary is exact, and name-shape classification is correct.

## Manual verification

N/A - unit coverage exercises the full sweep contract (removal, retention,
symlink/directory skipping, dry-run reporting, and fail-open error handling)
against `tmp_path`. The doctor section and the boot wiring are thin call sites
over the tested function; existing `test_cli_doctor.py` (79 tests) still passes
with the new section in place.

## Related Issues

Closes #4950
