### PR TITLE
docs: add macOS guide for the launchctl setenv PATH recipe (#4940)

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,6 +7,7 @@ system is built, see [../architecture/](../architecture/README.md).
 |---|---|
 | [install.md](install.md) | Installing and building Kiro Crew: source, wheel, and first run. |
 | [windows-install.md](windows-install.md) | Native Windows setup, and the per-feature status on Windows. |
+| [macos-troubleshooting.md](macos-troubleshooting.md) | macOS desktop app issues — a CLI that resolves in Terminal but is `command not found` inside the app, and the `launchctl setenv PATH` recipe that fixes it. |
 | [docker.md](docker.md) | Running Kiro Crew as a container. |
 | [docker-troubleshooting.md](docker-troubleshooting.md) | Diagnosing common Docker deployment issues. |
 | [remote-and-mobile.md](remote-and-mobile.md) | Running 24/7 on a remote host, keeping it alive as a service, and reaching it from a phone over a tunnel. |

--- a/docs/guides/macos-troubleshooting.md
+++ b/docs/guides/macos-troubleshooting.md
@@ -1,0 +1,113 @@
+# macOS Troubleshooting
+
+Fixes for problems specific to the macOS desktop app (`KiroCrew.app`). For
+install and build steps see [install.md](install.md); for problems that are not
+macOS-specific, start with `kirocrew doctor`.
+
+---
+
+## A command works in Terminal but is "command not found" in the app
+
+**Symptoms:** a CLI or MCP server binary runs fine in Terminal, but inside the
+desktop app an agent shell tool or an MCP server spawn fails with
+`command not found`. The binary is installed and executable; only the app
+cannot find it.
+
+### Why this happens
+
+A GUI-launched `.app` does not start from your shell. It inherits launchd's
+minimal environment, so its `PATH` is typically just:
+
+```
+/usr/bin:/bin:/usr/sbin:/sbin
+```
+
+The bundled Gateway and everything it spawns — agent shell tools, MCP servers,
+ACP runtimes — inherit that value. The backend does re-add a fixed list of
+well-known install locations (Apple Silicon Homebrew's `/opt/homebrew/bin`,
+`~/.local/bin`, common version-manager shim directories), so CLIs there
+resolve already. A CLI anywhere *outside* both the system `PATH` and that
+fixed list — Intel Homebrew's `/usr/local/bin`, a custom `~/bin`, a
+tool-managed directory like `~/.opencode/bin` — is unresolvable inside the
+app even though the same command works in Terminal.
+
+To recover your real `PATH`, the app reads the **launchd user domain**
+(`launchctl getenv PATH`) just before it spawns the Gateway and appends the
+directories found there. That domain is empty until something writes it: an
+`export PATH=...` in `~/.zprofile` or `~/.zshrc` configures shells only and
+never reaches launchd. That is why the fix below is a `launchctl setenv`, not
+another rc-file edit.
+
+### The fix
+
+1. From a Terminal window whose `PATH` is correct (one where the command
+   resolves), copy that `PATH` into the launchd user domain:
+
+   ```bash
+   launchctl setenv PATH "$PATH"
+   ```
+
+   Note the scope: the launchd user domain is shared, so every GUI app
+   launchd starts for your user afterwards inherits this `PATH` — not just
+   Kiro Crew. You are copying the same value your shells already use, but if
+   you prefer to keep the change minimal, set a `PATH` that starts with the
+   system directories and appends only the directories you need.
+
+2. **Fully quit and relaunch the app** — quit from the menu bar or with Cmd+Q,
+   not just the window close button. The Gateway keeps the environment it was
+   started with, and so do its MCP server and agent children, so nothing picks
+   up the new value until the app respawns the Gateway.
+
+To verify: `launchctl getenv PATH` in Terminal prints the full value, and the
+command now resolves inside the app (an agent shell tool running
+`command -v <name>` prints its path).
+
+### The setting does not survive a reboot
+
+`launchctl setenv` writes in-memory launchd state, so after a reboot or logout
+the domain is empty again and the app is back to the minimal `PATH` until the
+command is re-run. Either re-run it when the symptom reappears, or automate it
+with a LaunchAgent that runs at login. Save the following as
+`~/Library/LaunchAgents/dev.kirocrew.path.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.kirocrew.path</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/launchctl</string>
+    <string>setenv</string>
+    <string>PATH</string>
+    <string>/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+</dict>
+</plist>
+```
+
+A LaunchAgent does not run your shell rc files, so `$PATH` is not available
+inside it: write the literal value (print yours with `echo "$PATH"`) into the
+last `<string>`. Keep the system directories first and append your own, as in
+the example. If a directory name contains an XML-reserved character, escape
+it (`&` as `&amp;`, `<` as `&lt;`) — a raw `&` makes the file unparseable and
+the agent silently fails to load. Load it once with
+`launchctl load ~/Library/LaunchAgents/dev.kirocrew.path.plist`; from then on
+it runs at every login. If the app auto-starts at login, launch order is not
+guaranteed on the first login after adding the agent — quit and relaunch the
+app once if a command is still missing.
+
+### What the app does with the launchd `PATH`
+
+- Directories read from the launchd domain are **appended after** the app's
+  inherited `PATH`. Inside Kiro Crew they can make a name resolve that
+  resolved nowhere before, but can never shadow a system binary that already
+  resolves. (This guarantee is about the app's own merge — the
+  `launchctl setenv` step above is governed by whatever ordering you set.)
+- Only absolute entries are added: a relative entry, or one containing a `..`
+  segment, is ignored.
+- A Gateway started from a terminal (`kirocrew gateway`) is unaffected — it
+  inherits the shell's `PATH` directly and needs none of this.

--- a/src/kiro_crew/docs/troubleshooting.md
+++ b/src/kiro_crew/docs/troubleshooting.md
@@ -36,6 +36,13 @@ kiro-cli login
 `kirocrew doctor` reports the binary and the login state on separate lines, so
 check both.
 
+**macOS desktop app:** if a command resolves in Terminal but not inside the
+app, the cause is usually launchd's minimal `PATH`, which a shell rc file
+never changes. The fix is `launchctl setenv PATH "$PATH"` plus a full quit and
+relaunch — see the
+[macOS troubleshooting guide](https://github.com/kirodotdev/KiroCrew/blob/main/docs/guides/macos-troubleshooting.md)
+for the recipe and how to persist it across reboots.
+
 ### Dashboard asks for sign-in but `kiro-cli` is already authenticated
 
 Typical on a headless host that authenticates `kiro-cli` with an API key rather


### PR DESCRIPTION
## Problem / Motivation

On macOS, a CLI that resolves in Terminal can be `command not found` inside the desktop app: a GUI-launched `.app` inherits launchd's minimal environment (`/usr/bin:/bin:/usr/sbin:/sbin`), and the app's recovery mechanism reads the **launchd user domain** (`launchctl getenv PATH`) — which holds nothing until the user explicitly runs `launchctl setenv PATH "$PATH"`. A `PATH` exported from `~/.zprofile`/`~/.zshrc` never reaches that domain.

The two-step activation recipe (run the `setenv`, then fully quit and relaunch the app so the Gateway respawns with the new environment) existed only in a source comment in `website/electron/mac-env.js`. There is no user-facing doc that names it, so users hitting the symptom cannot discover the fix.

## Why it matters

Kiro Crew's whole job is launching user-installed CLIs and MCP servers. A user whose tool lives outside both the system `PATH` and the backend's fixed `_EXTRA_PATH_DIRS` list (e.g. Intel Homebrew's `/usr/local/bin`, `~/bin`, `~/.opencode/bin`) sees a misleading `command not found` for a binary that is installed and works, with no documented path to the fix.

## What changed (motivation → approach → change)

Symptom: undiscoverable activation recipe. Root cause: the recipe lives only in PR-description and source-comment form. Change: a user-facing troubleshooting page.

- New `docs/guides/macos-troubleshooting.md`: the symptom, the cause (launchd minimal env; rc-file exports never reach the launchd domain; the backend's fixed extra-dirs list already covers common locations like `/opt/homebrew/bin` and `~/.local/bin`), the two-step recipe (`launchctl setenv PATH "$PATH"` + full quit & relaunch, with a scope note that the launchd user domain is shared by all GUI apps), reboot persistence via a login LaunchAgent (valid plist, system dirs first, XML-escaping note), and the app-side merge guarantees (append-only, absolute entries only, terminal-launched Gateways unaffected) — each cross-checked against `website/electron/mac-env.js`.
- Indexed the page from `docs/guides/README.md` (the docs rule: every new doc is reachable from its directory index).
- Added a pointer from the **shipped** `src/kiro_crew/docs/troubleshooting.md` PATH section (the doc an installed user actually sees in the dashboard) to the new guide, so desktop-app users find the recipe where they first look — per the Design Review suggestion.

Docs-only; no code changes. Product shapes 2/3 on the underlying feature request (settings surface, refresh-and-restart action) are deliberately out of scope.

## Tests

N/A — docs-only. `./scripts/docs-lint.sh` passes (link integrity, index reachability); `BRAND_BASE_REF=main scripts/check_brand_name.py` passes; the LaunchAgent plist block in the page parses cleanly with `plistlib` (verified during review after a reviewer caught a comment preceding the XML declaration).

## Manual verification

N/A — unit-level docs gates sufficient; the recipe itself is the one shipped and tested in the PATH-recovery change (`mac-env.js`), restated for users.

<!-- no-visual-delta -->
**Why no screenshot:** docs-only change under `docs/guides/`; no watched frontend path touched and no rendered UI delta.

Closes #4940
