### PR TITLE
fix(updates): read chunked responses boundedly from feed

### DIFF
--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -17,7 +17,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import __version__ as _local_version
-from kiro_crew import shutdown_event
+from kiro_crew import net_utils, shutdown_event
 from kiro_crew.changelog import Release, base_version, build_release_list
 from kiro_crew.config.loader import (
     ConfigReadError,
@@ -767,7 +767,7 @@ async def _fetch_feed_bytes(url: str) -> tuple[int, bytes]:
             # truncated into a parse error. Mirrors the installer's
             # --max-filesize on this very document, and is enforced against
             # RECEIVED bytes rather than a Content-Length claim.
-            return resp.status, await resp.content.read(_FEED_MAX_BYTES + 1)
+            return resp.status, await net_utils.read_bounded(resp.content, _FEED_MAX_BYTES + 1)
 
 
 async def _check_release_feed(capability: UpdateCapability) -> None:

--- a/src/kiro_crew/net_utils.py
+++ b/src/kiro_crew/net_utils.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+
+async def read_bounded(stream: Any, max_bytes: int, chunk_size: int = 65536) -> bytes:
+    """Read from an aiohttp stream until EOF or max_bytes is exceeded.
+    
+    Returns the accumulated bytes. If the stream is larger than `max_bytes`,
+    the returned bytes will have length > `max_bytes`, allowing callers to
+    detect the overflow.
+    """
+    body = bytearray()
+    async for chunk in stream.iter_chunked(chunk_size):
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            break
+    return bytes(body)


### PR DESCRIPTION
This extracts the \ead_bounded\ shared helper and uses it to safely consume the release feed in \updates.py\, matching the behavior recently landed for the MCP registry in #2232.

As requested by @bolichen97, this is the standalone follow-up PR isolating the \updates.py\ chunking fix.