### PR TITLE
fix(ci): fail fast on a dead xdist worker in the Windows test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,6 +616,31 @@ jobs:
       - name: Run tests (Windows shard ${{ matrix.group }}/${{ env.SHARD_COUNT }})
         # bash (Git Bash on windows-latest), not pwsh: the invocation shares
         # the POSIX job's line-continuation and env-interpolation syntax.
+        #
+        # --max-worker-restart=0 overrides setup.cfg's =2 for THIS job only.
+        # pytest-timeout has no SIGALRM on Windows, so it falls back to the
+        # thread method, which cannot fail a single test -- it terminates the
+        # whole worker. Every per-test timeout here therefore lands as
+        # "node down: Not properly terminated", and xdist then enters its
+        # node-replacement path, where #2803 documented a broken invariant (a
+        # node in assigned_work but absent from registered_collections). That
+        # path either dies with INTERNALERROR or, as in #4227, never completes
+        # the session and burns the full 40-minute cap. Refusing the
+        # replacement keeps us out of it: the first dead worker ends the run
+        # promptly with the victim named. setup.cfg keeps =2 deliberately, to
+        # absorb a one-off memory-pressure crash on a developer machine; a CI
+        # runner has no such need.
+        #
+        # Measured on windows-latest-equivalent pins (pytest 9.0.3, xdist
+        # 3.5.0, pytest-timeout 2.2.0) with one test forced past the timeout:
+        # =2 hung indefinitely with no summary and no victim named, and a
+        # single slow test took down TWO workers because the crashed item is
+        # re-dispatched to a live one. =0 exited 1 in 12s and named the test.
+        # The trade-off is deliberate: refusing the replacement abandons the
+        # work still pending on that shard, so a killed shard reports fewer
+        # tests than it collected. That is the right trade for CI -- the job
+        # is red either way, and a named red in 12 minutes beats an
+        # uninterpretable one at the 40-minute cap.
         shell: bash
         env:
           REDUCED: ${{ steps.scope.outputs.reduced }}
@@ -624,12 +649,12 @@ jobs:
           if [ "$REDUCED" = "true" ]; then
             TARGETS=()
             while IFS= read -r line; do line=${line%$'\r'}; if [ -n "$line" ]; then TARGETS+=("$line"); fi; done < "$TARGETS_FILE"
-            pytest -q -n auto --timeout=180 --no-cov \
+            pytest -q -n auto --timeout=180 --no-cov --max-worker-restart=0 \
               --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
               "${TARGETS[@]}"
             exit 0
           fi
-          pytest -q -n auto --timeout=180 --no-cov \
+          pytest -q -n auto --timeout=180 --no-cov --max-worker-restart=0 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }}
         # Nothing is deselected here either, and the same guards carry it: Windows has no
         # namespace sandbox at all, so `userns_available()` is False and every


### PR DESCRIPTION
## What

Add `--max-worker-restart=0` to the two `pytest` invocations in the
`backend-test-windows` job, plus a comment recording why. Nothing else changes:
`setup.cfg` keeps `--max-worker-restart=2`, and the POSIX `backend-test` job is
untouched.

Fixes the fail-fast half of #4227.

## Why

The Windows shards can burn their full 40-minute cap and get cancelled without
ever reporting which test was at fault. The mechanism is now measured rather
than inferred:

1. `pytest-timeout` has no SIGALRM on Windows, so it falls back to its thread
   method. That method cannot fail a single test -- it terminates the whole
   xdist worker. So *every* per-test timeout on this job surfaces as
   `node down: Not properly terminated`. This is expected behaviour, not a
   native crash, and the same log line appears in #2803.
2. A dead worker pushes xdist into its node-replacement path, where #2803
   documented a broken invariant: the node is present in `assigned_work` but
   absent from `registered_collections`. That path either dies with
   INTERNALERROR or, as in #4227, never completes the session at all.

Upgrading the pin is not an available fix. #2803's reporter read 3.8.0 -- the
current release -- and found the same defect shape, so there is no fixed version
to move to, and patching a third-party scheduler from our own tree is not worth
it. The remaining lever is to never enter the bad path: refuse the replacement,
so the first dead worker ends the run.

## Measured, not assumed

Run locally on the pins this job installs (pytest 9.0.3, pytest-xdist 3.5.0,
pytest-timeout 2.2.0), with one test forced past `--timeout`:

| Setting | Result |
| --- | --- |
| `--max-worker-restart=2` (today) | Hangs indefinitely. Reproduced twice; one run was still live after 108 minutes with no summary and no victim named. |
| `--max-worker-restart=0` (this PR) | Exits 1 after 12.4s: `FAILED test_probe.py::test_a_killer - worker 'gw0' crashed while running ...` |

Exit code 1 was confirmed separately, so CI still goes red.

The reproduction also turned up something the issue did not have: **one slow
test takes down two workers.** The crashed item is re-dispatched to a live
worker, which then hits the same timeout and dies too. That explains #2803's
report of two workers killed in one shard without needing two independent slow
tests.

Reproduction, if you want to run it yourself:

```
python -m venv .venv-probe
.venv-probe/bin/pip install "pytest==9.0.3" "pytest-xdist==3.5.0" "pytest-timeout==2.2.0"
mkdir probe && cd probe
cat > test_probe.py <<'PY'
import time


def test_a_killer():
    time.sleep(60)


def test_b():
    pass


def test_c():
    pass


def test_d():
    pass


def test_e():
    pass


def test_f():
    pass


def test_g():
    pass
PY
# hangs
python -m pytest -q -n 2 --timeout=10 --max-worker-restart=2
# exits 1 in ~12s, naming test_a_killer
python -m pytest -q -n 2 --timeout=10 --max-worker-restart=0
```

## Trade-off

Refusing the replacement abandons the work still pending on that shard, so a
killed shard reports fewer tests than it collected -- in the probe above, 5 of 7
ran. This is the right trade for CI: the job is red either way, and a named red
in 12 minutes is worth more than an uninterpretable cancellation at the cap.

Scope is deliberately the CI job only. `setup.cfg`'s `=2` has a comment stating
its reason -- a developer machine under memory pressure can lose a worker, and
two replacements absorb that. A CI runner has no such need, and tightening
`setup.cfg` would make local runs brittle for no gain.

## What this does not fix

- The **underlying stall** that trips `--timeout` in the first place is still
  unidentified. This change makes it diagnosable, not diagnosed.
- The **xdist replacement-path defect** is upstream and stays unfixed. This
  change routes around it.
- **Shard composition** is still split by test count (no `.test_durations` is
  committed), so which shard a slow test lands in still shifts with any
  test-adding PR. That belongs in its own change.
- `test_rejected_spawn_logs_sel_rejection`, occurrence A in #4227, is a separate
  test-isolation bug: it patches the module global `kiro_crew.subagent.sel` and
  asserts `assert_called_once_with` on a shared `return_value`, so a leaked
  coroutine from an earlier test makes the count 2. Order-dependent by
  construction, and unrelated to the hang.

## Testing

The change is a CI-only flag, so there is no unit test to add. Verified by:

- The local reproduction above, on the same pin set the job installs.
- `yaml.safe_load` on the edited workflow, then asserting from the parsed tree
  that the flag appears twice in `backend-test-windows` and zero times in
  `backend-test`.