### PR TITLE
fix(apps): render the derived featured spotlight with side layout

### DIFF
--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -1014,6 +1014,7 @@ export default function AppsPage() {
                     <FeaturedSpotlight
                       type="app"
                       apps={[spotlight]}
+                      layout="side"
                       busyName={featuredBusyName(actionLoading, [spotlight])}
                       onGet={name => getApp(name)}
                       onEnable={name => enableApp(name)}


### PR DESCRIPTION
## Problem / Motivation

On the Apps → Discover page, the featured spotlight renders a huge full-width 16:9 art banner (~780px tall on a typical dashboard width) that dominates the viewport. The featured app's name, description, and install control are pushed far down or below the fold — the banner reads as the whole page rather than a card.

This happens whenever the editorial document has no published sections (the current default state: `editorial.json` ships `"sections": []`), so Discover falls back to the **derived** spotlight — a `featured`-flag-or-hero-art pick from the registry (e.g. Agent Worlds).

## Why it matters

The derived spotlight is what every user sees on a stock install today, since no editorial sections are published. The oversized banner buries the app's own name, description, and Get/Enable button, inverts the page hierarchy, and makes the "All apps" list start a full screen down. It's the first surface on the Apps page, so it sets the tone for the whole store.

## What changed (motivation → approach → change)

- **Symptom:** derived featured spotlight renders as a full-width 16:9 banner.
- **Root cause:** `FeaturedSpotlight` gained a `layout` prop (`"side"` | `"stacked"`, default `"stacked"`) and moved its art band from a fixed `h-[190px] md:h-[220px]` to `aspect-[16/9]`. The published editorial `full`-form block correctly passes `layout="side"` (art beside copy at ~44% width, ~248px tall). The **derived fallback caller** in `AppsPage.tsx` calls `FeaturedSpotlight` with no `layout` prop, so it defaults to `"stacked"` — and a stacked `aspect-[16/9]` at full width is the ~780px banner.
- **Change:** pass `layout="side"` on the derived spotlight, matching the published `full`-form block path. One line in the caller; no change to `FeaturedSpotlight` itself. The art now sits beside the copy at ~44% width and the card stays compact, with the editorial section and the "All apps" list above the fold.

## Tests

No new test — this is a one-line prop wiring on an existing, already-tested component path. The `AppsPageDiscover` suite (10 tests, covering the spotlight render, hero art, and provenance) passes unchanged; those tests assert on rendered text/roles, which are layout-independent.

## Manual verification

Verified against a real running build (isolated dev-backend serving the worktree's SPA, empty editorial doc to force the derived path, Agent Worlds as the derived pick — the exact reported scenario). Before: full-width stacked 16:9 banner. After: compact `side` layout. See screenshots below.

## Screenshots / video

Before — derived spotlight as a full-width stacked 16:9 banner, app name/description/Enable pushed down:

![Before: full-width stacked banner](https://github.com/RohanK6/KiroCrew/raw/e1eb1b379f2d687a25a5076688aedfb5c9dc6bbb/derived-spotlight-layout/before.png)

After — `side` layout, art beside copy at ~44% width, everything above the fold:

![After: compact side layout](https://github.com/RohanK6/KiroCrew/raw/e1eb1b379f2d687a25a5076688aedfb5c9dc6bbb/derived-spotlight-layout/after.png)

## Related Issues

Fixes #4943

## Contribution License Agreement

I have read and agree to the Contribution License Agreement.
