### PR TITLE
fix: put the side panel's version footer at the bottom on a phone

### DIFF
--- a/website/src/components/SidePanelLayout.tsx
+++ b/website/src/components/SidePanelLayout.tsx
@@ -156,7 +156,7 @@ export default function SidePanelLayout({ title, tabs, defaultTab, rememberKey, 
   return (
     <div className={`flex-1 min-h-0 flex overflow-hidden ${isMobile ? 'flex-col' : ''}`}>
       {isMobile ? (
-        <div className="shrink-0 border-b border-border bg-bg px-4 pt-3 pb-0">
+        <div data-testid="side-panel-mobile-header" className="shrink-0 border-b border-border bg-bg px-4 pt-3 pb-0">
           <div className="flex items-center justify-between mb-2">
             <div className="text-lg font-bold text-text-strong">{title}</div>
             {headerRight}
@@ -193,7 +193,6 @@ export default function SidePanelLayout({ title, tabs, defaultTab, rememberKey, 
               <div aria-hidden="true" data-testid="tab-strip-cue-right" className="pointer-events-none absolute right-0 top-0 bottom-2 w-6 bg-gradient-to-l from-bg to-transparent" />
             )}
           </div>
-          {footer && <div className="pt-2 pb-2">{footer}</div>}
         </div>
       ) : (
         <nav className="w-[200px] shrink-0 border-r border-border bg-bg overflow-y-auto pt-1 pb-3 px-3 flex flex-col gap-0.5">
@@ -246,6 +245,18 @@ export default function SidePanelLayout({ title, tabs, defaultTab, rememberKey, 
         <div data-testid="side-panel-pane" className={`${isMobile ? 'px-4 pt-3' : 'px-6'} ${fixed ? 'flex-1 min-h-0 flex flex-col' : 'flex-1 pb-8'}`}>
           {children(tab)}
         </div>
+        {/* The footer sits at the BOTTOM on both layouts, which on a phone means
+          * the end of the scrolling content rather than the header block it used
+          * to share with the tab strip — up there it read as a subtitle of the
+          * strip, and a reader looking for the version where desktop puts it
+          * (`mt-auto`, foot of the nav rail) concluded the phone did not show one.
+          * Deliberately in the content flow and not `position: fixed`: a fixed bar
+          * would spend a phone's vertical space on a version string, and in this
+          * shell it resolves against a transformed ancestor rather than the
+          * viewport, so it would need a portal to land where it claims to. */}
+        {isMobile && footer && (
+          <div data-testid="side-panel-footer" className="shrink-0 px-4 pt-3 pb-5">{footer}</div>
+        )}
       </div>
     </div>
   )

--- a/website/src/test/SidePanelLayout.mobileFooterAtBottom.test.tsx
+++ b/website/src/test/SidePanelLayout.mobileFooterAtBottom.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * The side panel's footer sits at the BOTTOM on a phone, not in the header block.
+ *
+ * Settings is the only caller that passes a `footer`, and what it passes is
+ * `KiroCrew v<version>`. On desktop that lands where a reader expects it: `mt-auto`
+ * at the foot of the 200px nav rail. The narrow branch used to render the same node
+ * inside the mobile header block, immediately under the scrolling tab strip — so on
+ * a phone the version read as a subtitle of the strip, and a reader looking for it
+ * where desktop puts it concluded the phone showed no version at all. It was
+ * present and in the wrong place, which is indistinguishable from missing.
+ *
+ * What is asserted here is DOM ORDER rather than pixels, because jsdom computes no
+ * geometry and order is the actual contract: the footer must follow the content
+ * pane, and must not be a descendant of the header block. The last assertion guards
+ * a specific trap — the footer must NOT be `position: fixed`. A fixed bar would
+ * spend a phone's scarce vertical space on a version string, and in this shell it
+ * resolves against a transformed ancestor rather than the viewport (the same bug
+ * that put an app's tab bar mid-screen until it was portalled to `document.body`),
+ * so it would not even land where it claims to.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SidePanelLayout, { type SidePanelTab } from '../components/SidePanelLayout'
+
+const mobile = vi.hoisted(() => ({ value: false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mobile.value }))
+
+const TABS: SidePanelTab[] = [
+  { key: 'form', label: 'Form', icon: null },
+  { key: 'archive', label: 'Archive', icon: null },
+]
+
+function renderPanel() {
+  return render(
+    <MemoryRouter initialEntries={['/page']}>
+      <SidePanelLayout
+        title="Test"
+        tabs={TABS}
+        footer={<span>KiroCrew v9.9.9</span>}
+      >
+        {tab => <div data-testid="pane-body">{tab}</div>}
+      </SidePanelLayout>
+    </MemoryRouter>,
+  )
+}
+
+describe('SidePanelLayout footer placement', () => {
+  beforeEach(() => { mobile.value = false })
+
+  it('renders the footer after the content pane on a phone', () => {
+    mobile.value = true
+    renderPanel()
+
+    const footer = screen.getByTestId('side-panel-footer')
+    const pane = screen.getByTestId('side-panel-pane')
+    expect(footer).toHaveTextContent('KiroCrew v9.9.9')
+    // Node.DOCUMENT_POSITION_FOLLOWING (4): the footer comes after the pane.
+    expect(pane.compareDocumentPosition(footer) & 4).toBe(4)
+  })
+
+  it('keeps the footer out of the header block that holds the tab strip', () => {
+    mobile.value = true
+    renderPanel()
+
+    const footer = screen.getByTestId('side-panel-footer')
+    const header = screen.getByTestId('side-panel-mobile-header')
+    // The header block is where the version used to live, reading as a subtitle of
+    // the pills. Asserting against the block itself — not some div near a pill —
+    // is what makes this fail if the footer moves back into it.
+    expect(header).toContainElement(screen.getByRole('button', { name: 'Form' }))
+    expect(header.contains(footer)).toBe(false)
+  })
+
+  it('never positions the footer fixed, so it cannot miss the viewport', () => {
+    mobile.value = true
+    renderPanel()
+
+    const cls = screen.getByTestId('side-panel-footer').className
+    expect(cls).not.toMatch(/(?:^|\s)(?:[a-z-]+:)?fixed(?:\s|$)/)
+    expect(cls).not.toMatch(/(?:^|\s)(?:[a-z-]+:)?absolute(?:\s|$)/)
+  })
+
+  it('leaves the desktop footer in the nav rail, pushed down by mt-auto', () => {
+    renderPanel()
+
+    // Desktop keeps its own footer node inside the rail; the narrow one is absent.
+    expect(screen.queryByTestId('side-panel-footer')).toBeNull()
+    const nav = document.querySelector('nav')
+    expect(nav?.textContent).toContain('KiroCrew v9.9.9')
+    expect(nav?.querySelector('.mt-auto')?.textContent).toContain('KiroCrew v9.9.9')
+  })
+})


### PR DESCRIPTION
Reported from a phone: the version number is not shown at the bottom. It was being rendered — just not at the bottom, which from the reader's side is the same thing as missing.

## What was wrong

`SettingsPage` is the **only** caller that passes a `footer` to `SidePanelLayout`, and what it passes is `KiroCrew v<version>`. The layout treated the two branches differently:

- **Desktop** (`SidePanelLayout.tsx`): `mt-auto pt-3 px-2.5` inside the 200px `<nav>` — pushed to the foot of the rail, where a reader looks for a version.
- **Phone**: the same node inside the mobile header block (`pt-2 pb-2`), directly beneath the scrolling tab-pill strip — i.e. at the **top** of the screen, reading as a subtitle of the pills.

## The fix

The footer now renders after the content pane on the narrow branch, so both layouts put it at the bottom.

Deliberately in the content flow and **not** `position: fixed`. Two reasons: a fixed bar would spend a phone's scarce vertical space on a version string; and in this shell a fixed element resolves against a transformed ancestor rather than the viewport — the same bug that left an app's tab bar stranded mid-screen until it was portalled to `document.body` — so it would need a portal to land where it claims to.

## Verification

Real render at 390×844 against an isolated pod (not the live gateway), Settings → Overview scrolled to the end — `Kiro Crew v0.5.0` sits below the last card:

`side-panel-footer` bounding box at that viewport: `{x: 0, y: 838, width: 390, height: 54}`.

- `npx tsc --noEmit` clean; `npm run build` clean.
- New `SidePanelLayout.mobileFooterAtBottom.test.tsx` (4 tests) plus the 4 existing side-panel suites: 36 tests pass.
- The tests assert **DOM order**, not pixels, because jsdom computes no geometry and order is the actual contract: the footer follows the pane, and is not a descendant of the header block. A third assertion pins that the footer is never `fixed`/`absolute`, guarding the portal trap above.
- Mutation-verified: restoring the footer to the mobile header block turns 2 of the 4 red. The first version of the "not in the header block" assertion passed under that mutation (it checked a div near a pill rather than the block itself), so the header block got an explicit `data-testid` and the assertion was rewritten against it.
- Brand-name gate clean.