### PR TITLE
fix(apps): invalidate the registry query when apps change

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1538,10 +1538,19 @@ export default function App() {
     return () => { if (appNavRetryRef.current) clearTimeout(appNavRetryRef.current) }
   }, [refreshAppNav])
   useEffect(() => {
-    const handler = () => refreshAppNav()
+    const handler = () => {
+      refreshAppNav()
+      // The Explore shelf's install state lives in the server-computed
+      // `installed` flag on the `['registry']` rows, which are cached with a
+      // multi-minute staleTime. Every install/uninstall/enable surface
+      // announces itself through this event, so drop that cache here too —
+      // otherwise a just-installed registry app keeps rendering a "Get"
+      // button until the cache expires.
+      queryClient.invalidateQueries({ queryKey: ['registry'] })
+    }
     window.addEventListener('mc:apps-changed', handler)
     return () => window.removeEventListener('mc:apps-changed', handler)
-  }, [refreshAppNav])
+  }, [refreshAppNav, queryClient])
   // Refetch the Apps nav when the gateway connection is *re*-established after a
   // drop — e.g. a `kirocrew update` restart disconnects then reconnects the
   // WebSocket. Only fires on a connected→disconnected→connected cycle, NOT the

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -566,7 +566,8 @@ export default function AppsPage() {
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ['apps'] })
-    queryClient.invalidateQueries({ queryKey: ['registry'] })
+    // ['registry'] is deliberately not invalidated here: the mc:apps-changed
+    // listener in App.tsx owns that, for every dispatch site at once.
     window.dispatchEvent(new Event('mc:apps-changed'))
   }
 

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -632,6 +632,21 @@ describe('App routing', () => {
     }
   })
 
+  it('invalidates the registry query on mc:apps-changed so install state refreshes', async () => {
+    // The Explore shelf renders Get vs Installed from the server-computed
+    // `installed` flag on the `['registry']` rows, cached with a multi-minute
+    // staleTime. Install/uninstall surfaces announce themselves via
+    // mc:apps-changed; the handler must drop that cache or a just-installed
+    // registry app keeps showing a "Get" button until the cache expires.
+    const { queryClient } = renderWithProviders(<App />, { route: '/chat' })
+    queryClient.setQueryData(['registry'], { apps: [] })
+    expect(queryClient.getQueryState(['registry'])?.isInvalidated).toBe(false)
+    act(() => { window.dispatchEvent(new Event('mc:apps-changed')) })
+    await waitFor(() => {
+      expect(queryClient.getQueryState(['registry'])?.isInvalidated).toBe(true)
+    })
+  })
+
   it('shows a portaled hover label for a collapsed (icon-only) nav item', async () => {
     // Covers useNavTip: in collapsed mode nav rows hide their text label and
     // instead show it via a portal to <body> on hover (so the rail's vertical


### PR DESCRIPTION
## Summary

The Explore (App Store Discover) shelf renders **Get vs Installed** from the server-computed `installed` flag on the `['registry']` query rows, which are cached client-side with a 5-minute `staleTime`.

Every install/uninstall/enable surface (AppDetailPage, SourcesPopover, MigrationPage, AppsPage) announces a change by dispatching `mc:apps-changed`, but the App-shell listener only refreshed the nav rail and the `['apps']` cache — nothing invalidated `['registry']`. Result: a **just-installed registry app kept rendering a "Get" button** on Explore until the cache expired. Built-ins never exposed the gap because their cached rows were already `installed: true`; only third-party/registry installs hit it (reproduced live with the `launchdarkly` catalog app).

## Fix

1. Invalidate `['registry']` inside the `mc:apps-changed` handler in `App.tsx` — the single listening point that all dispatch sites already funnel through. Deliberately NOT inside `refreshAppNav()`, so mount/reconnect nav refreshes don't trigger extra registry refetches; only explicit app-change events do.
2. **Delete AppsPage's own `invalidateQueries({ queryKey: ['registry'] })`** (in its `invalidate()` helper): it dispatches `mc:apps-changed` on the next line, so after (1) the local call is a duplicate spelling of the same refresh. AppsPage's registry refresh now rides the shared listener — which is always mounted, since AppsPage renders inside the App shell. (Adopted from the First Principles round-1 subtraction.)

## Tested

- New regression test in `App.test.tsx`: dispatching `mc:apps-changed` must mark the `['registry']` query invalidated. **Mutation-verified**: fails without the App.tsx change, passes with it.
- `npx tsc -b` clean; App + AppsPage + AppDetailPage test files all green after the AppsPage deletion.
- `scripts/local-gate.py --base origin/main` (frontend full): 22736 passed, 2 failed in `CliPanelCoverage.test.tsx` (xterm theme `waitFor` timeout). Triaged as load-dependent flake unrelated to this diff: the file passes 41/41 deterministically in isolation both **with and without** this change; this diff touches only the `mc:apps-changed` handler and CliPanel does not read `['registry']`.

<!-- no-visual-delta -->
**Why no screenshot:** No visual delta — this changes cache-invalidation timing only. Both button states ("Get" / "Installed") are pre-existing components; the fix only makes the data refresh immediately instead of after a 5-minute cache expiry.
