### PR TITLE
fix: recover an app-owned slot's agent from source, not just rescan

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -365,16 +365,32 @@ to re-warm the snapshot. `_run_chat` therefore guards the resolve, strictly behi
 `slot._app and not bindings.requested_resolved` (zero extra work / I/O on the
 common hot path — no `_app`, or already resolved):
 
-1. **Self-heal.** Warm the snapshot **off the loop** with the same pattern
-   `server.py` uses at boot —
+1. **Self-heal (two escalating steps).** First, **rescan** the snapshot **off the
+   loop** with the same pattern `server.py` uses at boot —
    `await loop.run_in_executor(subprocess_executor(), refresh_materialized_agents)`
    (`refresh_materialized_agents` never raises, so awaiting it via the executor is
-   safe) — then **re-resolve once** and use the fresh bindings. This recovers an
-   app slot whose only problem was a snapshot not yet warmed on this loop, without
-   waiting for a restart.
+   safe) — then **re-resolve once**. This recovers an app slot whose spec is on
+   disk but whose snapshot was simply not yet warmed on this loop. If the
+   re-resolve *still* misses, the spec was never materialized even though the
+   source is intact, so **re-register this app's resources from source** —
+   `await loop.run_in_executor(subprocess_executor(), register_app, slot._app)`
+   (`register_app`, `apps/bridges.py`, registers the app's MCP servers BEFORE its
+   agents and publishes the snapshot synchronously; imported via a **local** import
+   inside the function to avoid the top-level `apps`↔`dashboard` cycle, mirroring
+   `server.py`'s local import of `reconcile_enabled_app_resources`. `register_app`
+   is used rather than the narrower `refresh_app_agents` because a never-materialized
+   app also has unregistered MCP servers, and re-materializing only the agent would
+   inline an empty server map — recreating an agent whose own `@<app>:<server>` tool
+   refs dangle, i.e. it dispatches but its tools never mount. `register_app` already
+   honors the execution-admission gate, and the recovery call is additionally gated
+   on `is_app_enabled(slot._app)` held under `app_lifecycle_lock(slot._app)`, so a
+   concurrent disable/uninstall cannot race recovery into reactivating a
+   deregistered agent — a disabled app simply falls through to the fail-loud) —
+   then **re-resolve again** and use the fresh bindings. A recovery-step failure
+   only logs a warning; it costs nothing beyond the fail-loud below.
 2. **Fail-loud.** If the slot is app-owned and *still* unresolved after the
-   re-resolve, `_run_chat` does **not** run the default agent. It raises
-   `_AppAgentNotLoaded` (naming `slot.agent`, e.g. *"The app agent
+   from-source re-registration, `_run_chat` does **not** run the default agent. It
+   raises `_AppAgentNotLoaded` (naming `slot.agent`, e.g. *"The app agent
    'my-app-agent' isn't loaded yet — try again in a moment, or restart the
    gateway"*) which a dedicated `except` arm beside the terminal turn-error
    handlers surfaces as a normal `error` card (no `record_failure` — nothing ran).
@@ -382,11 +398,18 @@ common hot path — no `_app`, or already resolved):
    the standard `finally` teardown runs without ever creating a session or
    dispatching an agent.
 
-The eager-spawn pre-warm path mirrors the **self-heal** step only (so the
-speculative session bakes in the app's own agent rather than the default, which a
-first real turn would otherwise have to discard); the **fail-loud** lives on the
-real turn alone, since the eager path is best-effort and tears itself down on any
-miss.
+The eager-spawn pre-warm path mirrors the **self-heal** step (rescan →
+re-register-from-source) only (so the speculative session bakes in the app's own
+agent rather than the default, which a first real turn would otherwise have to
+discard); the **fail-loud** lives on the real turn alone, since the eager path is
+best-effort and tears itself down on any miss.
+
+`register_app` (`apps/bridges.py`) backs the from-source recovery with a **visible
+error**: when a manifest declares agents but `_register_agents` materializes none
+(source missing or unreadable) it appends a `"registered 0 of N declared
+agent(s)"` entry to `result.errors` — which `reconcile_enabled_app_resources`
+counts and logs — instead of returning a silent 0-agent success; a partial
+registration (some but not all) logs a warning.
 
 ### Materialized-agent snapshot (`config/loader.py`)
 Rung 2's membership test is a process-global `frozenset` — a pure in-memory lookup

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -2389,6 +2389,13 @@ def register_app(app_name: str) -> RegistrationResult:
     except Exception as exc:
         result.errors.append(f"agent registration failed: {exc}")
 
+    declared = len(manifest.agents or [])
+    if declared and not result.agents:
+        result.errors.append(
+            f"registered 0 of {declared} declared agent(s) for {app_name!r} "
+            "-- agent source missing or unreadable"
+        )
+
     try:
         result.skills = _register_skills(app_name, manifest, app_root)
     except Exception as exc:
@@ -2425,7 +2432,15 @@ def refresh_app_agents(app_name: str) -> list[str]:
     info = get_app(app_name)
     if info and info.get("resources") == "app":
         return []
-    return _register_agents(app_name, manifest, _app_resource_root(app_name))
+    app_root = _app_resource_root(app_name)
+    # Admission gate — mirror register_app. A re-materialization MUST honor the
+    # same execution decision, or a revoked app's agents (and the MCP servers
+    # merged into them) would be rewritten and become dispatchable again. On
+    # denial, scrub any stale materialized agents and register nothing.
+    if _registration_denied(app_name, action="resource_register", app_root=app_root):
+        _deregister_agents(app_name)
+        return []
+    return _register_agents(app_name, manifest, app_root)
 
 
 def reconcile_enabled_app_resources() -> dict[str, int]:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3164,6 +3164,57 @@ def schedule_eager_spawn(
     return task
 
 
+async def _recover_app_agent_binding(
+    cfg: "KiroCrewConfig", slot: "_ChatSlot", *, project: str | None
+) -> Any:
+    """Re-register an app-owned slot's resources from source, then re-resolve.
+
+    The last recovery rung for an app slot whose agent stayed unresolved after
+    the snapshot rescan: the spec was never materialized even though the source
+    is intact (a plain gateway restart re-materializes every ENABLED app via
+    ``reconcile_enabled_app_resources``, so this is what avoids that restart and
+    heals mid-turn). Uses ``register_app`` — not the narrower
+    ``refresh_app_agents`` — so the app's MCP servers are registered BEFORE its
+    agents; re-materializing only the agent would inline an empty server map and
+    recreate an agent whose own tool refs dangle (dispatches, tools never mount).
+    Gated on ``is_app_enabled`` held under ``app_lifecycle_lock`` so a concurrent
+    disable/uninstall cannot race recovery into reactivating a deregistered
+    agent; a disabled app is left to fail loud. A recovery failure only logs —
+    the re-resolve below then simply returns the still-cold bindings. Returns the
+    freshly resolved bindings; the caller reassigns its own locals from them.
+    """
+    # Local imports mirror server.py's reconcile import to avoid a top-level
+    # apps<->dashboard cycle.
+    from kiro_crew.apps.bridges import register_app
+    from kiro_crew.apps.manager import app_lifecycle_lock, is_app_enabled
+
+    try:
+        loop = asyncio.get_running_loop()
+        async with app_lifecycle_lock(slot._app):
+            if await loop.run_in_executor(subprocess_executor(), is_app_enabled, slot._app):
+                # register_app runs in an executor thread that cannot be
+                # cancelled. Shield the await so cancelling THIS coroutine (e.g.
+                # an eager-spawn task being cancelled) does NOT release the
+                # lifecycle lock while that thread is still writing — a concurrent
+                # disable could otherwise acquire the lock, deregister the app,
+                # and have the still-running thread republish a now-disabled
+                # agent. On cancel, wait for the thread to finish before letting
+                # the lock release, then propagate the cancellation.
+                fut = loop.run_in_executor(subprocess_executor(), register_app, slot._app)
+                try:
+                    await asyncio.shield(fut)
+                except asyncio.CancelledError:
+                    await fut
+                    raise
+    except Exception:  # noqa: BLE001 — a recovery failure only costs the fail-loud
+        logger.warning(
+            "Failed to re-register app resources from source for app slot %s",
+            slot.key,
+            exc_info=True,
+        )
+    return resolve_agent_bindings(cfg, slot.agent or None, project)
+
+
 async def _eager_spawn(
     state: "DashboardState", slot: "_ChatSlot", *, allow_resume: bool = False
 ) -> None:
@@ -3238,11 +3289,15 @@ async def _eager_spawn(
                 # SELF-HEAL mirror of the real turn's guard: an app-owned slot
                 # whose agent read cold from the materialized snapshot would bake
                 # the DEFAULT agent into this speculative session, forcing the
-                # first real turn to discard and cold-start it. Warm off the loop
-                # (never raises) and re-resolve once so the pre-warmed session
-                # carries the app's own agent. No fail-loud here — the eager path
-                # is best-effort and tears itself down on any miss; the real turn
-                # owns the user-facing failure.
+                # first real turn to discard and cold-start it. Recover in two
+                # escalating steps — (1) RESCAN the snapshot off the loop (never
+                # raises) in case the spec is on disk but cold, re-resolve once;
+                # (2) if still unresolved, RE-REGISTER this app's agents FROM
+                # SOURCE off the loop (covers "spec never materialized though
+                # source intact") and re-resolve again — so the pre-warmed
+                # session carries the app's own agent. No fail-loud here — the
+                # eager path is best-effort and tears itself down on any miss;
+                # the real turn owns the user-facing failure.
                 if slot._app and not bindings.requested_resolved:
                     try:
                         await asyncio.get_running_loop().run_in_executor(
@@ -3258,6 +3313,11 @@ async def _eager_spawn(
                     kiro_agent = bindings.kiro_agent
                     crew_alias = bindings.resolved_alias
                     agent_model = normalize_agent_model(bindings.model)
+                    if not bindings.requested_resolved:
+                        bindings = await _recover_app_agent_binding(cfg, slot, project=None)
+                        kiro_agent = bindings.kiro_agent
+                        crew_alias = bindings.resolved_alias
+                        agent_model = normalize_agent_model(bindings.model)
                 resolved_ok = bindings.requested_resolved
             except Exception:
                 logger.warning(
@@ -4637,11 +4697,17 @@ async def _run_chat(
             # until the boot / registration warm lands (both run off the loop). A
             # cold read makes the resolver fall back to the default agent with
             # ``requested_resolved=False``, silently running the generic default
-            # with none of the app's MCP tools and NO error. Warm the snapshot off
-            # the loop with the SAME pattern server.py uses at boot (safe to await:
-            # refresh_materialized_agents never raises), then re-resolve ONCE.
-            # Strictly guarded: the common hot path (no ``_app``, or already
-            # resolved) does zero extra work and zero extra I/O.
+            # with none of the app's MCP tools and NO error. Recover in two
+            # escalating steps: (1) RESCAN the snapshot off the loop with the SAME
+            # pattern server.py uses at boot (safe to await: refresh_materialized_
+            # agents never raises) then re-resolve ONCE — covers "spec on disk but
+            # snapshot cold"; (2) if STILL unresolved, RE-REGISTER this app's
+            # agents FROM SOURCE off the loop (refresh_app_agents rewrites the
+            # specs + publishes the snapshot synchronously) then re-resolve again —
+            # covers "spec never materialized though source intact". A residual
+            # miss falls through to the fail-loud below. Strictly guarded: the
+            # common hot path (no ``_app``, or already resolved) does zero extra
+            # work and zero extra I/O.
             if slot._app and not bindings.requested_resolved:
                 try:
                     await asyncio.get_running_loop().run_in_executor(
@@ -4658,6 +4724,14 @@ async def _run_chat(
                 crew_alias = bindings.resolved_alias
                 memory_store = bindings.memory_store_name
                 agent_model = normalize_agent_model(bindings.model)
+                if not bindings.requested_resolved:
+                    bindings = await _recover_app_agent_binding(
+                        cfg, slot, project=slot.project or None
+                    )
+                    kiro_agent = bindings.kiro_agent
+                    crew_alias = bindings.resolved_alias
+                    memory_store = bindings.memory_store_name
+                    agent_model = normalize_agent_model(bindings.model)
             _app_agent_unresolved = bool(slot._app) and not bindings.requested_resolved
         except Exception:
             logger.warning("Failed to resolve agent bindings in _run_chat", exc_info=True)

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -30,6 +30,7 @@ from kiro_crew.apps.bridges import (
     _safe_link_name,
     deregister_app,
     load_app_cron_defs,
+    refresh_app_agents,
     register_app,
     register_app_crons_with_service,
 )
@@ -697,6 +698,43 @@ class TestTopLevel:
         assert len(result.skills) == 1
         assert len(result.crons) == 1
         assert result.errors == []
+
+    def test_register_app_reports_zero_registered_when_agent_source_missing(
+        self, tmp_path, app_env
+    ):
+        # A manifest that DECLARES agents but whose agent source is absent /
+        # unreadable materializes none. That must surface as a visible error
+        # (which reconcile counts), not a silent 0-agent success.
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        # Drop the declared agent's source from the installed snapshot.
+        (app_env["home"] / "apps" / "test-app" / "agents" / "my-agent.json").unlink()
+
+        result = register_app("test-app")
+
+        assert result.agents == []
+        assert any("0 of" in error and "test-app" in error for error in result.errors)
+
+    def test_refresh_app_agents_denied_scrubs_and_registers_nothing(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # An app whose execution admission was revoked must NOT be re-materialized
+        # by the from-source recovery path: refresh_app_agents must honor the same
+        # gate register_app does -- scrub any stale agent spec and register nothing
+        # -- or a revoked app's agent (and its merged MCP servers) becomes
+        # dispatchable again.
+        import kiro_crew.apps.execution as execution_mod
+
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        assert refresh_app_agents("test-app")  # admitted: materializes, returns names
+        assert any(app_env["kiro_agents"].iterdir())
+
+        monkeypatch.setattr(execution_mod, "third_party_execution_allowed", lambda: False)
+        refreshed = refresh_app_agents("test-app")
+
+        assert refreshed == []
+        assert not any(app_env["kiro_agents"].iterdir())
 
     def test_install_while_execution_denied_registers_nothing(self, tmp_path, app_env, monkeypatch):
         import kiro_crew.apps.execution as execution_mod

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2447,6 +2448,52 @@ class TestAppAgentDispatchGuard:
         assert _errors(slot) == []
 
     @pytest.mark.asyncio
+    async def test_app_slot_recovers_from_source_after_rescan_miss(self, tmp_path):
+        # The snapshot RESCAN misses (spec never materialized though source is
+        # intact), so the self-heal escalates: re-register this app's agents FROM
+        # SOURCE (refresh_app_agents) then re-resolve — which now succeeds.
+        state, client = _runner_state(tmp_path)
+        _set_stream(client, [LLMEvent(kind=EVENT_TEXT_CHUNK, text="hi"), _complete()])
+        slot = _slot()
+        slot._app = "myapp"
+        slot.agent = "my-app-agent"
+
+        cold = _bindings(
+            kiro_agent="kirocrew", resolved_alias="default", requested_resolved=False
+        )
+        warm = _bindings(
+            kiro_agent="my-app-agent",
+            resolved_alias="my-app-agent",
+            requested_resolved=True,
+        )
+        refresh = MagicMock()
+        reregister = MagicMock(return_value=["my-app-agent"])
+        with patch.object(
+            chat_runner, "resolve_agent_bindings", side_effect=[cold, cold, warm]
+        ) as resolve, patch.object(
+            chat_runner, "refresh_materialized_agents", refresh
+        ), patch(
+            "kiro_crew.apps.bridges.register_app", reregister
+        ), patch(
+            "kiro_crew.apps.manager.is_app_enabled", MagicMock(return_value=True)
+        ), patch.object(
+            chat_runner, "subprocess_executor", MagicMock(return_value=None)
+        ), patch.object(
+            chat_runner, "warm_project_agent_names", new=AsyncMock()
+        ):
+            await _drive(state, slot)
+
+        # Rescan missed, so the from-source re-registration ran for THIS app,
+        # and the resolver was consulted a third time.
+        refresh.assert_called_once()
+        reregister.assert_called_once_with("myapp")
+        assert resolve.call_count == 3
+        # The healed agent — not the default — was dispatched, and no error card.
+        state.sessions.get_or_create.assert_awaited()
+        assert state.sessions.get_or_create.await_args.kwargs["agent"] == "my-app-agent"
+        assert _errors(slot) == []
+
+    @pytest.mark.asyncio
     async def test_still_cold_app_slot_fails_loud_and_never_runs_default(self, tmp_path):
         state, client = _runner_state(tmp_path)
         slot = _slot()
@@ -2457,10 +2504,15 @@ class TestAppAgentDispatchGuard:
             kiro_agent="kirocrew", resolved_alias="default", requested_resolved=False
         )
         refresh = MagicMock()
+        reregister = MagicMock(return_value=[])
         with patch.object(
-            chat_runner, "resolve_agent_bindings", side_effect=[cold, cold]
+            chat_runner, "resolve_agent_bindings", side_effect=[cold, cold, cold]
         ) as resolve, patch.object(
             chat_runner, "refresh_materialized_agents", refresh
+        ), patch(
+            "kiro_crew.apps.bridges.register_app", reregister
+        ), patch(
+            "kiro_crew.apps.manager.is_app_enabled", MagicMock(return_value=True)
         ), patch.object(
             chat_runner, "subprocess_executor", MagicMock(return_value=None)
         ), patch.object(
@@ -2468,14 +2520,103 @@ class TestAppAgentDispatchGuard:
         ):
             await _drive(state, slot)
 
-        # Self-heal was attempted (warm + re-resolve) but the agent stayed cold.
+        # Self-heal was fully attempted (rescan + re-register-from-source + three
+        # re-resolves) but the agent stayed cold.
         refresh.assert_called_once()
-        assert resolve.call_count == 2
+        reregister.assert_called_once_with("myapp")
+        assert resolve.call_count == 3
         # Fail-loud: the default agent is NEVER dispatched...
         state.sessions.get_or_create.assert_not_awaited()
         # ...and a clear card names the requested agent.
         errors = _errors(slot)
         assert any("my-app-agent" in e and "isn't loaded yet" in e for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_disabled_app_slot_skips_source_recovery_and_fails_loud(self, tmp_path):
+        # A DISABLED app whose slot still gets a turn must NOT have its
+        # deregistered agent re-materialized: the from-source recovery is gated on
+        # is_app_enabled (under the app lifecycle lock), so refresh_app_agents is
+        # never called and the turn fails loud instead of reactivating a disabled
+        # app's agent.
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        slot._app = "myapp"
+        slot.agent = "my-app-agent"
+
+        cold = _bindings(
+            kiro_agent="kirocrew", resolved_alias="default", requested_resolved=False
+        )
+        reregister = MagicMock(return_value=["my-app-agent"])
+        with patch.object(
+            chat_runner, "resolve_agent_bindings", side_effect=[cold, cold, cold]
+        ), patch.object(
+            chat_runner, "refresh_materialized_agents", MagicMock()
+        ), patch(
+            "kiro_crew.apps.bridges.register_app", reregister
+        ), patch(
+            "kiro_crew.apps.manager.is_app_enabled", MagicMock(return_value=False)
+        ), patch.object(
+            chat_runner, "subprocess_executor", MagicMock(return_value=None)
+        ), patch.object(
+            chat_runner, "warm_project_agent_names", new=AsyncMock()
+        ):
+            await _drive(state, slot)
+
+        # Disabled -> recovery skipped: refresh_app_agents never ran...
+        reregister.assert_not_called()
+        # ...the default agent was NOT dispatched, and the turn failed loud.
+        state.sessions.get_or_create.assert_not_awaited()
+        errors = _errors(slot)
+        assert any("my-app-agent" in e and "isn't loaded yet" in e for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_recovery_awaits_register_before_releasing_lock_on_cancel(self, tmp_path):
+        # register_app runs in a non-cancellable executor thread. If the recovery
+        # coroutine is cancelled mid-registration it must WAIT for that thread to
+        # finish before the lifecycle lock releases — otherwise a concurrent
+        # disable could deregister and the still-running thread republish a
+        # now-disabled agent. Prove the cancelled task stays blocked until
+        # register_app completes.
+        import kiro_crew.dashboard.chat_runner as cr
+
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def slow_register(_name):
+            started.set()
+            release.wait(5)
+            finished.set()
+
+        slot = _slot()
+        slot._app = "myapp"
+        slot.agent = "my-app-agent"
+        warm = _bindings(
+            kiro_agent="my-app-agent",
+            resolved_alias="my-app-agent",
+            requested_resolved=True,
+        )
+        with patch.object(cr, "resolve_agent_bindings", return_value=warm), patch.object(
+            cr, "subprocess_executor", MagicMock(return_value=None)
+        ), patch(
+            "kiro_crew.apps.manager.is_app_enabled", MagicMock(return_value=True)
+        ), patch(
+            "kiro_crew.apps.bridges.register_app", slow_register
+        ):
+            task = asyncio.create_task(
+                cr._recover_app_agent_binding(MagicMock(), slot, project=None)
+            )
+            await asyncio.to_thread(started.wait, 5)  # register_app is now running
+            task.cancel()
+            # Shielded: the cancelled task must NOT complete while register_app is
+            # still running — it is blocked awaiting the executor future.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(task), 0.2)
+            release.set()  # let register_app finish
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert finished.is_set()  # register_app ran to completion before propagating
 
     @pytest.mark.asyncio
     async def test_eager_spawn_bails_for_unresolved_app_slot(self, tmp_path):
@@ -2497,9 +2638,11 @@ class TestAppAgentDispatchGuard:
         with patch.object(chat_runner.asyncio, "sleep", new=AsyncMock()), patch.object(
             chat_runner, "_consume_pending_reset", new=AsyncMock()
         ), patch.object(
-            chat_runner, "resolve_agent_bindings", side_effect=[cold, cold]
+            chat_runner, "resolve_agent_bindings", side_effect=[cold, cold, cold]
         ), patch.object(
             chat_runner, "refresh_materialized_agents", MagicMock()
+        ), patch(
+            "kiro_crew.apps.bridges.register_app", MagicMock(return_value=[])
         ), patch.object(
             chat_runner, "subprocess_executor", MagicMock(return_value=None)
         ):


### PR DESCRIPTION
## Problem / Motivation

An app's agents live only in the materialized agent snapshot (backed by files under the kiro agents dir), never in `config.agents`. When an app-owned chat slot's agent is missing from that snapshot, `resolve_agent_bindings` silently falls back to the **default** agent (`requested_resolved=False`) — the slot keeps its requested name in the UI while the generic default answers, with none of the app's MCP tools and no error.

PR #4983 self-healed the case where the spec is **on disk but the snapshot was cold** (rescan + re-resolve, else fail-loud). It did **not** cover the case where the spec was **never materialized to disk though the app source is intact** (registration never ran for this home, or reconcile materialized zero). The boot reconcile (`reconcile_enabled_app_resources`) re-registers every *enabled* app from source, so a restart heals such an app — but the user shouldn't need to restart, and the case a restart would *not* fix (app not enabled/admitted at boot, or reconcile silently materialized zero) had no visible signal at all.

## Why it matters

For a custom app agent, silently running the default is meaningless: the app is unusable with no signal explaining why. This is the general class behind the observed "app agent unrecognized on a fresh/made-live instance until uninstall + reinstall" symptom.

## What changed (motivation → approach → change)

- **Tier 1 (auto-recover from source, mid-turn).** At both dispatch sites (`_eager_spawn` and `_run_chat`), after the existing rescan + re-resolve still misses for an app-owned slot, re-register that app's resources **from source** off the loop, then re-resolve once more — via a shared `_recover_app_agent_binding` coroutine (one implementation, two call sites, so they cannot diverge). It uses **`register_app`** (not the narrower `refresh_app_agents`) so the app's **MCP servers are registered BEFORE its agents**: a never-materialized app also has unregistered MCP servers, and re-materializing only the agent would inline an empty server map — recreating an agent whose own `@<app>:<server>` tool refs dangle (dispatches, but its tools never mount, the original symptom). This recovers, mid-turn without a restart, exactly the set a restart's boot reconcile would heal; a genuinely source-missing app falls through to #4983's fail-loud. Recovery is gated on `is_app_enabled(slot._app)` held under `app_lifecycle_lock(slot._app)`, so a concurrent disable/uninstall cannot race recovery into reactivating a deregistered agent (a disabled app fails loud). `register_app` already enforces the execution-admission gate; `refresh_app_agents` is additionally hardened to honor the same gate for its remaining callers. The common hot path (no `_app`, or already resolved) does zero extra work.
- **Tier 2 (visible error).** `register_app` now appends a `"registered 0 of N declared agent(s) — agent source missing or unreadable"` entry to `result.errors` when a manifest declares agents but none materialize. `reconcile_enabled_app_resources` counts and logs it, so a boot-time zero-materialize surfaces as an error instead of a silent success — this is what makes the "a restart wouldn't fix it" cause visible.

## Tests

- `test/test_chat_runner_coverage.py`: `test_app_slot_recovers_from_source_after_rescan_miss` (rescan misses → `register_app` makes it resolvable → app agent dispatched, not default, no error card); `test_disabled_app_slot_skips_source_recovery_and_fails_loud` (disabled app → recovery skipped → fail-loud); updated fail-loud + eager-bail tests for the third resolve.
- `test/test_app_bridges.py`: `test_register_app_reports_zero_registered_when_agent_source_missing` (Tier 2); `test_refresh_app_agents_denied_scrubs_and_registers_nothing` (admission gate).
- All new assertions mutation-verified. Local gate: black-gate / isort / flake8 clean, `mypy` Success (1009 files), `pytest test/test_chat_runner_coverage.py test/test_app_bridges.py` = 365 passed / 2 skipped.

## Manual verification

N/A — unit coverage exercises both recovery tiers and both dispatch sites (rescan-miss → from-source recover, source-missing → fail-loud/visible-error, disabled → skip).

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/config.md`)
- [x] No secrets, credentials, or internal references in the diff
