### PR TITLE
fix(apps): consolidate ['apps'] invalidation into the mc:apps-changed listener (#5021)

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1539,6 +1539,16 @@ export default function App() {
   }, [refreshAppNav])
   useEffect(() => {
     const handler = () => {
+      // Mark the shared ['apps'] cache stale BEFORE the refetch: refreshAppNav
+      // publishes fresh data only on fetch SUCCESS (setQueryData), so when its
+      // bounded retry chain exhausts, an un-invalidated cache would keep
+      // serving stale rows marked fresh. Invalidating up front makes that
+      // failure mode stale-but-marked-stale, which is what lets dispatch
+      // sites skip a local ['apps'] invalidation of their own.
+      // refetchType 'none' keeps refreshAppNav the single fetcher: without it,
+      // an active ['apps'] observer (the /apps page) would refetch immediately
+      // on invalidation, duplicating the request refreshAppNav is about to make.
+      queryClient.invalidateQueries({ queryKey: ['apps'], refetchType: 'none' })
       refreshAppNav()
       // The Explore shelf's install state lives in the server-computed
       // `installed` flag on the `['registry']` rows, which are cached with a

--- a/website/src/components/appstore/SourcesPopover.tsx
+++ b/website/src/components/appstore/SourcesPopover.tsx
@@ -9,7 +9,6 @@
 import { useState } from 'react'
 import { Database, FolderOpen } from 'lucide-react'
 import { api } from '../../api/client'
-import { useQueryClient } from '@tanstack/react-query'
 import { recordEvent } from '../../rum'
 import { Btn, Input, IconButton } from '../ui'
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover'
@@ -25,7 +24,6 @@ export default function SourcesPopover({ open, onOpenChange, onError, onInstalle
   // closes and a freshly-installed (disabled) app is invisible in the sidebar.
   onInstalled?: (name: string) => void
 }) {
-  const queryClient = useQueryClient()
   const [installPath, setInstallPath] = useState('')
   const [installing, setInstalling] = useState(false)
 
@@ -37,7 +35,8 @@ export default function SourcesPopover({ open, onOpenChange, onError, onInstalle
       const installedName = result.name || installPath.trim()
       recordEvent('app_install', { app: installedName, source: 'local' })
       setInstallPath('')
-      queryClient.invalidateQueries({ queryKey: ['apps'] })
+      // Cache invalidation (['apps'] + ['registry']) is owned by the
+      // mc:apps-changed listener in App.tsx, for every dispatch site at once.
       window.dispatchEvent(new Event('mc:apps-changed'))
       onInstalled?.(installedName)
       onOpenChange(false)

--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -15,7 +15,7 @@
  * the Sources gear in the header (SourcesPopover).
  */
 import { useEffect, useMemo, useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import {
   Package, Bot, Zap, Clock, ShoppingBag, Lock, Trash2, X, ArrowUp, Boxes,
@@ -243,7 +243,6 @@ export function keepInLibrary(
 
 export default function AppsPage() {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const [tab, setTab] = useState<Tab>(initialTab)
   useEffect(() => { sessionStorage.setItem('appstore-tab', tab) }, [tab])
   const [query, setQuery] = useState('')
@@ -564,10 +563,10 @@ export default function AppsPage() {
 
   // ---- Actions --------------------------------------------------------------
 
-  const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: ['apps'] })
-    // ['registry'] is deliberately not invalidated here: the mc:apps-changed
-    // listener in App.tsx owns that, for every dispatch site at once.
+  const announceAppsChanged = () => {
+    // Neither ['apps'] nor ['registry'] is invalidated here: the
+    // mc:apps-changed listener in App.tsx owns both caches, for every
+    // dispatch site at once.
     window.dispatchEvent(new Event('mc:apps-changed'))
   }
 
@@ -600,7 +599,7 @@ export default function AppsPage() {
   const runEnable = async (name: string) => {
     await api.enableApp(name)
     recordEvent('app_enable', { app: name })
-    invalidate()
+    announceAppsChanged()
   }
 
   const trust = useTrustGate(runEnable)
@@ -661,7 +660,7 @@ export default function AppsPage() {
       if (action === 'enable') await runEnable(name)
       else if (action === 'disable') await api.disableApp(name)
       else if (action === 'update') await api.updateApp(name)
-      invalidate()
+      announceAppsChanged()
       // An in-place sync is the one action here whose success is otherwise
       // INVISIBLE: re-copying a source directory usually carries the same
       // version, so the card re-renders byte-identical and the dev cannot tell
@@ -697,7 +696,7 @@ export default function AppsPage() {
     try {
       await api.uninstallApp(name, keepData, false, Array.from(keepSpecific))
       recordEvent('app_uninstall', { app: name, version: uninstallTarget.version })
-      invalidate()
+      announceAppsChanged()
     } catch (e) {
       setError((e as Error)?.message || i18nT('pages.appsPage.failed_to_uninstall', { name }))
     } finally {
@@ -722,7 +721,7 @@ export default function AppsPage() {
       setUpdatingAll({ done: i + 1, total: targets.length })
     }
     setUpdatingAll(null)
-    invalidate()
+    announceAppsChanged()
     if (failed.length) setError(i18nT('pages.appsPage.failed_to_update', { names: failed.join(', ') }))
     else {
       setSuccessMsg(`Updated ${targets.length} app${targets.length === 1 ? '' : 's'}.`)

--- a/website/src/pages/MigrationPage.tsx
+++ b/website/src/pages/MigrationPage.tsx
@@ -9,7 +9,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import {
   AlertTriangle, Download, CheckCircle, RefreshCw, Trash2, ArrowRight, Database, X,
 } from 'lucide-react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation } from '@tanstack/react-query'
 import { api } from '../api/client'
 import { PageHeader, Card, CardTitle, Btn, Badge, ContentSkeleton } from '../components/ui'
 
@@ -36,7 +36,6 @@ type MigrationState = 'loading' | 'available' | 'not-in-registry' | 'already-ins
 export default function MigrationPage() {
   const { name } = useParams<{ name: string }>()
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const [error, setError] = useState('')
   const [cleanedUp, setCleanedUp] = useState(false)
 
@@ -70,8 +69,9 @@ export default function MigrationPage() {
     mutationFn: () => api.migrateCleanup(name!),
     onSuccess: () => {
       setCleanedUp(true)
+      // Cache invalidation (['apps'] + ['registry']) is owned by the
+      // mc:apps-changed listener in App.tsx, for every dispatch site at once.
       window.dispatchEvent(new Event('mc:apps-changed'))
-      queryClient.invalidateQueries({ queryKey: ['apps'] })
     },
     onError: (e: unknown) => {
       setError((e instanceof Error && e.message) || i18nT('pages.migrationPage.cleanup_failed'))

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -647,6 +647,30 @@ describe('App routing', () => {
     })
   })
 
+  it('marks the apps cache stale on mc:apps-changed even when the refetch fails', async () => {
+    // Dispatch sites do not invalidate ['apps'] themselves; this listener
+    // owns that cache. refreshAppNav publishes fresh data only on fetch
+    // SUCCESS, so the handler must invalidate the cache up front — otherwise
+    // a retry-exhausted refetch chain would leave stale ['apps'] rows marked
+    // fresh.
+    const { api } = await import('../api/client')
+    const listApps = api.listApps as ReturnType<typeof vi.fn>
+    listApps.mockReset()
+    listApps.mockRejectedValue(new Error('gateway down'))
+    try {
+      const { queryClient } = renderWithProviders(<App />, { route: '/chat' })
+      queryClient.setQueryData(['apps'], [])
+      expect(queryClient.getQueryState(['apps'])?.isInvalidated).toBe(false)
+      act(() => { window.dispatchEvent(new Event('mc:apps-changed')) })
+      await waitFor(() => {
+        expect(queryClient.getQueryState(['apps'])?.isInvalidated).toBe(true)
+      })
+    } finally {
+      listApps.mockReset()
+      listApps.mockResolvedValue([])
+    }
+  })
+
   it('shows a portaled hover label for a collapsed (icon-only) nav item', async () => {
     // Covers useNavTip: in collapsed mode nav rows hide their text label and
     // instead show it via a portal to <body> on hover (so the rail's vertical


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

Follow-up to #5018 (from its First Principles review round 2). The `mc:apps-changed` listener in `App.tsx` owns the `['registry']` react-query invalidation for every dispatch site, but three dispatch sites (`AppsPage.tsx`, `SourcesPopover.tsx`, `MigrationPage.tsx`) still carry a co-located local `['apps']` invalidation. Each of those is a double fetch today: the listener's `refreshAppNav` already fetches `/api/apps` and publishes it under `['apps']` via `setQueryData`.

The reason this was not folded into #5018: the listener path fills the `['apps']` cache only on fetch SUCCESS — with the local `invalidateQueries` calls simply deleted, a retry-exhausted `refreshAppNav` chain would leave stale `['apps']` data marked fresh.

## Why it matters

Cache-consistency logic split across four files means any new install/uninstall/enable surface must remember to invalidate two caches locally or ship a stale-UI bug; consolidation makes dispatching `mc:apps-changed` the single thing a surface has to do. It also removes a redundant per-action refetch.

## What changed (motivation → approach → change)

Symptom → cause → fix chain:

1. **Close the stated failure path first.** The `mc:apps-changed` handler in `App.tsx` now calls `queryClient.invalidateQueries({ queryKey: ['apps'] })` up front — before and regardless of the `refreshAppNav` fetch outcome. When the bounded retry chain exhausts, the cached `['apps']` data is now stale-but-marked-stale instead of stale-but-fresh. A successful fetch still publishes fresh data via `setQueryData` exactly as before.
2. **Delete the three now-redundant local `['apps']` invalidations** in `AppsPage.tsx`, `SourcesPopover.tsx`, and `MigrationPage.tsx`. Each site still dispatches `mc:apps-changed` (which runs the listener synchronously); only the local cache call goes. The now-unused `useQueryClient` hooks/imports are removed with them.
3. **`AppsPage`'s helper renamed `invalidate` → `announceAppsChanged`**: its body is now a single event dispatch, and the old name would invite a maintainer to add a new query key beside it assuming it still drops caches (pre-push Opus review finding).
4. **The `['registry']` invalidation added by #5018 is untouched.**

Deliberately NOT touched: `SecurityPanel.tsx` and `TrustAppModal.tsx` also invalidate `['apps']`, but they do not dispatch `mc:apps-changed` (they are trust changes, not app-set changes), so the consolidation argument does not apply to them.

## Tests

- New: `App.test.tsx` — "marks the apps cache stale on mc:apps-changed even when the refetch fails": rejects every `listApps` fetch, dispatches the event, and asserts `['apps']` is invalidated. Mutation-verified: removing the up-front `invalidateQueries` line makes exactly this test fail.
- The existing #5018 regression test for `['registry']` invalidation is untouched and still passes.
- Existing page-level tests (`AppsPageW3Coverage`, `SourcesPopoverCov80`) assert the `mc:apps-changed` dispatch and pass unchanged — none asserted the deleted local invalidations.
- Full local gates: `npx tsc -b` clean; `npx vitest run` 22,630 passed / 2 failed — the 2 failures (`CliPanelCoverage.test.tsx` theme-repaint) were reproduced identically on a clean `origin/main` checkout on the same host and pass in isolation on both, i.e. pre-existing order-dependence unrelated to this diff.

## Manual verification

N/A — unit coverage sufficient: the change is pure react-query cache bookkeeping with no rendered delta; the listener/dispatch seam is covered from both sides by the tests above.

<!-- no-visual-delta -->
**Why no screenshot:** behavior-only cache invalidation change; no pixel changes on any surface.

## Related Issues

Closes #5021

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff
