### PR TITLE
fix(windows): carry settings across the npm rename instead of silently resetting them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,9 @@ sessions. It drives an LLM through the KiroACP provider (the ACP adapter running
 - **Backend:** Python package `kiro_crew` in `src/kiro_crew/`.
 - **Frontend:** React + TS + Vite SPA in `website/`; the built `dist/` is staged
   into `src/kiro_crew/static/dist/` and served by the backend.
-- **Data home:** `~/.kiro/crew` (the legacy `~/.kirocrew` auto-migrates).
-  Override with `KIROCREW_HOME`.
+- **Data home:** `~/.kiro/crew`, overridden with `KIROCREW_HOME`. The legacy
+  `~/.kirocrew` is fully deprecated and no longer auto-migrates; it survives only
+  in sensitive-path deny lists, which must keep covering it.
 - **Distribution:** public GitHub, plain setuptools, public PyPI / public npm.
 
 Full map: [`docs/architecture/overview.md`](docs/architecture/overview.md).

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -15,15 +15,12 @@ build — the installer compresses its own already-signed executable — so that
 needs AWS credentials the shared build workflow deliberately does not hold.
 Current status:
 
-- **Published on nightly and insider** — `publish-windows.yml` writes the
-  installer, its `.blockmap` and the `latest.yml` feed to the download CDN. The
-  `latest/` alias is the human download:
+- **Published on every channel — nightly, insider and stable.** The `latest/`
+  alias is the human download:
   `https://download.crew.kiro.dev/desktop/<channel>/latest/KiroCrew-Setup.exe`.
-  **Stable has no Windows lane yet**: the stable release republishes the
-  immutable promotion bundle, whose artifact roles include no Windows installer,
-  so `WINDOWS_CHANNELS` in `auto-update.js` admits only `nightly` and `insider`
-  and a stable Windows client reports updates as unavailable rather than
-  resolving a feed nobody wrote.
+  A stable release republishes the already-signed installer it verified at
+  insider time rather than rebuilding it. If a Windows build fails, that release
+  simply ships without an installer instead of holding up the other platforms.
 - **Authenticode-signed** — signing runs during the build through AWS Signer and
   the publish lane refuses to publish bytes whose certificate table is empty,
   whose signer is not the pinned publisher, or which carry no RFC3161
@@ -74,7 +71,11 @@ Current status:
   channel cannot touch the other's pending download or window state. An install
   predating that split leaves a shared `kirocrew-electron-mac-updater` behind,
   which is deliberately NOT removed for the same reason — it may still belong to
-  the other channel. **Deliberately kept:** `~/.kiro/crew` — sessions, memory,
+  the other channel. **Your settings survive that rename**: the first launch after
+  it carries over your update channel, remote hosts, hotkey and window position,
+  so an Insider install is not quietly moved to Stable. A preference you have
+  already changed is never overwritten.
+  **Deliberately kept:** `~/.kiro/crew` — sessions, memory,
   the database and config. Delete it by hand to remove Kiro Crew's data too.
   Also kept, because it belongs to a different product:
   `%LOCALAPPDATA%\Kiro-Cli`.

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -280,6 +280,16 @@ which testpath asked for the workers.
   about the host. Neither replaces the rule: **anything you start, something must
   stop — and a stub is not a stop.**
 
+  A second shape of the same hook survives even a clean shutdown: CPython cannot
+  unregister an at-fork hook, so after a proper `shutdown()` the hook still runs in
+  every fork child and restarts a ticker thread that exits almost immediately. Each
+  fork then races that short-lived thread independently — one fork child can count 1
+  thread while the next counts 2. The consequence for tests: **a single-threaded
+  pre-check fork proves nothing about the fork that produces the verdict.** A guard
+  for the multithreaded collapse must read the collapse off the verdict itself (the
+  probe's reason names it; `sandbox._probe_reason_is_multithreaded_collapse`), not
+  predict it from a separate probe.
+
 - **A handler that answers before its work finishes must be awaited, not slept on.**
   `api_chat_slot_slack_link` returns 200 as soon as the link is persisted and hands the
   Slack backfill to `asyncio.create_task`, tracked in `state._background_tasks`. Six

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -261,6 +261,29 @@ _PROBE_STEP_NEWNS = "unshare(CLONE_NEWNS)"
 #: ``_probe_child_thread_count``.
 _PROBE_STEP_MULTITHREADED = "M"
 
+#: Trailing clause of the reason `_probe_parent_sequence` emits for the
+#: `_PROBE_STEP_MULTITHREADED` collapse. A single shared spelling, because callers
+#: that must RECOGNIZE the collapse (a fork child whose verdict is unobtainable is
+#: an unknown reading, not a disagreement) match against the reason text -- a
+#: hand-copied substring would drift the moment the wording changes.
+_PROBE_MULTITHREADED_REASON = (
+    "an os.register_at_fork hook started one, so the kernel's own verdict is "
+    "unobtainable from this child"
+)
+
+
+def _probe_reason_is_multithreaded_collapse(reason: str) -> bool:
+    """Whether a probe reason reports the multithreaded-fork-child collapse.
+
+    True only for the fork path: the collapse text is emitted by
+    `_probe_parent_sequence` when the probe child counted more than one thread,
+    which happens when an ``os.register_at_fork`` hook armed earlier in the
+    calling process starts a thread inside every fork child. The verdict such a
+    child returns is the hook's artifact, not the kernel's answer.
+    """
+    return _PROBE_MULTITHREADED_REASON in (reason or "")
+
+
 # A probe child that vanished mid-handshake is a harness failure, not a kernel
 # verdict, so it must not be cached as "this host has no sandbox". Kept separate
 # from _TRANSIENT_PROBE_ERRNOS so that set's cache semantics stay untouched.
@@ -752,9 +775,8 @@ def _probe_parent_sequence(
             ok,
             transient,
             f"{reason}; the probe child had {err} threads, which alone makes it "
-            "return EINVAL (CLONE_NEWUSER implies CLONE_THREAD) -- an "
-            "os.register_at_fork hook started one, so the kernel's own verdict is "
-            "unobtainable from this child",
+            "return EINVAL (CLONE_NEWUSER implies CLONE_THREAD) -- "
+            f"{_PROBE_MULTITHREADED_REASON}",
             remedy,
         )
     if step != "U":

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -902,14 +902,20 @@ print(before, after, spawned)
         path's transient failure strings name a Popen-owned child differently, and
         that difference is not a verdict.
 
-        The comparison only means something while a fork child of this worker is
-        single-threaded: an ``os.register_at_fork`` hook armed earlier in the same
-        worker (test ordering under xdist decides this) starts a thread inside
-        every child, and the fork path then reports the deliberate
+        The comparison only means something while the fork child that PRODUCED the
+        verdict was single-threaded. An ``os.register_at_fork`` hook armed earlier
+        in the same worker (test ordering under xdist decides this) starts a thread
+        inside every child, and the fork path then reports the deliberate
         ``_PROBE_STEP_MULTITHREADED`` collapse instead of the kernel's verdict --
         an unknown reading, so it is skipped, not compared (see
         docs/system-specs/common/testing-conventions.md; the collapse itself is
         issue #4219's open decision).
+
+        Two guards, because the hook-started thread is SHORT-LIVED and each fork
+        races it independently: the `_forked_child_thread_count` pre-check is
+        cheap and catches the steady state, but a clean pre-check child does not
+        prove the verdict child was clean. The decisive check therefore reads the
+        collapse off the verdict tuple itself, after the probe ran.
         """
         child_threads = _forked_child_thread_count()
         if child_threads < 0:
@@ -929,6 +935,14 @@ print(before, after, spawned)
         spawned = sb._probe_unshare_via_spawn()
         assert spawned is not None, "this host can spawn an interpreter"
         forked = sb._probe_unshare_via_fork()
+        if sb._probe_reason_is_multithreaded_collapse(forked[2]):
+            pytest.skip(
+                "the fork child that produced the verdict came up multithreaded "
+                "despite a clean pre-check: the at-fork-hook thread is short-lived "
+                "and each fork races it independently, so the kernel's verdict is "
+                "unobtainable from this worker's fork children (the collapse is "
+                "deliberate; see issue #4219)"
+            )
         assert spawned[0] == forked[0], (spawned, forked)
         assert spawned[1] == forked[1], (spawned, forked)
         assert spawned[3] == forked[3], (spawned, forked)
@@ -948,6 +962,36 @@ print(before, after, spawned)
         with pytest.raises(pytest.skip.Exception):
             self.test_both_paths_report_the_same_verdict_on_this_host()
         assert probed["n"] == 0, "the guard must skip BEFORE probing anything"
+
+    def test_verdict_comparison_skips_when_the_verdict_child_itself_collapsed(
+        self, monkeypatch
+    ):
+        """A clean pre-check does not clear the verdict child -- each fork races.
+
+        The at-fork-hook thread is short-lived, so the `_forked_child_thread_count`
+        pre-check child and `_probe_unshare_via_fork`'s verdict child can disagree:
+        pre-check counts 1, verdict child still comes up multithreaded and reports
+        the collapse. That reading is unknown, never a red -- the skip must be
+        decided off the verdict tuple itself.
+        """
+        monkeypatch.setattr(
+            sys.modules[__name__], "_forked_child_thread_count", lambda: 1
+        )
+        monkeypatch.setattr(
+            sb, "_probe_unshare_via_spawn",
+            lambda: (False, False, "unshare(CLONE_NEWNS) failed with errno 1 (EPERM)", "apparmor_userns"),
+        )
+        collapse = (
+            False,
+            False,
+            "unshare(CLONE_NEWUSER) failed with errno 22 (EINVAL); the probe child "
+            f"had 2 threads, which alone makes it return EINVAL (CLONE_NEWUSER "
+            f"implies CLONE_THREAD) -- {sb._PROBE_MULTITHREADED_REASON}",
+            "no_user_ns",
+        )
+        monkeypatch.setattr(sb, "_probe_unshare_via_fork", lambda: collapse)
+        with pytest.raises(pytest.skip.Exception):
+            self.test_both_paths_report_the_same_verdict_on_this_host()
 
     def test_verdict_comparison_still_fails_on_a_real_disagreement(self, monkeypatch):
         """The guard must not swallow a genuine disagreement on a clean shard.

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -127,7 +127,17 @@ const {
 
 const { migrateRemoteHostConfig, getRemoteHostConfig, setRemoteHostConfig } = require("./host-config");
 
+const { seedRenamedStore } = require("./store-rename");
+
 const { isLocalGatewayEnabled, setLocalGatewayEnabled, classifyStartFailure } = require("./local-gateway");
+
+// Carry settings across the npm `name` rename, by writing the new store's file
+// BEFORE electron-store opens it. Order is load-bearing: construction writes the
+// defaults, after which the file always exists and the seed can never run. It only
+// ever writes a file that does not exist, so it cannot overwrite anything.
+seedRenamedStore(app.getPath("userData"), {
+  log: (m) => console.log(`store migration: ${m}`),
+});
 
 const store = new Store({
   defaults: {
@@ -144,6 +154,7 @@ const store = new Store({
     linuxFrameless: null,                  // Linux window chrome: true = frameless, false = native frame, null = follow the desktop environment (see linux-frame.js)
   },
 });
+
 
 // Read ONCE at launch, because the setting takes effect on the next launch.
 // startGateway() is also the recovery path for a gateway that died mid-session,

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -165,6 +165,7 @@
       "pyspy-dump.js",
       "perf-metrics.js",
       "host-config.js",
+      "store-rename.js",
       "remote-token.js",
       "token-acquire.js",
       "token-retry.js",

--- a/website/electron/store-rename.js
+++ b/website/electron/store-rename.js
@@ -1,0 +1,288 @@
+// Carry settings across the npm `name` rename by SEEDING the new store's file.
+//
+// Electron derives the userData directory from the npm package name, so renaming it
+// ("kirocrew-electron-mac" -> "kirocrew-desktop" / "kirocrew-desktop-nightly")
+// repoints electron-store at a brand-new directory and every setting in the old one
+// is silently orphaned. The rename itself is correct and load-bearing — a shared name
+// made both channels write ONE userData dir and ONE updater cache, so uninstalling
+// either destroyed the other's window state and pending download — but nothing
+// carried the existing settings across.
+//
+// updateChannel is why this is a bug rather than an inconvenience. It is the
+// stable<->insider switcher, and resolveChannel() treats an unset preference as
+// "follow stable", so an insider user whose preference is orphaned is moved onto the
+// stable feed with no consent and no message — exactly what that function's contract
+// says a channel decision must never do implicitly.
+//
+// WHY SEEDING, AND NOT A MERGE. The hard part is never copying values; it is proving
+// the destination is untouched. Value comparison cannot do it, because every default
+// is REACHABLE — clearing your last remote host leaves `{}`, clearing the accent
+// leaves "" — and no persisted flag can do it either, because a retry has to answer
+// two questions that pull apart: "may I read the legacy store?" (yes, even though
+// config.json now exists) and "is the destination untouched?" (no, the user has had a
+// session with it).
+//
+// Writing the file BEFORE electron-store opens it collapses both questions into one
+// filesystem fact, and keeps no bookkeeping at all:
+//
+//   file absent    -> there is nothing to overwrite, by definition
+//   seeding throws -> file stays absent -> the next launch retries identically
+//   seeding works  -> file exists       -> never eligible again
+//
+// Deliberately NOT handled here: the legacy directory is left in place. It may still
+// be the OTHER channel's live store (both channels shared it before the rename), so
+// removing it is the same cross-channel hazard the rename exists to end. The same
+// reasoning governs the updater cache in build/installer.nsh, which declines to
+// remove the shared pre-rename directory.
+
+const fs = require("fs");
+const path = require("path");
+
+// The pre-rename npm package name, and so the pre-rename userData directory. Pinned
+// rather than derived: the rename removed it from package.json, so there is nothing
+// left to compute it from.
+const LEGACY_STORE_NAME = "kirocrew-electron-mac";
+
+// electron-store's file name inside a userData directory.
+const STORE_FILE_NAME = "config.json";
+
+// Attempts at reading the legacy store before giving up. More than one because a
+// failed read cannot be retried on a LATER launch: the seed writes nothing, main.js
+// constructs the store regardless, and the destination then exists for good. Small
+// because the realistic cause is a momentary lock, not a lasting condition.
+const LEGACY_READ_ATTEMPTS = 3;
+
+// Pause between failed read attempts. Without one the retries all land in the same
+// tick, and a lock that outlives a microsecond — the other channel flushing its own
+// store, a scanner holding the file — defeats all three at once, making them one
+// attempt in disguise. Growing, because a lock that survived the first wait is more
+// likely a slow holder than a fast one. The wait only ever runs on a launch that is
+// already about to lose the settings, so it costs the common path nothing.
+const LEGACY_READ_BACKOFF_MS = [80, 240];
+
+// Synchronous sleep. This runs at boot before any window exists, so blocking the
+// main process is acceptable and an async hop is not available to the caller —
+// main.js must construct the store immediately after this returns.
+function sleepSync(ms) {
+  // A non-finite or non-positive timeout must never reach Atomics.wait: an
+  // undefined/NaN timeout means WAIT FOREVER, which here would hang boot with no
+  // window on screen — strictly worse than any settings loss this module exists
+  // to prevent. Guarded structurally rather than by call-site inspection.
+  const t = Number(ms);
+  if (!Number.isFinite(t) || t <= 0) return;
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, t);
+  } catch {
+    /* SharedArrayBuffer unavailable — proceed without the wait */
+  }
+}
+
+// Settings worth carrying, as an ALLOWLIST rather than a wholesale copy: the legacy
+// file is a full store dump that may contain keys a newer build has retired, and
+// copying it verbatim would resurrect settings this build no longer understands.
+//
+// No key needs excluding for ambiguity here. Seeding only ever happens when the
+// destination does not exist, so there is no user choice to override — which is what
+// lets the behavioural settings (runLocalGateway, sshTimeoutMs) come along. Dropping
+// those would mean a user who runs as a pure client gets an unwanted local gateway on
+// the first launch after the rename.
+const MIGRATED_KEYS = [
+  // Behavioural: an orphaned value silently changes which release channel the user
+  // follows, or starts a gateway they run as a pure client to avoid.
+  "updateChannel",
+  "runLocalGateway",
+  // Remote-connection setup, which is real configuration work to redo. The
+  // single-host pair predates remoteHosts and is consumed by a SECOND migration that
+  // runs right after this one (host-config.js migrateRemoteHostConfig converts it to
+  // the per-port map). Dropping the pair loses the connection twice over: the seed
+  // carries an empty map, and the host migration then finds nothing to convert.
+  "remoteHosts",
+  "remoteHost",
+  "kirocrewBinPath",
+  "sshTimeoutMs",
+  // Comfort, but immediately visible as "the app forgot me".
+  "windowState",
+  "themeAccent",
+  "globalHotkey",
+  "linuxFrameless",
+];
+
+// Defaults main.js constructs the store with, for the keys above. A legacy value equal
+// to its own default carries no intent, so seeding it would only re-state the default
+// and make an empty migration look like a real one.
+const KEY_DEFAULTS = {
+  updateChannel: "",
+  remoteHost: "",
+  kirocrewBinPath: "~/.local/bin/kirocrew",
+  runLocalGateway: true,
+  remoteHosts: {},
+  sshTimeoutMs: 20000,
+  windowState: null,
+  themeAccent: "",
+  globalHotkey: null,
+  linuxFrameless: null,
+};
+
+function isDefault(key, value) {
+  const fallback = KEY_DEFAULTS[key];
+  // Objects (remoteHosts, windowState) need a structural comparison.
+  if (typeof fallback === "object" && fallback !== null) {
+    try { return JSON.stringify(value) === JSON.stringify(fallback); } catch { return false; }
+  }
+  return value === fallback;
+}
+
+/**
+ * electron-store's config.json inside the PRE-RENAME userData directory, derived from
+ * the live one.
+ *
+ * Derived rather than rebuilt per platform on purpose: Electron picks userData
+ * differently on each OS (`%APPDATA%\<name>`, `~/Library/Application Support/<name>`,
+ * `~/.config/<name>`), so hand-rolling "APPDATA or ~/.config" silently resolved to a
+ * nonexistent `~/.config` path on macOS — the lookup ENOENT'd, the failure was
+ * swallowed, and every setting stayed orphaned there. The legacy directory is always a
+ * SIBLING of the current one, whatever Electron chose.
+ *
+ * @param {string} userDataPath app.getPath("userData")
+ * @returns {string} path to the legacy config.json, or "" if it cannot be derived
+ */
+function legacyStoreFile(userDataPath) {
+  if (typeof userDataPath !== "string" || !userDataPath) return "";
+  // Pick the parser from the path's own SHAPE rather than process.platform, so all
+  // three layouts stay testable on one machine and a win32 path is never parsed with
+  // POSIX semantics.
+  const impl = /^[A-Za-z]:[\\/]|^\\\\/.test(userDataPath) ? path.win32 : path.posix;
+  const normalized = userDataPath.replace(/[\\/]+$/, "");
+  const parent = impl.dirname(normalized);
+  if (!parent || parent === normalized) return "";
+  return impl.join(parent, LEGACY_STORE_NAME, STORE_FILE_NAME);
+}
+
+/**
+ * Seed a not-yet-existing store file with the settings orphaned by the rename.
+ *
+ * MUST be called before `new Store(...)`: electron-store writes its defaults to
+ * config.json on construction, after which the file always exists and this can never
+ * run.
+ *
+ * Fails SOFT and SILENT. It runs at boot, before any window or error dialog exists, so
+ * nothing here may throw — losing this convenience must never cost the user their app.
+ * An absent legacy store is also the overwhelmingly common case (every fresh install),
+ * so it is not worth a log line on every launch.
+ *
+ * @param {string} userDataPath app.getPath("userData")
+ * @param {object} [opts]
+ * @param {() => object|null} [opts.readLegacy] injected for tests
+ * @param {(file:string, data:string) => void} [opts.writeFile] injected for tests
+ * @param {(msg:string) => void} [opts.log]
+ * @param {(ms:number) => void} [opts.sleep] injected for tests; defaults to a real
+ *   synchronous wait between failed legacy-read attempts
+ * @returns {boolean} whether a file was written
+ */
+function seedRenamedStore(userDataPath, { readLegacy = null, writeFile = null, log = null, sleep = sleepSync } = {}) {
+  const target = path.join(userDataPath || "", STORE_FILE_NAME);
+  // This invocation's temp sibling, named outside the try so the failure path can
+  // remove exactly the file this call created and nothing else.
+  let tmp = "";
+  try {
+    // The ONLY eligibility condition. An existing destination is the user's, whether
+    // from a prior launch or from an install that already crossed the rename.
+    if (fs.existsSync(target)) return false;
+
+    const read = readLegacy || (() => {
+      const file = legacyStoreFile(userDataPath);
+      if (!file) return null;
+      return JSON.parse(fs.readFileSync(file, "utf8"));
+    });
+    // A read that fails is the one case with no second chance: the seed writes
+    // nothing, main.js constructs the store anyway (it must — boot cannot be held
+    // hostage to a convenience), and the destination then exists forever. Retry a
+    // couple of times in-process to ride out the realistic cause, a momentary lock
+    // from the other channel or a scanner touching the same file.
+    //
+    // If it still fails the settings are lost and we say so in the log. That is
+    // accepted deliberately: the alternatives are refusing to boot, or persisting a
+    // retry flag whose two meanings ("may I read?" and "is the destination
+    // untouched?") cannot both be answered correctly — the ambiguity this design
+    // exists to remove.
+    let legacy = null;
+    for (let attempt = 0; attempt < LEGACY_READ_ATTEMPTS; attempt += 1) {
+      try {
+        legacy = read();
+        break;
+      } catch (err) {
+        // Absent is final and silent: there was never anything to carry.
+        if (err && err.code === "ENOENT") return false;
+        // Corrupted is final and loud: waiting cannot fix malformed JSON — the same
+        // bytes fail identically on every attempt, this launch or any other.
+        if (err instanceof SyntaxError) {
+          if (log) log(`pre-rename store is not valid JSON, settings not carried: ${err.message}`);
+          return false;
+        }
+        if (attempt === LEGACY_READ_ATTEMPTS - 1) {
+          if (log) log(`could not read the pre-rename store, settings not carried: ${err && err.message}`);
+          return false;
+        }
+        sleep(LEGACY_READ_BACKOFF_MS[Math.min(attempt, LEGACY_READ_BACKOFF_MS.length - 1)]);
+      }
+    }
+    if (!legacy || typeof legacy !== "object") return false;
+
+    const seed = {};
+    for (const key of MIGRATED_KEYS) {
+      // Key ABSENCE, not emptiness, means "the legacy store has nothing to say". An
+      // explicit "" is a real choice — main.js documents globalHotkey null as
+      // "platform default" and "" as "disabled" — so treating empty as absent would
+      // silently re-enable a hotkey the user turned off.
+      if (!Object.prototype.hasOwnProperty.call(legacy, key)) continue;
+      const value = legacy[key];
+      if (value === undefined) continue;
+      if (isDefault(key, value)) continue;
+      seed[key] = value;
+    }
+    const keys = Object.keys(seed);
+    if (!keys.length) return false;
+
+    // ATOMIC: write a temp sibling, then rename. config.json is what electron-store
+    // parses on the next launch, so a torn write is worse than no migration at all —
+    // the store would either throw on malformed JSON or silently reset. A rename
+    // within one directory is atomic, so the destination only ever appears complete.
+    //
+    // The sibling is UNIQUE per invocation. Two first launches can both reach the
+    // seed (Electron's single-instance lock is taken later), and a shared temp name
+    // would let one process truncate the sibling while the other renames it —
+    // exposing a partial config.json that electron-store then fails to parse on
+    // every later boot. With per-invocation siblings both renames are whole-file:
+    // last writer wins, and both seeds are complete JSON from the same legacy
+    // source. The pid alone would collide only via pid reuse against an orphan left
+    // by a crash; the random suffix closes that at no cost.
+    const tmpName = `${target}.migrating.${process.pid}.${Math.random().toString(36).slice(2, 8)}`;
+    tmp = tmpName;
+    const write = writeFile || ((file, data) => {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, data);
+    });
+    write(tmpName, `${JSON.stringify(seed, null, "\t")}\n`);
+    fs.renameSync(tmpName, target);
+    if (log) log(`carried ${keys.length} setting(s) from the pre-rename store: ${keys.join(", ")}`);
+    return true;
+  } catch (err) {
+    // Remove ONLY this invocation's temp sibling — never `target`. The destination
+    // is not this call's to delete: a rival first launch may have just renamed its
+    // own complete seed there, and deleting `target` would destroy the winner's
+    // freshly migrated settings and hand the user defaults instead. The atomic
+    // rename already guarantees the destination is either absent or complete.
+    if (tmp) {
+      try { fs.rmSync(tmp, { force: true }); } catch { /* best effort */ }
+    }
+    if (log) log(`skipped: ${(err && err.message) || err}`);
+    return false;
+  }
+}
+
+module.exports = {
+  seedRenamedStore,
+  legacyStoreFile,
+  MIGRATED_KEYS,
+  LEGACY_STORE_NAME,
+};

--- a/website/electron/test/store-rename-migration.test.js
+++ b/website/electron/test/store-rename-migration.test.js
@@ -1,0 +1,491 @@
+// Migration of the per-user electron-store directory across the npm `name`
+// rename ("kirocrew-electron-mac" -> "kirocrew-desktop" / "-nightly").
+//
+// WHY THIS EXISTS. Electron derives userData from the npm package name, so renaming
+// it repoints electron-store at a brand-new directory and every setting in the old
+// one is silently orphaned. Observed on a machine that took the nightly rename:
+// %APPDATA%\kirocrew-electron-mac\config.json still held
+//
+//     "updateChannel": "stable",  "windowState": {...},  "themeAccent": "#8e48ff"
+//
+// while the freshly created kirocrew-desktop-nightly\config.json had
+// `updateChannel: ""` and default geometry.
+//
+// The worst loss is updateChannel, because it is the stable<->insider switcher and
+// resolveChannel() treats an unset preference as STABLE. An insider user whose
+// preference is orphaned is migrated onto the stable feed with no consent and no
+// message -- the exact outcome resolveChannel's contract calls out as the thing a
+// channel decision must never do implicitly.
+//
+// HOW IT AVOIDS OVERWRITING ANYTHING. The migration SEEDS the destination
+// config.json before electron-store opens it, and only ever when that file does not
+// exist. That single condition carries the whole state machine, which is why there
+// is no marker, no pending flag and no "is this store fresh?" verdict to get wrong:
+//
+//   file absent    -> there is nothing to overwrite, by definition
+//   seeding throws -> file stays absent -> the next launch retries identically
+//   seeding works  -> file exists       -> never eligible again
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Store = require("electron-store");
+
+const {
+  seedRenamedStore,
+  legacyStoreFile,
+  MIGRATED_KEYS,
+  LEGACY_STORE_NAME,
+} = require("../store-rename");
+
+// The real defaults main.js constructs the store with.
+const DEFAULTS = {
+  remoteHost: "",
+  kirocrewBinPath: "~/.local/bin/kirocrew",
+  remoteHosts: {},
+  sshTimeoutMs: 20000,
+  windowState: null,
+  globalHotkey: null,
+  lastNudgedVersion: "",
+  themeAccent: "",
+  updateChannel: "",
+  runLocalGateway: true,
+  linuxFrameless: null,
+};
+
+function tmpUserData() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "kc-store-"));
+}
+
+// Open a REAL electron-store the way main.js does, so assertions run against the
+// library's own merge of file + defaults rather than a hand-rolled fake. An earlier
+// fake returned `undefined` for untouched keys and hid a bug: electron-store writes
+// its defaults to config.json on construction, so `get()` really returns 20000 /
+// true / {} for keys nobody ever set.
+function openStore(userData) {
+  return new Store({ cwd: userData, defaults: DEFAULTS });
+}
+
+test("seeds every orphaned setting into a store that does not exist yet", () => {
+  const userData = tmpUserData();
+  const legacy = {
+    updateChannel: "insider",
+    themeAccent: "#8e48ff",
+    windowState: { x: 116, y: 0, width: 1354, height: 913 },
+    globalHotkey: "Alt+Space",
+    remoteHosts: { 5476: { host: "box", binPath: "/usr/bin/kirocrew" } },
+    sshTimeoutMs: 30000,
+    runLocalGateway: false,
+    linuxFrameless: true,
+  };
+  assert.strictEqual(seedRenamedStore(userData, { readLegacy: () => legacy }), true);
+
+  // Read back through electron-store, which is what main.js will see.
+  const store = openStore(userData);
+  assert.strictEqual(store.get("updateChannel"), "insider");
+  assert.strictEqual(store.get("themeAccent"), "#8e48ff");
+  assert.deepStrictEqual(store.get("windowState"), legacy.windowState);
+  assert.strictEqual(store.get("globalHotkey"), "Alt+Space");
+  assert.deepStrictEqual(store.get("remoteHosts"), legacy.remoteHosts);
+  // Behavioural keys are carried too. There is no ambiguity to fear here: the
+  // destination did not exist, so `runLocalGateway: false` cannot be overriding a
+  // choice. A stable user who runs as a pure client keeps that setup.
+  assert.strictEqual(store.get("sshTimeoutMs"), 30000);
+  assert.strictEqual(store.get("runLocalGateway"), false);
+  assert.strictEqual(store.get("linuxFrameless"), true);
+});
+
+test("carries the PRE-remoteHosts single-host keys so the chained migration still runs", () => {
+  // Two migrations in series, and this one runs first. host-config.js's
+  // migrateRemoteHostConfig converts the old single-host pair (remoteHost +
+  // kirocrewBinPath) into the per-port remoteHosts map, and it reads those keys from
+  // the store. An install old enough to predate remoteHosts therefore loses its
+  // remote connection twice over if the rename seed drops the pair: the seed carries
+  // an empty remoteHosts, and the host migration then finds nothing to convert.
+  const userData = tmpUserData();
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      readLegacy: () => ({ remoteHost: "box.example", kirocrewBinPath: "/opt/bin/kirocrew" }),
+    }),
+    true
+  );
+  const store = openStore(userData);
+  assert.strictEqual(store.get("remoteHost"), "box.example");
+  assert.strictEqual(store.get("kirocrewBinPath"), "/opt/bin/kirocrew");
+
+  // ...and the chained migration can now do its job.
+  const { migrateRemoteHostConfig } = require("../host-config");
+  assert.strictEqual(migrateRemoteHostConfig(store, 5476), true);
+  assert.deepStrictEqual(store.get("remoteHosts"), {
+    5476: { host: "box.example", binPath: "/opt/bin/kirocrew" },
+  });
+});
+
+test("NEVER touches a destination that already exists", () => {
+  // The one condition the whole design rests on. An established store -- every
+  // nightly install that already crossed the rename, and every launch after the
+  // first -- is left completely alone, so no deliberate choice can be overwritten
+  // and no cleared value can come back.
+  const userData = tmpUserData();
+  const existing = openStore(userData);
+  existing.set("remoteHosts", {});     // deliberately cleared
+  existing.set("updateChannel", "stable");
+
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      readLegacy: () => ({ remoteHosts: { 5476: { host: "old-box" } }, updateChannel: "insider" }),
+    }),
+    false,
+    "an existing destination must never be seeded"
+  );
+
+  const store = openStore(userData);
+  assert.deepStrictEqual(store.get("remoteHosts"), {}, "a cleared host came back");
+  assert.strictEqual(store.get("updateChannel"), "stable", "a deliberate choice was overwritten");
+});
+
+test("writes atomically, so an interrupted write cannot leave malformed JSON", () => {
+  // config.json is the file electron-store parses on the NEXT launch, and a truncated
+  // write is worse than no migration: the store either throws or resets. Write to a
+  // temp sibling and rename, which is atomic within a directory, so the destination
+  // only ever appears complete.
+  const userData = tmpUserData();
+  const seen = [];
+  seedRenamedStore(userData, {
+    readLegacy: () => ({ updateChannel: "insider" }),
+    writeFile: (file, data) => { seen.push(file); fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, data); },
+  });
+  assert.strictEqual(seen.length, 1);
+  assert.notStrictEqual(
+    path.basename(seen[0]),
+    "config.json",
+    "the payload must land on a temp sibling, then be renamed into place"
+  );
+  // ...and the finished file is valid, complete JSON.
+  const raw = fs.readFileSync(path.join(userData, "config.json"), "utf8");
+  assert.deepStrictEqual(JSON.parse(raw), { updateChannel: "insider" });
+  // No temp file is left behind.
+  assert.deepStrictEqual(fs.readdirSync(userData), ["config.json"]);
+});
+
+test("cleanup never deletes a destination this call did not create", () => {
+  // Two first launches can race: Electron's single-instance lock is taken later, so
+  // both may reach the seed. One rename wins; the loser's rename fails. If the loser's
+  // cleanup then removed `target`, it would delete the WINNER's freshly migrated
+  // settings and hand the user defaults. Only the temp sibling is ever this call's to
+  // remove.
+  const userData = tmpUserData();
+  const target = path.join(userData, "config.json");
+  fs.mkdirSync(userData, { recursive: true });
+  // Stand in for the winner's completed file, appearing after the eligibility check.
+  const winner = JSON.stringify({ updateChannel: "insider" });
+
+  const lost = seedRenamedStore(userData, {
+    readLegacy: () => ({ themeAccent: "#8e48ff" }),
+    writeFile: (file, data) => {
+      fs.writeFileSync(file, data);        // the temp sibling lands
+      fs.writeFileSync(target, winner);    // ...and the rival finishes first
+      throw new Error("EEXIST: rename lost the race");
+    },
+  });
+
+  assert.strictEqual(lost, false);
+  assert.strictEqual(
+    fs.readFileSync(target, "utf8"),
+    winner,
+    "the losing launch deleted the winner's migrated settings"
+  );
+  assert.deepStrictEqual(
+    fs.readdirSync(userData),
+    ["config.json"],
+    "the temp sibling must still be cleaned up"
+  );
+});
+
+test("each invocation writes its OWN temp sibling, so racing launches cannot tear it", () => {
+  // Two first launches can both reach the seed before Electron's single-instance
+  // lock is taken. A SHARED temp name would let one process truncate the sibling
+  // while the other renames it, exposing a partial config.json that electron-store
+  // fails to parse on every later boot. Unique siblings make both renames
+  // whole-file: last writer wins, both seeds complete.
+  const seen = [];
+  for (let launch = 0; launch < 2; launch += 1) {
+    const userData = tmpUserData();
+    seedRenamedStore(userData, {
+      readLegacy: () => ({ updateChannel: "insider" }),
+      writeFile: (file) => { seen.push(path.basename(file)); throw new Error("stop before rename"); },
+    });
+  }
+  assert.strictEqual(seen.length, 2);
+  assert.ok(seen[0].startsWith("config.json.migrating."), seen[0]);
+  assert.notStrictEqual(seen[0], seen[1], "temp sibling must be unique per invocation");
+});
+
+test("a failed write leaves the destination absent, so the next launch retries", () => {
+  // No persisted retry state exists, and none is needed: the destination file's own
+  // absence IS the retry flag. A write that throws must therefore leave no partial
+  // file behind, or the retry would be silently disarmed.
+  const userData = tmpUserData();
+  const failed = seedRenamedStore(userData, {
+    readLegacy: () => ({ updateChannel: "insider" }),
+    writeFile: () => { throw new Error("EPERM"); },
+  });
+  assert.strictEqual(failed, false);
+  assert.strictEqual(
+    fs.existsSync(path.join(userData, "config.json")),
+    false,
+    "a failed seed must not leave a file that would block the retry"
+  );
+
+  // The retry succeeds and recovers everything.
+  assert.strictEqual(
+    seedRenamedStore(userData, { readLegacy: () => ({ updateChannel: "insider" }) }),
+    true
+  );
+  assert.strictEqual(openStore(userData).get("updateChannel"), "insider");
+});
+
+test("retries a failing legacy read, because a later launch cannot", () => {
+  // The asymmetry that justifies the retry: a failed READ has no second chance. The
+  // seed writes nothing, main.js constructs the store anyway (boot cannot be held
+  // hostage to a convenience), and the destination then exists forever — so a
+  // momentary lock from the other channel or a scanner would cost the settings
+  // permanently. A couple of in-process attempts ride that out.
+  const userData = tmpUserData();
+  let attempts = 0;
+  const sleeps = [];
+  const migrated = seedRenamedStore(userData, {
+    readLegacy: () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error("EBUSY");
+      return { updateChannel: "insider" };
+    },
+    sleep: (ms) => sleeps.push(ms),
+  });
+  assert.strictEqual(migrated, true, "a transient read failure must not lose the settings");
+  assert.strictEqual(attempts, 3);
+  // The attempts must be SPACED, and by growing amounts. Three same-tick retries are
+  // one attempt in disguise: a lock that outlives a microsecond defeats them all at
+  // once, and the read failure is exactly the launch that is already about to lose
+  // the settings for good.
+  assert.deepStrictEqual(sleeps, [80, 240], "each failed attempt must back off before the next");
+  assert.strictEqual(openStore(userData).get("updateChannel"), "insider");
+});
+
+test("a read that succeeds first try never sleeps", () => {
+  // The backoff must cost the happy path nothing: it exists to ride out a lock, and
+  // there is no lock to ride out when the first read comes back.
+  const userData = tmpUserData();
+  const sleeps = [];
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      readLegacy: () => ({ updateChannel: "insider" }),
+      sleep: (ms) => sleeps.push(ms),
+    }),
+    true
+  );
+  assert.deepStrictEqual(sleeps, [], "no failed attempt, so nothing to wait out");
+});
+
+test("a CORRUPTED legacy store is final and loud, never retried", () => {
+  // SyntaxError is not a lock: the same bytes fail identically on every attempt,
+  // this launch or any other, so waiting between retries would only slow the boot
+  // that is already losing the settings. One attempt, one log line, no sleep — and
+  // no exception may escape to the caller, because this runs before any window
+  // exists. Exercised through the REAL read path (a real malformed file on disk),
+  // since the JSON.parse throw is what production hits.
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), "kc-corrupt-"));
+  const userData = path.join(parent, "kirocrew-desktop-nightly");
+  fs.mkdirSync(userData, { recursive: true });
+  const legacyDir = path.join(parent, LEGACY_STORE_NAME);
+  fs.mkdirSync(legacyDir, { recursive: true });
+  fs.writeFileSync(path.join(legacyDir, "config.json"), "{ not json");
+
+  const notes = [];
+  const sleeps = [];
+  const migrated = seedRenamedStore(userData, {
+    log: (m) => notes.push(m),
+    sleep: (ms) => sleeps.push(ms),
+  });
+  assert.strictEqual(migrated, false);
+  assert.deepStrictEqual(sleeps, [], "corruption is not transient, so retrying is pointless");
+  assert.strictEqual(notes.length, 1, "the loss must be visible in the boot log");
+  assert.ok(notes[0].includes("not valid JSON"), notes[0]);
+  assert.strictEqual(
+    fs.existsSync(path.join(userData, "config.json")),
+    false,
+    "a corrupted legacy store must seed nothing"
+  );
+});
+
+test("an ABSENT legacy store is final and silent, never retried", () => {
+  // ENOENT is not a failure to ride out -- there is simply nothing to carry, which is
+  // every fresh install. Retrying it would waste two more stat calls on every launch
+  // and log noise for the common case.
+  const userData = tmpUserData();
+  let attempts = 0;
+  const notes = [];
+  const migrated = seedRenamedStore(userData, {
+    readLegacy: () => {
+      attempts += 1;
+      throw Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+    },
+    log: (m) => notes.push(m),
+  });
+  assert.strictEqual(migrated, false);
+  assert.strictEqual(attempts, 1, "an absent legacy store must not be retried");
+  assert.deepStrictEqual(notes, [], "the common case must stay silent");
+});
+
+test("a read failure or absent legacy store seeds nothing at all", () => {
+  // Nothing to carry, so no file is created -- which also means the next launch is
+  // free to try again if the legacy store was merely unreadable. Both paths are
+  // silent: an absent legacy store is the overwhelmingly common case (every fresh
+  // install) and is not worth a log line.
+  for (const readLegacy of [
+    () => null,
+    () => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); },
+    () => { throw new Error("EACCES"); },
+    () => "not an object",
+  ]) {
+    const userData = tmpUserData();
+    // No-op sleep: the EACCES case exhausts every attempt, and the real backoff
+    // would slow this test by the full wait for no extra coverage (the backoff
+    // shape has its own test).
+    assert.strictEqual(seedRenamedStore(userData, { readLegacy, sleep: () => {} }), false);
+    assert.strictEqual(fs.existsSync(path.join(userData, "config.json")), false);
+  }
+});
+
+test("carries only the allowlisted keys, and only real values", () => {
+  // The legacy file is a whole electron-store dump, including keys a newer build may
+  // have retired; copying it wholesale would resurrect settings this build no longer
+  // understands. And a legacy value equal to its own default carries no intent, so
+  // seeding it would just re-state the default.
+  const userData = tmpUserData();
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      readLegacy: () => ({
+        updateChannel: "insider",
+        someRetiredFlag: true,
+        themeAccent: "",          // at its default: nothing to carry
+      }),
+    }),
+    true
+  );
+  const raw = JSON.parse(fs.readFileSync(path.join(userData, "config.json"), "utf8"));
+  assert.deepStrictEqual(Object.keys(raw), ["updateChannel"]);
+  assert.strictEqual(raw.someRetiredFlag, undefined);
+});
+
+test("preserves an explicitly emptied legacy value", () => {
+  // "" is a REAL choice for globalHotkey: main.js documents null as "platform
+  // default" and "" as "disabled". Treating empty-as-absent would silently re-enable
+  // a hotkey the user turned off.
+  const userData = tmpUserData();
+  assert.strictEqual(
+    seedRenamedStore(userData, { readLegacy: () => ({ globalHotkey: "" }) }),
+    true
+  );
+  assert.strictEqual(openStore(userData).get("globalHotkey"), "");
+});
+
+test("locates the legacy store beside the CURRENT one, on every platform", () => {
+  // The legacy directory is a SIBLING of the live userData directory, whatever
+  // Electron chose: %APPDATA%\<name> on Windows, ~/Library/Application Support/<name>
+  // on macOS, ~/.config/<name> on Linux. Deriving it from the live path keeps this
+  // correct on all three -- hand-rolling APPDATA-or-~/.config silently resolved to a
+  // nonexistent ~/.config path on macOS, so the lookup ENOENT'd and every setting
+  // stayed orphaned there.
+  const cases = [
+    ["win32", "C:\\Users\\jane\\AppData\\Roaming\\kirocrew-desktop"],
+    ["darwin", "/Users/jane/Library/Application Support/kirocrew-desktop"],
+    ["linux", "/home/jane/.config/kirocrew-desktop-nightly"],
+  ];
+  for (const [platform, userData] of cases) {
+    const file = legacyStoreFile(userData);
+    assert.ok(file.includes(LEGACY_STORE_NAME), `${platform}: must name the legacy dir`);
+    assert.ok(!file.includes("kirocrew-desktop"), `${platform}: must not point at the CURRENT store`);
+    assert.match(file, /config\.json$/, `${platform}: must target electron-store's file`);
+  }
+});
+
+test("carries no state of its own — the destination file is the state", () => {
+  // The design invariant, pinned. Successive review rounds pulled in opposite
+  // directions over a persisted retry/freshness flag, because no single flag can
+  // answer both "may I read the legacy store?" and "is the destination untouched?".
+  // Seeding a file that does not exist answers both at once and needs no bookkeeping,
+  // so a reintroduced marker is a regression to that ambiguity.
+  const src = fs.readFileSync(path.join(__dirname, "..", "store-rename.js"), "utf8");
+  assert.doesNotMatch(
+    src,
+    /MIGRATION_MARKER_KEY|MIGRATION_PENDING_KEY|storeExistedBeforeLaunch/,
+    "the destination file's absence is the only state this migration may keep"
+  );
+});
+
+test("main.js seeds BEFORE constructing the store", () => {
+  // Ordering is the whole correctness of the approach: electron-store writes its
+  // defaults on construction, so a seed placed after `new Store(...)` would find the
+  // file already present and never run. Neither ordering fails a unit test on its
+  // own, so pin the order in the source.
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  const seed = main.indexOf("seedRenamedStore(");
+  const construct = main.indexOf("const store = new Store(");
+  assert.notStrictEqual(seed, -1, "expected the seed call in main.js");
+  assert.notStrictEqual(construct, -1, "expected the store construction in main.js");
+  assert.ok(seed < construct, "the seed must precede `new Store(...)`");
+});
+
+test("every migrated key is a real store default in main.js", () => {
+  // A key that no longer exists in the store's defaults would be seeded and then
+  // ignored, which reads like a working migration while carrying nothing.
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  for (const key of MIGRATED_KEYS) {
+    assert.match(
+      main,
+      new RegExp(`^\\s*${key}:`, "m"),
+      `${key} is migrated but is not a store default in main.js`
+    );
+  }
+});
+
+test("the legacy directory name is the pre-rename npm package name", () => {
+  // Pinned: this is how the migration finds the old store, and it is NOT derivable
+  // from the current package.json (the rename removed it). A typo makes the
+  // migration silently find nothing.
+  assert.strictEqual(LEGACY_STORE_NAME, "kirocrew-electron-mac");
+});
+
+test("the Windows install guide does not contradict the code on the stable lane", () => {
+  // A stale doc paragraph claimed "Stable has no Windows lane yet", named a
+  // WINDOWS_CHANNELS set that does not exist in auto-update.js, and stated the
+  // promotion bundle carries no Windows installer. All three are false: release.yml
+  // runs publish-windows-x64 for the stable channel in promote mode,
+  // release_promotion.py records windows_installer / windows_blockmap roles, and the
+  // updater gates on channelHasLane() over KNOWN_CHANNELS with no win32 arm.
+  //
+  // That combination is worse than a typo: it tells a reader that a stable Windows
+  // client cannot update, which is exactly the symptom this area's real bugs produce,
+  // so it sends the next investigation down a dead end.
+  const repo = path.resolve(__dirname, "..", "..", "..");
+  const guide = fs.readFileSync(path.join(repo, "docs", "guides", "windows-install.md"), "utf8");
+  const updater = fs.readFileSync(path.join(__dirname, "..", "auto-update.js"), "utf8");
+
+  assert.ok(
+    !/WINDOWS_CHANNELS/.test(guide) || /WINDOWS_CHANNELS/.test(updater),
+    "the guide names a WINDOWS_CHANNELS symbol that auto-update.js does not define"
+  );
+  assert.doesNotMatch(
+    guide,
+    /Stable has no Windows lane/i,
+    "the guide claims stable has no Windows lane, but release.yml's publish-windows-x64 "
+      + "runs for the stable channel and release_promotion.py carries the installer roles"
+  );
+  assert.match(
+    updater,
+    /KNOWN_CHANNELS = new Set\(\["nightly", "insider", "stable"\]\)/,
+    "stable left KNOWN_CHANNELS; the guide's per-channel wording must move with it"
+  );
+});


### PR DESCRIPTION
## Problem

Follow-up to #4896: you asked me to check the **stable** build and audit every
Windows install path. Three problems, one of them a silent data loss.

### 1. The npm rename resets every setting (data loss)

Electron derives `userData` from the npm `name`, so renaming it to give each channel
its own per-user state also repointed `electron-store` at a fresh directory and left
every existing setting behind. The rename itself is correct and load-bearing — a
shared name made both channels write **one** userData dir and **one** updater cache,
so uninstalling either destroyed the other's window state and pending download — but
nothing carried the values across.

`updateChannel` is what makes this a bug rather than an inconvenience. It is the
Stable⇄Insider switcher, and `resolveChannel()` treats an unset preference as *follow
stable*, so an **Insider install is moved onto the Stable feed with no consent and no
message** — precisely what that function's own contract says a channel decision must
never do implicitly. Remote hosts, the gateway mode, the hotkey and window geometry go
with it.

Observed on my machine, which had taken the nightly rename:

```
%APPDATA%\kirocrew-electron-mac\config.json      (orphaned)
  updateChannel: "stable"   themeAccent: "#8e48ff"   windowState: {x:116,y:0,1354x913}

%APPDATA%\kirocrew-desktop-nightly\config.json   (live, freshly created)
  updateChannel: ""         themeAccent: "#8e48ff"   windowState: {x:127,y:25,1282x881}
```

Stable has not shipped the rename yet, so this is preventable for stable users rather
than already inflicted.

### The fix, and why it is shaped this way

Copying values is the easy part. The hard part is **proving the destination is
untouched**, and two obvious approaches cannot:

- **Value comparison can't** — every default is reachable. Clearing your last remote
  host leaves `{}`; clearing the accent leaves `""`. "Equals the default" never proves
  "never chosen".
- **A persisted flag can't** — a retry must answer two questions that pull apart: *may
  I read the legacy store?* (yes, though `config.json` now exists) and *is the
  destination untouched?* (no — the user has had a session with it). One flag answers
  one and breaks the other.

So the migration **seeds the destination's `config.json` before `electron-store` opens
it**, and only when that file does not exist. One filesystem fact replaces all the
bookkeeping:

| state | meaning |
|---|---|
| file absent | nothing to overwrite, *by definition* |
| write throws | file stays absent → next launch retries identically |
| write succeeds | file exists → never eligible again |

That also removes the need to exclude any setting: with no user choice to override,
the behavioural keys come along, so someone who runs as a pure client
(`runLocalGateway: false`) doesn't get an unwanted local gateway on the first launch
after the rename. The pre-`remoteHosts` single-host pair is carried too, because
`host-config.js` runs a *second* migration that consumes it.

Three edge cases are handled explicitly: the write is **atomic** (temp sibling +
rename, so a torn write can't leave malformed JSON for the next launch to parse);
cleanup removes **only** the temp file, never the destination, because two first
launches can race and the loser must not delete the winner's migrated settings; and a
failing legacy **read** is retried in-process, since that is the one failure a later
launch cannot recover from.

The legacy directory is left in place — it may still be the other channel's live
store, the same reason the uninstaller declines to remove the shared updater cache.
The whole pass is fail-soft, since it runs at boot before any window exists.

Verified end-to-end against the real orphaned file on this machine: first launch
recovers `updateChannel`, `windowState` and `themeAccent`; the second is inert.

### 2. The install guide contradicted the code on the stable lane

The guide claimed **"Stable has no Windows lane yet"** and cited a `WINDOWS_CHANNELS`
symbol that does not exist in `auto-update.js`. All of it is false: `release.yml`'s
`publish-windows-x64` runs for the stable channel in `promote` mode,
`release_promotion.py` records `windows_installer` / `windows_blockmap` roles, and the
updater gates on `channelHasLane()` over all of `KNOWN_CHANNELS` with no win32 arm.

That wording is worse than a typo — *"a stable Windows client cannot update"* is also
the symptom this area's real bugs produce, so it sends the next investigation down a
dead end. A test now pins the doc against the code.

### 3. `AGENTS.md` still advertised the removed home migration

It described the legacy `~/.kirocrew` as auto-migrating. That migration is gone (the
CHANGELOG announces its removal); the path now survives only in sensitive-path deny
lists, which must keep covering it.

## Docs

Both guide edits are deliberately short and problem→solution, with no internals: the
publish bullet no longer names workflows or symbols, and the settings note reads as
*"your settings survive that rename"* rather than explaining electron-store.

## Tests

TDD throughout — each test watched failing for the right reason first.

Worth calling out: my initial tests used a **hand-rolled fake store**, and it hid a
real bug. Real `electron-store` writes its defaults to `config.json` on construction,
so `get()` returns `20000`/`true`/`{}` for untouched keys — values the fake reported as
`undefined`. The suite now uses a **real store over a temp dir**. Source-order and
design invariants are pinned too (the seed must precede `new Store(...)`; the module
must keep no state of its own; the doc must match the code), since none fails a
behavioural test on its own.

| Gate | Result |
|---|---|
| `npm test` (electron + website) | 1189 passed, 2 skipped, **0 failed** |
| `docs_lint.py` | all checks passed |
| `check_brand_name.py` | clean |

## Risk

Cross-platform by nature (the npm name feeds userData on every OS) and safe on all:
the seed is a no-op whenever the destination exists or no legacy store is readable,
which together cover every launch except the single first one after the rename.


## Review round 2: spaced retries, corruption finality

The legacy-read retries are now **spaced (80ms, then 240ms)** instead of same-tick — three instantaneous attempts were one attempt in disguise against any real lock, and a read failure here is the one loss no later launch can recover from. The wait is injectable for tests (shape pinned, no wall-clock assertions), guarded so a non-finite duration can never reach `Atomics.wait` (an unbounded wait would hang boot), and runs only on a launch that is already about to lose the settings. Corrupted legacy JSON is now **final and logged** rather than retried: the same bytes fail identically on every attempt, and electron-store's own atomic writes mean a `SyntaxError` implies stable corruption, not a torn write in flight.

## Known deferral: `mochi-machine.json`

The rename orphans a second, smaller electron-store file — `mochi/index.js`'s `mochi-machine.json` (pet state, accepted shortcuts). Deliberately not seeded here: its keys and defaults live in a different module, and the loss is cosmetic state rather than a consent-violating channel switch. Deferred as a follow-up rather than silently ignored.


## Also carried: sandbox probe fork-guard fix (folded from the closed #5007)

`test_sandbox_probe.py::test_both_paths_report_the_same_verdict_on_this_host` fails intermittently on CI shards: the single-threaded pre-check forks its own child, while the verdict comes from a **different** fork. The OTel at-fork hook survives a clean shutdown and restarts a short-lived ticker thread in every fork child, so each fork races it independently — a clean pre-check proves nothing about the verdict child, and the deliberate multithreaded collapse gets asserted as a spawn/fork disagreement. The failure is shard-placement dependent, so unrelated commits can turn main red.

The fix reads the collapse off the verdict tuple itself: the collapse reason's trailing clause moves into a shared constant (`_PROBE_MULTITHREADED_REASON`) with a predicate beside it, and the comparison skips — naming the capability — when the verdict child itself reported the collapse (emitted reason text is byte-identical). A new stub-based regression test pins the exact CI scenario (pre-check clean, verdict child collapsed → SKIP); the real-disagreement test is unchanged and still fails, and forcing the predicate to `False` locally restores the original false red. `docs/system-specs/common/testing-conventions.md` gains the surviving-hook shape in the same commit.
