### PR TITLE
docs(spec): Add App Builder Kit spec

### DIFF
--- a/.kiro/specs/app-builder-kit/design.md
+++ b/.kiro/specs/app-builder-kit/design.md
@@ -1,0 +1,155 @@
+# Design — Kiro Crew App Builder Kit
+
+## Overview
+
+The App Builder Kit is a new frontend library at `website/src/kit/` that layers on the
+existing `website/src/app-sdk/`. `app-sdk` owns the **app contract** (identity, api, events,
+theme, chat); `kit` owns **reusable UI + patterns**. The two do not overlap: the kit imports
+from `app-sdk`, never the reverse.
+
+The kit is delivered as five modules — `ui`, `app`, `tool-views`, `data`, `gallery` — each
+independently importable and tree-shakeable. Heavy visualization dependencies (Recharts,
+MapLibre GL) are optional peer dependencies imported only by the component that needs them.
+
+## Architecture
+
+```
+website/src/
+├── app-sdk/                 # EXISTING (unchanged): AppApi, useAppApi, useTheme,
+│                            #   useNavigate, useNotify, useAppEvents, useChatLauncher,
+│                            #   ChatPanel, ChatEmbed, messageRenderers, protocol/
+└── kit/                     # NEW
+    ├── ui/                  # DataTable, Card, EmptyState, LoadingSkeleton, ErrorNotice,
+    │                        #   Toolbar, SplitLayout, Drawer, StatusBadge, ConfirmDialog
+    ├── app/                 # defineApp(); ListDetail / Settings / Dashboard templates
+    ├── tool-views/          # ToolViewFrame, ToolPreviewFrame, defineToolView, ToolRenderer
+    │   ├── chart/           #   ChartToolView + chartToolSchema        (peer: recharts)
+    │   ├── table/           #   TableToolView + tableToolSchema        (reuses ui/DataTable)
+    │   ├── map/             #   MapToolView + mapToolSchema            (peer: maplibre-gl)
+    │   ├── image/           #   ImageToolView + imageToolSchema
+    │   └── diff/            #   DiffToolView + diffToolSchema          (reuses DiffBlock)
+    ├── data/                # useAppResource/useAppMutation/useAppLiveResource
+    │                        #   (thin wrappers over @tanstack/react-query — already a dep)
+    └── gallery/             # dev-only route: every primitive + tool view × themes
+```
+
+### Boundary with existing components (verified paths)
+
+| Existing (`website/src/`) | Kit relationship |
+|---|---|
+| `app-sdk/index.ts` (`useTheme`, `useAppEvents`, `AppApi`) | Kit consumes; source of theme + events |
+| `apps/builtinRegistry.ts` (`registerBuiltinComponents`) | `kit/app/defineApp` wraps registration |
+| `components/ApprovalCard.tsx`, `components/ToolInputPreview.tsx` | Enhanced to host `ToolPreviewFrame` |
+| `components/ChatInput.tsx` (`api.approveChatSlot`) | Unchanged approval path the preview reuses |
+| `components/WidgetFrame.tsx`, `components/ArtifactBody.tsx` | Inline tool views render inside these |
+| `components/DiffBlock.tsx` | `DiffToolView` reuses it |
+| `components/ContentRenderer.tsx` | `ToolRenderer` dispatch integrates here |
+| `components/ErrorNotice.tsx` | Consolidated into `kit/ui/ErrorNotice` |
+| `api/client.ts` | `kit/data` wraps the existing client |
+
+## Components and Interfaces
+
+### kit/ui
+Presentational, theme-variable-driven, i18n via `i18nT()`. `DataTable<T>` takes
+`{ rows: T[]; columns: Column<T>[]; pageSize?; sortable? }` and owns sort/paginate state.
+State primitives (`EmptyState`, `LoadingSkeleton`, `ErrorNotice`) are the canonical
+loading/empty/error surfaces every app and tool view reuses.
+
+### kit/app
+`defineApp(config)` returns a registration object and calls `registerBuiltinComponents`
+with the app's lazy routes, honoring the existing seam-collision report (no silent
+overwrite). Screen templates (`ListDetailTemplate`, `SettingsTemplate`, `DashboardTemplate`)
+are composition shells mirroring the meetings app (`MeetingsPage`/`MeetingView`/`SettingsView`).
+
+### kit/tool-views
+- **Lifecycle contract:** a discriminated union over `state` — `input-streaming` |
+  `input-available` | `output-available` | `output-error` — mirroring AI-SDK
+  `UIToolInvocation<T>`. `ToolViewFrame` renders the state scaffold (skeleton / running /
+  result / error) and delegates the `output-available` body to the specific component.
+- **Schema contract:** each component publishes a **Zod** schema for the tool output it renders.
+  **Dependency note:** `zod` is NOT currently a `website/package.json` dependency — this kit
+  adds it (a new runtime dep, ~12KB gzipped min, tree-shakeable), alongside the acknowledged
+  `recharts` and `maplibre-gl` optional peers. `defineToolView(schema, InlineComponent,
+  PreviewComponent?)` co-locates schema + renderers and yields a typed entry. `z.infer<schema>`
+  is the component's output prop type — a drift between the tool's output and the renderer is a
+  compile error.
+- **Encoding + producer (see Requirement 8 — the load-bearing prerequisite).** This codebase
+  has **no typed `tool-<name>` part stream**: the chat transport is markdown + `<mcwidget>`
+  (`useBlockAssembler.ts`) and tool I/O is opaque strings (`input?/output?: string`,
+  `tool_input: string` in `types/index.ts`). So the kit does NOT borrow AI-SDK's wire model
+  literally. Instead:
+  - **Encoding:** a fenced `tool-view` JSON block carried in the agent's message text —
+    `{"tool":"<name>","schemaVersion":1,"data":{...}}` — parsed by `ContentRenderer` exactly
+    like it already parses `<mcwidget>` HTML. **No backend wire-format change.**
+  - **Producer:** an **agent prompt/skill convention** — the agent emits the `tool-view`
+    block just as it emits `<mcwidget>` today. This keeps the frontend-only scope intact;
+    there is no MCP or backend protocol change.
+  - The AI-SDK `UIToolInvocation` lifecycle union (`input-streaming` → … → `output-error`) is
+    reused only as the **component-internal state model** for `ToolViewFrame`, not as a claim
+    about the transport.
+- **Dispatch:** `ToolRenderer` maps a parsed `tool-view` block's `tool` field to a registered
+  `ToolViewDef` and validates `data` against its schema; on match it renders the typed
+  component, otherwise it falls through to the existing `<mcwidget>` render. Integrated at
+  `ContentRenderer`.
+- **Preview:** `ToolPreviewFrame` renders inside `ApprovalCard`. When a schema matches the
+  pending call's (partial) input it shows a rich preview; otherwise it renders the current
+  `ToolInputPreview` `<pre>`. Approve/deny is passed straight to the existing
+  `onApprove(decision, pattern?)` callback — no new API.
+
+### kit/data
+Thin wrappers over the repo's existing **`@tanstack/react-query`** (already in
+`website/package.json` at 5.96.0) — the kit does NOT ship a bespoke async cache.
+`useAppResource<T>(fetcher)` wraps `useQuery` (keyed off the `api/client.ts` call) →
+`{ data, loading, error, refetch }`. `useAppMutation` wraps `useMutation`, wiring optimistic
+apply + rollback through react-query's `onMutate`/`onError`/`onSettled`. `useAppLiveResource`
+composes `useAppResource` with `useAppEvents` (gated by `checkSubscribeAllowed`) and
+invalidates the relevant query keys on an event.
+
+## Data Models
+
+```ts
+// kit/tool-views/core/types.ts
+type ToolViewState<TIn, TOut> =
+  | { state: 'input-streaming';  input: Partial<TIn> }
+  | { state: 'input-available';  input: TIn }
+  | { state: 'output-available'; input: TIn; output: TOut }
+  | { state: 'output-error';     input: TIn; error: string }
+
+interface ToolViewDef<TIn, TOut> {
+  schema: ZodType<TOut>          // output contract
+  Inline: FC<{ invocation: ToolViewState<TIn, TOut> }>
+  Preview?: FC<{ input: Partial<TIn>; onApprove: (d: string, p?: string) => void }>
+}
+```
+
+Example schema (chart): `{ kind: 'line'|'bar'|'area'|'pie', series: {name,data:{x,y}[]}[],
+xLabel?, yLabel?, extra?: Record<string,unknown> }`. The `extra` passthrough keeps schemas
+strict without blocking app-specific fields.
+
+## Error Handling
+
+- Tool views never throw to the tree: `output-error` renders `kit/ui/ErrorNotice`; a schema
+  parse failure downgrades to the `<mcwidget>` fallback and logs via the existing logger.
+- `useAppResource` surfaces errors as state, not exceptions; `useAppMutation` rolls back
+  optimistic writes on rejection.
+- `defineApp` route collisions use the existing `reportSeamCollision` path, not a throw.
+
+## Testing Strategy
+
+- **Unit (vitest):** each primitive and tool view — state coverage (all four lifecycle
+  states), theme-variable usage (no literal colors), keyboard/ARIA. Reuse existing test
+  patterns (e.g. `WidgetFrame.test.tsx`).
+- **Type tests:** a fixture asserting a mismatched tool output fails to compile (`tsc`).
+- **Integration:** `ToolRenderer` dispatch + `<mcwidget>` fallback; `ApprovalCard` preview
+  path routing through a mocked `onApprove`/`approveChatSlot`.
+- **Visual/Screenshot Evidence:** capture the gallery route via dev-server + Playwright
+  (light path; dist build needs 6 GB) for the CI gate.
+- **Dogfood:** refactor one screen of an existing app (meetings) onto the kit and assert no
+  UX regression.
+
+## CI / constraints (repo-specific)
+
+- Screenshot Evidence gate — gallery route makes capture cheap; SHA-pinned screenshots in PR.
+- jscpd 0% — kit consolidates clones; kit components must not copy from each other.
+- catalogParity — all new `i18nT()` keys land in every locale file.
+- PR Hygiene — single squashed commit per PR.

--- a/.kiro/specs/app-builder-kit/requirements.md
+++ b/.kiro/specs/app-builder-kit/requirements.md
@@ -1,0 +1,107 @@
+# Requirements — Kiro Crew App Builder Kit
+
+## Introduction
+
+The Kiro Crew dashboard frontend (`website/src/`) already exposes an `app-sdk/` that defines
+the app contract (`AppApi`, `useAppApi`, `useTheme`, `useNavigate`, `useNotify`,
+`useAppEvents`, `useChatLauncher`, `ChatPanel`, `messageRenderers`, `protocol/`), with apps
+registered through `apps/builtinRegistry.ts`. However, UI building blocks are not
+consolidated: the ~15 apps under `apps/` each re-implement their own tables, cards, and
+loading/error/empty states, and agent tool-output rendering is hand-rolled (raw
+`<mcwidget>` HTML via `WidgetFrame.tsx`; the tool-request preview in `ApprovalCard.tsx` /
+`ToolInputPreview.tsx` renders input as a raw `<pre>` args dump).
+
+The **App Builder Kit** is a frontend build-velocity library that layers on the existing
+`app-sdk` to let a developer stand up a new app or feature fast, with production-quality
+theming, accessibility, i18n, and agent-output rendering by default. It absorbs the earlier
+"Generative-UI Tool Component Library" idea as one module (Tool Views).
+
+Scope is the React frontend only. This is not a backend/MCP toolkit, not an `app-sdk`
+rewrite, and not a design-system overhaul.
+
+## Requirements
+
+### Requirement 1 — Reusable UI primitives
+
+**User Story:** As an app author, I want themed, accessible UI primitives, so that I stop
+re-implementing tables, cards, and state views in every app.
+
+#### Acceptance Criteria
+1. WHEN a developer imports a kit primitive (DataTable, Card, EmptyState, LoadingSkeleton, ErrorNotice, Toolbar, SplitLayout, Drawer, StatusBadge, ConfirmDialog) THEN the kit SHALL render it using the dashboard theme CSS variables with no hard-coded colors.
+2. WHEN the active theme changes (light, dark, or custom) THEN each primitive SHALL reflect the new theme without additional code.
+3. WHEN a primitive renders user-facing text THEN it SHALL use `i18nT()` and the kit SHALL provide catalog keys in all shipped locale files.
+4. WHEN a `DataTable` receives rows and columns THEN it SHALL support sorting and pagination without app-level implementation.
+5. IF a primitive is interactive THEN it SHALL be keyboard operable and expose appropriate ARIA roles/labels (WCAG AA).
+
+### Requirement 2 — Typed tool-view components (inline)
+
+**User Story:** As an agent (and as an app author), I want typed components that render common tool outputs, so that I don't hand-write `<mcwidget>` HTML per response.
+
+#### Acceptance Criteria
+1. WHERE a tool output matches a kit-published schema THE kit SHALL provide a typed component that renders it inline (ChartToolView, TableToolView, MapToolView, ImageToolView, DiffToolView). NOTE: `MapToolView` (and its `maplibre-gl` peer dependency) is the one v1 component with no named consumer in the design boundary table; it SHALL be deferred out of the v1 shipping set until a shipped tool actually emits map output, and is retained here only as a planned module.
+2. WHEN a tool invocation is in `input-streaming`, `input-available`, `output-available`, or `output-error` state THEN the component SHALL render a defined view for that state (skeleton, running affordance, result, error surface respectively).
+3. WHEN a tool's output shape does not match the component's declared schema at author time THEN the mismatch between renderer and schema SHALL surface as a TypeScript compile-time error. Because tool output arrives at runtime from backend/MCP tools, the compile check binds the renderer to its schema only — the runtime guarantee is the parse-failure fallback in Requirement 2.5 (a payload that fails schema validation downgrades to the `<mcwidget>` fallback rather than mis-rendering).
+4. WHEN a `DiffToolView` renders THEN it SHALL reuse the existing `DiffBlock.tsx` and preserve the dashboard's Open-file diff-header affordance.
+5. IF no typed component matches a tool part THEN the kit SHALL fall back to the existing `<mcwidget>` rendering with no regression.
+6. WHEN a tool view is rendered inline THEN it SHALL be persistable as an artifact (`kind="widget"`) consistent with the artifacts system.
+
+### Requirement 3 — Rich tool-request preview and approval
+
+**User Story:** As an operator, I want a rich preview of a pending tool call before I approve it, so that I can intervene with full context instead of reading a raw args dump.
+
+#### Acceptance Criteria
+1. WHEN a pending tool call has a matching tool-view schema THEN the kit SHALL render a rich preview inside `ApprovalCard` / `ToolInputPreview` in place of the raw `<pre>` dump as the default view.
+2. WHERE a tool-view schema does not match THE approval surface SHALL fall back to the current `ToolInputPreview` `<pre>` behavior.
+3. WHEN the operator approves or rejects THEN the decision SHALL flow through the existing `onApprove(decision, pattern?)` callback and the kit SHALL NOT introduce a new approval API path.
+4. WHEN an approval decision is submitted from a chat slot THEN it SHALL resolve via the existing slot-scoped `api.approveChatSlot(slot, action, extra)` path in `ChatInput.tsx`.
+5. IF the approval controls are rendered THEN they SHALL be keyboard operable (operators batch-approve).
+6. WHERE a rich preview is shown for a pending tool call THE exact, unmodified raw tool input SHALL remain available to the operator one interaction away (e.g. an expandable "show raw input" control). A rich renderer is lossy by design (`extra` passthrough fields, truncated series, fields the view does not plot) and tool input is attacker-influenceable; the operator MUST be able to inspect the verbatim args before approving so a consequential argument is never hidden by the summary.
+
+### Requirement 4 — App scaffolding
+
+**User Story:** As an app author, I want a standard way to define and register an app with proven screen layouts, so that I start from a working shape instead of copying another app.
+
+#### Acceptance Criteria
+1. WHEN a developer calls `defineApp({ id, icon, routes, permissions })` THEN the kit SHALL register the app with `builtinRegistry` and populate `AppInfo`/`AppPermissions` in a single call.
+2. WHERE a new app needs a common layout THE kit SHALL provide ListDetail, Settings, and Dashboard screen templates modeled on the existing meetings app structure.
+3. WHEN two apps register the same route THEN the kit SHALL surface the existing seam-collision report rather than silently overwriting.
+4. WHEN the scaffold codegen (`scaffold-app <name>`) runs THEN it SHALL emit the app directory and its registry entry (this criterion MAY be deferred to a later milestone).
+
+### Requirement 5 — Data and async helpers
+
+**User Story:** As a feature dev, I want typed fetch/loading/error and live-update helpers, so that I stop re-writing the same async triad.
+
+#### Acceptance Criteria
+1. WHEN a developer uses `useAppResource` THEN it SHALL return typed loading, error, and data states as a **thin wrapper over the repo's existing `@tanstack/react-query`** (already a `website/package.json` dependency) — the kit SHALL NOT introduce a bespoke async cache that reimplements react-query.
+2. WHEN a mutation is performed with the kit's mutation helper THEN it SHALL provide optimistic update and rollback by configuring react-query's mutation cache (`onMutate`/`onError`/`onSettled`), not a hand-rolled rollback mechanism.
+3. WHERE an app subscribes to server events THE kit SHALL provide a live-update hook built on `useAppEvents` that respects `checkSubscribeAllowed` and invalidates the relevant react-query keys.
+
+### Requirement 6 — Non-regression and CI compliance
+
+**User Story:** As a maintainer, I want the kit to satisfy the repo's CI gates, so that adopting it does not create review or build friction.
+
+#### Acceptance Criteria
+1. WHEN a kit component introduces a user-visible surface change THEN the change SHALL ship with committed, SHA-pinned screenshots satisfying the Screenshot Evidence gate.
+2. WHEN kit code is added THEN it SHALL NOT introduce copy/paste clones that fail the jscpd 0% threshold.
+3. WHEN kit components add user-facing strings THEN the corresponding keys SHALL exist in all locale files (catalogParity).
+4. WHEN an existing app is refactored onto the kit THEN it SHALL show no UX regression versus its pre-refactor behavior.
+
+### Requirement 7 — Dogfood and discoverability
+
+**User Story:** As a maintainer, I want the kit proven on a real app and browsable, so that adoption is de-risked and discoverable.
+
+#### Acceptance Criteria
+1. WHEN v1 is complete THEN at least one existing app (e.g. meetings or ops-mission-control) SHALL be refactored onto the kit as a dogfood proof.
+2. WHERE a developer wants to see available primitives and tool views THE kit SHALL provide a dev-only gallery route rendering each in light, dark, and custom themes.
+
+### Requirement 8 — Tool-part encoding contract and producer (PREREQUISITE)
+
+**User Story:** As an implementer, I need a defined wire encoding for typed tool output AND a named producer that emits it, so that the tool-view renderers (Req 2/3) have something real to dispatch on instead of assuming an AI-SDK-style part stream this codebase does not produce.
+
+**Context (verified against the codebase):** The dashboard chat transport is markdown + `<mcwidget>` blocks (`website/src/hooks/useBlockAssembler.ts`), and tool activity reaches the frontend as **opaque strings** — `input?: string` / `output?: string` and `tool_input: string` in `website/src/types/index.ts`. There is no typed `tool-<name>` part stream today. Requirement 2/3's `ToolRenderer` therefore has no producer within a frontend-only scope, and the design must not silently smuggle in a backend wire-format change.
+
+#### Acceptance Criteria
+1. WHEN the kit defines how a typed tool view is addressed THEN the spec SHALL define the **encoding** carried inside the existing opaque `output`/`tool_input` string — the chosen mechanism SHALL be a **fenced `<mcwidget>`-adjacent JSON convention** (a `tool-view` block: `{"tool":"<name>","schemaVersion":1,"data":{...}}`) parsed by `ContentRenderer`, so it rides the existing markdown/`<mcwidget>` transport with NO backend wire-format change.
+2. WHERE the encoding must be produced THE spec SHALL name the **producer** explicitly as an **agent prompt/skill convention** (the agent emits the `tool-view` JSON block in its message text, exactly as it already emits `<mcwidget>` HTML) — NOT a backend or MCP protocol change, keeping the frontend-only scope intact.
+3. WHEN a message contains a `tool-view` block whose `tool` matches a registered `ToolViewDef` and whose `data` parses against that def's schema THEN `ContentRenderer` SHALL render the typed component; otherwise it SHALL fall back to the existing `<mcwidget>` / `ToolInputPreview` rendering (Req 2.5) with no regression.
+4. WHEN the encoding is defined THEN it SHALL be the FIRST implementation task (task 0), because the ImageToolView spike cannot prove the contract end-to-end without a producer emitting the block.

--- a/.kiro/specs/app-builder-kit/tasks.md
+++ b/.kiro/specs/app-builder-kit/tasks.md
@@ -1,0 +1,86 @@
+# Implementation Plan — Kiro Crew App Builder Kit
+
+- [ ] 0. Define the tool-part encoding contract + producer (PREREQUISITE — do this first)
+  - Specify the `tool-view` fenced JSON block carried in agent message text: `{"tool":"<name>","schemaVersion":1,"data":{...}}`, riding the existing markdown/`<mcwidget>` transport with NO backend wire-format change
+  - Parse it in `components/ContentRenderer.tsx`; on a registered-tool + schema match, hand off to the typed component, else fall through to the existing `<mcwidget>` / `ToolInputPreview` render
+  - Document the producer as an agent prompt/skill convention (agent emits the block like it emits `<mcwidget>`); write the convention doc + one example the ImageToolView spike (task 3.1) consumes end-to-end
+  - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+- [ ] 1. Scaffold the kit module and lifecycle core
+  - Create `website/src/kit/` with `ui/`, `app/`, `tool-views/`, `data/`, `gallery/` and barrel exports
+  - Implement `kit/tool-views/core/types.ts` (`ToolViewState`, `ToolViewDef`) and `defineToolView`; add `zod` as a `website/package.json` dependency (name it in the PR — not previously present)
+  - Implement `ToolViewFrame` rendering the four lifecycle states (skeleton / running / result / error)
+  - _Requirements: 2.2, 2.3_
+
+- [ ] 2. Build the UI primitives (kit/ui)
+- [ ] 2.1 Implement state primitives and consolidate ErrorNotice
+  - Add `EmptyState`, `LoadingSkeleton`; move `components/ErrorNotice.tsx` behavior into `kit/ui/ErrorNotice` and re-export for back-compat
+  - Drive all styling from theme CSS variables; route text through `i18nT()`
+  - Unit tests for theme-variable usage (no literal colors) and ARIA
+  - _Requirements: 1.1, 1.2, 1.3, 1.5, 6.3_
+- [ ] 2.2 Implement DataTable and layout primitives
+  - `DataTable<T>` with sorting + pagination owned internally; `Card`, `Toolbar`, `SplitLayout`, `Drawer`, `StatusBadge`, `ConfirmDialog`
+  - Keyboard navigation + ARIA on DataTable and Drawer/ConfirmDialog
+  - Unit tests covering sort, paginate, keyboard
+  - _Requirements: 1.1, 1.4, 1.5_
+
+- [ ] 3. Implement inline tool views
+- [ ] 3.1 ImageToolView + schema (spike component)
+  - Zod `imageToolSchema` (base64|url, partialImages); render all four states; download affordance
+  - Prove the `defineToolView` contract end-to-end inside `ToolViewFrame`
+  - _Requirements: 2.1, 2.2, 2.3, 2.6_
+- [ ] 3.2 DiffToolView reusing DiffBlock
+  - `diffToolSchema`; delegate render to `components/DiffBlock.tsx`; preserve Open-file diff-header affordance
+  - _Requirements: 2.1, 2.4_
+- [ ] 3.3 TableToolView reusing kit/ui DataTable
+  - `tableToolSchema`; map schema rows/columns onto `DataTable`
+  - _Requirements: 2.1, 1.4_
+- [ ] 3.4 ChartToolView (Recharts optional peer)
+  - `chartToolSchema` (line/bar/area/pie + `extra` passthrough); Recharts as optional peer, per-component import
+  - _Requirements: 2.1, 2.3_
+- [ ] 3.5 Type-safety test
+  - Add a `tsc` fixture asserting a mismatched tool output fails to compile
+  - _Requirements: 2.3_
+
+- [ ] 4. Dispatch and mcwidget fallback (builds on the task-0 encoding)
+  - Implement `ToolRenderer` mapping a parsed `tool-view` block's `tool` field (task 0 encoding) to registered `ToolViewDef`s, validating `data` against the def's schema
+  - Integrate at `components/ContentRenderer.tsx`; blocks with no registered tool or a failing schema parse fall through to the existing `<mcwidget>` render with no regression
+  - Integration test: matched → component, unmatched/parse-fail → `<mcwidget>`
+  - _Requirements: 2.1, 2.5, 8.3_
+
+- [ ] 5. Artifact persistence for inline tool views
+  - Ensure a rendered tool view body persists via `artifact_save(kind="widget")` and re-renders from `ArtifactBody.tsx`
+  - _Requirements: 2.6_
+
+- [ ] 6. Rich tool-request preview and approval
+  - Implement `ToolPreviewFrame`; render inside `components/ApprovalCard.tsx` when a schema matches the pending input, else fall back to `ToolInputPreview` `<pre>`
+  - Route approve/reject through the existing `onApprove(decision, pattern?)` → verify it reaches slot-scoped `api.approveChatSlot` (no new API)
+  - Keyboard-operable controls; integration test with mocked `onApprove`
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [ ] 7. App scaffolding (kit/app)
+- [ ] 7.1 defineApp + registration
+  - `defineApp({ id, icon, routes, permissions })` wrapping `registerBuiltinComponents` and populating `AppInfo`/`AppPermissions`; honor `reportSeamCollision` on duplicate routes
+  - _Requirements: 4.1, 4.3_
+- [ ] 7.2 Screen templates
+  - `ListDetailTemplate`, `SettingsTemplate`, `DashboardTemplate` modeled on the meetings app
+  - _Requirements: 4.2_
+
+- [ ] 8. Data and async helpers (kit/data) — thin wrappers over @tanstack/react-query (already a dep; do NOT reimplement it)
+  - `useAppResource<T>` wraps `useQuery` over `api/client.ts` (data/loading/error/refetch); `useAppMutation` wraps `useMutation` with optimistic apply + rollback via `onMutate`/`onError`/`onSettled`; `useAppLiveResource` composes `useAppResource` with `useAppEvents` (gated by `checkSubscribeAllowed`) and invalidates query keys on events
+  - Unit tests for loading/error transitions and rollback
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 9. Gallery route and screenshot evidence
+  - Dev-only gallery rendering every primitive + tool view across light/dark/custom themes
+  - Capture screenshots via dev-server + Playwright (light path) for the Screenshot Evidence gate
+  - _Requirements: 6.1, 7.2_
+
+- [ ] 10. Dogfood refactor + CI compliance
+  - Refactor one screen of an existing app (meetings or ops-mission-control) onto kit primitives + a tool view; verify no UX regression
+  - Confirm jscpd 0% (kit reduces clones), catalogParity keys in all locales, single-commit PR hygiene
+  - _Requirements: 6.2, 6.3, 6.4, 7.1_
+
+- [ ] 11. (Deferred) scaffold-app codegen
+  - `scaffold-app <name>` emitting the app directory + registry entry
+  - _Requirements: 4.4_


### PR DESCRIPTION
## Problem

Building a new feature or app in the KiroCrew dashboard (`website/src/`) is slower than it should be. There is a real `app-sdk/` (the app contract), but UI building blocks are not consolidated — the ~15 apps under `apps/` each re-implement their own tables, cards, and loading/error/empty states, and agent tool-output rendering is hand-rolled (raw `<mcwidget>` HTML via `WidgetFrame.tsx`; the tool-request preview in `ApprovalCard.tsx` / `ToolInputPreview.tsx` shows input as a raw `<pre>` args dump).

## Why it matters

Every new app or feature re-solves the same layout, theming, loading/error, and render problems from scratch. Time-to-first-screen is high and UX consistency is low. A shared kit also lets agent-oversight surfaces (richer tool-request previews, per-tool approval UIs) ship faster and more consistently.

## What this PR adds

A Kiro spec (planning artifact only — **no implementation**) for an **App Builder Kit**: a frontend build-velocity library layered on the existing `app-sdk`. Three standard spec files under `.kiro/specs/app-builder-kit/`:

- `requirements.md` — 7 requirements in EARS format (UI primitives, typed tool views, rich approval preview, app scaffolding, data/async helpers, CI non-regression, dogfood/discoverability).
- `design.md` — module layout (`kit/ui`, `kit/app`, `kit/tool-views`, `kit/data`, `kit/gallery`), an explicit boundary table mapping each kit piece to the existing file it consumes/enhances, the `ToolViewState`/`ToolViewDef` data model, error handling, and testing strategy.
- `tasks.md` — 11 sequenced, requirement-traced implementation tasks (spike-first).

It absorbs an earlier "Generative-UI Tool Component Library" idea as the tool-views module. Paths and integration points were verified against the current frontend (`app-sdk/index.ts`, `apps/builtinRegistry.ts`, `ApprovalCard.tsx`, `ToolInputPreview.tsx`, `DiffBlock.tsx`, `ContentRenderer.tsx`, and the `ChatInput.tsx` `approveChatSlot` path). Adjacent to the existing `app-sdk-gateway-hooks` spec.

## Tests

N/A — documentation/spec only, no code changes. No test surface.

## Manual verification

N/A — three markdown files; no runtime behavior. Matches the existing `.kiro/specs/*` three-file convention (verified against `app-sdk-gateway-hooks` and `builtin-app-migration`).

## Screenshots

N/A — no user-visible UI change (spec markdown only).
