### PR TITLE
fix(gateway): report a timed-out CLI probe as its own condition, not as missing

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -466,6 +466,26 @@ Modular aiohttp package at `127.0.0.1:5476` (configurable). Split into:
   during an operation, every three seconds for a waiting non-owner, and every
   30 seconds otherwise; those polls are now free reads that render whatever the
   latch says.
+  **A probe that TIMED OUT is a third condition, not a missing binary.**
+  `probe_timed_out` on the snapshot separates "the spawn never answered" from
+  both "no binary on disk" and "the sandbox refused the spawn". It is its own
+  field rather than a reuse of `sandbox_unavailable` because a timeout raises no
+  typed sandbox failure, so every `sandbox_*` field is legitimately empty, and a
+  consumer that maps `sandbox_unavailable` to a userns remedy must not be handed a
+  slow filesystem to fix with an AppArmor profile. A timeout with a runnable
+  candidate reports `installed=True` (the binary was stat'd; verification is what
+  failed) and `authenticated=False` as UNKNOWN, since `whoami` runs through the
+  same probe path and is never reached on such a host.
+  **Known interim gap:** `KiroPrerequisiteGate.tsx` keys only on
+  `sandbox_unavailable` / `installed` / `authenticated`, so `probe_timed_out` has
+  no UI consumer yet. On a FIRST-RUN host (`initial_setup_complete=false`) a
+  timed-out probe therefore falls past the `sandbox_unavailable` intercept into
+  the generic setup shell, which highlights signing in — a remedy that cannot
+  speed up a slow probe. That is not worse than the state it replaced (the same
+  host previously read `installed=false` and was told to install a CLI it already
+  has), but it is still wrong, and the field is the carrier for the intercept that
+  closes it. An established install is unaffected: `initial_setup_complete=true`
+  returns before either branch.
   **A mid-session logout is discovered by the ACP attempt, not by a probe.**
   Because the latch can be arbitrarily stale, turn-starting paths do **not**
   gate on it: `reject_if_kiro_not_ready()` is advisory and always admits (its

--- a/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
@@ -172,6 +172,11 @@ async def api_kiro_prerequisite_status(request: web.Request) -> web.Response:
             "sandbox_failure_kind": "",
             "sandbox_detail": "",
             "sandbox_remedy": "",
+            # Same redaction, same shape-stability reason: whether the probe timed out
+            # is a statement about how slow the HOST is, and only the owner can act on
+            # it. Present rather than omitted because a consumer that reads
+            # ``undefined`` branches on it as though the absence meant something.
+            "probe_timed_out": False,
             # Redacted for the same reason as the block above, and kept present
             # for the same shape-stability reason: only the owner can act on a
             # missing spec (the repair is an owner-gated POST). A non-owner on an

--- a/src/kiro_crew/dashboard/kiro_readiness.py
+++ b/src/kiro_crew/dashboard/kiro_readiness.py
@@ -21,14 +21,41 @@ latched value can be arbitrarily stale. That splits the callers in two:
 
 from __future__ import annotations
 
+import logging
+import time
+
 from aiohttp import web
 
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
+
+logger = logging.getLogger(__name__)
 
 _KIRO_NOT_READY_RESPONSE = {
     "error": "Kiro CLI setup or sign-in is required before starting a session.",
     "code": "kiro_prerequisite_required",
 }
+_KIRO_NOT_READY_CODE = _KIRO_NOT_READY_RESPONSE["code"]
+
+# When was the current refusal last reported at WARNING? ``None`` means "not yet, warn
+# now". Module-level because the gate must work with no service at all (the fail-closed
+# path has no object to hang state on), matching ``mcp_discovery``'s module-level
+# warn-once ledgers. See :func:`_warn_refused_once` for why it is one cell rather than
+# a per-path ledger.
+_refusal_warned_at: float | None = None
+
+# Longest an ongoing outage may stay silent at WARNING. Clearing on authorize
+# (:func:`_clear_refusal_warning`) re-arms immediately when a gated caller OBSERVES the
+# recovery, but nothing observes a recovery on a gateway whose dashboard is closed and
+# whose pollers have stopped, and the flag would then still be set when the NEXT outage
+# began — the subtler silence this whole mechanism exists to avoid. A floor makes the
+# guarantee unconditional: no outage is ever quiet for longer than this, whether or not
+# a recovery was ever seen. 30 minutes is ~2 lines/hour against a 1000-entry ring, four
+# orders below what one line per refused request costs.
+_REFUSAL_REWARN_SECS = 1800.0
+
+# Indirected so a test can advance it without touching the ``time`` module globally,
+# the same clock-injection shape ``KiroPrerequisiteService`` uses for its own staleness.
+_clock = time.monotonic
 
 # How stale a probe may be and still authorize a destructive or spawning call.
 # Small enough that an external logout cannot linger behind this gate, large
@@ -65,6 +92,120 @@ async def kiro_verified_ready(service: object) -> bool:
     if not isinstance(service, KiroPrerequisiteService):
         return False
     return await service.verified_ready(max_age_secs=_VERIFY_MAX_AGE_SECS)
+
+
+def _log_safe_path(request: object) -> str:
+    """The request path, rendered so it cannot forge a log line.
+
+    ``aiohttp``'s ``Request.path`` is URL-DECODED, so ``%0A`` in a path segment
+    arrives as a real newline, and the dynamic-route pattern for ``{slot}``
+    excludes only ``/{}`` — a newline matches it and reaches this gate. Logging
+    that verbatim lets a caller append arbitrary lines to ``gateway.log``, which
+    would defeat the entire reason the refusal is logged at all: the log is meant
+    to be evidence, and forgeable evidence is worse than none.
+
+    Scope of the threat, stated exactly, because the halves differ. Only
+    U+000A/U+000D put a real byte ``0a``/``0d`` in the file, so only those forge a
+    physical line there. ``%C2%85``/``%E2%80%A8``/``%E2%80%A9`` decode to
+    U+0085/U+2028/U+2029, which are multi-byte UTF-8 and therefore leave the FILE
+    one line — but they are ``str.splitlines()`` boundaries, so any Python consumer
+    that re-splits the log sees the forged line, and a rendered view may break on
+    them too. Invisible formatting characters forge nothing structurally and reorder
+    what a human reads. Every route ends at the same place: a line the reader cannot
+    trust.
+
+    ``repr`` does the escaping rather than a hand-written character class, because a
+    class narrow enough to write out is narrower than the threat. ``Cc``/``Cf``/``Zl``/
+    ``Zp`` alone misses four categories that ``yarl``'s percent-decoding can deliver:
+    ``%C2%A0`` and ``%E3%80%80`` are ``Zs``, ``%EE%80%80`` is ``Co``, ``%CD%B8`` is
+    ``Cn``. ``str.__repr__`` escapes everything ``str.isprintable()`` rejects, which is
+    all of those plus ``Cs``, and it takes that from the interpreter's own Unicode
+    tables rather than from a list somebody has to remember to extend. ``Cs`` is not
+    reachable here — ``yarl`` leaves an invalid escape like ``%ED%A0%80`` as literal
+    text rather than decoding it to a lone surrogate — but it matters that ``repr``
+    covers it anyway: a raw surrogate is a string a UTF-8 log handler cannot encode,
+    and ``logging`` swallows handler errors, so the line would vanish. Losing the line
+    is the one outcome this function exists to prevent.
+
+    ESCAPED rather than rejected, unlike dev_fleet's ``reject_unsafe``: this runs
+    on the fail-CLOSED branch, where raising would turn a correct 503 into a 500.
+    Escaped rather than stripped, too — a caller who sent one of these is exactly
+    what the reader wants to see, so the evidence is preserved, just rendered inert.
+    Visible non-ASCII survives (``repr`` escapes only the unprintable), so a path is
+    not ASCII-folded for the operators most likely to need to read it. The quotes
+    ``repr`` adds are wanted: they delimit the value, so trailing whitespace or an
+    empty path is visible instead of blending into the message. Non-``str``
+    (attribute absent, or a request-like double) degrades to the placeholder for the
+    same no-raise reason.
+    """
+    raw = getattr(request, "path", None)
+    if not isinstance(raw, str):
+        return "<unknown path>"
+    return repr(raw)
+
+
+def _warn_refused_once(path: str) -> None:
+    """WARNING on the transition into refusing, DEBUG thereafter.
+
+    Mirrors ``mcp_discovery._warn_probe_sandbox_unavailable_once``, and for the same
+    reason. Every post-spawn failure branch in ``api_models`` logs a WARNING, so a
+    reader who greps the log for that endpoint and finds nothing concludes it is
+    healthy. A silent refusal here therefore inverts the diagnosis rather than merely
+    withholding it, which is the misdiagnosis reported in issue #4577. An absent line
+    gets read as evidence; it is not. So the refusal must be visible.
+
+    It must ALSO not be visible 570 times an hour. A signed-out gateway with an open
+    dashboard polls ``/api/models`` every 8s and ``/api/sessions/usage`` every 30s,
+    and every one of those refuses HERE — the sibling branches that log in
+    ``api_models`` sit BELOW this gate (``agents.py:1014`` onward vs the gate at
+    ``:942``) and are never reached in that state, so one line per refused request is
+    not "the same order of magnitude as its siblings" — it is 570 lines/hour against
+    their none. The dashboard log ring is ``deque(maxlen=1000)``
+    (``handlers/updates.py:1381``), which that rate churns end to end every ~1.8
+    hours, evicting the genuine diagnostics an operator came to read. A line meant to
+    make the log trustworthy must not be the thing that empties it.
+
+    One line per outage is the honest amount: the condition reported is
+    gateway-global ("the CLI is not verified ready"), not per-endpoint, so the flag
+    is global too and the message names whichever caller hit it first. Deliberately
+    NOT keyed on the path — that is caller-controlled, and a per-path ledger would
+    grow without bound on request.
+    """
+    global _refusal_warned_at
+
+    now = _clock()
+    if _refusal_warned_at is not None and now - _refusal_warned_at < _REFUSAL_REWARN_SECS:
+        logger.debug("%s refused with 503 %s (already reported)", path, _KIRO_NOT_READY_CODE)
+        return
+    _refusal_warned_at = now
+    logger.warning(
+        "%s refused with 503 %s: Kiro CLI is not verified ready. Further refusals log "
+        "at DEBUG until it recovers or %.0fs elapse. Check the prerequisite snapshot "
+        "for which condition — a missing binary, a sandbox refusal and a timed-out "
+        "probe are three different failures.",
+        path,
+        _KIRO_NOT_READY_CODE,
+        _REFUSAL_REWARN_SECS,
+    )
+
+
+def _clear_refusal_warning() -> None:
+    """Forget the reported refusal once the gate authorizes again.
+
+    Without this the first outage after boot would consume the only WARNING the
+    process ever emits, and every LATER outage would be silent — the original
+    defect back in a subtler form, which is exactly why
+    ``mcp_discovery._clear_unresolvable`` exists alongside its warn-once.
+
+    This half only fires when a gated caller OBSERVES the recovery, which is why it
+    is not the whole answer: on a gateway whose dashboard is closed the pollers stop,
+    nothing calls this, and the flag would still be set when the next outage began.
+    ``_REFUSAL_REWARN_SECS`` bounds that case; this one makes an observed recovery
+    re-arm immediately rather than waiting the floor out.
+    """
+    global _refusal_warned_at
+
+    _refusal_warned_at = None
 
 
 def _service(request: web.Request) -> object:
@@ -107,5 +248,7 @@ async def reject_if_kiro_unverified(request: web.Request) -> web.Response | None
     """
 
     if await kiro_verified_ready(_service(request)):
+        _clear_refusal_warning()
         return None
+    _warn_refused_once(_log_safe_path(request))
     return web.json_response(_KIRO_NOT_READY_RESPONSE, status=503)

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -370,6 +370,17 @@ class PrerequisiteStatus:
     # only show the raw errno, which is the dead end reported in issue #1660: the
     # probe knows the fix is an AppArmor profile and the user cannot tell.
     sandbox_remedy: str = ""
+    # The verification probe hit ``_PROBE_TIMEOUT_SECS`` instead of answering. A
+    # THIRD condition, distinct from both a missing binary and a sandbox refusal:
+    # the spawn was accepted and raised no typed failure, so every ``sandbox_*``
+    # field stays empty and none of them can carry it. Without this the timeout
+    # collapsed into bare ``installed=False`` with all ``sandbox_*`` empty — a
+    # combination that does not merely fail to help, it actively rules out the true
+    # cause and sends the operator to reinstall or re-login, neither of which can
+    # work on a host whose CLI is installed, signed in, and serving turns the whole
+    # time (issue #4577: 4081 SEL ``probe_version`` events, every one
+    # ``outcome=failed error=timeout``, on exactly such a host).
+    probe_timed_out: bool = False
     # Kiro Crew's own agent specs (~/.kiro/agents/kirocrew*.json). ``ready``
     # requires these on disk, not merely a viable binary and a good ``whoami``:
     # without them kiro-cli answers every ``session/set_mode`` with
@@ -2107,6 +2118,68 @@ class KiroPrerequisiteService:
                         sandbox_failure_kind=kind,
                         sandbox_detail=detail,
                         sandbox_remedy=remedy,
+                    )
+                    self._last_probe_at = self._clock()
+                    self._has_probed = True
+                    return self._status
+                if (
+                    version_probe is not None
+                    and version_probe.timed_out
+                    and candidate_runnable
+                ):
+                    # A probe that never answered is not evidence of absence. The
+                    # spawn was accepted and raised no typed failure, so the
+                    # sandbox branch above cannot claim it, and falling through to
+                    # the bare default below asserts installed=False about a binary
+                    # this function just confirmed is present and executable.
+                    #
+                    # Reported as the SAME shape as a sandbox refusal, for the same
+                    # reason: present on disk, verification is what failed. The
+                    # timeout gets its own flag rather than reusing sandbox_* --
+                    # nothing about the sandbox failed here, and a caller that keys
+                    # a userns remedy off sandbox_unavailable must not be handed a
+                    # slow filesystem to fix with an AppArmor profile.
+                    #
+                    # WARNING on the TRANSITION into the condition, DEBUG while it
+                    # persists. This branch runs on EVERY probe, and on an affected
+                    # host that is one probe per ~40s (the readiness gate's 30s
+                    # staleness window plus this probe's own 10s timeout), so ~90
+                    # lines/hour into the dashboard's 1000-entry log ring. A line that
+                    # reports a slow host must not be the thing that evicts the rest of
+                    # the evidence about it.
+                    #
+                    # The latched status IS the transition record, so this needs no
+                    # timestamp and no re-warn floor: every probe rewrites
+                    # ``self._status``, so a recovery re-arms the warning by itself and
+                    # the next timeout speaks up. The dashboard gate needs the extra
+                    # floor only because it has no object to hang state on and its
+                    # clear path depends on a caller happening to observe the recovery.
+                    if self._status.probe_timed_out:
+                        logger.debug(
+                            "Kiro CLI at %s still unverified: probe timed out again "
+                            "after %ss (already reported)",
+                            first_candidate,
+                            _PROBE_TIMEOUT_SECS,
+                        )
+                    else:
+                        logger.warning(
+                            "Kiro CLI at %s is present and executable but could not be "
+                            "verified: the probe timed out after %ss. The CLI may be "
+                            "installed and signed in; this is not evidence it is "
+                            "missing. Further timeouts log at DEBUG until it recovers.",
+                            first_candidate,
+                            _PROBE_TIMEOUT_SECS,
+                        )
+                    self._status = PrerequisiteStatus(
+                        platform=_platform_label(self._platform),
+                        installed=True,
+                        # Unknown, not false: whoami runs through the same probe
+                        # path, and on this host it is never even reached.
+                        authenticated=False,
+                        ready=False,
+                        repair_required=False,
+                        initial_setup_complete=self._initial_setup_complete,
+                        probe_timed_out=True,
                     )
                     self._last_probe_at = self._clock()
                     self._has_probed = True

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -3742,6 +3742,11 @@ class TestKiroPrerequisiteHandlers:
             # reach the owner and leave this caller's client reading undefined.
             assert body["login_command"] == KIRO_CLI_LOGIN_COMMAND
             assert body["sso_login_command"] == KIRO_CLI_SSO_LOGIN_COMMAND
+            # Redacted-but-present for the same reason as the sandbox keys: whether
+            # the probe timed out describes how slow the HOST is. Asserted here
+            # because the hazard the comment above names is not hypothetical -- this
+            # branch is hand-built, so the key has to be added by hand with it.
+            assert body["probe_timed_out"] is False
             # The pre-upgrade-tab shim is served to every caller, so the payload
             # shape does not vary by who asks.
             assert body["operation"]["status"] == "idle"
@@ -4003,6 +4008,209 @@ class TestSandboxUnavailableIsNotAMissingBinary:
         assert status["sandbox_unavailable"] is False
         assert status["sandbox_failure_kind"] == ""
         assert status["sandbox_detail"] == ""
+        assert status["probe_timed_out"] is False
+
+
+class TestTimedOutProbeIsNotAMissingBinary:
+    """A probe that never ANSWERED must not be reported as "not installed".
+
+    The third condition, and the one issue #4577 was filed on. The sandbox branch
+    keys on a typed ``sandbox_failure``; a timeout raises none, so the timed-out
+    probe fell through to a bare ``PrerequisiteStatus`` whose every field is a
+    default: ``installed=False``, ``sandbox_unavailable=False`` and all
+    ``sandbox_*`` empty. That combination is worse than unhelpful — it rules the
+    true cause OUT, and points the operator at reinstalling or re-signing-in a CLI
+    that is installed, signed in, and serving chat turns the entire time.
+
+    Driven through ``ProcessResult.timed_out`` (the flag ``_run_process`` already
+    sets on the timeout path, and which the SEL audit already records as
+    ``error=timeout``) so no test here depends on real wall-clock timing.
+    """
+
+    @staticmethod
+    def _service(tmp_path: Path, run: Any) -> KiroPrerequisiteService:
+        return KiroPrerequisiteService(
+            platform_name="linux",
+            environ={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+    @staticmethod
+    async def _timed_out(
+        _command: str,
+        _args: list[str],
+        **_kwargs: Any,
+    ) -> ProcessResult:
+        """The runner shape ``_run_process`` produces when the probe never answers."""
+        return ProcessResult(ok=False, error="timeout", timed_out=True)
+
+    @pytest.mark.asyncio
+    async def test_timed_out_probe_does_not_claim_the_cli_is_missing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The load-bearing assertion: present on disk, so NOT ``installed=False``."""
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+
+        status = await self._service(tmp_path, self._timed_out).snapshot(force=True)
+
+        assert status["installed"] is True
+        assert status["probe_timed_out"] is True
+        assert status["ready"] is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_not_attributed_to_the_sandbox(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Over-claim guard, and the reason this is a new field not a reused one.
+
+        A caller that keys a userns remedy off ``sandbox_unavailable`` must not be
+        handed a slow filesystem to fix with an AppArmor profile. Nothing about the
+        sandbox failed here: the spawn was accepted and raised no typed failure.
+        """
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+
+        status = await self._service(tmp_path, self._timed_out).snapshot(force=True)
+
+        assert status["sandbox_unavailable"] is False
+        assert status["sandbox_failure_kind"] == ""
+        assert status["sandbox_detail"] == ""
+        assert status["sandbox_remedy"] == ""
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_offer_an_action_that_cannot_help(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Neither a reinstall nor a sign-in can speed up a slow probe.
+
+        ``authenticated`` is false as UNKNOWN, not as a verdict: ``whoami`` runs
+        through the same probe path and on this host is never reached at all, which
+        is why the report showed a signed-in account as signed out.
+        """
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+
+        status = await self._service(tmp_path, self._timed_out).snapshot(force=True)
+
+        assert status["repair_required"] is False
+        assert status["authenticated"] is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_without_a_runnable_candidate_is_still_not_installed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No binary on disk means the timeout says nothing about installation.
+
+        Symmetric with the sandbox branch's ``candidate_runnable`` requirement: the
+        claim ``installed=True`` rests on having STAT'd a runnable candidate, never
+        on the failure mode alone. Without that evidence the honest answer is the
+        unchanged default.
+
+        ``HOME`` is patched on the REAL process env, not just in the injected
+        ``environ``: candidate discovery runs the injected PATH through
+        ``env.augmented_path``, which resolves its extra directories from
+        ``os.path.expanduser("~")`` and so reaches the developer's own
+        ``~/.local/bin`` regardless of what this service was constructed with. Not
+        patching it makes the no-candidate premise silently false on any machine
+        that actually has kiro-cli installed — which is every machine a contributor
+        runs this on — and the test then asserts the opposite branch's behaviour.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        status = await self._service(tmp_path, self._timed_out).snapshot(force=True)
+
+        assert status["installed"] is False
+        assert status["probe_timed_out"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_persistent_timeout_warns_once_not_once_per_probe(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A line about a slow host must not evict the evidence about it.
+
+        This branch runs on EVERY probe, and on an affected host that is one probe per
+        ~40s (the readiness gate's 30s staleness window plus this probe's own 10s
+        timeout), i.e. ~90 lines/hour into the dashboard's 1000-entry log ring. The
+        latched status carries the transition, so no timestamp is needed to tell a new
+        outage from an ongoing one.
+        """
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+        service = self._service(tmp_path, self._timed_out)
+
+        with caplog.at_level("DEBUG", logger="kiro_crew.kiro_prerequisite"):
+            for _ in range(6):
+                status = await service.snapshot(force=True)
+
+        assert status["probe_timed_out"] is True
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        debugs = [
+            r
+            for r in caplog.records
+            if r.levelname == "DEBUG" and "already reported" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        # Accounted for, not dropped: a reader who turns up DEBUG sees the rest.
+        assert len(debugs) == 5
+
+    @pytest.mark.asyncio
+    async def test_a_recovered_probe_re_arms_the_timeout_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """One WARNING per OUTAGE, and the latched status re-arms it for free.
+
+        No clear-on-observe step and no floor: every probe rewrites the status, so a
+        recovery resets the transition record whether or not anything watched it
+        happen.
+        """
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+        healthy_calls = {"n": 0}
+
+        async def flapping(_command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            if healthy_calls["n"]:
+                healthy_calls["n"] -= 1
+                return ProcessResult(ok=args == ["--version"])
+            return ProcessResult(ok=False, error="timeout", timed_out=True)
+
+        service = self._service(tmp_path, flapping)
+
+        with caplog.at_level("DEBUG", logger="kiro_crew.kiro_prerequisite"):
+            await service.snapshot(force=True)  # outage 1 -> WARNING
+            await service.snapshot(force=True)  # same outage -> DEBUG
+            healthy_calls["n"] = 2
+            await service.snapshot(force=True)  # recovered
+            await service.snapshot(force=True)  # outage 2 -> WARNING again
+
+        timeouts = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and "the probe timed out" in r.getMessage()
+        ]
+        assert len(timeouts) == 2
+
+    @pytest.mark.asyncio
+    async def test_plain_failure_is_not_reported_as_a_timeout(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The ordinary broken-CLI path must keep its own reporting."""
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+
+        async def run(_command: str, _args: list[str], **_kwargs: Any) -> ProcessResult:
+            return ProcessResult(ok=False, error="exited with code 1")
+
+        status = await self._service(tmp_path, run).snapshot(force=True)
+
+        assert status["probe_timed_out"] is False
+        assert status["installed"] is False
 
 
 class TestKiroCrewNeverSetsUpKiroCli:

--- a/test/test_kiro_spawn_readiness_gate.py
+++ b/test/test_kiro_spawn_readiness_gate.py
@@ -30,11 +30,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from chat_test_helpers import _make_ready_kiro_prerequisite
 
+from kiro_crew.dashboard import kiro_readiness
 from kiro_crew.dashboard.handlers import agents, sessions
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
 
 _RESOLVE_TARGET = "kiro_crew.acp.client._resolve_kiro_bin_for_spawn"
 _FAKE_KIRO_BIN = "/usr/bin/kiro-cli"
+
+
+@pytest.fixture(autouse=True)
+def _reset_refusal_warning():
+    """Clear the gate's warn-once flag around every test in this module.
+
+    ``_refusal_warned_at`` is module state by necessity — the fail-closed path has no
+    service object to hang it on — so without this reset every test after the first
+    would see its refusal demoted to DEBUG, and the WARNING assertions would be
+    passing or failing on test ORDER rather than on behaviour.
+    """
+    kiro_readiness._clear_refusal_warning()
+    yield
+    kiro_readiness._clear_refusal_warning()
 
 
 class _SignedOutKiroPrerequisiteService(KiroPrerequisiteService):
@@ -125,3 +140,314 @@ async def test_api_models_still_reaches_spawn_path_when_ready() -> None:
     resolve.assert_awaited_once()
     assert resp.status == 503
     assert json.loads(resp.body) == {"error": "kiro binary not resolved"}
+
+
+@pytest.mark.asyncio
+async def test_refused_call_is_visible_in_the_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The gate must SAY it refused (issue #4577).
+
+    Every post-spawn failure branch in ``api_models`` logs a WARNING, so a reader
+    who greps the log for that endpoint and finds nothing concludes the endpoint is
+    healthy. When the gate refused silently that conclusion was exactly inverted,
+    and it cost hours of misdiagnosis. An absent log line gets read as evidence.
+    """
+    request = _request(_make_signed_out_kiro_prerequisite())
+    request.path = "/api/models"
+
+    with caplog.at_level("WARNING", logger="kiro_crew.dashboard.kiro_readiness"):
+        with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+            resp = await agents.api_models(request)
+
+    assert resp.status == 503
+    refusals = [
+        r
+        for r in caplog.records
+        if r.name == "kiro_crew.dashboard.kiro_readiness" and r.levelname == "WARNING"
+    ]
+    assert refusals, "the readiness gate refused a call without logging anything"
+    message = refusals[0].getMessage()
+    # The endpoint has to be IN the line: a grep for the path is how the reader
+    # arrives, and a line that omits it does not answer the question they asked.
+    assert "/api/models" in message
+    assert "kiro_prerequisite_required" in message
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_log_cannot_break_the_fail_closed_path() -> None:
+    """The diagnostic must not add a failure mode to the branch it reports on.
+
+    ``reject_if_kiro_unverified`` is the fail-CLOSED gate, so anything on that
+    branch has to survive a caller that is only request-LIKE — which is what
+    ``test_missing_route_prerequisite_wiring_fails_closed`` exercises. Reading
+    ``.path`` directly raises for such a caller and converts a correct 503 into a
+    500. A silent refusal is the defect this logging removes; an exception here is
+    worse than the silence it replaced.
+    """
+    request = SimpleNamespace(app={"kiro_prerequisite_service": None})
+
+    resp = await kiro_readiness.reject_if_kiro_unverified(request)  # type: ignore[arg-type]
+
+    assert resp is not None
+    assert resp.status == 503
+    assert json.loads(resp.body)["code"] == "kiro_prerequisite_required"
+
+
+@pytest.mark.asyncio
+async def test_a_non_str_path_does_not_reach_the_formatter() -> None:
+    """A request-like double whose ``path`` is not a string must still 503.
+
+    Distinct from the case above: there the attribute is ABSENT, here it exists
+    and is the wrong type, which a plain regex substitution would raise on. Both
+    have to degrade, because both are on the fail-closed branch.
+    """
+    request = _request(_make_signed_out_kiro_prerequisite())  # MagicMock: .path is a mock
+
+    with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+        resp = await agents.api_models(request)
+
+    assert resp.status == 503
+    assert kiro_readiness._log_safe_path(request) == "<unknown path>"
+
+
+@pytest.mark.asyncio
+async def test_a_newline_in_the_path_cannot_forge_a_log_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A decoded newline must not become a second ``gateway.log`` line.
+
+    ``Request.path`` is URL-decoded, so ``%0A`` in a ``{slot}`` segment arrives as
+    a real newline and the route pattern (which excludes only ``/{}``) matches it.
+    Logged verbatim, a caller could append whatever line they liked to the log —
+    forging the very evidence this logging exists to provide.
+
+    Asserted on the RECORD THE GATE ACTUALLY EMITS, not on the helper in
+    isolation: a helper-only test stays green if someone drops the sanitising
+    call from the ``logger.warning`` below, which is the whole regression worth
+    catching.
+    """
+    forged = "/api/chat/slots/a\nWARNING forged line/regenerate"
+    request = _request(_make_signed_out_kiro_prerequisite())
+    request.path = forged
+
+    with caplog.at_level("WARNING", logger="kiro_crew.dashboard.kiro_readiness"):
+        with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+            resp = await agents.api_models(request)
+
+    assert resp.status == 503
+    records = [r for r in caplog.records if r.name == "kiro_crew.dashboard.kiro_readiness"]
+    assert records, "the gate refused without logging anything"
+    message = records[0].getMessage()
+    # ``splitlines`` is the property that matters, not an absence of two literals:
+    # it is what a Python consumer of the log actually re-splits on, and it covers
+    # every boundary character at once.
+    assert len(message.splitlines()) == 1
+    # Neutralised, not discarded: a caller who sent a control byte is precisely
+    # what the reader of the log wants to know about. ``repr`` spells LF with the
+    # short escape, so this is ``\\n`` rather than ``\\x0a``.
+    assert "\\n" in message
+    assert "forged line" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("encoded", "escaped"),
+    [("\x85", "\\x85"), ("\u2028", "\\u2028"), ("\u2029", "\\u2029")],
+    ids=["U+0085-NEL", "U+2028-LS", "U+2029-PS"],
+)
+async def test_unicode_line_separators_cannot_forge_a_log_line(
+    caplog: pytest.LogCaptureFixture,
+    encoded: str,
+    escaped: str,
+) -> None:
+    """C0 is not the whole boundary set — ``splitlines()`` is wider than C0.
+
+    ``%C2%85`` / ``%E2%80%A8`` / ``%E2%80%A9`` decode to U+0085 / U+2028 / U+2029.
+    None of them is a ``0a`` byte, so none forges a physical line in the log FILE;
+    all three ARE ``str.splitlines()`` boundaries, so a Python consumer that
+    re-splits the log does see a forged line. A guard scoped to C0+DEL let every
+    one of them through.
+    """
+    request = _request(_make_signed_out_kiro_prerequisite())
+    request.path = f"/api/chat/slots/a{encoded}WARNING forged/regenerate"
+
+    with caplog.at_level("WARNING", logger="kiro_crew.dashboard.kiro_readiness"):
+        with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+            resp = await agents.api_models(request)
+
+    assert resp.status == 503
+    records = [r for r in caplog.records if r.name == "kiro_crew.dashboard.kiro_readiness"]
+    assert records, "the gate refused without logging anything"
+    message = records[0].getMessage()
+    assert len(message.splitlines()) == 1
+    assert escaped in message
+
+
+def test_every_control_byte_is_neutralised_not_just_crlf() -> None:
+    """The whole C0+DEL class, not the two bytes that happen to split a line.
+
+    An ESC byte reaching a terminal that is tailing the log is the same defect
+    wearing different clothes.
+    """
+    rendered = kiro_readiness._log_safe_path(SimpleNamespace(path="/api/a\x1b[2Kb\x00c\x7fd"))
+
+    assert rendered == "'/api/a\\x1b[2Kb\\x00c\\x7fd'"
+
+
+def test_invisible_formatting_characters_are_neutralised() -> None:
+    """``Cf`` splits no line and still forges evidence.
+
+    U+202E RIGHT-TO-LEFT OVERRIDE reorders what a human READS in a rendered log
+    view, and U+200B hides a boundary that is not there. Neither is a
+    ``splitlines()`` boundary, so a guard built only from line-breaking characters
+    would miss both — which is why the class is the ``Cf`` CATEGORY rather than a
+    list of the characters someone happened to think of.
+    """
+    rendered = kiro_readiness._log_safe_path(SimpleNamespace(path="/api/a\u202eb\u200bc"))
+
+    assert rendered == "'/api/a\\u202eb\\u200bc'"
+
+
+def test_categories_a_hand_written_set_would_miss() -> None:
+    """The reason this delegates to ``repr`` instead of listing categories.
+
+    A set of ``Cc``/``Cf``/``Zl``/``Zp`` — the categories that come to mind — lets all
+    of these through, and every one is reachable through ``yarl``'s percent-decoding:
+    ``%C2%A0`` and ``%E3%80%80`` are ``Zs``, ``%EE%80%80`` is ``Co``, ``%CD%B8`` is
+    ``Cn``. ``str.isprintable()`` rejects the lot, so ``repr`` covers them without
+    anyone having to remember to extend a list.
+    """
+    rendered = kiro_readiness._log_safe_path(
+        SimpleNamespace(path="/api/a\u00a0b\u3000c\ue000d\u0378e")
+    )
+
+    assert rendered == "'/api/a\\xa0b\\u3000c\\ue000d\\u0378e'"
+
+
+def test_a_lone_surrogate_still_produces_an_encodable_line() -> None:
+    """Robustness, not a live vector: ``yarl`` does not decode ``%ED%A0%80``.
+
+    Worth pinning anyway because of the failure mode it guards. A surrogate emitted
+    verbatim is a string a UTF-8 log handler cannot encode, and ``logging`` swallows
+    handler errors, so the line vanishes silently. A function whose whole purpose is
+    "the log must not lie about what happened" must not be able to delete the
+    record.
+    """
+    rendered = kiro_readiness._log_safe_path(SimpleNamespace(path="/api/a\ud800b"))
+
+    assert rendered.encode("utf-8")
+    assert "\\ud800" in rendered
+
+
+def test_visible_non_ascii_is_left_alone() -> None:
+    """Over-escaping guard: the goal is an unforgeable path, not an ASCII one.
+
+    Folding every non-ASCII byte would be the easy way to satisfy the finding and
+    would make a legitimate path unreadable for exactly the operators who most need
+    to read it.
+    """
+    rendered = kiro_readiness._log_safe_path(SimpleNamespace(path="/api/文档/café"))
+
+    assert rendered == "'/api/文档/café'"
+
+
+@pytest.mark.asyncio
+async def test_a_polled_outage_warns_once_not_once_per_request() -> None:
+    """The visible line must not become the thing that destroys the log.
+
+    A signed-out gateway with an open dashboard refuses ``/api/models`` every 8s and
+    ``/api/sessions/usage`` every 30s, and BOTH refuse at this gate — the sibling
+    branches that log in ``api_models`` sit below it and are never reached in that
+    state. Left per-request that is ~570 lines/hour into a ``deque(maxlen=1000)``,
+    which churns the whole ring every ~1.8 hours and evicts the diagnostics an
+    operator opened the log to read.
+    """
+    request = _request(_make_signed_out_kiro_prerequisite())
+    request.path = "/api/models"
+
+    with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+        with patch.object(kiro_readiness.logger, "warning") as warn:
+            with patch.object(kiro_readiness.logger, "debug") as dbg:
+                for _ in range(25):
+                    resp = await agents.api_models(request)
+
+    assert resp.status == 503
+    # Still visible: silence was the original defect and must not come back.
+    assert warn.call_count == 1
+    # And accounted for, not dropped — a reader who turns up DEBUG sees the rest.
+    assert dbg.call_count == 24
+
+
+@pytest.mark.asyncio
+async def test_a_later_outage_warns_again_after_recovery() -> None:
+    """One WARNING per OUTAGE, not one per process lifetime.
+
+    Without the clear-on-authorize half, the first outage after boot consumes the
+    only WARNING the process ever emits and every later outage is silent — the
+    original defect back in a subtler form. This is why
+    ``mcp_discovery._clear_unresolvable`` exists next to its warn-once.
+    """
+    signed_out = _request(_make_signed_out_kiro_prerequisite())
+    signed_out.path = "/api/models"
+    ready = _request(_make_ready_kiro_prerequisite())
+    ready.path = "/api/models"
+
+    with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+        with patch.object(kiro_readiness.logger, "warning") as warn:
+            await agents.api_models(signed_out)  # outage 1 -> WARNING
+            await agents.api_models(signed_out)  # same outage -> DEBUG
+            assert warn.call_count == 1
+
+            await kiro_readiness.reject_if_kiro_unverified(ready)  # recovered
+            await agents.api_models(signed_out)  # outage 2 -> WARNING again
+
+    assert warn.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unobserved_recovery_does_not_silence_the_next_outage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The clear-on-authorize half is not sufficient on its own.
+
+    Nothing calls the authorized branch on a gateway whose dashboard is closed: the
+    pollers have stopped, so a recovery that happens in that window is never OBSERVED
+    and the flag stays set. Without a floor the next outage logs only DEBUG — the
+    subtler silence the docstring names and the whole point of the mechanism. So the
+    guarantee cannot depend on seeing the recovery: after
+    ``_REFUSAL_REWARN_SECS`` an ongoing or fresh refusal speaks up regardless.
+    """
+    fake_now = [1000.0]
+    monkeypatch.setattr(kiro_readiness, "_clock", lambda: fake_now[0])
+    request = _request(_make_signed_out_kiro_prerequisite())
+    request.path = "/api/models"
+
+    with patch(_RESOLVE_TARGET, AsyncMock(return_value=_FAKE_KIRO_BIN)):
+        with patch.object(kiro_readiness.logger, "warning") as warn:
+            await agents.api_models(request)  # outage 1 -> WARNING
+            assert warn.call_count == 1
+
+            # Still inside the floor: quiet, so the ring is not churned.
+            fake_now[0] += kiro_readiness._REFUSAL_REWARN_SECS - 1
+            await agents.api_models(request)
+            assert warn.call_count == 1
+
+            # Floor elapsed, and NO authorized call ever happened in between.
+            fake_now[0] += 2
+            await agents.api_models(request)
+
+    assert warn.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_a_ready_gateway_logs_no_refusal() -> None:
+    """No line on the authorized path: the log must stay a signal, not a heartbeat."""
+    request = _request(_make_ready_kiro_prerequisite())
+    request.path = "/api/models"
+
+    with patch(_RESOLVE_TARGET, AsyncMock(return_value="")):
+        with patch.object(kiro_readiness.logger, "warning") as warn:
+            await agents.api_models(request)
+
+    warn.assert_not_called()


### PR DESCRIPTION
## Problem / Motivation

A Kiro CLI verification probe that never ANSWERS was reported as a CLI that is not
INSTALLED.

Only a *typed* sandbox failure took the `sandbox_unavailable` branch in
`kiro_prerequisite.py`. A probe that merely hit `_PROBE_TIMEOUT_SECS` raised no
typed failure, so it fell through to a bare `PrerequisiteStatus`:

```json
{"platform": "Linux", "installed": false, "authenticated": false, "ready": false,
 "sandbox_unavailable": false, "sandbox_failure_kind": "", "sandbox_detail": "",
 "initial_setup_complete": true}
```

That was captured on a host whose CLI was installed, signed in, and serving chat
turns the entire time.

The second half is a reporting gap of the same kind: `reject_if_kiro_unverified`
refused with 503 and logged nothing, while every post-spawn failure branch in
`api_models` logs a WARNING.

## Why it matters

The empty `sandbox_*` fields do not merely fail to help. They actively rule the
true cause OUT, and `installed: false` sends the operator to reinstall or
re-sign-in, neither of which can possibly work. On the reporting host the SEL audit
log holds 4081 `kiro_prerequisite_probe_version` events with
`outcome: failed, error: "timeout"`, each an exact 10s `invoked -> failed` gap, while
`kiro_prerequisite_probe_identity` never appears at all: the version probe never
yields a viable binary, so authentication is never attempted, which is why a
signed-in account reads as signed out.

The silent 503 is what made this expensive to diagnose. A reader grepped
`gateway.log` for the endpoint, found zero lines, and concluded the endpoint was
fine. That conclusion was exactly inverted. An absent log line gets read as
evidence; it is not.

## What changed (motivation → approach → change)

The information was already present at the branch and simply never reached the
status. `ProcessResult.timed_out` has always been set on the timeout path, and the
SEL audit already records it as `error=timeout`.

So a timed-out probe WITH a runnable candidate now reports the same shape the
sandbox branch already uses for "present on disk, verification is what failed":
`installed=True`, `ready=False`, `authenticated=False` as UNKNOWN rather than as a
verdict, plus a new `probe_timed_out` flag and a WARNING naming the timeout.

The timeout gets its own field rather than reusing `sandbox_*`. Nothing about the
sandbox failed here: the spawn was accepted and raised no typed failure. A caller
that keys a userns remedy off `sandbox_unavailable` must not be handed a slow
filesystem to fix with an AppArmor profile. `installed=True` still rests on having
stat'd a runnable candidate, never on the failure mode alone, so a host with no
binary keeps the unchanged default.

### Why the field earns its place

Reviewers have questioned `probe_timed_out` for having no code consumer yet, so the full
answer belongs here rather than in a review thread.

The issue asks for it in as many words: "A timed-out probe needs a status distinct from
both 'missing' and 'sandbox refused'." Without the field the snapshot is byte-identical to
signed-out, which IS the reported misdiagnosis — the operator is sent to a re-login that
cannot work. The field is what makes the three conditions distinguishable at the API at
all, and therefore what any future intercept has to be built on.

One suggestion was that the new probe WARNING already serves the only present (human)
reader, making the field redundant. It does not, and the reason is the warn-once change in
this same PR: after the transition, repeats log at DEBUG. Measured over five consecutive
timed-out probes, the WARNING count stays at 1 while DEBUG accumulates, so an operator
arriving at any point mid-outage sees ZERO recent WARNINGs while `probe_timed_out` is
still `true` in the snapshot. The log is a one-shot edge signal; the field is durable
current state. They are complements, and bounding the log's volume is exactly what makes
the field the only thing still answering the question an hour in.

The redacted **non-owner** payload in `dashboard/handlers/kiro_prerequisite.py` gains
the field too. That branch is hand-built and deliberately keeps every key present
with a redacted value — the reason is stated three times in its own comments, "so the
payload shape never varies by caller" — so a field that reached only the dataclass
would leave a non-owner's client reading `undefined` and branching on it. The
existing test for that branch even predicts this exact failure: "a field added only
to the dataclass would reach the owner and leave this caller's client reading
undefined." It enumerates fields by hand, which is why it did not catch it; the new
key is asserted there now.

Named for the maintainers rather than fixed here: comparing the dataclass fields
against that literal shows `rejected_agent_specs` and `agent_spec_rejection_detail`
are also absent from it, so the invariant has two gaps that predate this PR. A
structural superset assertion would be the durable fix and would fail today for
those two, which is someone else's redaction call to make.

`reject_if_kiro_unverified` now logs its refusal. The path goes through
`_log_safe_path`, which carries the two properties that branch requires.

It cannot RAISE. The branch is fail-CLOSED, and a bare `request.path` read raises
for any caller holding a request-like object whose `path` is absent or is not a
string, turning a correct 503 into a 500. The first draft did exactly that and
broke `test_missing_route_prerequisite_wiring_fails_closed`.

It cannot be used to FORGE a line. `Request.path` is URL-DECODED, so `%0A` in a
`{slot}` segment arrives as a real newline, and the dynamic-route pattern excludes
only `/{}` — a newline matches it and reaches the gate. Logged verbatim, a caller
could append arbitrary lines to `gateway.log`, defeating the entire reason the
refusal is logged: the log is meant to be evidence, and forgeable evidence is worse
than none. Control bytes are ESCAPED rather than rejected (rejecting reintroduces
the raise, which is why dev_fleet's `reject_unsafe` is not reusable here) and
rather than stripped (a caller who sent one is exactly what the reader wants to
see). Visible non-ASCII is left alone: the goal is an unforgeable path, not an
ASCII one.

The escaping is `repr`, not a character class. Two revisions of this PR got that
wrong in the same direction and it is worth recording why, since the pattern is the
point: first a C0+DEL range (`[\x00-\x1f\x7f]`, the class the tree uses elsewhere),
then a hand-listed category set (`Cc`/`Cf`/`Zl`/`Zp`). Both were narrower than the
threat, and the second was narrower in four ways that are all reachable through
`yarl`'s percent-decoding:

| input | decodes to | category | old set escaped it |
|---|---|---|---|
| `%C2%A0` | U+00A0 NBSP | `Zs` | no |
| `%E3%80%80` | U+3000 IDEOGRAPHIC SPACE | `Zs` | no |
| `%EE%80%80` | U+E000 private use | `Co` | no |
| `%CD%B8` | U+0378 unassigned | `Cn` | no |

`str.__repr__` escapes everything `str.isprintable()` rejects — those plus `Cs` —
and derives it from the interpreter's own Unicode tables rather than a list someone
has to remember to extend. That deletes the helper's escaping logic entirely
(net -33 lines in that file) while strictly widening coverage.

Worth naming precisely because it inverts: `%C2%85`, `%E2%80%A8` and `%E2%80%A9`
decode to U+0085/U+2028/U+2029, which are **not** `0a` bytes and so forge no
physical line in the log FILE, but they ARE `str.splitlines()` boundaries, so a
Python consumer that re-splits the log sees the forged line. `Cs` is not reachable
here (`yarl` leaves `%ED%A0%80` as literal text rather than decoding a lone
surrogate), but had it been, the hand-rolled version emitted a string a UTF-8 log
handler cannot encode, and `logging` swallows handler errors — so the line would
have gone missing entirely. The function that exists to stop the log lying would
have been deleting the record.

The quotes `repr` adds are wanted: they delimit the value, so trailing whitespace or
an empty path is visible instead of blending into the message.

Both new log lines report the TRANSITION into their condition, not every occurrence,
and that distinction is load-bearing rather than cosmetic. First Principles Review
caught the second one: an earlier revision of this PR built a warn-once mechanism for
the gate while leaving the probe branch firing per probe — the PR's own log-churn
analysis condemning the PR's own other line. Its arithmetic was exact: the probe branch
runs on every probe, and on an affected host that is one per ~40s (the gate's 30s
staleness window plus this probe's own 10s timeout), so ~90 lines/hour into the
1000-entry ring, churning it in ~11 hours.

The two halves need different mechanisms, and the asymmetry is the interesting part.
The probe branch needs nothing but a comparison: every probe rewrites `self._status`,
so the latched status IS the transition record and a recovery re-arms the warning by
itself — no timestamp, no floor. The gate has no object to hang state on (it must work
with no service at all on the fail-closed path), so it needs the module cell, the
clear-on-authorize, AND the floor. Only one of them needs the heavier machinery, and
the reason is structural rather than a matter of taste.

For the gate half specifically: The sibling branches sit BELOW this gate
(`agents.py:1014` onward vs the gate at `:942`), so in the signed-out state they are
never reached and log nothing — a per-request warning here is not "the same order of
magnitude as its siblings" (an earlier revision of this PR claimed exactly that, and
it was wrong), it is ~570 lines/hour where there were none, since `/api/models` polls
every 8s and `/api/sessions/usage` every 30s and both refuse here. The dashboard log
ring is `deque(maxlen=1000)` (`handlers/updates.py:1381`), so one gate would churn the
entire ring every ~1.8 hours and evict the diagnostics an operator opened the log to
read. A line added to make the log trustworthy would have been destroying its
contents.

So it follows `mcp_discovery`'s established warn-once shape, with both halves of the
recovery story rather than only the obvious one: WARNING on the transition into
refusing, DEBUG for repeats, cleared when a gated call authorizes — plus a
`_REFUSAL_REWARN_SECS` (30 min) floor on top.

The floor exists because clearing on authorize only fires when a gated caller
*observes* the recovery, which Design Review pointed out is not guaranteed: on a
gateway whose dashboard is closed the pollers stop, nothing calls the authorized
branch, and the flag would still be set when the NEXT outage began — the subtler
silence this mechanism exists to remove, and the one its own docstring named.
Measured before fixing: outage, unobserved recovery, second outage produced
`WARNING=1, DEBUG=1`, i.e. the second outage was entirely silent at WARNING level.
The floor makes the guarantee unconditional at ~2 lines/hour, four orders below the
570/hour that started this. Design's own suggestion was to clear it service-side on a
successful probe; that would make `kiro_prerequisite` reach into the dashboard gate's
log state, so the floor gets the same property without the reverse dependency.

Reverting the hunk outright was the other option on the table and would have
reintroduced the exact silence this fixes. The cell is global rather than per-path
because the condition is gateway-global, and because a per-path ledger keyed on
caller-controlled input would grow without bound.

The refusal REASON is deliberately not restated in the log; it lives in the
prerequisite snapshot, and a second copy could contradict it.

## Scope, and what is deliberately left out

This PR is the reporting layer only, which is what survives the issue's own
rewrite. The primary cause was a type bug already fixed on `main` by #4197
(`130eb893c`, verified present at `sandbox.py` in the `S_ISREG` guard).

Three of the issue's five open items are NOT addressed here, each because it
carries a design decision that is the maintainers' to make:

- Item 3, the frontend degradation hint. The state exists and is already
  subscribed; only the surfacing is missing, but where and how it surfaces is a UX
  call.
- Item 4, a wall-clock budget for the hardlink scan. Picking the deadline value is
  a policy choice.
- Item 5, an explicitly chosen scan root instead of an inherited `cwd`. This needs a
  contract between daemon hygiene and a security-relevant input, not a substitution.

`Refs`, not `Fixes`, for that reason: merging this should not auto-close the issue
and silently strand those three. The sandbox-refusal branch's own WARNING is still
per-probe and shares the pattern fixed here; it predates this change and is named
rather than altered.

### Declared interim gap, and one deferred sibling

Two things the AI review rounds surfaced that are worth stating plainly rather than
leaving implied. The first is recorded in the spec; the second, as Design Review
correctly pointed out, is not — see why below.

`KiroPrerequisiteGate.tsx` keys only on
`sandbox_unavailable` / `installed` / `authenticated`, so `probe_timed_out` has no UI
consumer yet. On a FIRST-RUN host (`initial_setup_complete=false`) a timed-out probe
now falls past the `sandbox_unavailable` intercept at `:816` into the generic setup
shell, which marks the sign-in step current (`:882`/`:899`/`:916`) and renders
"Kiro CLI is installed, finish signing in" at `:946` — a remedy that cannot speed up
a slow probe either. That is not worse than the state it replaces: the same host
previously read `installed=false` and was told to install a CLI it already has. But
it is still wrong, and the description should not imply otherwise. An established
install is untouched — `:802` returns for `initial_setup_complete=true`, which is the
case actually reported in the issue. Closing it is the item-3 slice, and where the
hint surfaces is a UX call for the maintainers.

A repo-wide grep for `request.path` reaching a logger finds exactly one other site,
`apps/builtins/md_notebook/server.py:1095`
(`logger.exception("md-notebook: unhandled error on %s", request.path)`). Same root
cause, same consequence, different builtin app and untouched by this diff, so it is
named rather than swept in. If it is picked up, the escaping belongs in a shared
helper both sites import — `dev_fleet`'s `reject_unsafe` is not that primitive, since
it raises.

This one is deliberately NOT in the spec hunk: `learn-cron-dashboard.md` documents the
prerequisite/dashboard surface, and a note about `md_notebook`'s logging has no
business there. That does mean the item currently lives only in this description,
which Design Review is right to flag as losable. A tracking issue is the correct
durable home and I am happy to file one on request rather than parking an off-topic
line in someone else's spec section.

## Tests

Two new test groups, both driven through the typed signal rather than real timing,
so nothing here depends on wall-clock or on the host's filesystem speed.

`TestTimedOutProbeIsNotAMissingBinary` (5 cases): the timed-out probe does not claim
the CLI is missing; the timeout is not attributed to the sandbox; no action that
cannot help is offered; a timeout with NO runnable candidate still reports
`installed=False`; an ordinary `--version` failure is not reported as a timeout.

Readiness gate (16 cases, plus one added to the existing non-owner payload test), and the probe branch gains two (a persistent timeout warns once across six probes with the other five at DEBUG; a recovery re-arms it so a later outage warns again): a refused call is visible in the log and names the
endpoint; the refusal log cannot break the fail-closed path when `path` is ABSENT;
nor when `path` exists but is not a string; a decoded newline cannot forge a second
log line; U+0085, U+2028 and U+2029 each cannot either (parametrized, one per
separator); every C0+DEL byte is neutralised rather than just CR/LF; invisible `Cf`
formatting characters are neutralised too; visible non-ASCII is NOT escaped
(over-escaping guard); a polled outage warns ONCE across 25 refusals with the other
24 accounted for at DEBUG; a later outage warns again after recovery; the four
categories a hand-written set missed are escaped; a lone surrogate still yields an
encodable line; an UNOBSERVED recovery does not silence the next outage (the floor,
driven by an injected clock so nothing sleeps); and a ready gateway logs no refusal,
so the line stays a signal rather than a heartbeat.

The forging assertions key on `len(message.splitlines()) == 1` rather than on the
absence of two literals — `splitlines` is what a Python consumer of the log actually
re-splits on, so it is the property that matters and it covers every boundary
character at once.

The forging case asserts on the record the GATE ACTUALLY EMITS, not on
`_log_safe_path` in isolation. A helper-only assertion stayed green when the
sanitising call was dropped from the `logger.warning` — which is the one regression
worth catching — so the first version of that test was not load-bearing and was
rewritten to drive the real gate.

Load-bearing, verified in both directions by reverting only the `src/` change: 5 of
the new cases fail on unfixed code and pass after. Of those, two prove the behaviour
change specifically (`installed is True` where it was `False`, and a log record
where there was none); three depend on the new field existing. The remaining two are
over-claim guards that must hold before AND after, so they pass on both sides by
design.

One incidental note for the maintainers, not changed here: the sibling
`test_missing_binary_still_reports_not_installed` reads as covering the
no-candidate path but passes for an unrelated reason on any machine that has
kiro-cli installed. Candidate discovery routes the injected PATH through
`env.augmented_path`, which resolves its extra directories from
`os.path.expanduser("~")` and so reaches the developer's real `~/.local/bin`
regardless of the injected `home`. The new no-candidate case patches `HOME` on the
real process env to make that premise actually true.

## Manual verification

Full CI gate set run locally on the whole tree with the CI-pinned versions
(black 26.3.1 via `scripts/check_black_formatting.py`, isort 6.0.0, flake8 7.1.0,
mypy 1.14.1) plus `scripts/docs_lint.py` for the spec change: all five clean.

`test_kiro_prerequisite.py` + `test_kiro_spawn_readiness_gate.py`: 176 passed.

Wider sweep over all 37 test files that touch the two modified modules: 2916 passed,
1 failed. That failure is `test_cli.py::TestManifest::test_packaged_manifest_declares_complete_oauth_scopes`,
confirmed to fail identically on an unmodified tree at the same base commit, so it
is pre-existing and unrelated.

The end-to-end symptom itself is not reproduced here and cannot be: it needs the
pre-#4197 code path to make the scan blow the 10s budget. What this change is
verified against is the condition that survives that fix, which is how the timeout
is reported once it happens.

## Related Issues

Refs #4577
