### PR TITLE
fix(test): read the fork-probe collapse off the verdict child itself

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -280,6 +280,16 @@ which testpath asked for the workers.
   about the host. Neither replaces the rule: **anything you start, something must
   stop — and a stub is not a stop.**
 
+  A second shape of the same hook survives even a clean shutdown: CPython cannot
+  unregister an at-fork hook, so after a proper `shutdown()` the hook still runs in
+  every fork child and restarts a ticker thread that exits almost immediately. Each
+  fork then races that short-lived thread independently — one fork child can count 1
+  thread while the next counts 2. The consequence for tests: **a single-threaded
+  pre-check fork proves nothing about the fork that produces the verdict.** A guard
+  for the multithreaded collapse must read the collapse off the verdict itself (the
+  probe's reason names it; `sandbox._probe_reason_is_multithreaded_collapse`), not
+  predict it from a separate probe.
+
 - **A handler that answers before its work finishes must be awaited, not slept on.**
   `api_chat_slot_slack_link` returns 200 as soon as the link is persisted and hands the
   Slack backfill to `asyncio.create_task`, tracked in `state._background_tasks`. Six

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -261,6 +261,29 @@ _PROBE_STEP_NEWNS = "unshare(CLONE_NEWNS)"
 #: ``_probe_child_thread_count``.
 _PROBE_STEP_MULTITHREADED = "M"
 
+#: Trailing clause of the reason `_probe_parent_sequence` emits for the
+#: `_PROBE_STEP_MULTITHREADED` collapse. A single shared spelling, because callers
+#: that must RECOGNIZE the collapse (a fork child whose verdict is unobtainable is
+#: an unknown reading, not a disagreement) match against the reason text -- a
+#: hand-copied substring would drift the moment the wording changes.
+_PROBE_MULTITHREADED_REASON = (
+    "an os.register_at_fork hook started one, so the kernel's own verdict is "
+    "unobtainable from this child"
+)
+
+
+def _probe_reason_is_multithreaded_collapse(reason: str) -> bool:
+    """Whether a probe reason reports the multithreaded-fork-child collapse.
+
+    True only for the fork path: the collapse text is emitted by
+    `_probe_parent_sequence` when the probe child counted more than one thread,
+    which happens when an ``os.register_at_fork`` hook armed earlier in the
+    calling process starts a thread inside every fork child. The verdict such a
+    child returns is the hook's artifact, not the kernel's answer.
+    """
+    return _PROBE_MULTITHREADED_REASON in (reason or "")
+
+
 # A probe child that vanished mid-handshake is a harness failure, not a kernel
 # verdict, so it must not be cached as "this host has no sandbox". Kept separate
 # from _TRANSIENT_PROBE_ERRNOS so that set's cache semantics stay untouched.
@@ -752,9 +775,8 @@ def _probe_parent_sequence(
             ok,
             transient,
             f"{reason}; the probe child had {err} threads, which alone makes it "
-            "return EINVAL (CLONE_NEWUSER implies CLONE_THREAD) -- an "
-            "os.register_at_fork hook started one, so the kernel's own verdict is "
-            "unobtainable from this child",
+            "return EINVAL (CLONE_NEWUSER implies CLONE_THREAD) -- "
+            f"{_PROBE_MULTITHREADED_REASON}",
             remedy,
         )
     if step != "U":

--- a/test/test_sandbox_probe.py
+++ b/test/test_sandbox_probe.py
@@ -902,14 +902,20 @@ print(before, after, spawned)
         path's transient failure strings name a Popen-owned child differently, and
         that difference is not a verdict.
 
-        The comparison only means something while a fork child of this worker is
-        single-threaded: an ``os.register_at_fork`` hook armed earlier in the same
-        worker (test ordering under xdist decides this) starts a thread inside
-        every child, and the fork path then reports the deliberate
+        The comparison only means something while the fork child that PRODUCED the
+        verdict was single-threaded. An ``os.register_at_fork`` hook armed earlier
+        in the same worker (test ordering under xdist decides this) starts a thread
+        inside every child, and the fork path then reports the deliberate
         ``_PROBE_STEP_MULTITHREADED`` collapse instead of the kernel's verdict --
         an unknown reading, so it is skipped, not compared (see
         docs/system-specs/common/testing-conventions.md; the collapse itself is
         issue #4219's open decision).
+
+        Two guards, because the hook-started thread is SHORT-LIVED and each fork
+        races it independently: the `_forked_child_thread_count` pre-check is
+        cheap and catches the steady state, but a clean pre-check child does not
+        prove the verdict child was clean. The decisive check therefore reads the
+        collapse off the verdict tuple itself, after the probe ran.
         """
         child_threads = _forked_child_thread_count()
         if child_threads < 0:
@@ -929,6 +935,14 @@ print(before, after, spawned)
         spawned = sb._probe_unshare_via_spawn()
         assert spawned is not None, "this host can spawn an interpreter"
         forked = sb._probe_unshare_via_fork()
+        if sb._probe_reason_is_multithreaded_collapse(forked[2]):
+            pytest.skip(
+                "the fork child that produced the verdict came up multithreaded "
+                "despite a clean pre-check: the at-fork-hook thread is short-lived "
+                "and each fork races it independently, so the kernel's verdict is "
+                "unobtainable from this worker's fork children (the collapse is "
+                "deliberate; see issue #4219)"
+            )
         assert spawned[0] == forked[0], (spawned, forked)
         assert spawned[1] == forked[1], (spawned, forked)
         assert spawned[3] == forked[3], (spawned, forked)
@@ -948,6 +962,36 @@ print(before, after, spawned)
         with pytest.raises(pytest.skip.Exception):
             self.test_both_paths_report_the_same_verdict_on_this_host()
         assert probed["n"] == 0, "the guard must skip BEFORE probing anything"
+
+    def test_verdict_comparison_skips_when_the_verdict_child_itself_collapsed(
+        self, monkeypatch
+    ):
+        """A clean pre-check does not clear the verdict child -- each fork races.
+
+        The at-fork-hook thread is short-lived, so the `_forked_child_thread_count`
+        pre-check child and `_probe_unshare_via_fork`'s verdict child can disagree:
+        pre-check counts 1, verdict child still comes up multithreaded and reports
+        the collapse. That reading is unknown, never a red -- the skip must be
+        decided off the verdict tuple itself.
+        """
+        monkeypatch.setattr(
+            sys.modules[__name__], "_forked_child_thread_count", lambda: 1
+        )
+        monkeypatch.setattr(
+            sb, "_probe_unshare_via_spawn",
+            lambda: (False, False, "unshare(CLONE_NEWNS) failed with errno 1 (EPERM)", "apparmor_userns"),
+        )
+        collapse = (
+            False,
+            False,
+            "unshare(CLONE_NEWUSER) failed with errno 22 (EINVAL); the probe child "
+            f"had 2 threads, which alone makes it return EINVAL (CLONE_NEWUSER "
+            f"implies CLONE_THREAD) -- {sb._PROBE_MULTITHREADED_REASON}",
+            "no_user_ns",
+        )
+        monkeypatch.setattr(sb, "_probe_unshare_via_fork", lambda: collapse)
+        with pytest.raises(pytest.skip.Exception):
+            self.test_both_paths_report_the_same_verdict_on_this_host()
 
     def test_verdict_comparison_still_fails_on_a_real_disagreement(self, monkeypatch):
         """The guard must not swallow a genuine disagreement on a clean shard.


### PR DESCRIPTION
## Problem / Motivation

`test_sandbox_probe.py::TestProbeRunsInAFreshProcess::test_both_paths_report_the_same_verdict_on_this_host` fails intermittently on ubuntu-24.04 CI shards (first observed on main run 32520257176) with `'apparmor_userns' != 'no_user_ns'`: the spawned probe reports the real kernel verdict while the forked probe reports the deliberate multithreaded collapse.

## Why it matters

The failure is shard-placement dependent (pytest-split even-split with no duration cache), so any commit that shifts test distribution can turn main and every open PR red on a test unrelated to the change.

## What changed

The existing guard forks a pre-check child, counts its threads, and skips when it is multithreaded. But the at-fork hook the OTel SDK arms cannot be unregistered even after a clean `shutdown()`, and the ticker thread it restarts in each fork child exits almost immediately, so **every fork races that short-lived thread independently**: the pre-check child can count 1 thread while the verdict child still collapses. Two independent races, compared as if they were one.

The fix reads the collapse off the verdict tuple itself: the collapse reason's trailing clause moves from an inline literal in `_probe_parent_sequence` into a shared module constant (`_PROBE_MULTITHREADED_REASON`) with a predicate (`_probe_reason_is_multithreaded_collapse`) beside it, and the comparison test skips — naming the capability — when the verdict child itself reported the collapse. The cheap pre-check stays for the steady state. Emitted reason text is byte-identical.

The runner image was ruled out (identical `ubuntu24/20260816.277` in passing and failing runs), and the window between the last passing and first failing main run contains exactly one commit, which only adds tests — a pure shard-redistribution trigger, not an at-fork consumer.

## Tests

- New: `test_verdict_comparison_skips_when_the_verdict_child_itself_collapsed` — pre-check pinned clean, verdict child stubbed with the production collapse tuple, asserts SKIP (this is the CI scenario; it red-fails without the fix).
- Unchanged: `test_verdict_comparison_still_fails_on_a_real_disagreement` — its stubs carry reason `"ok"`, which the predicate does not match, so genuine disagreements still fail.
- Falsified locally: forcing the predicate to `False` restores the original false red; the predicate matches the production-emitted reason string.
- `docs/system-specs/common/testing-conventions.md` updated in the same commit with the surviving-hook shape (a clean pre-check fork proves nothing about the verdict fork).

## Manual verification

N/A — the collapse path is fully exercised by stub-based tests; the Linux-only live paths run on CI.

<!-- no-visual-delta -->
**Why no screenshot:** backend test/probe change, no rendered surface.

no linked issue: the collapse design decision is tracked in #4219; this PR fixes the guard gap, not that decision.
