### PR TITLE
test(isolation): pin the agent-spec home for every testpath

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ test collected from any testpath, because what they protect is the
 developer's machine rather than the correctness of one suite. Everything that is
 merely suite-specific isolation stays in ``test/conftest.py``.
 
-The floor has four parts, and each one exists because the "remember to isolate
+The floor has five parts, and each one exists because the "remember to isolate
 this" contract failed at least once:
 
 * **Services.** ``$XDG_CONFIG_HOME`` is redirected and the stdlib spawn funnels
@@ -25,6 +25,12 @@ this" contract failed at least once:
   under ``src/kiro_crew/apps/builtins/*/tests/`` -- which see this conftest and no
   other -- write the operator's live ``~/.kiro/crew`` the moment they touch
   ``config_dir()``.
+* **The agent-spec home.** ``kiro_agents_dir()`` is a LAZY resolver, so neither of
+  the two above reaches it, and a test that reaches the spec write path rewrites
+  the machine-wide ``<kiro home>/agents/kirocrew.json`` -- the file that decides
+  which MCP servers the operator's real agent has (issue #4912). The per-module
+  override seams are pinned instead of ``KIRO_HOME``, which cannot be pinned
+  without overriding ~35 tests' own ``Path.home()`` isolation.
 * **The system temp directory.** ``tempfile``'s base is redirected to a per-run
   directory for the whole process, so a bare ``mkdtemp()`` whose cleanup is missing
   or skipped leaves its directory somewhere this run owns and removes, instead of
@@ -1486,6 +1492,183 @@ def _isolate_subagents_dir(_isolation_dirs, monkeypatch):
         "kiro_crew.subagent_persistence._SUBAGENTS_DIR",
         _isolation_dirs("subagents"),
     )
+
+
+#: Modules carrying the documented ``KIRO_AGENTS_DIR`` override hook (``None`` = live).
+#: Each is ``(module, attribute)``; the fixture below points them all at ONE per-test
+#: directory, so the hook production already offers "a caller (test/tooling)" is set
+#: by default instead of per test.
+_AGENT_SPEC_HOOKS: tuple[tuple[str, str], ...] = (
+    ("kiro_crew.agent", "KIRO_AGENTS_DIR"),
+    ("kiro_crew.agent_discovery", "_KIRO_AGENTS_DIR"),
+    ("kiro_crew.apps.bridges", "KIRO_AGENTS_DIR"),
+    ("kiro_crew.cli_doctor", "KIRO_AGENTS_DIR"),
+)
+
+#: Modules that WRITE through a bound ``config.paths.kiro_agents_dir`` name, which no
+#: hook reaches. Deliberately short: this file's remit is the host-MUTATION floor, and
+#: redirecting a read-only consumer's bound name costs more than it protects -- the
+#: dominant isolation idiom in this suite is ``patch("<module>.Path.home", ...)`` and
+#: then reading through that module's own resolver, which a redirect silently overrides.
+#: Every read-only consumer is therefore listed as excluded, with that reason, in
+#: ``test_host_isolation_floor.py``'s ratchet rather than pinned here.
+#:
+#: ``kiro_crew.config.paths`` is the DEFINITION, and patching it is what reaches a writer
+#: that imports the name inside a function body -- ``auto_improvement.spine.agent_runner``
+#: copies agent specs that way, so no module-level binding exists to pin.
+#:
+#: ``kiro_crew.agent.kiro_agents_dir`` is deliberately ABSENT, and adding it would break
+#: the suite on the setup this repo mandates for development. That binding is not a
+#: write target -- ``agent`` writes exclusively through ``kiro_agents_dir_path()``, which
+#: reads the hook above -- it is the AMBIENT reference
+#: ``_decline_shared_agent_home`` compares the target against to decide whether the
+#: target is shared at all. Leaving it resolving the real home is what makes the pinned
+#: hook read as "a caller redirected this somewhere the ambient environment would never
+#: produce", which returns early and allows the write. Patch it too and target ==
+#: ambient, so the guard falls through to its ephemerality check and DECLINES from a
+#: linked git worktree -- every test that reaches ``rebuild_agent_config`` would then
+#: pass in CI and fail on a developer's machine.
+_AGENT_SPEC_RESOLVER_BINDINGS: tuple[tuple[str, str], ...] = (
+    ("kiro_crew.config.paths", "kiro_agents_dir"),
+    ("kiro_crew.dashboard.handlers.mcp", "kiro_agents_dir"),
+)
+
+
+@pytest.fixture(scope="session")
+def _agent_spec_seam_modules():
+    """Import the HOOK modules once per worker process.
+
+    Ordering is what this buys: the per-test fixture below can only patch a module that
+    is already imported, and these four carry the write seams #4912 names, so "whatever
+    collection happened to import" is not a strong enough guarantee for them.
+
+    Scoped to the hook table on purpose. The resolver-binding table is far wider and
+    includes the heaviest modules in the repo (``slack.gateway``), which no worker should
+    import to protect a binding that module cannot reach unless a test imported it
+    anyway. Those keep the patch-if-imported tolerance ``_isolate_shared_kiro_paths``
+    uses.
+
+    ``ImportError`` is tolerated per module, matching the convention the other fixtures
+    here follow: a partial checkout must not break collection, and a module that cannot
+    import has no binding to leak.
+    """
+    for module, _attr in _AGENT_SPEC_HOOKS:
+        try:
+            importlib.import_module(module)
+        except ImportError:  # pragma: no cover - partial checkout
+            continue
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agent_spec_home(_agent_spec_seam_modules, _isolation_dirs, monkeypatch):
+    """Pin the AGENT-SPEC home to a per-test tmp dir, for EVERY testpath.
+
+    A third isolation axis, distinct from both the data home and the import-time
+    ``~/.kiro`` bindings above. The agent specs are the file kiro-cli reads to learn
+    which MCP servers exist, and ``kiro_agents_dir()`` is a LAZY resolver
+    (``kiro_home()`` -> ``$KIRO_HOME`` or ``Path.home()/.kiro``), so neither
+    ``KIROCREW_HOME`` nor ``_SHARED_KIRO_PATHS`` reaches it -- the shared-path ratchet's
+    own docstring records that lazy resolvers are outside its scope.
+
+    Without this, any test reaching the write path (``rebuild_agent_config`` and the
+    per-agent writers around it, ``apps.bridges._register_agents``) rewrites the
+    operator's machine-wide ``<kiro home>/agents/kirocrew.json``. Confirmed live
+    (#4912): a suite run inside a throwaway clone left every managed server's
+    ``command`` pointing into that clone's venv and pinned the per-test data home into
+    their ``env``, because ``_managed_mcp_env`` stamps the WRITER's paths. Both stop
+    existing when the run ends, so afterwards every new session on the machine spawned
+    ``kirocrew-core`` from a deleted venv against a data home recreated empty ->
+    ``read_local_secret()`` returned "" -> every internal HTTP call failed
+    ``internal_auth_mismatch`` (``received=absent``), killing ``spawn_run``,
+    ``learn_add`` and ``cron_*`` while in-process tools kept working. A gateway restart
+    healed it, and the next suite run re-broke it, which is what made it look
+    intermittent and unfixable.
+
+    ``KIRO_HOME`` is NOT the lever used here, deliberately -- see
+    ``_isolate_kirocrew_home`` for why pinning that variable is refused: ~35 tests
+    isolate ``kiro_home()`` the other way round with
+    ``patch("pathlib.Path.home", ...)``, and an env pin overrides their own isolation
+    so they read an empty directory instead of the tree they just built. Pinning the
+    per-module seams instead leaves both of those levers untouched.
+
+    One directory for every entry, not one each: production resolves a single agents
+    dir, so a test that writes a spec through one seam and reads it through another
+    (``rebuild_agent_config`` then ``agent_discovery``) has to see the same tree.
+
+    Unlike ``_isolate_shared_kiro_paths``, the HOOK half does not settle for patching
+    whatever happens to be in ``sys.modules``. That fixture's residual hole -- a module
+    first imported inside a test's own body, after the fixture already ran -- is
+    tolerable for a path that is only read, and not for these: ``rebuild_agent_config``
+    and ``apps.bridges._register_agents`` WRITE, and a test that imports its subject in
+    its own body is a normal shape here. ``_agent_spec_seam_modules`` therefore imports
+    those four once per worker process. MEASURED cold on this tree: agent 177 ms,
+    cli_doctor 87 ms, bridges 33 ms, agent_discovery 19 ms -- ~315 ms per worker for a
+    whole session, against a shard that runs for minutes. Per-TEST import would have
+    been the unaffordable shape, which is what that other fixture's tolerance is really
+    about.
+
+    The resolver-binding half keeps the patch-if-imported tolerance: it is wide and
+    includes the repo's heaviest modules, and a module nobody imported has no bound name
+    for a test to reach.
+
+    Creates nothing -- an absent agents dir is the normal fresh-install state, and
+    every writer ``mkdir(parents=True)`` first.
+
+    A test that sets its own value still wins, through EITHER lever. ``monkeypatch``
+    applied later in setup overrides the seams directly; and a test that sets
+    ``KIRO_HOME`` -- the documented env override, which several tests use to place the
+    agents dir under their own ``tmp_path`` -- is deferred to by the replacement
+    resolver installed here. Deferring is safe because the variable is CLEARED first,
+    so anything visible afterwards was chosen by the test rather than exported by the
+    operator (whose value would name another real home).
+    """
+    monkeypatch.delenv("KIRO_HOME", raising=False)
+    root = _isolation_dirs("kiro-agents")
+    paths = sys.modules.get("kiro_crew.config.paths")
+    real = getattr(paths, "kiro_agents_dir", None) if paths is not None else None
+
+    def _pinned_agents_dir() -> pathlib.Path:
+        """The per-test dir, unless this test chose a kiro home of its own."""
+        if os.environ.get("KIRO_HOME") and real is not None:
+            return real()
+        return root
+
+    for module, attr in _AGENT_SPEC_HOOKS:
+        mod = sys.modules.get(module)
+        if mod is not None:
+            monkeypatch.setattr(mod, attr, root, raising=False)
+    for module, attr in _AGENT_SPEC_RESOLVER_BINDINGS:
+        mod = sys.modules.get(module)
+        if mod is not None:
+            monkeypatch.setattr(mod, attr, _pinned_agents_dir, raising=False)
+    return real
+
+
+@pytest.fixture
+def unpinned_agent_spec_home(_isolate_agent_spec_home, monkeypatch):
+    """Opt out of the agent-spec pin, for a test that ASSERTS on the real layout.
+
+    Two drift guards need the real resolution rather than an isolated copy: one checks
+    that ``security``'s ``.kiro/agents`` literal is still the home-relative tail of
+    ``kiro_agents_dir()``, the other that ``apps.bridges`` still targets the
+    machine-wide registry (which is why a pod may not run ``app``). Pinned to a tmp
+    path, both assert about a path that does not ship -- weakening the guard to satisfy
+    an isolation fixture, which is backwards. Same call the shared-path ratchet's
+    ``_EXCLUDED`` makes for its security anchors.
+
+    READ-ONLY use only. This hands back the real machine-wide location, so a test that
+    WRITES through it edits the operator's live agent. Nothing here stops that; the
+    two current users only assert.
+    """
+    for module, attr in _AGENT_SPEC_HOOKS:
+        mod = sys.modules.get(module)
+        if mod is not None:
+            monkeypatch.setattr(mod, attr, None, raising=False)
+    for module, attr in _AGENT_SPEC_RESOLVER_BINDINGS:
+        mod = sys.modules.get(module)
+        if mod is not None and _isolate_agent_spec_home is not None:
+            monkeypatch.setattr(mod, attr, _isolate_agent_spec_home, raising=False)
+    return _isolate_agent_spec_home
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -126,6 +126,245 @@ class TestTheDataHomeIsPinnedForEveryTestpath:
         assert config_dir().resolve() == mine.resolve()
 
 
+class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
+    """The agent specs decide which MCP servers the operator's real agent has.
+
+    A third axis, and the reason it needs one: ``kiro_agents_dir()`` is a LAZY
+    resolver (``kiro_home()`` -> ``$KIRO_HOME`` or ``Path.home()/.kiro``), so the data
+    home does not reach it and neither does ``_SHARED_KIRO_PATHS`` -- whose own ratchet
+    docstring records lazy resolvers as outside its scope. Before this floor part
+    existed, a suite run inside a throwaway clone rewrote the machine-wide
+    ``kirocrew.json`` with that clone's venv and a per-test data home in ``env``, and
+    every new session on the machine then failed ``internal_auth_mismatch`` once both
+    were deleted (#4912).
+    """
+
+    def test_the_spec_write_target_is_not_the_operators_real_home(self) -> None:
+        from kiro_crew import agent
+
+        target = agent.kiro_agents_dir_path().resolve()
+
+        assert not _inside_a_guarded_root(target), (
+            f"the agent-spec write target is a real home path: {target}"
+        )
+
+    def test_every_seam_in_the_tables_is_actually_pinned(self) -> None:
+        """A table entry nobody patches is documentation, not isolation.
+
+        Resolver bindings are checked only when their module is loaded, matching the
+        fixture's own tolerance: an unimported module has no bound name to reach.
+        """
+        unpinned = []
+        for module, attr in _root._AGENT_SPEC_HOOKS:
+            mod = sys.modules.get(module)
+            if mod is None:
+                unpinned.append(f"{module} not imported, so {attr} could not be set")
+                continue
+            value = getattr(mod, attr, None)
+            if value is None or _inside_a_guarded_root(pathlib.Path(value).resolve()):
+                unpinned.append(f"{module}.{attr} = {value!r}")
+        for module, attr in _root._AGENT_SPEC_RESOLVER_BINDINGS:
+            mod = sys.modules.get(module)
+            if mod is None:
+                continue
+            resolved = getattr(mod, attr)()
+            if _inside_a_guarded_root(pathlib.Path(resolved).resolve()):
+                unpinned.append(f"{module}.{attr}() -> {resolved}")
+
+        assert not unpinned, "these agent-spec seams still resolve a real home:\n" + "\n".join(
+            f"    {entry}" for entry in unpinned
+        )
+
+    def test_the_hook_modules_are_imported_so_the_table_can_reach_them(self) -> None:
+        """The session fixture's whole job: patching cannot precede importing.
+
+        Distinct from the assertion above, which would also pass if a module simply
+        happened to be imported by collection. This one is what makes the four write
+        seams' coverage independent of collection order.
+        """
+        missing = [
+            module for module, _attr in _root._AGENT_SPEC_HOOKS if sys.modules.get(module) is None
+        ]
+
+        assert not missing, f"hook modules never imported, so their seams leak: {missing}"
+
+    def test_one_directory_is_shared_across_the_seams(self) -> None:
+        """A spec written through one seam has to be readable through another."""
+        from kiro_crew import agent, agent_discovery
+
+        assert agent.KIRO_AGENTS_DIR == agent_discovery._KIRO_AGENTS_DIR
+
+    def test_the_guards_ambient_reference_is_left_resolving_the_real_home(self) -> None:
+        """``agent.kiro_agents_dir`` must NOT be pinned, and this says why in a test.
+
+        It is the AMBIENT reference ``_decline_shared_agent_home`` compares the target
+        against. Leaving it real is what makes the pinned hook read as a privately
+        redirected target, which returns early and allows the write. Pin it too and
+        target == ambient, so the guard falls through to its ephemerality check and
+        declines from a linked git worktree -- green in CI, red on a developer machine,
+        which is the setup this repo mandates.
+        """
+        from kiro_crew import agent
+
+        assert _inside_a_guarded_root(agent.kiro_agents_dir().resolve()), (
+            "agent.kiro_agents_dir was pinned; the write guard can no longer tell a "
+            "redirected target from the shared one"
+        )
+        assert agent._decline_shared_agent_home(audit=False) is None, (
+            "the floor's pinned target is being treated as the shared agent home"
+        )
+
+    def test_a_test_can_still_override_the_seams_itself(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is a safety net, not a cage."""
+        from kiro_crew import agent
+
+        mine = tmp_path / "my-own-agents"
+        monkeypatch.setattr(agent, "KIRO_AGENTS_DIR", mine)
+
+        assert agent.kiro_agents_dir_path() == mine
+
+
+class TestTheAgentSpecSeamRatchet:
+    """A NEW agents-dir consumer must not land unpinned.
+
+    Same contract as the shared-path ratchet above: an entry is either pinned by one of
+    the two tables or excluded with a stated reason, so adding a consumer forces a
+    decision. Covers the two shapes that actually leak -- a module-level
+    ``KIRO_AGENTS_DIR`` hook, and a module-level ``from ... import kiro_agents_dir``
+    whose bound name the resolver patch cannot reach.
+    """
+
+    #: Agents-dir bindings that deliberately need no redirect.
+    #:
+    #: The large group is READ-ONLY consumers, excluded for one shared reason worth
+    #: stating once: this floor's remit is host MUTATION, and the dominant isolation
+    #: idiom in this suite is ``patch("<module>.Path.home", ...)`` followed by a read
+    #: through that same module's resolver. Redirecting the bound name silently
+    #: overrides that, so a test that carefully built its own tree reads an empty
+    #: directory instead -- the same trap ``_isolate_kirocrew_home`` documents for
+    #: ``KIRO_HOME``. A read that resolves the operator's real specs can still make a
+    #: test's outcome depend on the operator's machine; that is a determinism concern
+    #: rather than host mutation, and it is not what this file is for.
+    _EXCLUDED: dict[tuple[str, str], str] = {
+        # The guard's AMBIENT reference, not a write target: `agent` writes exclusively
+        # through `kiro_agents_dir_path()`, which reads the hook. Pinning this one makes
+        # target == ambient inside `_decline_shared_agent_home`, so the guard stops
+        # seeing a privately redirected target and declines from a linked worktree.
+        ("kiro_crew/agent.py", "kiro_agents_dir"): "the write guard's ambient reference",
+        # NOT a resolved path -- the RELATIVE string `.kiro/agents`, used as a security
+        # MATCHER. Same reasoning the home-binding ratchet applies to its anchors: a
+        # redirected value would make the guard stop matching the thing it protects.
+        # `test_a_security_matcher_is_not_mistaken_for_a_path_binding` pins the shape so
+        # an edit that turns it into a real path comes back through this table.
+        ("kiro_crew/security.py", "_KIRO_AGENTS_DIR"): "security matcher: a relative string",
+        # Covered by their own hook, which the fixture pins: every call site in these
+        # three routes through a private `_kiro_agents_dir()` that prefers it.
+        ("kiro_crew/agent_discovery.py", "kiro_agents_dir"): "covered by its own hook",
+        ("kiro_crew/apps/bridges.py", "kiro_agents_dir"): "covered by its own hook",
+        ("kiro_crew/cli_doctor.py", "kiro_agents_dir"): "covered by its own hook",
+        # Read-only consumers: see the note above this table.
+        ("kiro_crew/config/loader.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/context.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/cron_script.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/mcp_discovery.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/acp/runtime.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/dashboard/handlers/_shared.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/dashboard/handlers/sessions.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/slack/events.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/slack/gateway.py", "kiro_agents_dir"): "read-only consumer",
+        ("kiro_crew/slack/handler.py", "kiro_agents_dir"): "read-only consumer",
+        (
+            "kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py",
+            "kiro_agents_dir",
+        ): "read-only consumer",
+    }
+
+    @staticmethod
+    def _agents_dir_bindings() -> dict[tuple[str, str], int]:
+        """Module-level ``KIRO_AGENTS_DIR`` hooks and bound ``kiro_agents_dir`` names.
+
+        Parsed rather than grepped for the same reason as the home-binding ratchet: a
+        name imported inside a FUNCTION body is re-resolved per call and so already
+        follows the patched resolver, and only the module-level shape freezes a
+        reference a test can reach.
+        """
+        found: dict[tuple[str, str], int] = {}
+        for path in sorted(_SRC.rglob("*.py")):
+            if "_vendor" in path.parts or "/tests/" in path.as_posix():
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError):  # pragma: no cover - unreadable source
+                continue
+            rel = path.relative_to(_REPO_ROOT / "src").as_posix()
+            pending: list[ast.stmt] = list(tree.body)
+            while pending:
+                node = pending.pop(0)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    continue
+                pending.extend(
+                    child for child in ast.iter_child_nodes(node) if isinstance(child, ast.stmt)
+                )
+                if isinstance(node, ast.ImportFrom):
+                    for alias in node.names:
+                        if alias.name == "kiro_agents_dir":
+                            found[(rel, alias.asname or alias.name)] = node.lineno
+                    continue
+                if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                    continue
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    if isinstance(target, ast.Name) and target.id.endswith("KIRO_AGENTS_DIR"):
+                        found[(rel, target.id)] = node.lineno
+        return found
+
+    def test_every_agents_dir_binding_is_pinned_or_excluded(self) -> None:
+        pinned = {
+            (module.replace(".", "/") + ".py", attr)
+            for module, attr in _root._AGENT_SPEC_HOOKS + _root._AGENT_SPEC_RESOLVER_BINDINGS
+        }
+        # The definition itself is the resolver, not a consumer's frozen reference.
+        pinned.add(("kiro_crew/config/paths.py", "kiro_agents_dir"))
+        unhandled = {
+            key: line
+            for key, line in self._agents_dir_bindings().items()
+            if key not in pinned and key not in self._EXCLUDED
+        }
+
+        assert not unhandled, (
+            "these agents-dir bindings are neither pinned by the rootdir conftest's "
+            "_AGENT_SPEC_HOOKS / _AGENT_SPEC_RESOLVER_BINDINGS nor excluded with a "
+            "reason:\n"
+            + "\n".join(
+                f"    {mod}:{line} {attr}" for (mod, attr), line in sorted(unhandled.items())
+            )
+            + "\nA test that reaches one of these resolves the operator's real agent "
+            "specs. Pin it, or exclude it and say why."
+        )
+
+    def test_the_exclusion_list_has_not_gone_stale(self) -> None:
+        """An exclusion for a binding that no longer exists hides the next one."""
+        bindings = self._agents_dir_bindings()
+        stale = [key for key in self._EXCLUDED if key not in bindings]
+
+        assert not stale, f"_EXCLUDED names bindings that no longer exist: {stale}"
+
+    def test_a_security_matcher_is_not_mistaken_for_a_path_binding(self) -> None:
+        """``security._KIRO_AGENTS_DIR`` is the relative string ``.kiro/agents``.
+
+        It is a MATCHER, not a resolved path, so it must never be redirected -- the
+        same reasoning the home-binding ratchet applies to its security anchors. Pinned
+        here because the name matches this ratchet's suffix rule, so a future edit that
+        turns it into a real path has to come back through this test.
+        """
+        from kiro_crew import security
+
+        assert security._KIRO_AGENTS_DIR == ".kiro/agents"
+        assert not isinstance(security._KIRO_AGENTS_DIR, pathlib.Path)
+
+
 class TestTheSharedKiroPathsArePinned:
     """``~/.kiro`` is kiro-cli's own home -- machine-wide, shared with the real agent.
 

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -149,6 +149,11 @@ class TestListServers:
         installed = {"mcpServers": {"kirocrew-cron": {"command": "kirocrew", "args": ["mcp-cron"]}}}
         (kiro_dir / "kirocrew.json").write_text(json.dumps(installed))
         monkeypatch.setattr("kiro_crew.mcp_discovery.Path.home", lambda: tmp_path)
+        # The installed-config branch resolves ``kiro_agents_dir()``, which reads
+        # ``Path.home`` in ``config.paths`` -- NOT the name patched above. Point the
+        # binding this module holds at the tmp tree instead, or the assertion below is
+        # answered by whatever the operator's own ~/.kiro/agents happens to contain.
+        monkeypatch.setattr("kiro_crew.mcp_discovery.kiro_agents_dir", lambda: kiro_dir)
         monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (tmp_path / "nope.json",))
         servers = list_servers()
         names = {s.name for s in servers}

--- a/test/test_pod_self_contained.py
+++ b/test/test_pod_self_contained.py
@@ -204,7 +204,7 @@ def test_host_scoped_verbs_are_refused(verb):
         rt.require_pod_safe_verb([verb], "wt-feature")
 
 
-def test_app_is_refused_because_it_rewrites_the_host_agent_registry():
+def test_app_is_refused_because_it_rewrites_the_host_agent_registry(unpinned_agent_spec_home):
     """`apps/bridges.py` symlinks app agents into `Path.home()/.kiro/agents` and
     edits `~/.kiro/settings/mcp.json` — the HOST registry. A pod install/uninstall
     would replace or delete symlinks the live gateway depends on."""
@@ -215,6 +215,10 @@ def test_app_is_refused_because_it_rewrites_the_host_agent_registry():
     # directly would assert the override rather than the path bridges actually
     # writes to. The claim under test is unchanged -- bridges targets the
     # machine-wide HOST registry, which is why a pod may not run `app`.
+    #
+    # ``unpinned_agent_spec_home`` because that override is exactly what the rootdir
+    # floor now sets for every test: leaving it pinned would assert that bridges
+    # targets a per-test tmp dir, which is the opposite of the claim.
     assert bridges._kiro_agents_dir() == Path.home() / ".kiro" / "agents"
     assert "app" not in rt._POD_SAFE_VERBS
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -4714,7 +4714,9 @@ class TestKiroAgentsDirWriteProtection:
     write-protected leaves it mirrors.
     """
 
-    def test_directory_is_tail_of_kiro_agents_dir(self, monkeypatch) -> None:
+    def test_directory_is_tail_of_kiro_agents_dir(
+        self, monkeypatch, unpinned_agent_spec_home
+    ) -> None:
         # Drift guard: the literal in security.py must stay the home-relative tail
         # of config.paths.kiro_agents_dir() (kept a literal only to avoid a
         # config->security import cycle). If kiro-cli's layout moves, this fails
@@ -4724,6 +4726,10 @@ class TestKiroAgentsDirWriteProtection:
         # override case), and ``relative_to(Path.home())`` raises ValueError then.
         # The literal is the home-relative default tail, so the assertion is about
         # the default home; clear the overrides to make it deterministic.
+        #
+        # ``unpinned_agent_spec_home`` for the same reason: the rootdir floor points
+        # the resolver at a per-test tmp dir, which has no home-relative tail to
+        # compare. The claim under test is about the REAL default layout.
         monkeypatch.delenv("KIRO_HOME", raising=False)
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         from kiro_crew.config.paths import kiro_agents_dir


### PR DESCRIPTION
## What is the problem?

The suite's host-mutation floor isolates the DATA home per test, and the `~/.kiro` paths production binds at IMPORT time. It does not isolate the AGENT-SPEC home. `kiro_agents_dir()` is a LAZY resolver (`kiro_home()` -> `$KIRO_HOME` or `Path.home()/.kiro`), which is a shape the existing coverage explicitly does not reach -- the shared-path ratchet's own docstring records lazy resolvers as outside its scope.

So any test that reached the spec write path without locally patching a seam rewrote the operator's machine-wide `<kiro home>/agents/kirocrew.json`. Measured on this branch's base, inside a test with the full floor active: the data home resolved to a per-test tmp dir while `agent.kiro_agents_dir_path()` resolved the real `~/.kiro/agents`, and all four of the modules' `KIRO_AGENTS_DIR` override hooks were `None`.

## Why this issue matters to the user

That file is what kiro-cli reads to learn which MCP servers exist, and the writer stamps ITS OWN paths into it: `_managed_mcp_env` pins the writing instance's venv into every managed server's `command` and its data home into their `env`.

Confirmed live. After a suite run inside a throwaway clone, every new session on the machine spawned `kirocrew-core` / `kirocrew-cron` from that clone's venv with a per-test data home pinned in `env`. Both were gone by then; the home was recreated empty on first use, `read_local_secret()` returned `""`, and every internal HTTP call failed `internal_auth_mismatch` with `received=absent` -- `spawn_run`, `learn_add` and `cron_*` all dead while in-process tools kept working. A gateway restart healed it, because boot re-runs `rebuild_agent_config`; the next suite run broke it again. That loop is why the failure looked intermittent and resistant to fixes.

#4932 closed the production guard half of this (a temp-dir checkout is now refused). This is the test-seam half: it holds even if the guard regresses, and it also covers a DURABLE checkout, which the guard deliberately allows.

## How our fix solves it

The chain is symptom -> stale spec -> a test resolving the real agents dir -> nothing in the floor pinning it. The fix acts at the last link.

A fifth part is added to the floor, pinning the per-module override seams at one per-test directory:

- **`_AGENT_SPEC_HOOKS`** -- the four modules carrying the documented `KIRO_AGENTS_DIR` hook (`agent`, `agent_discovery`, `apps.bridges`, `cli_doctor`). Production already offers this hook for "a caller (test/tooling)"; the floor just sets it by default instead of per test.
- **`_AGENT_SPEC_RESOLVER_BINDINGS`** -- the 16 modules that bind `kiro_agents_dir` by NAME, which no hook can reach. Includes `config.paths` itself, which catches consumers importing the name inside a function body (`auto_improvement.spine.agent_runner` copies specs that way).

Three decisions worth naming, because each one is a trap:

1. **Not `KIRO_HOME`.** The issue suggested pinning it; `_isolate_kirocrew_home` already documents why that is refused -- ~35 tests isolate `kiro_home()` the other way round with `patch("pathlib.Path.home", ...)`, and an env pin overrides their own isolation so they read an empty directory instead of the tree they just built. Pinning the seams leaves both levers alone. The installed resolver additionally DEFERS to a test that sets `KIRO_HOME` itself (the variable is cleared first, so anything visible afterwards was chosen by the test, not exported by the operator).
2. **`agent.kiro_agents_dir` is deliberately NOT pinned.** It is not a write target -- `agent` writes exclusively through `kiro_agents_dir_path()`, which reads the hook. It is the AMBIENT reference `_decline_shared_agent_home` compares the target against. Leaving it real is what makes the pinned hook read as a privately redirected target, which returns early and allows the write. Pin it too and target == ambient, so the guard falls through to its ephemerality check and declines from a linked git worktree: green in CI, red on a developer machine, which is the setup this repo mandates. A test asserts this rather than only a comment.
3. **Eager import for the hooks only.** `_isolate_shared_kiro_paths` tolerates "patch whatever is in `sys.modules`", whose residual hole is a module first imported inside a test's own body. That is fine for a read-only path and not for these four, which WRITE. They are imported once per worker process: measured cold, agent 177 ms + cli_doctor 87 ms + bridges 33 ms + agent_discovery 19 ms = ~315 ms per worker for a whole session. The resolver-binding table keeps the tolerance, since it is far wider and includes the repo's heaviest modules.

## What tests we did

- **Reproduced first**, on the unmodified base, with a read-only probe: data home isolated, `kiro_agents_dir_path()` = the real `~/.kiro/agents`, all four hooks `None`. It never wrote there. Re-run after the fix, every seam resolves the per-test directory.
- **6 behaviour tests** in `TestTheAgentSpecHomeIsPinnedForEveryTestpath`: the write target is not a real home; every table entry is actually pinned; the hook modules are imported so the table can reach them; one directory is shared across seams; the guard's ambient reference is still real AND the guard still allows the write; a test can still override the seams itself.
- **3 ratchet tests** in `TestTheAgentSpecSeamRatchet`, AST-based like the home-binding ratchet: every module-level agents-dir binding is pinned or excluded with a reason, the exclusion list is not stale, and `security._KIRO_AGENTS_DIR` is still a relative string rather than a resolved path. The ratchet earned its place immediately -- it found 9 consumers a grep had missed, including a writer in `dashboard/handlers/mcp`.
- **Mutation-verified**: flipping the fixture to `autouse=False` turns 4 of the new tests red.
- **61 affected test files** (every file referencing `kiro_agents_dir` / `KIRO_AGENTS_DIR` / `rebuild_agent_config` / `_register_agents`): 5681 passed, 22 skipped, 0 failed. `black` / `flake8` / `mypy` clean on the touched files; the brand gate passes.

Seven tests failed on the first pass and each was a real interaction, not noise:

- Four isolate themselves with `monkeypatch.setenv("KIRO_HOME", ...)`, and replacing the resolver outright had voided that lever. Fixed in the fixture by deferring to a test-chosen `KIRO_HOME`, which is better than editing four tests.
- Two are drift guards that ASSERT on the real layout (`security`'s `.kiro/agents` literal being the home-relative tail; `apps.bridges` targeting the machine-wide registry, which is why a pod may not run `app`). They now take the opt-in `unpinned_agent_spec_home` fixture. Pinning them would have made each assert about a path that does not ship -- weakening a guard to satisfy an isolation fixture.
- One was a latent defect this floor exposed: `test_list_merges_installed_config` patched `mcp_discovery.Path.home`, but the branch under test resolves `kiro_agents_dir()`, which reads `Path.home` in `config.paths`. The assertion was being answered by whatever the operator's own `~/.kiro/agents/kirocrew.json` happened to contain. It now points the binding at its own tmp tree.

## Any other suggestions on the work

- `unpinned_agent_spec_home` hands back the real machine-wide location, so it is READ-ONLY by contract and its docstring says so. Nothing mechanically enforces that. If a third user ever appears, a guard that fails when a test writes through it would be worth more than the docstring.
- The resolver-binding table is wide because 16 modules each froze their own reference to one resolver. Routing them through a single accessor (the shape `agent` and three others already use) would shrink the table to the hooks alone. That is a production refactor and does not belong here.
- The ratchet catches a module-level `from ... import kiro_agents_dir` and a `*KIRO_AGENTS_DIR` assignment. A binding DERIVED from another is invisible to it, the same limitation the home-binding ratchet documents about itself.

Closes #4912
