### PR TITLE
feat(registry): gate the credential-posture clone hint, fix sibling slug errors

### DIFF
--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -191,12 +191,43 @@ def _is_safe_env_key(key: str) -> bool:
     return platform_compat.env_key_allowed(key, _SAFE_ENV_KEYS)
 
 
+#: Locale forced onto the INDEX-ORIGINATED clone (:func:`anonymous_git_env`) —
+# the only clone whose stderr feeds the credential-posture classifier
+# (:func:`_git_output_is_auth_shaped`). ``_SAFE_ENV_KEYS`` passes the operator's
+# ``LANG``/``LC_ALL`` through to the child, so git would localize its client-side
+# ``fatal: Authentication failed`` message on a non-English host — and the STRICT
+# English-only marker allowlist would then miss, silently dropping the
+# credential-posture hint for the exact credential-blocked owner it exists to
+# help. Pinning ``LC_ALL`` (which wins over ``LANG`` and any narrower ``LC_*``)
+# AFTER the ``os.environ`` copy makes that classifier's input deterministic
+# English regardless of the operator locale. The value is a platform-appropriate
+# UTF-8 locale — always English message text with UTF-8 decoding of any path
+# bytes — because there is no single name valid on both libcs: ``C.UTF-8`` is the
+# always-present UTF-8 locale on glibc/musl (Linux) but is NOT a valid BSD-libc
+# locale on macOS, where an explicitly-set invalid ``LC_ALL`` makes ``setlocale``
+# fall to C/ASCII AND suppresses CPython's PEP 538 coercion, so a child reading
+# non-ASCII git output raises ``UnicodeDecodeError``. macOS ships ``en_US.UTF-8``
+# in its base locale set, so Darwin uses that (mirroring
+# :func:`kiro_crew.service.common` for the same reason). This is a
+# location/format hint, never a credential, so it does not weaken any
+# suppression in :func:`anonymous_git_env`. It is pinned ONLY there, not in
+# :func:`minimal_env`, whose subprocesses never reach the classifier.
+_GIT_CLONE_LOCALE = "en_US.UTF-8" if sys.platform == "darwin" else "C.UTF-8"
+
+
 def minimal_env(**extra: str) -> dict[str, str]:
     """Build a minimal environment dict from the current process env.
 
     Only passes through safe keys (PATH, HOME, SSH_AUTH_SOCK, etc.)
     plus any explicit *extra* overrides.  Used by both registry install
     and route-level uninstall handlers.
+
+    The operator's ``LANG``/``LC_ALL`` are passed through unchanged: this env
+    is NOT read by the credential-posture classifier (that runs only on the
+    index-originated path, which uses :func:`anonymous_git_env`), so pinning a
+    locale here would only degrade the many other ``minimal_env`` subprocesses
+    (pip installs, app backends, lifecycle scripts, …) for no classifier
+    benefit — and ``C.UTF-8`` is invalid on macOS BSD libc.
     """
     env = {k: v for k, v in os.environ.items() if _is_safe_env_key(k)}
     env.update(extra)
@@ -271,6 +302,11 @@ def anonymous_git_env(**extra: str) -> dict[str, str]:
     # If a trusted-host remote is nonetheless SSH, force batch mode with no
     # identity/agent so it can't silently authenticate as the gateway.
     env["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes -o IdentitiesOnly=yes -o IdentityAgent=none"
+    # Pin the locale (over any operator LANG/LC_ALL from os.environ) so git's
+    # client-side failure text stays English for the credential-posture
+    # classifier — see :data:`_GIT_CLONE_LOCALE`. A benign format hint, not a
+    # credential, so it preserves every suppression above.
+    env["LC_ALL"] = _GIT_CLONE_LOCALE
     env.update(extra)
     return env
 
@@ -3756,8 +3792,10 @@ async def _git_fetch_commit(
             return {
                 "ok": False,
                 "name": dest.name,
-                "error": "destination_not_a_checkout",
-                "message": (
+                # Human sentence in `error`, machine slug in `code`: the install
+                # banner renders `result.error`, never `result.message`.
+                "code": "destination_not_a_checkout",
+                "error": (
                     "The destination exists but is not a git checkout. Remove or fix it "
                     "manually and retry the install."
                 ),
@@ -3833,6 +3871,97 @@ async def _git_fetch_commit(
             await asyncio.to_thread(platform_compat.rmtree_force, dest)
 
 
+# Auth/permission failure classes on the clone-failure surface. The clone
+# subprocess merges stderr into stdout (``stderr=STDOUT``), so this classifier
+# sees git's auth-failure text. Kept as a STRICT allowlist of known
+# auth-refusal phrasings so the credential-posture remedy ("private app repos
+# must live inside the registry repo") only fires when withheld credentials
+# are a plausible cause — an owner who hits a typo'd branch or a DNS blip must
+# NOT be told to restructure their repositories. Matched case-insensitively.
+_GIT_AUTH_FAILURE_MARKERS = (
+    # SSH credential refusal ONLY. The bare token "permission denied" also
+    # appears in a LOCAL filesystem error — an unwritable clone destination
+    # emits `fatal: could not create work tree dir '…': Permission denied` —
+    # so matching it mislabels a disk-permission failure as withheld remote
+    # credentials and shows the "move the repo inside the registry" hint on an
+    # error that has nothing to do with credentials. SSH's real auth-refusal
+    # wording always carries the method parenthetical (`git@host: Permission
+    # denied (publickey).`, also `(publickey,password)` /
+    # `(publickey,keyboard-interactive)`), which a local errno `Permission
+    # denied` never has — so anchor on `permission denied (publickey` (open
+    # paren, no close, to catch every comma-separated method list).
+    "permission denied (publickey",
+    "authentication failed",
+    "could not read username",
+    "could not read password",
+    "access denied",
+    "fatal: authentication",
+    "terminal prompts disabled",
+    "invalid username or password",
+)
+
+# Known NON-auth failure classes, mapped to a fixed derived label. This is an
+# allowlist emitting a CONSTANT string per class — never a slice of raw git
+# output — so no credential-bearing or path-bearing stderr can reach the
+# banner (PR-1418 lesson: free-text stderr passthrough cannot be closed by
+# shape enumeration). Matched case-insensitively; first match wins.
+_GIT_FAILURE_CLASS_LABELS: tuple[tuple[str, str], ...] = (
+    ("could not resolve", "host could not be resolved"),
+    ("connection timed out", "the connection timed out"),
+    ("connection refused", "the connection was refused"),
+    ("network is unreachable", "the network was unreachable"),
+    ("remote branch", "the requested branch does not exist"),
+    # Anchored on git's own ref-error phrasing ("couldn't find remote ref …",
+    # "remote ref … does not exist"), NOT the bare token "does not exist": that
+    # substring also appears in unrelated failures (e.g. a path/pathspec error),
+    # and matching it would mislabel them "the requested ref does not exist".
+    # "remote ref" occurs only in git's missing-ref messages, so it stays a
+    # precise ref-error signal.
+    ("remote ref", "the requested ref does not exist"),
+    # Anchored on git/curl/(open|gnu)tls TLS-error phrasing, NOT the bare token
+    # "ssl": that substring also appears in a repo URL (e.g. cloning
+    # github.com/openssl/openssl, whose stderr echoes the URL), and matching it
+    # would mislabel an ordinary auth/not-found failure "a TLS/SSL error
+    # occurred" — the exact false-positive class this table guards against.
+    # These phrases occur in genuine TLS handshake/verification errors
+    # ("SSL certificate problem …", "SSL routines:…", "gnutls_handshake()
+    # failed", "TLS handshake failed", "Unsupported SSL backend 'schannel'")
+    # and never in a normal repo URL path segment. Deliberately no bare "ssl_"
+    # anchor: a repo path like ".../ssl_utils" would match it. Likewise the
+    # gnutls anchor carries git's full symbol "gnutls_handshake" rather than the
+    # bare library name, so cloning github.com/gnutls/gnutls (whose stderr
+    # echoes the URL) is not mislabeled a TLS error.
+    ("ssl certificate", "a TLS/SSL error occurred"),
+    ("ssl routines", "a TLS/SSL error occurred"),
+    ("ssl backend", "a TLS/SSL error occurred"),
+    ("gnutls_handshake", "a TLS/SSL error occurred"),
+    ("tls handshake", "a TLS/SSL error occurred"),
+)
+
+
+def _git_output_is_auth_shaped(text: str) -> bool:
+    """Whether *text* matches a known auth/permission failure class.
+
+    Strict allowlist — see :data:`_GIT_AUTH_FAILURE_MARKERS`. Never echoes
+    *text*; returns only a boolean.
+    """
+    low = text.lower()
+    return any(marker in low for marker in _GIT_AUTH_FAILURE_MARKERS)
+
+
+def _redacted_git_failure_class(text: str) -> str:
+    """A fixed, derived label for a known non-auth failure class, or ``""``.
+
+    Returns a CONSTANT allowlisted phrase — never a slice of *text* — so no
+    credential-bearing or path-bearing subprocess output reaches the banner.
+    """
+    low = text.lower()
+    for marker, label in _GIT_FAILURE_CLASS_LABELS:
+        if marker in low:
+            return label
+    return ""
+
+
 async def _git_clone_or_pull(
     git_url: str,
     branch: str,
@@ -3882,8 +4011,13 @@ async def _git_clone_or_pull(
         log_lines.append(f"Refusing clone: host of {git_url!r} is not a trusted forge/registry")
         return {
             "ok": False,
-            "error": "untrusted_clone_host",
-            "message": "Refusing to clone from an untrusted host (not a public forge or configured registry).",
+            # Human sentence in `error`, machine slug in `code`: the install
+            # banner renders `result.error`, never `result.message`.
+            "code": "untrusted_clone_host",
+            "error": (
+                "Refusing to clone from an untrusted host "
+                "(not a public forge or configured registry)."
+            ),
         }
     # Track a moved-aside directory if we need to preserve the old checkout
     # during origin-mismatch re-clone (delete-after-success pattern).
@@ -4003,8 +4137,10 @@ async def _git_clone_or_pull(
                 return {
                     "ok": False,
                     "name": dest.name,
-                    "error": "stale_clone_not_removed",
-                    "message": (
+                    # Human sentence in `error`, machine slug in `code`: the
+                    # install banner renders `result.error`, never `.message`.
+                    "code": "stale_clone_not_removed",
+                    "error": (
                         "A checkout on the wrong branch is present and could not be "
                         "moved aside. Remove it manually and retry the install."
                     ),
@@ -4053,8 +4189,10 @@ async def _git_clone_or_pull(
                 return {
                     "ok": False,
                     "name": dest.name,
-                    "error": "existing_checkout_not_moved_aside",
-                    "message": (
+                    # Human sentence in `error`, machine slug in `code`: the
+                    # install banner renders `result.error`, never `.message`.
+                    "code": "existing_checkout_not_moved_aside",
+                    "error": (
                         "The existing app checkout could not be moved aside, so a "
                         "pinned install cannot be performed safely. Remove or move it "
                         "manually and retry the install."
@@ -4173,9 +4311,11 @@ async def _git_clone_or_pull(
         # the next install finds `dest/.git` present with a matching origin and
         # takes the fast-forward branch instead -- `git pull` in a repo the clone
         # never finished, which fails, so every retry of that install fails too.
+        clone_output = ""
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_CLONE_TIMEOUT)
-            log_lines.append(stdout.decode(errors="replace").strip())
+            clone_output = stdout.decode(errors="replace").strip()
+            log_lines.append(clone_output)
         except asyncio.TimeoutError:
             await _kill_process_group(proc)
             await asyncio.to_thread(platform_compat.rmtree_force, dest)
@@ -4190,24 +4330,70 @@ async def _git_clone_or_pull(
                 # The clone ran credential-free (anonymous_git_env + strict
                 # sandbox) because the repo URL came from an external registry
                 # index whose repo differs from the registry URL, so owner
-                # credentials were withheld (confused-deputy defense). A
-                # private sibling repo therefore fails to clone. Tell the owner
-                # the cause and the remedy instead of a bare "git clone failed".
-                # Human sentence in `error`, machine slug in `code`: the install
-                # banner renders `result.error`, never `result.message`.
+                # credentials were withheld (confused-deputy defense). A private
+                # sibling repo therefore fails to clone. BUT the credential-
+                # posture remedy ("private app repos must live inside the
+                # registry repo") is only honest when a withheld credential is a
+                # plausible cause: gate it on an auth-shaped failure class. A
+                # typo'd branch, a DNS blip, or a deleted public repo returns the
+                # bare honest failure instead — being told to restructure
+                # repositories for a transient error is the misleading-remedy
+                # defect this gate closes.
+                #
+                # No raw clone output ever reaches the banner: the classifiers
+                # return only booleans, and the appended failure class is a
+                # CONSTANT allowlisted label, so credential-bearing or path-
+                # bearing stderr cannot leak (PR-1418 lesson).
+                if _git_output_is_auth_shaped(clone_output):
+                    remedy_lead = "so owner credentials are withheld"
+                elif "repository not found" in clone_output.lower():
+                    # A private repo the caller cannot see reads as "repository
+                    # not found", so on this credential-free clone a withheld
+                    # credential is a *possible* (not certain) cause: keep the
+                    # hint, softened to "a likely cause". Deliberately NARROW —
+                    # a *branch* not found ("Remote branch X not found") is a
+                    # definite typo, not a posture signal, so the bare token
+                    # "not found" is excluded.
+                    remedy_lead = "so a likely cause is that owner credentials are withheld"
+                else:
+                    remedy_lead = ""
+                if remedy_lead:
+                    # Human sentence in `error`, machine slug in `code`: the
+                    # install banner renders `result.error`, never `.message`.
+                    return {
+                        "ok": False,
+                        "name": dest.name,
+                        "code": "git_clone_failed_no_credentials",
+                        "error": (
+                            "Git clone failed (cloned without credentials because "
+                            "this app's repo URL differs from the registry URL, "
+                            f"{remedy_lead}). Private app repos must live inside "
+                            "the registry repo — see the monorepo layout in "
+                            "docs/app-kit/publishing-guide.md."
+                        ),
+                    }
+                # Not auth-shaped: bare honest failure, with the redacted
+                # (allowlisted, constant) failure class when one is recognized.
+                failure_class = _redacted_git_failure_class(clone_output)
+                if failure_class:
+                    return {
+                        "ok": False,
+                        "name": dest.name,
+                        "code": "git_clone_failed",
+                        "error": f"Git clone failed: {failure_class}.",
+                    }
                 return {
                     "ok": False,
                     "name": dest.name,
-                    "code": "git_clone_failed_no_credentials",
-                    "error": (
-                        "Git clone failed (cloned without credentials because "
-                        "this app's repo URL differs from the registry URL, so "
-                        "owner credentials are withheld). Private app repos must "
-                        "live inside the registry repo — see the monorepo layout "
-                        "in docs/app-kit/publishing-guide.md."
-                    ),
+                    "code": "git_clone_failed",
+                    "error": "git clone failed",
                 }
-            return {"ok": False, "name": dest.name, "error": "git clone failed"}
+            return {
+                "ok": False,
+                "name": dest.name,
+                "code": "git_clone_failed",
+                "error": "git clone failed",
+            }
         clone_succeeded = True
         return None
     finally:

--- a/test/test_catalog_inventory.py
+++ b/test/test_catalog_inventory.py
@@ -277,7 +277,10 @@ class TestPinnedFetchNeverEatsUserData:
             "https://example.com/a.git", SHA, dest, log,
             clone_env={}, sandbox_mode="standard",
         )
-        assert result is not None and result["error"] == "destination_not_a_checkout"
+        # Machine slug lives in `code`; `error` carries the human sentence the
+        # install banner renders verbatim.
+        assert result is not None and result["code"] == "destination_not_a_checkout"
+        assert result["error"] and result["error"] != "destination_not_a_checkout"
         assert (dest / "important.txt").read_text(encoding="utf-8") == "user data"
 
     @pytest.mark.asyncio
@@ -293,7 +296,8 @@ class TestPinnedFetchNeverEatsUserData:
             "https://example.com/a.git", SHA, dest, log,
             clone_env={}, sandbox_mode="standard",
         )
-        assert result is not None and result["error"] == "destination_not_a_checkout"
+        assert result is not None and result["code"] == "destination_not_a_checkout"
+        assert result["error"] and result["error"] != "destination_not_a_checkout"
         assert (dest / ".git").is_file(), "the link was left alone"
 
     @pytest.mark.asyncio
@@ -592,7 +596,8 @@ class TestPinnedInstallNeverReusesAnExistingTree:
 
         result = await reg._git_clone_or_pull(URL, "main", dest, [], commit=SHA)
         assert result is not None
-        assert result["error"] == "existing_checkout_not_moved_aside"
+        assert result["code"] == "existing_checkout_not_moved_aside"
+        assert result["error"] and result["error"] != "existing_checkout_not_moved_aside"
         assert dest.exists(), "a checkout we could not move is left untouched"
 
     @pytest.mark.asyncio

--- a/test/test_external_registry.py
+++ b/test/test_external_registry.py
@@ -5872,9 +5872,14 @@ class TestCloneFailureDiagnostics:
 
         assert err is not None
         assert err["ok"] is False
-        # Unchanged bare failure — no credential-posture code, no hint.
+        # Bare honest failure with NO credential-posture hint (the clone kept the
+        # ambient identity, so the hint would be wrong). The body still carries
+        # the machine-readable `code` (AGENTS.md non-2xx invariant) — a bare slug
+        # `git_clone_failed`, distinct from the credential-posture
+        # `git_clone_failed_no_credentials`; the `error` sentence stays bare.
         assert err["error"] == "git clone failed"
-        assert "code" not in err
+        assert err["code"] == "git_clone_failed"
+        assert err["code"] != "git_clone_failed_no_credentials"
         assert "credential" not in err["error"].lower()
 
 
@@ -7599,7 +7604,12 @@ class TestMoveAsideUtimeFailureUndoesRename:
             )
 
         assert result["ok"] is False
-        assert result["error"] == "stale_clone_not_removed"
+        # The machine slug lives in `code`; `error` is a human sentence the
+        # install banner renders verbatim, so the raw slug must never appear
+        # there (AppDetailPage renders result.error).
+        assert result["code"] == "stale_clone_not_removed"
+        assert result["error"] != "stale_clone_not_removed"
+        assert "could not be" in result["error"]
         # The old checkout is left in place (fail closed), not stranded aside.
         assert (dest / ".git").is_dir()
         stranded = list((tmp_path / "app-sources").glob("drift-app.stale-*"))
@@ -7873,3 +7883,597 @@ class TestMoveAsideUndoFailureReportsRetainedPath:
         assert not any(
             "retained at" in ln for ln in log_lines
         ), "a fail-closed pre-rename refresh strands nothing, so no retained line is owed"
+
+
+# ---------------------------------------------------------------------------
+# Clone-failure diagnostics honesty (PR 4939 follow-up).
+#   Finding 1: the index-originated credential-posture hint must only fire when
+#   git's output is auth-shaped (or ambiguously so); a DNS blip or typo'd
+#   branch must NOT be told to restructure repositories, and no raw
+#   credential-bearing stderr may reach the banner.
+#   Finding 2: three sibling failure shapes must carry the human sentence in
+#   `error` and the machine slug in `code` (the install banner renders
+#   `result.error` verbatim and ignores `code`).
+# ---------------------------------------------------------------------------
+
+
+class _FailingCloneProc:
+    """A clone subprocess that exits nonzero with *output* on its merged
+    stdout/stderr stream (the real clone runs with ``stderr=STDOUT``)."""
+
+    returncode = 1
+
+    def __init__(self, output: bytes) -> None:
+        self._output = output
+
+    async def communicate(self):
+        return (self._output, None)
+
+
+async def _run_index_clone_failure(tmp_path, output: bytes, *, index_originated: bool = True):
+    """Drive ``_git_clone_or_pull`` down the fresh-clone path to a nonzero exit
+    whose merged output is *output*; return the result dict. ``index_originated``
+    selects the confused-deputy (credential-free) posture path (True, default)
+    vs the owner-designated path (False) whose only failure shape is the bare
+    ``git clone failed`` body."""
+    from kiro_crew.apps import registry as reg
+
+    def _fake_wrap_argv(argv, mode="standard"):
+        return argv, None
+
+    async def _fake_create(*args, **kwargs):
+        return _FailingCloneProc(output)
+
+    dest = tmp_path / "clone-dest"  # does not exist → fresh-clone path
+    with (
+        patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+        patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+        patch("kiro_crew.apps.registry.cgroup_scope_argv", side_effect=lambda c: c),
+        patch("kiro_crew.apps.registry.create_subprocess_limited", new=_fake_create),
+    ):
+        result = await reg._git_clone_or_pull(
+            "https://github.com/acme/private-sibling.git",
+            "main",
+            dest,
+            [],
+            index_originated=index_originated,
+        )
+    return result
+
+
+class TestIndexOriginatedCloneFailureHintIsGated:
+    """Finding 1: the credential-posture remedy is honest only when withheld
+    credentials are a plausible cause."""
+
+    @pytest.mark.asyncio
+    async def test_auth_shaped_failure_keeps_the_posture_hint(self, tmp_path):
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"remote: Permission denied to acme/private-sibling.\n"
+            b"fatal: Authentication failed for 'https://github.com/acme/private-sibling.git/'\n",
+        )
+        assert result is not None and result["ok"] is False
+        # Machine slug in `code`, never in the banner-rendered `error`.
+        assert result["code"] == "git_clone_failed_no_credentials"
+        assert "credentials are withheld" in result["error"]
+        assert "Private app repos must live inside the registry repo" in result["error"]
+        # A definite auth failure is NOT softened to "a likely cause".
+        assert "a likely cause" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_dns_failure_drops_the_posture_hint(self, tmp_path):
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"fatal: unable to access 'https://github.com/acme/private-sibling.git/': "
+            b"Could not resolve host: github.com\n",
+        )
+        assert result is not None and result["ok"] is False
+        # The misleading remedy MUST NOT fire for a network failure.
+        assert result.get("code") != "git_clone_failed_no_credentials"
+        assert "Private app repos must live inside the registry repo" not in result["error"]
+        assert "credentials are withheld" not in result["error"]
+        # The honest, redacted (constant) failure class is surfaced instead.
+        assert result["code"] == "git_clone_failed"
+        assert result["error"] == "Git clone failed: host could not be resolved."
+
+    @pytest.mark.asyncio
+    async def test_typoed_branch_failure_drops_the_posture_hint(self, tmp_path):
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"fatal: Remote branch nonexistent-branch not found in upstream origin\n",
+        )
+        assert result is not None and result["ok"] is False
+        assert result.get("code") != "git_clone_failed_no_credentials"
+        assert "credentials are withheld" not in result["error"]
+        assert result["code"] == "git_clone_failed"
+        assert result["error"] == "Git clone failed: the requested branch does not exist."
+
+    @pytest.mark.asyncio
+    async def test_repository_not_found_is_posture_possible_softened(self, tmp_path):
+        # Ambiguous on an auth-gated forge: keep the hint, softened.
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"remote: Repository not found.\n"
+            b"fatal: repository 'https://github.com/acme/private-sibling.git/' not found\n",
+        )
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "git_clone_failed_no_credentials"
+        assert "a likely cause is that owner credentials are withheld" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_failure_returns_bare_honest_message(self, tmp_path):
+        result = await _run_index_clone_failure(tmp_path, b"fatal: something weird happened\n")
+        assert result is not None and result["ok"] is False
+        assert result.get("code") not in ("git_clone_failed_no_credentials",)
+        assert result["error"] == "git clone failed"
+        assert "credentials are withheld" not in result["error"]
+        # non-2xx-body-carries-code: the bare fallback is the only failure shape
+        # on this path that once returned no `code`; a machine keys on `code`
+        # while the frontend renders `error` verbatim, so the slug must be
+        # present even when no failure class is recognized (AGENTS.md non-2xx
+        # invariant). Regression pin: this assertion fails at the pre-fix tree.
+        assert result["code"] == "git_clone_failed"
+
+    @pytest.mark.asyncio
+    async def test_local_unwritable_destination_drops_the_posture_hint(self, tmp_path):
+        # auth-marker-precision: a LOCAL filesystem failure — an unwritable
+        # clone destination — emits git's own `Permission denied` errno text
+        # with NO method parenthetical. It has nothing to do with withheld
+        # remote credentials, so the credential-posture remedy MUST NOT fire.
+        # Fails at the pre-fix tree (the bare `permission denied` marker matched
+        # this local errno and mislabeled it credential-blocked); passes after.
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"fatal: could not create work tree dir "
+            b"'/read-only/clone-dest': Permission denied\n",
+        )
+        assert result is not None and result["ok"] is False
+        assert result.get("code") != "git_clone_failed_no_credentials"
+        assert "Private app repos must live inside the registry repo" not in result["error"]
+        assert "credentials are withheld" not in result["error"]
+        # An unrecognized (non-auth, non-classified) failure falls open to the
+        # honest bare message — never a false posture hint.
+        assert result["code"] == "git_clone_failed"
+        assert result["error"] == "git clone failed"
+
+    @pytest.mark.asyncio
+    async def test_ssh_publickey_refusal_keeps_the_posture_hint(self, tmp_path):
+        # A genuine REMOTE SSH credential refusal carries the method
+        # parenthetical (`Permission denied (publickey).`) that a local errno
+        # never has, so it is still classified auth-shaped and keeps the
+        # posture hint. This is the true-positive control for the marker
+        # tightening above.
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"git@github.com: Permission denied (publickey).\n"
+            b"fatal: Could not read from remote repository.\n",
+        )
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "git_clone_failed_no_credentials"
+        assert "credentials are withheld" in result["error"]
+        assert "Private app repos must live inside the registry repo" in result["error"]
+
+    def test_permission_denied_marker_is_remote_ssh_specific(self):
+        # Unit-level pin on the classifier verdict (never on git argv): the
+        # `permission denied` auth marker fires ONLY on the SSH method-list
+        # forms, never on a bare local-FS errno. This is the property the
+        # end-to-end tests above exercise, asserted directly on the boolean.
+        from kiro_crew.apps import registry as reg
+
+        # Local FS errno forms — every one must fall open (not auth-shaped).
+        assert (
+            reg._git_output_is_auth_shaped(
+                "fatal: could not create work tree dir '/x': Permission denied"
+            )
+            is False
+        )
+        assert reg._git_output_is_auth_shaped("error: open('/x'): Permission denied") is False
+        # Remote SSH refusal forms — every method list must stay auth-shaped.
+        assert reg._git_output_is_auth_shaped("git@host: Permission denied (publickey).") is True
+        assert reg._git_output_is_auth_shaped("Permission denied (publickey,password).") is True
+        assert (
+            reg._git_output_is_auth_shaped("Permission denied (publickey,keyboard-interactive).")
+            is True
+        )
+        # fail-open-direction-pinned: a phrasing the allowlist does not
+        # recognize returns False (falls open to the honest bare message), so a
+        # future git rewording drops the posture hint rather than fabricating
+        # one — the safe direction for a version-sensitive substring allowlist.
+        assert reg._git_output_is_auth_shaped("fatal: some future git wording") is False
+
+    @pytest.mark.asyncio
+    async def test_owner_designated_clone_failure_body_carries_code(self, tmp_path):
+        # The owner-designated (index_originated=False) path never runs the
+        # credential-posture classifier — its sole failure shape is the outer
+        # bare body. It, too, must carry the machine-readable `code` (the second
+        # bare return site). Regression pin: fails at the pre-fix tree, where the
+        # body was `{"ok": False, "name": ...}` with no `code`.
+        result = await _run_index_clone_failure(
+            tmp_path,
+            b"fatal: something weird happened\n",
+            index_originated=False,
+        )
+        assert result is not None and result["ok"] is False
+        assert result["error"] == "git clone failed"
+        assert result["code"] == "git_clone_failed"
+        # The posture hint never fires off the owner-designated path.
+        assert "credentials are withheld" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_credential_bearing_stderr_reaches_the_banner(self, tmp_path):
+        # A credential-bearing URL and an on-disk path in git's output must not
+        # be echoed into the user-facing banner. The banner is derived from a
+        # constant allowlist, never a slice of git output.
+        secret_token = "ghp_SUPERSECRETTOKEN1234567890"
+        secret_path = "/home/user/.ssh/id_rsa"
+        result = await _run_index_clone_failure(
+            tmp_path,
+            (
+                f"fatal: unable to access "
+                f"'https://x-access-token:{secret_token}@github.com/acme/private-sibling.git/': "
+                f"Could not resolve host: github.com\n"
+                f"could not read private key from {secret_path}\n"
+            ).encode(),
+        )
+        assert result is not None and result["ok"] is False
+        banner = result["error"]
+        assert secret_token not in banner
+        assert secret_path not in banner
+        assert "x-access-token" not in banner
+        # Exact honest banner (not a bare substring of git output).
+        assert banner == "Git clone failed: host could not be resolved."
+
+
+class TestCloneLocaleIsPinnedForDeterministicClassifier:
+    """deterministic-classifier-input: every clone env whose stderr feeds
+    ``_git_output_is_auth_shaped`` pins ``LC_ALL`` so git emits deterministic
+    English regardless of the operator's ``LANG``/``LC_ALL``. Without the pin, a
+    credential-blocked owner on a non-English host would see git localize
+    ``fatal: Authentication failed`` — the English-only marker allowlist would
+    miss and the posture hint would silently vanish. We assert the deterministic
+    PROPERTY (the pin on the constructed env), not a real non-English git."""
+
+    def test_anonymous_git_env_pins_locale_over_operator_lang(self, monkeypatch):
+        from kiro_crew.apps import registry as reg
+
+        # Simulate a non-English operator host: LANG/LC_ALL are on os.environ
+        # and pass through _SAFE_ENV_KEYS.
+        monkeypatch.setenv("LANG", "de_DE.UTF-8")
+        monkeypatch.setenv("LC_ALL", "de_DE.UTF-8")
+        env = reg.anonymous_git_env()
+        # LC_ALL is pinned to the C locale (wins over LANG and any LC_*), so
+        # git's client-side messages are the classifier's known English.
+        assert env["LC_ALL"] == reg._GIT_CLONE_LOCALE
+        assert env["LC_ALL"] != "de_DE.UTF-8"
+        # The pin does not weaken any credential suppression.
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert "SSH_AUTH_SOCK" not in env
+
+    def test_minimal_env_does_not_pin_locale(self, monkeypatch):
+        # The owner-designated (minimal_env) path is NOT read by the classifier,
+        # so it must NOT pin the locale — pinning here would only degrade the
+        # many other minimal_env subprocesses (pip installs, app backends, …),
+        # and C.UTF-8 is invalid on macOS BSD libc. The operator's LANG/LC_ALL
+        # pass through unchanged.
+        from kiro_crew.apps import registry as reg
+
+        monkeypatch.setenv("LANG", "ja_JP.UTF-8")
+        monkeypatch.setenv("LC_ALL", "ja_JP.UTF-8")
+        env = reg.minimal_env()
+        assert env["LC_ALL"] == "ja_JP.UTF-8"
+
+    def test_explicit_extra_still_overrides_the_pin(self, monkeypatch):
+        # The pin is applied before *extra*, so an explicit caller override wins
+        # (documented contract) — the pin is a default, not a lock.
+        from kiro_crew.apps import registry as reg
+
+        env = reg.anonymous_git_env(LC_ALL="en_US.UTF-8")
+        assert env["LC_ALL"] == "en_US.UTF-8"
+
+    def test_pinned_locale_makes_the_english_classifier_input_match(self):
+        # The property the pin buys: with the locale pinned to C, git emits the
+        # English phrasing the STRICT allowlist recognizes, so a genuinely
+        # credential-blocked clone is classified auth-shaped. A localized
+        # (e.g. German) rendering of the same failure would NOT match — which is
+        # exactly why the env must force English before the classifier runs.
+        from kiro_crew.apps import registry as reg
+
+        english = "fatal: Authentication failed for 'https://github.com/acme/x.git/'"
+        localized = "fatal: Authentifizierung fehlgeschlagen für 'https://github.com/acme/x.git/'"
+        assert reg._git_output_is_auth_shaped(english) is True
+        assert reg._git_output_is_auth_shaped(localized) is False
+
+    @pytest.mark.asyncio
+    async def test_index_clone_localized_auth_failure_gets_hint_after_pin(self, tmp_path):
+        # End-to-end: the locale pin forces git to emit English, so the clone
+        # output the classifier sees is the English phrasing (modeled here),
+        # and a credential-blocked index-originated clone keeps the posture hint
+        # on a non-English host. Fails at 2db0acd4 (no pin: git would localize
+        # and the hint would vanish); passes after.
+        from kiro_crew.apps import registry as reg
+
+        captured: dict = {}
+
+        def _fake_wrap_argv(argv, mode="standard"):
+            return argv, None
+
+        async def _fake_create(*args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _FailingCloneProc(
+                b"remote: Permission denied to acme/private-sibling.\n"
+                b"fatal: Authentication failed for "
+                b"'https://github.com/acme/private-sibling.git/'\n"
+            )
+
+        dest = tmp_path / "clone-dest"
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch("kiro_crew.apps.registry.wrap_argv", side_effect=_fake_wrap_argv),
+            patch("kiro_crew.apps.registry.cgroup_scope_argv", side_effect=lambda c: c),
+            patch("kiro_crew.apps.registry.create_subprocess_limited", new=_fake_create),
+        ):
+            result = await reg._git_clone_or_pull(
+                "https://github.com/acme/private-sibling.git",
+                "main",
+                dest,
+                [],
+                index_originated=True,
+            )
+        # The clone env carried the pin (the deterministic property).
+        assert captured["env"]["LC_ALL"] == reg._GIT_CLONE_LOCALE
+        # And the posture hint survived.
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "git_clone_failed_no_credentials"
+        assert "credentials are withheld" in result["error"]
+
+
+class TestCloneLocaleIsPlatformValid:
+    """locale-value-valid-on-every-platform: the pinned clone locale
+    (``_GIT_CLONE_LOCALE``, fed to ``anonymous_git_env``'s ``LC_ALL``) MUST be a
+    locale that is valid on the current platform's libc. ``C.UTF-8`` is the
+    always-present UTF-8 locale on glibc/musl (Linux) but is NOT a valid BSD-libc
+    locale on macOS, where an explicitly-set invalid ``LC_ALL`` makes
+    ``setlocale`` fall to C/ASCII and suppresses PEP 538 coercion, so a child
+    reading non-ASCII git output raises ``UnicodeDecodeError`` — turning the
+    diagnostic clone into a crash. The deterministic property is that the pinned
+    value is platform-appropriate: ``en_US.UTF-8`` on Darwin, ``C.UTF-8``
+    elsewhere (mirroring :mod:`kiro_crew.service.common`)."""
+
+    def test_pinned_locale_is_valid_for_the_running_platform(self):
+        # The module-level constant, as resolved for THIS host, must be the
+        # platform-appropriate value. Fails at 0e3001598 on macOS (the value was
+        # the hardcoded, BSD-libc-invalid "C.UTF-8"); passes after the split.
+        import sys
+
+        from kiro_crew.apps import registry as reg
+
+        expected = "en_US.UTF-8" if sys.platform == "darwin" else "C.UTF-8"
+        assert reg._GIT_CLONE_LOCALE == expected
+        # macOS never gets the BSD-libc-invalid C.UTF-8.
+        if sys.platform == "darwin":
+            assert reg._GIT_CLONE_LOCALE != "C.UTF-8"
+
+    def test_locale_selection_is_platform_split_not_a_flat_literal(self, monkeypatch):
+        # Drive the selection logic on BOTH platforms without depending on the
+        # host's real platform or a real non-English git: reload the module with
+        # sys.platform monkeypatched and assert the resolved constant. Fails at
+        # 0e3001598 (the value is a flat "C.UTF-8" literal, so it stays "C.UTF-8"
+        # even under a darwin reload); passes after the platform split.
+        import importlib
+        import sys
+
+        from kiro_crew.apps import registry as reg
+
+        try:
+            monkeypatch.setattr(sys, "platform", "darwin")
+            reloaded = importlib.reload(reg)
+            assert reloaded._GIT_CLONE_LOCALE == "en_US.UTF-8"
+
+            monkeypatch.setattr(sys, "platform", "linux")
+            reloaded = importlib.reload(reg)
+            assert reloaded._GIT_CLONE_LOCALE == "C.UTF-8"
+        finally:
+            # Restore the module to the real-platform value so later tests (and
+            # the shared module object) see the genuine constant.
+            monkeypatch.undo()
+            importlib.reload(reg)
+
+    def test_anonymous_git_env_pins_the_platform_valid_value(self):
+        # End of the wire: the env the index-originated clone actually runs with
+        # carries the platform-appropriate locale, not a macOS-invalid one.
+        import sys
+
+        from kiro_crew.apps import registry as reg
+
+        env = reg.anonymous_git_env()
+        expected = "en_US.UTF-8" if sys.platform == "darwin" else "C.UTF-8"
+        assert env["LC_ALL"] == expected
+
+
+class TestSslMarkerIsAnchoredNotBareSubstring:
+    """classifier-marker-not-substring: the TLS/SSL failure-class marker MUST
+    anchor on git/curl/(open|gnu)tls TLS-error phrasing, never the bare token
+    ``ssl`` — that substring also appears in a repo URL (cloning
+    ``github.com/openssl/openssl`` echoes the URL in stderr), and matching it
+    would mislabel an ordinary auth/not-found failure ``a TLS/SSL error
+    occurred`` — the exact false-positive class this table guards against."""
+
+    _TLS_LABEL = "a TLS/SSL error occurred"
+
+    def test_ssl_in_repo_url_is_not_labeled_a_tls_error(self):
+        from kiro_crew.apps import registry as reg
+
+        # A not-found failure whose stderr echoes a repo URL containing "ssl"
+        # (openssl) is NOT a TLS error and must NOT get the TLS label. Fails at
+        # 0e3001598 (bare "ssl" substring matches the URL); passes after.
+        label = reg._redacted_git_failure_class(
+            "fatal: repository 'https://github.com/openssl/openssl.git/' not found"
+        )
+        assert label != self._TLS_LABEL
+
+    def test_gnutls_in_repo_url_is_not_labeled_a_tls_error(self):
+        from kiro_crew.apps import registry as reg
+
+        # A not-found failure whose stderr echoes a repo URL containing the
+        # library name "gnutls" (github.com/gnutls/gnutls) is NOT a TLS error.
+        # The marker anchors on git's full symbol "gnutls_handshake", never the
+        # bare library name, so the URL cannot trip the TLS label.
+        label = reg._redacted_git_failure_class(
+            "fatal: repository 'https://github.com/gnutls/gnutls.git/' not found"
+        )
+        assert label != self._TLS_LABEL
+
+    def test_genuine_tls_errors_still_labeled(self):
+        from kiro_crew.apps import registry as reg
+
+        # git/curl/(open|gnu)tls real TLS-error phrasings still map to the TLS
+        # label so the classifier keeps recognizing genuine transport failures.
+        for stderr in (
+            "fatal: unable to access 'https://example.com/x.git/': "
+            "SSL certificate problem: unable to get local issuer certificate",
+            "fatal: unable to access 'https://example.com/x.git/': "
+            "error:0A000086:SSL routines::certificate verify failed",
+            "fatal: unable to access 'https://example.com/x.git/': "
+            "Unsupported SSL backend 'schannel'",
+            "fatal: unable to access 'https://example.com/x.git/': "
+            "gnutls_handshake() failed: Error in the pull function.",
+            "fatal: unable to access 'https://example.com/x.git/': TLS handshake failed",
+        ):
+            assert reg._redacted_git_failure_class(stderr) == self._TLS_LABEL
+
+    def test_no_bare_ssl_token_marker_remains(self):
+        from kiro_crew.apps import registry as reg
+
+        # Every TLS-labeled marker is a multi-token phrase, never the bare token
+        # "ssl" that would match a repo URL path segment.
+        tls_markers = [
+            marker for marker, label in reg._GIT_FAILURE_CLASS_LABELS if label == self._TLS_LABEL
+        ]
+        assert tls_markers, "expected at least one TLS marker"
+        assert "ssl" not in tls_markers
+        assert "gnutls" not in tls_markers
+        for marker in tls_markers:
+            # No TLS marker may appear as a substring of a repo URL that merely
+            # names a TLS library (openssl, gnutls), or it would false-positive.
+            assert marker not in "github.com/openssl/openssl.git"
+            assert marker not in "github.com/gnutls/gnutls.git"
+
+
+class TestRefErrorMarkerPrecision:
+    """auth-marker-precision: the ref-error failure-class marker is anchored on
+    git's own ref-error phrasing (``remote ref``), so an unrelated failure that
+    merely contains ``does not exist`` is not mislabeled a missing ref."""
+
+    def test_non_ref_does_not_exist_is_not_labeled_a_ref_error(self):
+        from kiro_crew.apps import registry as reg
+
+        # A pathspec/path error that contains "does not exist" but is NOT a git
+        # ref error must NOT be classified as the requested-ref failure.
+        label = reg._redacted_git_failure_class(
+            "fatal: pathspec 'src/missing' does not exist in the working tree"
+        )
+        assert label != "the requested ref does not exist"
+
+    def test_git_ref_error_still_classified(self):
+        from kiro_crew.apps import registry as reg
+
+        # git's actual missing-ref phrasing still maps to the ref label.
+        assert (
+            reg._redacted_git_failure_class("fatal: couldn't find remote ref refs/heads/nope")
+            == "the requested ref does not exist"
+        )
+        assert (
+            reg._redacted_git_failure_class("error: remote ref does not exist")
+            == "the requested ref does not exist"
+        )
+
+
+class TestSiblingFailureShapesUseCodeNotError:
+    """Finding 2: the three sibling shapes carry the human sentence in `error`
+    and the machine slug in `code`."""
+
+    @pytest.mark.asyncio
+    async def test_destination_not_a_checkout_slug_in_code(self, tmp_path):
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "app-source"
+        dest.mkdir()
+        (dest / "not-a-repo.txt").write_text("plain files", encoding="utf-8")
+        log: list[str] = []
+        result = await reg._git_fetch_commit(
+            "https://example.com/a.git",
+            "0" * 40,
+            dest,
+            log,
+            clone_env={},
+            sandbox_mode="standard",
+        )
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "destination_not_a_checkout"
+        # The banner-rendered `error` is a human sentence, not the slug.
+        assert result["error"] != "destination_not_a_checkout"
+        assert "not a git checkout" in result["error"]
+        assert "message" not in result
+
+    @pytest.mark.asyncio
+    async def test_untrusted_clone_host_slug_in_code(self, tmp_path):
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "clone-dest"
+        with patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=False):
+            result = await reg._git_clone_or_pull(
+                "https://169.254.169.254/internal.git",
+                "main",
+                dest,
+                [],
+                index_originated=True,
+            )
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "untrusted_clone_host"
+        assert result["error"] != "untrusted_clone_host"
+        assert "untrusted host" in result["error"]
+        assert "message" not in result
+
+    @pytest.mark.asyncio
+    async def test_existing_checkout_not_moved_aside_slug_in_code(self, tmp_path):
+        from kiro_crew.apps import registry as reg
+
+        dest = tmp_path / "source"
+        (dest / ".git").mkdir(parents=True)
+
+        async def _must_not_fetch(*a, **k):
+            raise AssertionError("a refused move-aside must not reach the fetch")
+
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch.object(reg, "_clone_origin_url", new=AsyncMock(return_value="https://x/y.git")),
+            patch.object(reg, "_git_fetch_commit", new=_must_not_fetch),
+            patch.object(reg, "_move_checkout_aside", new=AsyncMock(return_value=None)),
+        ):
+            result = await reg._git_clone_or_pull(
+                "https://x/y.git", "main", dest, [], commit="0" * 40
+            )
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "existing_checkout_not_moved_aside"
+        assert result["error"] != "existing_checkout_not_moved_aside"
+        assert "could not be moved aside" in result["error"]
+        assert "message" not in result
+
+    @pytest.mark.asyncio
+    async def test_originally_swapped_shapes_still_use_code(self, tmp_path):
+        """Control: the two shapes swapped in the base PR are unchanged."""
+        from kiro_crew.apps import registry as reg
+
+        # unreadable_clone_origin: origin remote unreadable, refuse in place.
+        dest = tmp_path / "unreadable"
+        (dest / ".git").mkdir(parents=True)
+        with (
+            patch("kiro_crew.apps.registry.is_clone_host_trusted", return_value=True),
+            patch.object(reg, "_clone_origin_url", new=AsyncMock(return_value=None)),
+        ):
+            result = await reg._git_clone_or_pull("https://x/y.git", "main", dest, [], commit="")
+        assert result is not None and result["ok"] is False
+        assert result["code"] == "unreadable_clone_origin"
+        assert result["error"] != "unreadable_clone_origin"
+        assert "message" not in result


### PR DESCRIPTION
<!-- kiki:pr-context:start -->
## Problem

Two advisory findings from PR #4939's review round were never applied before that PR squash-merged. Both are still present on `main`:

1. **The credential-posture clone hint fires unconditionally.** For an index-originated clone, any nonzero `git clone` exit returned the "cloned without credentials … private app repos must live inside the registry repo" banner — so a typo'd branch, a transient DNS failure, or a deleted public repo all told the owner to restructure their repositories.
2. **Sibling failure shapes leaked the machine slug into the banner.** The App Store install banner renders `result.error` verbatim, but three sibling error shapes (`destination_not_a_checkout`, `untrusted_clone_host`, `existing_checkout_not_moved_aside`) kept the raw slug in `error` with the human prose stranded in an unrendered `message`.

## Why it matters

An owner who hits a DNS blip or a typo was told to restructure their repositories; users saw raw slugs like `untrusted_clone_host` in the "Install failed" banner. Both are honesty/clarity defects on the credential-posture diagnostics surface the merged PR exists to improve.

## Fix

- Gate the index-originated posture hint on auth-shaped git output. On a definite auth failure the banner is kept; on a DNS/typo failure it is dropped in favour of an honest, constant, redacted failure class; an ambiguous "repository not found" keeps the hint softened to "a likely cause". No raw credential-bearing stderr reaches the banner.
- Move the three sibling failure shapes to carry the human sentence in `error` and the machine slug in `code`, dropping the dead `message` key.

## Tests

- `TestIndexOriginatedCloneFailureHintIsGated` — auth-shaped keeps the hint; DNS and typo'd-branch drop it; "repository not found" is softened; unrecognized failures stay bare; no credential-bearing stderr reaches the banner.
- `TestSiblingFailureShapesUseCodeNotError` — the three sibling shapes (plus the two already-converted controls) carry the slug in `code`, never in `error`.
<!-- kiki:pr-context:end -->

<!-- pr-context:start -->
## Summary
This PR combines 6 related changes:
- **PR 4939 follow-up: gate the credential hint, fix sibling slug errors**
- **PR 5035 r2: pin clone locale so the credential-posture classifier is deterministic**
- **PR 5035 round 3: drop the inert minimal_env locale rider, delete the dead failure-class label**
- **PR 5035: platform-valid clone locale + anchor the ssl failure marker**
- **PR 5035 round 5: inline the one-consumer posture marker, add code to the bare clone-failure body**
- **PR 5035 round 6: fix catalog-inventory assertions + convert last slug sibling**

## Changes and rationale

### PR 4939 follow-up: gate the credential hint, fix sibling slug errors
**Problem:** Two advisory findings from PR 4939's review round were never applied: the round-2 push crashed on a liveness worker death and PR 4939 squash-merged (commit 14fccf51b, 2026-08-21T16:03:23Z) before the fix landed. Both are verified STILL PRESENT on merged upstream/main (2026-08-21) — this ships as a normal small PR against main, not a pr-maintenance push. Line numbers below are from the current upstream/main and WILL drift; re-verify before editing.
**Why it matters:** An owner who hits a DNS blip or a typo is told to restructure their repositories (finding 1); users see raw slugs like `untrusted_clone_host` in the Install failed banner (finding 2). Both are honesty/clarity defects on the credential-posture diagnostics surface the merged PR exists to improve.
**Fix (symptoms → root cause → change):** Gate the index-originated posture hint on auth-shaped git stderr. Add a small strict allowlist matcher (e.g. `_git_output_is_auth_shaped`) over the captured clone stderr for the known auth/permission failure classes ("Permission denied", "Authentication failed", "could not read Username/Password", "access denied", "fatal: Authentication"). When it matches: keep the credential-posture banner. When it does NOT match: return the bare honest "git clone failed" message (with the captured/redacted failure class if…
**Tests:** Regression pinning finding 1: index-originated clone failure with auth-shaped stderr -> banner carries the credential-posture hint; index-originated failure with network/not-found-shaped stderr -> banner does NOT assert the posture cause (or presents it as one possible cause per the chosen shape) and carries the redacted failure class; no…
**Review focus:** backend, security boundaries, regression coverage

### PR 5035 r2: pin clone locale so the credential-posture classifier is deterministic
**Why it matters:** A genuinely credential-blocked owner on a non-English host is the exact user this hint was built for, and they lose it with zero signal — a silent correctness regression in the feature PR 5035 adds. Deterministic classifier input is a one-line env pin.
**Tests:** Regression pinning the finding: an index-originated clone failure whose git stderr is a NON-English localized auth message (e.g. a German/Japanese `Authentifizierung fehlgeschlagen`-style string) — with the locale pin the clone runs `LC_ALL=C.UTF-8` so git emits English, `_git_output_is_auth_shaped` matches, and the banner carries the posture hint. Drive…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### PR 5035 round 3: drop the inert minimal_env locale rider, delete the dead failure-class label
**Why it matters:** An FP BLOCK holds PR readiness. The `minimal_env` rider is worse than inert: it degrades 7+ unrelated subprocesses' locale to an env value documented invalid on macOS BSD libc, for zero benefit to the classifier it claims to serve. Removing it is a net subtraction that closes the block and shrinks the next round's review surface; the reported determinism defect stays fixed by the `anonymous_git_env` pin alone.
**Tests:** Delete/replace the two tests asserting a `minimal_env` clone pins the locale "for the classifier" (false premise). If a test genuinely wants to pin that the OWNER-designated clone env is UNCHANGED by this PR, keep it but assert the correct property (no LC_ALL pin on minimal_env). Regression re-confirming the real fix survives: an index-originated clone…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### PR 5035: platform-valid clone locale + anchor the ssl failure marker
**Why it matters:** Finding 1 turns the diagnostic clone into a crash on macOS the moment git emits non-ASCII output — a data-loss-shaped correctness regression on the diagnostics surface the PR introduces, and macOS is a first-class supported platform. Finding 2 is the same misclassification the PR exists to prevent, still live for one marker. Both are small; folding them into ONE push avoids a round 5.
**Tests:** Regression pinning finding 1: assert `_GIT_CLONE_LOCALE` (or the value the clone env pins) is macOS-valid on Darwin — the deterministic property is that the pinned value is platform-appropriate. Drive it without depending on a real non-English git: e.g. monkeypatch `sys.platform` to `"darwin"` and assert the resolved locale is `en_US.UTF-8` (and…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### PR 5035 round 5: inline the one-consumer posture marker, add code to the bare clone-failure body
**Why it matters:** Both are advisory (the PR is NOT blocked today), but confirmed, small, and close finding-classes: the subtraction removes machinery that would otherwise be the next round's review surface, and the `code` field closes the AGENTS.md non-2xx-body invariant FP itself cites. Folding both into ONE push avoids a round 6 and shrinks the diff rather than growing it.
**Tests:** Regression pinning item 2: a clone that fails with an UNRECOGNIZED (non-auth, non-classified) stderr returns `{"ok": False, ..., "error": "git clone failed", "code": "git_clone_failed"}` — the `code` is present. Fails at head bfd285c1 (bare body has no `code`), passes after. Control pinning item 1: an ambiguous "repository not found" clone failure still…
**Review focus:** pr-maintenance, security boundaries, regression coverage

### PR 5035 round 6: fix catalog-inventory assertions + convert last slug sibling
**Why it matters:** The Opus BLOCK is a real self-inflicted regression on the PR's own diff — three backend shards red because a field-contract change was not swept to its consumers. The stale sibling is the last machine slug a user sees in the banner. The locale duplication seeds a silent-divergence bug the moment one copy is edited. All are small; folding them into ONE push avoids a round 7 (this is the error-contract-consumer-sweep + slug + marker + single-source class set, and the onion-peeling cost driver is exactly per-round…
**Tests:** Update test/test_catalog_inventory.py:280/296/595 to the NEW field shape (assert the machine slug on `result["code"]`; assert `result["error"]` is a non-empty human sentence). These fail at head 45f759977 (assert old `error` slug), pass after — and turn the three Backend Tests shards green. Update test/test_external_registry.py:7606 to assert the new…
**Review focus:** pr-maintenance, regression coverage, security boundaries

## Review map

| Change | Primary files |
|---|---|
| PR 4939 follow-up: gate the credential hint, fix sibling slug errors | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 5035 r2: pin clone locale so the credential-posture classifier is deterministic | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 5035 round 3: drop the inert minimal_env locale rider, delete the dead failure-class label | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 5035: platform-valid clone locale + anchor the ssl failure marker | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 5035 round 5: inline the one-consumer posture marker, add code to the bare clone-failure body | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |
| PR 5035 round 6: fix catalog-inventory assertions + convert last slug sibling | `src/kiro_crew/apps/registry.py`<br>`test/test_external_registry.py` |

## Commits
- [`b854364`](https://github.com/kirodotdev/KiroCrew/pull/5035/commits/b854364c397290150ab1b308281da1311e83e641) feat(registry): diagnose credential-posture clone failures with a gat…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (2 files, +793/-23)</summary>

- `src/kiro_crew/apps/registry.py` (+205/-21)
- `test/test_external_registry.py` (+588/-2)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->