### PR TITLE
docs(spec): Add Human-in-the-Loop Tool-Approval Layer spec

### DIFF
--- a/.kiro/specs/tool-approval-layer/design.md
+++ b/.kiro/specs/tool-approval-layer/design.md
@@ -1,0 +1,185 @@
+# Design — Human-in-the-Loop Tool-Approval Layer
+
+## Overview
+
+The approval layer is the seam between an autonomous agent and any consequential action.
+It already exists in Kiro Crew as three cooperating pieces:
+
+1. **Enforcement (backend):** `HookManager.on_tool_call` in `src/kiro_crew/hooks.py`
+   returns `TOOL_ALLOW` / `TOOL_AUTO_APPROVE` / `TOOL_DENY` at the PreToolUse boundary,
+   applying sensitive-path, exfiltration, write-protected-config, deny-by-default-shell,
+   and governance (ceiling ∩ profile) rules. This is the **only** policy authority.
+2. **Render (frontend):** `components/ApprovalCard.tsx` + `components/ToolInputPreview.tsx`
+   render a pending call as a card, currently as a raw `<pre>` args dump.
+3. **Resume (frontend → backend):** `components/ChatInput.tsx` submits the decision via
+   `api.approveChatSlot(slot, action, extra)`; the paused turn resumes with the tool
+   either executed or rejected.
+
+This design does NOT add a second policy. It (a) enriches the **render** step with a typed
+preview and a batch affordance, (b) documents the **resume** step against the AI-SDK
+interruption seam so the pattern is portable, and (c) leaves enforcement exactly where it
+is. The App Builder Kit's `kit/tool-views` module supplies the typed preview components;
+this spec is the approval-loop contract that consumes them.
+
+## Architecture
+
+```
+Agent turn
+   │  emits tool call (PreToolUse event)
+   ▼
+┌──────────────────────────────────────────────┐
+│ HookManager.on_tool_call  (hooks.py) — AUTHORITY│
+│   TOOL_DENY ──────────► blocked + SEL audit     │  (never surfaced)
+│   TOOL_AUTO_APPROVE ──► executes, no prompt      │
+│   TOOL_ALLOW ─────────► held as pending decision │
+└──────────────────────────────────────────────┘
+   │  pending decision (title, purpose, input, tool-call id, slot)
+   ▼
+┌──────────────────────────────────────────────┐
+│ ApprovalCard.tsx  (render via generative UI)    │
+│   ToolPreviewFrame (kit/tool-views)             │
+│     schema match  → rich typed preview          │
+│     no match      → ToolInputPreview <pre>      │
+│   [show raw input] always one interaction away  │
+│   batch: N pending → one multi-select action    │
+└──────────────────────────────────────────────┘
+   │  operator clicks approve / reject (+ optional pattern)
+   ▼
+┌──────────────────────────────────────────────┐
+│ onApprove(decision, pattern?) → ChatInput.tsx   │
+│   api.approveChatSlot(slot, action, extra)      │  (EXISTING transport)
+└──────────────────────────────────────────────┘
+   │  resume the SAME interrupted invocation (slot + tool-call id)
+   ▼
+Tool executes (approved) or is skipped (rejected); agent turn continues
+```
+
+### Boundary with existing code (verified paths)
+
+| Existing | Layer relationship |
+|---|---|
+| `src/kiro_crew/hooks.py` (`on_tool_call`) | **Unchanged.** Sole policy authority; the layer reads its verdict. |
+| `website/src/components/ApprovalCard.tsx` | Hosts `ToolPreviewFrame` + the batch affordance. |
+| `website/src/components/ToolInputPreview.tsx` | The fallback preview and the "show raw input" surface. |
+| `website/src/components/ChatInput.tsx` (`approveChatSlot`) | **Unchanged** resume transport the layer reuses. |
+| `website/src/hooks/useWebSocket.ts` | Delivers the pending-decision + resume events (existing). |
+| `website/src/kit/tool-views/` (App Builder Kit) | Supplies `ToolPreviewFrame` / schema-matched typed previews. |
+| `website/src/types/index.ts` (`tool_input: string`) | The opaque input string a preview parses; no new wire field. |
+
+## Components and Interfaces
+
+### Pending-decision model (frontend, mirrors AI-SDK `UIToolInvocation`)
+
+```ts
+// state model only — NOT a transport claim
+type ToolInvocationState<TIn, TOut> =
+  | { state: 'input-streaming';  input: Partial<TIn> }   // args still arriving
+  | { state: 'input-available';  input: TIn }            // ← the approvable moment
+  | { state: 'output-available'; input: TIn; output: TOut }
+  | { state: 'output-error';     input: TIn; error: string }
+
+interface PendingDecision {
+  slot: string
+  toolCallId: string           // pins the resume to the SAME invocation (Req 3.4)
+  title: string                // display title/purpose from the PreToolUse event
+  rawInput: string             // verbatim tool_input — the "show raw input" source (Req 2.4)
+  invocation: ToolInvocationState<unknown, unknown>  // at 'input-available'
+}
+```
+
+The approvable moment is `state: 'input-available'`: the input is complete but the tool
+has not run. The card renders from this state; resume moves it to `output-available` /
+`output-error`.
+
+### Render: `ApprovalCard` + `ToolPreviewFrame`
+
+`ApprovalCard` receives one or more `PendingDecision`s. For each, it delegates the input
+body to `ToolPreviewFrame` (from `kit/tool-views`):
+
+- **Schema match** → typed rich preview (e.g. a diff, a table, a chart of the args).
+- **No match** → the existing `ToolInputPreview` `<pre>` (Req 2.3, non-regression).
+- **Always** → a collapsed "show raw input" control revealing the verbatim `rawInput`
+  (Req 2.4). The rich preview is lossy by design; the raw string is the ground truth the
+  operator can inspect before approving.
+
+Controls (approve / reject / optional pattern field) are keyboard operable with ARIA
+roles (Req 2.5).
+
+### Resume: `onApprove` → `approveChatSlot`
+
+The decision is passed straight to the existing callback:
+
+```ts
+onApprove(decision: 'approve' | 'reject', pattern?: string)
+// → api.approveChatSlot(slot, decision, pattern)   (ChatInput.tsx, unchanged)
+```
+
+`toolCallId` + `slot` pin the resume to the interrupted invocation (Req 3.4). The optional
+`pattern` (e.g. an "always allow this shape" rule) is forwarded verbatim as `extra`
+(Req 3.5); it is a hint to the *next* `on_tool_call` evaluation, never a frontend policy.
+
+### Batch approval
+
+Batch is a **UI affordance over the per-call resume**, not a new transport (Req 4.2).
+When N calls are pending in a slot, `ApprovalCard` renders a multi-select; submitting a
+batch iterates `approveChatSlot` per included call. A call the gate would deny is visibly
+excluded and never included in the batch set (Req 4.3–4.4) — the frontend cannot approve
+what the backend denies.
+
+## Portable AI-SDK mapping (Requirement 5)
+
+The portable shape is three steps; the table names what an adopter substitutes.
+
+| Step | Portable shape | Kiro Crew binding | AI-SDK binding |
+|---|---|---|---|
+| Intercept | evaluate the call before it executes | `HookManager.on_tool_call` | a tool with no `execute`, or `prepareStep`/`onStepFinish` interruption |
+| Render | build a card from the invocation state | `ApprovalCard` + `ToolPreviewFrame` | render from `UIToolInvocation` at `input-available` |
+| Resume | apply the decision to the same invocation | `approveChatSlot(slot, action, extra)` | `addToolResult({ toolCallId, output })` + continued stream |
+
+**Explicit boundary (Req 5.3):** the *enforcement* (`on_tool_call`) and the *transport*
+(`approveChatSlot`) are Kiro-Crew-specific — an adopter swaps in their own. The *portable*
+part is: intercept before execute, render a card from the invocation state, resume the
+same `toolCallId` on decision. **The AI-SDK `UIToolInvocation` union is reused as a state
+model, not a transport claim (Req 5.4)** — Kiro Crew's chat transport is markdown +
+`<mcwidget>` opaque strings (`useBlockAssembler.ts`, `types/index.ts`), not a typed
+`tool-<name>` part stream, exactly as documented for the App Builder Kit tool-view encoding.
+
+## Data Models
+
+The layer adds **no new backend wire field.** A `PendingDecision` is assembled on the
+frontend from the existing PreToolUse event (title, `tool_input` string) already delivered
+over `useWebSocket.ts`. The typed preview parses `rawInput` against a `kit/tool-views`
+schema; a parse failure downgrades to `<pre>` (no throw).
+
+## Error Handling
+
+- A schema parse failure on the preview downgrades to `ToolInputPreview` `<pre>` and logs
+  via the existing logger — it never blocks the operator from deciding.
+- A resume that references a stale/closed `toolCallId` is a no-op with a surfaced notice,
+  never a re-issued call (Req 3.4).
+- A batch that includes a now-denied call excludes it and reports the exclusion; the
+  remaining approvals proceed.
+- Enforcement errors (governance deny, sensitive-path) are owned by `on_tool_call` and its
+  SEL audit — the layer surfaces the deny, it does not handle or suppress it.
+
+## Testing Strategy
+
+- **Unit (vitest):** `ApprovalCard` renders each `PendingDecision` state; schema-match vs
+  `<pre>` fallback; "show raw input" reveals verbatim `rawInput`; keyboard/ARIA on controls.
+- **Resume:** approve and reject each route through a mocked `onApprove`/`approveChatSlot`
+  with the correct `slot`/`toolCallId`/`pattern`; a stale `toolCallId` is a no-op.
+- **Batch:** multi-select resolves per-call; a denied call is excluded, not approved.
+- **Enforcement non-bypass:** a `TOOL_DENY` verdict never yields an approvable card and
+  no operator affordance executes it (Req 6.1–6.2).
+- **Backend (pytest):** reuse `test/test_dashboard_approval.py`, `test_auto_approve.py`,
+  `test_approval_threading.py` patterns to assert the gate verdicts are unchanged and the
+  SEL audit still fires.
+- **Screenshot Evidence:** capture pending / approved / rejected / raw-expanded states via
+  dev-server + Playwright (light path) for the CI gate.
+
+## CI / constraints (repo-specific)
+
+- Screenshot Evidence gate — the four approval states are the required frames.
+- jscpd 0% — reuse `ApprovalCard`/`ToolInputPreview`/`ChatInput`; do not fork them.
+- catalogParity — all new `i18nT()` keys land in every locale file.
+- PR Hygiene — single squashed commit per PR.

--- a/.kiro/specs/tool-approval-layer/requirements.md
+++ b/.kiro/specs/tool-approval-layer/requirements.md
@@ -1,0 +1,111 @@
+# Requirements — Human-in-the-Loop Tool-Approval Layer
+
+## Introduction
+
+Kiro Crew already intercepts every agent tool call before it executes. The backend
+`HookManager.on_tool_call` gate (`src/kiro_crew/hooks.py`) classifies each PreToolUse
+event as `TOOL_ALLOW`, `TOOL_AUTO_APPROVE`, or `TOOL_DENY` — enforcing sensitive-path,
+exfiltration, write-protected-config, deny-by-default-shell, and governance rules
+*before* the tool runs. When a call is neither auto-approved nor denied, the frontend
+surfaces it for a human decision: `ApprovalCard.tsx` renders the pending call, the
+operator approves or rejects, and the decision flows back through
+`onApprove(decision, pattern?)` → `api.approveChatSlot(slot, action, extra)`
+(`ChatInput.tsx`) to resume the paused turn.
+
+This is Kiro Crew's **batch-approve + inline tool-request preview** differentiator: a
+verification checkpoint that sits between an autonomous agent and any consequential
+action. The trust story is that delegation is safe *because* interception is always
+running — the operator can intervene with full context instead of crossing their fingers.
+
+The **Tool-Approval Layer** formalizes that capability as a **portable pattern**:
+intercept a tool call before execution, render an approval card via generative UI,
+resume on the operator's click. It is expressed against the Vercel AI SDK's tool-call
+lifecycle (`UIToolInvocation` states and interrupted tool execution + client resume) so
+the same shape lands in any AI-SDK app, not only Kiro Crew's dashboard.
+
+Scope is the interception → render → resume loop and its contracts. It is NOT a rewrite
+of the existing `on_tool_call` security gate (that gate remains the enforcement authority),
+NOT a new approval transport (it reuses `approveChatSlot`), and NOT a change to how tools
+are defined or executed.
+
+## Requirements
+
+### Requirement 1 — Interception before execution
+
+**User Story:** As an operator, I want every consequential tool call paused before it
+runs, so that no side effect happens without a decision I could have made.
+
+#### Acceptance Criteria
+1. WHEN an agent emits a tool call THEN the layer SHALL evaluate it through the existing `HookManager.on_tool_call` gate BEFORE the tool executes.
+2. WHEN the gate returns `TOOL_DENY` THEN the call SHALL be blocked and SHALL NOT reach the approval surface (a denied call is not a pending decision).
+3. WHEN the gate returns `TOOL_AUTO_APPROVE` THEN the call SHALL execute without a human prompt (reads and pre-authorized tools do not nag).
+4. WHEN the gate returns `TOOL_ALLOW` (neither auto-approved nor denied) THEN the call SHALL be held as a pending decision and surfaced for human approval before it executes.
+5. IF the gate cannot verify a shell tool's command (deny-by-default) THEN the call SHALL be denied, not surfaced as an approvable pending decision.
+
+### Requirement 2 — Approval card rendered via generative UI
+
+**User Story:** As an operator, I want the pending call rendered as a rich, contextual
+card, so that I understand what the agent is about to do instead of reading a raw args dump.
+
+#### Acceptance Criteria
+1. WHEN a call is held as a pending decision THEN the layer SHALL render an approval card describing the tool, its purpose/title, and its input.
+2. WHERE a tool-view schema matches the pending call's input THE card SHALL render a rich, typed preview of the input in place of the raw `<pre>` dump as the default view.
+3. WHERE no schema matches THE card SHALL fall back to the current `ToolInputPreview` `<pre>` rendering with no regression.
+4. WHERE a rich preview is shown THE exact, unmodified raw tool input SHALL remain available to the operator one interaction away (an expandable "show raw input" control), because a rich renderer is lossy and tool input is attacker-influenceable — a consequential argument must never be hidden by the summary.
+5. IF the approval card is rendered THEN its controls SHALL be keyboard operable and expose appropriate ARIA roles/labels (WCAG AA), because operators batch-approve.
+
+### Requirement 3 — Resume on decision
+
+**User Story:** As an operator, I want my approve/reject click to resume the exact paused
+turn, so that the agent continues with my decision applied and no state is lost.
+
+#### Acceptance Criteria
+1. WHEN the operator approves a pending call THEN the decision SHALL flow through the existing `onApprove(decision, pattern?)` callback and the paused tool call SHALL execute.
+2. WHEN the operator rejects a pending call THEN the tool SHALL NOT execute and the agent turn SHALL resume with the rejection recorded.
+3. WHEN an approval decision is submitted from a chat slot THEN it SHALL resolve via the existing slot-scoped `api.approveChatSlot(slot, action, extra)` path in `ChatInput.tsx` — the layer SHALL NOT introduce a new approval API path.
+4. WHEN a decision resumes a turn THEN the resumed state SHALL be the same interrupted invocation (same slot, same tool-call id), never a re-issued or duplicated call.
+5. IF the operator provides an approval `pattern` (e.g. "always allow this shape") THEN it SHALL be forwarded verbatim as the `extra`/`pattern` argument the existing path already accepts.
+
+### Requirement 4 — Batch approval
+
+**User Story:** As an operator supervising an autonomous run, I want to approve or reject
+several pending calls at once, so that supervision scales past one-click-per-call.
+
+#### Acceptance Criteria
+1. WHERE more than one call is pending in a slot THE layer SHALL present them such that the operator can act on multiple pending decisions in one interaction.
+2. WHEN a batch decision is submitted THEN each included pending call SHALL resolve through the same per-call `approveChatSlot` path (batch is a UI affordance over the existing per-call resume, not a new transport).
+3. WHEN a batch approval includes a call the gate would deny THEN that call SHALL still be denied — batch approval SHALL NOT override the security gate.
+4. IF a batch spans calls of differing risk THEN a denied or ineligible call SHALL be visibly excluded from the batch rather than silently approved.
+
+### Requirement 5 — Portable AI-SDK lifecycle mapping
+
+**User Story:** As an app author on the Vercel AI SDK, I want this approval loop expressed
+in AI-SDK terms, so that I can adopt the pattern in my own app without Kiro Crew internals.
+
+#### Acceptance Criteria
+1. WHEN the layer models a tool call's state THEN it SHALL map to the AI-SDK `UIToolInvocation` lifecycle union (`input-streaming` | `input-available` | `output-available` | `output-error`) as the component-internal state model.
+2. WHERE the AI SDK exposes an interruption/resume seam (a tool whose execution is interrupted pending client input, resumed via `addToolResult`/a continued stream) THE layer's resume step SHALL be documented against that seam so a non-Kiro-Crew app can wire the same intercept → render → resume loop.
+3. WHEN the pattern is documented THEN it SHALL state explicitly which parts are Kiro-Crew-specific (the `on_tool_call` gate, `approveChatSlot`) and which are the portable shape (intercept before execute, render a card from the invocation state, resume on decision), so an adopter substitutes their own enforcement and transport without misreading the boundary.
+4. WHERE Kiro Crew's transport differs from AI-SDK's typed part stream THE mapping SHALL NOT claim a wire-format equivalence that does not exist — the AI-SDK lifecycle union is reused as a state model, not as a transport claim (consistent with the App Builder Kit tool-view encoding).
+
+### Requirement 6 — Enforcement authority is unchanged
+
+**User Story:** As a maintainer, I want the approval layer to add UI and resume mechanics
+only, so that the security guarantees keep living in one audited place.
+
+#### Acceptance Criteria
+1. WHEN the layer decides whether a call is approvable THEN the decision SHALL come from `HookManager.on_tool_call` (and the governance ceiling ∩ profile it already applies), NOT from a second, parallel policy in the frontend.
+2. WHEN a call is denied by the gate THEN the layer SHALL NOT expose an operator affordance that would execute it anyway (no frontend override of a backend deny).
+3. WHEN a governance or security deny fires THEN the existing SEL audit trail SHALL record it unchanged — the layer SHALL NOT bypass or duplicate audit emission.
+4. IF the layer needs richer per-call metadata to render a card THEN it SHALL derive that from data already on the PreToolUse event (title, purpose, input), NOT by widening what the agent can self-authorize.
+
+### Requirement 7 — Non-regression and CI compliance
+
+**User Story:** As a maintainer, I want the layer to satisfy the repo's CI gates, so that
+adopting it does not create review or build friction.
+
+#### Acceptance Criteria
+1. WHEN the approval card introduces a user-visible surface change THEN the change SHALL ship with committed, SHA-pinned screenshots satisfying the Screenshot Evidence gate (pending, approved, rejected, and raw-input-expanded states).
+2. WHEN layer code adds user-facing strings THEN the corresponding keys SHALL exist in all locale files (catalogParity).
+3. WHEN layer code is added THEN it SHALL NOT introduce copy/paste clones that fail the jscpd 0% threshold, and SHALL reuse `ApprovalCard`/`ToolInputPreview`/`ChatInput` rather than forking them.
+4. WHEN the existing approval flow is exercised THEN it SHALL show no regression versus its pre-change behavior (the auto-approve, deny, and single-approve paths keep working).

--- a/.kiro/specs/tool-approval-layer/tasks.md
+++ b/.kiro/specs/tool-approval-layer/tasks.md
@@ -1,0 +1,72 @@
+# Implementation Plan — Human-in-the-Loop Tool-Approval Layer
+
+This plan enriches the render + resume steps of Kiro Crew's existing approval loop and
+documents the portable AI-SDK mapping. The backend enforcement gate (`on_tool_call`) is
+NOT modified. Depends on the App Builder Kit's `kit/tool-views` module for the typed
+preview components.
+
+- [ ] 0. Establish the `PendingDecision` frontend model and confirm the resume seam
+  - Define `PendingDecision` (`slot`, `toolCallId`, `title`, `rawInput`, `invocation`) and
+    the `ToolInvocationState` union in a shared types module, mirroring AI-SDK
+    `UIToolInvocation` as a state model only.
+  - Confirm (via reading `useWebSocket.ts` + `ChatInput.tsx`) that a `PendingDecision` can
+    be assembled from the existing PreToolUse event with NO new backend wire field, and that
+    `approveChatSlot(slot, action, extra)` already pins resume to the slot.
+  - _Requirements: 3.3, 3.4, 5.1, 6.4_
+
+- [ ] 1. Rich preview inside `ApprovalCard` (default view, with raw-input fallback)
+  - Host `ToolPreviewFrame` (from `kit/tool-views`) inside `ApprovalCard`/`ToolInputPreview`.
+  - Render the typed preview when a schema matches the pending input; fall back to the
+    existing `<pre>` when none matches.
+  - Add an always-present, collapsed "show raw input" control revealing verbatim `rawInput`.
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [ ] 2. Keyboard + ARIA on the approval controls
+  - Make approve / reject / pattern controls keyboard operable with correct ARIA roles and
+    labels (WCAG AA); verify tab order and focus management for batch operation.
+  - _Requirements: 2.5_
+
+- [ ] 3. Wire the resume path (approve / reject / pattern)
+  - Route the decision through the existing `onApprove(decision, pattern?)` →
+    `api.approveChatSlot(slot, action, extra)`; forward `pattern` verbatim as `extra`.
+  - Ensure resume targets the same `slot` + `toolCallId`; a stale/closed id is a no-op with
+    a surfaced notice, never a re-issued call.
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [ ] 4. Batch approval affordance
+  - Render a multi-select when N calls are pending in a slot; submitting a batch iterates
+    the per-call `approveChatSlot` resume (no new transport).
+  - Visibly exclude any call the gate would deny; never include it in the batch set.
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [ ] 5. Enforce the single-authority boundary
+  - Assert the frontend never renders an approvable card for a `TOOL_DENY` verdict and
+    exposes no affordance that would execute a denied call.
+  - Confirm the SEL audit for a deny still fires unchanged (no bypass, no duplication).
+  - _Requirements: 6.1, 6.2, 6.3_
+
+- [ ] 6. Document the portable AI-SDK mapping
+  - Write the intercept → render → resume mapping table naming the Kiro-Crew-specific parts
+    (`on_tool_call`, `approveChatSlot`) vs the portable shape, and the AI-SDK resume seam
+    (`addToolResult` / continued stream).
+  - State explicitly that the `UIToolInvocation` union is a state model, not a transport
+    equivalence (Kiro Crew's transport is markdown + `<mcwidget>` opaque strings).
+  - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+- [ ] 7. Tests — render, resume, batch, non-bypass
+  - Unit (vitest): each `PendingDecision` state; schema-match vs `<pre>` fallback;
+    raw-input reveal; keyboard/ARIA.
+  - Resume: approve/reject route with correct `slot`/`toolCallId`/`pattern`; stale id no-op.
+  - Batch: per-call resolution; denied call excluded.
+  - Non-bypass: a `TOOL_DENY` never yields an approvable card.
+  - Backend (pytest): reuse `test_dashboard_approval.py` / `test_auto_approve.py` /
+    `test_approval_threading.py` to assert gate verdicts + SEL audit unchanged.
+  - _Requirements: 2.*, 3.*, 4.*, 6.*, 7.4_
+
+- [ ] 8. CI compliance + non-regression
+  - Capture SHA-pinned screenshots of pending / approved / rejected / raw-expanded states
+    for the Screenshot Evidence gate.
+  - Land all new `i18nT()` keys in every locale file (catalogParity).
+  - Reuse `ApprovalCard`/`ToolInputPreview`/`ChatInput` (jscpd 0%); confirm the
+    auto-approve, deny, and single-approve paths show no regression.
+  - _Requirements: 7.1, 7.2, 7.3, 7.4_


### PR DESCRIPTION
## Problem
Kiro Crew's human-in-the-loop tool-approval flow — intercept a tool call, render an approval card, resume on the user's click — is one of its clearest differentiators, but it lives only as implementation (the `on_tool_call` policy gate plus the `ApprovalCard` → `approveChatSlot` frontend path). There is no written spec that names the pattern, its boundaries, or how it maps onto a standard agent tool-call lifecycle, so it cannot be reasoned about, reused, or ported.

## Why it matters
Without a spec, the differentiator is invisible to anyone not reading the source, and any reuse (in another app, or as a portable pattern on the Vercel AI SDK tool-call lifecycle) risks re-deriving the enforcement boundary incorrectly — moving policy authority out of `on_tool_call` and creating a security regression. A spec pins the enforcement authority in place and describes only the additive render + resume + batch layer on top.

## Fix (symptoms → root cause → change)
Symptom: the approval pattern exists only as code with no design-of-record. Root cause: it was built incrementally and never formalized as a spec sibling to the App Builder Kit. Change: add a three-file Kiro spec under `.kiro/specs/tool-approval-layer/`:
- `requirements.md` — 7 EARS requirements. Enforcement stays in `on_tool_call` (Req 6); the layer adds interception-before-execution, generative-UI approval card, resume-on-decision, batch approval, and a portable AI-SDK lifecycle mapping (`UIToolInvocation` + `addToolResult`).
- `design.md` — architecture grounded in the real, verified code paths (`HookManager.on_tool_call` in `hooks.py`; `ApprovalCard` / `ToolPreviewFrame`; `onApprove` → `api.approveChatSlot`), with the portable AI-SDK mapping described as a state model, not a transport change.
- `tasks.md` — implementation plan traced to the requirements.

No behavior change: this is documentation only, adding a spec sibling of `.kiro/specs/app-builder-kit/`.

## Tests
N/A — docs-only change (3 markdown files under `.kiro/specs/`). No code, tests, dependencies, CI, or config are touched.

## Manual verification
Verified the diff adds exactly the 3 spec files (`git show --stat`), the branch is a single commit on fresh `origin/main`, and the content contains no one-word brand usage (Brand Name Gate), no internal tokens/secrets, and no leaky absolute paths.
