### PR TITLE
test(harness): spawned feature gateways own their agent-spec home

### DIFF
--- a/src/kiro_crew/testing/harness.py
+++ b/src/kiro_crew/testing/harness.py
@@ -456,6 +456,23 @@ def spawn_feature_gateway(
             **os.environ,
             "PYTHONPATH": str(src) + os.pathsep + os.environ.get("PYTHONPATH", ""),
             "KIROCREW_HOME": str(home),
+            # Isolate the AGENT-SPEC home too, not just the data home (issue #4912).
+            # ``kirocrew gateway`` boot runs ``rebuild_agent_config``, which writes the
+            # managed MCP specs into ``kiro_agents_dir()``. Left at the default that
+            # resolves the operator's real machine-wide ``~/.kiro/agents`` -- and the
+            # spawned gateway is an ordinary (non-worktree) install, so ``agent.py``'s
+            # write guard takes the "writing its own shared home" branch and does NOT
+            # decline. It would then stamp this throwaway checkout's venv + tmp data
+            # home into the real install's specs, breaking every managed MCP call on
+            # the machine until the next gateway restart heals it.
+            #
+            # Pointing ``KIRO_HOME`` at ``<home>/kiro`` makes ``kiro_agents_dir()``
+            # resolve to ``<home>/kiro/agents`` -- which is EXACTLY
+            # ``isolated_agents_dir(<home>)``, the dedicated dir the write guard's
+            # private-target exemption already lets this instance own. The whole tree
+            # is removed with ``home`` on teardown, so the gateway writes only its own
+            # specs and leaves the shared install untouched.
+            "KIRO_HOME": str(home / "kiro"),
             # Marks this gateway as a test rig. It grants no launch privilege —
             # the packaged fake backend is exec'd by the ordinary in-place path
             # like any other runnable executable.

--- a/test/test_harness.py
+++ b/test/test_harness.py
@@ -540,6 +540,61 @@ def test_spawn_feature_gateway_happy_path() -> None:
     assert "--no-crons" in captured_cmd[0]
 
 
+def test_spawn_feature_gateway_isolates_the_agent_spec_home() -> None:
+    """The spawned gateway must write its agent specs under its OWN throwaway home.
+
+    Regression guard for issue #4912. The gateway boot runs ``rebuild_agent_config``,
+    which writes the managed MCP specs into ``kiro_agents_dir()``. With only
+    ``KIROCREW_HOME`` isolated (the data home) and ``KIRO_HOME`` left at the default,
+    that resolver names the operator's real machine-wide ``~/.kiro/agents`` -- and the
+    spawned gateway is an ordinary (non-worktree) install, so ``agent.py``'s write
+    guard takes the "writing its own shared home" branch and does NOT decline. It would
+    then poison the real install's specs with this checkout's venv + a per-test data
+    home, 403-ing every managed MCP call on the machine.
+
+    The harness pins ``KIRO_HOME`` to ``<home>/kiro`` so ``kiro_agents_dir()`` resolves
+    to exactly ``isolated_agents_dir(<home>)`` -- the dedicated dir the write guard's
+    private-target exemption already lets an isolated instance own -- and the whole tree
+    is removed with ``home`` on teardown.
+    """
+    from kiro_crew.config.paths import isolated_agents_dir
+
+    fake_proc = _make_fake_proc_with_ready(
+        '{"port": 51234, "token": "t-abc", "pid": 9876, "home": "/tmp/x"}'
+    )
+    captured_env: dict[str, str] = {}
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> FakePopen:
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        captured_env.update(env)
+        return fake_proc
+
+    with (
+        patch("kiro_crew.testing.harness.subprocess.Popen", side_effect=fake_popen),
+        patch("kiro_crew.testing.harness._terminate_process_group"),
+    ):
+        with spawn_feature_gateway(fixture="empty") as handle:
+            data_home = handle.home
+
+            # KIRO_HOME is set, points UNDER the gateway's throwaway data home, and is
+            # NOT the operator's real kiro-cli home.
+            assert "KIRO_HOME" in captured_env, "spawned gateway did not isolate KIRO_HOME"
+            kiro_home = Path(captured_env["KIRO_HOME"])
+            assert kiro_home == data_home / "kiro"
+            real_home = Path.home() / ".kiro"
+            assert kiro_home.resolve() != real_home.resolve()
+
+            # The agents dir the gateway will write to (``<KIRO_HOME>/agents``) is
+            # EXACTLY the write guard's private-target exemption for this instance's
+            # own data home -- so the boot-time ``rebuild_agent_config`` is allowed to
+            # write, but only into a directory this test rig owns and tears down.
+            assert kiro_home / "agents" == isolated_agents_dir(data_home)
+
+            # And the data home stays isolated too (unchanged by this fix).
+            assert captured_env["KIROCREW_HOME"] == str(data_home)
+
+
 def test_spawn_feature_gateway_crons_opt_in() -> None:
     """``crons=True`` drops ``--no-crons`` so the scheduler thread runs.
 


### PR DESCRIPTION
## What is the problem?

A feature gateway spawned by the offline E2E harness (`testing/harness.py spawn_feature_gateway`) boots with a throwaway `KIROCREW_HOME` but leaves `KIRO_HOME` at its default. Its boot-time `rebuild_agent_config` therefore writes the operator's real machine-wide agent specs: the spawned gateway is an ordinary (non-worktree) install, so the shared-home write guard takes the owns-its-shared-home branch and does not decline.

## Why this issue matters to the user

The write stamps the throwaway checkout's venv and tmp data home into the real install's specs. When the harness tears the checkout down, those paths go dead and every managed MCP server on the machine fails to mount until the next gateway restart heals the spec -- the exact operator breakage class in #4912, reachable from simply running the E2E suite.

## How our fix solves it

Export `KIRO_HOME=<home>/kiro` into the spawned gateway's environment. `kiro_agents_dir()` then resolves to exactly `isolated_agents_dir(<home>)` -- the dedicated directory the write guard's private-target exemption already lets an instance own -- and the whole tree is removed with the harness home on teardown. The spawned gateway writes only its own specs and never touches the shared install.

## What tests we did

`test_harness.py` gained coverage asserting the spawned env carries the isolated `KIRO_HOME` and that it lands under the harness home; full file 37 passed / 1 skipped locally.

## Any other suggestions on the work

This PR deliberately carries only the SUBPROCESS half of #4912: an in-process conftest seam pin cannot reach a spawned gateway's own resolver. The in-process suite floor is #4969, which should land as the primary fix for #4912; the two are complementary and conflict-free (this PR touches only `testing/harness.py` + `test/test_harness.py`).

Refs #4912