### PR TITLE
fix: extract JSON body from task-plan response with prose preamble (#4947)

### DIFF
--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -1333,7 +1333,11 @@ async def _resolve_permission(
 _JSON_DECODER = json.JSONDecoder()
 
 
-def _extract_json_of_type(text: str, expected_type: type) -> dict | list | None:
+def _extract_json_of_type(
+    text: str,
+    expected_type: type | tuple[type, ...],
+    prefer: Callable[[Any], bool] | None = None,
+) -> dict | list | None:
     """Extract the first top-level JSON value of *expected_type* embedded in prose.
 
     Scans successive ``{`` (dict) or ``[`` (list) offsets and uses the stdlib
@@ -1347,7 +1351,17 @@ def _extract_json_of_type(text: str, expected_type: type) -> dict | list | None:
     ``{`` nested inside an earlier-starting ``[ ... ]`` is consumed by that
     array's decode, so a dict request never digs a nested object out of a
     surrounding array.
+
+    When *prefer* is given, a preferred value is returned only when the choice
+    is UNAMBIGUOUS: all preferred matches in the text must be equal (a model
+    restating the same payload twice is not ambiguity). Two or more DIFFERENT
+    preferred matches return None — the caller cannot know which one is the
+    real payload, and guessing (e.g. executing a worked example that precedes
+    the actual plan) is worse than failing. When no preferred match exists,
+    the first type-matching value is returned as a fallback.
     """
+    preferred: list[dict | list] = []
+    fallback: dict | list | None = None
     i = 0
     n = len(text)
     while i < n:
@@ -1367,10 +1381,20 @@ def _extract_json_of_type(text: str, expected_type: type) -> dict | list | None:
             i += 1
             continue
         if isinstance(data, expected_type):
-            return data  # type: ignore[return-value]
-        # Valid JSON of the wrong type — skip past its full extent.
+            if prefer is None:
+                return data  # type: ignore[return-value]
+            if prefer(data):
+                preferred.append(data)
+            elif fallback is None:
+                fallback = data  # type: ignore[assignment]
+        # Valid JSON that is not an immediate result — skip past its full extent.
         i = end
-    return None
+    if preferred:
+        first = preferred[0]
+        if all(candidate == first for candidate in preferred[1:]):
+            return first
+        return None
+    return fallback
 
 
 def _parse_llm(text: str, expected_type: type) -> dict | list | None:

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -807,6 +807,11 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # third party — the redaction is defensive so a credential-bearing
         # installer error cannot leak into the log ring / /api/logs stream.
         "platform/update_provider.py",
+        # Same shape: redacts the unparseable LLM decomposition response before
+        # writing the diagnostic ERROR line to the gateway log. Defensive log
+        # hygiene so a response echoing a credential or exfiltration URL cannot
+        # leak into the log ring / /api/logs stream; not an egress boundary.
+        "task_planner.py",
         # The shared recursive redactor helper itself — a pure scrubber, not an
         # egress boundary; the modules that CALL it (mochi routes/hooks) are the
         # registered sinks.

--- a/src/kiro_crew/task_planner.py
+++ b/src/kiro_crew/task_planner.py
@@ -10,7 +10,9 @@ from typing import TYPE_CHECKING, Any
 
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_DENY
+from kiro_crew.llm_helpers import _extract_json_of_type
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.task_models import (
     SESSION_PREFIX,
@@ -138,12 +140,34 @@ def normalize_cross_group_deps(tasks: list[Task]) -> list[Task]:
 # ── Task Parsing ──
 
 
+def _plan_shaped(parsed: Any) -> bool:
+    """True when a parsed JSON value carries at least one title-bearing task.
+
+    Mirrors the key precedence in ``parse_tasks``: a dict's ``tasks``/``steps``
+    list, or a bare list. An empty or title-less plan is NOT plan-shaped — an
+    example snippet like ``{"steps": []}`` in the preamble must not be selected
+    over the real body that follows. A genuinely empty plan as the whole
+    response is still honored through the extractor's first-match fallback.
+    """
+    if isinstance(parsed, dict):
+        parsed = parsed.get("tasks", parsed.get("steps"))
+    if not isinstance(parsed, list):
+        return False
+    return any(isinstance(item, dict) and "title" in item for item in parsed)
+
+
 def parse_tasks(text: str) -> list[Task]:
     """Parse LLM output into Task objects.
 
     Accepts either:
     - A JSON object with "steps" key (preferred)
     - A plain JSON array of tasks (backward compat)
+
+    Tolerates a prose preamble/suffix around the JSON body: when the direct
+    parse fails, the shared prose-tolerant extractor finds the embedded JSON,
+    preferring a plan-shaped value so a trivial parseable token in the
+    preamble (e.g. ``[1]`` or an example ``{"steps": []}``) cannot mask the
+    real body.
     """
     text = text.strip()
     if not text:
@@ -153,10 +177,21 @@ def parse_tasks(text: str) -> list[Task]:
         text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
 
     try:
-        parsed = json.loads(text)
+        parsed: Any = json.loads(text)
     except json.JSONDecodeError:
-        logger.error("Failed to parse tasks JSON: %.200s", text)
-        return []
+        parsed = _extract_json_of_type(text, (dict, list), prefer=_plan_shaped)
+        if parsed is None:
+            # Bound the payload: an uncapped ERROR record would evict the
+            # rotating gateway.log window other subsystems tail, and the raw
+            # LLM text can echo credentials or exfiltration URLs, so redact
+            # before the bounded slice is written to log surfaces. URLs are
+            # redacted FIRST: replacing a credential embedded in a URL would
+            # split the URL so the URL redactor no longer matches it, leaving
+            # the rest of its sensitive query string in the log.
+            snippet, _ = redact_exfiltration_urls(text)
+            snippet, _ = redact_credentials(snippet)
+            logger.error("Failed to parse tasks JSON (%d chars): %.500s", len(text), snippet)
+            return []
 
     if isinstance(parsed, dict):
         data = parsed.get("tasks", parsed.get("steps", []))

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -142,6 +142,126 @@ class TestParseSteps:
         assert len(steps) == 1
         assert steps[0].title == "has title"
 
+    def test_prose_preamble_before_json_object(self) -> None:
+        # Reporter's real shape: a one-line preamble before a complete
+        # {"steps": [...]} object, despite the prompt demanding bare JSON.
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        body = json.dumps(
+            {
+                "steps": [
+                    {"title": "Set up scaffolding", "description": "Init the repo"},
+                    {"title": "Implement feature", "description": "Write the code"},
+                ]
+            }
+        )
+        text = "Here is the decomposed task plan you asked for:\n" + body
+        steps = runner._parse_tasks(text)
+        assert len(steps) == 2
+        assert steps[0].title == "Set up scaffolding"
+        assert steps[1].index == 2
+
+    def test_prose_preamble_and_suffix_around_json_array(self) -> None:
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        text = 'Sure! Plan below.\n[{"title": "A"}, {"title": "B"}]\nLet me know if you need more.'
+        steps = runner._parse_tasks(text)
+        assert [s.title for s in steps] == ["A", "B"]
+
+    def test_preamble_with_stray_brace_still_finds_body(self) -> None:
+        # A brace in the preamble prose must not mask the real JSON body.
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        text = 'Note: use {placeholder} syntax.\n{"steps": [{"title": "A"}]}'
+        steps = runner._parse_tasks(text)
+        assert len(steps) == 1
+        assert steps[0].title == "A"
+
+    def test_preamble_json_with_braces_inside_strings(self) -> None:
+        # Braces/brackets inside string values must not end the span early.
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        body = json.dumps({"steps": [{"title": 'Fix "{}" rendering', "description": "x]}"}]})
+        steps = runner._parse_tasks("Plan:\n" + body)
+        assert len(steps) == 1
+        assert steps[0].title == 'Fix "{}" rendering'
+
+    def test_genuinely_unparseable_returns_empty(self) -> None:
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        assert runner._parse_tasks("no json here at all") == []
+        assert runner._parse_tasks("broken { not json [ anywhere") == []
+
+    def test_json_like_token_in_preamble_does_not_mask_body(self) -> None:
+        # A trivial parseable span in the preamble (here "[1]") must not win
+        # over the plan-shaped body that follows it.
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        text = 'Steps use depends_on: [1] for ordering.\n{"steps": [{"title": "Real task"}]}'
+        steps = runner._parse_tasks(text)
+        assert len(steps) == 1
+        assert steps[0].title == "Real task"
+
+    def test_empty_plan_snippet_in_preamble_does_not_mask_body(self) -> None:
+        # An empty-plan example in the preamble (e.g. '{"steps": []}') must not
+        # be selected over the real title-bearing plan that follows it.
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        text = 'The shape is {"steps": []} with items like:\n{"steps": [{"title": "Real task"}]}'
+        steps = runner._parse_tasks(text)
+        assert len(steps) == 1
+        assert steps[0].title == "Real task"
+
+    def test_nested_example_snippet_in_preamble_does_not_starve_scan(self) -> None:
+        # A deeply nested example plus stray prose braces before the body must
+        # not exhaust the extractor (raw_decode skips past each parsed value).
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        text = (
+            'Example: {"a": {"b": {"c": [1, 2, {"d": []}]}}} and tokens {x} {y} {z}.\n'
+            '{"steps": [{"title": "Real task"}]}'
+        )
+        steps = runner._parse_tasks(text)
+        assert len(steps) == 1
+        assert steps[0].title == "Real task"
+
+    def test_two_different_plans_is_ambiguous_and_fails_safe(self) -> None:
+        # A title-bearing worked EXAMPLE before the real plan is ambiguous: the
+        # parser cannot know which plan is real, and executing a guess is worse
+        # than failing. Two different plan-shaped values -> [] (logged).
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        text = (
+            'For example {"steps": [{"title": "Example task"}]} — here is the plan:\n'
+            '{"steps": [{"title": "Real task"}]}'
+        )
+        assert runner._parse_tasks(text) == []
+
+    def test_identical_restated_plan_is_not_ambiguous(self) -> None:
+        # A model restating the SAME payload twice is not ambiguity.
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        body = '{"steps": [{"title": "Real task"}]}'
+        steps = runner._parse_tasks(f"Plan:\n{body}\nAgain, the plan is:\n{body}")
+        assert len(steps) == 1
+        assert steps[0].title == "Real task"
+
+    def test_unparseable_error_log_is_bounded_and_redacted(self, caplog) -> None:
+        import logging
+
+        sessions = _make_mock_sessions()
+        runner = TaskRunner(sessions=sessions, auto_test=False)
+        secret = "ghp_" + "a" * 36
+        text = "totally not json " + secret + " " + "x" * 5000
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.task_planner"):
+            assert runner._parse_tasks(text) == []
+        record = next(r for r in caplog.records if "Failed to parse tasks JSON" in r.getMessage())
+        message = record.getMessage()
+        assert secret not in message
+        assert str(len(text)) in message
+        # Payload slice is bounded so one record cannot evict the log window.
+        assert len(message) < 700
+
 
 # ── Build step prompt ──
 


### PR DESCRIPTION
## Problem / Motivation

`parse_tasks()` in `src/kiro_crew/task_planner.py` consumes the LLM response produced by `decompose()`. It strips a leading markdown code fence, then passes the text straight to `json.loads()`. When the model emits any prose preamble before the opening `{`/`[` — which happens even though the prompt demands bare JSON — `json.loads()` raises, `parse_tasks()` returns `[]`, and the whole task run fails with "Failed to decompose spec into tasks". A reporter confirmed the JSON body itself was complete and valid (7478 chars, 11 well-formed steps); the only problem was a one-line preamble before the opening `{`. The failure log line also truncated the payload at 200 chars, hiding what actually came back.

## Why it matters

An otherwise well-formed plan is discarded and zero steps execute — the user's entire task run dies on a cosmetic quirk of model output. Because the model is asked to not use fences, this failure mode recurs across providers and retries, and the truncated diagnostic makes it look like the model produced garbage when it produced a valid plan.

## What changed (motivation → approach → change)

Symptom: decomposition fails whenever prose surrounds the JSON body. Root cause: `parse_tasks()` only tolerated a code fence, never a preamble/suffix, and gave up on the first `JSONDecodeError`.

Change, kept minimal and self-contained to `parse_tasks()` and its helpers:

- When the direct parse fails, fall back to the repo's shared prose-tolerant extractor, `llm_helpers._extract_json_of_type` (stdlib `JSONDecoder.raw_decode` over successive `{`/`[` offsets — full-grammar validation, string/escape handling, and skip-past-parsed-value come free, no attempt cap needed). The existing fast path (text already parses) is unchanged.
- The extractor gains an optional `prefer` predicate with unambiguous-choice semantics: a preferred value is returned only when all preferred matches in the text are equal (a restated identical payload is fine); two or more different preferred values return None so the caller fails safe instead of executing a guessed plan, and the first type-matching value is the fallback when nothing is preferred. `parse_tasks` passes `_plan_shaped` — a value carrying at least one title-bearing task under `parse_tasks` key precedence (`tasks` over `steps`) — so a trivial parseable token (e.g. `[1]` in "steps use depends_on: [1]") or an empty-plan example snippet (`{"steps": []}`) in the preamble cannot mask the real body. A genuinely empty plan as the whole response is still honored via the fallback.
- Widen the diagnostic: the error line now reports the full text length plus a 500-char slice, run through `redact_credentials()` + `redact_exfiltration_urls()` before logging. Bounded so one oversized ERROR record cannot evict the rotating `gateway.log` window that other subsystems tail; redacted so a response echoing a credential or exfiltration URL cannot leak into the log ring / `/api/logs` stream. `task_planner.py` is registered in `NON_EGRESS_REDACTION_MODULES` (gate-side log hygiene, same shape as the adjacent `platform/update_provider.py` entry). Graceful `return []` on total failure is kept.

## Tests

All in `test/test_taskrunner.py::TestParseSteps` (the module covering `parse_tasks` via `TaskRunner._parse_tasks`):

- `test_prose_preamble_before_json_object` — the reporter's real shape: one-line preamble + complete `{"steps": [...]}` parses correctly.
- `test_prose_preamble_and_suffix_around_json_array` — prose on both sides of a JSON array.
- `test_preamble_with_stray_brace_still_finds_body` — a `{placeholder}` token in the preamble does not mask the real body.
- `test_preamble_json_with_braces_inside_strings` — braces/brackets inside string values do not end the span early.
- `test_json_like_token_in_preamble_does_not_mask_body` — a trivially-parseable `[1]` token in the preamble does not beat the plan-shaped body.
- `test_genuinely_unparseable_returns_empty` — unparseable text still returns `[]` without raising.
- `test_unparseable_error_log_is_bounded_and_redacted` — the ERROR record omits a `ghp_…` secret, reports the true length, and stays bounded.
- Existing plain-JSON and code-fenced paths remain covered by `test_valid_json` / `test_markdown_fenced_json`.

## Manual verification

N/A — unit coverage sufficient: the change is a pure text-parsing function with no I/O; the fixture reproduces the reporter's exact failure shape.

## Related Issues

Closes #4947

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only parsing change in `src/kiro_crew/task_planner.py`; no frontend paths touched, nothing renders differently.


