### PR TITLE
chore(release): re-stamp release/0.4.0 as RC in-code (0.4.0rc4 / 0.4.0-rc.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.5.0"
+version = "0.4.0-rc.4"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.5.0"
+__version__ = "0.4.0-rc.4"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.5.0",
+  "version": "0.4.0-rc.4",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
## What

release/0.4.0 was force-moved to latest main (`8f1633f4f`) to pick up #4891 (min-version gate fix that killed the insider.3 RC gate) plus everything merged since. Same 5-file shape as #4887:

- **Version re-stamp** (the force-move brought main's `0.5.0` along -- this is the ONLY 0.5.0 content and it is overwritten here): `__init__.py` + `pyproject.toml` -> PEP 440 `0.4.0rc4`, `package.json` -> semver `0.4.0-rc.4`. rc4 matches the upcoming `v0.4.0-insider.4` tag.
- **Doc restore**: CONTRIBUTING.md + docs/build/release.md three-dialect version-policy text restored **verbatim** from `509b68387` (#4887) -- those doc changes existed only on the old release branch tip and the force-move discarded them (verified main never touched either file since the previous force-move point).

## Verification
- No residual `0.5.0` in the three declaration files (grep clean)
- 174 version/release tests pass locally (incl. `test_stable_version_display` #4876 fold, `test_apps_version` #4891 rc-stamp regression, nightly version contract)
- Local CI lint: black gate passed, isort/flake8 clean

**Why no screenshot:** version-declaration + docs change; no UI surface.

## Next
Merge -> verify HEAD content -> tag `v0.4.0-insider.4` (the clean promotion candidate for next Thursday's 0.4.0 stable).