### PR TITLE
fix(code-review-sage): run the review worker under the resolved interpreter

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import sys
 import threading
 import time
@@ -43,6 +42,7 @@ from aiohttp import web
 
 from kiro_crew import hooks, model_registry
 from kiro_crew.apps.manager import is_app_enabled
+from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger("kirocrew.app.code-review-sage")
 
@@ -145,15 +145,37 @@ def _runs_file() -> Path:
     return store.data_dir() / "runs.json"
 
 
-def _save_runs() -> None:
-    """Atomically persist the run registry (0600). Never raises."""
+def _write_runs(payload: str) -> None:
+    """Blocking half of :func:`_save_runs` — never call this on the event loop.
+
+    The owner-only lockdown spawns ``icacls`` on Windows, so this whole function
+    is a blocking syscall sequence and belongs in a worker thread (the same
+    reason ``_write_review_section`` and ``store.remove_run_dir`` are offloaded).
+    """
+    f = _runs_file()
+    f.parent.mkdir(parents=True, exist_ok=True)
+    # The shared helper already does everything this write needs, and does one
+    # thing the hand-rolled version did not: it replaces through
+    # ``replace_with_retry``, so a transient Windows sharing violation does not
+    # silently lose the save (the defect class tracked in #4701 / #4898). It also
+    # picks a random mkstemp name, applies the owner-only lockdown to the temp
+    # BEFORE the payload lands, and refuses to follow a planted parent link --
+    # the three properties the review worker's writable tree requires, since it
+    # is prompt-injectable and shares this directory.
+    atomic_write(f, payload, restrict_to_owner=True)
+
+
+async def _save_runs() -> None:
+    """Atomically persist the run registry (owner-only). Never raises.
+
+    The registry is serialized HERE, on the loop, so the payload is a consistent
+    snapshot taken under whatever lock the caller holds; only the file write and
+    the lockdown are offloaded. Serializing inside the thread instead would let
+    ``_RUNS`` mutate mid-iteration.
+    """
     try:
-        f = _runs_file()
-        f.parent.mkdir(parents=True, exist_ok=True)
-        tmp = f.with_name(f.name + ".tmp")
-        tmp.write_text(json.dumps(_RUNS, indent=2), encoding="utf-8")
-        os.chmod(tmp, 0o600)
-        os.replace(tmp, f)
+        payload = json.dumps(_RUNS, indent=2)
+        await asyncio.to_thread(_write_runs, payload)
     except Exception:  # pragma: no cover - defensive
         logger.warning("failed to persist runs.json", exc_info=True)
 
@@ -236,7 +258,7 @@ async def _record(run: dict) -> None:
             else:
                 evicted.append(str(r.get("run_id") or ""))
         _RUNS[:] = keep
-        _save_runs()
+        await _save_runs()
     for run_id in evicted:
         if run_id:
             await asyncio.to_thread(store.remove_run_dir, run_id)
@@ -493,7 +515,7 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
             _release_claims(run)
         _CANCELLED.discard(run_id)
         async with _LOCK:
-            _save_runs()
+            await _save_runs()
         await _notify_finished(run)
 
 
@@ -913,7 +935,7 @@ async def _handle_run_cancel(request: web.Request) -> web.Response:
                 {"code": "run_not_running", "error": f"run is {run.get('status')}, not running"}, status=409)
         _CANCELLED.add(run_id)
         run["cancel_requested_at"] = _now()
-        _save_runs()
+        await _save_runs()
     return web.json_response({
         "ok": True, "run_id": run_id, "status": "cancelling",
         "message": "queued changes dropped; a review already in progress will finish",
@@ -944,7 +966,7 @@ async def _handle_run_delete(request: web.Request) -> web.Response:
                           "it to finish"},
                 status=409)
         _RUNS.remove(run)
-        _save_runs()
+        await _save_runs()
     await asyncio.to_thread(store.remove_run_dir, run_id)
     return web.json_response({"ok": True, "run_id": run_id})
 
@@ -1025,7 +1047,7 @@ async def _post_comments_bg(run_id: str, run: dict,
                 rec = by_cid.get(str(r.get("change_id")))
                 if rec is not None:
                     review_driver.apply_post_outcome(rec, r)
-            _save_runs()
+            await _save_runs()
         # Indexing is what stops the re-review; do it on the retry path too, and
         # only after the records above reflect what actually landed.
         await asyncio.to_thread(_record_reviewed, run)
@@ -1035,7 +1057,7 @@ async def _post_comments_bg(run_id: str, run: dict,
         async with _LOCK:
             run["posting"] = False
             run["post_error"] = str(e)
-            _save_runs()
+            await _save_runs()
     finally:
         # Same contract as a review's claims: release on EVERY terminal path, or
         # the change stays unreviewable until the gateway restarts.
@@ -1171,7 +1193,7 @@ async def _handle_run_post(request: web.Request) -> web.Response:
                 _INFLIGHT[_stage_key(cid)] = run_id
         run["posting"] = True
         run["post_error"] = None
-        _save_runs()
+        await _save_runs()
 
     # Keep a strong ref like the review path does, so the poster cannot be
     # garbage-collected mid-flight and leave `posting` set with nothing to clear
@@ -1289,7 +1311,7 @@ async def _handle_run_archive(request: web.Request) -> web.Response:
         run = _find_run(run_id)
         if run is not None:
             run["report_slug"] = slug
-        _save_runs()
+        await _save_runs()
     return web.json_response({"ok": True, "run_id": run_id, "report_slug": slug,
                               "created": True})
 
@@ -1581,10 +1603,9 @@ def _write_review_section(patch: dict) -> dict:
         review["max_concurrent"] = max(1, min(mc, review_pool.MAX_CONCURRENT_CEIL))
 
     cfg["review"] = review
-    tmp = cfg_path.with_name(cfg_path.name + ".tmp")
-    tmp.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, cfg_path)
+    # Same helper, same reasons as ``_write_runs`` -- including the retrying
+    # replace this write also lacked.
+    atomic_write(cfg_path, json.dumps(cfg, indent=2), restrict_to_owner=True)
     return review
 
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/discovery.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/discovery.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
-import tempfile
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -106,20 +104,6 @@ def gh_bin() -> str:
 
     Set ``KIROCREW_SAGE_GH`` to an absolute path to override (still validated).
     Raises :class:`GhSetupError` when no acceptable executable is found."""
-    if sys.platform == "win32":
-        # The provider-CLI trust gate this app shares with Issue Radar now works
-        # on Windows, but Sage needs a SECOND thing Issue Radar does not: its
-        # review prompts and its `sage-review` skill hand the worker session
-        # `python3 sage_lib/...` commands, and `python3` is not an interpreter on
-        # Windows -- the name resolves to the Microsoft Store app-execution
-        # alias, or to nothing. Enabling Sage here would trade a clear refusal
-        # for a review that starts and then produces no result record, so the
-        # refusal stays until the worker names the running interpreter.
-        raise GhSetupError(
-            "Code Review Sage is not yet supported on Windows: its review worker "
-            "invokes `python3`, which is not an interpreter on this platform "
-            "(tracked separately). Issue Radar does work on Windows."
-        )
     if github_runner is None:  # pragma: no cover - standalone fallback
         raise RuntimeError("gh_bin requires the Kiro Crew runtime")
     try:
@@ -389,13 +373,12 @@ def _write_repos(repos: list[dict], root: Path | None = None) -> Path:
     store.ensure_layout(root)
     path = repos_path(root)
     payload = json.dumps({"repos": repos}, indent=2).encode("utf-8")
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd, tmp = store.open_locked_temp(path.parent)
     try:
         try:
             os.write(fd, payload)
         finally:
             os.close(fd)
-        os.chmod(tmp, 0o600)
         os.replace(tmp, path)
     finally:
         if os.path.exists(tmp):

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py
@@ -32,7 +32,6 @@ import re
 import shutil
 import stat
 import sys
-import tempfile
 import threading
 import time
 from collections.abc import Sequence
@@ -304,13 +303,12 @@ def list_patterns_for_review(root: Path | None = None) -> list[dict]:
 
 def _atomic_write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd, tmp = store.open_locked_temp(path.parent)
     try:
         try:
             os.write(fd, text.encode("utf-8"))
         finally:
             os.close(fd)  # always close the fd, even if os.write raised
-        os.chmod(tmp, 0o600)
         os.replace(tmp, path)
     finally:
         if os.path.exists(tmp):

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
@@ -17,7 +17,6 @@ import json
 import os
 import re
 import sys
-import tempfile
 import time
 from pathlib import Path
 from urllib.parse import urlparse
@@ -800,19 +799,18 @@ def _atomic_write(path: Path, text: str) -> None:
 
     The reports dir is reachable by the review worker, so any of these output
     names can be a planted symlink; `write_text` would follow it and overwrite
-    the linked file, and the `os.chmod` after it would follow it too. Staging a
+    the linked file, and the lockdown after it would follow it too. Staging a
     private temp file in the same directory and renaming over the name swaps the
     NAME without following a link, so a plant is destroyed rather than honoured.
     Mirrors `learning.py:_atomic_write`.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd, tmp = store.open_locked_temp(path.parent)
     try:
         try:
             os.write(fd, text.encode("utf-8"))
         finally:
             os.close(fd)  # always close the fd, even if os.write raised
-        os.chmod(tmp, 0o600)  # 0600 before it takes the real name, not after
         os.replace(tmp, path)
     finally:
         if os.path.exists(tmp):

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import tempfile
 import threading
 from pathlib import Path
 
@@ -73,13 +72,12 @@ def write_reviewed(index: dict, root: Path | None = None) -> Path:
     store.ensure_layout(root)
     path = reviewed_path(root)
     data = json.dumps(index, indent=2).encode("utf-8")
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd, tmp = store.open_locked_temp(path.parent)
     try:
         try:
             os.write(fd, data)
         finally:
             os.close(fd)
-        os.chmod(tmp, 0o600)
         os.replace(tmp, path)
     finally:
         if os.path.exists(tmp):
@@ -248,13 +246,12 @@ def write_result(record: dict, root: Path | None = None,
         store.ensure_layout(root)
     path = result_path(record["change_id"], root, run_id)
     data = json.dumps(record, indent=2).encode("utf-8")
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd, tmp = store.open_locked_temp(path.parent)
     try:
         try:
             os.write(fd, data)
         finally:
             os.close(fd)  # always close the fd, even if os.write raised
-        os.chmod(tmp, 0o600)
         os.replace(tmp, path)
     finally:
         if os.path.exists(tmp):
@@ -468,10 +465,9 @@ def adopt_from_shared(change_id: str, root: Path | None = None,
     # and the rename replaces the NAME without following a link planted there.
     tmp = None
     try:
-        fd, tmp = tempfile.mkstemp(dir=str(dst.parent), prefix=".adopt-", suffix=".json")
+        fd, tmp = store.open_locked_temp(dst.parent, prefix=".adopt-", suffix=".json")
         with open(fd, "wb") as fh:
             fh.write(raw)
-        os.chmod(tmp, 0o600)
         os.replace(tmp, dst)
         tmp = None
     except OSError:
@@ -529,10 +525,9 @@ def publish_to_shared(change_id: str, root: Path | None = None,
                 max_bytes=_RECORD_MAX_BYTES)
         if raw is None:
             return False
-        fd, tmp = tempfile.mkstemp(dir=str(shared), prefix=".publish-", suffix=".json")
+        fd, tmp = store.open_locked_temp(shared, prefix=".publish-", suffix=".json")
         with open(fd, "wb") as fh:
             fh.write(raw)
-        os.chmod(tmp, 0o600)
         os.replace(tmp, dst)
         tmp = None
     except OSError:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -267,6 +267,46 @@ def _confirmed_host(link: str) -> str:
         return ""
 
 
+def python_command() -> str:
+    """Absolute interpreter the worker must use for the app's ``sage_lib/...`` commands.
+
+    The prompts hand a session on some host shell a command line, so they have to
+    name an interpreter that exists there. ``python3`` does not: neither the
+    python.org installer nor ``python -m venv`` creates a ``python3.exe`` on
+    Windows, where the name instead resolves to a Microsoft Store app-execution
+    alias that runs no Python — the command then produces no result record and
+    the review yields nothing while looking like it ran. ``sys.executable`` is an
+    absolute path to a real interpreter on every platform, so it satisfies that.
+
+    This returns the path RAW, and deliberately does no shell quoting. Quoting
+    requires knowing the worker's shell, which is not pinned: on Windows the
+    session may get PowerShell or cmd, and the two disagree — a quoted path is a
+    string literal needing PowerShell's call operator in one and a syntax error
+    with that operator in the other. Since a Windows profile with a space in it
+    (``C:\\Users\\First Last\\...``) is ordinary rather than exceptional, guessing
+    wrong would restore the same silent no-result failure for a large share of
+    Windows users. The worker knows its own shell, so the prompt tells it to
+    quote as that shell requires.
+    Deliberately NOT the shared ``resolve_app_python(app_root)`` policy, which
+    prefers ``<app_root>/.venv``'s interpreter. ``store.app_root()`` resolves under
+    ``KIROCREW_HOME`` -- the same writable tree the review worker itself writes into,
+    and that worker is prompt-injectable. A worker that planted an executable at
+    ``.venv/Scripts/python.exe`` would have the NEXT review execute it: arbitrary
+    code execution as the gateway plus forged result records, and persistence into
+    a later run rather than a capability it already had. So the interpreter is taken
+    from the process the prompt is built IN, never from a path the worker can write.
+
+    Nothing is given up by declining the venv preference here. That preference
+    exists so an app's own dependencies are importable, and this app has no
+    ``requirements.txt``; the only non-stdlib import anywhere in ``sage_lib`` is
+    ``kiro_crew`` itself, which is importable under ``sys.executable`` by
+    construction because that is the interpreter running the gateway. An app venv
+    would in fact be the weaker choice: it need not have ``kiro_crew`` installed
+    at all, which would fail every ``sage_lib`` import instead of just the review.
+    """
+    return sys.executable
+
+
 def _fetch_instruction(link: str) -> str:
     """Platform-aware FETCH instruction for the gate/deep prompts (GitHub only),
     carrying the link's confirmed host so the worker pulls the PR from ITS
@@ -360,17 +400,22 @@ def build_review_task(change_link: str) -> str:
     separate gated stage; the driver runs neither a gate turn nor a convergence
     loop. The session RECORDS findings only — it never posts (the driver builds the
     Python-redacted bodies and a separate poster publishes them verbatim)."""
+    py = python_command()
     return (
         "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
         "Do the COMPLETE review of EXACTLY ONE change in a SINGLE thorough pass: "
         + change_link + ". There is NO separate gate and NO follow-up round — cover "
         "everything now, carefully, at maximum thinking effort.\n"
+        "Run every `sage_lib/...` command — the ones below AND the ones the skill "
+        "writes as `<python> ...` — with this interpreter: `" + py + "`. Use that "
+        "absolute path verbatim (quote it as YOUR shell requires if it contains "
+        "spaces); do NOT substitute `python3` or `python`.\n"
         "Load the `sage-review` skill and follow its per-change review ruleset:\n"
         "  1. Self-heal the store; load patterns from active namespaces "
-        "(`python3 sage_lib/learning.py list-for-review`).\n"
+        "(`" + py + " sage_lib/learning.py list-for-review`).\n"
         "  2. Resolve the per-repo rule pack (if any) and apply it as additional rules.\n"
         "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
-        "normalize via `python3 sage_lib/pipeline.py prepare --link " + change_link
+        "normalize via `" + py + " sage_lib/pipeline.py prepare --link " + change_link
         + " --payload-file <file>`.\n"
         "  4. DESIGN dimension (THINK DEEPLY — highest leverage): work the change "
         "through the skill's `Deep design reasoning` lenses (architectural fit, "
@@ -417,7 +462,7 @@ def build_review_task(change_link: str) -> str:
         "  8. If this change is itself a FIX (is_fix), run INLINE miss-analysis "
         "(learn-from-sage): trace the introducing change, ask which dimension was "
         "blind, and STAGE the learning "
-        "(`python3 sage_lib/learning.py stage --file <pattern.json> --source fix_introduce`) "
+        "(`" + py + " sage_lib/learning.py stage --file <pattern.json> --source fix_introduce`) "
         "— NOT applied to the live ruleset until a human consolidates.\n"
         "Do NOT spawn further subagents. Execute; do not ask questions."
     )
@@ -429,16 +474,21 @@ def build_review_followup_task(change_link: str) -> str:
     changed files and APPENDS only net-new findings (never repeats/removes existing
     ones), then marks coverage complete. It runs at most one targeted pass,
     signal-driven, not count-delta-driven."""
+    py = python_command()
     return (
         "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
         "A prior pass reviewed EXACTLY ONE change: " + change_link + " but reported "
         "INCOMPLETE file coverage (coverage_complete=false) in data/results/<id>.json.\n"
+        "Run every `sage_lib/...` command — the ones below AND the ones the skill "
+        "writes as `<python> ...` — with this interpreter: `" + py + "`. Use that "
+        "absolute path verbatim (quote it as YOUR shell requires if it contains "
+        "spaces); do NOT substitute `python3` or `python`.\n"
         "Load the `sage-review` skill and follow its per-change review ruleset:\n"
         "  1. Self-heal the store; load patterns "
-        "(`python3 sage_lib/learning.py list-for-review`).\n"
+        "(`" + py + " sage_lib/learning.py list-for-review`).\n"
         "  2. Resolve the per-repo rule pack (if any) and apply it as additional rules.\n"
         "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
-        "normalize via `python3 sage_lib/pipeline.py prepare --link " + change_link
+        "normalize via `" + py + " sage_lib/pipeline.py prepare --link " + change_link
         + " --payload-file <file>`. READ the existing record: its `findings` and "
         "`files_covered`.\n"
         "  4. Review ONLY the changed files NOT already in `files_covered`, against "

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
@@ -28,6 +28,7 @@ import json
 import os
 import re
 import shutil
+import tempfile
 from pathlib import Path
 
 # Canonical KiroCrew data-root accessor. Imported at module top but kept guarded
@@ -38,6 +39,13 @@ try:
     from kiro_crew.config.paths import config_dir as _config_dir
 except ImportError:  # pragma: no cover - standalone fallback
     _config_dir = None  # type: ignore[assignment]
+
+# Owner-only lockdown, same guard shape as ``config_dir`` above: a raw
+# ``os.chmod`` cannot express one on Windows (see ``restrict_to_owner``).
+try:
+    from kiro_crew.platform_compat import restrict_to_owner as _runtime_restrict
+except ImportError:  # pragma: no cover - standalone fallback
+    _runtime_restrict = None  # type: ignore[assignment]
 
 APP_NAME = "code-review-sage"
 
@@ -121,6 +129,60 @@ def app_root() -> Path:
     default, honoring ``KIROCREW_HOME``); ``crew_home`` keeps a standalone
     fallback so the store stays importable outside the KiroCrew runtime."""
     return crew_home() / "apps" / APP_NAME
+
+
+def restrict_to_owner(path: str | os.PathLike) -> None:
+    """Lock a file this app stages down to its owner, before it takes its name.
+
+    Every record, report and cache written here carries change content, so each
+    one is restricted while it is still a private temp file. ``os.chmod(0o600)``
+    expresses that only on POSIX: on Windows it toggles the read-only attribute,
+    leaves the inherited DACL untouched, and *succeeds* — so the file stays
+    readable by every other local account and nothing is raised to notice.
+    Delegating to the runtime's helper applies a real owner-only DACL there,
+    while the POSIX path stays the same chmod, including the fail-loud
+    ``OSError`` the callers' temp-file cleanup relies on.
+
+    The standalone fallback is that bare chmod, matching the guard on
+    ``config_dir`` above: outside the Kiro Crew runtime there is no stdlib way to
+    set a Windows DACL, and refusing the write would be worse than the POSIX
+    behaviour this app has always had.
+    """
+    if _runtime_restrict is not None:
+        _runtime_restrict(path)
+        return
+    os.chmod(path, 0o600)  # pragma: no cover - standalone fallback
+
+
+def open_locked_temp(directory: str | os.PathLike, *,
+                     prefix: str = "", suffix: str = ".tmp") -> tuple[int, str]:
+    """Create a temp file in ``directory`` that is ALREADY owner-only, and return
+    ``(fd, path)`` with the file still open for writing.
+
+    The lockdown has to happen before the caller writes a byte. ``mkstemp`` gives
+    a POSIX file mode ``0600`` from creation, but on Windows access comes from the
+    DACL, and a new file simply inherits the directory's -- so restricting only
+    after the payload is written leaves a window in which the content is readable
+    by everyone the parent grants. Nothing in this app tightens its data
+    directories, so that window is real rather than theoretical.
+
+    The returned fd is opened before the DACL changes, and Windows checks access
+    at open time, so the caller's write still succeeds. If the lockdown itself
+    fails the caller never receives either handle, so this closes the descriptor
+    AND removes the temp file here -- the exception escapes before the caller's
+    own ``try/finally`` is entered, so nothing downstream would clean either up.
+    """
+    fd, tmp = tempfile.mkstemp(dir=str(directory), prefix=prefix, suffix=suffix)
+    try:
+        restrict_to_owner(tmp)
+    except BaseException:
+        os.close(fd)
+        try:
+            os.unlink(tmp)
+        except OSError:  # pragma: no cover - best-effort cleanup
+            pass
+        raise
+    return fd, tmp
 
 
 # Optional Kiro Crew redaction. Lives here rather than in `pipeline` because readers

--- a/src/kiro_crew/apps/builtins/code_review_sage/skills/learn-from-sage/SKILL.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/skills/learn-from-sage/SKILL.md
@@ -17,11 +17,21 @@ Two files, one rule each:
   Reviews do NOT read it. It is merged into `learned-patterns.md` only when a
   human triggers **consolidation** (a one-shot AI merge), after which it's cleared.
 
+## The interpreter in every command below
+
+Commands here are written as `<python> …`. Replace `<python>` with the absolute
+interpreter path the task prompt names — it is the one the app itself runs, and
+it is the only interpreter guaranteed to exist on this host. Never substitute a
+bare `python3`: Windows has no such interpreter (the name resolves to a
+Microsoft Store app-execution alias that runs nothing), so the command would
+stage nothing and the learning would be silently lost. Outside a review
+session, use the interpreter running the app.
+
 ## Self-heal (first)
 
 ```bash
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/store.py --ensure
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py seed   # no-op if already seeded
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/store.py --ensure
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py seed   # no-op if already seeded
 ```
 
 ## Admissible sources only (no self-poisoning)
@@ -63,7 +73,7 @@ review** (not a separate pass):
    or drop it. When in doubt, prefer fewer, broader rules over many narrow ones.
 4. **Stage** it (cheap, no model merge yet):
    ```bash
-   python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py stage \
+   <python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py stage \
        --file /tmp/pattern.json --source fix_introduce [--namespace <name>]
    ```
    The pattern JSON carries: `title, scope (common), dimension, impact, guidance`.
@@ -97,7 +107,7 @@ When the human asks to consolidate (or the app's "Consolidate" button routes her
 3. Write the merged markdown to a temp file and apply it atomically — this
    replaces `learned-patterns.md` and clears the candidate:
    ```bash
-   python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py consolidate \
+   <python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py consolidate \
        --merged-file /tmp/merged-learned-patterns.md
    ```
    `consolidate` refuses empty content (never wipes the ruleset) and records a
@@ -112,11 +122,11 @@ When the human asks to consolidate (or the app's "Consolidate" button routes her
 
 Inspect staging anytime:
 ```bash
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-candidate [--namespace <name>]
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-patterns [--namespace <name>]
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py clear-candidate [--namespace <name>]
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-namespaces
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-for-review  # union of active namespaces
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-candidate [--namespace <name>]
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-patterns [--namespace <name>]
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py clear-candidate [--namespace <name>]
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-namespaces
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-for-review  # union of active namespaces
 ```
 
 > Namespaces are supported: learnings are grouped by namespace. The `default`

--- a/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
@@ -19,10 +19,20 @@ supplied as context, not baked in:
 2. **An optional per-repo rule pack** — the *only* runtime composition (see
    "Per-repo rule pack" at the end). The generic core stays clean for any repo.
 
+## The interpreter in every command below
+
+Commands here are written as `<python> …`. Replace `<python>` with the absolute
+interpreter path the review task prompt names — it is the one the app itself
+runs, and it is the only interpreter guaranteed to exist on this host. Never
+substitute a bare `python3`: Windows has no such interpreter (the name resolves
+to a Microsoft Store app-execution alias that runs nothing), so the command
+would produce no record and the review would end with no result. Outside a
+review session, use the interpreter running the app.
+
 ## Self-heal (run first, always — idempotent)
 
 ```bash
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/store.py --ensure
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/store.py --ensure
 ```
 
 ## Load learning context (before reviewing)
@@ -31,7 +41,7 @@ Load patterns from all **active namespaces** (configured in config.json →
 `review.active_namespaces`). The CLI command unions them for you:
 
 ```bash
-python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-for-review
+<python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py list-for-review
 ```
 
 Or read them manually — the "default" namespace maps to `common/`, others live
@@ -445,7 +455,7 @@ from the `learn-from-sage` skill:
 3. If it passes the quality gate (general, non-trivial, fits a dimension),
    **stage** it into the candidate file (`source=fix_introduce`):
    ```bash
-   python3 ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py stage \
+   <python> ~/.kiro/crew/apps/code-review-sage/sage_lib/learning.py stage \
        --file /tmp/pattern.json --source fix_introduce
    ```
    This appends to `learned-patterns.candidate.md` only — it does NOT touch the
@@ -513,7 +523,7 @@ the durable source of truth the Focus Report reads. **Findings JSON contract**
 }
 ```
 
-> Use the `change_id` emitted by `python3 sage_lib/pipeline.py prepare` **verbatim** — do NOT invent or reformat it (it must match the driver's `_cid`, or the record write and read hit different files).
+> Use the `change_id` emitted by `<python> sage_lib/pipeline.py prepare` **verbatim** — do NOT invent or reformat it (it must match the driver's `_cid`, or the record write and read hit different files).
 
 **One record, written in one pass.** Every review writes exactly ONE record with
 `deep_reviewed: true` and a fully populated `phase1` block (design dimension) —

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
@@ -1,19 +1,16 @@
 """Collection-time platform gate for the Code Review Sage suite.
 
-Two independent reasons, both still true:
+The app itself now runs on Windows: the provider-CLI trust gate it shares with
+Issue Radar answers from the Windows ACL, and the review worker is handed the
+absolute interpreter the app resolves rather than the bare `python3` that is not
+an interpreter there.
 
-* the app refuses to run on Windows — `sage_lib/discovery.py` raises because its
-  review worker invokes `python3`, which is not an interpreter there; and
-* these tests assert POSIX behaviour throughout anyway (`0600` file modes,
-  forward-slash path suffixes, shell-script `gh` stubs the Windows runner cannot
-  execute).
-
-Note what changed and what did not. The provider-CLI trust gate Sage shares with
-Issue Radar is no longer POSIX-only: `github_runner.validate_provider_executable`
-now answers from the Windows ACL. Sage's own refusal is narrower than it was — it
-names the interpreter, not the trust check — but it is still a refusal, so
-running this suite on Windows would still exercise a configuration the app
-rejects.
+What still gates the suite is the suite, not the app. These tests assert POSIX
+behaviour throughout — `0600` file modes as `st_mode` bits (Windows expresses
+owner-only as a DACL and always reports `0o666`), forward-slash path suffixes,
+and shell-script `gh` stubs the Windows runner cannot execute — so running them
+there would fail on the harness rather than on anything under test. Making them
+Windows-native is separate work from making the app run.
 
 This lives next to the suite it gates, so the reason travels with the tests
 rather than sitting in a CI workflow that would hide it.
@@ -27,7 +24,7 @@ collect_ignore_glob = ["*"] if os.name == "nt" else []
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt",
-    reason="Code Review Sage does not run on Windows yet (see sage_lib/discovery.py)",
+    reason="Code Review Sage's test harness is POSIX-only (see this conftest's docstring)",
 )
 
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -38,6 +38,15 @@ from sage_lib import review_pool as _rp  # noqa: E402
 from sage_lib.review_driver import _all_delivered  # noqa: E402
 
 
+async def _noop_save() -> None:
+    """Stand-in for ``routes._save_runs``, which is a coroutine.
+
+    The registry write is offloaded to a worker thread because its owner-only
+    lockdown spawns ``icacls`` on Windows, so a plain ``lambda: None`` stub is
+    not awaitable and the patched call site would raise instead of no-op.
+    """
+
+
 def _load_routes_module():
     spec = importlib.util.spec_from_file_location("sage_backend_routes_under_test", str(_ROUTES))
     assert spec and spec.loader
@@ -63,7 +72,7 @@ class TestRunsPersistence(unittest.TestCase):
 
     def test_save_then_load_roundtrip(self):
         self.mod._RUNS = [{"run_id": "a1", "status": "done", "changes": ["CR-1"]}]
-        self.mod._save_runs()
+        asyncio.run(self.mod._save_runs())
         self.assertTrue(self.mod._runs_file().is_file())
         self.mod._RUNS = []  # simulate a fresh process
         self.mod._load_runs()
@@ -72,7 +81,7 @@ class TestRunsPersistence(unittest.TestCase):
 
     def test_orphaned_running_becomes_interrupted_on_load(self):
         self.mod._RUNS = [{"run_id": "b2", "status": "running", "changes": ["CR-9"]}]
-        self.mod._save_runs()
+        asyncio.run(self.mod._save_runs())
         self.mod._RUNS = []
         self.mod._load_runs()  # simulates a gateway restart
         self.assertEqual(self.mod._RUNS[0]["status"], "interrupted")
@@ -86,8 +95,83 @@ class TestRunsPersistence(unittest.TestCase):
     )
     def test_runs_file_is_0600(self):
         self.mod._RUNS = [{"run_id": "c3", "status": "done"}]
-        self.mod._save_runs()
+        asyncio.run(self.mod._save_runs())
         self.assertEqual(oct(self.mod._runs_file().stat().st_mode)[-3:], "600")
+
+    def test_a_planted_tmp_symlink_is_not_followed(self):
+        """The review worker writes into this tree and is prompt-injectable, so it
+        must not be able to steer the registry write at an arbitrary file.
+
+        A predictable ``runs.json.tmp`` was guessable: planting a symlink there
+        made the gateway's own ``touch`` / lockdown / write land on the target,
+        permission-changing and overwriting a user-owned file outside the sandbox.
+        The randomly-named O_EXCL temp cannot open a path that already exists.
+        """
+        outsider = Path(self.tmp) / "precious.txt"
+        outsider.write_text("do not touch", encoding="utf-8")
+        runs = self.mod._runs_file()
+        runs.parent.mkdir(parents=True, exist_ok=True)
+        planted = runs.with_name(runs.name + ".tmp")
+        try:
+            os.symlink(outsider, planted)
+        except (OSError, NotImplementedError) as exc:  # pragma: no cover
+            self.skipTest(f"symlink creation unavailable on this host: {exc}")
+
+        self.mod._RUNS = [{"run_id": "d4", "status": "done"}]
+        asyncio.run(self.mod._save_runs())
+
+        self.assertEqual(outsider.read_text(encoding="utf-8"), "do not touch",
+                         "the planted symlink was followed and its target rewritten")
+        self.assertIn("d4", runs.read_text(encoding="utf-8"))
+
+    def test_the_predictable_tmp_name_is_never_used(self):
+        """Symlink-free twin of the test above, so the invariant is also covered on
+        Windows -- where creating a symlink needs a privilege CI does not grant, yet
+        which is the platform this whole change targets.
+
+        Anything the worker can pre-place at the guessable path must survive: if the
+        write still used ``<name>.tmp`` this file would be silently clobbered.
+        """
+        runs = self.mod._runs_file()
+        runs.parent.mkdir(parents=True, exist_ok=True)
+        squatter = runs.with_name(runs.name + ".tmp")
+        squatter.write_text("planted", encoding="utf-8")
+
+        self.mod._RUNS = [{"run_id": "e5", "status": "done"}]
+        asyncio.run(self.mod._save_runs())
+
+        self.assertEqual(squatter.read_text(encoding="utf-8"), "planted",
+                         "the write still targets the predictable <name>.tmp path")
+        self.assertIn("e5", runs.read_text(encoding="utf-8"))
+
+    def test_the_lockdown_never_runs_on_the_event_loop(self):
+        """The owner-only lockdown spawns ``icacls`` on Windows, so persisting the
+        registry must not block the single gateway loop -- a freeze there stalls
+        every chat turn and the liveness heartbeat, not just this write.
+
+        Asserted structurally rather than by timing, so it holds regardless of how
+        fast the syscall happens to be on this host. The thread is RECORDED and
+        compared afterwards rather than asserted inside the patch: ``_save_runs``
+        deliberately swallows every exception, so an ``AssertionError`` raised in
+        there would be logged and the test would pass on a real regression.
+        """
+        seen: dict[str, int] = {}
+
+        def _record_thread(payload: str) -> None:
+            seen["write"] = threading.get_ident()
+
+        async def _drive() -> None:
+            seen["loop"] = threading.get_ident()
+            with unittest.mock.patch.object(self.mod, "_write_runs", _record_thread):
+                await self.mod._save_runs()
+
+        self.mod._RUNS = [{"run_id": "d4", "status": "done"}]
+        asyncio.run(_drive())
+        self.assertIn("write", seen, "_write_runs was never reached")
+        self.assertNotEqual(
+            seen["write"], seen["loop"],
+            "_write_runs ran on the event-loop thread; the icacls spawn inside it "
+            "would freeze the gateway")
 
 
 class TestRecordReviewedDelivery(unittest.TestCase):
@@ -732,7 +816,7 @@ class TestRetentionKeepsActiveRuns(unittest.IsolatedAsyncioTestCase):
         self.mod._RUNS[:] = []
 
     async def _record_many(self, statuses):
-        with unittest.mock.patch.object(self.mod, "_save_runs", lambda: None), \
+        with unittest.mock.patch.object(self.mod, "_save_runs", _noop_save), \
                 unittest.mock.patch.object(self.mod.store, "remove_run_dir",
                                   lambda rid, *a, **k: self.removed.append(rid)):
             for i, st in enumerate(statuses):
@@ -754,7 +838,7 @@ class TestRetentionKeepsActiveRuns(unittest.IsolatedAsyncioTestCase):
         # Evicting it deletes the subtree mid-delivery and loses the record of what
         # landed. The delete handler already refused this; retention did not.
         cap = self.mod._RUNS_MAX
-        with unittest.mock.patch.object(self.mod, "_save_runs", lambda: None), \
+        with unittest.mock.patch.object(self.mod, "_save_runs", _noop_save), \
                 unittest.mock.patch.object(self.mod.store, "remove_run_dir",
                                            lambda rid, *a, **k: self.removed.append(rid)):
             await self.mod._record({"run_id": "run-0", "status": "done",
@@ -770,7 +854,7 @@ class TestRetentionKeepsActiveRuns(unittest.IsolatedAsyncioTestCase):
         # The guard must not pin the run forever: once posting clears, it is
         # terminal and reclaimable on the next _record.
         cap = self.mod._RUNS_MAX
-        with unittest.mock.patch.object(self.mod, "_save_runs", lambda: None), \
+        with unittest.mock.patch.object(self.mod, "_save_runs", _noop_save), \
                 unittest.mock.patch.object(self.mod.store, "remove_run_dir",
                                            lambda rid, *a, **k: self.removed.append(rid)):
             done = {"run_id": "run-0", "status": "done", "posting": True}

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -1,6 +1,7 @@
 """Unit tests for the code-enforced two-stage review driver (gap A + phase switch)."""
 import re
 import shutil
+import sys
 import tempfile
 import threading
 import unittest
@@ -410,10 +411,10 @@ class TestReviewDriver(unittest.TestCase):
 
 
 class TestWorkerPromptScriptPaths(unittest.TestCase):
-    """Guard: every ``python3 <path>`` the worker prompts instruct must point at a
-    script that actually ships in the app. This catches a rename (e.g. the
-    ``lib`` -> ``sage_lib`` move) that misses a prompt string — which would make
-    the worker run a non-existent path and silently produce no verdict."""
+    """Guard: every script path the worker prompts instruct must point at a script
+    that actually ships in the app. This catches a rename (e.g. the ``lib`` ->
+    ``sage_lib`` move) that misses a prompt string — which would make the worker
+    run a non-existent path and silently produce no verdict."""
 
     def test_prompts_reference_existing_script_paths(self):
         app_root = Path(__file__).resolve().parents[1]
@@ -421,11 +422,112 @@ class TestWorkerPromptScriptPaths(unittest.TestCase):
                    D.build_review_followup_task("CR-12345678")]
         refs = set()
         for p in prompts:
-            refs.update(re.findall(r"python3 ([\w./-]+\.py)", p))
+            refs.update(re.findall(r"(sage_lib/[\w./-]+\.py)", p))
         self.assertTrue(refs, "expected the worker prompts to reference a script")
         for rel in sorted(refs):
             self.assertTrue((app_root / rel).is_file(),
                             f"worker prompt references a missing path: {rel}")
+
+
+class TestWorkerPromptInterpreter(unittest.TestCase):
+    """The worker runs the app's scripts through a shell on an unknown host, so the
+    prompts must name an interpreter that exists there. ``python3`` does not on
+    Windows — the name is a Microsoft Store app-execution alias, not an
+    interpreter — and the failure is silent: the command runs no Python, no result
+    record is written, and the review ends with no verdict."""
+
+    LINK = "https://github.com/o/r/pull/12345678"
+
+    def _prompts(self):
+        return [D.build_review_task(self.LINK), D.build_review_followup_task(self.LINK)]
+
+    def test_no_prompt_names_a_bare_interpreter(self):
+        for p in self._prompts():
+            self.assertNotIn("python3 ", p)
+            self.assertNotIn("`python ", p)
+
+    def test_every_script_command_carries_the_resolved_interpreter(self):
+        py = D.python_command()
+        for p in self._prompts():
+            for cmd in re.findall(r"`([^`]*sage_lib/[\w./-]+\.py[^`]*)`", p):
+                self.assertTrue(cmd.startswith(py + " "),
+                                f"script command does not name the interpreter: {cmd}")
+
+    def test_prompt_states_the_interpreter_for_the_skill_commands(self):
+        # The shipped skills write their commands as `<python> ...`; the prompt is
+        # the only place that can tell the worker what to substitute.
+        for p in self._prompts():
+            self.assertIn("<python>", p)
+            self.assertIn(D.python_command(), p)
+
+    def test_resolved_interpreter_is_an_absolute_path(self):
+        self.assertTrue(Path(D.python_command()).is_absolute())
+
+    def test_the_interpreter_is_never_taken_from_a_worker_writable_path(self):
+        """``store.app_root()`` is under ``KIROCREW_HOME``, which the review worker
+        writes into and which a prompt injection therefore controls. Resolving the
+        interpreter through it would let a planted ``.venv/Scripts/python.exe`` be
+        executed by the NEXT review. Any reintroduction of that lookup fails here.
+        """
+        with mock.patch.object(
+            D.store,
+            "app_root",
+            side_effect=AssertionError("python_command must not consult app_root"),
+        ):
+            self.assertEqual(D.python_command(), sys.executable)
+
+
+class TestInterpreterIsHandedOverRaw(unittest.TestCase):
+    """The prompts do NOT shell-quote the interpreter, and that is deliberate.
+
+    Quoting needs the worker's shell, which is not pinned: a Windows session may
+    get PowerShell or cmd, and a form valid in one is a syntax error in the
+    other. Three separate defects came out of guessing (``$`` expanding inside a
+    double-quoted PowerShell string, ``\\`` consumed as an escape by a POSIX
+    shell, and the PowerShell call operator breaking cmd), so the responsibility
+    moved to the worker, which knows its own shell.
+    """
+
+    LINK = "https://github.com/o/r/pull/12345678"
+
+    def test_the_resolved_path_is_not_quoted_or_escaped(self):
+        # Injected at the seam the interpreter now comes from: the gateway's own
+        # ``sys.executable``. Whatever it contains -- a space, a ``$``, a backslash
+        # run -- must arrive verbatim, since each of those was a separate defect.
+        for exe in (r"C:\Program Files\Py\python.exe",
+                    r"C:\tools\$python v2\python.exe",
+                    "/home/u/my py/bin/python3",
+                    r"/home/u/kiro\home/bin/python3"):
+            with mock.patch.object(D.sys, "executable", exe):
+                self.assertEqual(D.python_command(), exe)
+
+    def test_the_prompt_tells_the_worker_to_quote_for_its_own_shell(self):
+        # Without this instruction a space-containing path -- ordinary on Windows,
+        # where profiles are named "First Last" -- would be split by the shell and
+        # the command would run nothing, which is the failure this PR removes.
+        for prompt in (D.build_review_task(self.LINK),
+                       D.build_review_followup_task(self.LINK)):
+            self.assertIn("quote it as YOUR shell requires", prompt)
+
+
+class TestShippedSkillsNameNoBareInterpreter(unittest.TestCase):
+    """The skills ship in the wheel and the worker is told to load them, so a
+    ``python3`` command left in one reaches the worker exactly as a prompt string
+    would — the prompt guard above cannot see it."""
+
+    def test_no_skill_command_names_a_bare_interpreter(self):
+        # Matches an interpreter name followed by a script path ANYWHERE in the
+        # line, not just at its start: the one surviving `python3` in these files
+        # was inside a `>` blockquote, which a line-anchored pattern cannot see.
+        # The lookbehind keeps `<python> foo.py` (the placeholder) from matching.
+        bare = re.compile(r"(?<![<\w])python3?\s+\S*\.py\b")
+        skills = Path(__file__).resolve().parents[1] / "skills"
+        found = list(skills.glob("*/SKILL.md"))
+        self.assertTrue(found, "expected the app to ship skills")
+        for md in found:
+            for i, line in enumerate(md.read_text(encoding="utf-8").splitlines(), 1):
+                self.assertNotRegex(line, bare,
+                                    f"{md.name}:{i} names a bare interpreter")
 
 
 class TestDeterministicPosting(unittest.TestCase):

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
@@ -4,10 +4,12 @@ Locks in the fix for the "Initializing…" stuck state: when the generic app
 config handler has already seeded an empty ``{}`` config.json, ensure_layout
 must upgrade it to include ``resolved_paths`` so the UI can bootstrap."""
 import json
+import os
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from sage_lib import store
 
@@ -119,3 +121,81 @@ class TestReadConfigQuiet(unittest.TestCase):
         except (OSError, NotImplementedError):  # pragma: no cover
             self.skipTest("symlinks unavailable on this host")
         self.assertEqual(store.read_config_quiet(self.root), {})
+
+
+class TestRestrictToOwner(unittest.TestCase):
+    """Every record, report and cache this app stages is locked to its owner before
+    it takes its final name. The lockdown must go through the runtime helper, not a
+    raw ``os.chmod``: on Windows a chmod only toggles the read-only attribute,
+    leaves the inherited DACL intact, and SUCCEEDS — so the file would stay
+    readable by other local accounts with nothing raised to notice."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        # Registered before the write below: a failure there skips tearDown, and
+        # the directory would survive the run.
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.path = Path(self.tmp) / "record.json"
+        self.path.write_text("{}", encoding="utf-8")
+
+    def test_delegates_to_the_runtime_helper(self):
+        seen: list[object] = []
+        with mock.patch.object(store, "_runtime_restrict", seen.append):
+            store.restrict_to_owner(self.path)
+        self.assertEqual(seen, [self.path])
+
+    def test_lockdown_failure_propagates(self):
+        # The callers stage into a private temp file and unlink it in a ``finally``;
+        # they rely on the OSError to reach that cleanup instead of renaming a
+        # file whose permissions were never applied.
+        def boom(_path):
+            raise OSError("icacls failed")
+
+        with mock.patch.object(store, "_runtime_restrict", boom):
+            with self.assertRaises(OSError):
+                store.restrict_to_owner(self.path)
+
+    def test_applies_owner_only_permissions(self):
+        store.restrict_to_owner(self.path)
+        if os.name == "posix":
+            self.assertEqual(self.path.stat().st_mode & 0o777, 0o600)
+
+    def test_the_temp_file_is_locked_before_any_payload_byte_is_written(self):
+        """A new file inherits the directory's DACL on Windows, so restricting it
+        only after the payload is written leaves a window in which the content is
+        readable by everyone the parent grants -- and nothing tightens this app's
+        data directories. The fd must therefore come back already restricted.
+
+        Asserted by ORDER, not by permissions: the mode bits cannot express this on
+        Windows, and the whole point is that the lockdown precedes the write.
+        """
+        order: list[str] = []
+        real = store.restrict_to_owner
+
+        def _tracked(path):
+            order.append("lock")
+            return real(path)
+
+        with mock.patch.object(store, "restrict_to_owner", _tracked):
+            fd, tmp = store.open_locked_temp(self.tmp)
+            try:
+                order.append("write")
+                os.write(fd, b"sensitive")
+            finally:
+                os.close(fd)
+        self.assertEqual(order, ["lock", "write"])
+        self.assertTrue(Path(tmp).is_file())
+
+    def test_a_failed_lockdown_leaves_no_descriptor_and_no_temp_file(self):
+        # The caller never receives the fd or the path on this path, so nothing
+        # else can close or remove them: a leak here would orphan one descriptor
+        # and one stray temp file per failed write.
+        def boom(_path):
+            raise OSError("icacls failed")
+
+        before = set(os.listdir(self.tmp))
+        with mock.patch.object(store, "restrict_to_owner", boom):
+            with self.assertRaises(OSError):
+                store.open_locked_temp(self.tmp)
+        self.assertEqual(set(os.listdir(self.tmp)), before,
+                         "a temp file was left behind by the failed lockdown")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -546,6 +546,30 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # completion. No child process, and every payload is a literal in the test
         # file.
         "apps/builtins/issue_radar/tests/test_assignees.py::_await",
+        # NOT subprocess spawns: the AST heuristic matches ``asyncio.run`` (attr
+        # ``run`` on base ``asyncio``). These four TEST functions drive Code Review
+        # Sage's ``_save_runs`` coroutine to completion without a running loop --
+        # the registry write is a coroutine because its owner-only lockdown spawns
+        # ``icacls`` on Windows and so must be offloaded off the event loop (that
+        # real spawn is ``platform_compat.py::restrict_to_owner``, allowlisted
+        # below). No child process is created here and nothing is
+        # agent-influenced: every run record in these tests is a literal dict.
+        # Same classification as the other ``asyncio.run`` sites in this list.
+        "apps/builtins/code_review_sage/tests/test_backend_routes.py"
+        "::test_save_then_load_roundtrip",
+        "apps/builtins/code_review_sage/tests/test_backend_routes.py"
+        "::test_orphaned_running_becomes_interrupted_on_load",
+        "apps/builtins/code_review_sage/tests/test_backend_routes.py" "::test_runs_file_is_0600",
+        "apps/builtins/code_review_sage/tests/test_backend_routes.py"
+        "::test_the_lockdown_never_runs_on_the_event_loop",
+        # Same construct and classification: these two drive ``_save_runs`` to prove
+        # the registry write no longer targets a predictable ``runs.json.tmp`` that a
+        # prompt-injected worker could pre-plant a symlink at. The pre-planted path is
+        # built by the test itself, so nothing here is agent-influenced either.
+        "apps/builtins/code_review_sage/tests/test_backend_routes.py"
+        "::test_a_planted_tmp_symlink_is_not_followed",
+        "apps/builtins/code_review_sage/tests/test_backend_routes.py"
+        "::test_the_predictable_tmp_name_is_never_used",
         # md-notebook shells out to the real git binary rather than a pure-Python
         # implementation, because a server refuses a push from the shallow clone
         # isomorphic-git produces. The command is the literal "git"; the remote


### PR DESCRIPTION
## Problem / Motivation

Code Review Sage does not run on Windows. Its review worker is handed
`python3 sage_lib/...` commands, and `python3` is not an interpreter there:
neither the python.org installer nor `python -m venv` creates a `python3.exe`,
and the name resolves instead to a Microsoft Store app-execution alias that runs
no Python. The command produces no result record, so a review starts and ends
with no verdict — a silent failure. Rather than ship that, the app refused on
Windows, which was the last reason Sage did not work there while Issue Radar
(after #4613) did.

## Why it matters

Windows users get no code review from the app at all. The refusal is the good
outcome of the two available today: without it, the review appears to run and
silently yields nothing, which is worse than a clear message. Removing the
refusal is the acceptance criterion for #4630, and it is only safe once the
worker names an interpreter that exists on the host.

## What changed (motivation → approach → change)

Symptom: the worker's Python commands never run on Windows. Root cause: the
prompts and the shipped skills name a platform-specific alias instead of an
interpreter. So the change stops naming an alias.

**The five prompt sites** in `sage_lib/review_driver.py` now name the gateway's
own `sys.executable` — an absolute path to a real interpreter on every platform.

This is deliberately **not** the shared `resolve_app_python(app_root)` policy,
which prefers `<app_root>/.venv`. `store.app_root()` resolves under
`KIROCREW_HOME`, the same writable tree the review worker writes into, and that
worker is prompt-injectable: a planted `.venv/Scripts/python.exe` would be
executed by the *next* review, which is arbitrary code execution as the gateway
plus forged result records — persistence into a later run rather than a
capability the worker already had. Nothing is given up by declining the venv
preference here: that preference exists so an app's own dependencies are
importable, this app ships no `requirements.txt`, and the only non-stdlib import
anywhere in `sage_lib/` is `kiro_crew` itself, which is importable under
`sys.executable` by construction. An app venv would in fact be the weaker choice,
since it need not have `kiro_crew` installed at all.

**The path is handed over raw, with no shell quoting.** Quoting requires knowing
the worker's shell, which is not pinned: a Windows session may get PowerShell or
cmd, and a form valid in one is a syntax error in the other (a quoted path needs
PowerShell's call operator, which cmd rejects). Since a Windows profile with a
space in it is ordinary rather than exceptional, guessing wrong would restore the
same silent no-result failure for a large share of Windows users. The prompt
therefore tells the worker to quote as its own shell requires.

**The two shipped skills** carry commands too, and app skills are registered by
symlink/junction into `~/.kiro/crew/skills` rather than copied
(`apps/bridges.py`), so there is no rendered file to substitute a placeholder
into at load time. They therefore stop naming an interpreter at all: commands
read `<python> …`, and each skill opens with a note pointing at the one the task
prompt names. `learn-from-sage/SKILL.md` is included because the review prompt
routes inline miss-analysis through it, so its commands reach the worker exactly
as the review skill's do.

**The refusal** in `sage_lib/discovery.py` is removed, which is what closes the
issue.

**Removing it makes a second Windows gap live, so this closes it too.** Every
record, report and cache the app stages was locked to its owner with
`os.chmod(0o600)`, which expresses that only on POSIX: on Windows it toggles the
read-only attribute, leaves the inherited DACL intact, and *succeeds* — so the
files would stay readable by every other local account with nothing raised to
notice. The `sage_lib` call sites now route through one seam,
`store.open_locked_temp`, which creates the temp with `mkstemp` and applies
`platform_compat.restrict_to_owner` **before** returning the descriptor; the
POSIX path is the same chmod, including the fail-loud `OSError` the callers' temp
cleanup relies on.

**Two further changes in `backend/routes.py` follow from that one and are called
out because they are behaviour changes, not refactors.**

- *The temp files are no longer predictably named.* Both writers (the run
  registry and the settings writer) previously used `<name>.tmp` and a bare
  `os.replace`. A predictable name in a worker-writable directory lets a
  prompt-injected worker pre-plant a symlink there, and `Path.touch()` follows
  one — so the lockdown and the payload would both land on an arbitrary
  user-owned file. Both now call `kiro_crew.atomic_write.atomic_write(...,
  restrict_to_owner=True)`, which picks an unpredictable `mkstemp` name, locks the
  temp down before the payload, refuses a planted parent link, and replaces
  through `replace_with_retry` — closing a transient-sharing-violation gap on
  Windows that the bare `os.replace` had (the class tracked in #4701 / #4898).
- *The registry save is now offloaded.* `restrict_to_owner` spawns `icacls` on
  Windows, so the write can no longer run on the gateway's event loop. `_save_runs`
  is now a coroutine that serializes the registry **on** the loop — preserving the
  snapshot-under-the-caller's-lock property — and offloads only the file write via
  `asyncio.to_thread`; all eight call sites `await` it.

The test suite stays gated on Windows and its conftest now says why: the
*harness* is POSIX-only (`0600` as `st_mode` bits, forward-slash suffixes,
shell-script `gh` stubs), which is separate work from making the app run. The
docstring previously gave two reasons; one is now false, so only the true one
remains.

## Tests

- The existing worker-prompt guard asserted the prompts contain a
  `python3 <path>` reference, so it **failed** on this change rather than
  passing vacuously. It is now interpreter-agnostic, still checking every
  referenced script path exists.
- `TestWorkerPromptInterpreter` — no prompt names a bare interpreter; every
  script command carries the resolved one; the prompt states the interpreter for
  the skills' `<python>` placeholder; the resolved value is absolute; and
  `test_the_interpreter_is_never_taken_from_a_worker_writable_path` patches
  `store.app_root` to raise, so any reintroduction of the app-root lookup fails
  the suite.
- `TestInterpreterIsHandedOverRaw` — a path containing a space, a `$`, or a
  backslash run arrives verbatim. Each of those was a separate defect in an
  earlier revision of this change, so the guard pins all three at once.
- `TestShippedSkillsNameNoBareInterpreter` — reads the shipped `SKILL.md` files
  and fails on a bare-interpreter command. A `python3` left in a skill reaches
  the worker exactly as a prompt string would, and the prompt guard cannot see
  it.
- `TestRestrictToOwner` — the lockdown delegates to the runtime helper (not a raw
  chmod, which succeeds while doing nothing on Windows), a lockdown failure
  propagates so the callers' temp-file cleanup still runs, owner-only permissions
  are applied on POSIX, and a failed lockdown leaves behind neither the
  descriptor nor the temp file.
- Registry-write guards in `test_backend_routes.py` — the owner-only lockdown
  never runs on the event loop (the test records the executing thread id and
  compares after the call, rather than asserting inside a swallowed `except`);
  a planted `runs.json.tmp` symlink is not followed; and the predictable
  `<name>.tmp` path is never written, which is the symlink-free twin so the
  invariant is also covered on Windows, where creating a symlink needs a
  privilege CI does not grant.

## Manual verification

Verified on a Windows 11 host that `python_command()` returns an absolute
interpreter and that all four commands in the built prompt carry it.

Sage's own suite was run on Windows with the collection gate lifted, against a
baseline captured at the same commit: **750 passed / 21 failed** on this branch
vs **735 / 21** on the base. The 21 are the same pre-existing symlink-plant
tests, which need a privilege this account does not hold (`WinError 1314`) — so
this change adds passing tests and no failures. That comparison is also what
substantiates the conftest's new claim that the harness, not the app, is what is
POSIX-bound.

Also green locally: `isort`, `flake8`, the black gate (run with the pinned
`black==26.3.1`, since a locally-installed 25.x reports a different verdict),
`mypy --platform linux` over all 1,038 source files (3 pre-existing
`wecom/client.py` errors in an untouched file come from a local aiohttp version
differing from CI's pin), the brand-name gate, and the subprocess-spawn audit.
The full backend suite was not completed on this host; CI is the backstop for it.

## Related Issues

Fixes #4630
