### PR TITLE
refactor(eval): drop two dead guards and dedupe three sites

### DIFF
--- a/src/kiro_crew/eval/bench/ingest.py
+++ b/src/kiro_crew/eval/bench/ingest.py
@@ -58,7 +58,7 @@ from kiro_crew.vector_memory import (
     _contains_injection,
 )
 
-from .corpus import BenchInstance, BenchTurn
+from .corpus import BenchInstance, BenchSession, BenchTurn
 from .errors import BenchRefusal
 
 logger = logging.getLogger(__name__)
@@ -324,8 +324,28 @@ def fragment_text(turn: BenchTurn, *, speaker_prefix: bool) -> str:
     return turn.text
 
 
-def _session_fragment(session_id: str, turns: tuple[BenchTurn, ...], *, speaker_prefix: bool) -> str:
+def _session_fragment(turns: tuple[BenchTurn, ...], *, speaker_prefix: bool) -> str:
     return "\n".join(fragment_text(t, speaker_prefix=speaker_prefix) for t in turns)
+
+
+def _ingest_units(session: BenchSession, cfg: IngestConfig) -> list[tuple[str, str]]:
+    """The ``(unit_id, text)`` pairs one session contributes at *cfg*'s granularity.
+
+    ``"session"`` yields exactly one pair keyed on the SESSION id — which is why
+    :attr:`IngestedInstance.turn_attribution` goes false in that mode; ``"turn"``
+    yields one pair per utterance, keyed on the turn id.
+    """
+    if cfg.granularity == "session":
+        return [
+            (
+                session.session_id,
+                _session_fragment(session.turns, speaker_prefix=cfg.speaker_prefix),
+            )
+        ]
+    return [
+        (t.turn_id, fragment_text(t, speaker_prefix=cfg.speaker_prefix))
+        for t in session.turns
+    ]
 
 
 # ── Ingest ───────────────────────────────────────────────────────────────────
@@ -411,29 +431,16 @@ def ingest_instance(
 
         times, unparsed, span = _session_times(inst, cfg.timeline)
         report.unparsed_timestamps = unparsed
-        report.decay_span_days = span if cfg.timeline != "now" else 0
+        # `"now"` short-circuits before parsing, so `_session_times` already
+        # reports a zero span for it.
+        report.decay_span_days = span
 
         gold_turns = {tid for q in inst.queries for tid in q.gold_turn_ids}
         text_to_turn: dict[str, str] = {}
         dropped_gold: list[str] = []
 
         for session in inst.sessions:
-            if cfg.granularity == "session":
-                units: list[tuple[str, str]] = [
-                    (
-                        session.session_id,
-                        _session_fragment(
-                            session.session_id, session.turns, speaker_prefix=cfg.speaker_prefix
-                        ),
-                    )
-                ]
-            else:
-                units = [
-                    (t.turn_id, fragment_text(t, speaker_prefix=cfg.speaker_prefix))
-                    for t in session.turns
-                ]
-
-            for unit_id, text in units:
+            for unit_id, text in _ingest_units(session, cfg):
                 if not text.strip():
                     continue
                 report.attempted += 1
@@ -472,13 +479,12 @@ def ingest_instance(
                     # None here is an INFERENCE failure, not a benign empty input.
                     # Storing the row anyway leaves a NULL vector that search_episodic
                     # can only reach through the FTS5 keyword fallback, while the
-                    # report still presents its recall as a semantic measurement. The
-                    # previous behaviour counted these and carried on, which surfaced
-                    # a warning -- but a warning does not stop the headline number
-                    # from being published, and this harness refuses rather than
-                    # annotates. `prepare_embedder` already makes that trade at
-                    # startup; a mid-run failure has to make it too, or the guarantee
-                    # covers only the first fragment.
+                    # report still presents its recall as a semantic measurement.
+                    # Counting it and carrying on would surface a warning, and a
+                    # warning does not stop the headline number from being published;
+                    # this harness refuses rather than annotates. `prepare_embedder`
+                    # makes that trade at startup, so a mid-run failure has to make it
+                    # too, or the guarantee covers only the first fragment.
                     raise IngestError(
                         "the embedder returned no vector for a non-empty fragment "
                         f"after readiness was confirmed ({report.attempted} fragments "
@@ -501,8 +507,8 @@ def ingest_instance(
                     report.dropped_fragments += 1
                     # Classify the cause while the text is still to hand. `write_episodic` returns
                     # a bare bool, so re-applying the store's own screen is the only way to report
-                    # WHY. Worth it: the report used to attribute every refusal to dedup or the
-                    # capacity cap, and the one refusal LoCoMo produces is neither.
+                    # WHY. Worth it because the alternative is attributing every refusal to dedup
+                    # or the capacity cap, and the one refusal LoCoMo produces is neither.
                     if _contains_injection(text):
                         report.injection_rejected += 1
                     # `gold_turns` holds TURN ids. In session mode `unit_id` is a
@@ -526,11 +532,11 @@ def ingest_instance(
         # backend is reported separately rather than inferred from this call.
         store.build_faiss_index()
 
-        # No null-embedding warning here any more: the ingest loop refuses on the first
-        # NULL rather than finishing a degraded run, so this point is only reached when
-        # the count is zero. The field is retained on the report (always 0) because it
-        # is a published key -- dropping it would change the report schema and make
-        # existing baselines non-comparable for a cosmetic reason.
+        # No null-embedding warning is emitted here: the ingest loop refuses on the
+        # first NULL rather than finishing a degraded run, so this point is only
+        # reached when the count is zero. The field is retained on the report (always
+        # 0) because it is a published key -- dropping it would change the report
+        # schema and make existing baselines non-comparable for a cosmetic reason.
 
         return IngestedInstance(
             inst,

--- a/src/kiro_crew/eval/bench/run.py
+++ b/src/kiro_crew/eval/bench/run.py
@@ -213,12 +213,12 @@ def _production_embedder_id() -> str:
 def _ingest_warnings(reports: list[IngestReport], icfg: IngestConfig) -> list[str]:
     """Caveats a reader needs ABOVE the numbers, derived from the ingest reports.
 
-    A separate function so each warning can be tested without running a retrieval. They
-    were inline until one of them was found attributing a refused gold fragment to
-    "dedup or the capacity cap" when the actual cause was the store's prompt-injection
-    screen, which no dedup setting can change. A warning that sends the reader to a
-    setting that cannot help is worse than a vague one, and an inline warning is one
-    nobody can test.
+    A separate function so each warning can be tested without running a retrieval,
+    which an inline warning cannot be. That matters because the failure mode is a
+    warning whose attribution is wrong — pointing a refused gold fragment at "dedup or
+    the capacity cap" when the cause is the store's prompt-injection screen, which no
+    dedup setting can change. A warning that sends the reader to a setting that cannot
+    help is worse than a vague one.
     """
     warnings: list[str] = []
 
@@ -238,7 +238,7 @@ def _ingest_warnings(reports: list[IngestReport], icfg: IngestConfig) -> list[st
             f"{icfg.dedup_threshold} and the capacity cap; re-run with dedup "
             "disabled to separate 'ranking missed it' from 'it was never stored'."
         )
-    # `null_embeddings` is structurally zero now -- ingest refuses on the first NULL
+    # `null_embeddings` is structurally zero -- ingest refuses on the first NULL
     # embedding instead of completing a degraded run -- so no warning is emitted for it.
     # Kept as a published report key for schema stability.
     span = max((r.decay_span_days for r in reports), default=0)
@@ -381,7 +381,7 @@ def _metric_cell(block: dict, name: str) -> str:
     """The ONLY way this module renders a metric into a table.
 
     Exists so ``block.get(name, 0.0)`` cannot be written: a default is a value to be
-    wrong about, and the per-category block is exactly where that default fabricated
+    wrong about, and the per-category block is exactly where such a default fabricates
     a ``0.000`` recall for categories whose ``@5`` was measurable for nobody.
     """
     value = block.get(name)
@@ -393,11 +393,11 @@ def _metric_cell(block: dict, name: str) -> str:
 def _excluded_phrase(m: RetrievalAggregate) -> str:
     """Name WHY queries were excluded, one clause per reason that occurred.
 
-    The single "with no resolvable gold" clause covered both reasons and was wrong for
-    the bigger one: on LoCoMo the excluded population is overwhelmingly questions that
-    are unanswerable BY DESIGN, where refusal is the correct behaviour and retrieval has
-    nothing to be right about. Printing them as broken records invited the reader to
-    distrust the corpus instead of understanding the denominator.
+    One clause for both reasons would be wrong for the bigger one: on LoCoMo the
+    excluded population is overwhelmingly questions that are unanswerable BY DESIGN,
+    where refusal is the correct behaviour and retrieval has nothing to be right about.
+    Printing those as "no resolvable gold" invites the reader to distrust the corpus
+    instead of understanding the denominator.
     """
     parts: list[str] = []
     if m.unanswerable_queries:
@@ -580,9 +580,9 @@ def _section(report: object, *names: str) -> dict:
     so a malformed report has to reach the not-comparable branch rather than a
     traceback.
 
-    Round 8 put this rule on leaf values (``_measurable_count``) and left the
-    container access unguarded — the same enforcement point at the wrong altitude.
-    Both levels now go through a reader.
+    Both altitudes go through a reader — this one for containers, ``_measurable_count``
+    for leaf values. Guarding only the leaves puts the enforcement point one level
+    below where the ``AttributeError`` is raised.
     """
     node: object = report
     for name in names:
@@ -624,6 +624,24 @@ def _metric_value(block: dict, name: str) -> float | None:
     return value
 
 
+def _not_comparable(k: int, reason: str) -> str:
+    """The one rendering of a refused session-level comparison.
+
+    Every refusal below the config check returns this and nothing else. Emitting a
+    heading plus a delta table would invite exactly the reading the refusal exists
+    to prevent, so "no delta is reported" is part of the shape rather than
+    something each call site remembers to append.
+    """
+    return "\n".join(
+        [
+            f"## session-level @{k} — not comparable",
+            f"- {reason}",
+            "",
+            "No delta is reported.",
+        ]
+    )
+
+
 def compare_reports(baseline: dict, candidate: dict, *, k: int = 5) -> str:
     """Diff two saved JSON reports, refusing the comparisons that are invalid.
 
@@ -638,10 +656,9 @@ def compare_reports(baseline: dict, candidate: dict, *, k: int = 5) -> str:
     c_corpus = _section(candidate, "corpus")
     # Presence first, then equality. Comparing by inequality alone makes two reports
     # that BOTH lack a fingerprint compare as compatible -- `None != None` is False --
-    # so an unattributable delta would be published as exact. The old comment below
-    # claimed a missing key could not silently pass; that held for one-sided absence
-    # only, and `_section` returning {} for a malformed report made the two-sided case
-    # easy to reach.
+    # so an unattributable delta would be published as exact. Inequality alone catches
+    # one-sided absence only, and `_section` returning {} for a malformed report puts
+    # the two-sided case well within reach.
     if not b_corpus.get("fingerprint") or not c_corpus.get("fingerprint"):
         problems.append(
             "one or both reports carry no corpus fingerprint, so it cannot be shown "
@@ -651,13 +668,13 @@ def compare_reports(baseline: dict, candidate: dict, *, k: int = 5) -> str:
         problems.append("corpus fingerprints differ — the two runs read different data")
     b_cfg = _section(baseline, "config")
     c_cfg = _section(candidate, "config")
-    # `embedder` is in this list for a reason that bit once already: a report saved
-    # from a `--toy-embedder` run carried no embedder identity, so it compared as
-    # equivalent to a real run and published an "exact" delta between a hashed
-    # bag-of-words and a language model. Absence is now refused outright rather than
-    # being compared, which covers the case where BOTH sides lack the key.
-    # `environment` joins this list for the reason the list exists: a delta is
-    # only attributable to the code when everything else held still.
+    # `embedder` is in this list because a report saved from a `--toy-embedder` run
+    # carries no embedder identity: comparing by inequality would call it equivalent
+    # to a real run and publish an "exact" delta between a hashed bag-of-words and a
+    # language model. Absence is therefore refused outright rather than compared,
+    # which also covers the case where BOTH sides lack the key. `environment` is in
+    # the list for the reason the list exists: a delta is only attributable to the
+    # code when everything else held still.
     for key in ("ingest", "retrieval", "search_backend", "embedder", "environment"):
         b_val, c_val = b_cfg.get(key), c_cfg.get(key)
         if b_val is None or c_val is None:
@@ -688,15 +705,16 @@ def compare_reports(baseline: dict, candidate: dict, *, k: int = 5) -> str:
     b_sess = _section(baseline, "metrics", "session")
     c_sess = _section(candidate, "metrics", "session")
 
-    # Two ways a cut-off can be incomparable, and both used to print a number.
+    # Two ways a cut-off can be incomparable, each of which a naive read prints a
+    # number for.
     #
     # 1. ABSENT ON ONE SIDE. A cut-off the retrieval window never exposed is omitted
     #    from the metric dict (that is what makes an unmeasurable k visible rather
-    #    than falsely low). The old `name in b or name in c` with `.get(name, 0.0)`
-    #    turned "the baseline could not measure this" into "the baseline scored zero",
-    #    manufacturing an exact-looking improvement of the full candidate value. This
-    #    hole was created by the fix that added the measurability filter — a new field
-    #    with a default is a new way to be wrong.
+    #    than falsely low). A `name in b or name in c` test paired with
+    #    `.get(name, 0.0)` turns "the baseline could not measure this" into "the
+    #    baseline scored zero", manufacturing an exact-looking improvement of the full
+    #    candidate value — the measurability filter's own omitted keys are what make
+    #    that reachable, so a default here is a new way to be wrong.
     #
     # 2. DIFFERENT POPULATIONS. Even present on both sides, the two means can be over
     #    different query sets: measured on LoCoMo, @5 is measurable for 1977 queries
@@ -753,13 +771,7 @@ def compare_reports(baseline: dict, candidate: dict, *, k: int = 5) -> str:
             )
 
     if population_note is not None:
-        lines += [
-            f"## session-level @{k} — not comparable",
-            f"- {population_note}",
-            "",
-            "No delta is reported.",
-        ]
-        return "\n".join(lines)
+        return _not_comparable(k, population_note)
 
     rows: list[tuple[str, ...]] = []
     missing: list[str] = []
@@ -776,13 +788,7 @@ def compare_reports(baseline: dict, candidate: dict, *, k: int = 5) -> str:
             missing.append(name)
 
     if not rows:
-        lines += [
-            f"## session-level @{k} — not comparable",
-            "- no metric at this cut-off is present in both reports",
-            "",
-            "No delta is reported.",
-        ]
-        return "\n".join(lines)
+        return _not_comparable(k, "no metric at this cut-off is present in both reports")
 
     lines += [
         f"## session-level @{k}  ({bn} queries in each arm)",

--- a/src/kiro_crew/eval/runner.py
+++ b/src/kiro_crew/eval/runner.py
@@ -115,16 +115,17 @@ def score_by_dimension(results: list[ScenarioResult]) -> dict[str, dict[str, Any
     dim_stats: dict[str, dict[str, int]] = {}
     for r in results:
         for dim in r.dimensions:
-            if dim not in dim_stats:
-                dim_stats[dim] = {"total": 0, "passed": 0}
-            dim_stats[dim]["total"] += 1
-            dim_stats[dim]["passed"] += 1 if r.passed else 0
+            stats = dim_stats.setdefault(dim, {"total": 0, "passed": 0})
+            stats["total"] += 1
+            stats["passed"] += int(r.passed)
 
+    # Every entry is created by the loop above and immediately counted, so `total`
+    # is at least 1 for each key and the division needs no zero guard.
     return {
         dim: {
             "total": s["total"],
             "passed": s["passed"],
-            "rate": round(s["passed"] / s["total"], 3) if s["total"] > 0 else 1.0,
+            "rate": round(s["passed"] / s["total"], 3),
         }
         for dim, s in dim_stats.items()
     }


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only — the diff touches three files under
`src/kiro_crew/eval/`, nothing under `website/`, so there is no rendered surface
to show.

## Problem / Motivation

`src/kiro_crew/eval/` had never had a readability pass, and it carries the
densest complexity signal of the unswept backend modules: 7 functions over 60
lines and 7 nested past three levels, peaking at depth 7. Three specific things
make it harder to read than it needs to be:

- **Two guards that cannot fire.** `report.decay_span_days` was assigned through
  a `span if cfg.timeline != "now" else 0` ternary even though `_session_times`
  short-circuits `"now"` *before* parsing and already returns a zero span
  (`ingest.py:288`). `score_by_dimension` divided under `if s["total"] > 0 else
  1.0` even though every key is created and incremented in the same loop
  iteration. A guard that cannot fire still costs a reader the time to work out
  whether it can.
- **One dead parameter.** `_session_fragment(session_id, turns, *, ...)` never
  read `session_id`.
- **Three duplicated or over-nested sites.** `compare_reports` rendered the same
  four-line "not comparable" block at two refusal points; `ingest_instance`
  carried a 14-line granularity if/else inline in an already six-deep loop.

On top of that, ~40 comment lines in these files were task-log narration —
including a literal `Round 8` review-round marker in a docstring — which
[AGENTS.md](../blob/main/AGENTS.md) prohibits: comments state current behaviour
in present tense and are not a history of how the code got here.

## Why it matters

This is the memory-benchmark harness. Its whole job is refusing to publish a
number it cannot stand behind, so the refusal paths are the part a reader most
needs to be able to follow — and they were the parts carrying the unreachable
guards and the duplicated rendering. A reader who cannot tell a live guard from
a dead one either preserves both forever or removes the wrong one.

The comment narration compounds it: `Round 8 put this rule on leaf values … Both
levels now go through a reader` describes a review round, not the code, and it
ages into a false statement the moment either level changes.

## What changed (motivation → approach → change)

Behaviour-preserving only. Nothing here changes an output, an exit code, or a
refusal condition — see **Manual verification** for the differential proofs.

**Dead code → removed, with the invariant that makes it dead written down.**

| Site | Why it was unreachable |
|---|---|
| `ingest.py` `decay_span_days` ternary | `_session_times(inst, "now")` returns span `0` before parsing; pinned independently by `test_bench_ingest.py:235` |
| `runner.py` `if s["total"] > 0 else 1.0` | every `dim_stats` key is created by the loop above and incremented in the same iteration, so `total >= 1`; the empty-input case returns `{}` without dividing |
| `_session_fragment`'s `session_id` param | unused in the body; one call site, no test or other module references it |

Each removal is replaced by a one-line comment stating the invariant, so the next
reader does not have to re-derive it.

**Duplication → one owner each.**

- `compare_reports`' two refusal sites both built `["## session-level @{k} — not
  comparable", "- {reason}", "", "No delta is reported."]` into a `lines` list
  that is provably empty at that point (the only earlier writer is the `if
  problems:` branch, which returns). Both now `return _not_comparable(k,
  reason)`. Putting `"No delta is reported."` inside the helper makes it part of
  the shape rather than something each call site has to remember.
- The granularity if/else that builds a session's `(unit_id, text)` pairs moves
  into `_ingest_units(session, cfg)`. That removes a nesting level from the
  ingest loop and drops the asymmetry the inline form required, where only the
  `if` arm carried the `list[tuple[str, str]]` annotation mypy needed.

**Comment hygiene, in these three files only** (so the churn rides along with
substantive change instead of becoming its own sweep). Narration goes; the
substantive claim each sentence carried stays. Explicitly preserved: the measured
LoCoMo numbers (91.5% oversized session fragments, 1977-vs-746 measurable
queries), the toy-embedder identity rationale, the prompt-injection attribution,
and the schema-stability reason for retaining an always-zero report key.

**Deliberately NOT touched, and why:**

- **`bench/safepath.py`** — it is this module's path-traversal / `O_NOFOLLOW`
  guard. It gets keystone treatment even though it is not on the campaign's
  keystone list, so neither it nor any call to it appears in this diff, despite
  two of its functions being on the long/deeply-nested list.
- **`runner.py`'s tool-approval path** — the five `sel().log_tool_invocation`
  emits in `_run_turn` are near-identical and would dedupe cleanly, but reshaping
  an audit emit is not something to do inside a cleanup PR. `_classify_safe_tool`,
  `_extract_path_from_input`, the in-function `from kiro_crew.security import
  is_sensitive_path`, and the approve/reject decisions are all unchanged.
- **`format_report`'s `block.get(f"recall_all@{k}", 0.0)` defaults** — these sit
  next to `_metric_cell`, whose docstring says such a default must not be
  written, so they look inconsistent. Changing them would render `—` where
  `0.000` renders today, which is a behaviour change and possibly a real fix.
  Flagging it rather than smuggling it into a no-op PR; happy to file it as its
  own issue if a maintainer agrees it is one.

## Tests

**No test changes, and that is the point** — a behaviour-preserving sweep that
needed a test edit would not be behaviour-preserving. The existing suite is what
pins the two removed guards, and it passes unchanged:

- `test_bench_ingest.py:235` pins `_session_times(..., "now") == (…, 0, 0)`, and
  `:258` / `:295` pin `decay_span_days` at 0 for `now` and 10 for `anchored` —
  together they are what make the removed ternary demonstrably dead.
- `test_eval_harness.py::test_score_by_dimension` and the empty-input case pin
  `score_by_dimension`, including that `[]` yields `{}` without dividing.
- The substring assertions in `test_bench_round4/7/9/10/13`, `test_bench_cli.py`
  and `test_bench_review_fixes.py` pin `compare_reports`' rendered refusal text,
  which is what makes the `_not_comparable` extraction falsifiable.

Run green locally on the Python 3.12 CI-parity venv: **547 passed, 4 skipped**
across every `test_bench_*.py` plus `test_eval_harness.py`,
`test_cli_bench_cov80.py` and `test_memory_benchmark_workflow.py`; plus the 8
`test_cli_commands_coverage.py` tests that exercise `score_by_dimension`'s
consumer.

## Manual verification

Gate-green is not proof of equivalence, so each rewrite was checked
**differentially** — the pre-diff function loaded side by side with the new one
and both run over the same inputs, comparing full outputs:

| Function | Inputs compared | Result |
|---|---|---|
| `compare_reports` | 11 report pairs × k ∈ {1,5,10} — every refusal branch (absent/differing fingerprint, each of the 5 config keys, absent/zero/unequal measurable counts, absent/differing population digests, no metric present, one-sided metric, malformed `null` containers) | 33/33 **byte-identical** |
| `ingest_instance` | 12 configs — both granularities × all three timelines × `speaker_prefix` on/off, over a corpus with an unparsed timestamp, a blank turn, and a byte-identical duplicate of a *gold* turn | 12/12 identical on the full `IngestReport`, the `text_to_turn` map, `turn_attribution` and `recall_ceiling_note` |
| `score_by_dimension` | 1730 input shapes — dimension lists incl. empty, repeated and reordered, × pass/fail flags, × a zero-session scenario | 1730/1730 identical |

Gates run from the worktree on the 3.12 CI-parity venv, all exit 0: `flake8`,
`isort --check-only`, `mypy src/kiro_crew` (1008 files), `check_brand_name.py`,
`check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`.

`black --target-version py310` leaves every line this PR adds byte-identical
(its only complaint in `ingest.py` is a pre-existing hunk at `_session_times`'
signature, which this PR does not touch and which is in
`.github/black-baseline.txt`).

Not run, and not runnable at PR time: `memory-benchmark.yml` is the only CI that
executes `bench retrieval` / `bench compare` end-to-end, and it is
schedule/dispatch-only. The differential runs above are the substitute.

One thing worth naming because I hit it: importing `kiro_crew.eval.runner` as the
first import raises a circular `ImportError` via `providers.base` →
`acp.runtime` → `session_pid`. **That reproduces identically on pristine
`origin/main`**, so it is pre-existing and out of scope here; the real
entrypoints import `kiro_crew.acp` first, which is what the suite and the
differential harness do.

## Related Issues

no linked issue: a module-scoped readability sweep with no filed bug behind it.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass; no new tests, because no behaviour changed (the
      existing tests are what pin the removed guards)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, `eval/` has no
      `docs/system-specs/modules/` page and no documented API changed
- [x] No secrets, credentials, or internal references in the diff

---

### Pre-open review

Five read-only reviewers were run over the diff before opening, each on a
distinct lens and grounded in this repo's own rules rather than generic taste:
(1) `AUTOSDE.yaml` blocking rules + the AGENTS.md sections, (2) behaviour
preservation, briefed to *falsify* each of the five equivalence claims, (3)
import semantics + comment accuracy, (4) the `code-review.yml` /
`codex-review.yml` / `claude-review.yml` contracts, each mirrored against its
own severity bar, (5) security keystone + boot path.

All five returned no findings. Notable confirmations rather than assertions: no
blocking AUTOSDE rule's `file-patterns` match a changed file; no in-function
import was deleted and no lazy import hoisted (`import math` in `_metric_value`
and the `is_sensitive_path` import in `_run_turn` are both untouched); the
boot-path rule's patterns (`slack/gateway.py`, `dashboard/server.py`,
`dashboard/handlers/**`, `cli.py`) match nothing here; `_ingest_units` is called
inside the `try:` that owns `store.close()`, so the `except BaseException`
cleanup still covers it.

**One finding was raised and dropped after checking it:** a Low note that the
added `_ingest_units` comprehension was not black-formatted. Running `black
--target-version py310` on the file shows it leaves that block byte-identical, so
the note does not hold.
