### PR TITLE
style: fix isort ordering in validation.py

### DIFF
--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -32,13 +32,13 @@ from typing import Any
 # reads as "the computer-use vocabulary" rather than bare names.
 from kiro_crew.computer_use import types as _cu_types
 from kiro_crew.constants import WINDOWS_DEVICE_STEMS
-from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # Reasoning-effort vocabulary: ``effort.py`` is the single source of truth for
 # the valid levels; EFFORT_VALUES additionally admits ``""`` ("unset — defer to
 # the role pin / provider default"). Import-safe: ``effort`` pulls in only
 # ``model_registry`` (stdlib-only), so no cycle back into validation.
 from kiro_crew.effort import EFFORT_VALUES
+from kiro_crew.project_scope import SCOPE_FRAGMENT_RE
 
 # ── Constants ──
 


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/validation.py` has incorrectly ordered imports (`project_scope` before `effort`), so the whole-tree `isort --check-only` in CI's Backend Lint & Type Check fails. This is pre-existing on `main` (introduced by #4852/#4883), not from any feature change, and it blocks unrelated PRs' lint checks.

## Why it matters

A red whole-tree isort gate on `main` fails Backend Lint on every open PR that rebases onto it.

## What changed

Ran `isort` on `validation.py` — a one-line reorder (move `from kiro_crew.project_scope import SCOPE_FRAGMENT_RE` after `from kiro_crew.effort import EFFORT_VALUES`). Import-only, no logic change.

## Tests

N/A — formatting-only. `isort --check-only src/kiro_crew/validation.py` now passes.

## Manual verification

N/A — isort is the check.

## Related Issues

N/A

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — formatting-only)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A)
- [x] No secrets, credentials, or internal references in the diff
