### PR TITLE
test: observe SEL rotation via segment sequence, not count (#5017)

### DIFF
--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -98,6 +98,46 @@ def _fill(log: SecurityEventLog, count: int, *, start: int = 0, step_secs: int =
         )
 
 
+#: Iteration cap for the bounded poll loops below. Generous against a healthy
+#: writer (the rotation loop needs 1-2 batches; a healthy top-up usually needs
+#: zero), tight enough that a genuinely broken one fails fast without flooding
+#: the shared session dir -- that dir lives under pytest's basetemp, which is
+#: retained across runs, so an unbounded failure loop would persist tens of MB
+#: per red run.
+_POLL_ITERATION_CAP = 40
+
+
+def _fill_until_over_cap(log: SecurityEventLog, *, deadline: float, start: int) -> int:
+    """Top up through the async writer until the live log is over the size cap.
+
+    Two mechanisms can leave the live log BELOW the cap after a large fill even
+    with a perfectly healthy writer: ``flush()`` waits on the pending-event
+    counter with a bounded timeout and RETURNS on expiry, so under runner load
+    the tail of the fill may not be on disk yet; and a mid-fill batch boundary
+    can itself enter the rotation window and rotate, resetting the live log to
+    nearly empty. Both are harness properties, not defects, so the over-the-cap
+    precondition is established by topping up in small batches rather than
+    asserted after one fixed fill (#5017). Bounded by *deadline* and by
+    ``_POLL_ITERATION_CAP``; the diagnostic reports the pending-queue depth so
+    a wedged writer is distinguishable from a rotation problem.
+
+    Returns the next unused ``seq=`` number for the caller's own fills.
+    """
+    seq = start
+    iterations = 0
+    while log._live_size() <= sel_mod._SEGMENT_MAX_BYTES:
+        iterations += 1
+        assert iterations <= _POLL_ITERATION_CAP and time.monotonic() < deadline, (
+            f"precondition never reached: live log stayed at {log._live_size()} "
+            f"bytes (cap {sel_mod._SEGMENT_MAX_BYTES}) after {iterations - 1} "
+            f"top-up batches, {log._pending} events still pending in the writer"
+        )
+        _fill(log, 5, start=seq)
+        seq += 5
+        log.flush()
+    return seq
+
+
 class TestHmacKeyManagement:
     def test_creates_key_file_on_first_init(self, sel_dir):
         SecurityEventLog(base_dir=sel_dir, sync=True)
@@ -2427,20 +2467,55 @@ class TestCriticalWritesDoNotRotateInline:
     def test_the_background_writer_still_rotates(self, small_segments):
         """Deferring must not mean never.
 
-        Two batches, because the window is entered once per batch and reads the
-        size ALREADY on disk -- the first batch sees a file below the cap and
-        correctly does not rotate, which is the documented one-batch overshoot.
+        Batches, not one shot, for two reasons that are both harness properties
+        of the async writer: the window is entered once per batch and reads the
+        size ALREADY on disk -- a batch sees the file below the cap and correctly
+        does not rotate, which is the documented one-batch overshoot -- and
+        ``flush()`` waits on the pending counter with a bounded timeout and
+        returns on expiry, so under load a batch may not be on disk when the
+        test looks. The test therefore polls for the condition with a bounded
+        budget instead of asserting after a fixed number of batches
+        (testing-conventions § Determinism).
+
+        The observable is the highest segment SEQUENCE NUMBER, not the segment
+        count. Rotation ends with a retention sweep, and this class runs against
+        the shared session dir, so how many segments it already holds depends on
+        which tests ran earlier on this worker: at ``_SEGMENT_KEEP`` segments a
+        successful rotation adds one and the sweep deletes the oldest in the same
+        breath, leaving the COUNT flat -- a real rotation that a count comparison
+        calls "never rotated" (#5017). The sequence only ever rises
+        (``_next_segment_path`` continues from the highest segment still on
+        disk, precisely so retention cannot make it go backwards), so it
+        observes the rotation no matter what the sweep did.
         """
         log = SecurityEventLog(sync=False)
         _fill(log, 200)
         log.flush()
-        assert log._live_size() > sel_mod._SEGMENT_MAX_BYTES, "precondition: over the cap"
-        before = log._segments_oldest_first()
-        _fill(log, 5, start=500)
-        log.flush()
-        assert len(log._segments_oldest_first()) > len(before), (
-            "background writer never rotated"
-        )
+
+        def highest_seq() -> int:
+            segments = log._segments_oldest_first()
+            return sel_mod._segment_seq(segments[-1]) if segments else 0
+
+        seq = _fill_until_over_cap(log, deadline=time.monotonic() + 30.0, start=500)
+
+        # Fresh budget for the phase actually under test, so a slow precondition
+        # cannot eat the writer's rotation window and misattribute the failure.
+        deadline = time.monotonic() + 30.0
+        before = highest_seq()
+        iterations = 0
+        while highest_seq() <= before:
+            iterations += 1
+            assert iterations <= _POLL_ITERATION_CAP and time.monotonic() < deadline, (
+                f"background writer never rotated: highest segment sequence "
+                f"stayed at {before} after {iterations - 1} batches, with the "
+                f"live log at {log._live_size()} bytes (cap "
+                f"{sel_mod._SEGMENT_MAX_BYTES}), "
+                f"{len(log._segments_oldest_first())} segments on disk, "
+                f"{log._pending} events still pending in the writer"
+            )
+            _fill(log, 5, start=seq)
+            seq += 5
+            log.flush()
 
     def test_a_critical_write_still_fails_closed(self, sel_dir, small_segments):
         """Skipping rotation must not weaken audit-or-deny.
@@ -2649,11 +2724,15 @@ class TestOnlyTheWriterThreadRotates:
         to whatever the shared directory already holds.
         """
         log = SecurityEventLog(sync=False)
-        # Get the log over the cap first, through a path that is allowed to rotate.
+        # Get the log over the cap first, through a path that is allowed to
+        # rotate. Topped up rather than asserted after one fixed fill: the same
+        # two harness properties that broke the rotation test (#5017) -- a
+        # bounded flush() and a mid-fill batch-boundary rotation -- can leave
+        # the live log below the cap here too.
         _fill(log, 200)
         log.flush()
+        _fill_until_over_cap(log, deadline=time.monotonic() + 30.0, start=700)
         before = log._segments_oldest_first()
-        assert log._live_size() > sel_mod._SEGMENT_MAX_BYTES, "precondition: over the cap"
 
         entered: list[str] = []
         real_window = SecurityEventLog._rotation_window


### PR DESCRIPTION
## Problem

`test/test_sel.py::TestCriticalWritesDoNotRotateInline::test_the_background_writer_still_rotates` fails deterministically on the `Backend Tests (3.12, 3)` shard — on `main` itself and on PRs that touch zero backend files — with `AssertionError: background writer never rotated`. Every PR then fails `Backend Tests (3.12, 3)` → `Coverage Gate` → `PR Readiness`, so the repo's merge path is blocked regardless of PR content (#5017).

## Why it matters

The whole repository's CI is red on an assertion that fires when the code under test behaves **correctly**. Until it is fixed, every open PR burns reruns against a failure it cannot influence.

## Mechanism proved (this is a third mechanism, not either candidate in the issue)

The issue proposed two candidate mechanisms: a `flush()` deadline expiry, and a lost non-blocking rotation lock. **Both are refuted; the proven mechanism is the retention sweep offsetting the rotation in the segment COUNT.**

1. **From the CI failure output itself** (run 32536026565 / job 96938820193): `assert 3 > 3` with `before` = segments `000001, 000002, 000003` and `after` = segments `000002, 000003, 000004`. The highest sequence rose 3 → 4 — **rotation happened** — and retention deleted `000001` in the same call, leaving the count flat. A timed-out flush or a deferred rotation would have shown an *unchanged* after-list, not a shifted one.
2. **Reproduced locally with instrumentation** (single process, `-n0`, shared session dir pre-seeded to the retention cap the way earlier tests on a CI worker leave it): `_rotate_under_lock` recorded `segments 3 -> 3`, the retention sweep recorded 1 deletion, `flush()` drained fully both times (pending == 0), and every `try_acquire_lock` succeeded. That is mechanism three firing with mechanisms one and two ruled out on the same run.

Why it is ordering-dependent: `_rotate_under_lock` ends with `_enforce_segment_retention_locked()`, and the `small_segments` fixture shrinks `_SEGMENT_KEEP` to 3. The class deliberately runs against the **shared session SEL dir** (see its docstring — a per-test tmp dir is re-created by the daemon writer after cleanup). So whether the dir already holds 3 segments when this test runs depends on which tests preceded it on that xdist worker — which is why a shard-composition change flipped it from intermittent to consistently red without any behavior regression.

**CI-shard repro honesty:** running the shard the way CI does (`pytest -q -n auto/-n 4 --timeout=120 --splits 4 --group 3`, Python 3.12, pytest-split 0.11.0) did **not** reproduce the failure on my host — the local worker distribution differs, so the SEL class did not land at the retention cap. The seeded single-process repro above reproduces the exact CI failure signature (`3 -> 3` with shifted sequence numbers) deterministically, and the CI log independently confirms the same mechanism.

## Fix (symptoms → root cause → change)

The test's observable — closed-segment **count** increases — is not monotone under retention: at the cap, one rotation ± one sweep = flat. The strictly monotone observable is the highest segment **sequence number**: `_next_segment_path` continues from the highest segment still on disk precisely so retention cannot make the sequence go backwards. The test now:

- asserts the **highest segment sequence** rises, instead of the count;
- polls batch-by-batch with a bounded budget (testing-conventions § Determinism): a 30s monotonic deadline **re-armed between the precondition phase and the rotation phase** (so a slow precondition cannot eat the rotation budget and misattribute the failure), plus a 40-iteration cap so a genuinely broken writer fails fast without flooding the retained basetemp dir;
- establishes the over-the-cap precondition by **topping up** through a shared `_fill_until_over_cap` helper instead of asserting after one fixed fill — a bounded `flush()` (returns on timeout expiry) and a mid-fill batch-boundary rotation can both leave the live log below the cap on a perfectly healthy writer;
- reports rich diagnostics on failure: observed sequence, batch count, live size, cap, segment count, and the writer's **pending-queue depth**, so a wedged writer is distinguishable from a rotation defect;
- applies the same precondition helper to `test_the_writer_start_fallback_does_not_rotate`, which carried the identical latent precondition flake (found by the pre-push Opus review lane).

Test-only; `src/kiro_crew/sel.py` is untouched — the evidence shows no rotation defect. The class's three sibling properties (critical writes skip the window; the writer still rotates; a critical write still fails closed) all remain genuinely asserted, and the class keeps the shared session dir per its docstring.

## Tests

This PR is a test fix; its own verification:

- **Mutation-verified, both directions:** with `_rotate_under_lock` no-op'd (a real rotation regression), the repaired test FAILS — fast, via the iteration cap (0.04s, bytes bounded) — and also fails under a fast-clock budget exhaustion. With the shared dir pre-seeded to the retention cap (the CI scenario), it PASSES. The sibling fallback test also passes when seeded at the cap.
- `test/test_sel.py` full file: 204/204 green serially (`-n0`) and under xdist (`-n4 --dist loadgroup`).

## Manual verification

Full local gate run: isort ✅ flake8 ✅ mypy ✅ (1012 files), full backend pytest 60085 passed / 39 failed — all 39 verified pre-existing on clean `main` in a throwaway worktree on this host (env-dependent families: missing Node 20, jq version, PTY integration, xdist host-budget; three additionally shown to be load-flakes that pass on re-run of identical code).

## Pre-push review

GPT (gpt-5.6-sol): no findings. Opus (claude-opus-5): 0 blocking, 6 advisories — 5 fixed (iteration caps, re-armed deadline, sibling-test precondition, docstring accuracy, pending-depth diagnostics), 1 rebutted (asserting rotation within ≤2 batches would re-introduce a host-timing assertion; testing-conventions § "Wall-clock races" prescribes poll-with-deadline, and batch composition through the async writer is scheduler-dependent). A focused verifier confirmed all closures against the final head and judged the rebuttal sound.

## Screenshots

N/A — backend test-only change, no user-visible UI.

Closes #5017
