### PR TITLE
refactor: consolidate the file-browser rail drag grip onto useColumnResize

### DIFF
--- a/website/src/hooks/useColumnResize.ts
+++ b/website/src/hooks/useColumnResize.ts
@@ -1,10 +1,14 @@
 // Drag-to-resize behaviour shared by the dashboard's fixed-width workspace
 // columns (Issue Radar's left rail and issue / PR lists, Task Runner's run
-// rail, the Webhooks rail). Every column behaves the same way — the handle sits
-// on its right edge,
-// dragging right widens it, the width is clamped while dragging and persisted to
-// localStorage on release — so the logic lives here once instead of being
-// duplicated per column.
+// rail, the Webhooks rail). Every column behaves the same way — the width is
+// clamped while dragging and persisted to localStorage on release — so the
+// logic lives here once instead of being duplicated per column.
+//
+// The handle usually sits on the column's RIGHT edge (a left-side rail), where
+// dragging right widens it. A right-side rail puts its grip on the LEFT edge,
+// so the drag direction flips: pass `edge: 'left'` and the hook negates the
+// pointer delta instead of every such caller hand-rolling the same block with
+// a minus sign in it.
 //
 // A column may also opt into COLLAPSING (the rails do): drag far enough
 // past the minimum and the column snaps to a narrow icon strip instead of
@@ -12,6 +16,7 @@
 // distance back out, so the snap has hysteresis and doesn't flicker around the
 // boundary.
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { safeSetItem } from '../utils/safeStorage'
 import { useIsMobile } from './useIsMobile'
 import { usePointerDrag } from './usePointerDrag'
 
@@ -46,8 +51,9 @@ export interface ColumnResize {
   dragging: boolean
   /** Re-open a collapsed column at the width the user last dragged it to. */
   expand: () => void
-  /** Move the column by `dx` px and persist, clamping / collapsing the same way
-   *  a drag of that distance would. Drives the handle's arrow keys. */
+  /** Move the grip by `dx` px and persist, clamping / collapsing the same way
+   *  a drag of that distance would (so on a left-edge grip, positive `dx`
+   *  narrows). Drives the handle's arrow keys. */
   nudge: (dx: number) => void
   /** Collapse to the icon strip without a drag — e.g. on a narrow viewport,
    *  where a fixed-width column would squeeze the pane beside it. No-op when the
@@ -64,7 +70,15 @@ export function useColumnResize(
   max: number,
   collapse?: CollapseConfig,
   loadCollapsed?: () => boolean,
+  /** Which edge of the column the grip sits on. On a `'left'` grip (a
+   *  right-side rail) dragging LEFT grows the column, so the pointer delta is
+   *  negated before it reaches the resolver. */
+  edge: 'right' | 'left' = 'right',
 ): ColumnResize {
+  // Folding the grip's direction into a sign keeps resolve/apply edge-agnostic.
+  // nudge shares it so arrow keys follow the grip's direction too: on a
+  // left-edge grip, ArrowRight moves the grip right, which narrows the column.
+  const sign = edge === 'left' ? -1 : 1
   // The stored width is always an EXPANDED width, so collapsing and reopening
   // restores the user's chosen size rather than the default.
   const [openWidth, setOpenWidth] = useState<number>(load)
@@ -148,18 +162,17 @@ export function useColumnResize(
   }, [resolve, narrowMode])
 
   const persist = useCallback((next: { openWidth: number, collapsed: boolean }) => {
-    try {
-      // Always the OPEN width — the collapsed strip width is never a column width.
-      localStorage.setItem(storageKey, String(next.openWidth))
-      // The collapsed flag is a DESKTOP preference. While the viewport is narrow
-      // the column's collapsed state is ephemeral (`openedWhileNarrow`), so
-      // writing it here would let a phone visit — even a single tap on the drag
-      // handle, which resolves to the strip it is already showing — come back as
-      // a collapsed rail on the next desktop session.
-      if (collapse && !narrowMode) localStorage.setItem(collapse.storageKey, next.collapsed ? '1' : '0')
-    } catch {
-      /* storage blocked or full — the layout still applies for this session */
-    }
+    // safeSetItem reclaims disposable caches under quota pressure and never
+    // throws — a blocked or full store means the layout applies for this
+    // session only.
+    // Always the OPEN width — the collapsed strip width is never a column width.
+    safeSetItem(storageKey, String(next.openWidth))
+    // The collapsed flag is a DESKTOP preference. While the viewport is narrow
+    // the column's collapsed state is ephemeral (`openedWhileNarrow`), so
+    // writing it here would let a phone visit — even a single tap on the drag
+    // handle, which resolves to the strip it is already showing — come back as
+    // a collapsed rail on the next desktop session.
+    if (collapse && !narrowMode) safeSetItem(collapse.storageKey, next.collapsed ? '1' : '0')
   }, [storageKey, collapse, narrowMode])
 
   const handleProps = usePointerDrag({
@@ -173,11 +186,11 @@ export function useColumnResize(
       document.body.style.cursor = 'col-resize'
       document.body.style.userSelect = 'none'
     },
-    onMove: ({ dx }) => { apply(dx) },
+    onMove: ({ dx }) => { apply(sign * dx) },
     onEnd: ({ dx }) => {
       draggingRef.current = false
       setDragging(false)
-      persist(apply(dx))
+      persist(apply(sign * dx))
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     },
@@ -221,12 +234,15 @@ export function useColumnResize(
   // resolved from the CURRENT width rather than a drag origin, so repeated
   // presses accumulate the way held-arrow behaviour is expected to.
   const nudge = useCallback((dx: number) => {
+    // `dx` is a grip movement, like the drag's: on a left-edge grip a positive
+    // step (ArrowRight) narrows the column, matching the pointer.
+    const d = sign * dx
     const live = liveRef.current
     const clamp = (v: number) => Math.min(max, Math.max(min, v))
     // Collapsed and growing: reopen at the remembered width instead of the
     // minimum, mirroring how the drag resolver treats an outward pull.
     if (collapse && live.collapsed) {
-      if (dx <= 0) return
+      if (d <= 0) return
       const next = { openWidth: clamp(live.openWidth), collapsed: false }
       if (narrowMode) setOpenedWhileNarrow(true)
       else setCollapsed(false)
@@ -234,7 +250,7 @@ export function useColumnResize(
       persist(next)
       return
     }
-    const raw = live.openWidth + dx
+    const raw = live.openWidth + d
     // Shrinking past the minimum collapses, matching the drag's snap rather
     // than stopping dead at a wall the keyboard can never get past.
     const next = collapse && raw < min
@@ -244,7 +260,7 @@ export function useColumnResize(
     else setCollapsed(next.collapsed)
     setOpenWidth(next.openWidth)
     persist(next)
-  }, [min, max, collapse, persist, narrowMode])
+  }, [min, max, collapse, persist, narrowMode, sign])
 
   return {
     width, collapsed: collapsedEffective, dragging, expand, nudge,

--- a/website/src/pages/chat/FileBrowserRail.tsx
+++ b/website/src/pages/chat/FileBrowserRail.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { Files, Diff, Search, X, RefreshCw } from 'lucide-react'
 import { api } from '../../api/client'
 import { cn } from '../../lib/utils'
-import { usePointerDrag } from '../../hooks/usePointerDrag'
-import { safeSetItem } from '../../utils/safeStorage'
+import { useColumnResize } from '../../hooks/useColumnResize'
 import { PierreWorkspaceTree } from '../../pierre/tree'
 
 /** Rail width bounds; the grip clamps between them. */
@@ -98,35 +97,21 @@ export default function FileBrowserRail({ projectDir, onFileOpen, selectedPath }
     }
   }
 
-  const [railW, setRailW] = useState(() => {
-    const v = parseInt(localStorage.getItem(RAIL_W_KEY) || '', 10)
-    return Number.isFinite(v) ? Math.min(RAIL_MAX_W, Math.max(RAIL_MIN_W, v)) : RAIL_MIN_W
-  })
-  const startWRef = useRef(0)
-  const latestWRef = useRef(railW)
-  latestWRef.current = railW
-  // The grip sits on the rail's LEFT edge, so dragging left (dx < 0) grows it.
-  const grip = usePointerDrag({
-    threshold: 0,
-    onStart: () => {
-      startWRef.current = latestWRef.current
-      document.body.style.userSelect = 'none'
-      document.body.style.cursor = 'col-resize'
+  // The grip sits on the rail's LEFT edge, so the hook negates the drag delta
+  // (edge: 'left'): dragging left grows the rail. Clamping and the persisted
+  // width key are unchanged from the hand-rolled block this replaces.
+  const rail = useColumnResize(
+    RAIL_W_KEY,
+    () => {
+      const v = parseInt(localStorage.getItem(RAIL_W_KEY) || '', 10)
+      return Number.isFinite(v) ? Math.min(RAIL_MAX_W, Math.max(RAIL_MIN_W, v)) : RAIL_MIN_W
     },
-    onMove: ({ dx }) => {
-      setRailW(Math.min(RAIL_MAX_W, Math.max(RAIL_MIN_W, startWRef.current - dx)))
-    },
-    onEnd: () => {
-      document.body.style.userSelect = ''
-      document.body.style.cursor = ''
-      safeSetItem(RAIL_W_KEY, String(latestWRef.current))
-    },
-  })
-  // Safety: restore body styles if unmounted mid-drag.
-  useEffect(() => () => {
-    document.body.style.userSelect = ''
-    document.body.style.cursor = ''
-  }, [])
+    RAIL_MIN_W,
+    RAIL_MAX_W,
+    undefined,
+    undefined,
+    'left',
+  )
 
   const segBtn = (on: boolean) =>
     cn('flex items-center justify-center gap-1.5 h-[22px] px-2 rounded-[5px] text-[11.5px] font-medium cursor-pointer border-none transition-colors',
@@ -135,13 +120,14 @@ export default function FileBrowserRail({ projectDir, onFileOpen, selectedPath }
   return (
     <>
       <div
-        {...grip}
+        {...rail.handleProps}
         role="separator"
         aria-orientation="vertical"
         aria-label={t('pages.chat.fileBrowserRail.resize')}
         className="w-1 shrink-0 cursor-col-resize bg-transparent hover:bg-accent/40 active:bg-accent/60 transition-colors"
+        style={{ touchAction: 'none' }}
       />
-      <div style={{ width: railW }} className="shrink-0 min-h-0 border-l border-border flex flex-col">
+      <div style={{ width: rail.width }} className="shrink-0 min-h-0 border-l border-border flex flex-col">
         <div className="flex items-center gap-1.5 px-2 h-[40px] shrink-0 border-b border-border">
           <div
             className="flex flex-none bg-bg-elevated border border-border rounded-[7px] p-[2px] gap-[2px]"

--- a/website/src/test/useColumnResize.leftEdge.test.tsx
+++ b/website/src/test/useColumnResize.leftEdge.test.tsx
@@ -1,0 +1,87 @@
+// A right-side rail puts its resize grip on the column's LEFT edge, so the
+// drag direction flips: dragging LEFT grows the column. `useColumnResize`
+// absorbs that with `edge: 'left'` instead of each such rail hand-rolling the
+// same pointer block with a negated delta. These tests pin the flip end to
+// end — pointer drag, clamping, persistence, and the keyboard nudge, which
+// must follow the GRIP's direction so arrows match the pointer.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+import { useColumnResize } from '../hooks/useColumnResize'
+import ResizeHandle from '../components/ResizeHandle'
+
+const WIDTH_KEY = 'kc:test:left-edge-col-width'
+const MIN = 300
+const MAX = 520
+const START = 400
+
+const loadWidth = () => {
+  const raw = Number(localStorage.getItem(WIDTH_KEY))
+  return Number.isFinite(raw) && raw > 0 ? Math.min(MAX, Math.max(MIN, raw)) : START
+}
+
+function Harness({ edge }: { edge: 'right' | 'left' }) {
+  const col = useColumnResize(WIDTH_KEY, loadWidth, MIN, MAX, undefined, undefined, edge)
+  return (
+    <div>
+      <aside data-testid="col" style={{ width: col.width }} />
+      <ResizeHandle handleProps={col.handleProps} label="Resize rail" onNudge={col.nudge} />
+    </div>
+  )
+}
+
+function drag(handle: HTMLElement, from: number, to: number, id = 1) {
+  fireEvent.pointerDown(handle, { clientX: from, pointerId: id })
+  fireEvent.pointerMove(handle, { clientX: to, pointerId: id })
+  fireEvent.pointerUp(handle, { clientX: to, pointerId: id })
+}
+
+const widthOf = (el: HTMLElement) => el.style.width
+
+describe('useColumnResize with a left-edge grip', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem(WIDTH_KEY, String(START))
+  })
+
+  it('a leftward drag GROWS the column and persists the result', () => {
+    const { getByTestId, getByRole } = render(<Harness edge="left" />)
+    drag(getByRole('separator'), 500, 440)
+    expect(widthOf(getByTestId('col'))).toBe(`${START + 60}px`)
+    expect(localStorage.getItem(WIDTH_KEY)).toBe(String(START + 60))
+  })
+
+  it('a rightward drag SHRINKS the column', () => {
+    const { getByTestId, getByRole } = render(<Harness edge="left" />)
+    drag(getByRole('separator'), 500, 560)
+    expect(widthOf(getByTestId('col'))).toBe(`${START - 60}px`)
+  })
+
+  it('clamps to [min, max] in the flipped directions', () => {
+    const { getByTestId, getByRole } = render(<Harness edge="left" />)
+    drag(getByRole('separator'), 500, -5000)
+    expect(widthOf(getByTestId('col'))).toBe(`${MAX}px`)
+    drag(getByRole('separator'), 500, 9000, 2)
+    expect(widthOf(getByTestId('col'))).toBe(`${MIN}px`)
+    expect(localStorage.getItem(WIDTH_KEY)).toBe(String(MIN))
+  })
+
+  it('arrow keys follow the grip direction: ArrowLeft grows, ArrowRight shrinks', () => {
+    const { getByTestId, getByRole } = render(<Harness edge="left" />)
+    const handle = getByRole('separator')
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' })
+    expect(widthOf(getByTestId('col'))).toBe(`${START + 16}px`)
+    fireEvent.keyDown(handle, { key: 'ArrowRight' })
+    fireEvent.keyDown(handle, { key: 'ArrowRight' })
+    expect(widthOf(getByTestId('col'))).toBe(`${START - 16}px`)
+  })
+
+  it('the default right edge is unchanged: dragging right grows', () => {
+    const { getByTestId, getByRole } = render(<Harness edge="right" />)
+    drag(getByRole('separator'), 500, 560)
+    expect(widthOf(getByTestId('col'))).toBe(`${START + 60}px`)
+    expect(localStorage.getItem(WIDTH_KEY)).toBe(String(START + 60))
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Several dashboard components hand-roll the same pointer-drag column-resize block — `document.body.style.cursor = 'col-resize'` + `userSelect` lock, a drag-origin ref, min/max clamping, persist-on-release, and a mid-drag unmount guard — instead of using the shared `useColumnResize` hook, which already centralizes exactly this for the workspace columns. The file-browser rail (`FileBrowserRail.tsx`) could not adopt the hook at all: its grip sits on the rail's LEFT edge (a right-side rail), and the hook only expressed a right-edge grip, so the duplication there was structural, not accidental. Raised by First Principles review on PR #4895.

## Why it matters

Every duplicated copy of the drag block is a copy that drifts: the sites disagree today on quota-safe persistence (`safeSetItem` vs raw `localStorage.setItem`), `touch-action`, and unmount-guard shape. Fixes to the shared hook (like the narrow-viewport handling it already gained) never reach the hand-rolled copies. Removing the structural blocker (left-edge grips) is also what lets the PR-panel tree rail on #4895 adopt the hook instead of adding yet another copy.

## What changed (motivation → approach → change)

Goal: consolidate onto the existing abstraction without changing behavior, and keep the hook's surface minimal.

- **`useColumnResize` gains an `edge: 'right' | 'left'` parameter** (default `'right'`, so all 8 existing callers are byte-for-byte unaffected). A `'left'` grip negates the pointer delta before it reaches the resolver, which stays edge-agnostic; the keyboard `nudge` shares the sign so arrow keys follow the grip's direction, matching the pointer.
- **The hook's persist now routes through `safeSetItem`** (quota-reclaiming, never throws) instead of a raw `try/catch` write — so migrating `FileBrowserRail`, which already used `safeSetItem`, is not a persistence downgrade, and every existing hook caller gains quota-safe writes.
- **`FileBrowserRail` drops its hand-rolled block** (~30 lines: state + two refs + `usePointerDrag` wiring + unmount guard) for one `useColumnResize(..., 'left')` call. Its bounds (300–520px), persisted key (`mc-files-rail-w`), load/clamp logic, drag direction, and grip markup are unchanged. The grip additionally gets `touch-action: none`, matching every other resize handle in the app, so a touch drag resizes instead of scrolling.

**Scope: why the other grep hits are NOT migrated here.** The issue's grep (`document.body.style.cursor = 'col-resize'`) also matches four other sites; each breaks the hook's ownership contract (the hook owns the width state and persists it to its own localStorage key on release), so force-fitting them would mean growing the hook's API for zero user-visible change — beyond the bounded consolidation the issue asks for:

- `ChatSidebar.tsx` — width has two programmatic writers outside the drag (board-view auto-widen and pre-board restore) plus synchronous per-move parent callbacks (`onWidthChange`/`onDragChange` into `ChatPage`); the hook would need a public `setWidth` and callback plumbing, and effect-based propagation would add a render of lag on a hot drag path.
- `BottomTerminalPanel.tsx` — width lives in a shared module store (`useBottomTerminal`), not component state, and its twin grip is a *row* (vertical) resize a column hook cannot serve.
- `SpecDetail.tsx` (spec-builder) — a container-relative *percentage* split computed from the pane's bounding rect, not a px-delta model.
- `FileExplorerPage.tsx` — width persists inside a composite debounced state blob (with the tab set), not its own key; migrating would fork the persistence format.

Also of note: `PullRequestPanel.tsx`, named in the issue, has no resize code on `main` — its tree-rail grip lives on the still-open PR #4895, which can now adopt the hook via `edge: 'left'`.

## Tests

- `website/src/test/useColumnResize.leftEdge.test.tsx` (new, 5 tests): on a left-edge grip a leftward drag GROWS the column and persists; a rightward drag shrinks; clamping holds in the flipped directions; arrow keys follow the grip's direction (ArrowLeft grows, ArrowRight shrinks); and the default right edge behaves exactly as before.
- `website/src/test/FileBrowserRail.test.tsx` (pre-existing, unchanged, 22 tests) pins the migrated rail's contract — left-edge drag direction, 300–520 clamp, and persistence to `mc-files-rail-w` on release — and passes against the migrated code.
- Pre-existing hook/caller suites all pass: `useColumnResize.narrowViewport` (11), `IssueRadarColumnResize` (19), `IssueRadarListResize` (4), `ChatSidebar.resizeTouch` (5), plus `WebhooksPage`/`ProjectsPage`/`CodeReviewSagePageCov80` (70).

## Manual verification

N/A — unit coverage sufficient: the rail's drag direction, clamping, and persisted width are pinned by the pre-existing `FileBrowserRail` grip suite (which did not change), and the flipped-edge math is pinned at the hook level by the new suite.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** behavior-preserving refactor of drag mechanics onto the shared hook — identical markup, classes, and rendered output; no pixel changes in any state. Drag direction/clamp/persistence equivalence is proven by the unchanged 22-test `FileBrowserRail` suite rather than stills, which cannot capture a drag.

## Related Issues

Closes #4994

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — hook doc comments updated in the same commit; no external doc covers this hook
- [x] No secrets, credentials, or internal references in the diff
