### PR TITLE
docs: port the dual-valid RC version spelling policy to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,8 +282,18 @@ is what makes nightlies read as previews of the *next* release:
 | `pyproject.toml` | `[project] version` — what the wheel carries |
 | `website/electron/package.json` | `version` — the updater's version compare |
 
-Keep it a bare `X.Y.Z`: `nightly.yml` builds both a semver and a PEP 440 stamp
-from it, and a suffixed base (`.dev0`) produces invalid versions.
+Keep it a bare `X.Y.Z` **on `main`**: `nightly.yml` builds both a semver and a
+PEP 440 stamp from it, and a suffixed base (`.dev0`) produces invalid versions.
+
+On an **insider release branch** the in-code version instead carries the RC, so
+a source/dev checkout reads as the candidate it is. All three files use the
+**same dual-valid spelling** `X.Y.Z-rc.N` (e.g. `0.4.0-rc.4`): it is valid
+SemVer for `package.json` **and** valid (non-canonical) PEP 440, which pip and
+setuptools normalize to `X.Y.ZrcN`. Do not use the canonical PEP 440 spelling
+(`0.4.0rc4`) in `__init__.py` — `packaging/build-desktop.sh` greps `__version__`
+straight into electron-builder's `extraMetadata.version`, which rejects
+non-SemVer and kills a local `make desktop`. The tag still overrides all three
+at build time (see `docs/build/release.md` → "Version numbering policy").
 
 ### One trap worth knowing
 

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -402,9 +402,15 @@ the in-code value is what a non-tag build reports and what the promote sequence
 manipulates — the final byte stamp is decided by the tag, not this value.
 
 - **On an insider release branch, `__version__` carries the RC suffix, and the
-  tag matches.** The branch reads as what it is: `__version__ = "X.Y.ZrcN"`,
+  tag matches.** The branch reads as what it is: `__version__ = "X.Y.Z-rc.N"`,
   tags `vX.Y.Z-insider.N`. Do not leave a release branch declaring a bare
-  `X.Y.Z` while it is still cutting RCs.
+  `X.Y.Z` while it is still cutting RCs. All three version files
+  (`src/kiro_crew/__init__.py`, `pyproject.toml`,
+  `website/electron/package.json`) use the **same dual-valid spelling**
+  `X.Y.Z-rc.N` — valid SemVer and valid (non-canonical) PEP 440. The canonical
+  PEP 440 form (`0.4.0rc4`) is forbidden in `__init__.py`:
+  `packaging/build-desktop.sh` feeds `__version__` verbatim to
+  electron-builder, which requires SemVer.
 - **Promoting an insider line to stable is a three-step sequence:**
   1. **Drop the RC in a PR** — change `__version__` from `X.Y.ZrcN` to the bare
      `X.Y.Z`. This is the release commit; it also sets the base the stable


### PR DESCRIPTION
## What

Ports the version-policy doc text from the release/0.4.0 rc4-stamp PR #4966 **verbatim** (two files, docs only, no code):

- On an insider release branch, **all three** version declaration files (`src/kiro_crew/__init__.py`, `pyproject.toml`, `website/electron/package.json`) use the **same dual-valid spelling** `X.Y.Z-rc.N` — valid SemVer for package.json **and** valid (non-canonical) PEP 440 that pip/setuptools normalize to `X.Y.ZrcN`.
- The canonical PEP 440 form (`0.4.0rc4`) is **forbidden in `__init__.py`**: `packaging/build-desktop.sh:103` greps `__version__` verbatim into electron-builder's `extraMetadata.version` (`:493`), which requires SemVer — so it kills a local `make desktop` on a release branch (GPT review catch on #4966, the second latent bug ignited by the rc-in-source policy after #4891).

## Why main needs this

The version-numbering policy docs live on main as the recovery source, but the 'three dialects' text from #4887 only ever existed on the (twice force-moved, now discarded) release branch tips — main's copies predate it entirely. Without this port, the next release-branch cut restores stale policy that the build-desktop.sh constraint has since invalidated.

main's own version stays a bare `X.Y.Z` per the unchanged nightly rule — this text governs release branches only.

## Verification

Whole-file port verified safe: `git diff 4e9dedda8..origin/main` on both files is empty (main never touched them), and the release-branch copies were byte-identical to main's before #4966's edit.

**Why no screenshot:** docs-only change; no UI surface.