### PR TITLE
fix(wait): let a mid-turn steer end a sleeping wait instead of outwaiting it

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -4699,7 +4699,19 @@ class AcpClient:
         await self._send_request(
             "_session/steer", {"sessionId": self._session_id, "message": wrapped}
         )
+        # See AcpSessionHandle.steer for why the stamp is taken at the write.
+        self._last_steer_monotonic = time.monotonic()
         return True
+
+    # Monotonic stamp of the last steer handed to the backend, 0.0 when never
+    # steered. Mirrors AcpSessionHandle.last_steer_monotonic — the dashboard's
+    # keepalive route reads whichever of the two backs the live session.
+    _last_steer_monotonic: float = 0.0
+
+    @property
+    def last_steer_monotonic(self) -> float:
+        """Monotonic time of the last steer written to the backend (0.0 if none)."""
+        return self._last_steer_monotonic
 
     @property
     def supports_steer(self) -> bool:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -1156,7 +1156,30 @@ class AcpSessionHandle:
             "_session/steer",
             {"sessionId": self._session_id, "message": wrapped},
         )
+        # Stamped HERE, at the innermost write, because this is the one point
+        # every steer funnels through: the dashboard steers the inner client
+        # directly while the IM transports steer the provider wrapper, and both
+        # end up on this line. A reader of the stamp therefore needs no
+        # per-transport wiring. See ``last_steer_monotonic``.
+        self._last_steer_monotonic = time.monotonic()
         return True
+
+    # Monotonic stamp of the last steer handed to the backend, 0.0 when this
+    # session has never been steered. Read by the dashboard's keepalive route to
+    # decide whether a sleeping `wait` should return early: a steer can only be
+    # injected at a model-inference boundary, and an in-flight tool call is the
+    # absence of one, so a sleep that outlasts the steer would hold the user's
+    # correction in the backend's queue until it elapses.
+    #
+    # Deliberately monotonic, not wall clock: it is only ever compared against
+    # another monotonic stamp taken in the same process (the sleep's start), and
+    # mixing the two clocks is how a suspend-resume silently reorders them.
+    _last_steer_monotonic: float = 0.0
+
+    @property
+    def last_steer_monotonic(self) -> float:
+        """Monotonic time of the last steer written to the backend (0.0 if none)."""
+        return self._last_steer_monotonic
 
     @property
     def supports_steer(self) -> bool:

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -271,6 +271,11 @@ class AcpSessionProvider(LLMProvider):
         return await self._guarded(self._handle.steer(message))
 
     @property
+    def last_steer_monotonic(self) -> float:
+        """Monotonic time of the handle's last steer (0.0 if never steered)."""
+        return float(getattr(self._handle, "last_steer_monotonic", 0.0) or 0.0)
+
+    @property
     def supports_steer(self) -> bool:
         """True when the backing handle supports mid-turn steer (kiro-cli)."""
         return self._handle.supports_steer

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -10,7 +10,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from kiro_crew.providers.base import LLMProvider  # noqa: F811
@@ -1483,8 +1483,68 @@ async def api_session_keepalive(request: web.Request) -> web.Response:
     reply: dict = {"ok": True}
     wait_id = str(body.get("wait_id") or "").strip()[:64]
     if wait_id:
-        _service_wait_ping(state, session_key, wait_id, body, reply)
+        _service_wait_ping(state, session_key, wait_id, body, reply, provider)
     return web.json_response(reply)
+
+
+def _wait_end_reason(slot, wait_id: str, provider: Any) -> str | None:
+    """Why this sleep should return early, or None to keep sleeping.
+
+    Exactly two reasons, and the narrowness is the design:
+
+    ``"user"``
+        The End-wait button parked an explicit request naming this ``wait_id``.
+
+    ``"steer"``
+        A mid-turn steer reached the backend AFTER this sleep began. kiro-cli
+        can only inject a steer at a model-inference boundary and an in-flight
+        tool call is the absence of one, so without this the user's correction
+        sits in the backend's steer queue until the sleep elapses — up to the
+        tool's 1800s ceiling — while the agent sleeps through it.
+
+    "After this sleep began" is decided by comparing the provider's steer stamp
+    against the reading taken when this sleep was minted, so the handler reads
+    no clock of its own: the only two values ever compared are two readings of
+    the same monotonic source. That is deliberate — a wall-clock stamp on one
+    side and a monotonic one on the other is how a suspend silently reorders
+    the comparison.
+
+    Re-taking the baseline at every mint is also what makes the reason fire
+    once. A steer the backend has accepted but not yet injected stays newer
+    than nothing at all, so without a per-sleep baseline it would end sleep
+    after sleep for the rest of the turn and hand the model a `wait` that
+    returns instantly.
+
+    Not extended to the other long block on this route. ``spawn_sub_agents``
+    can wait 7200s on live sub-agents and pings the same endpoint, but sends no
+    ``wait_id`` and so never reaches this decision — an exclusion worth keeping
+    deliberately: ending a sleep discards nothing, while cutting a sub-agent
+    collection short orphans work that keeps running with nobody left to read
+    its results.
+    """
+    if slot._end_wait_request and slot._end_wait_request == wait_id:
+        return "user"
+    tracked = slot._wait_state or {}
+    if tracked.get("wait_id") != wait_id:
+        # Not the sleep this slot is tracking (contested identity, stale ping).
+        return None
+    steered_at = _provider_steer_stamp(provider)
+    return "steer" if steered_at > slot._wait_steer_baseline else None
+
+
+def _provider_steer_stamp(provider: Any) -> float:
+    """Monotonic time of the session's last steer, 0.0 when never steered or
+    when the provider does not expose one (a non-kiro backend, a test double).
+
+    Read through ``getattr`` rather than an interface method because this route
+    is reached by every backend, and a missing stamp must read as "no steer" —
+    the direction that keeps sleeping — rather than raise on the keepalive that
+    stops the watchdog killing the session mid-sleep.
+    """
+    try:
+        return float(getattr(provider, "last_steer_monotonic", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _service_wait_ping(
@@ -1493,13 +1553,14 @@ def _service_wait_ping(
     wait_id: str,
     body: dict,
     reply: dict,
+    provider: Any = None,
 ) -> None:
     """Track an in-flight `wait` sleep and hand back any early-end request.
 
-    Mutates ``reply`` in place, adding ``end_wait`` when the user asked to end
-    this exact wait. Silent no-op when the calling session has no dashboard tab
-    (a Slack/cron session can call `wait` too — it just has nothing to render a
-    countdown on).
+    Mutates ``reply`` in place, adding ``end_wait`` when the sleep should return
+    early (see :func:`_wait_end_reason`). Silent no-op when the calling session
+    has no dashboard tab (a Slack/cron session can call `wait` too — it just has
+    nothing to render a countdown on).
     """
     # Local import: this module's other chat_utils uses are function-local for
     # the same circular-import reason (handlers/__init__ re-exports this module).
@@ -1525,6 +1586,7 @@ def _service_wait_ping(
             slot._wait_state = None
             slot._end_wait_request = None
             slot._wait_last_ping = 0.0
+            slot._wait_steer_baseline = 0.0
             state.push_slots_update()
         return
     # ── Ambiguous-identity guard ──
@@ -1556,6 +1618,7 @@ def _service_wait_ping(
             slot._wait_state = None
             slot._end_wait_request = None
             slot._wait_last_ping = 0.0
+            slot._wait_steer_baseline = 0.0
             state.push_slots_update()
         return
     prev = slot._wait_state
@@ -1565,6 +1628,7 @@ def _service_wait_ping(
             slot._wait_state = None
             slot._end_wait_request = None
             slot._wait_last_ping = 0.0
+            slot._wait_steer_baseline = 0.0
             logger.info("two concurrent waits share session %s; countdown suppressed", session_key)
             state.push_slots_update()
             return
@@ -1588,20 +1652,28 @@ def _service_wait_ping(
         }
         # A brand-new wait cannot inherit an end request aimed at an older one.
         slot._end_wait_request = None
+        # Baseline for the steer reason: re-read on every mint, so only a steer
+        # that lands after THIS sleep began can end it. No clock read here —
+        # the baseline and the later comparison are two readings of the same
+        # provider stamp.
+        slot._wait_steer_baseline = _provider_steer_stamp(provider)
         slot._wait_last_ping = now
         state.push_slots_update()
     else:
         # Heartbeat only. Held OFF the wire payload so the deadline the browser
         # counts down against stays byte-identical between pushes.
         slot._wait_last_ping = now
-    if slot._end_wait_request and slot._end_wait_request == wait_id:
+    reason = _wait_end_reason(slot, wait_id, provider)
+    if reason is not None:
         # Consume exactly once. Leaving it set would make the NEXT wait in this
         # session return instantly, which is the failure mode a session-scoped
         # boolean flag would have had.
         slot._end_wait_request = None
         slot._wait_state = None
         slot._wait_last_ping = 0.0
+        slot._wait_steer_baseline = 0.0
         reply["end_wait"] = wait_id
+        logger.info("wait ending early for %s (reason=%s)", session_key, reason)
         state.push_slots_update()
 
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1469,6 +1469,7 @@ class _ChatSlot:
         "_wait_state",
         "_end_wait_request",
         "_wait_last_ping",
+        "_wait_steer_baseline",
         "_wait_contested",
         "_question_pending",
     )
@@ -1927,6 +1928,12 @@ class _ChatSlot:
         # _service_wait_ping tells a legitimate hand-over from two concurrent
         # waits colliding on one session key.
         self._wait_last_ping: float = 0.0
+        # The session's steer stamp as it read when the tracked wait was minted.
+        # Server-side only (deliberately NOT in to_dict). A steer newer than
+        # this baseline is what ends the sleep early; re-reading it per sleep is
+        # what stops ONE unconsumed steer from ending every subsequent sleep in
+        # the turn and handing the model a `wait` that returns instantly.
+        self._wait_steer_baseline: float = 0.0
         # True once two sleeps have been seen sharing this slot: neither may be
         # tracked or ended, because there is no way to know which one the user is
         # looking at. Latched for the rest of the turn and cleared by the same

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -511,7 +511,10 @@ def wait(name: str, args: dict[str, Any]) -> str:
     deadline = mcp_core.time.monotonic() + seconds
     # Identity for THIS sleep. The dashboard's "end wait now" button echoes
     # it back through the keepalive response, so a request left over from an
-    # earlier sleep can never terminate the next one in the same session.
+    # earlier sleep can never terminate the next one in the same session. The
+    # same reply also ends the sleep when a mid-turn steer lands after it
+    # began: the backend can only inject a steer at a model-inference
+    # boundary, and this sleep is the absence of one (see _wait_end_reason).
     wait_id = uuid.uuid4().hex
     # Ping session-keepalive every WAIT_PING_SECS so the gateway's
     # is_responsive() doesn't flag this session as stale and SIGTERM the ACP

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -1339,6 +1339,11 @@ class AcpProvider(LLMProvider):
         return await self._client.steer(message)
 
     @property
+    def last_steer_monotonic(self) -> float:
+        """Monotonic time of the inner client's last steer (0.0 if never)."""
+        return float(getattr(self._client, "last_steer_monotonic", 0.0) or 0.0)
+
+    @property
     def supports_steer(self) -> bool:
         """True when the inner client supports mid-turn steer."""
         return bool(getattr(self._client, "supports_steer", False))

--- a/src/kiro_crew/providers/base.py
+++ b/src/kiro_crew/providers/base.py
@@ -240,6 +240,24 @@ class LLMProvider(ABC):
         return False
 
     @property
+    def last_steer_monotonic(self) -> float:
+        """Monotonic time of the last steer this provider handed to its backend,
+        0.0 when it has never steered one.
+
+        Part of the steer capability rather than an optional extra to it. The
+        dashboard's keepalive route compares this against the reading taken when
+        a sleeping ``wait`` began, because a sleep is one of the few places a
+        steer cannot be injected: the backend needs a model-inference boundary
+        and an in-flight tool call is the absence of one. So a provider that
+        returns True from :attr:`supports_steer` and leaves this at the default
+        steers perfectly well and silently never interrupts a wait — a failure
+        with no error to notice. ``test_harness_parity`` ratchets the two
+        together for that reason; the route's own defensive default is a
+        backstop, not the guarantee.
+        """
+        return 0.0
+
+    @property
     def is_session_sharing_eligible(self) -> bool:
         """True when the provider can host multiplexed sub-agent sessions on one
         process. Default False — session sharing is opt-in, never inherited."""

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -4335,11 +4335,48 @@ async def test_handle_steer_sends_session_steer():
     rt.send_request = _send_request
     handle = AcpSessionHandle("sA", asyncio.Queue(), rt)
     assert handle.supports_steer is True
+    assert handle.last_steer_monotonic == 0.0  # never steered
     ok = await handle.steer("please focus on X")
     assert ok is True
     assert sent["method"] == "_session/steer"
     assert "please focus on X" in sent["params"]["message"]
     assert await handle.steer("   ") is False
+
+
+@pytest.mark.asyncio
+async def test_handle_steer_stamps_write_time_and_provider_passes_it_through():
+    """The stamp lives at the innermost write because that is the one point
+    every steer funnels through — the dashboard steers the client directly
+    while the IM transports steer the provider wrapper. The dashboard's
+    keepalive route reads it to decide whether a sleeping `wait` should return
+    early, so a refused steer must not move it.
+    """
+    rt = MagicMock()
+
+    async def _send_request(method, params):
+        return 1
+
+    rt.send_request = _send_request
+    handle = AcpSessionHandle("sA", asyncio.Queue(), rt)
+    from kiro_crew.acp.session_provider import AcpSessionProvider
+
+    prov = AcpSessionProvider.__new__(AcpSessionProvider)
+    prov._handle = handle
+    prov._runtime = rt
+
+    assert prov.last_steer_monotonic == 0.0
+    before = time.monotonic()
+    assert await handle.steer("focus on X") is True
+    after = time.monotonic()
+    stamped = handle.last_steer_monotonic
+    assert before <= stamped <= after
+    # The wrapper the IM transports hold must report the same fact.
+    assert prov.last_steer_monotonic == stamped
+
+    # A refused steer (empty text) never reached the wire, so it must not
+    # look newer than the sleep it would otherwise cut short.
+    assert await handle.steer("  ") is False
+    assert handle.last_steer_monotonic == stamped
 
 
 # ── Round-3 fixes: cancel_session grace + idempotent cancel ──

--- a/test/test_harness_parity.py
+++ b/test/test_harness_parity.py
@@ -148,6 +148,47 @@ def test_steer_is_opt_in() -> None:
     assert ACP_BACKEND_CLAUDE not in ACP_BACKENDS_STEER
 
 
+def test_steer_capability_declares_its_stamp() -> None:
+    """H15: a provider that can steer must also report WHEN it steered.
+
+    The pair is load-bearing because the failure of the second half is silent.
+    A sleeping ``wait`` is one of the few regions where a steer cannot be
+    injected — the backend needs a model-inference boundary and an in-flight
+    tool call is the absence of one — so the keepalive route ends the sleep by
+    comparing ``last_steer_monotonic`` against the reading taken when the sleep
+    began. A provider that overrides ``supports_steer`` and inherits the default
+    stamp accepts steers correctly and never interrupts a wait, with nothing
+    raised and nothing logged.
+
+    The route reads the stamp defensively (a keepalive must not fail on the ping
+    that stops the watchdog killing the session mid-sleep), which is exactly why
+    the guarantee has to live here instead: a defensive read cannot tell "this
+    backend does not steer" from "this backend forgot the stamp".
+    """
+    from kiro_crew.acp.session_provider import AcpSessionProvider  # noqa: F401
+    from kiro_crew.providers.acp import AcpProvider  # noqa: F401
+    from kiro_crew.providers.base import LLMProvider
+
+    def _walk(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from _walk(sub)
+
+    checked = []
+    for cls in _walk(LLMProvider):
+        if cls.supports_steer is LLMProvider.supports_steer:
+            continue  # cannot steer, so has nothing to stamp
+        assert cls.last_steer_monotonic is not LLMProvider.last_steer_monotonic, (
+            f"{cls.__name__} overrides supports_steer but inherits the default "
+            "last_steer_monotonic, so a steer it accepts can never end a sleeping wait"
+        )
+        checked.append(cls.__name__)
+
+    # Fail-closed: an import that stopped registering the subclasses would make
+    # the loop vacuous and the ratchet a no-op.
+    assert len(checked) >= 2, f"expected at least 2 steer-capable providers, saw {checked}"
+
+
 def test_is_kiro_cli_is_positive() -> None:
     """H7: the sandbox-delegation flag is membership at every spawn site.
 

--- a/test/test_wait_countdown_keepalive.py
+++ b/test/test_wait_countdown_keepalive.py
@@ -51,7 +51,14 @@ def _mock_state(slot: _ChatSlot | None = None) -> DashboardState:
     return state
 
 
-def _ping(state, body: dict, *, session_key: str = "known", tab: str = SLOT) -> dict:
+def _ping(
+    state,
+    body: dict,
+    *,
+    session_key: str = "known",
+    tab: str = SLOT,
+    provider: object | None = None,
+) -> dict:
     """Invoke _service_wait_ping the way api_session_keepalive does.
 
     ``dashboard_slot_key`` is patched rather than seeded through the surface
@@ -64,7 +71,7 @@ def _ping(state, body: dict, *, session_key: str = "known", tab: str = SLOT) -> 
     with patch(
         "kiro_crew.dashboard.chat_utils.dashboard_slot_key", return_value=tab
     ) as slot_key:
-        _service_wait_ping(state, session_key, wait_id, body, reply)
+        _service_wait_ping(state, session_key, wait_id, body, reply, provider)
     slot_key.assert_called_once_with(session_key)
     return reply
 
@@ -532,7 +539,7 @@ class TestKeepaliveRouteBody:
         state = MagicMock(spec=DashboardState)
         state.sessions = _FakeSessions(provider=provider)
 
-        def _fake(state_arg, session_key, wait_id, body, reply):
+        def _fake(state_arg, session_key, wait_id, body, reply, provider_arg=None):
             reply["end_wait"] = wait_id
 
         with patch.object(sessions_mod, "_service_wait_ping", side_effect=_fake) as f:
@@ -550,6 +557,9 @@ class TestKeepaliveRouteBody:
         assert args[1] == "known"
         assert args[2] == "w1"
         assert args[3]["remaining"] == 297
+        # The resolved provider is forwarded: it carries the session's steer
+        # stamp, which is the other half of the end-early decision.
+        assert args[5] is provider
 
     @pytest.mark.asyncio
     async def test_oversized_wait_id_is_truncated_before_use(self):
@@ -621,3 +631,149 @@ class TestSlotToDict:
 
         assert "end_wait_request" not in d
         assert "_end_wait_request" not in d
+
+
+class TestSteerEndsWait:
+    """A mid-turn steer must not have to outwait a sleeping `wait`.
+
+    kiro-cli can only inject a steer at a model-inference boundary, and an
+    in-flight tool call is the absence of one. So a steer that lands while
+    `wait` is sleeping sits in the backend's queue until the sleep elapses —
+    up to the tool's 1800s ceiling. The keepalive reply is the sleep's only
+    inbound channel, which makes this handler the one place the decision can
+    be delivered.
+    """
+
+    @staticmethod
+    def _provider(steered_at: float = 0.0):
+        """Mutable stand-in for the session provider. Only ``steer()`` moves the
+        stamp in production, so a test bumps it directly to express "a steer
+        landed"."""
+        return SimpleNamespace(last_steer_monotonic=steered_at)
+
+    def test_steer_during_the_sleep_ends_it(self):
+        """The bug: a steer arriving after the sleep began now returns the
+        sleep on its next poll instead of waiting out the full budget."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+        prov = self._provider()
+        _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600}, provider=prov)
+        assert slot._wait_steer_baseline == 0.0
+
+        prov.last_steer_monotonic = 500.0  # steer lands mid-sleep
+        reply = _ping(
+            state, {"wait_id": "w1", "seconds": 600, "remaining": 595}, provider=prov
+        )
+
+        assert reply["end_wait"] == "w1"
+        # Same retirement the button path performs: nothing left to re-fire on.
+        assert slot._wait_state is None
+        assert slot._wait_steer_baseline == 0.0
+
+    def test_steer_older_than_the_sleep_does_not_end_it(self):
+        """A steer the backend already had before this sleep began is not a
+        reason to cut it short — otherwise every sleep in the turn would
+        return instantly and the model could spin on `wait`."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+        prov = self._provider(500.0)  # already steered before the sleep
+
+        _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600}, provider=prov)
+        assert slot._wait_steer_baseline == 500.0
+        reply = _ping(
+            state, {"wait_id": "w1", "seconds": 600, "remaining": 595}, provider=prov
+        )
+
+        assert "end_wait" not in reply
+        assert slot._wait_state is not None
+
+    def test_one_steer_ends_only_the_sleep_it_arrived_during(self):
+        """The loop guard, stated as behaviour: the baseline is re-read on every
+        mint, so a steer the backend has not yet injected cannot end sleep
+        after sleep for the rest of the turn."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+        prov = self._provider()
+
+        _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600}, provider=prov)
+        prov.last_steer_monotonic = 500.0
+        first = _ping(
+            state, {"wait_id": "w1", "seconds": 600, "remaining": 595}, provider=prov
+        )
+        # Model calls wait again; the SAME steer is still unconsumed.
+        _ping(state, {"wait_id": "w2", "seconds": 600, "remaining": 600}, provider=prov)
+        second = _ping(
+            state, {"wait_id": "w2", "seconds": 600, "remaining": 595}, provider=prov
+        )
+
+        assert first["end_wait"] == "w1"
+        assert "end_wait" not in second
+        assert slot._wait_state is not None
+        assert slot._wait_state["wait_id"] == "w2"
+        assert slot._wait_steer_baseline == 500.0
+
+    def test_contested_slot_is_not_ended_by_a_steer(self):
+        """Two sleeps sharing one session key suppress the countdown because
+        there is no way to know which one the user is looking at. A steer must
+        not reopen that hole from the other side."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+        clk = _Clock()
+        prov = self._provider()
+        with patch.object(sessions_mod, "time", clk):
+            _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600}, provider=prov)
+            reply_contest = _ping(
+                state, {"wait_id": "w2", "seconds": 600, "remaining": 600}, provider=prov
+            )
+            prov.last_steer_monotonic = 500.0
+            reply = _ping(
+                state, {"wait_id": "w1", "seconds": 600, "remaining": 595}, provider=prov
+            )
+
+        assert slot._wait_contested is True
+        assert "end_wait" not in reply_contest
+        assert "end_wait" not in reply
+
+    def test_button_path_still_works_with_no_provider(self):
+        """Regression on the reason that already existed: a session whose
+        provider exposes no steer stamp (or none at all) must still honour an
+        explicit End-wait click."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+
+        _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600})
+        slot._end_wait_request = "w1"
+        reply = _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 595})
+
+        assert reply["end_wait"] == "w1"
+        assert slot._wait_state is None
+
+    def test_never_steered_session_sleeps_normally(self):
+        """A provider that has never been steered reports 0.0, which must not
+        read as "steered at the epoch" and end every sleep."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+        prov = self._provider(0.0)
+
+        _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600}, provider=prov)
+        reply = _ping(
+            state, {"wait_id": "w1", "seconds": 600, "remaining": 595}, provider=prov
+        )
+
+        assert "end_wait" not in reply
+        assert slot._wait_state is not None
+
+    def test_unreadable_steer_stamp_keeps_sleeping(self):
+        """A backend whose stamp is not a number must not raise on the ping that
+        is also what stops the watchdog killing the session mid-sleep."""
+        slot = _ChatSlot(SLOT)
+        state = _mock_state(slot)
+        prov = SimpleNamespace(last_steer_monotonic="not-a-number")
+
+        _ping(state, {"wait_id": "w1", "seconds": 600, "remaining": 600}, provider=prov)
+        reply = _ping(
+            state, {"wait_id": "w1", "seconds": 600, "remaining": 595}, provider=prov
+        )
+
+        assert "end_wait" not in reply
+        assert slot._wait_state is not None


### PR DESCRIPTION
## What is the problem?

A mid-turn steer cannot reach the model while the `wait` tool is sleeping, so the
user's correction is held until the sleep elapses -- up to the tool's 1800s
ceiling.

The backend can only inject a steer at a model-inference boundary, and an
in-flight tool call is the absence of one. Its steer lifecycle says so directly:
a steer is first acknowledged as `steering_queued`, then later injected as
`steering_consumed`, and nothing moves it from the first state to the second
until a tool result comes back. So the dashboard reports the steer as delivered
the instant the bytes leave -- the "Steered into the running turn" badge
appears, the message is persisted -- while the agent goes on sleeping through
it.

`wait` already has the one channel that could carry the interrupt. It has no
listener of its own, so it polls `/api/session-keepalive` every 5s, and the
reply may carry `end_wait: <wait_id>` meaning "return early, keep the turn".
Only the dashboard's End-wait button ever set that. A steer, which is the same
request expressed by typing instead of clicking, did not.

## Why this issue matters to the user

Waiting is when a user is most likely to intervene: the agent is visibly parked
on a poll, and "stop waiting, do this instead" is the natural thing to type. The
dashboard confirms the steer, so the silence that follows reads as the steer
having been dropped rather than queued. The two available escapes both cost
something the steer did not ask for: the End-wait button requires noticing that
a *second* control exists for what was just typed, and Stop kills the whole turn
along with any in-flight results.

## How our fix solves it

The symptom is a steer that lands but is not acted on; the cause is that the one
place able to deliver an interrupt only recognised one reason to. So the reason
set grows by one, in that place, and nothing else changes:

- `_wait_end_reason()` in `handlers/sessions.py` is now the single home for
  "should this sleep return early", with exactly two reasons -- `user` (the
  button parked a request for this `wait_id`) and `steer` (a steer reached the
  backend after this sleep began). The steer handler is untouched, so there is
  no reverse coupling from steering into the wait tool's plumbing and no
  per-tool branch.
- The steer stamp is taken at the innermost write, in `AcpSessionHandle.steer`
  and `AcpClient.steer`, because that is the one point every steer funnels
  through: the dashboard steers the inner client directly while the IM
  transports steer the provider wrapper. Stamping anywhere above it would have
  worked from the dashboard and silently not from Slack or Telegram. The two
  provider wrappers expose it as `last_steer_monotonic`.
- "After this sleep began" is decided by comparing that stamp against the
  reading taken when the sleep was minted, so the handler reads no clock of its
  own and the only two values ever compared come from the same monotonic
  source. A wall-clock stamp on one side would let a suspend reorder them.
- Re-reading the baseline per sleep is also the loop guard. A steer the backend
  has accepted but not yet injected stays newer than nothing at all, so a single
  session-scoped stamp would end sleep after sleep for the rest of the turn and
  hand the model a `wait` that returns instantly.
- `last_steer_monotonic` is declared on the `LLMProvider` contract with a 0.0
  default, and `test_harness_parity` (H15) ratchets it to `supports_steer`: a
  provider that overrides one and inherits the other would accept steers
  correctly and silently never interrupt a wait. The route reads the stamp
  defensively because a keepalive must not fail on the ping that stops the
  watchdog killing the session mid-sleep -- and a defensive read cannot tell
  "this backend does not steer" from "this backend forgot the stamp", which is
  why the guarantee lives in the parity gate instead.

`spawn_sub_agents` is deliberately left out. It can wait 7200s on live
sub-agents and polls the same endpoint, but sends no `wait_id` and so never
reaches this decision. That exclusion is worth keeping rather than closing:
ending a sleep discards nothing, while cutting a sub-agent collection short
orphans work that keeps running with nobody left to read its results.

No wire-payload change -- the baseline is server-side state and stays out of
`_ChatSlot.to_dict`, so the frontend is untouched.

## What tests we did

`TestSteerEndsWait` (7 cases) covers the new reason and the three ways it must
not fire: a steer older than the sleep, a second sleep facing the same
unconsumed steer, and a contested slot where two sleeps share one session key.
`test_handle_steer_stamps_write_time_and_provider_passes_it_through` pins the
stamp to the write (a refused empty steer must not move it) and the wrapper
passthrough. The route test now asserts the resolved provider is forwarded.

Mutation-checked in three directions, because a test that passes on unfixed code
proves nothing:

- Strip the steer reason to `return None`: 2 tests go red.
- Pin the per-sleep baseline to a constant: the runaway surfaces exactly as the
  loop guard predicts, `end_wait` returned for a sleep that should have slept.
- Delete one provider's stamp so it inherits the contract default: H15 fails by
  name, turning the silent version of this bug into a build failure.

424 tests green under random ordering across the touched suites
(`test_wait_countdown_keepalive`, `test_chat_slot_end_wait`,
`test_wait_tool_early_end`, `test_acp_runtime`, `test_acp_client_more_coverage`,
`test_session_keepalive`). black (baselined), isort, flake8 and scrub-lint pass;
mypy clean on all six changed modules.

## Any other suggestions on the work

Two things this does not fix, both worth naming rather than folding in:

1. A long `sleep` run through the backend's builtin shell tool has no inbound
   channel at all, so it is still uninterruptible. Measured on a standalone
   backend process: signalling the command's own process does make it produce a
   tool result and finish the turn within ~3s rather than wedging, so the
   mechanism is available -- but signalling the *inner* child instead of the
   process the tool is waiting on yields exit status 0, which would tell the
   model a killed command succeeded. Fine for a sleep, dangerous for a build.
   The cheaper half of that is guidance: long waits should go through `wait`,
   which is the tool that can be interrupted.
2. A tool-call region is uninterruptible in general -- this PR narrows the one
   case where the region is pure waiting and the channel already existed.
