### PR TITLE
ci: retry the woke download so a CDN reset cannot fail the gate

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -193,7 +193,12 @@ jobs:
           asset="woke-${WOKE_VERSION}-linux-amd64.tar.gz"
           archive="${RUNNER_TEMP}/${asset}"
           bin_dir="${RUNNER_TEMP}/woke-bin"
-          curl -sSfL \
+          # --retry-all-errors is required in addition to --retry: a bare
+          # --retry covers transient HTTP statuses and timeouts but not a
+          # mid-transfer connection reset (curl exit 35), which is how the
+          # Releases CDN fails here. The sha256sum check below still gates a
+          # truncated or substituted download.
+          curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
             "https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/${asset}" \
             -o "$archive"
           printf '%s  %s\n' "$WOKE_SHA256" "$archive" | sha256sum -c -

--- a/test/test_github_workflow_security.py
+++ b/test/test_github_workflow_security.py
@@ -4,11 +4,15 @@ ROOT = Path(__file__).resolve().parents[1]
 CODE_REVIEW_WORKFLOW = ROOT / ".github" / "workflows" / "code-review.yml"
 
 
-def test_woke_install_is_version_pinned_and_checksum_verified():
+def _woke_install_step() -> str:
     workflow = CODE_REVIEW_WORKFLOW.read_text(encoding="utf-8")
-    install_step = workflow.split("      - name: Install woke\n", 1)[1].split(
+    return workflow.split("      - name: Install woke\n", 1)[1].split(
         "      - name: Scan only changed lines\n", 1
     )[0]
+
+
+def test_woke_install_is_version_pinned_and_checksum_verified():
+    install_step = _woke_install_step()
 
     assert "raw.githubusercontent.com/get-woke/woke/main/install.sh" not in install_step
     assert "| bash" not in install_step
@@ -22,3 +26,22 @@ def test_woke_install_is_version_pinned_and_checksum_verified():
     assert "--strip-components=1 \\" in install_step
     assert '"woke-${WOKE_VERSION}-linux-amd64/woke"' in install_step
     assert 'echo "$bin_dir" >> "$GITHUB_PATH"' in install_step
+
+
+def test_woke_download_retries_transient_cdn_failures():
+    """A single connection reset from the Releases CDN must not fail the gate.
+
+    The Inclusive Language job is a required check that fork contributors
+    cannot re-run job-by-job, so an unretried download turns a CDN hiccup into
+    a full-pipeline re-roll. ``--retry-all-errors`` is the load-bearing flag:
+    plain ``--retry`` does not cover a mid-transfer reset (curl exit 35).
+    """
+    install_step = _woke_install_step()
+
+    assert "--retry 3" in install_step
+    assert "--retry-delay 2" in install_step
+    assert "--retry-all-errors" in install_step
+    # The checksum gate must survive the retry change, so a partial or
+    # substituted download still fails loudly instead of being retried into a
+    # bad binary.
+    assert "sha256sum -c -" in install_step


### PR DESCRIPTION
## Problem / Motivation

The `Inclusive Language` check failed on a PR whose entire diff was one line (`layout="side"`), containing no flagged terms at all. The scanner never ran — the job died 140ms into the step that downloads the `woke` binary:

```
Run asset="woke-${WOKE_VERSION}-linux-amd64.tar.gz"
  curl -sSfL \
    "https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/${asset}" \
    -o "$archive"
env:
  WOKE_VERSION: 0.19.0
curl: (35) Recv failure: Connection reset by peer
##[error]Process completed with exit code 35.
```

`curl: (35)` is a TLS-layer connection reset from the GitHub Releases CDN. Nothing about it relates to the PR's contents.

## Why it matters

- **Every PR rolls this dice.** One CDN hiccup red-lights an otherwise-green PR on a required check.
- **Fork contributors cannot recover cheaply.** Re-running a single job needs admin rights (`POST /actions/jobs/<id>/rerun` → `403 Must have admin rights to Repository`). The only contributor-side remedy is an empty amend + force-push, which throws away every other check that already completed in that run and re-queues the entire pipeline.
- **The repo already solved this everywhere else.** `--retry`/`--retry-delay` guard the curl downloads in `publish-linux.yml`, `publish-windows.yml`, `publish-cli.yml`, `sign-and-notarize.yml` and `ship-report.yml`. The woke download is the lone outlier.

## What changed (motivation → approach → change)

Symptom: a required check fails with no findings and no scanner output. Root cause: `.github/workflows/code-review.yml` fetches the woke release asset with a bare `curl -sSfL` and no retry flags, so a single transient reset fails the gate closed.

The change adds the retry flags already conventional in this repo's other release-artifact downloads:

```yaml
curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
  "https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/${asset}" \
  -o "$archive"
```

`--retry-all-errors` is the load-bearing flag rather than a stylistic addition: a bare `--retry` covers transient HTTP statuses and timeouts but **not** a mid-transfer connection reset, which is exactly the exit-35 failure observed. Retries stay bounded at 3 attempts, and `-f` still fails on HTTP errors.

The integrity gate is deliberately untouched. The existing `printf '%s  %s\n' "$WOKE_SHA256" "$archive" | sha256sum -c -` on the very next line still verifies the payload, so a truncated or substituted download fails loudly instead of being silently retried into a bad binary.

## Tests

`test/test_github_workflow_security.py` already asserted the install step's pinning and checksum properties. This extracts the shared step-slicing into a `_woke_install_step()` helper and adds `test_woke_download_retries_transient_cdn_failures`, which locks in:

- all three retry flags are present on the download, so a future edit cannot silently drop them and reintroduce the fail-closed behaviour;
- `sha256sum -c -` survives alongside the retry, so the ratchet fails if someone ever trades integrity verification for resilience.

Verified the test actually catches the bug: with the workflow hunk reverted to `main` and the test kept, `test_woke_download_retries_transient_cdn_failures` fails on `assert "--retry 3" in install_step`; with the fix applied it passes.

## Manual verification

N/A — unit coverage sufficient. The changed surface is a declarative curl invocation whose properties the ratchet test asserts directly; the transient CDN reset that triggered the bug is not reproducible on demand. Local gates run green: 172 tests pass across `test_github_workflow_security.py`, `test_workflow_permissions.py`, `test_ci_surface_tests.py` and `test_ai_review_workflows.py`; `isort` and `flake8` clean; the workflow YAML parses.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow and test-only change — no user-visible surface is touched, so there is no rendered delta to capture.

## Related Issues

Fixes #4961

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

**Note for the maintainer:** this diff necessarily touches `.github/`, so the auto-approval bot will not grant workflow approval — each push needs a manual "Approve and run". That is inherent to the fix, since the bug is in a workflow file.
