### PR TITLE
test: pin install() idempotent early return deterministically (#5019)

### DIFF
--- a/test/test_crash_guard.py
+++ b/test/test_crash_guard.py
@@ -11,6 +11,9 @@ to the config dir that was active when the handler was installed.
 from __future__ import annotations
 
 import asyncio
+import atexit
+import faulthandler
+import sys
 
 import pytest
 
@@ -137,3 +140,80 @@ class TestUnclosedConnectionDowngrade:
         crash_log = tmp_path / "home" / "logs" / "crash.log"
         assert crash_log.exists()
         assert "Some other problem" in crash_log.read_text()
+
+
+class TestInstallIdempotent:
+    """``install()`` is documented "Idempotent." — pin the early-return contract.
+
+    The ``if _INSTALLED: return`` arc in ``install()`` previously executed only
+    when two tests calling ``install()`` landed in the same pytest-xdist worker,
+    so its line coverage was a scheduling coin flip that flipped the per-file
+    coverage floor on unrelated PRs (#5019). These tests exercise that arc
+    unconditionally and deterministically: one sets the flag explicitly, the
+    other forces the flag off so the first call is the real installation and
+    the second call takes the early return.
+
+    Both tests monkeypatch ``atexit.register`` (to a recorder) and
+    ``faulthandler.enable`` (to a no-op) BEFORE calling ``install()``, so no
+    real registration and no faulthandler re-targeting ever happens: pytest's
+    own faulthandler plugin binds the dump fd to the real stderr, and a bare
+    ``faulthandler.enable()`` inside a test would silently re-point fatal-signal
+    dumps at the captured ``sys.stderr`` for the rest of the worker process.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_install_state(self, tmp_path, monkeypatch):
+        """Save/restore the module globals the tests mutate.
+
+        ``_CRASH_LOG`` is restored by the module-level autouse fixture. The
+        atexit and faulthandler side effects need no rollback because both are
+        monkeypatched away before any ``install()`` call in this class.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        saved_installed = crash_guard._INSTALLED
+        saved_hook = sys.excepthook
+        yield
+        crash_guard._INSTALLED = saved_installed
+        sys.excepthook = saved_hook
+
+    @staticmethod
+    def _neutralize_globals(monkeypatch) -> list[object]:
+        """Spy ``atexit.register`` and no-op ``faulthandler.enable``."""
+        registrations: list[object] = []
+        monkeypatch.setattr(
+            atexit, "register", lambda fn, *a, **kw: registrations.append(fn)
+        )
+        monkeypatch.setattr(faulthandler, "enable", lambda *a, **kw: None)
+        return registrations
+
+    def test_early_return_when_flag_already_set(self, monkeypatch):
+        """The early-return arc, exercised regardless of prior worker state."""
+        crash_guard._INSTALLED = True
+        registrations = self._neutralize_globals(monkeypatch)
+        hook_before = sys.excepthook
+        crash_log_before = crash_guard._CRASH_LOG
+
+        crash_guard.install()
+
+        assert sys.excepthook is hook_before
+        assert registrations == []
+        assert crash_guard._CRASH_LOG is crash_log_before
+
+    def test_second_install_is_a_noop(self, monkeypatch):
+        """A real install followed by a second call that must change nothing."""
+        crash_guard._INSTALLED = False  # deterministic: first call really installs
+        registrations = self._neutralize_globals(monkeypatch)
+
+        crash_guard.install()
+
+        assert crash_guard._INSTALLED is True
+        assert registrations == [crash_guard._atexit_handler]
+        assert sys.excepthook is crash_guard._excepthook
+        crash_log_after_first = crash_guard._CRASH_LOG
+        assert crash_log_after_first is not None
+
+        crash_guard.install()
+
+        assert sys.excepthook is crash_guard._excepthook
+        assert registrations == [crash_guard._atexit_handler]
+        assert crash_guard._CRASH_LOG is crash_log_after_first


### PR DESCRIPTION
## Problem

`src/kiro_crew/crash_guard.py` (68 lines) is deliberately NOT in `.github/coverage-baselines/backend.txt`, and it sits exactly on the Coverage Gate's per-file 80% floor: 55/68 = 80.9% passes, 54/68 = 79.4% fails. The swing line is the idempotent early return in `install()` (`if _INSTALLED: return`, line 126). That arc only executed when two tests calling `install()` happened to land in the same pytest-xdist worker, so the gate flipped red on PRs whose diff never touched the file (issue #5019 attaches two consecutive runs of the same diff, one 55/68 green, one 54/68 red).

## Fix (test-only)

Add `TestInstallIdempotent` to `test/test_crash_guard.py`:

- `test_early_return_when_flag_already_set` sets `crash_guard._INSTALLED = True` explicitly, so the early-return arc is exercised **unconditionally**, immune to xdist worker assignment.
- `test_second_install_is_a_noop` forces the flag off so the first `install()` deterministically performs the real installation, then asserts the second call is an observable no-op: `sys.excepthook` unchanged, no additional `atexit` registration, `_CRASH_LOG` untouched. This pins the documented "Idempotent." contract on observable effects, not just the private flag.

Process-global hygiene (per the `no-test-side-effects` AUTOSDE rule): both tests monkeypatch `atexit.register` to a recorder and `faulthandler.enable` to a no-op **before** calling `install()`, so no real registration happens and pytest's own faulthandler dump fd is never re-pointed at the captured stderr. A class fixture pins `KIROCREW_HOME` to `tmp_path` and restores `_INSTALLED` + `sys.excepthook`; `_CRASH_LOG` is restored by the file's existing autouse fixture.

`crash_guard.py` itself is untouched, and the file stays unbaselined **on purpose**: baselining would hide the boundary file permanently, while this closes the whole flake class by making the swing line deterministic.

## Measured margin

From `test/test_crash_guard.py` alone (`pytest test/test_crash_guard.py -n0 --cov=kiro_crew.crash_guard`):

- before: 46/68 covered, missing set includes lines 125-144 (line 126 among them)
- after: 55/68 = 80.9%, lines 125-126 no longer in the missing set

`scripts/check_per_file_coverage.py --floor 80 --baseline .github/coverage-baselines/backend.txt` run against the generated XML passes on this file's coverage from this test file alone, i.e. the floor no longer depends on which worker any other `install()` caller lands in. In full-suite CI terms the file moves from a nondeterministic 54-or-55/68 to a deterministic >= 55/68.

## Verification

- `isort` / `flake8` / `mypy` / black gate: green
- Full backend `pytest`: 59975 passed; 5 failures are host-environment issues reproduced on pristine main (3 PTY integration, 1 order-dependent, 1 tmpfs mtime-granularity flake in `test_history_coverage.py`, unrelated to this diff)
- Pre-push review: GPT 5.6 + Opus 5 subagents; both flagged the same real finding (faulthandler dump-fd restore), plus two advisories; all three adopted in this revision

Closes #5019
