### PR TITLE
fix(sel): segment reads validate the descriptor they opened (#4992)

### DIFF
--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -26,6 +26,7 @@ Retention: configurable, default 365 days per Amazon Security Event Logging Stan
 from __future__ import annotations
 
 import atexit
+import errno
 import hashlib
 import hmac
 import json
@@ -42,7 +43,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import IO
+from typing import IO, Literal, overload
 
 from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
@@ -1246,8 +1247,15 @@ class SecurityEventLog:
         unrelated file an operator parked in the segment dir is never treated as
         rotation output (and so never deleted by retention). A candidate must
         ALSO be a real regular file: the name check is what protects an
-        operator's file, the ``lstat`` check is what stops a PLANTED link from
-        being read as audit history.
+        operator's file, the ``lstat`` check is the cheap first filter that
+        stops a PLANTED link from being read as audit history. It judges the
+        dirent at SCAN time only, so the readers re-validate at open time via
+        :func:`_open_segment` — a link planted between scan and open is refused
+        there rather than followed. A hardlink ALIAS is deliberately NOT
+        deduplicated: every key such a decision could use is
+        attacker-controlled here, so a dedupe lets a planted name DISPLACE the
+        real segment (see the comment at the scan); an alias's worst case is
+        repeating already-signed records, which admission gating bounds.
 
         The link case is reachable on an upgrade and matters on the read side,
         not the delete side: ``security_events.d`` was not on the sensitive-path
@@ -1276,6 +1284,16 @@ class SecurityEventLog:
             scanner = os.scandir(self._segment_dir)
         except OSError:
             return []
+        # A hardlink ALIAS is deliberately NOT handled here (or anywhere):
+        # an alias IS the regular file its name points at, so telling it from
+        # the original requires a cross-name decision — and every key
+        # available for that decision (which name sorts first, which survives)
+        # is attacker-controlled in this directory. A dedupe keyed on names
+        # lets a planted alias DISPLACE the real segment and corrupt read
+        # chronology, which is strictly worse than what an alias can do on its
+        # own: duplicate already-signed records in bounded reads. That
+        # duplication is admission-gated (_read_sources_newest_first requires
+        # a record signed with the out-of-tree key) and cannot forge history.
         named: list[Path] = []
         examined = 0
         truncated = False
@@ -1730,18 +1748,52 @@ class SecurityEventLog:
             valid += file_valid
         return total, valid
 
+    @overload
+    def _reader_handle(self, path: Path, *, binary: Literal[True]) -> IO[bytes] | None: ...
+
+    @overload
+    def _reader_handle(self, path: Path, *, binary: Literal[False]) -> IO[str] | None: ...
+
+    def _reader_handle(self, path: Path, *, binary: bool) -> IO[str] | IO[bytes] | None:
+        """Reader-side open policy, shared by both readers.
+
+        The LIVE log opens with ordinary ``open()``: it is a fixed
+        module-owned path, never an enumerated name, and its WRITER follows
+        an operator's symlink (``O_CREAT | O_APPEND``), so a reader that
+        refuses one turns the live log write-only — events keep landing
+        while every read reports empty and ``verify_integrity`` counts a
+        clean ``(0, 0)``. Rotated segments ARE enumerated, attacker-nameable
+        entries, and take the descriptor-validating funnel
+        (:func:`_open_segment`).
+        """
+        if path == self._path:
+            try:
+                if binary:
+                    return open(path, "rb")
+                return open(path, encoding="utf-8")
+            except OSError:
+                logger.warning("SEL could not open the live log %s", path.name, exc_info=True)
+                return None
+        fd = _open_segment(path)
+        if fd is None:
+            return None
+        if binary:
+            return os.fdopen(fd, "rb")
+        return os.fdopen(fd, encoding="utf-8")
+
     def _verify_file(self, path: Path) -> tuple[int, int]:
         """Verify one log file's chain. Returns (total, valid).
 
         Streamed line by line so a capped-but-large segment is never loaded whole.
+        The handle comes from :meth:`_reader_handle`, so a symlink or FIFO
+        planted under a segment name is refused here rather than followed; a
+        refused file is not audit history and counts as (0, 0).
         """
         total = 0
         valid = 0
         prev_hash = ""
-        try:
-            handle = open(path, encoding="utf-8")
-        except OSError:
-            logger.warning("SEL could not open %s for verification", path, exc_info=True)
+        handle = self._reader_handle(path, binary=False)
+        if handle is None:
             return 0, 0
         with handle:
             for raw_line in handle:
@@ -1896,9 +1948,17 @@ class SecurityEventLog:
         gigabyte-long unterminated line would exhaust the process. Hitting the cap
         ends the scan, so a caller sees the lines it already got and admission
         simply fails to find a signed record -- which is the safe direction.
+
+        The handle comes from :meth:`_reader_handle`, so a symlink or FIFO
+        planted under a segment name yields nothing here instead of being
+        followed (or, for a FIFO, blocking the reader inside ``open``); the
+        live log itself opens ordinarily, matching its writer.
         """
+        handle = self._reader_handle(path, binary=True)
+        if handle is None:
+            return
         try:
-            with open(path, "rb") as f:
+            with handle as f:
                 f.seek(0, 2)
                 pos = f.tell()
                 buf = b""
@@ -2099,6 +2159,102 @@ def _segment_seq(path: Path) -> int:
     """
     match = _SEGMENT_NAME_RE.fullmatch(path.name)
     return int(match.group("seq")) if match else 0
+
+
+def _open_segment(path: Path) -> int | None:
+    """Open *path* read-only as a validated ROTATED SEGMENT, or ``None``.
+
+    The dirent check in :meth:`SecurityEventLog._segments_oldest_first` judges
+    what a directory entry WAS when scanned; this opener judges what the name
+    IS at open time, closing the scan->open window in which a substitute can
+    be planted (the read-side TOCTOU). Segments are the enumerated,
+    attacker-nameable surface; the LIVE log deliberately does not come here —
+    its writer follows an operator's symlink, so its readers must too
+    (:meth:`SecurityEventLog._reader_handle` owns that split).
+
+    Three layers, each covering what the previous one cannot:
+
+    - ``O_NOFOLLOW`` fails a planted symlink at the open itself where the
+      platform has it (``ELOOP`` on Linux/macOS; some BSDs say ``EMLINK`` or
+      ``EFTYPE``). ``O_NONBLOCK`` is load-bearing for a planted FIFO: without
+      it the read-side ``os.open`` blocks until a writer appears, before any
+      descriptor-level check is reachable; it has no effect on regular files.
+      Both degrade to 0 via ``getattr`` on Windows, and ``O_BINARY`` keeps the
+      descriptor out of Windows text mode there.
+    - ``fstat`` on the DESCRIPTOR — which nothing can swap afterwards —
+      requires a regular file, refusing FIFOs, directories, and device nodes
+      on every platform.
+    - An identity check makes the flag degradation safe: the opened file must
+      be exactly the file *path* names right now (``lstat`` dev/ino equal to
+      the descriptor's). A symlink's own ``lstat`` identity never equals its
+      target's, so a symlink swap is refused even where ``O_NOFOLLOW`` does
+      not exist, and a mid-swap mismatch fails closed. (On a filesystem that
+      reports ``st_ino == 0`` for everything, the comparison degrades to the
+      flag and type checks; such filesystems do not support symlinks.)
+
+    A HARDLINK is deliberately not judged here: a hardlink IS the regular
+    file its name points at, indistinguishable at the per-file level, and a
+    link count above one is routinely legitimate (``rsync --link-dest`` and
+    ``cp -al`` backups). Nor is a planted second name deduplicated anywhere
+    else — every key such a decision could use is attacker-controlled, so a
+    dedupe would let a planted alias DISPLACE the real segment (see the scan
+    comment in :meth:`SecurityEventLog._segments_oldest_first`). An alias's
+    bounded worst case is repeating already-signed records.
+
+    Returns a descriptor at position 0, ready for ``os.fdopen``; ownership
+    passes to the caller. A refusal warns in the same "planted link?" style as
+    the dirent filter, so the two layers read consistently in the log.
+    """
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        if exc.errno in (
+            errno.ELOOP,
+            getattr(errno, "EMLINK", -1),
+            getattr(errno, "EFTYPE", -1),
+        ):
+            logger.warning(
+                "SEL refusing audit file %s: it is a symlink (planted link?); "
+                "it is not audit history",
+                path.name,
+            )
+        elif exc.errno == errno.ENOENT:
+            # Deleted by retention between the caller's exists() check and
+            # this open — a normal race, not an incident.
+            logger.debug("SEL audit file %s vanished before open", path.name)
+        else:
+            logger.warning("SEL could not open audit file %s", path.name, exc_info=True)
+        return None
+    try:
+        opened = os.fstat(fd)
+        named = os.lstat(path)
+    except OSError:
+        os.close(fd)
+        logger.warning("SEL could not stat opened audit file %s", path.name, exc_info=True)
+        return None
+    if not stat.S_ISREG(opened.st_mode):
+        os.close(fd)
+        logger.warning(
+            "SEL ignoring non-regular audit file %s (planted link?); "
+            "it is not audit history",
+            path.name,
+        )
+        return None
+    if (named.st_dev, named.st_ino) != (opened.st_dev, opened.st_ino):
+        os.close(fd)
+        logger.warning(
+            "SEL refusing audit file %s: it is not the file its name points "
+            "at (planted link?); it is not audit history",
+            path.name,
+        )
+        return None
+    return fd
 
 
 def _parse_timestamp(raw: object) -> datetime | None:

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -2889,6 +2889,153 @@ class TestSegmentDirIsNotFollowedThroughALink:
         assert total == valid
 
 
+class TestSegmentOpensValidateTheDescriptor:
+    """The scan->open window is closed at OPEN time, not just at scan time.
+
+    ``_segments_oldest_first`` judges the DIRENT; a link or FIFO planted after
+    that judgment must still be refused by the open itself. ``_open_segment``
+    opens ``O_NOFOLLOW | O_NONBLOCK``, requires the DESCRIPTOR to be a regular
+    file, and requires the opened identity to be exactly what the name points
+    at — so both consumers (``_verify_file`` for verify_integrity,
+    ``_iter_lines_backward`` for recent) are exercised here with the planted
+    path handed to them DIRECTLY, as if it had passed the scan. Hardlink
+    ALIASES are deliberately not deduplicated (a cross-name decision keyed on
+    attacker-controlled names lets a plant displace real history); the
+    displacement test locks that invariant.
+    """
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_symlink_is_refused_by_both_consumers(self, sel_dir, small_segments):
+        """O_NOFOLLOW (and the lstat identity check where it is absent) is what
+        catches this: a followed link to a regular file yields a perfectly
+        regular descriptor, so fstat alone would pass it."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)  # rotation creates the real segment dir
+        secret = sel_dir / "outside.jsonl"
+        secret.write_text(json.dumps({"chain": "s3cr3t-outside"}) + "\n", encoding="utf-8")
+        planted = sel_dir / "security_events.d" / "security_events-000001-20200101T000000Z.jsonl"
+        planted.unlink(missing_ok=True)
+        try:
+            planted.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform/filesystem")
+
+        assert log._verify_file(planted) == (0, 0), "linked file counted as audit history"
+        assert list(log._iter_lines_backward(planted)) == [], "linked file's lines surfaced"
+        # End to end: nothing surfaced by the readers, nothing counted as valid.
+        assert "s3cr3t-outside" not in json.dumps(log.recent(limit=10_000))
+        total, valid = log.verify_integrity()
+        assert total == valid
+        # The link's target survives: the entry is ignored, never chased.
+        assert secret.exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hardlink semantics")
+    def test_an_alias_plant_cannot_displace_newer_history(self, sel_dir, small_segments):
+        """A LOWER-sequence hardlink of the newest segment must not displace
+        the real name from the read order. Aliases are deliberately NOT
+        deduplicated — every key such a decision could use (which name sorts
+        first, which survives) is attacker-controlled in this directory, so a
+        dedupe hands the plant the power to hide or reorder real history. An
+        alias's worst case without dedupe is repeating already-signed records;
+        it can never displace, hide, or forge them."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        segments = log._segments_oldest_first()
+        assert len(segments) > 1, "precondition: several segments"
+        newest = segments[-1]
+        alias = sel_dir / "security_events.d" / "security_events-000000-20000101T000000Z.jsonl"
+        alias.unlink(missing_ok=True)
+        os.link(newest, alias)  # newest content under the lowest-sorting name
+
+        listed = log._segments_oldest_first()
+        assert newest in listed, "the real newest segment was displaced by its alias"
+        order = list(log._read_sources_newest_first())
+        assert newest in order, "the real newest segment vanished from the read order"
+        assert order.index(newest) < order.index(alias), (
+            "the alias outranked the real newest segment in newest-first reads"
+        )
+        total, valid = log.verify_integrity()
+        assert total == valid, "alias duplication broke signature validity"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hardlink semantics")
+    def test_a_backup_hardlink_does_not_suppress_audit_history(self, sel_dir, small_segments):
+        """Backup tools (rsync --link-dest, cp -al, rsnapshot) hardlink audit
+        files from OUTSIDE the segment dir. A link count above one must not
+        refuse the file: history keeps reading and verifying, and retention
+        keeps moving — refusing here silently blanked real audit history while
+        verify_integrity still reported clean."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        before_recent = len(log.recent(limit=10_000))
+        before = log.verify_integrity()
+        backups = sel_dir / "backup"
+        backups.mkdir()
+        os.link(sel_dir / "security_events.jsonl", backups / "live.jsonl")
+        for i, seg in enumerate(log._segments_oldest_first()):
+            os.link(seg, backups / f"seg{i}.jsonl")
+
+        assert len(log.recent(limit=10_000)) == before_recent, "backup links suppressed history"
+        assert log.verify_integrity() == before
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are POSIX-only")
+    def test_a_fifo_does_not_block_and_is_skipped(self, sel_dir, small_segments):
+        """O_NONBLOCK is load-bearing: without it the read-side open of a FIFO
+        with no writer blocks forever, BEFORE any descriptor check is reachable
+        — this test hangs, loudly, if that flag is dropped."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        fifo = sel_dir / "security_events.d" / "security_events-000001-20200101T000000Z.jsonl"
+        fifo.unlink(missing_ok=True)
+        os.mkfifo(fifo)
+
+        assert log._verify_file(fifo) == (0, 0), "a FIFO counted as audit history"
+        assert list(log._iter_lines_backward(fifo)) == [], "a FIFO yielded lines"
+        total, valid = log.verify_integrity()
+        assert total == valid
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_a_symlinked_live_log_stays_readable(self, sel_dir, small_segments):
+        """An operator may relocate the live log via symlink. The WRITER
+        follows it (O_CREAT | O_APPEND open), so the readers must too — a
+        reader that refuses the link turns the live log write-only: events
+        keep landing while recent() reports empty and verify_integrity()
+        counts a clean (0, 0)."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 20)
+        live = sel_dir / "security_events.jsonl"
+        relocated = sel_dir / "relocated.jsonl"
+        os.replace(live, relocated)
+        live.symlink_to(relocated)
+        _fill(log, 5, start=1000)  # the writer keeps appending through the link
+
+        recent = log.recent(limit=10_000)
+        assert any(
+            e.get("resources") == "seq=1004" for e in recent
+        ), "reads went dark through the linked live log"
+        total, valid = log.verify_integrity()
+        assert total == valid
+        assert total > 0
+
+    def test_regular_segments_read_identically_through_the_funnel(
+        self, sel_dir, small_segments
+    ):
+        """The guard must not change what a REAL segment verifies or yields."""
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        _fill(log, 200)
+        segments = log._segments_oldest_first()
+        assert segments, "precondition: rotation happened"
+        seg = segments[0]
+        expected = [
+            line.strip().decode("utf-8")
+            for line in reversed(seg.read_bytes().splitlines())
+            if line.strip()
+        ]
+        assert list(log._iter_lines_backward(seg)) == expected
+        total, valid = log.verify_integrity()
+        assert total == valid
+        assert total > 0
+
+
 class TestPlantedSegmentsAreNotReadAsHistory:
     """A forged segment must never surface through the read path.
 


### PR DESCRIPTION
## Problem / Motivation

SEL segment reads have a validate-dirent/open-by-path TOCTOU. `_segments_oldest_first()` correctly judges each directory entry with `entry.stat(follow_symlinks=False)` + `S_ISREG` and skips non-regular entries with a "planted link?" warning — but the two consumers then re-open the returned `Path` **by name** with plain `open()`: `_verify_file()` (backing `verify_integrity()`) and `_iter_lines_backward()` (backing `recent()`, the dashboard's SEL events endpoint). There is no `O_NOFOLLOW` anywhere in the module's read path.

Consequences:
- a **symlink** planted between scan and open is followed — its target is returned by `recent()` and counted by `verify_integrity()` as audit history, exactly what the `S_ISREG` guard exists to prevent;
- a **FIFO** planted there blocks inside `open()` before any descriptor-level check is reachable.

Severity per the issue: defence-in-depth, not a remote hole — exploiting it needs write access inside `security_events.d/`, which is created `0o700`. The module already refuses planted links in rotation (`_ensure_segment_dir`), the trust dir, and the HMAC key paths; the read path was the remaining gap.

## Why it matters

SEL is the audit log the rest of the system trusts: `recent()` feeds the dashboard's security events view and `verify_integrity()` is the tamper check. A planted link that surfaces arbitrary file content as "audit history" defeats the purpose of the fence, and a planted FIFO turns a read into an indefinite hang.

## What changed (motivation → approach → change)

Symptom → root cause: the dirent check judges what an entry *was* at scan time; the open trusts the *name* at open time. The fix validates at the moment that matters — on the descriptor actually opened — via one funnel for **rotated segments** (the enumerated, attacker-nameable surface), `_open_segment()`:

1. `os.open(O_RDONLY | O_NOFOLLOW | O_NONBLOCK)` — `O_NOFOLLOW` fails a planted symlink at the open itself (`ELOOP` on Linux/macOS, `EMLINK`/`EFTYPE` on some BSDs); `O_NONBLOCK` is load-bearing for a planted FIFO, which otherwise blocks the open before any check can run. Both degrade to 0 via `getattr` on Windows; `O_BINARY` keeps the descriptor out of Windows text mode.
2. `fstat` on the descriptor — which nothing can swap afterwards — requires `S_ISREG`, refusing FIFOs, directories, and device nodes on every platform.
3. an identity check makes the flag degradation safe: `lstat(path)` dev/ino must equal the descriptor's. A symlink's own `lstat` identity never equals its target's, so the symlink swap is refused even where `O_NOFOLLOW` does not exist (Windows); a mid-swap mismatch fails closed.

The **live log deliberately does not take the funnel** (`_reader_handle()` owns the split): it is a fixed module-owned path, never an enumerated name, and its writer follows an operator's symlink (`O_CREAT | O_APPEND`) — a reader that refused the link would turn the live log write-only, with events landing while every read reports empty and verification counts a clean `(0, 0)`. Readers match the writer.

A hardlink **alias** is deliberately **not deduplicated** — here or anywhere. An alias *is* the regular file its name points at, so telling it from the original requires a cross-name decision, and every key available for that decision (which name sorts first, which survives) is attacker-controlled inside the segment dir: any dedupe hands a planted name the power to DISPLACE the real segment and corrupt read chronology. Without dedupe, an alias's worst case is repeating already-signed records in bounded reads — it cannot displace, hide, or forge history — and admission gating (`_segment_is_signed_by_us`) bounds what a planted file can surface at all. Backup-tool hardlinks (`rsync --link-dest`, `cp -al`) are likewise unaffected: no link-count check exists.

`_verify_file()` and `_iter_lines_backward()` take their handle from `_reader_handle()` and skip a refused file with the same "planted link?" warning style as the dirent filter. The dirent scan stays as the cheap first filter; it just stops being the only guard. Read bounding (`_TAIL_CHUNK_BYTES` / `_MAX_LINE_BYTES`) is untouched, per the issue.

Deliberately out of scope (noted for reviewers):
- **The segment *directory* itself being a pre-planted symlink** (scan-time `scandir` follows it; `_ensure_segment_dir` repairs at rotation/prune time). Pre-existing surface, not introduced or worsened here; `recent()` is additionally gated by per-segment HMAC admission (`_segment_is_signed_by_us`), though `verify_integrity()` deliberately has no such gate, so the residual there is a false-tamper signal, not disclosure. Tracked as a follow-up issue (dir_fd-pinned enumeration).
- On a filesystem reporting `st_ino == 0` for everything (some SMB mounts) the identity check degrades to the flag/type checks; FAT/exFAT do not support symlinks, so the degradation is not reachable there.

## Tests

All POSIX-marked with the repo's existing `skipif` conventions, in `test/test_sel.py::TestSegmentOpensValidateTheDescriptor`:
- `test_a_symlink_is_refused_by_both_consumers` — planted segment-named symlink: both consumers refuse it directly, `recent()` never surfaces the target's content, `verify_integrity()` stays clean, the target file is never touched.
- `test_a_hardlink_plant_cannot_duplicate_audit_records` — aliases of a real segment and of the live log are dropped by the enumerator; the real segment keeps reading; no duplicate `entry_hash` in `recent()`, no record lost, `verify_integrity()` unchanged.
- `test_a_hardlink_plant_cannot_duplicate_audit_records` → replaced by `test_an_alias_plant_cannot_displace_newer_history` — a lower-sequence alias of the newest segment cannot displace the real name from the newest-first read order (locks the no-name-keyed-dedupe invariant).
- `test_a_backup_hardlink_does_not_suppress_audit_history` — rsync-style hardlinks from outside the segment dir change nothing: history keeps reading and verifying (regression lock for the link-count refusal this PR deliberately does NOT do).
- `test_a_symlinked_live_log_stays_readable` — an operator-relocated (symlinked) live log keeps reading and verifying, matching the writer that follows the link (regression lock for the write-only split-brain).
- `test_a_fifo_does_not_block_and_is_skipped` — `os.mkfifo` plant: both consumers return empty without blocking (hangs loudly if `O_NONBLOCK` is ever dropped).
- `test_regular_segments_read_identically_through_the_funnel` — a real segment verifies and reads byte-identically to a plain reversed read.

## Manual verification

N/A — unit coverage sufficient: the tests exercise both consumers directly with planted paths (bypassing the scan, as a racing attacker would) and end-to-end through `recent()`/`verify_integrity()`. Full backend gates run locally (pytest 59,537 passed; isort/flake8/mypy/black clean); the 33 failing tests on this host fail identically on unmodified `main` (environment-specific: old `jq`, no Playwright install).

## Related Issues

Closes #4992

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — module docstrings updated in the same commit
- [x] No secrets, credentials, or internal references in the diff
