### PR TITLE
docs: add an owner-only directory row to the cross-platform shim table (#4981)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,7 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Fork-bomb / memory ceiling on a spawned tree | `sandbox.apply_windows_resource_ceiling(pid)` after the spawn, alongside `cgroup_scope_argv` | `cgroup_scope_argv` alone (a no-op on Windows, so no ceiling at all) |
 | File mode | `chmod_safe(path, mode)` / `fchmod_safe(fd, mode)` | `os.chmod` / `os.fchmod` (no `os.fchmod` on Windows) |
 | Owner-only secret (fail-loud) | `restrict_to_owner(path)` | `os.chmod(path, 0o600)` under `if IS_POSIX` (silent no-op leaves secrets world-readable) |
+| Owner-only secret directory (fail-loud, inheritable) | `restrict_dir_to_owner(path)`; `make_owner_only_dir(path)` to also create it (its tighten step is best-effort) | `restrict_to_owner(path)` on a directory (its Windows grants carry no `(OI)(CI)`, so files created inside land on the default DACL, not owner-only; its `0o600` also drops the execute bit a directory needs) |
 | Directory link | `symlink_or_junction(target, link)` | `os.symlink` (`WinError 1314` without elevation) |
 | Detect/remove a dir link | `is_link_or_junction(path)` / `unlink_link_or_junction(path)` | `path.is_symlink()` (misses a Windows junction) |
 | Process RSS (live) / peak RSS / CPU | `proc_rss_bytes()` / `proc_peak_rss_bytes()` / `proc_cpu_seconds()` | `resource.getrusage` (`ru_maxrss` is a high-water mark, never a live reading, and its unit is KiB on Linux but bytes on macOS) |

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -251,6 +251,22 @@ security-warning handlers in each caller fire — a naive `if IS_POSIX: os.chmod
 guard would silently no-op on Windows, leaving secrets group/world-readable
 under NTFS.
 
+`restrict_to_owner` is file-shaped by design: its grants are deliberately
+non-inheritable (inheritance flags mean nothing on a file). A **directory**
+holding secrets must instead go through `platform_compat.restrict_dir_to_owner`
+— the directory twin — whose grants carry `(OI)(CI)` so files and
+subdirectories created inside it inherit the owner-only DACL, and which uses
+`0o700` on POSIX (a directory needs the execute bit to be traversable, which
+the file helper's `0o600` drops). `make_owner_only_dir` wraps creation
+(with parents) plus a best-effort tighten for the common case. Calling the
+file helper on a directory tightens only the directory node itself and leaves
+every file later created inside on the creating token's default DACL — the
+runtime logs a warning when it detects that misuse. Inheritance governs only
+what is created from then on: a file that already existed inside keeps its own
+DACL and — because Windows grants *Bypass Traverse Checking* to Everyone by
+default — stays reachable through the tightened parent, so repairing an
+existing install needs a per-file pass, not a parent tighten.
+
 ## File locking on Windows
 
 `platform_compat.file_lock` / `acquire_lock` provide a genuine *blocking*


### PR DESCRIPTION
## What is the problem?

AGENTS.md's cross-platform shim table has a single row for owner-only secrets, and it is file-shaped: `restrict_to_owner(path)`. There is no directory row, so a contributor who needs an owner-only DIRECTORY reads that table and reaches for the file helper. On Windows that helper's grants are deliberately non-inheritable (no `(OI)(CI)`), so the directory node itself gets tightened while every file later created inside lands on the creating token's default DACL - unprotected. That is exactly how three call sites (`kiro_prerequisite.py:836`, `:854`, `mcp_gateway/apps.py:128`) came to pass a directory to the file helper before PR #4948 fixed them. `docs/guides/windows-install.md`'s "Secret-at-rest posture on Windows" section had the same gap: it described only the file helper.

## Why this issue matters to the user

The shim table is the reference a contributor reads BEFORE writing the call. PR #4948 added `restrict_dir_to_owner`, fixed the three call sites, and added a runtime misuse warning - but the docs still steer the next contributor at the file helper, so the same defect class regrows one call site at a time. The end-user consequence of that regrowth is real: files inside an "owner-only" directory (secrets, credential sidecars) readable by other local users on Windows.

## How our fix solves it

Docs-only, +17 lines across the two documents a contributor actually consults:

- `AGENTS.md`: one new row directly under the owner-only file row - Need "Owner-only secret directory (fail-loud, inheritable)", Use `restrict_dir_to_owner(path)` (with `make_owner_only_dir(path)` to also create it; its tighten step is best-effort), NOT `restrict_to_owner(path)` on a directory, with the reason inline (grants carry no `(OI)(CI)` on Windows; `0o600` also drops the execute bit a directory needs).
- `docs/guides/windows-install.md`: one paragraph in "Secret-at-rest posture on Windows" stating the file/directory split - the file helper is non-inheritable by design, directories go through `restrict_dir_to_owner` (`(OI)(CI)` inheritance, `0o700` on POSIX), `make_owner_only_dir` wraps create+tighten, the runtime warns on misuse, and the limits: inheritance only governs newly created children, and a permissive pre-existing file stays reachable through a tightened parent (Windows grants Bypass Traverse Checking to Everyone by default), so repairing an existing install needs a per-file pass.

Every claim in the added text was verified against `src/kiro_crew/platform_compat.py` (`make_owner_only_dir`, `restrict_to_owner`, `restrict_dir_to_owner`, `_icacls_owner_only`) rather than copied from the issue. Acceptance from the issue holds: both documents name `restrict_dir_to_owner`, and neither implies `restrict_to_owner` is right for a directory.

## What tests we did

- `scripts/docs_lint.py`: pass (219 markdown files scanned).
- `scripts/check_brand_name.py` and `check_brand_name.py --test`: pass.
- `flake8 src/kiro_crew test`: clean. `isort`/`mypy` report only hits on files byte-identical to `origin/main` (host tool-version skew: `validation.py` isort, boto3-stub noise in `transcribe.py` / `ops_mission_control/.../cloudwatch.py`) - nothing from this diff, which touches no Python.
- Targeted pytest: `test_brand_name_gate.py` (96 passed), `test_black_gate_contract.py`, `test_windows_kill_probe_audit.py` (4 passed) - the tests that read AGENTS.md or gate doc claims.
- Two model-pinned pre-push reviewers (GPT lane and Opus lane): both CLEAN. The Opus lane cross-checked 15 doc claims against `platform_compat.py` with file:line evidence, all MATCH; its one substantive advisory (the paragraph omitted the Bypass Traverse Checking caveat) is incorporated in this revision.

## Any other suggestions on the work

None. Scope is deliberately the two documents the issue names; CHANGELOG.md is untouched per the changelog-at-version-bump-only rule.

Closes #4981
