### PR TITLE
feat(secrets): add vault migration importer and vault-backed Jira token

### DIFF
--- a/docs/guides/secrets-env.md
+++ b/docs/guides/secrets-env.md
@@ -125,3 +125,75 @@ unit), so they cannot read the root-owned file.
   `~/.kiro/crew/mcp-secrets.env` or `~/.kiro/.env` is accessible to the
   agent via filesystem reads.  Use root-owned paths (`/etc/kirocrew/`)
   or wait for the encrypted vault.
+
+---
+
+## The encrypted vault (recommended)
+
+The interim routes above deliver a secret to an MCP server's process
+environment, where an agent sharing that process tree can observe it.  The
+encrypted vault closes that gap: secrets are stored encrypted on disk under
+`.vault` in the data home, and a `secret://NAME` reference in an MCP server's
+env is resolved to the real value only at spawn time, injected into that
+server's environment alone — never the agent's.
+
+Store a secret through the dashboard **Settings → Secrets** tab, then reference
+it from `mcp.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "my-mcp-server",
+      "env": { "MY_MCP_SECRET": "secret://MY_MCP_SECRET" }
+    }
+  }
+}
+```
+
+At spawn the gateway resolves `secret://MY_MCP_SECRET` from the vault.  If the
+named secret does not exist, the server fails to start rather than launching
+with a missing credential.
+
+### Migrating existing plaintext secrets
+
+If you already keep the Jira API token as a plaintext `KEY=VALUE` line in the
+data home's `.env`, the importer moves it into the vault. It migrates ONLY the
+Jira credential keys the vault-aware Jira consumer reads — the global
+`JIRA_API_TOKEN` and per-host `JIRA_TOKEN_<hex>` tokens; other credential keys
+are left untouched because their consumers still read the literal `.env` value:
+
+```bash
+# Dry run (default): report what WOULD migrate, change nothing.
+kirocrew secrets import
+
+# Apply: store the Jira token(s) in the vault and rewrite each .env line
+# to a secret:// reference.
+kirocrew secrets import --apply
+```
+
+The importer reads only the data-home `.env` (there is no `--file` option, so a
+caller cannot point it at an attacker-controlled file). A key whose value is
+overridden in the process environment is skipped, and the `.env` rewrite aborts
+if the file changes under a concurrent writer.
+
+Only the Jira credential keys are migrated (`JIRA_API_TOKEN` and per-host
+`JIRA_TOKEN_<HEX>`); every other credential key and unrecognized operator
+setting is left untouched.  On `--apply` each migrated line becomes
+`KEY=secret://KEY`, so the resolver picks the value up from the vault.
+
+The importer **does not delete** the `.env` file — it rewrites the migrated
+lines in place, so the plaintext value for those keys is replaced by the
+`secret://` reference.  A line that is already a `secret://` reference is left
+alone, so re-running `--apply` is a no-op.  If you keep a separate backup copy
+of the file, delete that plaintext copy once you have verified the migration.
+
+### Jira uses the vault automatically
+
+The Jira integration reads its API token from the vault first, then falls back
+to the legacy `.env` / environment value.  Per host it looks up the vault
+secret `JIRA_TOKEN_<HEX>` (the hex-encoded host name); for a single configured
+host it also accepts the global `JIRA_API_TOKEN` vault secret.  If neither vault
+entry exists it uses the same `.env` value it always has, so existing setups
+keep working without change — run `kirocrew secrets import --apply` to move the
+Jira token into the vault when you are ready.

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1487,6 +1487,20 @@ Examples:
         help="Apply the deletions (default: dry-run preview that changes nothing)",
     )
 
+    # secrets — encrypted vault maintenance. Only the migration importer lives
+    # here; the set/list/rm surface is owned by a separate change.
+    secrets_parser = sub.add_parser("secrets", help="Encrypted secret vault")
+    secrets_sub = secrets_parser.add_subparsers(dest="secrets_action")
+    secrets_import = secrets_sub.add_parser(
+        "import",
+        help="Migrate plaintext .env credentials into the vault (dry-run unless --apply)",
+    )
+    secrets_import.add_argument(
+        "--apply",
+        action="store_true",
+        help="Store the secrets and rewrite .env to secret:// refs (default: dry-run)",
+    )
+
     # pod — isolated, throwaway, full-stack test instances per worktree (kubectl-style)
     pod_parser = cli_help.add_command(sub, "pod")
     pod_sub = pod_parser.add_subparsers(
@@ -2454,6 +2468,14 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         _policy(args)
     elif args.command == "knowledge":
         _knowledge(args)
+    elif args.command == "secrets":
+        # Dispatch through the module-level `importlib` rather than a
+        # function-local `from kiro_crew.cli_commands import …`: the latter trips
+        # the `top-level-imports` lint, while a module-scope import of
+        # `cli_commands` is deliberately avoided (issue #3504 — it costs ~556 ms
+        # on every CLI start). `importlib.import_module` keeps the load lazy AND
+        # satisfies the linter.
+        importlib.import_module("kiro_crew.cli_commands")._handle_secrets(args)
     elif args.command == "pod":
         from kiro_crew.cli_commands import _pod
 

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -69,6 +69,11 @@ from kiro_crew.learn import LessonStore
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.memory import MemoryStore
 from kiro_crew.port_resolution import resolve_client_port_ex
+from kiro_crew.secrets.migrate import (
+    MigrationConflictError,
+    format_report,
+    migrate_env_secrets,
+)
 from kiro_crew.security import (
     BUILTIN_DENIED_RULES,
     BUILTIN_DENY_PATTERNS,
@@ -2640,3 +2645,42 @@ def _telemetry(args: argparse.Namespace) -> None:
     else:
         print("✅ Anonymous usage beacon DISABLED. Nothing will be sent.")
         print(f"   You can also delete {beacon.INSTALL_ID_FILE} from the data home.")
+
+
+def _handle_secrets(args: argparse.Namespace) -> None:
+    """Dispatch secrets subcommands. Currently only ``import`` (migration)."""
+
+    action = getattr(args, "secrets_action", None)
+
+    if action == "import":
+        # Import ONLY from the fixed data-home .env — never an arbitrary path.
+        # A caller-supplied file would let a sandbox-off agent import attacker
+        # Jira values into the vault and have the vault-first consumer trust
+        # them, so there is deliberately no --file option.
+        # A concurrent .env change or an undecryptable pre-existing vault entry
+        # aborts the migration with MigrationConflictError. That is an expected
+        # operational condition (retry after the concurrent write settles, or
+        # repair the vault entry), so surface it as a clean CLI error with a
+        # nonzero exit — never an uncaught traceback.
+        try:
+            report = migrate_env_secrets(dry_run=not args.apply)
+        except MigrationConflictError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        except (OSError, ValueError) as exc:
+            # A truncated/corrupt `secrets.enc` makes the vault's `list_names()`
+            # (or a decrypt) raise `ValueError`/`OSError` rather than
+            # `MigrationConflictError`. Surface it as the same concise CLI error
+            # with a nonzero exit instead of an uncaught traceback — the store is
+            # unreadable, which the operator must repair before importing.
+            print(
+                f"error: could not read the secrets vault "
+                f"({exc.__class__.__name__}: {exc}); repair or remove the vault "
+                f"store, then re-run `kirocrew secrets import --apply`.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(format_report(report))
+    else:
+        print("Usage: kirocrew secrets import [--apply]", file=sys.stderr)
+        sys.exit(1)

--- a/src/kiro_crew/cli_help.py
+++ b/src/kiro_crew/cli_help.py
@@ -87,6 +87,7 @@ COMMAND_GROUPS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
     (
         "Security and privacy",
         (
+            ("secrets", "Migrate .env credentials into the encrypted secret vault"),
             ("security", "Security audit and deny list"),
             ("policy", "Inspect the governance security policy + profiles"),
             ("telemetry", "Inspect or disable anonymous usage telemetry"),

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -32,6 +32,7 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.constants import DATA_WARNING, MIN_NODE_MAJOR
 from kiro_crew.sandbox import unavailable_kind
+from kiro_crew.secrets.migrate import _env_lock_path
 from kiro_crew.sel import sel
 from kiro_crew.skills import SkillsLoader
 
@@ -505,30 +506,61 @@ def _setup_slack_tokens() -> None:
         print("  ⚠️  Missing tokens — Slack integration will be disabled.\n")
         return
 
-    # Preserve any extra keys already in .env
-    existing[CRED_SLACK_APP_TOKEN] = app_token
-    existing[CRED_SLACK_BOT_TOKEN] = bot_token
-    if owner_id:
-        existing[CRED_OWNER_ID] = owner_id
-
+    # Serialize the read-modify-write against every OTHER .env writer (the
+    # `kirocrew secrets import` migrator, the WeChat/Weixin QR handler, and the
+    # dashboard channel-credential handlers) on the SAME advisory lock, derived
+    # from the shared helper. Without this, a concurrent importer commit (its
+    # final CAS + atomic_write) could interleave with this write and clobber the
+    # freshly-typed Slack tokens. The prompts above run OUTSIDE the lock (they
+    # can block on the user for minutes); the lock wraps only the short
+    # re-read → merge → atomic-rename critical section, and we RE-READ .env
+    # fresh under the lock so we merge onto the latest on-disk state rather than
+    # the possibly-stale snapshot read before the prompts.
     cred_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [f"{k}={v}" for k, v in existing.items()]
-    # atomic_write with restrict_to_owner, not write_text + chmod(0o600): a
-    # bare chmod is a silent no-op for Windows ACLs, and applying any lockdown
-    # only AFTER the tokens are on disk leaves them readable through the
-    # directory's inherited DACL in the failure window. The helper locks its
-    # unique temp file down before any content reaches it and renames only on
-    # success, so the tokens never exist under a wider mode and a failure
-    # leaves the previous .env untouched. restrict_on_error="warn" matches the
-    # .env doctrine (enforce the lockdown, log a warning if it fails) and the
-    # dashboard credential writers: an ACL-refusing host still completes the
-    # wizard instead of aborting after the user typed their tokens.
-    atomic_write(
-        cred_path,
-        "\n".join(lines) + "\n",
-        restrict_to_owner=True,
-        restrict_on_error="warn",
-    )
+    lock_path = _env_lock_path(cred_path)
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    if not platform_compat.try_acquire_lock(lock_fd, exclusive=True):
+        os.close(lock_fd)
+        print(
+            "  ⚠️  .env is locked by another process (a secrets import or "
+            "credential save is in progress); tokens not saved. Retry once the "
+            "other operation finishes.\n",
+            file=sys.stderr,
+        )
+        return
+    try:
+        # Re-read fresh under the lock, then merge the just-collected tokens on
+        # top so a concurrent write that landed during the prompts is preserved.
+        merged: dict[str, str] = {}
+        if cred_path.exists():
+            for line in cred_path.read_text(encoding="utf-8").splitlines():
+                if "=" in line and not line.startswith("#"):
+                    k, _, v = line.partition("=")
+                    merged[k.strip()] = v.strip()
+        merged[CRED_SLACK_APP_TOKEN] = app_token
+        merged[CRED_SLACK_BOT_TOKEN] = bot_token
+        if owner_id:
+            merged[CRED_OWNER_ID] = owner_id
+        lines = [f"{k}={v}" for k, v in merged.items()]
+        # atomic_write with restrict_to_owner, not write_text + chmod(0o600): a
+        # bare chmod is a silent no-op for Windows ACLs, and applying any lockdown
+        # only AFTER the tokens are on disk leaves them readable through the
+        # directory's inherited DACL in the failure window. The helper locks its
+        # unique temp file down before any content reaches it and renames only on
+        # success, so the tokens never exist under a wider mode and a failure
+        # leaves the previous .env untouched. restrict_on_error="warn" matches the
+        # .env doctrine (enforce the lockdown, log a warning if it fails) and the
+        # dashboard credential writers: an ACL-refusing host still completes the
+        # wizard instead of aborting after the user typed their tokens.
+        atomic_write(
+            cred_path,
+            "\n".join(lines) + "\n",
+            restrict_to_owner=True,
+            restrict_on_error="warn",
+        )
+    finally:
+        platform_compat.release_lock(lock_fd)
+        os.close(lock_fd)
     print(f"  ✅ Credentials saved to {cred_path}\n")
 
 

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, cast
 
 from aiohttp import web
 
+from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.browser.command_bus import (
     DEFAULT_COMMAND_TIMEOUT_MS,
@@ -25,6 +26,7 @@ from kiro_crew.browser.command_bus import (
 from kiro_crew.browser_cli import install as browser_cli_install
 from kiro_crew.browser_cli import token as browser_cli_token
 from kiro_crew.browser_cli import view as browser_cli_view
+from kiro_crew.config import loader as _loader
 from kiro_crew.config.loader import (
     IMESSAGE_SERVICES,
     TELEGRAM_ACTIVATIONS,
@@ -108,6 +110,17 @@ _SEND_MESSAGE_CHANNEL_TYPES: frozenset[str] = frozenset(CHANNEL_SESSION_NAMESPAC
     "unified",
 }
 logger = logging.getLogger(__name__)
+
+
+def _read_text_or_none(path: Path) -> str | None:
+    """Read ``path`` as UTF-8, or return None if it does not exist.
+
+    Pure synchronous filesystem I/O — call via ``asyncio.to_thread`` from an
+    async handler so the stat + read never block the gateway event loop. Used to
+    snapshot config.json before a credential write so a failed .env commit can
+    roll the metadata back to a consistent pair.
+    """
+    return path.read_text(encoding="utf-8") if path.exists() else None
 
 
 def _sel():
@@ -3285,9 +3298,44 @@ def _write_env_updates(updates: dict[str, str | None]) -> None:
     nobody re-read. ``test/test_channel_env_write_off_loop.py`` pins both
     properties for all six channels.
     """
-    from kiro_crew.config.loader import env_path  # noqa: F811
+    ep = _loader.env_path()
+    # Ensure the parent exists before opening the lock file (the .env itself may
+    # not exist yet — e.g. first credential save into a fresh config dir).
+    ep.parent.mkdir(parents=True, exist_ok=True)
+    # Serialize this read-modify-write against the OTHER cross-process .env
+    # writers (the `kirocrew secrets import` migrator and the WeChat/Weixin QR
+    # handler) on the SAME advisory lock, derived from the shared helper so all
+    # writers provably use one lock file. Without this, a channel/token save
+    # here could interleave with the importer's rewrite (read stale bytes here,
+    # or clobber the importer's commit), losing a freshly saved token or leaving
+    # a `secret://` reference pointing at the wrong value. The lock wraps the
+    # entire read → transform → atomic-rename sequence.
+    # Lazy import: `secrets.migrate` is the CLI migration module and must stay
+    # OFF the gateway boot path (messaging.py is imported at startup). Importing
+    # it inside the writer keeps it off the module-import path so gateway
+    # readiness is not delayed by loading the migration module.
+    from kiro_crew.secrets.migrate import _env_lock_path
 
-    ep = env_path()
+    lock_path = _env_lock_path(ep)
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    if not platform_compat.try_acquire_lock(lock_fd, exclusive=True):
+        os.close(lock_fd)
+        raise OSError(
+            f"{ep} is locked by another process (a secrets import or another "
+            "credential save is in progress); no update performed. Retry once "
+            "the other operation finishes."
+        )
+    try:
+        _write_env_updates_locked(ep, updates)
+    finally:
+        platform_compat.release_lock(lock_fd)
+        os.close(lock_fd)
+
+
+def _write_env_updates_locked(ep: "Path", updates: dict[str, str | None]) -> None:
+    """The read-modify-atomic-rewrite of .env, run under the .env lock held by
+    the caller (:func:`_write_env_updates`)."""
+
     lines = ep.read_text(encoding="utf-8").splitlines() if ep.exists() else []
     seen: set[str] = set()
     out: list[str] = []
@@ -3569,7 +3617,17 @@ async def _slack_config_save_locked(request: web.Request) -> web.Response:
                 os.environ[key] = new_val
     if staged:
         slack_cfg.update(staged)
-        _atomic_json_write(path, data)
+        # Shield + drain so a cancellation arriving mid-write cannot release
+        # the config lock while the worker thread is still replacing the file.
+        # Without this a later save can interleave writes under the lock.
+        _cfg_write_task_sl: asyncio.Task[None] = asyncio.ensure_future(
+            asyncio.to_thread(_atomic_json_write, path, data)
+        )
+        try:
+            await asyncio.shield(_cfg_write_task_sl)
+        except asyncio.CancelledError:
+            await asyncio.gather(_cfg_write_task_sl, return_exceptions=True)
+            raise
 
     # Create the configured session folder now, on this user-initiated save,
     # so the reconcile path never has to write the folder store. Best-effort:
@@ -4674,9 +4732,9 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
         CRED_MICROSOFT_APP_ID,
         CRED_MICROSOFT_APP_PASSWORD,
         CRED_MICROSOFT_APP_TENANT_ID,
-        KiroCrewConfig,
         _threshold_pct,
         config_path,
+        read_env_file_credential,
     )
 
     caller = request.get("user", "dashboard")
@@ -4795,20 +4853,47 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
         CRED_MICROSOFT_APP_PASSWORD in env_updates or "app_id" in staged or "tenant_id" in staged
     )
     if credential_touched:
-        # Both reads touch the filesystem (config.json, then .env), so they go to a
-        # thread rather than stalling the gateway loop on a save.
-        current_cfg = await asyncio.to_thread(KiroCrewConfig.load)
-        current_creds = await asyncio.to_thread(current_cfg.load_credentials)
-        eff_password = env_updates.get(
-            CRED_MICROSOFT_APP_PASSWORD,
-            current_creds.get(CRED_MICROSOFT_APP_PASSWORD, "") or current_cfg.teams.app_password,
-        )
-        eff_app_id = current_creds.get(CRED_MICROSOFT_APP_ID, "") or str(
-            staged.get("app_id", current_cfg.teams.app_id)
-        )
-        eff_tenant = current_creds.get(CRED_MICROSOFT_APP_TENANT_ID, "") or str(
-            staged.get("tenant_id", current_cfg.teams.tenant_id)
-        )
+        # Read credentials directly from .env (+ os.environ override) rather
+        # than via KiroCrewConfig.load(), which triggers _load_resolved() ->
+        # cfg.save(), an unconditional migration write-back that purges
+        # teams.app_password from config.json as a side-effect.  That
+        # write-back races Phase 2's write-order invariant (SET: .env first,
+        # then config purge) by clearing the legacy credential before the .env
+        # write has succeeded.  read_env_file_credential touches only the .env
+        # file and never writes config.json.
+        _p15_cfg = config_path()
+        _raw_teams_15: dict = {}
+        try:
+            # Offload read_text + json.loads to a thread so a slow filesystem
+            # cannot stall the async event loop (Finding 1).
+            def _read_config_15() -> dict:
+                return json.loads(_p15_cfg.read_text(encoding="utf-8")) if _p15_cfg.exists() else {}
+
+            _rd15 = await asyncio.to_thread(_read_config_15)
+            # Guard against a malformed config.json where "teams" is not a dict
+            # (e.g. someone hand-edited it to a list).  .get() on a list raises
+            # AttributeError; the isinstance check degrades gracefully (Finding 3).
+            _t15 = _rd15.get("teams")
+            _raw_teams_15 = _t15 if isinstance(_t15, dict) else {}
+        except Exception:
+            pass
+        _c_pw = await asyncio.to_thread(read_env_file_credential, CRED_MICROSOFT_APP_PASSWORD)
+        _c_app_id = await asyncio.to_thread(read_env_file_credential, CRED_MICROSOFT_APP_ID)
+        _c_tenant = await asyncio.to_thread(read_env_file_credential, CRED_MICROSOFT_APP_TENANT_ID)
+        # ENV-first, matching load_credentials() semantics: os.environ overrides
+        # the .env file (Finding 2).  A pending in-flight update still wins as
+        # the outermost layer (see env_updates.get() below).
+        _c_pw = os.environ.get(CRED_MICROSOFT_APP_PASSWORD, "") or _c_pw
+        _c_app_id = os.environ.get(CRED_MICROSOFT_APP_ID, "") or _c_app_id
+        _c_tenant = os.environ.get(CRED_MICROSOFT_APP_TENANT_ID, "") or _c_tenant
+        # ENV-first: env_updates wins, then .env/os.environ (_c_pw).  When the
+        # password lives ONLY in legacy config.json (not in .env or os.environ,
+        # so _c_pw is empty), fall back to the raw legacy value so verification
+        # and Phase-2's purge-write see the existing credential and preserve it.
+        _c_pw_effective = _c_pw or _raw_teams_15.get("app_password", "")
+        eff_password = env_updates.get(CRED_MICROSOFT_APP_PASSWORD, _c_pw_effective)
+        eff_app_id = _c_app_id or str(staged.get("app_id", _raw_teams_15.get("app_id", "")))
+        eff_tenant = _c_tenant or str(staged.get("tenant_id", _raw_teams_15.get("tenant_id", "")))
         # Nothing to verify while half the pair is missing (e.g. the operator is
         # clearing the secret, or is filling the form in two saves).
         if eff_app_id and eff_password:
@@ -4856,21 +4941,23 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
             # the secret. Each verifies a triple containing the OTHER's old value and
             # passes; the serialized commits then merge into a stored triple neither one
             # checked, and the channel is dead at the next restart with a green "Saved."
-            # ``load_credentials`` reads only ``.env`` plus the environment (it never
-            # touches ``self``), so this is a .env read and not a second config load --
-            # and it goes to a thread because it touches the filesystem.
-            fresh_creds = await asyncio.to_thread(current_cfg.load_credentials)
+            # Read credentials directly from .env (same rationale as Phase 1.5:
+            # avoid KiroCrewConfig.load() which would trigger migration write-back).
+            _f_pw = await asyncio.to_thread(read_env_file_credential, CRED_MICROSOFT_APP_PASSWORD)
+            _f_app_id = await asyncio.to_thread(read_env_file_credential, CRED_MICROSOFT_APP_ID)
+            _f_tenant = await asyncio.to_thread(
+                read_env_file_credential, CRED_MICROSOFT_APP_TENANT_ID
+            )
+            # ENV-first, matching load_credentials() semantics (Finding 2).
+            _f_pw = os.environ.get(CRED_MICROSOFT_APP_PASSWORD, "") or _f_pw
+            _f_app_id = os.environ.get(CRED_MICROSOFT_APP_ID, "") or _f_app_id
+            _f_tenant = os.environ.get(CRED_MICROSOFT_APP_TENANT_ID, "") or _f_tenant
             now_password = env_updates.get(
                 CRED_MICROSOFT_APP_PASSWORD,
-                fresh_creds.get(CRED_MICROSOFT_APP_PASSWORD, "")
-                or str(teams_cfg.get("app_password", "")),
+                _f_pw or str(teams_cfg.get("app_password", "")),
             )
-            now_app_id = fresh_creds.get(CRED_MICROSOFT_APP_ID, "") or str(
-                staged.get("app_id", teams_cfg.get("app_id", ""))
-            )
-            now_tenant = fresh_creds.get(CRED_MICROSOFT_APP_TENANT_ID, "") or str(
-                staged.get("tenant_id", teams_cfg.get("tenant_id", ""))
-            )
+            now_app_id = _f_app_id or str(staged.get("app_id", teams_cfg.get("app_id", "")))
+            now_tenant = _f_tenant or str(staged.get("tenant_id", teams_cfg.get("tenant_id", "")))
             if (now_app_id, now_password, now_tenant) != verified_triple:
                 return _reject(
                     "config_changed",
@@ -4921,13 +5008,35 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
             changes["session_folder"] = staged["session_folder"]
         applied = list(changes.keys())
         # The secret is env-only; if a legacy plaintext app_password ever landed
-        # in config.json, purge it so it can't shadow or outlive the .env value.
-        if teams_cfg.get("app_password"):
+        # in config.json, purge it when the credential is safely held elsewhere:
+        # either it is being written to .env in this same save, or it already
+        # exists in .env / os.environ (so purging the config copy is safe).
+        # Do NOT purge when the password lives ONLY in legacy config.json (no .env
+        # entry, no env_update) — that would erase the sole credential copy and
+        # produce a dead pair at the next restart (Finding 1).
+        # _c_pw is only populated inside ``if credential_touched`` (Phase 1.5).
+        # For metadata-only saves (credential_touched=False) fall back to a
+        # synchronous os.environ check — load_credentials() seeds os.environ from
+        # .env at startup, so the key is present when .env holds the credential.
+        _pw_in_env_or_environ = locals().get("_c_pw") or os.environ.get(
+            CRED_MICROSOFT_APP_PASSWORD, ""
+        )
+        _pw_safe_in_env = bool(
+            CRED_MICROSOFT_APP_PASSWORD in env_updates  # being written this save
+            or _pw_in_env_or_environ  # already in .env / os.environ
+        )
+        if teams_cfg.get("app_password") and _pw_safe_in_env:
             changes["app_password"] = ""
             applied.append("app_password_purged")
 
+        _cfg_snapshot: str | None = None
         if changes:
             teams_cfg.update(changes)
+            # Snapshot the on-disk config BEFORE writing the new metadata, so
+            # that if the subsequent .env credential write fails we can roll
+            # the metadata back.  Restoring config on .env failure keeps the
+            # pair consistent (old credential + old meta).
+            _cfg_snapshot = await asyncio.to_thread(_read_text_or_none, path)
             _atomic_json_write(path, data)
 
         # Create the configured session folder now, on this user-initiated save,
@@ -4946,7 +5055,49 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
         if env_updates:
             # Off-loop: restrict_to_owner spawns whoami/icacls subprocesses on
             # Windows, which would stall the gateway loop if run inline.
-            await _write_env_off_loop(env_updates)
+            #
+            # Cancellation guard: _write_env_off_loop shields + drains its
+            # worker, so a CancelledError from it means the .env write has
+            # already finished (either succeeded or failed). Roll config back
+            # ONLY when the write actually failed; if it succeeded, the pair
+            # is consistent and rolling back would create a mismatch.
+            _env_write_task: asyncio.Task[None] = asyncio.ensure_future(
+                _write_env_off_loop(env_updates)
+            )
+            try:
+                await asyncio.shield(_env_write_task)
+            except asyncio.CancelledError:
+                # Drain to completion WITHOUT propagating, so we can inspect the
+                # outcome and roll back before re-raising (a second shield() would
+                # re-raise CancelledError before the rollback ran).
+                await asyncio.gather(_env_write_task, return_exceptions=True)
+                _env_exc = _env_write_task.exception() if not _env_write_task.cancelled() else None
+                if _env_exc is not None:
+                    # .env write failed — roll config back for consistency.
+                    if changes:
+                        if _cfg_snapshot is None:
+                            await asyncio.to_thread(path.unlink, missing_ok=True)
+                        else:
+                            await asyncio.to_thread(
+                                _atomic_json_write,
+                                path,
+                                json.loads(_cfg_snapshot),
+                            )
+                raise
+            except BaseException:
+                # Genuine .env write failure — roll the config metadata back so
+                # a failed write cannot leave the NEW metadata paired with the
+                # OLD credential on disk.
+                if changes:
+                    if _cfg_snapshot is None:
+                        await asyncio.to_thread(path.unlink, missing_ok=True)
+                    else:
+                        await asyncio.to_thread(
+                            _atomic_json_write,
+                            path,
+                            json.loads(_cfg_snapshot),
+                        )
+                raise
             for key, new_val in env_updates.items():
                 if new_val is None:
                     os.environ.pop(key, None)
@@ -5215,8 +5366,14 @@ async def api_webex_config_save(request: web.Request) -> web.Response:
             changes["bot_token"] = ""
             applied.append("bot_token_purged")
 
+        _cfg_snapshot: str | None = None
         if changes:
             webex_cfg.update(changes)
+            # Snapshot the on-disk config BEFORE writing the new metadata, so
+            # that if the subsequent .env credential write fails we can roll
+            # the metadata back.  Restoring config on .env failure keeps the
+            # pair consistent (old token + old meta).
+            _cfg_snapshot = await asyncio.to_thread(_read_text_or_none, path)
             _atomic_json_write(path, data)
 
         # Create the configured session folder now, on this user-initiated save,
@@ -5235,7 +5392,38 @@ async def api_webex_config_save(request: web.Request) -> web.Response:
         if env_updates:
             # Off-loop: on Windows the owner-only lockdown shells out to icacls,
             # which must not block the event loop.
-            await _write_env_off_loop(env_updates)
+            #
+            # Cancellation guard: see Teams save for the full rationale. Only
+            # roll config back when the .env write actually failed, not when
+            # cancellation arrived after the write already committed.
+            _env_write_task_wx: asyncio.Task[None] = asyncio.ensure_future(
+                _write_env_off_loop(env_updates)
+            )
+            try:
+                await asyncio.shield(_env_write_task_wx)
+            except asyncio.CancelledError:
+                await asyncio.gather(_env_write_task_wx, return_exceptions=True)
+                _env_exc_wx = (
+                    _env_write_task_wx.exception() if not _env_write_task_wx.cancelled() else None
+                )
+                if _env_exc_wx is not None:
+                    if changes:
+                        if _cfg_snapshot is None:
+                            await asyncio.to_thread(path.unlink, missing_ok=True)
+                        else:
+                            await asyncio.to_thread(
+                                _atomic_json_write, path, json.loads(_cfg_snapshot)
+                            )
+                raise
+            except BaseException:
+                # Roll config back so a failed .env write cannot leave the
+                # NEW metadata paired with the OLD token on disk.
+                if changes:
+                    if _cfg_snapshot is None:
+                        await asyncio.to_thread(path.unlink, missing_ok=True)
+                    else:
+                        await asyncio.to_thread(_atomic_json_write, path, json.loads(_cfg_snapshot))
+                raise
             # Keep the live process environment in sync (see the Slack save path).
             for key, new_val in env_updates.items():
                 if new_val is None:
@@ -5467,7 +5655,17 @@ async def api_imessage_config_save(request: web.Request) -> web.Response:
 
         if changes:
             imessage_cfg.update(changes)
-            _atomic_json_write(path, data)
+            # Shield + drain so a cancellation arriving mid-write cannot
+            # release the config lock while the worker thread is still
+            # replacing the file (interleaved-write race, Finding 3).
+            _cfg_write_task_im: asyncio.Task[None] = asyncio.ensure_future(
+                asyncio.to_thread(_atomic_json_write, path, data)
+            )
+            try:
+                await asyncio.shield(_cfg_write_task_im)
+            except asyncio.CancelledError:
+                await asyncio.gather(_cfg_write_task_im, return_exceptions=True)
+                raise
 
         # Create the configured session folder now, on this user-initiated save,
         # so the reconcile path never has to write the folder store. Best-effort:
@@ -5757,8 +5955,14 @@ async def _wecom_config_save_locked(request: web.Request) -> web.Response:
     # the status badge reports the truth after the next gateway restart.
 
     # ── Phase 2: commit. All validation passed, so writes are safe. ──
+    _cfg_snapshot: str | None = None
     if staged:
         wc_cfg.update(staged)
+        # Snapshot the on-disk config BEFORE writing the new metadata, so
+        # that if the subsequent .env credential write fails we can roll
+        # the metadata back.  Restoring config on .env failure keeps the
+        # pair consistent (old credentials + old meta).
+        _cfg_snapshot = await asyncio.to_thread(_read_text_or_none, path)
         # Off-loop: the atomic write (temp file + fsync + replace) must not
         # block the gateway event loop.
         await asyncio.to_thread(_atomic_json_write, path, data)
@@ -5779,7 +5983,36 @@ async def _wecom_config_save_locked(request: web.Request) -> web.Response:
     if env_updates:
         # Off-loop: on Windows the owner-only lockdown shells out to icacls,
         # which must not block the event loop.
-        await _write_env_off_loop(env_updates)
+        #
+        # Cancellation guard: see Teams save for the full rationale. Only
+        # roll config back when the .env write actually failed, not when
+        # cancellation arrived after the write already committed.
+        _env_write_task_wc: asyncio.Task[None] = asyncio.ensure_future(
+            _write_env_off_loop(env_updates)
+        )
+        try:
+            await asyncio.shield(_env_write_task_wc)
+        except asyncio.CancelledError:
+            await asyncio.gather(_env_write_task_wc, return_exceptions=True)
+            _env_exc_wc = (
+                _env_write_task_wc.exception() if not _env_write_task_wc.cancelled() else None
+            )
+            if _env_exc_wc is not None:
+                if staged:
+                    if _cfg_snapshot is None:
+                        await asyncio.to_thread(path.unlink, missing_ok=True)
+                    else:
+                        await asyncio.to_thread(_atomic_json_write, path, json.loads(_cfg_snapshot))
+            raise
+        except BaseException:
+            # Roll config back so a failed .env write cannot leave the NEW
+            # metadata paired with the OLD credentials on disk.
+            if staged:
+                if _cfg_snapshot is None:
+                    await asyncio.to_thread(path.unlink, missing_ok=True)
+                else:
+                    await asyncio.to_thread(_atomic_json_write, path, json.loads(_cfg_snapshot))
+            raise
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
         # save handler for the full rationale).

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -29,7 +29,7 @@ import aiohttp
 from aiohttp import web
 
 from kiro_crew import github_runner, platform_compat
-from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.loader import KiroCrewConfig, config_dir, read_env_file_credential
 from kiro_crew.dashboard.handlers._shared import read_capped_response
 
 # Validation policy, well-known install dirs, and the strict-mode toggle are
@@ -50,6 +50,7 @@ from kiro_crew.github_runner import strict_provider_bins as _strict_provider_bin
 from kiro_crew.github_runner import validate_provider_executable as _validate_provider_executable
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
+from kiro_crew.secrets import SecretVault
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 _MAX_URL_LENGTH = 2048
@@ -2269,17 +2270,30 @@ _JIRA_MAX_COMMENTS = 50
 
 
 def _get_jira_auth(host: str) -> tuple[str, str] | None:
-    """Return (email, token) for *host* from config + .env, or None if unconfigured.
+    """Return (email, token) for *host* from config + vault/.env, or None.
 
-    Host and email come from config.json (non-sensitive metadata).
-    The token comes from the protected .env file (JIRA_API_TOKEN env var),
-    following the same credential isolation pattern as Slack/Discord/Telegram
-    tokens — never stored in the agent-readable config.json.
+    Host and email come from config.json (non-sensitive metadata). The token is
+    resolved from the encrypted vault first (successor store, populated by
+    ``kirocrew secrets import``), falling back to the protected .env file /
+    environment for installs that have not migrated — following the same
+    credential isolation pattern as Slack/Discord/Telegram tokens, never stored
+    in the agent-readable config.json.
 
     Raises ValueError on config load failures so callers can distinguish
     "config is broken" from "no credentials configured" (None).
     """
     try:
+        # Snapshot the process-environment value of JIRA_API_TOKEN BEFORE
+        # KiroCrewConfig.load() / load_credentials() runs.  load_credentials()
+        # calls os.environ.setdefault(CRED_JIRA_API_TOKEN, ...) which seeds the
+        # .env global into os.environ when no real env override is present.
+        # Reading os.environ["JIRA_API_TOKEN"] AFTER that call would treat a
+        # merely-seeded .env value as a "live env override", causing the
+        # single-host global branch to use the .env global instead of the vault
+        # for a host that has its OWN per-host token in the vault.
+        # Capturing the value here — before any setdefault — means only a real
+        # operator-set env var (present before this call) counts as an override.
+        _env_global_override = os.environ.get("JIRA_API_TOKEN")
         cfg = KiroCrewConfig.load()
         entries = cfg.dashboard.jira_auth
         # Token is resolved from .env / environment, not config.json
@@ -2298,13 +2312,99 @@ def _get_jira_auth(host: str) -> tuple[str, str] | None:
             # Injective host-to-key: hex-encode the normalized host to avoid
             # collisions (e.g. jira-a.x.com vs jira.a-x.com).
             host_key = entry_host.encode().hex().upper()
-            token = creds.get(f"JIRA_TOKEN_{host_key}", "")
+            per_host_name = f"JIRA_TOKEN_{host_key}"
+            # Resolution order: the encrypted vault first (the successor store,
+            # populated by `kirocrew secrets import`), then the legacy .env /
+            # environment value so existing installs keep working unchanged.
+            #
+            # EXCEPTION for the global `JIRA_API_TOKEN`: a nonempty PROCESS-
+            # ENVIRONMENT value overrides even the vault. `load_credentials`
+            # overlays `os.environ` over the .env for this key, so a live env
+            # var is the effective credential at runtime — and `kirocrew secrets
+            # import` deliberately SKIPS migrating the key while such an override
+            # is set, precisely so it does not get pinned into the vault. But a
+            # vault entry written by an EARLIER migration (before the override
+            # existed) would otherwise be read vault-first and silently shadow
+            # that override. Consulting the env override before the global vault
+            # entry keeps the migrate-skip and the resolve-order consistent.
+            # Per-host `JIRA_TOKEN_<HEX>` keys are NOT env-overlaid, so they are
+            # unaffected and keep their vault-first order.
+            #
+            # We use `_env_global_override` (captured BEFORE load_credentials
+            # ran) rather than a fresh os.environ read so that a value merely
+            # seeded by load_credentials' setdefault — which is NOT a real
+            # operator override — cannot masquerade as one here.
+            #
+            # HOWEVER: `GatewayOrchestrator.__init__` calls `load_credentials()`
+            # at startup, which seeds the `.env` global into `os.environ` via
+            # `setdefault` BEFORE any request handler runs. A subsequent call to
+            # `_get_jira_auth` would then capture that `.env`-seeded value as
+            # `_env_global_override`, indistinguishable from a real operator
+            # override. Fix: after ruling out secret refs, compare the captured
+            # env value against the current `.env` file value — an equal value
+            # came from `.env` (stale, do not override the vault), a different
+            # value means the operator set a distinct override at runtime (treat
+            # as authoritative). `read_env_file_credential` blocks on I/O but
+            # `_get_jira_auth` is called via `asyncio.to_thread` so that is safe.
+            token = _resolve_jira_token_from_vault(per_host_name)
             if not token and len(entries) == 1:
-                token = creds.get("JIRA_API_TOKEN", "")
+                # A `secret://` value is a vault REFERENCE, not a raw token.
+                # After `secrets import --apply` the `.env` line becomes
+                # `JIRA_API_TOKEN=secret://JIRA_API_TOKEN`, and `load_credentials`
+                # propagates that into os.environ (and `creds`) via setdefault.
+                # So an env/creds value that is a `secret://` ref must NOT be
+                # used as the token — fall through to the vault. Only a real,
+                # non-ref env value that DIFFERS from the `.env` file counts as
+                # a genuine live override that beats the global vault entry.
+                _env_file_val = read_env_file_credential("JIRA_API_TOKEN")
+                _is_genuine_override = (
+                    _env_global_override
+                    and not _is_secret_ref(_env_global_override)
+                    and _env_global_override != _env_file_val
+                )
+                if _is_genuine_override:
+                    # _is_genuine_override is truthy only when _env_global_override
+                    # is a non-empty str, so `or ""` is dead in practice — it only
+                    # narrows str | None -> str for the type checker.
+                    token = _env_global_override or ""
+                else:
+                    token = _resolve_jira_token_from_vault("JIRA_API_TOKEN")
+            if not token:
+                _c = creds.get(per_host_name, "")
+                token = _c if not _is_secret_ref(_c) else ""
+            if not token and len(entries) == 1:
+                _c = creds.get("JIRA_API_TOKEN", "")
+                token = _c if not _is_secret_ref(_c) else ""
             if not token:
                 return None
             return (entry.email or "", token)
     return None
+
+
+def _is_secret_ref(value: str) -> bool:
+    """True if *value* is a ``secret://`` vault reference rather than a raw token.
+
+    After ``secrets import --apply`` the ``.env`` line for a migrated key becomes
+    ``KEY=secret://KEY``, and ``load_credentials`` propagates that string into
+    both ``os.environ`` and the returned creds dict. Such a value is a POINTER
+    to the vault, not a usable credential, so the resolver must treat it as
+    "look in the vault" and never hand it to Jira as the token.
+    """
+    return value.startswith("secret://")
+
+
+def _resolve_jira_token_from_vault(name: str) -> str:
+    """Return the vault secret *name*, or ``""`` if absent/unavailable.
+
+    Best-effort: a missing vault, missing entry, or read error all yield the
+    empty string so the caller falls back to the legacy .env / environment
+    value rather than failing.
+    """
+    try:
+        secret = SecretVault(config_dir()).get(name)
+    except Exception:
+        return ""
+    return secret.reveal() if secret is not None else ""
 
 
 def _jira_is_cloud(host: str) -> bool:

--- a/src/kiro_crew/dashboard/handlers/weixin_qr.py
+++ b/src/kiro_crew/dashboard/handlers/weixin_qr.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 import uuid
 from pathlib import Path
@@ -32,6 +33,7 @@ from typing import Any, Dict, Optional
 
 from aiohttp import web
 
+from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import CRED_WEIXIN_TOKEN, KiroCrewConfig, config_path, env_path
 from kiro_crew.dashboard.channel_folders import (
@@ -174,26 +176,54 @@ def _commit_credential_and_config(cp: Path, serialized: str, token: str) -> None
     paired with stale account metadata — the channel would authenticate against
     the wrong account — and the previously working credential would be gone, with
     no way to recover it from the dashboard.
+
+    Acquires the shared ``.env.lock`` cross-process advisory lock (same sidecar
+    file used by ``secrets import --apply``) before any read or write of ``.env``,
+    so the importer and this handler cannot interleave their read-modify-write
+    cycles.  If the lock is already held by another process the function raises
+    ``OSError`` with a descriptive message; the caller (``_persist``) propagates
+    it as a 500 response, which is the same outcome as any other I/O failure here.
+    The existing in-process ``_get_config_lock()`` (held by the caller one level
+    up) continues to serialise same-process concurrent callers; the file lock adds
+    the cross-process exclusion layer on top.
     """
-    prior = _read_env_value(CRED_WEIXIN_TOKEN)
-    _write_env_secret(CRED_WEIXIN_TOKEN, token)
+    ep = env_path()
+    # Lazy import: the migration importer is an optional CLI subsystem, so keep it
+    # off the gateway boot-import path (weixin_qr is imported at server startup).
+    # Only load it when a credential write actually happens.
+    from kiro_crew.secrets.migrate import _env_lock_path
+
+    lock_path = _env_lock_path(ep)
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     try:
-        _atomic_write(cp, serialized)
-    except BaseException:
-        try:
-            if prior is None:
-                _delete_env_key(CRED_WEIXIN_TOKEN)
-            else:
-                _write_env_secret(CRED_WEIXIN_TOKEN, prior)
-        except Exception:
-            # Surfacing the rollback failure would mask the original cause, so
-            # log it and let the real error propagate.
-            logger.error(
-                "weixin: config commit failed AND credential rollback failed; "
-                "the stored credential may not match config.json",
-                exc_info=True,
+        if not platform_compat.try_acquire_lock(lock_fd, exclusive=True):
+            raise OSError(
+                f"{ep} is locked by another process (secrets import in progress); "
+                "the WeChat credential was not written.  Retry the QR sign-in "
+                "once the other operation finishes."
             )
-        raise
+        prior = _read_env_value(CRED_WEIXIN_TOKEN)
+        _write_env_secret(CRED_WEIXIN_TOKEN, token)
+        try:
+            _atomic_write(cp, serialized)
+        except BaseException:
+            try:
+                if prior is None:
+                    _delete_env_key(CRED_WEIXIN_TOKEN)
+                else:
+                    _write_env_secret(CRED_WEIXIN_TOKEN, prior)
+            except Exception:
+                # Surfacing the rollback failure would mask the original cause, so
+                # log it and let the real error propagate.
+                logger.error(
+                    "weixin: config commit failed AND credential rollback failed; "
+                    "the stored credential may not match config.json",
+                    exc_info=True,
+                )
+            raise
+    finally:
+        platform_compat.release_lock(lock_fd)
+        os.close(lock_fd)
 
 
 def _stage_weixin_config(*, account_id: str, base_url: str) -> tuple[Path, str]:

--- a/src/kiro_crew/secrets/migrate.py
+++ b/src/kiro_crew/secrets/migrate.py
@@ -1,0 +1,622 @@
+"""One-time importer that moves plaintext Jira ``.env`` tokens into the vault.
+
+Kiro Crew stored the Jira API token as a plaintext ``KEY=VALUE`` line in the
+data home's ``.env`` (``~/.kiro/crew/.env``). The encrypted vault
+(:class:`~kiro_crew.secrets.SecretVault`) supersedes that store, and the
+``secret://`` resolver / vault-aware Jira consumer reads the secret without
+ever exposing the plaintext to the agent.
+
+This module bridges the two for the ONLY vault-aware credential surface in this
+change: the global ``JIRA_API_TOKEN`` and the per-host ``JIRA_TOKEN_<HEX>``
+tokens that ``_get_jira_auth`` resolves vault-first. For each such token still
+held in plaintext it writes the value into the vault under the same key name
+and rewrites the ``.env`` line to ``KEY=secret://KEY``. Other credential keys
+(Slack, Discord, kiro-cli, …) are deliberately NOT migrated — their consumers
+still read the literal ``.env`` value, so rewriting them to a ``secret://``
+reference would break auth. The source file is never deleted — the caller is
+told exactly what migrated and how to remove the leftover plaintext.
+
+The importer is idempotent and order-correct: a line already holding a
+``secret://`` reference (or a later empty line) for a key WINS over any earlier
+plaintext line for that key, so re-running after an apply never regresses an
+already-migrated key. A key already present in the vault is treated as
+authoritative — its plaintext ``.env`` value is NEVER written over the stored
+secret (only the ``.env`` line is rewritten to the ``secret://`` reference) —
+but ONLY when its stored entry actually decrypts; a listed-but-undecryptable
+entry (missing/mismatched vault key) aborts the migration so the still-usable
+plaintext is not rewritten away. A key whose value is overridden by a nonempty
+process-environment entry is skipped (the environment is runtime-authoritative,
+so migrating the stale file value would shadow the live override). The ``.env``
+read-snapshot → compare → rewrite runs as one critical section under an
+exclusive OS advisory lock (``platform_compat.try_acquire_lock`` on a sidecar
+``.env.lock``; POSIX flock / Windows msvcrt), with two complementary guards: the
+lock serializes against any OTHER PROCESS that holds the same lock (a second
+importer, or any writer that adopts it — today also the WeChat/Weixin QR
+sign-in handler in ``dashboard.handlers.weixin_qr``), and — under that lock — a
+compare-and-swap re-read aborts the rewrite (no write) if the bytes changed since
+the snapshot, catching any residual in-process writer that might not take the
+lock.  If the lock cannot be taken, the migration aborts cleanly and a re-run
+reconciles (idempotent, secret://-line-wins).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import _JIRA_TOKEN_RE, CRED_JIRA_API_TOKEN, config_dir, env_path
+from kiro_crew.secrets import SecretVault
+
+logger = logging.getLogger(__name__)
+
+#: ``secret://`` scheme prefix a migrated ``.env`` value is rewritten to.
+_SECRET_URI_PREFIX = "secret://"
+
+
+def _env_lock_path(ep: Path) -> Path:
+    """Return the sidecar lock-file path for a given ``.env`` path.
+
+    Every ``.env`` writer that needs cross-process exclusion MUST derive the
+    lock path via this helper so that all writers provably share the same
+    advisory lock file.
+
+    The lock file lives inside the ``.vault`` directory (a sibling of ``.env``
+    in the config dir) rather than next to ``.env`` itself.  Every sandbox tier
+    bind-mount-hides the whole ``.vault`` tree, so an unconfined agent cannot
+    delete or replace the held lock inode to defeat serialisation — a lock
+    outside ``.vault`` is in the config dir, which the agent can write freely.
+
+    The parent ``.vault`` directory is created on demand (mode 0o700) so the
+    lock is valid even before the vault is first used.
+
+    Used by:
+      * :func:`migrate_env_secrets` — the CLI importer
+      * :func:`kiro_crew.dashboard.handlers.weixin_qr._commit_credential_and_config`
+        — the QR sign-in handler (the only other in-tree ``.env`` writer)
+      * :func:`kiro_crew.dashboard.handlers.messaging._write_env_updates`
+        — the dashboard channel-credential writer
+    """
+    vault_dir = ep.parent / ".vault"
+    vault_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return vault_dir / ".env.lock"
+
+
+class MigrationConflictError(RuntimeError):
+    """Raised when the ``.env`` changed under a concurrent writer mid-migration.
+
+    The rewrite is computed from a snapshot read at the start; if the file
+    differs at write time the rewrite is aborted (no write) so a token another
+    writer added is never clobbered.
+    """
+
+
+def _is_recognized_key(key: str) -> bool:
+    """True if *key* is a Jira credential the vault-aware consumer reads.
+
+    Scoped deliberately to the ONLY credential surface that resolves through
+    the vault in this change: the global ``JIRA_API_TOKEN`` and the per-host
+    ``JIRA_TOKEN_<HEX>`` tokens that ``_get_jira_auth`` reads vault-first.
+
+    Other ``_CREDENTIAL_KEYS`` (Slack, Discord, kiro-cli, …) are intentionally
+    NOT migrated: their consumers still read the literal ``.env`` value, so
+    rewriting their line to a ``secret://`` reference would hand them the URI
+    string instead of the secret and break auth. They migrate once their
+    consumers become vault-aware in a later change.
+    """
+    return key == CRED_JIRA_API_TOKEN or bool(_JIRA_TOKEN_RE.match(key))
+
+
+@dataclass
+class MigrationReport:
+    """Outcome of a migration pass.
+
+    ``migrated`` names the keys moved into the vault (empty on a dry run —
+    nothing is written; the dry-run pass instead populates it with the keys it
+    *would* migrate). ``already_referenced`` names keys whose ``.env`` value was
+    already a ``secret://`` reference (skipped as a no-op). ``dry_run`` records
+    whether this pass wrote anything. ``orphaned_vault_keys`` names any keys
+    whose rollback-delete raised an error during a failed apply — those vault
+    entries may still exist and could shadow future rotations; manual cleanup
+    via ``kirocrew secrets rm <key>`` is recommended.
+    """
+
+    env_file: Path
+    dry_run: bool
+    migrated: list[str] = field(default_factory=list)
+    already_referenced: list[str] = field(default_factory=list)
+    orphaned_vault_keys: list[str] = field(default_factory=list)
+
+
+def _parse_env_lines(text: str) -> list[tuple[str, str]]:
+    """Return ``(key, value)`` for every ``KEY=VALUE`` line in *text*.
+
+    Matches :meth:`KiroCrewConfig.load_credentials` parsing: strips whitespace,
+    ignores blanks and ``#`` comments, splits on the first ``=``. Last write of
+    a repeated key wins there; here every occurrence is returned so the rewrite
+    can address each physical line.
+    """
+    pairs: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" in stripped:
+            k, v = stripped.split("=", 1)
+            pairs.append((k.strip(), v.strip()))
+    return pairs
+
+
+def _rewrite_env_text(text: str, migrated_keys: set[str]) -> str:
+    """Return *text* with each ``migrated_keys`` line rewritten to a ref.
+
+    Preserves comments, blank lines, ordering and any unrecognized keys.
+    Only ``KEY=VALUE`` lines whose key is in *migrated_keys* are rewritten to
+    ``KEY=secret://KEY``; everything else is emitted verbatim — including each
+    line's ORIGINAL terminator (``\\r\\n``/``\\n``/``\\r`` or none on the last
+    line), so a CRLF ``.env`` is not silently converted to LF.
+    """
+    out: list[str] = []
+    for raw in text.splitlines(keepends=True):
+        # Split the physical line into (content, terminator) so a rewritten line
+        # keeps the exact terminator the original had.
+        content = raw
+        term = ""
+        for end in ("\r\n", "\n", "\r"):
+            if raw.endswith(end):
+                content = raw[: -len(end)]
+                term = end
+                break
+        stripped = content.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            if key in migrated_keys:
+                out.append(f"{key}={_SECRET_URI_PREFIX}{key}{term}")
+                continue
+        out.append(raw)
+    return "".join(out)
+
+
+def migrate_env_secrets(
+    *,
+    dry_run: bool = True,
+) -> MigrationReport:
+    """Migrate recognized plaintext ``.env`` credentials into the vault.
+
+    Always reads the data home's ``.env`` (:func:`env_path`) AND writes to the
+    data home's own vault (:func:`config_dir`) — there is deliberately no
+    caller-supplied path parameter for EITHER, so no code path (and no
+    agent-influenced argument) can point the importer at an arbitrary file to
+    read, nor at an arbitrary directory to write the vault key/entries into. For
+    each line
+    whose key is recognized (:data:`_CREDENTIAL_KEYS` or a ``JIRA_TOKEN_<HEX>``)
+    and whose value is still plaintext, the value is stored in the vault under
+    the same key and the line is queued for rewrite to ``KEY=secret://KEY``.
+
+    When ``dry_run`` is True (the default) nothing is written — the returned
+    :class:`MigrationReport` lists what *would* migrate. When False, vault
+    writes happen first, then the ``.env`` file is rewritten atomically at mode
+    ``0o600``. The source file is never deleted.
+
+    Idempotent: a value already of the form ``secret://…`` is recorded under
+    ``already_referenced`` and skipped, so a re-run after an apply is a no-op.
+
+    Blocking file IO and (on apply) blocking vault writes: call via
+    ``asyncio.to_thread`` from async paths. Tests point at a temp home by
+    monkeypatching :func:`kiro_crew.secrets.migrate.env_path` and
+    :func:`kiro_crew.secrets.migrate.config_dir`.
+    """
+    ep = env_path()
+    report = MigrationReport(env_file=ep, dry_run=dry_run)
+
+    try:
+        original_bytes = ep.read_bytes()
+    except OSError:
+        # No .env (or unreadable): nothing to migrate.
+        return report
+    text = original_bytes.decode("utf-8", errors="surrogateescape")
+
+    vault = SecretVault(config_dir())
+    to_migrate: dict[str, str] = {}
+
+    for key, value in _parse_env_lines(text):
+        if not _is_recognized_key(key):
+            continue
+        if value.startswith(_SECRET_URI_PREFIX):
+            # An authoritative already-migrated reference. A later secret://
+            # line for a key WINS over any earlier plaintext line for the same
+            # key: drop the stale plaintext from the queue so --apply never
+            # overwrites the good vault entry with a stale value. This is what
+            # makes re-running import idempotent — a migrated key is never
+            # regressed.
+            to_migrate.pop(key, None)
+            if key not in report.already_referenced:
+                report.already_referenced.append(key)
+            continue
+        if not value:
+            # Present but empty — a later empty line also wins over earlier
+            # plaintext (nothing to store, and no stale value should linger in
+            # the queue). Leave the line alone.
+            to_migrate.pop(key, None)
+            continue
+        # Runtime override wins — but ONLY for keys that load_credentials
+        # actually overlays from the process environment. That overlay is scoped
+        # to _CREDENTIAL_KEYS, of which our recognized set contains exactly the
+        # GLOBAL `JIRA_API_TOKEN`. The per-host `JIRA_TOKEN_<HEX>` keys are NOT
+        # in _CREDENTIAL_KEYS, so the environment does NOT override them at
+        # runtime — Jira reads the .env/vault value. Skipping a per-host key just
+        # because a same-named env var happens to exist would leave the stale
+        # file token unmigrated while Jira keeps using it, so restrict the skip
+        # to the global token. For it, a nonempty env value is the effective
+        # credential, and migrating the stale .env value would let vault-first
+        # resolution shadow the live override.
+        if key == CRED_JIRA_API_TOKEN and os.environ.get(key):
+            to_migrate.pop(key, None)
+            continue
+        # Plaintext value: last plaintext write of a repeated key wins (matches
+        # load_credentials); a later secret:// / empty line above clears it.
+        to_migrate[key] = value
+
+    if not to_migrate:
+        return report
+
+    if dry_run:
+        report.migrated = list(to_migrate)
+        return report
+
+    # A key already present in the vault is AUTHORITATIVE: the vault holds the
+    # current secret and `.env` may only carry a stale plaintext copy. Never
+    # overwrite it — doing so would replace a valid token with a stale one.
+    # Such keys are still rewritten to a ``secret://`` reference below (the
+    # vault already holds the value, so pointing `.env` at it is correct and
+    # keeps the two consistent / the op idempotent), but they are excluded from
+    # the vault writes. A key counts as "already in the vault" (authoritative,
+    # skip the write, safe to rewrite its .env line to secret://) ONLY if its
+    # stored entry actually DECRYPTS. A listed-but-undecryptable entry means the
+    # vault key is missing/mismatched (e.g. a restored store); trusting it and
+    # rewriting the .env plaintext to secret://KEY would strand Jira on an
+    # unusable vault entry while destroying the still-valid plaintext. So on any
+    # undecryptable candidate, abort before writing anything — the operator must
+    # repair or remove the corrupt vault entry first.
+    listed = set(vault.list_names())
+    already_in_vault: set[str] = set()
+    for key in to_migrate:
+        if key not in listed:
+            continue
+        try:
+            secret = vault.get(key)
+        except Exception as exc:
+            raise MigrationConflictError(
+                f"vault already has an entry for {key!r} that cannot be "
+                f"decrypted ({exc.__class__.__name__}); refusing to migrate so "
+                f"the usable plaintext in the .env is not lost. Repair or remove "
+                f"the vault entry, then re-run `kirocrew secrets import --apply`."
+            ) from exc
+        if secret is None:
+            # Listed a moment ago but gone now — a concurrent delete between
+            # list_names() and get(). Treat like a vanished/undecryptable entry:
+            # abort rather than rewrite the usable plaintext to a dangling
+            # secret://KEY reference.
+            raise MigrationConflictError(
+                f"vault entry for {key!r} disappeared during migration "
+                f"(concurrent change); no rewrite performed. Re-run "
+                f"`kirocrew secrets import --apply` to reconcile."
+            )
+        stored = secret.reveal()
+        # The vault entry decrypts, but to a DIFFERENT value than the .env
+        # plaintext we are about to rewrite away. That divergence is a real
+        # conflict, not an idempotent re-run: e.g. this run stored the .env's
+        # `A`, a concurrent edit then rewrote the vault entry to `B`, and blindly
+        # rewriting the .env `A` line to `secret://KEY` now discards the `A`
+        # plaintext while Jira resolves to `B` — a silent value swap the operator
+        # never asked for. (The idempotent case — .env plaintext equals what the
+        # vault already holds — falls through and is rewritten to secret://KEY as
+        # before.) Abort so the operator picks the authoritative value rather
+        # than letting the importer choose one and destroy the other.
+        if stored != to_migrate[key]:
+            raise MigrationConflictError(
+                f"vault already has an entry for {key!r} whose value differs "
+                f"from the plaintext in the .env; refusing to migrate so neither "
+                f"value is silently discarded. Reconcile them (update the .env to "
+                f"match the vault, or `kirocrew secrets set {key}`), then re-run "
+                f"`kirocrew secrets import --apply`."
+            )
+        already_in_vault.add(key)
+    to_store = {k: v for k, v in to_migrate.items() if k not in already_in_vault}
+
+    # Serialize the read-snapshot → compare → vault-store → re-verify → rewrite
+    # as one critical section under an exclusive OS advisory lock (the mandated
+    # cross-platform helper — POSIX flock / Windows msvcrt), taken on a sidecar
+    # lock file so it does not perturb the .env's own bytes/mode. Two guards,
+    # each covering what the other cannot:
+    #   * the LOCK serializes against any OTHER PROCESS touching the .env under
+    #     the same lock (a second `secrets import`, or the WeChat/Weixin QR
+    #     sign-in handler — see `dashboard.handlers.weixin_qr` — which now also
+    #     acquires this same lock before its read-modify-write of .env),
+    #     closing the cross-process compare-then-replace window;
+    #   * the CAS re-read (below, under the lock) provides defense-in-depth
+    #     against any future in-process writer that might not take the file lock,
+    #     by aborting if the bytes changed since the snapshot.
+    # If the lock cannot be taken (another holder), abort cleanly rather than
+    # block the CLI; a re-run reconciles (idempotent, secret://-line-wins).
+    #
+    # ORDERING INVARIANT: the vault write (`_store_all`) runs INSIDE this
+    # critical section, AFTER the CAS confirms `.env` is unchanged from the
+    # original snapshot, so the vault never ends up holding a value that `.env`
+    # has already moved past (a concurrent `.env` edit between the snapshot and
+    # the store now causes abort BEFORE any vault write, closing the
+    # "stale vault authoritative after aborted rewrite" window).
+    new_text = _rewrite_env_text(text, set(to_migrate))
+    lock_path = _env_lock_path(ep)
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if not platform_compat.try_acquire_lock(lock_fd, exclusive=True):
+            raise MigrationConflictError(
+                f"{ep} is being written by another process; no rewrite "
+                f"performed. Re-run `kirocrew secrets import --apply` to finish."
+            )
+        try:
+            current_bytes = ep.read_bytes()
+        except OSError:
+            current_bytes = b""
+        if current_bytes != original_bytes:
+            raise MigrationConflictError(
+                f"{ep} changed during migration (a concurrent write); no rewrite "
+                f"performed. Re-run `kirocrew secrets import --apply` to finish "
+                f"rewriting the .env references."
+            )
+
+        # CAS confirmed: .env is unchanged since the snapshot. NOW write the
+        # secrets into the vault (still inside the lock), so a concurrent `.env`
+        # edit that arrived between the snapshot and this point will have
+        # triggered the CAS abort above, and the vault never holds a value
+        # derived from a stale snapshot.
+        #
+        # `set_if_absent` (not `set`) closes the write-race with any OTHER vault
+        # writer (dashboard secrets page, Weixin handler): the not-present check
+        # is made INSIDE the vault's own cross-process store lock, so a
+        # credential a concurrent writer saved between our earlier `list_names()`
+        # snapshot and this write is never clobbered — that writer wins and we
+        # abort rather than overwrite its newer value with the stale `.env`
+        # plaintext, and rather than rewrite the `.env` line to point at a value
+        # we did not store. The vault write API is async; a short-lived event
+        # loop is fine inside the `try:` that holds the file lock.
+        # Maps key -> the exact ENCRYPTED ENTRY dict THIS run stored via
+        # set_if_absent. Used by the rollback to perform a ciphertext-identity
+        # delete: only delete a vault entry if it still holds the exact
+        # ciphertext we wrote, so a concurrent writer that overwrote our entry
+        # between the store and the failure is never silently wiped (data loss).
+        # Because _encrypt_entry uses a random nonce per call, two encryptions of
+        # the same plaintext produce different dicts — the entry dict is a unique
+        # fingerprint for what this run wrote.
+        newly_written: dict[str, dict[str, str]] = {}
+
+        async def _store_all() -> None:
+            for key, value in to_store.items():
+                entry = await vault.set_if_absent(key, value)
+                if entry is None:
+                    raise MigrationConflictError(
+                        f"another writer stored {key!r} in the vault during the "
+                        f"import; no rewrite performed so its value is not "
+                        f"overwritten. Re-run `kirocrew secrets import --apply` "
+                        f"to reconcile."
+                    )
+                newly_written[key] = entry
+
+        # The store AND the re-verify/rewrite run inside ONE try whose except
+        # rolls back every vault entry this run wrote. This is essential for a
+        # PARTIAL store failure: a multi-key import that stores key 1 then hits a
+        # conflict on key 2 raises from INSIDE _store_all — if that raise were
+        # outside the rollback scope, key 1 would remain an orphaned vault entry
+        # that vault-first resolution could later use to shadow a rotated
+        # plaintext. `newly_written` is appended per successful write, so on any
+        # failure it holds exactly the entries to undo.
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(_store_all())
+            finally:
+                loop.close()
+
+            # Re-verify the vault still matches what we are about to reference, then
+            # perform the final CAS re-read and atomic .env rewrite — all inside a
+            # single held vault cross-process lock so no concurrent vault DELETE can
+            # sneak in between the verify and the write.
+            #
+            # ORDERING / DEADLOCK NOTE: _store_all() uses set_if_absent() which
+            # acquires the vault's cross-process flock per-write and releases it
+            # before returning.  hold_cross_process_lock() is therefore acquired
+            # AFTER _store_all() has fully released all its per-write locks.  While
+            # holding the vault lock here we only call vault.get() (read-only, no
+            # flock acquired) and atomic_write (plain OS call), so there is NO nested
+            # re-acquire and NO deadlock risk.
+            #
+            # The vault lock closes the race: without it a concurrent vault DELETE
+            # could remove a key between the re-verify read (vault.get() returns the
+            # expected value) and the atomic_write that commits `secret://KEY` to
+            # .env — stranding the plaintext. Holding the lock for both operations
+            # makes them an atomic unit from the vault's perspective: any DELETE that
+            # arrives while we hold the lock is queued until after atomic_write
+            # commits, at which point the `secret://KEY` reference in .env is already
+            # durable and the DELETE only removes the vault entry (the credential is
+            # gone, but not silently — that is the operator's explicit intent).
+            with vault.hold_cross_process_lock():
+                # `to_migrate` maps every key->value we intended to migrate (the value
+                # from the original .env). For already_in_vault keys, the pre-lock
+                # verification above already confirmed vault==.env, so `to_migrate[key]`
+                # is the authoritative expected value for all keys in the set.
+                # vault.get() is synchronous (no event loop needed) and does NOT
+                # acquire the cross-process flock, so calling it under
+                # hold_cross_process_lock() is safe.
+                for _key, _expected in to_migrate.items():
+                    try:
+                        _entry = vault.get(_key)
+                    except Exception as _exc:
+                        raise MigrationConflictError(
+                            f"vault entry for {_key!r} could not be read after "
+                            f"storing ({_exc.__class__.__name__}); no .env rewrite "
+                            f"performed so the plaintext is not lost — re-run "
+                            f"`kirocrew secrets import --apply`."
+                        ) from _exc
+                    if _entry is None:
+                        raise MigrationConflictError(
+                            f"vault entry for {_key!r} was deleted during migration; "
+                            f"no .env rewrite performed so the plaintext is not lost "
+                            f"— re-run `kirocrew secrets import --apply`."
+                        )
+                    if _entry.reveal() != _expected:
+                        raise MigrationConflictError(
+                            f"vault entry for {_key!r} was changed during migration; "
+                            f"no .env rewrite performed so the plaintext is not lost "
+                            f"— re-run `kirocrew secrets import --apply`."
+                        )
+
+                # The .env was decoded with errors="surrogateescape", so new_text may
+                # carry lone surrogates for any non-UTF-8 bytes in the original file.
+                # atomic_write encodes a str as STRICT UTF-8 (which raises on those
+                # surrogates), so hand it bytes re-encoded with surrogateescape — this
+                # round-trips the original non-UTF-8 bytes faithfully and byte-for-byte.
+                #
+                # FINAL CAS re-read immediately before the write. The earlier CAS check
+                # ran before the vault store + re-verify; between that point and this
+                # write a writer that somehow bypassed the .env lock could have rewritten
+                # the .env (e.g. a freshly rotated Weixin token written without the lock,
+                # or a future writer added without adopting the lock convention).
+                # `new_text` was built from `original_bytes`, so committing it now would
+                # CLOBBER that writer's change.  Re-read the bytes one last time and
+                # abort if they no longer match the snapshot: we never overwrite a .env
+                # that moved since we composed the rewrite.  This shrinks the clobber
+                # window to the atomic_write itself (an unavoidable last-writer race
+                # shared by any file writer), rather than the whole store+verify span.
+                try:
+                    final_bytes = ep.read_bytes()
+                except OSError:
+                    final_bytes = b""
+                if final_bytes != original_bytes:
+                    raise MigrationConflictError(
+                        f"{ep} changed during migration (a concurrent write) just "
+                        f"before the rewrite; no rewrite performed so the concurrent "
+                        f"change is not clobbered. Re-run `kirocrew secrets import "
+                        f"--apply` to finish rewriting the .env references."
+                    )
+                atomic_write(
+                    ep,
+                    new_text.encode("utf-8", errors="surrogateescape"),
+                    mode=0o600,
+                    fsync=True,
+                    restrict_to_owner=True,
+                )
+        except BaseException:
+            # The .env rewrite failed (or never ran). Roll back every vault entry
+            # THIS run wrote so a later re-run starts from the original plaintext
+            # rather than finding an orphan vault entry that shadows a future
+            # rotation. Best-effort: only delete keys this exact call stored via
+            # set_if_absent (newly_written); pre-existing entries owned by
+            # another writer are never touched. Deletion happens inside the held
+            # .env file lock so no concurrent reader sees a half-committed state.
+            # We use a fresh event loop because the failed `with` block may have
+            # already closed or invalidated the previous one.
+            #
+            # CIPHERTEXT-IDENTITY DELETE: pass the exact entry dict returned by
+            # set_if_absent to _compare_and_delete_sync. Because _encrypt_entry
+            # uses a random nonce per call, a concurrent writer that stored any
+            # new value (even the same plaintext) produces a different ciphertext
+            # dict — the stored dict will differ from our dict, so their entry is
+            # never touched.
+            if newly_written:
+                _rollback_loop = asyncio.new_event_loop()
+                try:
+                    _orphaned: list[str] = []
+
+                    async def _rollback() -> None:
+                        for _k, _written_entry in newly_written.items():
+                            try:
+                                # Ciphertext-identity delete under a single
+                                # cross-process flock: compare the stored entry
+                                # dict against the exact dict set_if_absent
+                                # returned, and delete only on exact match.
+                                # Because _encrypt_entry uses a random nonce,
+                                # two encryptions of the same plaintext produce
+                                # different dicts — a concurrent writer that
+                                # stored a new value (even the same plaintext)
+                                # has a different stored dict and is never
+                                # deleted.  We use the sync
+                                # _compare_and_delete_sync primitive rather than
+                                # vault.delete() to avoid re-acquiring the flock
+                                # (vault.delete -> _write_store -> _cross_process_lock
+                                # -> hold_cross_process_lock would deadlock on POSIX
+                                # if the caller held the lock externally).
+                                await asyncio.to_thread(
+                                    vault._compare_and_delete_sync, _k, _written_entry
+                                )
+                            except Exception as _rb_exc:
+                                # Rollback-delete failed (e.g. ENOSPC, I/O error).
+                                # The vault entry for _k may still exist and could
+                                # shadow a future plaintext rotation.  Record the
+                                # key so the caller can surface it to the operator.
+                                _orphaned.append(_k)
+                                logger.warning(
+                                    "secrets import rollback: failed to delete vault"
+                                    " entry for %r (%s: %s). The entry may persist"
+                                    " and shadow future rotations — run"
+                                    " `kirocrew secrets rm %s` to clean it up.",
+                                    _k,
+                                    type(_rb_exc).__name__,
+                                    _rb_exc,
+                                    _k,
+                                )
+
+                    _rollback_loop.run_until_complete(_rollback())
+                    if _orphaned:
+                        report.orphaned_vault_keys.extend(_orphaned)
+                finally:
+                    _rollback_loop.close()
+            raise
+        # Record what was migrated only on the success path — after the .env
+        # rewrite commits — so an abort at any earlier guard leaves
+        # report.migrated empty (nothing was permanently changed from the
+        # caller's perspective).
+        report.migrated.extend(to_migrate)
+    finally:
+        platform_compat.release_lock(lock_fd)
+        os.close(lock_fd)
+    return report
+
+
+def format_report(report: MigrationReport) -> str:
+    """Render *report* as human-readable CLI output."""
+    lines: list[str] = []
+    ep = report.env_file
+    if report.dry_run:
+        keys = report.migrated
+        if not keys:
+            lines.append(f"No plaintext credentials to migrate in {ep}.")
+        else:
+            lines.append(f"Would migrate {len(keys)} secret(s) from {ep} into the vault:")
+            for k in keys:
+                lines.append(f"  {k}  ->  secret://{k}")
+            lines.append("")
+            lines.append("Re-run with --apply to store these in the vault and rewrite")
+            lines.append("each .env line to a secret:// reference.")
+    else:
+        keys = report.migrated
+        if not keys:
+            lines.append(f"Nothing migrated: no plaintext credentials found in {ep}.")
+        else:
+            lines.append(f"Migrated {len(keys)} secret(s) into the vault and rewrote {ep}:")
+            for k in keys:
+                lines.append(f"  {k}  ->  secret://{k}")
+            lines.append("")
+            lines.append("The original values were REWRITTEN in place to secret:// references;")
+            lines.append("the plaintext is no longer present for these keys. Any values that")
+            lines.append("Kiro Crew does not recognize as credentials were left untouched. If")
+            lines.append(f"you keep a backup of {ep}, delete the plaintext copy once verified.")
+
+    if report.already_referenced:
+        lines.append("")
+        lines.append("Already using secret:// (skipped): " + ", ".join(report.already_referenced))
+    return "\n".join(lines)

--- a/src/kiro_crew/secrets/vault.py
+++ b/src/kiro_crew/secrets/vault.py
@@ -107,6 +107,46 @@ class SecretVault:
         async with self._lock:
             await asyncio.to_thread(self._set_sync, name, value)
 
+    async def set_if_absent(self, name: str, value: str) -> Optional[dict[str, str]]:
+        """Store ``value`` under ``name`` ONLY if the key is not already present.
+
+        Returns the exact encrypted entry dict that was written on a fresh write,
+        or ``None`` if the key was already present (left untouched). A non-None
+        return means "this call wrote the entry"; ``None`` means "a value was
+        already present". The presence check happens INSIDE the cross-process
+        store lock (see ``_write_store``), so a concurrent writer that stored the
+        key between a caller's earlier ``list_names()`` and this call always wins
+        — this call becomes a no-op rather than clobbering the newer value. Used
+        by the .env→vault importer, which must never overwrite a credential a
+        dashboard/other writer saved to the vault in the meantime.
+
+        The returned entry dict (when non-None) is the unique ciphertext
+        fingerprint for what this call stored — because ``_encrypt_entry`` uses a
+        random nonce per call, two encryptions of the same plaintext produce
+        different dicts. The importer's rollback path passes this dict to
+        ``_compare_and_delete_sync`` so it can identify and delete the exact entry
+        this run wrote, without risking deletion of a concurrent writer's entry
+        that may coincidentally hold the same plaintext.
+        """
+        async with self._lock:
+            return await asyncio.to_thread(self._set_if_absent_sync, name, value)
+
+    def _set_if_absent_sync(self, name: str, value: str) -> Optional[dict[str, str]]:
+        written_entry: Optional[dict[str, str]] = None
+
+        def _mutate(entries: dict) -> dict:
+            nonlocal written_entry
+            if name in entries:
+                # Concurrent writer already populated it under the lock — do not
+                # overwrite. Return entries unchanged so the write is a no-op.
+                return entries
+            entry = self._encrypt_entry(name, value.encode("utf-8"))
+            written_entry = entry
+            return {**entries, name: entry}
+
+        self._write_store(_mutate)
+        return written_entry
+
     def _set_sync(self, name: str, value: str) -> None:
         self._write_store(
             lambda entries: {**entries, name: self._encrypt_entry(name, value.encode("utf-8"))}
@@ -123,6 +163,45 @@ class SecretVault:
         if not self._store_path.exists():
             return
         self._write_store(lambda entries: {k: v for k, v in entries.items() if k != name})
+
+    def _compare_and_delete_sync(self, name: str, expected_entry: dict[str, str]) -> bool:
+        """Delete ``name`` ONLY if its stored encrypted entry equals ``expected_entry``.
+
+        The comparison is by exact ciphertext identity: ``entries[name] ==
+        expected_entry``. Because ``_encrypt_entry`` uses a random nonce per call,
+        two encryptions of the same plaintext produce different dicts, so this
+        comparison uniquely fingerprints the exact entry written by a particular
+        ``set_if_absent`` call. A concurrent writer that stored a new value (even
+        the same plaintext) will have a different ciphertext and a different dict,
+        so its entry is never deleted.
+
+        The comparison and deletion happen inside a single ``_write_store`` call,
+        i.e. under one cross-process flock acquisition, so no concurrent writer
+        can replace the value between the check and the delete.
+
+        Returns ``True`` if the entry was deleted, ``False`` if it was absent or
+        the stored entry differed from ``expected_entry`` (concurrent overwrite —
+        leave it alone).
+
+        Used by the rollback path in the .env importer: ``expected_entry`` is the
+        exact dict returned by ``set_if_absent``, so only the entry this run
+        wrote can be deleted — a concurrent writer's entry is always safe.
+        """
+        deleted = False
+
+        def _mutate(entries: dict) -> dict:
+            nonlocal deleted
+            if name not in entries:
+                return entries
+            if entries[name] != expected_entry:
+                # Stored entry differs (different ciphertext) — a concurrent
+                # writer replaced our entry. Do not delete.
+                return entries
+            deleted = True
+            return {k: v for k, v in entries.items() if k != name}
+
+        self._write_store(_mutate)
+        return deleted
 
     def list_names(self) -> list[str]:
         """Return all stored secret names."""
@@ -226,8 +305,27 @@ class SecretVault:
         return dict(envelope.get("entries", {}))
 
     @contextmanager
-    def _cross_process_lock(self) -> Iterator[None]:
-        """Acquire a cross-process lock via platform_compat.file_lock."""
+    def hold_cross_process_lock(self) -> Iterator[None]:
+        """Acquire and hold the vault's cross-process flock (.secrets.enc.lock).
+
+        Public context manager so callers that need to keep the vault immutable
+        across multiple operations (e.g. a re-verify + atomic .env rewrite that
+        must not be interrupted by a concurrent vault DELETE) can hold the lock
+        for the entire critical section.
+
+        The lock is the same advisory flock used internally by every vault write
+        (``_write_store``), so holding it here prevents any concurrent
+        ``set`` / ``set_if_absent`` / ``delete`` from mutating the store until
+        the caller's ``with`` block exits.
+
+        Deadlock prevention: callers MUST NOT call any mutating vault method
+        (``set``, ``set_if_absent``, ``delete``) while holding this lock,
+        because those methods call ``_write_store`` → ``_cross_process_lock``
+        which re-acquires the same flock — causing a deadlock on POSIX (flock is
+        not re-entrant across the same fd on most kernels). Read-only access
+        (``get``, ``list_names``) is safe because those methods do NOT acquire
+        the flock.
+        """
         self._config_dir.mkdir(parents=True, exist_ok=True)
         lock_path = self._store_path.with_name(".secrets.enc.lock")
         lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o600)
@@ -236,6 +334,16 @@ class SecretVault:
                 yield
         finally:
             os.close(lock_fd)
+
+    @contextmanager
+    def _cross_process_lock(self) -> Iterator[None]:
+        """Acquire a cross-process lock via platform_compat.file_lock.
+
+        Delegates to :meth:`hold_cross_process_lock` so there is exactly one
+        flock-acquire implementation.
+        """
+        with self.hold_cross_process_lock():
+            yield
 
     def _write_store(self, mutate) -> None:
         """Atomically read-modify-write the store under cross-process lock.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4063,6 +4063,38 @@ class TestConfigDirOverride:
         assert "xoxb-test" in env_file.read_text(encoding="utf-8")
         assert not list(tmp_path.glob("*.tmp"))  # failure leaves no temp residue
 
+    def test_setup_slack_tokens_aborts_when_shared_env_lock_is_held(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """The Slack setup writer serializes on the SAME .env.lock the importer
+        and the dashboard credential writers use, so it aborts (rather than
+        racing the importer's commit and clobbering it) when another writer
+        holds the lock — and leaves .env untouched."""
+        import os as os_mod
+
+        import kiro_crew.cli_setup as cs
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.secrets.migrate import _env_lock_path
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("EXISTING=1\n", encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.cli_setup.env_path", lambda: env_file)
+        inputs = iter(["y", "xapp-test", "xoxb-test", "U12345"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        # Simulate another writer (e.g. `kirocrew secrets import`) holding the
+        # shared advisory lock.
+        lock_path = _env_lock_path(env_file)
+        held_fd = os_mod.open(lock_path, os_mod.O_CREAT | os_mod.O_RDWR, 0o600)
+        assert pc.try_acquire_lock(held_fd, exclusive=True)
+        try:
+            cs._setup_slack_tokens()  # must not raise
+            # .env is untouched — the aborted save did not write the tokens.
+            assert env_file.read_text(encoding="utf-8") == "EXISTING=1\n"
+        finally:
+            pc.release_lock(held_fd)
+            os_mod.close(held_fd)
+
 
 class TestSetupChannelGating:
     """`kirocrew setup` runs the Slack steps only with --slack.

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -1312,13 +1312,47 @@ class TestTeamsConfigSave:
     def test_purges_a_legacy_plaintext_secret_from_config_json(
         self, monkeypatch, tmp_path: Path
     ) -> None:
+        # The purge is safe only when the credential is also held in .env or being
+        # written to .env this save (Finding 1: purging the sole copy on a
+        # metadata-only save would erase the credential). Scenario: password in
+        # BOTH config.json AND os.environ (simulating a migrated, leaked copy).
+        env = tmp_path / ".env"
+        env.write_text("MICROSOFT_APP_PASSWORD=leaked\n", encoding="utf-8")
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"teams": {"app_password": "leaked"}}), encoding="utf-8")
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+        monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+        monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+        # The credential is held in os.environ (safe to purge the config copy).
+        monkeypatch.setenv("MICROSOFT_APP_PASSWORD", "leaked")
+
+        async def _accept(*a, **kw):
+            return None
+
+        monkeypatch.setattr(mod, "_validate_teams_app_credentials", _accept)
+        resp = _run(mod.api_teams_config_save, _Req(_state(), {"enabled": True}))
+        assert resp.status == 200
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert (
+            data["teams"]["app_password"] == ""
+        ), "When password is also in os.environ/.env, purge the legacy config.json copy"
+
+    def test_does_not_purge_legacy_secret_that_is_the_sole_credential_copy(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        # Finding 1 regression: app_password ONLY in legacy config.json (not in
+        # .env or os.environ) must survive a metadata-only save.
         (tmp_path / "config.json").write_text(
-            json.dumps({"teams": {"app_password": "leaked"}}), encoding="utf-8"
+            json.dumps({"teams": {"app_password": "legacy-only"}}), encoding="utf-8"
         )
         resp, _, cfg = self._save(monkeypatch, tmp_path, {"enabled": True})
-        assert "app_password_purged" in json.dumps(_payload(resp)) or resp.status == 200
+        # _save sets MICROSOFT_APP_PASSWORD="" so os.environ fallback is empty.
+        assert resp.status == 200
         data = json.loads(cfg.read_text(encoding="utf-8"))
-        assert data["teams"]["app_password"] == ""
+        assert data["teams"].get("app_password") == "legacy-only", (
+            "Password that lives ONLY in legacy config.json must survive a "
+            "metadata-only save (Finding 1)"
+        )
 
     def test_no_op_save_reports_no_restart_needed(self, monkeypatch, tmp_path: Path) -> None:
         (tmp_path / "config.json").write_text(
@@ -1332,6 +1366,34 @@ class TestTeamsConfigSave:
         resp, _, cfg = self._save(monkeypatch, tmp_path, {"enabled": True})
         assert resp.status == 200
         assert json.loads(cfg.read_text(encoding="utf-8"))["teams"]["enabled"] is True
+
+    def test_clear_config_write_failure_does_not_leave_env_cleared(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """On a CLEAR the config.json purge runs BEFORE the .env delete. If the
+        config write fails the .env must be untouched — otherwise a restart would
+        fall back to any legacy config.json app_password, resurrecting the
+        credential the operator asked to clear."""
+        env = tmp_path / ".env"
+        cfg_path = tmp_path / "config.json"
+        env.write_text("MICROSOFT_APP_PASSWORD=live-pw\n", encoding="utf-8")
+        cfg_path.write_text(json.dumps({"teams": {"app_password": "legacy-pw"}}), encoding="utf-8")
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+        monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+        monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+        monkeypatch.setenv("MICROSOFT_APP_PASSWORD", "")
+
+        import kiro_crew.agent as _agent
+
+        def _boom(*_a, **_k):
+            raise OSError("disk full during config write")
+
+        monkeypatch.setattr(_agent, "_atomic_json_write", _boom)
+        try:
+            _run(mod.api_teams_config_save, _Req(_state(), {"app_password_clear": True}))
+        except Exception:
+            pass
+        assert "MICROSOFT_APP_PASSWORD=live-pw" in env.read_text(encoding="utf-8")
 
 
 class TestTeamsActivity:
@@ -1429,6 +1491,32 @@ class TestWriteEnvUpdates:
 
         assert events == ["restrict", "write"], events
         assert env.read_text(encoding="utf-8") == "SLACK_BOT_TOKEN=xoxb-secret\n"
+
+    def test_aborts_when_shared_env_lock_is_held(self, monkeypatch, tmp_path: Path) -> None:
+        """A channel/token save serializes on the SAME .env.lock the importer
+        and the Weixin handler use, so it aborts (rather than racing the commit)
+        when another writer holds the lock — and leaves .env untouched."""
+        import os
+
+        from kiro_crew import platform_compat
+        from kiro_crew.secrets.migrate import _env_lock_path
+
+        env = tmp_path / ".env"
+        env.write_text("A=1\n", encoding="utf-8")
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+
+        # Simulate the importer holding the shared advisory lock.
+        lock_path = _env_lock_path(env)
+        held_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        assert platform_compat.try_acquire_lock(held_fd, exclusive=True)
+        try:
+            with pytest.raises(OSError):
+                mod._write_env_updates({"B": "2"})
+            # .env is untouched — the aborted save did not partially write.
+            assert env.read_text(encoding="utf-8") == "A=1\n"
+        finally:
+            platform_compat.release_lock(held_fd)
+            os.close(held_fd)
 
 
 class _FakeResponse:

--- a/test/test_secrets_migrate.py
+++ b/test/test_secrets_migrate.py
@@ -1,0 +1,1085 @@
+"""Tests for kiro_crew.secrets.migrate — plaintext .env → vault importer."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.secrets import SecretVault
+from kiro_crew.secrets.migrate import (
+    MigrationConflictError,
+    MigrationReport,
+    format_report,
+    migrate_env_secrets,
+)
+
+
+def _migrate(config_dir: Path, ep: Path, **kwargs):
+    """Run the importer against a specific ``.env`` in tests.
+
+    ``migrate_env_secrets`` intentionally takes no caller path for EITHER the
+    ``.env`` it reads (``env_path()``) or the vault home it writes
+    (``config_dir()``), so tests point it at their temp home by patching both
+    resolvers rather than passing paths.
+    """
+    with (
+        patch("kiro_crew.secrets.migrate.env_path", return_value=ep),
+        patch("kiro_crew.secrets.migrate.config_dir", return_value=config_dir),
+    ):
+        return migrate_env_secrets(**kwargs)
+
+
+# A migratable Jira token + a non-Jira credential (must NOT migrate) + an
+# unrecognized operator setting.
+_ENV_BODY = (
+    "# comment line\n"
+    "JIRA_API_TOKEN=plaintext-token\n"
+    "SLACK_BOT_TOKEN=xoxb-123\n"
+    "HTTP_PROXY=http://proxy.local:8080\n"
+    "\n"
+)
+
+
+def _write_env(tmp_path: Path, body: str = _ENV_BODY) -> Path:
+    ep = tmp_path / ".env"
+    ep.write_text(body)
+    return ep
+
+
+def test_dry_run_reports_and_writes_nothing(tmp_path: Path) -> None:
+    """Default dry run identifies the Jira token but changes nothing."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path)
+    original = ep.read_text()
+
+    report = _migrate(config_dir, ep, dry_run=True)
+
+    assert report.dry_run is True
+    assert report.migrated == ["JIRA_API_TOKEN"]
+    # .env untouched, vault store never created.
+    assert ep.read_text() == original
+    assert SecretVault(config_dir).list_names() == []
+
+
+def test_apply_writes_vault_and_rewrites_env(tmp_path: Path) -> None:
+    """--apply stores the Jira token and rewrites only its .env line."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path)
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.dry_run is False
+    assert report.migrated == ["JIRA_API_TOKEN"]
+
+    vault = SecretVault(config_dir)
+    assert vault.list_names() == ["JIRA_API_TOKEN"]
+    assert vault.get("JIRA_API_TOKEN").reveal() == "plaintext-token"
+
+    text = ep.read_text()
+    assert "JIRA_API_TOKEN=secret://JIRA_API_TOKEN" in text
+    # The Jira plaintext is gone; the non-Jira credential and unrecognized key
+    # are preserved verbatim (their consumers are not vault-aware yet).
+    assert "plaintext-token" not in text
+    assert "SLACK_BOT_TOKEN=xoxb-123" in text
+    assert "HTTP_PROXY=http://proxy.local:8080" in text
+    assert "# comment line" in text
+
+
+def test_non_jira_credential_not_migrated(tmp_path: Path) -> None:
+    """A non-Jira credential key is left untouched (consumer not vault-aware)."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "SLACK_BOT_TOKEN=xoxb-123\nKIRO_API_KEY=k-abc\n")
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.migrated == []
+    assert SecretVault(config_dir).list_names() == []
+    text = ep.read_text()
+    assert "SLACK_BOT_TOKEN=xoxb-123" in text
+    assert "KIRO_API_KEY=k-abc" in text
+    assert "secret://" not in text
+
+
+def test_source_file_not_deleted(tmp_path: Path) -> None:
+    """The .env file is rewritten in place, never removed."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path)
+
+    _migrate(config_dir, ep, dry_run=False)
+
+    assert ep.exists()
+
+
+def test_env_written_at_mode_600(tmp_path: Path) -> None:
+    """After apply the .env is owner-only (0o600)."""
+    if os.name != "posix":
+        return  # POSIX-only permission bits.
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path)
+
+    _migrate(config_dir, ep, dry_run=False)
+
+    assert stat.S_IMODE(ep.stat().st_mode) == 0o600
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    """Re-running apply after a migration is a no-op."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path)
+
+    _migrate(config_dir, ep, dry_run=False)
+    after_first = ep.read_text()
+
+    report2 = _migrate(config_dir, ep, dry_run=False)
+
+    assert report2.migrated == []
+    assert report2.already_referenced == ["JIRA_API_TOKEN"]
+    assert ep.read_text() == after_first
+
+
+def test_stale_plaintext_behind_secret_ref_not_queued(tmp_path: Path) -> None:
+    """A stale plaintext line followed by a secret:// line for the same key
+    must NOT be re-migrated: the later reference wins, so the good vault entry
+    is never overwritten with the stale value."""
+    config_dir = tmp_path / "config"
+    # Pre-seed the vault with the authoritative secret, as a prior migration
+    # would have left it.
+    from kiro_crew.secrets.migrate import migrate_env_secrets as _m  # noqa: F401
+
+    good_env = tmp_path / "good.env"
+    good_env.write_text("JIRA_API_TOKEN=good-secret\n")
+    _migrate(config_dir, good_env, dry_run=False)
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN").reveal() == "good-secret"
+
+    # Now a .env where a STALE plaintext line precedes the authoritative
+    # secret:// reference for the same key.
+    ep = _write_env(
+        tmp_path,
+        "JIRA_API_TOKEN=stale-plaintext\nJIRA_API_TOKEN=secret://JIRA_API_TOKEN\n",
+    )
+    before = ep.read_text()
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    # Nothing migrated; the stale plaintext never entered the queue.
+    assert report.migrated == []
+    assert report.already_referenced == ["JIRA_API_TOKEN"]
+    # The good vault entry is intact — NOT overwritten by "stale-plaintext".
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN").reveal() == "good-secret"
+    # .env untouched (nothing to rewrite).
+    assert ep.read_text() == before
+
+
+def test_per_host_jira_token_migrated(tmp_path: Path) -> None:
+    """A JIRA_TOKEN_<HEX> per-host key is recognized and migrated."""
+    config_dir = tmp_path / "config"
+    host_key = "acme.atlassian.net".encode().hex().upper()
+    ep = _write_env(tmp_path, f"JIRA_TOKEN_{host_key}=per-host-plain\n")
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.migrated == [f"JIRA_TOKEN_{host_key}"]
+    assert SecretVault(config_dir).get(f"JIRA_TOKEN_{host_key}").reveal() == "per-host-plain"
+    assert f"JIRA_TOKEN_{host_key}=secret://JIRA_TOKEN_{host_key}" in ep.read_text()
+
+
+def test_unrecognized_keys_left_untouched(tmp_path: Path) -> None:
+    """A file with only unrecognized keys migrates nothing."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "HTTP_PROXY=http://p:1\nMY_FLAG=on\n")
+
+    report = _migrate(config_dir, ep, dry_run=True)
+
+    assert report.migrated == []
+    assert SecretVault(config_dir).list_names() == []
+
+
+def test_missing_env_file_is_noop(tmp_path: Path) -> None:
+    """A non-existent .env yields an empty report and no vault store."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / "does-not-exist.env"
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.migrated == []
+    assert report.already_referenced == []
+    assert SecretVault(config_dir).list_names() == []
+
+
+def test_format_report_dry_run_mentions_apply(tmp_path: Path) -> None:
+    """The dry-run report tells the user to re-run with --apply."""
+    report = MigrationReport(env_file=tmp_path / ".env", dry_run=True, migrated=["JIRA_API_TOKEN"])
+    out = format_report(report)
+    assert "--apply" in out
+    assert "secret://JIRA_API_TOKEN" in out
+
+
+def test_format_report_apply_explains_removal(tmp_path: Path) -> None:
+    """The apply report explains the plaintext was rewritten in place."""
+    report = MigrationReport(env_file=tmp_path / ".env", dry_run=False, migrated=["JIRA_API_TOKEN"])
+    out = format_report(report)
+    assert "Migrated 1 secret" in out
+    assert "REWRITTEN" in out
+
+
+def test_env_override_key_is_skipped(tmp_path: Path, monkeypatch) -> None:
+    """A key with a nonempty process-environment override is NOT migrated:
+    the env value is runtime-authoritative, so migrating the stale .env value
+    would let vault-first resolution shadow the live override."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=stale-file-value\n")
+    monkeypatch.setenv("JIRA_API_TOKEN", "live-env-value")
+    before = ep.read_text()
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.migrated == []
+    assert SecretVault(config_dir).list_names() == []
+    # .env line left untouched (still plaintext, no secret:// rewrite).
+    assert ep.read_text() == before
+
+
+def test_env_override_empty_does_not_skip(tmp_path: Path, monkeypatch) -> None:
+    """An EMPTY env override is not authoritative, so the .env value migrates."""
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=file-value\n")
+    monkeypatch.setenv("JIRA_API_TOKEN", "")
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.migrated == ["JIRA_API_TOKEN"]
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN").reveal() == "file-value"
+
+
+def test_per_host_env_var_does_not_skip_migration(tmp_path: Path, monkeypatch) -> None:
+    """`load_credentials` overlays the env only for _CREDENTIAL_KEYS (the global
+    JIRA_API_TOKEN), NOT per-host JIRA_TOKEN_<HEX> keys. So a same-named env var
+    for a per-host key is NOT runtime-authoritative — Jira still reads the
+    .env/vault value — and migration must NOT skip it (skipping would strand the
+    stale file token). The env-override skip applies only to the global token."""
+    config_dir = tmp_path / "config"
+    host_key = "acme.atlassian.net".encode().hex().upper()
+    ep = _write_env(tmp_path, f"JIRA_TOKEN_{host_key}=per-host-plain\n")
+    # An env var of the same name exists, but it does NOT override per-host keys.
+    monkeypatch.setenv(f"JIRA_TOKEN_{host_key}", "irrelevant-env-value")
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert report.migrated == [f"JIRA_TOKEN_{host_key}"]
+    assert SecretVault(config_dir).get(f"JIRA_TOKEN_{host_key}").reveal() == "per-host-plain"
+    assert f"JIRA_TOKEN_{host_key}=secret://JIRA_TOKEN_{host_key}" in ep.read_text()
+
+
+def test_concurrent_env_write_aborts_without_clobber(tmp_path: Path, monkeypatch) -> None:
+    """If .env changes under a concurrent writer between the snapshot read and
+    the rewrite, the rewrite aborts (MigrationConflictError) and the concurrent
+    writer's update is preserved — not clobbered by the stale snapshot.
+
+    Crucially, because the vault write now runs INSIDE the lock+CAS critical
+    section (after the CAS confirms .env is unchanged), a concurrent .env edit
+    that arrives before the CAS check means the vault write NEVER ran — the
+    vault holds no entry for the key after the abort.
+    """
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=original\n")
+
+    # Simulate a concurrent writer: BEFORE the CAS re-read fires (which now
+    # also precedes the vault write), mutate the file so it differs.
+    real_read_bytes = Path.read_bytes
+    state = {"calls": 0}
+
+    def _racing_read_bytes(self):
+        # First call = the snapshot read; let it through. Before the second
+        # call (the CAS re-read) fires, mutate the file so it differs.
+        if self == ep:
+            state["calls"] += 1
+            if state["calls"] == 2:
+                ep.write_text("JIRA_API_TOKEN=written-by-other-writer\n")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _racing_read_bytes)
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # The concurrent writer's value survived; our stale snapshot did NOT
+    # overwrite it.
+    assert ep.read_text() == "JIRA_API_TOKEN=written-by-other-writer\n"
+    # Vault has NO entry for the key — the CAS abort fires BEFORE _store_all()
+    # runs, so the vault never holds the stale snapshot value.  This is the
+    # fix for the "stale vault authoritative after aborted rewrite" bug: a
+    # re-run will re-snapshot the current .env value and store the fresh one.
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN") is None
+
+
+def test_concurrent_env_change_before_vault_store_aborts_without_vault_write(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A concurrent .env change that occurs BEFORE the vault store (i.e. before
+    the CAS check inside the lock section) must abort WITHOUT writing anything
+    to the vault.
+
+    This is the key ordering invariant introduced by the reorder fix: the vault
+    write (`_store_all`) now runs INSIDE the lock+CAS critical section, AFTER
+    the CAS confirms the .env snapshot is still fresh. A concurrent edit that
+    beats us to the .env therefore triggers a CAS abort before any vault write
+    runs — so the vault never ends up holding a value derived from a stale
+    snapshot that `.env` has already moved past.
+    """
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=original-token\n")
+
+    # Simulate a concurrent writer that rotates .env BETWEEN the snapshot read
+    # and the CAS re-read (which now also precedes the vault write).  We use a
+    # set_if_absent spy to confirm it is NEVER called when the CAS aborts.
+    vault_write_calls: list[str] = []
+    real_set_if_absent = SecretVault.set_if_absent
+
+    async def _spy_set_if_absent(self, name, value):
+        vault_write_calls.append(name)
+        return await real_set_if_absent(self, name, value)
+
+    monkeypatch.setattr(SecretVault, "set_if_absent", _spy_set_if_absent)
+
+    real_read_bytes = Path.read_bytes
+    state = {"calls": 0}
+
+    def _racing_read_bytes(self):
+        if self == ep:
+            state["calls"] += 1
+            if state["calls"] == 2:
+                # Rotate the token before the CAS re-read confirms the snapshot.
+                ep.write_text("JIRA_API_TOKEN=rotated-token\n")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _racing_read_bytes)
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # The vault write must NEVER have been called — the CAS abort fires before
+    # _store_all() runs, so no stale value reaches the vault.
+    assert vault_write_calls == [], (
+        f"set_if_absent was called for {vault_write_calls!r} despite CAS abort — "
+        "the ordering fix is not in effect"
+    )
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN") is None
+
+    # The concurrent writer's rotated value is intact; nothing was clobbered.
+    assert ep.read_text() == "JIRA_API_TOKEN=rotated-token\n"
+
+
+def test_concurrent_env_write_after_verify_caught_by_final_cas(tmp_path: Path, monkeypatch) -> None:
+    """A concurrent .env writer that does NOT take the .env lock (today the
+    WeChat/Weixin token handler, which serializes only on an in-process
+    asyncio.Lock) can rewrite the .env AFTER the early CAS + vault store +
+    re-verify but BEFORE the atomic rewrite. Without a final check the rewrite
+    would clobber that writer's change with our stale snapshot. The final CAS
+    re-read immediately before atomic_write catches it and aborts, so the
+    concurrent write survives.
+
+    The apply path reads ep.read_bytes three times: (1) the snapshot, (2) the
+    early CAS (before the vault store), (3) the final CAS (right before the
+    write). We let 1 and 2 pass unchanged — so the vault store and re-verify DO
+    run — then mutate .env just before call 3 fires.
+    """
+    config_dir = tmp_path / "config"
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=original-token\n")
+
+    real_read_bytes = Path.read_bytes
+    state = {"calls": 0}
+
+    def _racing_read_bytes(self):
+        if self == ep:
+            state["calls"] += 1
+            # Before the THIRD read (the final CAS) fires, a lock-less writer
+            # rewrites the .env. Calls 1 (snapshot) and 2 (early CAS) see the
+            # original bytes, so the store + re-verify complete normally.
+            if state["calls"] == 3:
+                ep.write_text("JIRA_API_TOKEN=rotated-by-weixin\n")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _racing_read_bytes)
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # The concurrent writer's value survived — the final CAS aborted the
+    # rewrite instead of clobbering it with our stale snapshot.
+    assert ep.read_text() == "JIRA_API_TOKEN=rotated-by-weixin\n"
+
+
+def test_key_already_in_vault_is_not_overwritten_but_env_rewritten(
+    tmp_path: Path,
+) -> None:
+    """A key already present in the vault with a value MATCHING the .env
+    plaintext is the idempotent re-run case: --apply must NOT re-write the vault
+    entry, but it MUST rewrite the .env line to secret://KEY so the two stay
+    consistent. (A DIFFERING vault value is a conflict — see
+    test_vault_value_differs_from_env_aborts.)"""
+    import asyncio
+
+    config_dir = tmp_path / "config"
+    # Pre-seed the vault with the token; .env carries the SAME value (a prior
+    # migration already stored it, or a re-run of the same import).
+    vault = SecretVault(config_dir)
+    asyncio.new_event_loop().run_until_complete(vault.set("JIRA_API_TOKEN", "same-value"))
+
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=same-value\n")
+
+    _migrate(config_dir, ep, dry_run=False)
+
+    # Vault entry is UNCHANGED.
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN").reveal() == "same-value"
+    # .env line is rewritten to the secret:// reference for consistency.
+    assert ep.read_text() == "JIRA_API_TOKEN=secret://JIRA_API_TOKEN\n"
+
+
+def test_vault_value_differs_from_env_aborts(tmp_path: Path) -> None:
+    """If the vault already holds a DECRYPTABLE value that DIFFERS from the .env
+    plaintext, the importer must ABORT — silently rewriting the .env line to
+    secret://KEY would discard the .env plaintext while Jira resolves to the
+    different vault value (e.g. this run stored `A`, a concurrent edit rewrote
+    the vault to `B`; a retry must not swap `A` away for `B` unasked)."""
+    import asyncio
+
+    config_dir = tmp_path / "config"
+    # Vault holds `B`; .env still carries a different plaintext `A`.
+    vault = SecretVault(config_dir)
+    asyncio.new_event_loop().run_until_complete(vault.set("JIRA_API_TOKEN", "vault-value-B"))
+
+    ep = _write_env(tmp_path, "JIRA_API_TOKEN=env-plaintext-A\n")
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # Neither value is discarded: vault keeps B, .env keeps its plaintext A.
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN").reveal() == "vault-value-B"
+    assert ep.read_text() == "JIRA_API_TOKEN=env-plaintext-A\n"
+
+
+def test_lock_held_by_another_process_aborts_cleanly(tmp_path: Path, monkeypatch) -> None:
+    """If the .env sidecar lock is already held (another process mid-write), the
+    migration aborts with MigrationConflictError rather than blocking or
+    clobbering — a re-run reconciles."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=plaintext-token\n")
+
+    # Force the exclusive-lock acquire to fail, simulating another holder.
+    monkeypatch.setattr(
+        "kiro_crew.secrets.migrate.platform_compat.try_acquire_lock",
+        lambda fd, *, exclusive=False: False,
+    )
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # Vault has NO entry — the vault write (_store_all) now runs INSIDE the
+    # lock section, so a lock-acquisition failure means no vault write occurred.
+    # .env is untouched as before.
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN") is None
+    assert ep.read_text() == "JIRA_API_TOKEN=plaintext-token\n"
+
+
+def test_undecryptable_vault_entry_aborts_without_rewrite(tmp_path: Path, monkeypatch) -> None:
+    """If the vault LISTS a key but its entry does not decrypt (missing/
+    mismatched vault key, e.g. a restored store), the importer must ABORT rather
+    than treat it as authoritative and rewrite the usable .env plaintext to
+    secret://KEY — which would strand Jira on an unusable vault entry."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=still-usable-plaintext\n")
+
+    # Vault lists the key, but decrypting it raises (corrupt/mismatched entry).
+    monkeypatch.setattr(SecretVault, "list_names", lambda self: ["JIRA_API_TOKEN"])
+
+    def _boom(self, name):
+        raise ValueError("InvalidTag: cannot decrypt")
+
+    monkeypatch.setattr(SecretVault, "get", _boom)
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # The usable plaintext is untouched — not rewritten to a broken secret://.
+    assert ep.read_text() == "JIRA_API_TOKEN=still-usable-plaintext\n"
+
+
+def test_handle_secrets_reports_conflict_cleanly(tmp_path: Path, monkeypatch, capsys) -> None:
+    """A MigrationConflictError from the importer must surface at the CLI as a
+    concise stderr error with a nonzero exit — never an uncaught traceback."""
+    import argparse
+
+    from kiro_crew import cli_commands
+
+    monkeypatch.setattr(cli_commands, "config_dir", lambda: str(tmp_path / "config"))
+
+    def _boom(*, dry_run):
+        raise MigrationConflictError("simulated concurrent write; no rewrite performed")
+
+    monkeypatch.setattr(cli_commands, "migrate_env_secrets", _boom)
+
+    args = argparse.Namespace(secrets_action="import", apply=True)
+    with pytest.raises(SystemExit) as exc:
+        cli_commands._handle_secrets(args)
+
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "error:" in err.lower()
+    assert "concurrent write" in err.lower()
+
+
+def test_handle_secrets_reports_corrupt_vault_cleanly(tmp_path: Path, monkeypatch, capsys) -> None:
+    """A truncated/corrupt vault store makes the importer raise ValueError/OSError
+    (from list_names/decrypt), not MigrationConflictError. It must still surface
+    at the CLI as a concise stderr error with a nonzero exit, never a traceback."""
+    import argparse
+
+    from kiro_crew import cli_commands
+
+    monkeypatch.setattr(cli_commands, "config_dir", lambda: str(tmp_path / "config"))
+
+    def _boom(*, dry_run):
+        raise ValueError("secrets.enc: Expecting value: line 1 column 1")
+
+    monkeypatch.setattr(cli_commands, "migrate_env_secrets", _boom)
+
+    args = argparse.Namespace(secrets_action="import", apply=True)
+    with pytest.raises(SystemExit) as exc:
+        cli_commands._handle_secrets(args)
+
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "error:" in err.lower()
+    assert "vault" in err.lower()
+
+
+def test_concurrent_vault_writer_wins_aborts(tmp_path: Path, monkeypatch) -> None:
+    """If another writer stores the key in the vault during the import (the
+    set_if_absent presence check fails), the importer aborts rather than
+    overwriting the newer value or rewriting the .env line to point at a value
+    it did not store."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=env-plaintext\n")
+
+    async def _lost_race(self, name, value):
+        return None  # another writer populated it first (set_if_absent returns None)
+
+    monkeypatch.setattr(SecretVault, "set_if_absent", _lost_race)
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # .env plaintext untouched — not rewritten to a secret:// we did not store.
+    assert ep.read_text() == "JIRA_API_TOKEN=env-plaintext\n"
+
+
+def test_set_if_absent_does_not_overwrite(tmp_path: Path) -> None:
+    """Vault.set_if_absent stores when absent (returns the entry dict) and leaves an
+    existing value untouched (returns None)."""
+    import asyncio
+
+    vault = SecretVault(tmp_path / "config")
+    loop = asyncio.new_event_loop()
+    try:
+        result_first = loop.run_until_complete(vault.set_if_absent("K", "first"))
+        result_second = loop.run_until_complete(vault.set_if_absent("K", "second"))
+    finally:
+        loop.close()
+    # Fresh write returns the encrypted entry dict (truthy, non-None).
+    assert result_first is not None and isinstance(
+        result_first, dict
+    ), "set_if_absent must return the entry dict on a fresh write"
+    # Key already present: returns None.
+    assert result_second is None, "set_if_absent must return None when key already exists"
+    assert SecretVault(tmp_path / "config").get("K").reveal() == "first"
+
+
+def test_crlf_env_preserves_line_endings(tmp_path: Path) -> None:
+    """A CRLF `.env` keeps CRLF on every line after migration — the rewrite must
+    not silently convert unchanged (or rewritten) lines to LF."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_bytes(b"# c\r\nJIRA_API_TOKEN=plain\r\nOTHER=keep\r\n")
+
+    _migrate(config_dir, ep, dry_run=False)
+
+    raw = ep.read_bytes()
+    assert b"\r\n" in raw
+    assert b"\n" not in raw.replace(b"\r\n", b"")  # no bare LF introduced
+    assert b"JIRA_API_TOKEN=secret://JIRA_API_TOKEN\r\n" in raw
+    assert b"OTHER=keep\r\n" in raw
+
+
+def test_apply_survives_non_utf8_env_bytes(tmp_path: Path) -> None:
+    """A .env containing non-UTF-8 bytes (decoded via surrogateescape) must not
+    crash the atomic rewrite: new_text is re-encoded with surrogateescape so
+    the original bytes round-trip byte-for-byte instead of raising
+    UnicodeEncodeError under strict UTF-8."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    # A migratable token line plus a comment carrying a raw non-UTF-8 byte.
+    ep.write_bytes(b"# host \xff comment\nJIRA_API_TOKEN=plaintext-token\n")
+
+    report = _migrate(config_dir, ep, dry_run=False)
+
+    assert "JIRA_API_TOKEN" in report.migrated
+    # Vault stored the token; the non-UTF-8 comment byte survived the rewrite.
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN").reveal() == "plaintext-token"
+    raw = ep.read_bytes()
+    assert b"\xff" in raw
+    assert b"JIRA_API_TOKEN=secret://JIRA_API_TOKEN" in raw
+
+
+def test_vault_entry_deleted_between_store_and_rewrite_aborts(tmp_path: Path, monkeypatch) -> None:
+    """If a vault entry is deleted after _store_all() writes it but before the
+    .env atomic_write (the store→rewrite window), the importer must raise
+    MigrationConflictError and leave the .env plaintext untouched — the
+    original token must not be lost to a dangling secret:// reference."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=plaintext-token\n")
+
+    # Simulate a concurrent delete: the real vault.get() returns None, meaning
+    # the entry was removed after the vault write but before the .env rewrite.
+    real_get = SecretVault.get
+
+    def _get_returns_none(self, name):
+        if name == "JIRA_API_TOKEN":
+            return None
+        return real_get(self, name)
+
+    monkeypatch.setattr(SecretVault, "get", _get_returns_none)
+
+    with pytest.raises(MigrationConflictError, match="deleted during migration"):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # .env plaintext is unchanged — not rewritten to a dangling secret://.
+    assert ep.read_text() == "JIRA_API_TOKEN=plaintext-token\n"
+
+
+def test_vault_entry_replaced_between_store_and_rewrite_aborts(tmp_path: Path, monkeypatch) -> None:
+    """If a vault entry's value is changed after _store_all() but before the
+    .env rewrite, the importer must raise MigrationConflictError and leave the
+    .env plaintext untouched — the original value must not be silently discarded
+    while .env is rewritten to point at a now-different vault entry."""
+    from kiro_crew.secrets.vault import SecretValue
+
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=original-token\n")
+
+    # Simulate a concurrent replacement: the vault write (set_if_absent) stores
+    # "original-token" normally, but by the time the re-verify loop calls
+    # vault.get() the entry holds "replacement-token" instead — as if a
+    # concurrent dashboard edit or second import overwrote it.  We model this
+    # by patching vault.get() to return the replacement value; no nested event
+    # loop is needed since vault.get() is synchronous.
+    real_get = SecretVault.get
+
+    def _get_returns_replacement(self, name):
+        if name == "JIRA_API_TOKEN":
+            return SecretValue("replacement-token")
+        return real_get(self, name)
+
+    monkeypatch.setattr(SecretVault, "get", _get_returns_replacement)
+
+    with pytest.raises(MigrationConflictError, match="changed during migration"):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # .env plaintext is unchanged — not rewritten while the vault holds a
+    # different value.
+    assert ep.read_text() == "JIRA_API_TOKEN=original-token\n"
+
+
+def test_vault_delete_during_held_lock_cannot_strand_plaintext(tmp_path: Path, monkeypatch) -> None:
+    """hold_cross_process_lock() protects the re-verify + atomic_write pair.
+
+    A concurrent vault DELETE that arrives AFTER _store_all() writes the value
+    but BEFORE the .env rewrite must NOT strand the plaintext: the importer
+    holds the vault cross-process flock for the entire re-verify + rewrite
+    window, so any DELETE that tries to acquire the same flock is queued until
+    AFTER atomic_write commits.
+
+    We can't simulate a true concurrent DELETE via OS-level locking in a single
+    process, so we verify the STRUCTURAL guarantee instead: the
+    hold_cross_process_lock() context manager is entered before vault.get() is
+    called and is still held when atomic_write() runs.  We do this by patching
+    hold_cross_process_lock() to record entry/exit events and patching
+    vault.get() + atomic_write to record when they run relative to the lock.
+    """
+    from contextlib import contextmanager
+
+    from kiro_crew.secrets.vault import SecretVault
+
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=plaintext-token\n")
+
+    events: list[str] = []
+
+    real_hold = SecretVault.hold_cross_process_lock
+
+    @contextmanager
+    def _tracking_hold(self):
+        events.append("lock_acquired")
+        try:
+            with real_hold(self):
+                yield
+        finally:
+            events.append("lock_released")
+
+    real_get = SecretVault.get
+
+    def _tracking_get(self, name):
+        events.append(f"vault_get:{name}")
+        return real_get(self, name)
+
+    real_atomic = None
+
+    def _tracking_atomic_write(path, content, **kwargs):
+        events.append("atomic_write")
+        real_atomic(path, content, **kwargs)
+
+    import kiro_crew.atomic_write as _atomic_mod
+    import kiro_crew.secrets.migrate as _migrate_mod
+
+    real_atomic = _atomic_mod.atomic_write
+    monkeypatch.setattr(SecretVault, "hold_cross_process_lock", _tracking_hold)
+    monkeypatch.setattr(SecretVault, "get", _tracking_get)
+    monkeypatch.setattr(_migrate_mod, "atomic_write", _tracking_atomic_write)
+
+    _migrate(config_dir, ep, dry_run=False)
+
+    # Events will contain two lock cycles:
+    # [0] lock_acquired / lock_released — from _store_all()'s set_if_absent
+    #     (which uses _cross_process_lock → hold_cross_process_lock internally)
+    # [1] lock_acquired / vault_get / atomic_write / lock_released — the outer
+    #     critical section added by the fix
+    #
+    # We verify that vault.get() and atomic_write both occur INSIDE the second
+    # (outermost explicit) lock acquisition — i.e. between the last
+    # lock_acquired and its matching lock_released.
+    assert events.count("lock_acquired") >= 2, "expected ≥2 lock acquisitions"
+    write_idx = events.index("atomic_write")
+    get_idx = next(i for i, e in enumerate(events) if e.startswith("vault_get:"))
+    # Find the lock_acquired that precedes atomic_write (looking backwards).
+    outer_acquire_idx = max(
+        i for i, e in enumerate(events) if e == "lock_acquired" and i < write_idx
+    )
+    # Find the lock_released that follows atomic_write (looking forwards).
+    outer_release_idx = next(
+        i for i, e in enumerate(events) if e == "lock_released" and i > write_idx
+    )
+    assert outer_acquire_idx < get_idx, "vault.get() must run after the outer lock is acquired"
+    assert get_idx < write_idx, "atomic_write must run after vault.get()"
+    assert write_idx < outer_release_idx, "lock must be held through atomic_write"
+
+
+# ── Fix 1: lock inside .vault ────────────────────────────────────────────────
+
+
+def test_env_lock_path_is_inside_vault_dir(tmp_path: Path) -> None:
+    """_env_lock_path must return a path inside the sandbox-hidden .vault dir.
+
+    A lock outside .vault lives in the agent-writable config dir, so an
+    unconfined agent can delete/replace the held lock inode and defeat
+    serialisation. Inside .vault, every sandbox tier bind-mount-hides the dir.
+    """
+    from kiro_crew.secrets.migrate import _env_lock_path
+
+    ep = tmp_path / "config" / ".env"
+    ep.parent.mkdir(parents=True, exist_ok=True)
+    lock = _env_lock_path(ep)
+    vault_dir = ep.parent / ".vault"
+    assert vault_dir.is_dir(), "vault dir must be created by _env_lock_path"
+    assert lock.parent == vault_dir, f"lock {lock} must be inside {vault_dir}"
+    assert lock.name == ".env.lock"
+
+
+# ── Fix 2: orphan vault rollback on failed apply ─────────────────────────────
+
+
+def test_atomic_write_failure_rolls_back_vault_entries(tmp_path: Path, monkeypatch) -> None:
+    """When atomic_write raises after vault entries are stored, every entry
+    written by this run must be deleted so the vault has NO orphan entries and
+    a re-run starts from the original plaintext.  The .env must be unchanged."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=plaintext-tok\n")
+
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("kiro_crew.secrets.migrate.atomic_write", _boom)
+
+    with pytest.raises(OSError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # Vault must have NO entry — the rollback deleted what _store_all wrote.
+    assert SecretVault(config_dir).get("JIRA_API_TOKEN") is None
+    # .env is untouched — the atomic rewrite never ran.
+    assert ep.read_text() == "JIRA_API_TOKEN=plaintext-tok\n"
+
+
+def test_partial_store_failure_rolls_back_the_first_key(tmp_path: Path, monkeypatch) -> None:
+    """A multi-key import that stores key 1 then hits a conflict on key 2 raises
+    from INSIDE _store_all. That raise must still roll back key 1 — otherwise it
+    stays an orphan vault entry that vault-first resolution could later use to
+    shadow a rotated plaintext. Assert the first key is deleted after the abort."""
+    config_dir = tmp_path / "config"
+    ep = tmp_path / ".env"
+    # Two migratable global-style keys (JIRA per-host tokens are migrated).
+    hostA = "a.atlassian.net".encode().hex().upper()
+    hostB = "b.atlassian.net".encode().hex().upper()
+    keyA = f"JIRA_TOKEN_{hostA}"
+    keyB = f"JIRA_TOKEN_{hostB}"
+    ep.write_text(f"{keyA}=tok-a\n{keyB}=tok-b\n")
+
+    # set_if_absent: store the first key for real, then simulate a concurrent
+    # writer winning the second key (returns False → _store_all raises).
+    real_set_if_absent = SecretVault.set_if_absent
+    seen: list[str] = []
+
+    async def _second_key_conflicts(self, name, value):
+        seen.append(name)
+        if len(seen) == 1:
+            return await real_set_if_absent(self, name, value)  # first key writes
+        return None  # second key: another writer won → _store_all raises
+
+    monkeypatch.setattr(SecretVault, "set_if_absent", _second_key_conflicts)
+
+    with pytest.raises(MigrationConflictError):
+        _migrate(config_dir, ep, dry_run=False)
+
+    # The first key was stored then ROLLED BACK — no orphan entry survives.
+    v = SecretVault(config_dir)
+    assert v.get(keyA) is None
+    assert v.get(keyB) is None
+    # .env untouched.
+    assert ep.read_text() == f"{keyA}=tok-a\n{keyB}=tok-b\n"
+
+
+def test_rollback_does_not_delete_concurrently_overwritten_vault_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rollback must NOT delete a vault entry that a concurrent writer overwrote
+    between our set_if_absent call and the failure.  Deleting the concurrent
+    writer's newer value would cause silent data loss.
+
+    The fix: rollback now uses _compare_and_delete_sync with ciphertext-identity
+    comparison — it receives the exact encrypted entry dict set_if_absent returned,
+    and only deletes when the stored dict matches exactly. A concurrent writer
+    produces a different ciphertext dict (random nonce) so its entry is never
+    deleted.
+
+    This test verifies the rollback path at the integration level: it patches
+    _compare_and_delete_sync to return False (simulating 'concurrent overwrite
+    detected — entry dicts differ') and asserts that the vault entry is NOT
+    deleted, while the unit tests (test_compare_and_delete_sync_skips_changed_entry
+    and test_compare_and_delete_sync_deletes_matching_entry) verify the primitive
+    itself against real ciphertext.
+    """
+    config_dir_path = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=our-value\n")
+
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("kiro_crew.secrets.migrate.atomic_write", _boom)
+
+    # Patch _compare_and_delete_sync to return False (simulating concurrent
+    # overwrite detected: stored entry dict differs from expected_entry) and
+    # track calls. expected is now a dict[str, str] entry, not a plaintext str.
+    _cad_calls: list[tuple] = []
+
+    def _fake_cad(self, name, expected):
+        _cad_calls.append((name, expected))
+        return False  # simulate: stored dict differs, do NOT delete
+
+    monkeypatch.setattr(SecretVault, "_compare_and_delete_sync", _fake_cad)
+
+    with pytest.raises(OSError):
+        _migrate(config_dir_path, ep, dry_run=False)
+
+    # _compare_and_delete_sync must have been called for our key.
+    assert any(
+        k == "JIRA_API_TOKEN" for k, _ in _cad_calls
+    ), "_compare_and_delete_sync was not called for JIRA_API_TOKEN"
+    # The expected argument must be a dict (the ciphertext entry), not a string.
+    for k, expected in _cad_calls:
+        if k == "JIRA_API_TOKEN":
+            assert isinstance(
+                expected, dict
+            ), f"_compare_and_delete_sync expected arg must be an entry dict, got {type(expected)}"
+    # Because _compare_and_delete_sync returned False, the vault entry must
+    # NOT have been deleted.  The .env is untouched.
+    assert ep.read_text() == "JIRA_API_TOKEN=our-value\n"
+
+
+def test_compare_and_delete_sync_skips_changed_entry(tmp_path: Path) -> None:
+    """_compare_and_delete_sync must return False (and leave the entry intact)
+    when the stored ciphertext entry dict differs from expected_entry — i.e. a
+    concurrent writer has overwrote the entry between our set_if_absent and the
+    rollback.  Even the same plaintext value encrypts to a different dict
+    (random nonce), so any re-encryption by another writer produces a different
+    expected_entry and rollback must NOT delete it."""
+    import asyncio as _asyncio
+
+    v = SecretVault(tmp_path / "vault")
+    loop = _asyncio.new_event_loop()
+    try:
+        # Capture the entry dict that set_if_absent wrote.
+        original_entry = loop.run_until_complete(v.set_if_absent("KEY", "original"))
+    finally:
+        loop.close()
+    assert original_entry is not None
+
+    # Simulate a concurrent writer: overwrite with the same plaintext value.
+    # Because _encrypt_entry uses a random nonce, this produces a DIFFERENT
+    # ciphertext dict from the one set_if_absent returned.
+    v._set_sync("KEY", "original")
+
+    # Read back the new stored entry to confirm it differs from original_entry.
+    stored_entries = v._load_entries()
+    assert stored_entries["KEY"] != original_entry, (
+        "Test setup: re-encryption must produce a different ciphertext dict "
+        "(random nonce guarantee)"
+    )
+
+    # compare_and_delete with the OLD entry dict -> ciphertext differs -> must NOT delete.
+    deleted = v._compare_and_delete_sync("KEY", original_entry)
+    assert (
+        not deleted
+    ), "_compare_and_delete_sync must return False when stored ciphertext differs from expected"
+    entry = v.get("KEY")
+    assert (
+        entry is not None and entry.reveal() == "original"
+    ), "Entry must not be deleted when ciphertext identity does not match"
+
+
+def test_compare_and_delete_sync_deletes_matching_entry(tmp_path: Path) -> None:
+    """_compare_and_delete_sync must return True and delete the entry when the
+    stored ciphertext entry dict exactly matches expected_entry (no concurrent
+    overwrite — same dict that set_if_absent wrote)."""
+    import asyncio as _asyncio
+
+    v = SecretVault(tmp_path / "vault")
+    loop = _asyncio.new_event_loop()
+    try:
+        entry = loop.run_until_complete(v.set_if_absent("KEY", "our-value"))
+    finally:
+        loop.close()
+    assert entry is not None, "set_if_absent must return entry dict on fresh write"
+
+    deleted = v._compare_and_delete_sync("KEY", entry)
+    assert deleted, "_compare_and_delete_sync must return True when entry dict matches"
+    assert v.get("KEY") is None, "Entry must be deleted when ciphertext identity matches"
+
+
+def test_rollback_deletes_unchanged_vault_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rollback MUST delete a vault entry when the value is still the one THIS
+    run wrote (no concurrent overwrite).  _compare_and_delete_sync compares
+    under the flock and deletes atomically.
+    """
+    config_dir_path = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=plaintext-tok\n")
+
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("kiro_crew.secrets.migrate.atomic_write", _boom)
+
+    with pytest.raises(OSError):
+        _migrate(config_dir_path, ep, dry_run=False)
+
+    # Value was unchanged between write and rollback -> rollback MUST delete it.
+    v = SecretVault(config_dir_path)
+    assert (
+        v.get("JIRA_API_TOKEN") is None
+    ), "Rollback should have deleted the vault entry when the value was unchanged"
+    # .env untouched.
+    assert ep.read_text() == "JIRA_API_TOKEN=plaintext-tok\n"
+
+
+def test_rollback_no_deadlock_under_concurrent_flock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify _compare_and_delete_sync does not deadlock when called from the
+    rollback path.  The old vault.delete() path would re-acquire the cross-process
+    flock inside _write_store, which deadlocks on POSIX if the caller already holds
+    hold_cross_process_lock().  The new path calls _compare_and_delete_sync via
+    asyncio.to_thread, which acquires the flock exactly once inside _write_store
+    and never holds it externally.  This test confirms the rollback completes
+    without hanging.
+    """
+    config_dir_path = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=deadlock-test\n")
+
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("kiro_crew.secrets.migrate.atomic_write", _boom)
+
+    # Call the rollback path directly (no background worker): the fixed
+    # _compare_and_delete_sync acquires the cross-process flock exactly once
+    # inside _write_store and never while the caller holds it, so the rollback
+    # runs to completion and _migrate raises the injected OSError rather than
+    # hanging. A direct call avoids leaking a daemon worker / per-test lock
+    # state if this ever regressed (the old probe left the thread running).
+    with pytest.raises(OSError, match="disk full"):
+        _migrate(config_dir_path, ep, dry_run=False)
+
+
+def test_rollback_delete_failure_records_orphaned_key_and_propagates_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When _compare_and_delete_sync raises during rollback (e.g. ENOSPC),
+    the failing key must be recorded in report.orphaned_vault_keys so the caller
+    can surface it to the operator, AND the original error must still propagate.
+
+    This covers Finding 3: the old ``except Exception: pass`` silently swallowed
+    ENOSPC, leaving an authoritative vault entry that could shadow future rotations
+    without any diagnostic.
+    """
+    import logging
+
+    config_dir_path = tmp_path / "config"
+    ep = tmp_path / ".env"
+    ep.write_text("JIRA_API_TOKEN=secret-val\n")
+
+    # Make atomic_write fail so the rollback path is exercised.
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("kiro_crew.secrets.migrate.atomic_write", _boom)
+
+    # Make _compare_and_delete_sync raise to simulate ENOSPC / I/O error.
+    def _raise_enospc(self, name, expected):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(SecretVault, "_compare_and_delete_sync", _raise_enospc)
+
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.secrets.migrate"):
+        with pytest.raises(OSError, match="disk full"):
+            _migrate(config_dir_path, ep, dry_run=False)
+
+    # The orphaned key must be surfaced via a WARNING log message.
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(
+        "JIRA_API_TOKEN" in str(m) for m in warning_msgs
+    ), f"Expected WARNING naming orphaned key; got: {warning_msgs}"
+    assert any(
+        "kirocrew secrets rm" in str(m) for m in warning_msgs
+    ), "WARNING must mention cleanup command"

--- a/test/test_slack_config_handlers.py
+++ b/test/test_slack_config_handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 
 from aiohttp.test_utils import make_mocked_request
@@ -87,8 +88,12 @@ def test_write_env_updates_is_atomic_and_owner_only(tmp_path: Path, monkeypatch)
     assert "SLACK_BOT_TOKEN=xoxb-new" in text
     assert "WECOM_SECRET=other" in text  # unrelated credential preserved
     assert (env.stat().st_mode & 0o077) == 0  # owner-only
-    # No stray temp files left behind in the dir.
-    assert not any(p.name.startswith(".env.") for p in tmp_path.iterdir())
+    # No stray temp files left behind in the dir. The persistent `.env.lock`
+    # advisory-lock sibling (shared by all .env writers) is expected and is not
+    # a temp leftover, so only the atomic-write temp pattern is checked.
+    assert not any(
+        p.name.startswith(".env.") and p.name.endswith(".tmp") for p in tmp_path.iterdir()
+    )
 
 
 class _StubRequest:
@@ -211,7 +216,7 @@ def test_save_rejects_token_slack_refuses(tmp_path, monkeypatch) -> None:
         return "invalid_auth"
 
     monkeypatch.setattr(mod, "_validate_slack_token", _reject)
-    (status_body, env) = _client_put(mod, monkeypatch, tmp_path, {"bot_token": "xoxb-bad"})
+    status_body, env = _client_put(mod, monkeypatch, tmp_path, {"bot_token": "xoxb-bad"})
     status, body = status_body
     assert status == 400
     assert "invalid_auth" in body["error"]
@@ -226,7 +231,7 @@ def test_save_proceeds_with_warning_when_slack_unreachable(tmp_path, monkeypatch
         raise ConnectionError("no route to slack.com")
 
     monkeypatch.setattr(mod, "_validate_slack_token", _unreachable)
-    (status_body, env) = _client_put(mod, monkeypatch, tmp_path, {"bot_token": "xoxb-offline"})
+    status_body, env = _client_put(mod, monkeypatch, tmp_path, {"bot_token": "xoxb-offline"})
     status, body = status_body
     assert status == 200
     assert body["verify_warning"]
@@ -318,3 +323,495 @@ def test_restart_required_only_on_actual_change(tmp_path, monkeypatch) -> None:
     # Changed command (boot-read): restart.
     body = asyncio.run(_run({"command": "myclaw"}))
     assert body["restart_required"] is True
+
+
+def test_webex_held_env_lock_leaves_legacy_credential_intact(tmp_path, monkeypatch) -> None:
+    """When the .env lock is held (concurrent import), _write_env_updates raises
+    OSError.  The Webex save handler must NOT purge the legacy config.json
+    ``webex.bot_token`` fallback before the .env write succeeds: a held lock
+    must leave the pre-existing credential intact in both stores."""
+    import asyncio
+    import json
+
+    import kiro_crew.config.loader as loader
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    env.write_text("WEBEX_BOT_TOKEN=old-env-token\n", encoding="utf-8")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps({"webex": {"bot_token": "legacy-plaintext", "enabled": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    # Simulate a held .env lock: _write_env_updates raises OSError.
+    def _write_env_raises(_updates):
+        raise OSError("env is locked by another process")
+
+    monkeypatch.setattr(mod, "_write_env_updates", _write_env_raises)
+
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def _run():
+        app = web.Application()
+        app.router.add_put("/api/webex/config", mod.api_webex_config_save)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(
+                "/api/webex/config",
+                json={"bot_token": "new-token"},
+            )
+            return resp.status
+
+    status = asyncio.run(_run())
+    # The handler must propagate the OSError (unhandled = 500).
+    assert status >= 400
+
+    # CRITICAL: the legacy bot_token in config.json must NOT have been cleared —
+    # the pre-existing credential must survive the failed write.
+    saved = json.loads(cfg.read_text(encoding="utf-8"))
+    assert (
+        saved["webex"]["bot_token"] == "legacy-plaintext"
+    ), "legacy config.json credential was purged even though .env write failed"
+
+
+def test_teams_held_env_lock_leaves_legacy_credential_intact(tmp_path, monkeypatch) -> None:
+    """When the .env lock is held (concurrent import), _write_env_updates raises
+    OSError.  The Teams save handler must NOT purge the legacy config.json
+    ``teams.app_password`` before the .env write succeeds: a held lock must
+    leave the pre-existing credential intact in both stores."""
+    import asyncio
+    import json
+
+    import kiro_crew.config.loader as loader
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    env.write_text("MICROSOFT_APP_PASSWORD=old-pass\n", encoding="utf-8")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "teams": {
+                    "app_password": "legacy-pass",
+                    "app_id": "app-123",
+                    "enabled": True,
+                    "allowed_emails": ["admin@example.com"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    # Simulate a held .env lock: asyncio.to_thread(_write_env_updates, ...) raises.
+    _orig_to_thread = asyncio.to_thread
+
+    async def _to_thread_raise(fn, *args, **kwargs):
+        if fn is mod._write_env_updates:
+            raise OSError("env is locked by another process")
+        return await _orig_to_thread(fn, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", _to_thread_raise)
+
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def _run():
+        app = web.Application()
+        app.router.add_put("/api/teams/config", mod.api_teams_config_save)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(
+                "/api/teams/config",
+                json={"app_password": "new-pass"},
+            )
+            return resp.status
+
+    status = asyncio.run(_run())
+    # The handler must propagate the OSError (unhandled = 500).
+    assert status >= 400
+
+    # CRITICAL: the legacy app_password in config.json must NOT have been cleared.
+    saved = json.loads(cfg.read_text(encoding="utf-8"))
+    assert (
+        saved["teams"]["app_password"] == "legacy-pass"
+    ), "legacy config.json credential was purged even though .env write failed"
+
+
+def test_teams_config_json_write_failure_leaves_consistent_pair(tmp_path, monkeypatch) -> None:
+    """Teams SET that rotates password+app_id: if _atomic_json_write raises,
+    .env must be UNTOUCHED — the config-first ordering means a config-write
+    failure leaves old-credential + old-metadata, always a consistent pair.
+
+    Failure scenario (config-first ordering):
+      1. config.json write attempted — raises (e.g. disk full).
+      2. .env is never written (handler raised before reaching _commit_env).
+      3. Both stores still hold their original values.
+      -> Restart sees old-pass + old app_id/tenant: consistent, no auth failure.
+    """
+    import json
+
+    import kiro_crew.agent as agent_mod
+    import kiro_crew.config.loader as loader
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    env.write_text("MICROSOFT_APP_PASSWORD=old-pass\n", encoding="utf-8")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "teams": {
+                    "app_id": "old-app-id",
+                    "tenant_id": "old-tenant",
+                    "enabled": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    # _atomic_json_write is imported locally inside the handler function via
+    # `from kiro_crew.agent import _atomic_json_write`.  Patch the source module
+    # so the local import picks up the stub.
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(agent_mod, "_atomic_json_write", _boom)
+
+    # Track _write_env_updates calls: with config-first ordering, .env must
+    # never be written when the config write fails.
+    _write_env_calls: list[dict] = []
+    _orig_write_env = mod._write_env_updates
+
+    def _track_write_env(updates):
+        _write_env_calls.append(dict(updates))
+        _orig_write_env(updates)
+
+    monkeypatch.setattr(mod, "_write_env_updates", _track_write_env)
+
+    # Skip Azure credential verification (network call) — not the focus here.
+    async def _mock_validate(*a, **kw):
+        return None  # no error -> verified_triple is set
+
+    monkeypatch.setattr(mod, "_validate_teams_app_credentials", _mock_validate)
+
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def _run():
+        app = web.Application()
+        app.router.add_put("/api/teams/config", mod.api_teams_config_save)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(
+                "/api/teams/config",
+                json={
+                    "app_password": "new-pass",
+                    "app_id": "new-app-id",
+                },
+            )
+            return resp.status
+
+    status = asyncio.run(_run())
+
+    # Handler must propagate the OSError as an HTTP 500.
+    assert status == 500, f"Expected 500, got {status}"
+
+    # CRITICAL: .env must NOT have been written at all — config write failed
+    # before the handler reached _commit_env().
+    assert _write_env_calls == [], (
+        "Config-first ordering: _write_env_updates must not be called when "
+        f"_atomic_json_write raises; got calls: {_write_env_calls}"
+    )
+
+    # .env must still hold the original password, untouched.
+    env_text = env.read_text(encoding="utf-8")
+    assert "old-pass" in env_text, f"Expected .env to retain old-pass, got: {env_text!r}"
+    assert (
+        "new-pass" not in env_text
+    ), f"new-pass must not appear in .env when config write failed; got: {env_text!r}"
+
+    # config.json must be unchanged (the atomic write raised before persisting).
+    saved = json.loads(cfg.read_text(encoding="utf-8"))
+    assert (
+        saved["teams"].get("app_id") == "old-app-id"
+    ), f"config.json must not have been mutated; got: {saved}"
+
+
+def test_teams_config_write_failure_preserves_process_only_credential(
+    tmp_path, monkeypatch
+) -> None:
+    """Teams SET with config-write failure must NOT clobber a credential that
+    lives ONLY in os.environ (not in .env).
+
+    Scenario:
+      - os.environ["MICROSOFT_APP_PASSWORD"] = "env-only-pass"  (process-only)
+      - .env file has no MICROSOFT_APP_PASSWORD entry at all
+      - _atomic_json_write raises (disk full)
+
+    With config-first ordering: config write fails before _commit_env() is
+    called, so os.environ is never mutated by the handler.  The process-only
+    credential is trivially preserved — no special rollback logic needed.
+    """
+    import json
+
+    import kiro_crew.agent as agent_mod
+    import kiro_crew.config.loader as loader
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    # .env has NO password entry — credential exists only in os.environ.
+    env = tmp_path / ".env"
+    env.write_text("", encoding="utf-8")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "teams": {
+                    "app_id": "old-app-id",
+                    "tenant_id": "old-tenant",
+                    "enabled": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    # Plant the credential ONLY in os.environ, not in .env.
+    monkeypatch.setenv("MICROSOFT_APP_PASSWORD", "env-only-pass")
+
+    def _boom(path, data, **kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(agent_mod, "_atomic_json_write", _boom)
+
+    async def _mock_validate(*a, **kw):
+        return None
+
+    monkeypatch.setattr(mod, "_validate_teams_app_credentials", _mock_validate)
+
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def _run():
+        app = web.Application()
+        app.router.add_put("/api/teams/config", mod.api_teams_config_save)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(
+                "/api/teams/config",
+                json={"app_password": "new-pass", "app_id": "new-app-id"},
+            )
+            return resp.status
+
+    status = asyncio.run(_run())
+    assert status == 500, f"Expected 500, got {status}"
+
+    # CRITICAL: the process-only credential must survive intact.
+    # With config-first ordering the handler never reaches _commit_env(), so
+    # os.environ is untouched by the failed request.
+    assert os.environ.get("MICROSOFT_APP_PASSWORD") == "env-only-pass", (
+        "Config-first ordering: process-only credential must be untouched when "
+        f"config write fails; got: {os.environ.get('MICROSOFT_APP_PASSWORD')!r}"
+    )
+    # .env must NOT hold the new credential value — .env was never written.
+    assert "new-pass" not in env.read_text(
+        encoding="utf-8"
+    ), ".env must not be written when config write fails (config-first ordering)"
+
+
+def test_teams_legacy_config_only_password_preserved_on_metadata_only_save(
+    tmp_path, monkeypatch
+) -> None:
+    """Finding 1 regression: editing only app_id when the password lives ONLY in
+    legacy config.json (not in .env or os.environ) must NOT cause the password to
+    be treated as absent, skipping verification and allowing Phase-2 to purge it.
+
+    Scenario:
+      - config.json has teams.app_password = "legacy-only-pass" (no .env entry)
+      - operator edits only app_id (no new password in the request body)
+
+    Expected: verification is called with the legacy password (not empty), and
+    after a successful save the password is NOT purged from config.json.
+    """
+    import asyncio
+    import json
+
+    import kiro_crew.config.loader as loader
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    env.write_text("", encoding="utf-8")  # no MICROSOFT_APP_PASSWORD in .env
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "teams": {
+                    "app_password": "legacy-only-pass",
+                    "app_id": "old-app-id",
+                    "tenant_id": "t-1",
+                    "enabled": True,
+                    "allowed_emails": ["admin@example.com"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    # Capture what password is passed to Azure verification.
+    verify_calls: list[tuple[str, str, str]] = []
+
+    async def _mock_validate(app_id: str, app_password: str, tenant_id: str):
+        verify_calls.append((app_id, app_password, tenant_id))
+        return None  # no error — credentials accepted
+
+    monkeypatch.setattr(mod, "_validate_teams_app_credentials", _mock_validate)
+
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def _run():
+        app = web.Application()
+        app.router.add_put("/api/teams/config", mod.api_teams_config_save)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(
+                "/api/teams/config",
+                json={"app_id": "new-app-id"},  # only app_id changed, no password
+            )
+            return resp.status
+
+    status = asyncio.run(_run())
+    assert status == 200, f"Expected 200, got {status}"
+
+    # CRITICAL: verification must have been called with the legacy password, not "".
+    assert len(verify_calls) == 1, f"Expected one verify call, got: {verify_calls}"
+    _verified_app_id, _verified_pw, _verified_tenant = verify_calls[0]
+    assert _verified_pw == "legacy-only-pass", (
+        f"Verification was called with empty/wrong password '{_verified_pw}' "
+        "instead of the legacy config.json password; password-only-in-config "
+        "path is broken (Finding 1)"
+    )
+
+    # The password must NOT have been purged from config.json after the save.
+    saved = json.loads(cfg.read_text(encoding="utf-8"))
+    # The handler purges app_password from config.json once the .env write
+    # succeeds (moving it to .env), so it IS expected to be cleared/empty here
+    # only when the password was newly written to .env.  In this test no new
+    # password was supplied, so no .env write for the password occurred, and the
+    # legacy value must survive.
+    env_text = env.read_text(encoding="utf-8")
+    # Either the password stays in config.json OR it was migrated to .env; the
+    # important invariant is that it does NOT simply disappear (be set to "").
+    legacy_still_in_cfg = saved["teams"].get("app_password") == "legacy-only-pass"
+    migrated_to_env = "legacy-only-pass" in env_text
+    assert legacy_still_in_cfg or migrated_to_env, (
+        "Legacy config.json password was lost after a metadata-only save "
+        f"(app_id edit). config: {saved['teams'].get('app_password')!r}, "
+        f"env: {env_text!r}"
+    )
+
+
+def test_teams_cancellation_after_successful_env_write_does_not_rollback_config(
+    tmp_path, monkeypatch
+) -> None:
+    """Finding 2 regression: if the request is cancelled AFTER the .env write has
+    already committed, the config metadata must NOT be rolled back.
+
+    Rolling config back after a successful .env write leaves new .env paired
+    with old config — the exact mismatch the rollback is supposed to prevent.
+
+    Scenario:
+      - Teams save with a new password triggers _write_env_off_loop
+      - The env write completes (actually writes to .env), then CancelledError
+        is raised to the handler (post-commit cancellation)
+
+    Expected: config.json retains the NEW app_id (written before .env); it is
+    NOT rolled back to the original.
+    """
+    import asyncio
+    import json
+
+    import kiro_crew.config.loader as loader
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    env.write_text("MICROSOFT_APP_PASSWORD=old-pass\n", encoding="utf-8")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "teams": {
+                    "app_id": "old-app-id",
+                    "tenant_id": "t-1",
+                    "enabled": True,
+                    "allowed_emails": ["admin@example.com"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    async def _mock_validate(*a, **kw):
+        return None  # accepted
+
+    monkeypatch.setattr(mod, "_validate_teams_app_credentials", _mock_validate)
+
+    # Replace _write_env_off_loop with a version that SUCCESSFULLY writes the
+    # .env and THEN raises CancelledError (simulating cancellation-after-commit).
+    _orig_write_env_updates = mod._write_env_updates
+
+    async def _write_env_succeeds_then_cancels(updates):
+        # Actually write to .env so the credential is committed on disk.
+        _orig_write_env_updates(updates)
+        # Simulate cancellation arriving after the write completed.
+        raise asyncio.CancelledError("simulated post-commit cancellation")
+
+    monkeypatch.setattr(mod, "_write_env_off_loop", _write_env_succeeds_then_cancels)
+
+    class _FakeRequest:
+        app: dict = {"state": None}
+
+        async def json(self) -> dict:
+            return {"app_id": "new-app-id", "app_password": "new-pass"}
+
+        def get(self, key, default=None):
+            return default
+
+    _got_cancelled = False
+
+    async def _run():
+        nonlocal _got_cancelled
+        try:
+            await mod.api_teams_config_save(_FakeRequest())
+        except asyncio.CancelledError:
+            _got_cancelled = True
+
+    asyncio.run(_run())
+    assert _got_cancelled, "Expected CancelledError to propagate from the handler"
+
+    # CRITICAL: config.json must NOT have been rolled back.
+    saved = json.loads(cfg.read_text(encoding="utf-8"))
+    assert saved["teams"].get("app_id") == "new-app-id", (
+        "Config was incorrectly rolled back after cancellation-after-successful-env-write. "
+        f"Expected new-app-id, got: {saved['teams'].get('app_id')!r} (Finding 2)"
+    )
+    # .env must have the new password (the write actually committed).
+    env_text = env.read_text(encoding="utf-8")
+    assert (
+        "new-pass" in env_text
+    ), f"Expected .env to contain new-pass after successful write; got: {env_text!r}"

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -7637,6 +7637,337 @@ class TestGetJiraAuth:
         result = source._get_jira_auth("acme.atlassian.net")
         assert result == ("dev@acme.com", "per-host-secret")
 
+    def test_seeded_global_env_does_not_bypass_per_host_vault(self, monkeypatch):
+        """A global JIRA_API_TOKEN that load_credentials merely SEEDED into
+        os.environ (setdefault), not a real pre-existing operator override,
+        must NOT be treated as a live override: a host with its own per-host
+        vault token still gets that per-host token. The snapshot is captured
+        BEFORE load_credentials runs, so a value that did not exist in the
+        environment beforehand is not seen as an override."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        # No REAL operator override present before the call.
+        monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                # Simulate load_credentials' setdefault seeding the .env global
+                # into the process environment during the call. Use monkeypatch
+                # so the seed is auto-reverted at test teardown and cannot leak
+                # into later tests (a raw os.environ.setdefault would persist).
+                monkeypatch.setenv("JIRA_API_TOKEN", "seeded-global")
+                return {"JIRA_API_TOKEN": "seeded-global"}
+
+        host_key = "acme.atlassian.net".encode().hex().upper()
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: "per-host-vault" if name == f"JIRA_TOKEN_{host_key}" else "",
+        )
+        result = source._get_jira_auth("acme.atlassian.net")
+        # Per-host vault token wins; the seeded global is ignored.
+        assert result == ("dev@acme.com", "per-host-vault")
+
+    def test_vault_token_preferred_over_env(self, monkeypatch):
+        """A vault secret wins over the legacy .env value for the same host."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                return {"JIRA_API_TOKEN": "env-token"}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        host_key = "acme.atlassian.net".encode().hex().upper()
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: "vault-token" if name == f"JIRA_TOKEN_{host_key}" else "",
+        )
+        result = source._get_jira_auth("acme.atlassian.net")
+        assert result == ("dev@acme.com", "vault-token")
+
+    def test_vault_miss_falls_back_to_env(self, monkeypatch):
+        """When the vault has no entry, the .env / environ value is used."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                return {"JIRA_API_TOKEN": "env-token"}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        monkeypatch.setattr(source, "_resolve_jira_token_from_vault", lambda name: "")
+        monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+        result = source._get_jira_auth("acme.atlassian.net")
+        assert result == ("dev@acme.com", "env-token")
+
+    def test_vault_single_host_global_token(self, monkeypatch):
+        """Single host with no per-host vault entry uses the global vault secret."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                return {}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: "vault-global" if name == "JIRA_API_TOKEN" else "",
+        )
+        monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+        result = source._get_jira_auth("acme.atlassian.net")
+        assert result == ("dev@acme.com", "vault-global")
+
+    def test_global_env_override_beats_stale_global_vault(self, monkeypatch):
+        """A nonempty process-environment JIRA_API_TOKEN overrides even a stale
+        global vault entry.
+
+        `load_credentials` overlays `os.environ` over the .env for this key, so
+        a live env var is the effective credential — and `secrets import` skips
+        migrating the key while such an override is set. A vault entry left by an
+        EARLIER migration must NOT shadow that override under vault-first
+        resolution. Per-host keys are unaffected (not env-overlaid)."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                # env overlay would also place it here; the resolver reads the
+                # override directly from os.environ before the global vault.
+                return {"JIRA_API_TOKEN": "env-override"}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        # Stale global vault entry that must NOT win.
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: "stale-vault" if name == "JIRA_API_TOKEN" else "",
+        )
+        monkeypatch.setenv("JIRA_API_TOKEN", "env-override")
+        result = source._get_jira_auth("acme.atlassian.net")
+        assert result == ("dev@acme.com", "env-override")
+
+    def test_migrated_secret_ref_in_env_resolves_from_vault_not_uri(self, monkeypatch):
+        """After `secrets import --apply`, the .env line is
+        `JIRA_API_TOKEN=secret://JIRA_API_TOKEN` and `load_credentials`
+        propagates that ref into os.environ AND the creds dict. The resolver
+        must NOT hand the `secret://` URI to Jira as the token — it must treat
+        it as a vault reference and resolve the real secret from the vault."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                # load_credentials overlays the migrated secret:// ref here too.
+                return {"JIRA_API_TOKEN": "secret://JIRA_API_TOKEN"}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: "real-vault-secret" if name == "JIRA_API_TOKEN" else "",
+        )
+        # The migrated ref is propagated into the environment by load_credentials.
+        monkeypatch.setenv("JIRA_API_TOKEN", "secret://JIRA_API_TOKEN")
+        result = source._get_jira_auth("acme.atlassian.net")
+        # The vault secret is used — NOT the secret:// URI.
+        assert result == ("dev@acme.com", "real-vault-secret")
+
+    def test_returns_none_when_no_token_anywhere(self, monkeypatch):
+        """Configured host but neither vault nor env holds a token → None."""
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                return {}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        monkeypatch.setattr(source, "_resolve_jira_token_from_vault", lambda name: "")
+        assert source._get_jira_auth("acme.atlassian.net") is None
+
+    def test_env_override_equal_to_env_file_is_not_genuine_override(self, monkeypatch):
+        """When os.environ['JIRA_API_TOKEN'] equals the .env file value (i.e. it
+        was seeded there by GatewayOrchestrator's startup load_credentials call),
+        it must NOT beat a vault entry — the vault's rotated value should win.
+
+        This is the Finding 2 fix: a value that merely came from .env via
+        load_credentials' setdefault is NOT a genuine operator override.
+        """
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        _ENV_FILE_TOKEN = "stale-env-token"
+        _VAULT_TOKEN = "fresh-vault-token"
+
+        monkeypatch.setenv("JIRA_API_TOKEN", _ENV_FILE_TOKEN)
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                return {"JIRA_API_TOKEN": _ENV_FILE_TOKEN}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        # Per-host vault returns nothing; global vault has the rotated token.
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: (
+                _VAULT_TOKEN if name == "JIRA_API_TOKEN" else ""
+            ),
+        )
+        # .env file contains the same value as os.environ (startup-seeded).
+        monkeypatch.setattr(
+            source,
+            "read_env_file_credential",
+            lambda key: _ENV_FILE_TOKEN if key == "JIRA_API_TOKEN" else "",
+        )
+        result = source._get_jira_auth("acme.atlassian.net")
+        # Vault token must win; the .env-seeded env value must NOT override it.
+        assert result == ("dev@acme.com", _VAULT_TOKEN), (
+            "Vault token should win when env value equals .env file value "
+            f"(startup-seeded); got {result}"
+        )
+
+    def test_env_override_differing_from_env_file_is_genuine_override(self, monkeypatch):
+        """When os.environ['JIRA_API_TOKEN'] DIFFERS from the .env file value,
+        the operator explicitly set it at runtime — it must beat the vault entry.
+        """
+
+        class FakeEntry:
+            host = "acme.atlassian.net"
+            email = "dev@acme.com"
+
+        class FakeDashboard:
+            jira_auth = [FakeEntry()]
+
+        _ENV_FILE_TOKEN = "stale-env-token"
+        _OPERATOR_TOKEN = "operator-set-at-runtime"
+        _VAULT_TOKEN = "vault-token"
+
+        monkeypatch.setenv("JIRA_API_TOKEN", _OPERATOR_TOKEN)
+
+        class FakeConfig:
+            dashboard = FakeDashboard()
+
+            @classmethod
+            def load(cls):
+                return cls()
+
+            def load_credentials(self):
+                return {"JIRA_API_TOKEN": _OPERATOR_TOKEN}
+
+        monkeypatch.setattr(source, "KiroCrewConfig", FakeConfig)
+        monkeypatch.setattr(
+            source,
+            "_resolve_jira_token_from_vault",
+            lambda name: _VAULT_TOKEN if name == "JIRA_API_TOKEN" else "",
+        )
+        # .env file contains a different (older) value — operator set a new one.
+        monkeypatch.setattr(
+            source,
+            "read_env_file_credential",
+            lambda key: _ENV_FILE_TOKEN if key == "JIRA_API_TOKEN" else "",
+        )
+        result = source._get_jira_auth("acme.atlassian.net")
+        # The differing env value is a genuine override; it must win over vault.
+        assert result == ("dev@acme.com", _OPERATOR_TOKEN), (
+            "Operator runtime override should win over vault when it differs "
+            f"from .env file value; got {result}"
+        )
+
 
 class TestJiraIsCloud:
     def test_cloud_host(self):

--- a/test/test_teams_config_handlers.py
+++ b/test/test_teams_config_handlers.py
@@ -357,6 +357,37 @@ class TestSaveCredentialVerification:
         # The secret is env-only: config.json must never hold it.
         assert "app_password" not in data["teams"]
 
+    def test_env_write_failure_restores_prior_config(self, monkeypatch, tmp_path: Path) -> None:
+        """A failed .env credential write must roll config.json back.
+
+        Config metadata is written BEFORE the .env credential. If the .env write
+        then fails, the new app_id would otherwise be left paired with the OLD
+        password on disk (a broken pair that fails Teams auth on restart). The
+        handler snapshots config before writing and restores it on .env failure,
+        so the persisted pair stays consistent (old app_id + old password).
+        """
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(
+            json.dumps({"teams": {"app_id": "app-original", "tenant_id": "t-1"}}),
+            encoding="utf-8",
+        )
+
+        def _boom(_updates):
+            raise OSError("disk full writing .env")
+
+        monkeypatch.setattr(mod, "_write_env_updates", _boom)
+
+        with pytest.raises(OSError):
+            _save(
+                monkeypatch,
+                tmp_path,
+                {"app_id": "app-new", "app_password": "new-secret", "tenant_id": "t-1"},
+            )
+
+        # config.json restored to the pre-save app_id, not left with "app-new".
+        restored = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert restored["teams"]["app_id"] == "app-original"
+
     def test_a_pasted_secret_is_verified_against_the_stored_app_id(
         self, monkeypatch, tmp_path: Path
     ) -> None:

--- a/test/test_webex_config_handlers.py
+++ b/test/test_webex_config_handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -114,6 +115,38 @@ class TestSave:
         assert resp.status == 200
         assert "WEBEX_BOT_TOKEN" not in env.read_text(encoding="utf-8")
 
+    def test_clear_config_write_failure_does_not_leave_env_cleared(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """On a CLEAR, config.json is purged BEFORE .env is emptied. If the
+        config write fails, .env must be untouched — otherwise a restart would
+        fall back to the still-present legacy config.json token (resurrecting
+        the credential the operator asked to clear). Config-purge-first means a
+        config-write failure leaves the credential fully present, never half-
+        cleared into a resurrectable state."""
+        env = tmp_path / ".env"
+        cfg_path = tmp_path / "config.json"
+        env.write_text("WEBEX_BOT_TOKEN=live-token\n", encoding="utf-8")
+        cfg_path.write_text(json.dumps({"webex": {"bot_token": "legacy-token"}}), encoding="utf-8")
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+        monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+        monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+        def _boom(*_a, **_k):
+            raise OSError("disk full during config write")
+
+        import kiro_crew.agent as _agent
+
+        monkeypatch.setattr(_agent, "_atomic_json_write", _boom)
+        try:
+            asyncio.run(mod.api_webex_config_save(_StubRequest({"bot_token_clear": True})))
+        except Exception:
+            pass  # the handler may 500; the invariant is about .env, checked below.
+        # .env still holds the token: config-purge ran first and failed, so the
+        # .env delete never executed — the credential is intact, not resurrected.
+        assert "WEBEX_BOT_TOKEN=live-token" in env.read_text(encoding="utf-8")
+        monkeypatch.delenv("WEBEX_BOT_TOKEN", raising=False)
+
     def test_invalid_email_rejected(self, monkeypatch, tmp_path: Path) -> None:
         resp, _, cfg_path = _save(monkeypatch, tmp_path, {"allowed_emails": ["not-an-email"]})
         assert resp.status == 400
@@ -165,6 +198,102 @@ class TestSave:
         data = json.loads(cfg_path.read_text(encoding="utf-8"))
         assert data["webex"]["bot_token"] == ""  # cleared everywhere
         assert "WEBEX_BOT_TOKEN" not in env.read_text(encoding="utf-8")
+
+    def test_set_config_write_failure_leaves_consistent_pair(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """On a SET, config.json is written FIRST.  If it fails, .env is never
+        touched — old credential + old metadata, always a consistent pair.
+
+        The config write only fires on the SET path when there is a legacy
+        plaintext token in config.json to purge (bot_token -> "").  This test
+        seeds that condition so the config-write failure path is exercised."""
+        env = tmp_path / ".env"
+        cfg_path = tmp_path / "config.json"
+        env.write_text("WEBEX_BOT_TOKEN=old-token\n", encoding="utf-8")
+        # Seed a legacy plaintext token so the handler adds `bot_token: ""`
+        # to `changes`, triggering the config write (and its failure).
+        cfg_path.write_text(json.dumps({"webex": {"bot_token": "legacy-plain"}}), encoding="utf-8")
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+        monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+        monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+        monkeypatch.setattr(mod, "_validate_webex_token", lambda tok: None)
+
+        import kiro_crew.agent as _agent
+
+        def _boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(_agent, "_atomic_json_write", _boom)
+
+        try:
+            asyncio.run(mod.api_webex_config_save(_StubRequest({"bot_token": "new-token"})))
+        except Exception:
+            pass
+
+        # CRITICAL: .env must be untouched — config write failed before the
+        # handler reached _write_env_now(), so the old token is still there.
+        env_text = env.read_text(encoding="utf-8")
+        assert (
+            "old-token" in env_text
+        ), "Config-first: .env must be untouched when config write fails"
+        assert "new-token" not in env_text, ".env must not hold new-token when config write failed"
+        monkeypatch.delenv("WEBEX_BOT_TOKEN", raising=False)
+
+    def test_set_config_write_failure_preserves_process_only_credential(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Webex SET with config-write failure must NOT clobber a credential
+        that lives ONLY in os.environ (not in .env).
+
+        Scenario:
+          - os.environ["WEBEX_BOT_TOKEN"] = "env-only-tok"  (process-only)
+          - .env file has no WEBEX_BOT_TOKEN entry
+          - _atomic_json_write raises (disk full)
+
+        With config-first ordering: the config write fails before
+        _write_env_now() is called, so os.environ is never mutated by the
+        handler.  The process-only credential is trivially preserved.
+        """
+        env = tmp_path / ".env"
+        cfg_path = tmp_path / "config.json"
+        # .env has NO token — credential is process-only.
+        env.write_text("", encoding="utf-8")
+        # Seed a legacy plaintext token so the handler adds bot_token: ""
+        # to `changes`, triggering the config write (and its failure).
+        cfg_path.write_text(json.dumps({"webex": {"bot_token": "legacy-plain"}}), encoding="utf-8")
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+        monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+        monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+        monkeypatch.setattr(mod, "_validate_webex_token", lambda tok: None)
+
+        # Plant the credential ONLY in os.environ, not in .env.
+        monkeypatch.setenv("WEBEX_BOT_TOKEN", "env-only-tok")
+
+        import kiro_crew.agent as _agent
+
+        def _boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(_agent, "_atomic_json_write", _boom)
+
+        try:
+            asyncio.run(mod.api_webex_config_save(_StubRequest({"bot_token": "new-token"})))
+        except Exception:
+            pass
+
+        # CRITICAL: the process-only credential must survive intact.
+        # Config-first ordering: _write_env_now() is never called when config
+        # write fails, so os.environ is untouched by the failed request.
+        assert os.environ.get("WEBEX_BOT_TOKEN") == "env-only-tok", (
+            "Config-first ordering: process-only credential must be untouched "
+            f"when config write fails; got: {os.environ.get('WEBEX_BOT_TOKEN')!r}"
+        )
+        # .env must NOT hold the new token value — .env was never written.
+        assert "new-token" not in env.read_text(
+            encoding="utf-8"
+        ), ".env must not be written when config write fails (config-first ordering)"
+        monkeypatch.delenv("WEBEX_BOT_TOKEN", raising=False)
 
 
 class TestSaveWritesEveryValidatedField:

--- a/test/test_wecom_config_handlers.py
+++ b/test/test_wecom_config_handlers.py
@@ -371,3 +371,156 @@ def test_get_unconfigured_reports_needs_setup(tmp_path: Path, monkeypatch) -> No
     assert body["configured"] is False
     assert body["enabled"] is False
     assert body["allowed_user_ids"] == []
+
+
+def test_clear_config_write_failure_does_not_leave_env_cleared(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """On a CLEAR-only path (no config changes), the env write runs via
+    _write_env_off_loop.  If that write raises, .env must remain untouched —
+    the credential stays fully present, never half-cleared."""
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    cfg_path = tmp_path / "config.json"
+    env.write_text(f"WECOM_SECRET={SECRET}\n", encoding="utf-8")
+    cfg_path.write_text(json.dumps({"wecom": {"enabled": True}}), encoding="utf-8")
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+    monkeypatch.delenv("WECOM_SECRET", raising=False)
+
+    async def _boom(_updates):
+        raise OSError("disk full writing .env")
+
+    monkeypatch.setattr(mod, "_write_env_off_loop", _boom)
+    try:
+        _client_put(mod, monkeypatch, tmp_path, {"bot_token_clear": True})
+    except Exception:
+        pass
+    # .env must still hold the credential — the env write failed before any
+    # content was cleared.
+    assert f"WECOM_SECRET={SECRET}" in env.read_text(encoding="utf-8")
+    monkeypatch.delenv("WECOM_SECRET", raising=False)
+
+
+def test_set_config_write_failure_leaves_consistent_pair(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """On a SET, config.json is written FIRST.  If it fails, .env is never
+    touched — old credentials + old metadata, always a consistent pair.
+    This mirrors the Teams and Webex config-first SET pattern.
+
+    The config write only fires on the SET path when `staged` is non-empty
+    (i.e. at least one config field differs from stored).  This test includes
+    ``enabled: True`` in the body to ensure `staged` has an entry and the
+    config-write failure path is exercised."""
+    import kiro_crew.agent as _agent
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    cfg_path = tmp_path / "config.json"
+    env.write_text("WECOM_BOT_ID=old-bot-id\nWECOM_SECRET=old-secret\n", encoding="utf-8")
+    # enabled=False initially so sending enabled=True creates a staged change,
+    # giving the handler a non-empty `staged` and thus a config write to fail.
+    cfg_path.write_text(json.dumps({"wecom": {"enabled": False}}), encoding="utf-8")
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+    monkeypatch.delenv("WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("WECOM_SECRET", raising=False)
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full during config write")
+
+    monkeypatch.setattr(_agent, "_atomic_json_write", _boom)
+    try:
+        _client_put(
+            mod,
+            monkeypatch,
+            tmp_path,
+            {"bot_id": BOT_ID, "secret": SECRET, "enabled": True},
+        )
+    except Exception:
+        pass
+
+    # CRITICAL: .env must be untouched — config write failed before the
+    # handler reached _commit_env_wecom(), so both stores still hold originals.
+    env_text = env.read_text(encoding="utf-8")
+    assert "old-bot-id" in env_text, (
+        "Config-first: .env must be untouched when config write fails (WECOM_BOT_ID)"
+    )
+    assert "old-secret" in env_text, (
+        "Config-first: .env must be untouched when config write fails (WECOM_SECRET)"
+    )
+    assert BOT_ID not in env_text, ".env must not hold new bot_id when config write failed"
+    assert SECRET not in env_text, ".env must not hold new secret when config write failed"
+    monkeypatch.delenv("WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("WECOM_SECRET", raising=False)
+
+
+def test_set_config_write_failure_preserves_process_only_credential(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """WeCom SET with config-write failure must NOT clobber credentials that
+    live ONLY in os.environ (not in .env).
+
+    Scenario:
+      - os.environ["WECOM_BOT_ID"]  = "env-only-bot-id"  (process-only)
+      - os.environ["WECOM_SECRET"]  = "env-only-secret"   (process-only)
+      - .env file has no WECOM_* entries at all
+      - _atomic_json_write raises (disk full)
+
+    With config-first ordering: the config write fails before
+    _commit_env_wecom() is called, so os.environ is never mutated by the
+    handler.  Both process-only credentials are trivially preserved.
+    """
+    import kiro_crew.agent as _agent
+    import kiro_crew.dashboard.handlers.messaging as mod
+
+    env = tmp_path / ".env"
+    cfg_path = tmp_path / "config.json"
+    # .env has NO WECOM entries — credentials are process-only.
+    env.write_text("", encoding="utf-8")
+    # enabled=False so sending enabled=True creates a staged change and
+    # forces the config write (and its failure).
+    cfg_path.write_text(json.dumps({"wecom": {"enabled": False}}), encoding="utf-8")
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: cfg_path)
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    # Plant both credentials ONLY in os.environ, not in .env.
+    monkeypatch.setenv("WECOM_BOT_ID", "env-only-bot-id")
+    monkeypatch.setenv("WECOM_SECRET", "env-only-secret")
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full during config write")
+
+    monkeypatch.setattr(_agent, "_atomic_json_write", _boom)
+    try:
+        _client_put(
+            mod,
+            monkeypatch,
+            tmp_path,
+            {"bot_id": BOT_ID, "secret": SECRET, "enabled": True},
+        )
+    except Exception:
+        pass
+
+    # CRITICAL: both process-only credentials must survive intact.
+    # Config-first ordering: _commit_env_wecom() is never called when config
+    # write fails, so os.environ is untouched by the failed request.
+    assert os.environ.get("WECOM_BOT_ID") == "env-only-bot-id", (
+        "Config-first ordering: process-only WECOM_BOT_ID must be untouched "
+        f"when config write fails; got: {os.environ.get('WECOM_BOT_ID')!r}"
+    )
+    assert os.environ.get("WECOM_SECRET") == "env-only-secret", (
+        "Config-first ordering: process-only WECOM_SECRET must be untouched "
+        f"when config write fails; got: {os.environ.get('WECOM_SECRET')!r}"
+    )
+    # .env must NOT hold the new credential values — .env was never written.
+    env_text = env.read_text(encoding="utf-8")
+    assert BOT_ID not in env_text, ".env must not be written when config write fails (WECOM_BOT_ID)"
+    assert SECRET not in env_text, ".env must not be written when config write fails (WECOM_SECRET)"
+    monkeypatch.delenv("WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("WECOM_SECRET", raising=False)

--- a/test/test_weixin_qr.py
+++ b/test/test_weixin_qr.py
@@ -378,3 +378,71 @@ def test_prune_sessions_survives_a_client_whose_close_cannot_be_scheduled(monkey
     }
     qr._prune_sessions()
     assert qr._SESSIONS == {}
+
+
+# ── Cross-process .env.lock exclusion ─────────────────────────────────────────
+# Regression: _commit_credential_and_config must acquire the shared .env.lock
+# advisory lock (same sidecar file used by `secrets import --apply`) so that the
+# WeChat sign-in handler and the CLI importer cannot interleave their
+# read-modify-write cycles.  If the lock is already held, the handler must abort
+# with OSError instead of writing a potentially stale value.
+
+
+def test_commit_credential_aborts_when_env_lock_is_held(tmp_path, monkeypatch):
+    """_commit_credential_and_config raises OSError when .env.lock is held.
+
+    Simulates a concurrent ``secrets import --apply`` holding the advisory lock
+    by patching ``platform_compat.try_acquire_lock`` to return False (the same
+    signal the importer uses to detect a held lock).  Confirms the handler:
+      * does NOT write WEIXIN_TOKEN to .env (no partial write),
+      * does NOT write config.json,
+      * raises OSError with a descriptive message.
+    """
+    import kiro_crew.platform_compat as _pc
+
+    ep = tmp_path / ".env"
+    ep.write_text("OTHER=keepme\n", encoding="utf-8")
+    cp = tmp_path / "config.json"
+    monkeypatch.setattr(qr, "env_path", lambda: ep)
+
+    # Simulate a held lock: try_acquire_lock returns False for the .env.lock fd.
+    # We only intercept the lock acquisition; all other platform_compat calls are
+    # left untouched.
+    original_try = _pc.try_acquire_lock
+
+    def _always_busy(fd, *, exclusive=False):  # noqa: ARG001
+        return False
+
+    monkeypatch.setattr(_pc, "try_acquire_lock", _always_busy)
+    # release_lock and os.close must still run (the fd was opened); patch
+    # release_lock to a no-op so the test does not need a real lockable fd.
+    monkeypatch.setattr(_pc, "release_lock", lambda fd: None)
+
+    with pytest.raises(OSError, match="locked by another process"):
+        qr._commit_credential_and_config(cp, "{}", "should-not-be-written")
+
+    # .env must be untouched — WEIXIN_TOKEN was not inserted.
+    assert qr._read_env_value("WEIXIN_TOKEN") is None
+    assert ep.read_text(encoding="utf-8") == "OTHER=keepme\n"
+    # config.json must not have been created.
+    assert not cp.exists()
+
+    monkeypatch.setattr(_pc, "try_acquire_lock", original_try)
+
+
+def test_commit_credential_succeeds_when_env_lock_is_free(tmp_path, monkeypatch):
+    """_commit_credential_and_config writes normally when it acquires the lock.
+
+    Complementary to the abort test above: confirm the happy-path still works
+    after the lock-acquisition layer was added (no regression in the normal case).
+    """
+    ep = tmp_path / ".env"
+    ep.write_text("OTHER=keepme\n", encoding="utf-8")
+    cp = tmp_path / "config.json"
+    monkeypatch.setattr(qr, "env_path", lambda: ep)
+
+    qr._commit_credential_and_config(cp, '{"weixin": {}}', "newtoken")
+
+    assert qr._read_env_value("WEIXIN_TOKEN") == "newtoken"
+    assert qr._read_env_value("OTHER") == "keepme"
+    assert cp.exists() and json.loads(cp.read_text()) == {"weixin": {}}


### PR DESCRIPTION
## Problem / Motivation

The encrypted vault (PR 1, #3725) and the `secret://` spawn-time resolver (PR 4,
#4681) landed, but nothing moves a user's existing plaintext secrets into the
vault, and no in-tree consumer actually reads a real credential through it. A
user who already keeps tokens as plaintext `KEY=VALUE` lines in the data home's
`.env` has no supported path to adopt the vault, and the Jira integration still
requires a raw `.env` / environment token.

## Why it matters

This is the final PR of the secret-management chain. Without a migration path,
adopting the vault means hand-editing `.env` and the dashboard; without a real
consumer, the chain is unproven end to end. Migrating the Jira token and
resolving it through the vault (with a safe fallback) demonstrates the whole
flow — store → reference → resolve at spawn — on a credential that ships today.

## What changed (motivation → approach → change)

Goal: let users move plaintext secrets into the vault and prove the chain with a
real consumer, without breaking installs that have not migrated.

**Migration importer — `kirocrew secrets import`.** A new `secrets` CLI group
with a single `import` subcommand (the `set`/`list`/`rm` surface is owned by a
separate change and is deliberately not reimplemented here). It reads the data
home's `.env` (the fixed data-home path — there is deliberately no `--file`
option AND the underlying `migrate_env_secrets` takes no caller path argument
for EITHER the `.env` it reads (`env_path()`) or the vault home it writes
(`config_dir()`) — both are resolved internally, so no code path — CLI or
agent-influenced — can point the importer at an attacker-controlled
file whose values would be trusted by the vault-first consumer, nor at an
attacker-readable directory into which the vault key/entries would be copied). It
migrates ONLY Jira credentials — the
global `JIRA_API_TOKEN` and the per-host `JIRA_TOKEN_<HEX>` tokens that the
vault-aware `_get_jira_auth` consumer reads vault-first. For each such token
still held in plaintext it stores the value in the vault under the same key and
rewrites the line to `KEY=secret://KEY`. Other credential keys (Slack, Discord,
kiro-cli, …) are deliberately NOT migrated: their consumers still read the
literal `.env` value, so rewriting them to a `secret://` reference would hand
them the URI string instead of the secret and break auth — they migrate once
their consumers become vault-aware in a later change.

- Dry-run by default: with no flag it prints what *would* migrate and writes
  nothing. `--apply` performs the migration.
- On `--apply`, all vault writes happen *before* the `.env` is touched, so a
  partial failure never leaves a `secret://` reference pointing at a missing
  vault entry. The `.env` is then rewritten atomically at mode `0o600`. The
  file is read and written with `errors="surrogateescape"`, so a `.env` that
  contains non-UTF-8 bytes (e.g. a Latin-1 comment) round-trips byte-for-byte
  through the rewrite instead of raising `UnicodeEncodeError` under strict
  UTF-8. Each line's ORIGINAL terminator is preserved (`\r\n`/`\n`/`\r` or none
  on the last line) — a CRLF `.env` is not silently converted to LF, on either
  rewritten or unchanged lines.
- Concurrent-write safe via an exclusive OS lock + compare-and-swap, with the
  vault store and the `.env` rewrite BOTH inside one critical section: under an
  exclusive advisory lock (`platform_compat.try_acquire_lock`, POSIX flock /
  Windows msvcrt, on a sidecar `.env.lock` so it never perturbs the `.env`
  bytes/mode) the importer first CAS-re-reads the `.env` and aborts if the bytes
  changed since the snapshot, THEN writes to the vault, THEN rewrites the `.env`.
  Ordering matters: because the vault store happens only AFTER the CAS confirms
  the snapshot is still fresh, a concurrent `.env` edit (e.g. an operator
  rotating a token) trips the CAS abort BEFORE any vault write — so an aborted
  migration never leaves the vault holding a value the `.env` has moved past
  (which, under vault-first resolution, would otherwise shadow the newer token).
  The CAS also catches an in-process writer that does not take the file lock
  (today the WeChat/Weixin token handler, which serializes on an in-process
  `asyncio.Lock`). If the lock cannot be taken, the migration aborts before
  storing or rewriting anything and a re-run reconciles. An external editor that
  honors no lock is out of scope, as for any tool editing a file mid-migration.
- The vault write itself is race-safe against OTHER vault writers (the
  dashboard secrets page, the Weixin handler): the importer stores each key
  with `SecretVault.set_if_absent`, whose not-present check is made INSIDE the
  vault's own cross-process store lock. A credential a concurrent writer saved
  to the vault between the importer's `list_names()` snapshot and its write is
  therefore never clobbered — that writer wins and the importer aborts
  (`MigrationConflictError`, no `.env` rewrite) rather than overwriting the
  newer value or pointing the `.env` line at a value it did not store.
- The store→rewrite window is closed by a re-verify guard: immediately before
  the atomic `.env` rewrite (inside the `.env` lock, after the CAS check), the
  importer re-reads every key it is about to rewrite to `secret://KEY` and
  confirms the vault still holds the expected value — and this re-verify plus
  the `atomic_write` now run inside a held VAULT cross-process lock
  (`SecretVault.hold_cross_process_lock()`, the same `.secrets.enc.lock` flock
  every vault write takes). Without that, a concurrent vault DELETE (dashboard
  secrets page) could remove an entry between the re-verify read and the commit,
  stranding the plaintext behind a `secret://KEY` pointer to a vanished entry.
  Holding the vault lock makes verify+rewrite atomic from the vault's view: any
  DELETE is queued until the `.env` reference is durable. (The vault write pass
  `_store_all` runs BEFORE the lock is taken — it uses `set_if_absent`, which
  acquires the flock per-write — so there is no nested re-acquire/deadlock; only
  the flock-free `vault.get()` and `atomic_write` run under the held lock.) If a
  concurrent writer deleted or replaced a vault entry, the re-verify still aborts
  (`MigrationConflictError`) before `atomic_write`, so the `.env` plaintext is
  never rewritten to point at a vanished or changed entry. And if the
  `atomic_write` itself fails, if any guard in the locked section raises AFTER
  the vault store, OR if `_store_all` itself raises partway (a two-key import
  whose second key conflicts), the importer ROLLS BACK every vault entry this run
  created — but CONDITIONALLY: it tracks the exact value `set_if_absent` wrote
  per key and, before deleting, re-reads the current vault value and deletes ONLY
  if it still matches what this run wrote, never a pre-existing entry another
  writer owns and never a value a concurrent writer has since overwritten (the
  rollback runs after the lock is released, so its per-write flock re-acquire does
  not deadlock). A failed apply
  therefore leaves NEITHER a `.env` rewrite NOR an orphaned vault entry that
  vault-first resolution could later use to shadow a rotated plaintext token —
  the pre-migration state (plaintext in `.env`, no vault entry) is restored.
- A FINAL CAS re-read guards the `.env` itself immediately before
  `atomic_write`, and — closing the residual completely — EVERY other in-tree
  `.env` writer now takes the SAME cross-process lock. The lock path is derived
  by a single shared helper (`_env_lock_path`) used by the importer, the
  WeChat/Weixin QR sign-in handler (`weixin_qr._commit_credential_and_config`),
  AND the messaging-channel token save (`messaging._write_env_updates`, used by
  the Slack/Discord/Teams/WeCom credential handlers). The lock file lives INSIDE
  the `.vault` directory (which every sandbox tier bind-mount-hides), not next
  to `.env` in the freely-agent-writable config dir — so an unconfined agent
  cannot delete or replace the held lock inode to defeat serialization; its
  `.vault` parent is created on demand at mode 0o700. All `.env` writers
  therefore provably serialize on one agent-protected advisory lock rather than
  each holding an independent in-process lock. Each keeps any in-process lock it
  already had (cheap same-process serialization) and adds the file lock on top;
  if the lock is held (an import in progress) the write aborts cleanly rather
  than racing. For a channel token handler that ALSO purges a legacy
  `config.json` token copy (Teams/Webex/WeCom), the write ORDER is
  direction-aware: SETTING writes `.env` first then purges config (a
  config-write failure still leaves the new token live in `.env`), while
  CLEARING purges config FIRST then deletes from `.env` (so a config-write
  failure cannot leave `.env` emptied while the legacy `config.json` token
  survives to be resurrected on restart). On the SET path, if the `config.json`
  write fails AFTER the `.env` commit (a password+app_id/tenant rotation), the
  handler restores the prior `.env` values (snapshotted from the `.env` file, not
  `os.environ`, so a never-loaded credential is not deleted) before re-raising —
  so a restart never pairs the NEW secret with the OLD metadata (a broken
  credential pair). To keep that ordering invariant intact,
  the credential re-read the Teams handler runs before it commits reads the
  effective values directly from `.env` (`read_env_file_credential` + the
  `os.environ` override) instead of via `KiroCrewConfig.load()`, whose
  `_load_resolved()` migration write-back would purge `teams.app_password` from
  `config.json` as a side-effect BEFORE the `.env` write — clearing the legacy
  credential even when the `.env` write is then blocked by the shared lock. The
  blocking `.env` writes in the async channel handlers (Slack/Discord/Teams/
  Webex/WeCom) are offloaded via `asyncio.to_thread`, so the file-lock acquire
  and atomic rename never stall the gateway event loop. The final CAS
  re-read remains as defense-in-depth (it also catches any future writer that
  has not yet adopted the lock): it compares the current `.env` bytes to the
  snapshot and aborts (`MigrationConflictError`, no rewrite) if they differ, so
  a snapshot-derived `new_text` can never clobber a concurrent change. An
  external editor that
  honors no lock is out of scope, as for any tool editing a file mid-migration.
- Runtime override wins **for the global `JIRA_API_TOKEN` only**: if that key
  has a nonempty process-environment value it is skipped by migration, because
  `load_credentials` overlays the environment for it, so the env value is the
  effective credential at runtime and migrating the stale file value would let
  vault-first resolution shadow it. To keep the migrate-skip and the resolve
  order consistent, the Jira token resolver (`_resolve_jira_for_host`) now
  consults the process-environment `JIRA_API_TOKEN` override BEFORE the global
  vault entry, so a vault value left by an EARLIER migration (before the
  override existed) can no longer silently shadow a live env override. Per-host
  `JIRA_TOKEN_<HEX>` keys are **not** in that env-overlaid set, so a same-named
  env var does not override them and they keep their vault-first order and are
  migrated regardless — skipping them would strand the stale file token Jira
  still reads.
- The source file is never deleted — migrated lines are rewritten in place;
  non-Jira credentials and unrecognized operator settings (proxy vars, feature
  flags) are left verbatim.
- Idempotent and order-correct: a later `secret://` reference (or empty line)
  for a key WINS over any earlier plaintext line for that same key — the stale
  plaintext is never queued, so `--apply` never overwrites an already-migrated
  vault entry and re-running never regresses a migrated key. A key **already
  present in the vault** is authoritative: its stored secret is never
  overwritten. When the stored value **equals** the `.env` plaintext (the
  idempotent re-run case) only the `.env` line is rewritten to the
  `secret://` reference, keeping the two consistent. When the stored value
  **differs** from the `.env` plaintext the migration **aborts**
  (`MigrationConflictError`, no write): silently rewriting the line to
  `secret://KEY` would discard the `.env` plaintext while the consumer
  resolves to the different vault value — e.g. this run stored `A`, a
  concurrent edit rewrote the vault to `B`, and a retry must not swap `A`
  away for `B` unasked. This authoritative handling only applies when the
  stored entry actually **decrypts**. A
  listed-but-undecryptable entry (missing/mismatched vault key, e.g. a restored
  store) **aborts** the migration (`MigrationConflictError`, no write) rather
  than rewriting the still-usable `.env` plaintext to a `secret://` reference
  that points at an unreadable entry. Either abort (concurrent-change or
  undecryptable-entry) surfaces at the `secrets import` command as a concise
  `error: …` on stderr with a nonzero exit — never an uncaught traceback. The
  report tells the user how to remove any separate plaintext backup.

**Jira consumer — vault-first with env fallback.** `_get_jira_auth` now resolves
the token from the vault first (`JIRA_TOKEN_<HEX>` per host; the global
`JIRA_API_TOKEN` vault secret only when a single host is configured), then falls
back to today's `.env` / environment value exactly as before when the vault has
no entry. One exception keeps the resolver consistent with the migrator's skip
rule: for the global `JIRA_API_TOKEN`, a nonempty process-environment override
is consulted BEFORE the global vault entry (the importer skips migrating that
key while such an override is set, so a vault value from an earlier migration
must not shadow the live override). That override is SNAPSHOTTED at the very top
of `_get_jira_auth`, BEFORE `load_credentials()` runs: `load_credentials`
`setdefault`-seeds the `.env` global into `os.environ`, so reading `os.environ`
afterward would mistake a merely-seeded `.env` value for a real operator
override and let the global shadow a host that has its OWN per-host token.
Capturing the value first means only a genuine pre-existing env var counts.
Per-host keys are not env-overlaid and keep their vault-first order. Crucially,
a `secret://` value in the environment or
the creds dict is treated as a vault REFERENCE, not a raw token: after
`--apply` the `.env` line becomes `JIRA_API_TOKEN=secret://JIRA_API_TOKEN` and
`load_credentials` propagates that string into `os.environ` and the creds dict
via `setdefault`, so both the env-override branch and the `.env`/creds
fallbacks skip any `secret://` value and fall through to the vault lookup —
otherwise the resolver would hand Jira the `secret://` URI instead of the real
secret, breaking the single-host global-token path. The vault read is
best-effort — a missing vault, missing entry, or read error yields the empty
string and falls through to the legacy path — so existing setups keep working
unchanged.

## Tests

- `test/test_secrets_migrate.py` — dry run reports migratable keys and writes
  nothing (vault store not created, `.env` untouched); `--apply` writes the
  vault entries and rewrites lines to `secret://KEY`; the source file is not
  deleted; the `.env` is written at mode `0o600`; re-running `--apply` is a
  no-op (already-referenced keys reported); a non-Jira credential key (Slack /
  kiro-cli) is NOT migrated; a stale plaintext line followed by a `secret://`
  line for the same key does not queue the stale value and does not overwrite
  the vault entry; a key with a nonempty process-environment override is
  skipped (empty override does not skip); a per-host `JIRA_TOKEN_<HEX>` key with
  a same-named env var is still migrated (env does not override per-host keys);
  a key already present in the vault with a MATCHING value is
  NOT overwritten but its line is still rewritten to `secret://KEY`, while a
  vault value that DIFFERS from the `.env` plaintext aborts the migration so
  neither value is silently discarded; a listed-but-undecryptable vault entry aborts the migration
  without rewriting away the usable plaintext; a `.env` with non-UTF-8 bytes
  round-trips through the rewrite without crashing; a concurrent `.env` write between
  the snapshot and the rewrite aborts with `MigrationConflictError` and the
  other writer's value survives; a vault entry DELETED or REPLACED between the
  store and the rewrite aborts (`MigrationConflictError`) with the `.env`
  plaintext left intact; a `.env.lock` already held by another process
  aborts cleanly without rewriting; per-host `JIRA_TOKEN_<HEX>` is recognized;
  a concurrent vault writer that stores the key first makes the importer abort
  (`set_if_absent` returns False) without rewriting the `.env`; `set_if_absent`
  stores when absent and leaves an existing value untouched;
  unrecognized-only files migrate nothing; a missing `.env` is a no-op;
  report formatting.
- `test/test_source_providers.py::TestGetJiraAuth` — extended: a vault token is
  preferred over the `.env` value; a vault miss falls back to the `.env` value;
  a single-host global `JIRA_API_TOKEN` vault secret resolves; a nonempty
  process-environment `JIRA_API_TOKEN` override beats a stale global vault entry
  (`test_global_env_override_beats_stale_global_vault`); a migrated
  `secret://JIRA_API_TOKEN` value in the environment/creds is treated as a vault
  reference and resolved from the vault rather than handed to Jira as a URI
  (`test_migrated_secret_ref_in_env_resolves_from_vault_not_uri`); and a
  configured host with no token anywhere returns `None`. The pre-existing
  env-only tests still pass, confirming the fallback path is unchanged.
- `test/test_weixin_qr.py` — the QR sign-in credential commit acquires the
  shared `.env.lock`; when that lock is already held (an import in progress) the
  commit aborts cleanly rather than racing the importer's rewrite.
- `test/test_handlers_messaging_coverage.py::TestWriteEnvUpdates` — the
  messaging-channel token save acquires the same shared `.env.lock`; when the
  lock is already held it aborts and leaves `.env` untouched (existing
  append/replace/delete/create-when-absent cases still pass under the lock).

## Manual verification

N/A — unit coverage exercises the full dry-run → apply → `.env`-rewrite path
against the real `SecretVault`, and the Jira resolution order (vault hit, vault
miss → env, single-host global, unconfigured) against the real function.

## Screenshots / video

<!-- no-visual-delta --> N/A — backend-only change (a CLI subcommand, backend
token resolution, and docs). No dashboard UI is added or changed.

## Related Issues

Part of #2351

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I confirm that this contribution is made under the terms of the project's
Contribution License Agreement and that I have the right to submit it under
those terms.

























