### PR TITLE
fix(ci): restore backend lint on main (isort + black baseline)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -183,12 +183,9 @@ src/kiro_crew/autonudge_authz.py
 src/kiro_crew/beacon.py
 src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
 src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
-src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/diff_signals.py
-src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/enable_automerge.py
 src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
 src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_findings.py
 src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
-src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/resolve_profile.py
 src/kiro_crew/changelog.py
 src/kiro_crew/channel.py
 src/kiro_crew/channel_history.py
@@ -306,7 +303,6 @@ src/kiro_crew/deploy/pricing.py
 src/kiro_crew/deploy/profiles.py
 src/kiro_crew/deploy/render.py
 src/kiro_crew/deploy/scan.py
-src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
 src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
 src/kiro_crew/deploy/skills/artifact-deploy/scripts/reaper_lambda/index.py
 src/kiro_crew/deploy/skills/artifact-deploy/templates/handler-example.py
@@ -677,7 +673,6 @@ test/test_cloud_launch_job.py
 test/test_collection_status_endpoint.py
 test/test_completion_result_read_off_loop.py
 test/test_computer_use_apps.py
-test/test_computer_use_ffi.py
 test/test_computer_use_overlay.py
 test/test_computer_use_skylight.py
 test/test_computer_use_snapshot_macos.py
@@ -1243,7 +1238,6 @@ test/test_skill_update_flow.py
 test/test_skill_versioning.py
 test/test_skills.py
 test/test_slack_agent_passthrough.py
-test/test_slack_config_handlers.py
 test/test_slack_dashboard_live_sync.py
 test/test_slack_events_coverage.py
 test/test_slack_gateway.py
@@ -1274,7 +1268,6 @@ test/test_slot_detail_offload.py
 test/test_slot_needs_input_status.py
 test/test_slot_sync_on_create.py
 test/test_slots_broadcast_coalesce.py
-test/test_snapshot.py
 test/test_socketsec.py
 test/test_source_providers.py
 test/test_source_providers_comment_guard.py

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -32,13 +32,13 @@ from typing import Any
 # reads as "the computer-use vocabulary" rather than bare names.
 from kiro_crew.computer_use import types as _cu_types
 from kiro_crew.constants import WINDOWS_DEVICE_STEMS
-from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # Reasoning-effort vocabulary: ``effort.py`` is the single source of truth for
 # the valid levels; EFFORT_VALUES additionally admits ``""`` ("unset — defer to
 # the role pin / provider default"). Import-safe: ``effort`` pulls in only
 # ``model_registry`` (stdlib-only), so no cycle back into validation.
 from kiro_crew.effort import EFFORT_VALUES
+from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # ── Constants ──
 


### PR DESCRIPTION
## Problem / Motivation

Backend Lint & Type Check fails on main HEAD (`8c61bc1f0`) and therefore on every open PR's merge ref. Two independent breaks landed within the last hour:

1. `src/kiro_crew/validation.py`: the `SCOPE_FRAGMENT_RE` import is out of isort order (landed via #4883).
2. `.github/black-baseline.txt`: seven baselined files are now black-clean, and `scripts/check_black_formatting.py` fails until graduated entries are pruned so the baseline only ever shrinks.

## Why it matters

Every open PR inherits the red lint job through `refs/pull/N/merge`, so main is currently blocking all PRs from going green.

## What changed

- Ran isort on `src/kiro_crew/validation.py` (one import moved below the reasoning-effort comment block, comment attachment preserved).
- Ran `scripts/check_black_formatting.py --update-baseline` to prune the 7 graduated entries (1394 remain).

## Tests

The gates themselves are the test: `isort --check-only src/kiro_crew test conftest.py xdist_budget.py`, `flake8` (same scope), and `python3 scripts/check_black_formatting.py` all exit 0 on this branch with CI-pinned tool versions. `mypy src/kiro_crew/` reports only the four known macOS-typeshed divergences (`os.*xattr`, `CLOCK_BOOTTIME`) that do not occur on CI's Linux runners.

## Manual verification

N/A — lint-only change, no runtime behavior.

<!-- no-visual-delta -->
**Why no screenshot:** lint-only fix (one import reorder + baseline prune), no rendered surface touched.

no linked issue: CI-breakage fix, no tracked issue exists.
