### PR TITLE
fix(side): stop a side turn answering as the default agent on an app slot

### DIFF
--- a/src/kiro_crew/dashboard/handlers/side.py
+++ b/src/kiro_crew/dashboard/handlers/side.py
@@ -18,7 +18,11 @@ from aiohttp import web
 
 from kiro_crew.acp.client import AcpAuthRequired
 from kiro_crew.agent_discovery import warm_project_agent_names
-from kiro_crew.config.loader import KiroCrewConfig, resolve_agent_bindings
+from kiro_crew.config.loader import (
+    KiroCrewConfig,
+    refresh_materialized_agents,
+    resolve_agent_bindings,
+)
 from kiro_crew.dashboard.side_context import build_side_message
 from kiro_crew.dashboard.side_state import (
     MAX_SIDE_QUEUE,
@@ -29,6 +33,7 @@ from kiro_crew.dashboard.side_state import (
 )
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.ws import broadcast_side_queue, broadcast_side_result
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
@@ -271,6 +276,14 @@ async def _run_side_turn(
     is_first_turn: bool,
 ) -> None:
     """Background task: drive one side turn and broadcast chunks over WS."""
+    # Local import: chat_runner imports this package, so a module-level import
+    # would close a cycle. Bound here rather than inside the try below because
+    # the ``except`` clause has to name the exception.
+    from kiro_crew.dashboard.chat_runner import (
+        _AppAgentNotLoaded,
+        _recover_app_agent_binding,
+    )
+
     side_key = _side_session_key(slot.key)
     # The sidecar this turn belongs to. Every later mutation is gated on the slot
     # still pointing at THIS object, so a close+reopen part-way through can never
@@ -339,21 +352,67 @@ async def _run_side_turn(
         # a config-load failure degrades to the raw slot.agent rather than
         # crashing the turn.
         kiro_agent: str | None = None
+        # An app-owned slot whose agent never resolved (see the fail-loud guard
+        # after this block). Captured inside the try so the raise lives OUTSIDE
+        # it and is not swallowed by the resolve except.
+        _app_agent_unresolved = False
         try:
             cfg = KiroCrewConfig.load()
             # Warm off-loop, resolve inline — same reasoning as the main chat path
             # (offloading the resolver itself would swallow a StopIteration into a
             # Future and hang the await).
             await warm_project_agent_names(slot.project)
-            kiro_agent = resolve_agent_bindings(
-                cfg, slot.agent or None, slot.project or None
-            ).kiro_agent
+            bindings = resolve_agent_bindings(cfg, slot.agent or None, slot.project or None)
+            kiro_agent = bindings.kiro_agent
+            # SELF-HEAL an app-owned slot whose agent did not resolve, on the same
+            # two escalating rungs `_run_chat` uses, for the same reason: an app's
+            # agents live only in ``~/.kiro/agents/<app>--<agent>.json``, so the
+            # resolver can honor them only through the materialized-agent snapshot,
+            # which is COLD on the event loop until a warm lands. A cold read falls
+            # back to the default agent with ``requested_resolved=False``.
+            #
+            # A side turn reaches this with its OWN session, so it cannot ride on
+            # the main chat having healed first — a user can open the side panel on
+            # an app slot that has never taken a turn. Guarded so the common path
+            # (no ``_app``, or already resolved) does zero extra work and no I/O.
+            if slot._app and not bindings.requested_resolved:
+                try:
+                    await asyncio.get_running_loop().run_in_executor(
+                        subprocess_executor(), refresh_materialized_agents
+                    )
+                except Exception:  # noqa: BLE001 — a warm failure only costs the fail-loud
+                    logger.warning(
+                        "Side turn: failed to warm materialized agents for app slot %s",
+                        slot.key,
+                        exc_info=True,
+                    )
+                bindings = resolve_agent_bindings(cfg, slot.agent or None, slot.project or None)
+                kiro_agent = bindings.kiro_agent
+                if not bindings.requested_resolved:
+                    bindings = await _recover_app_agent_binding(
+                        cfg, slot, project=slot.project or None
+                    )
+                    kiro_agent = bindings.kiro_agent
+            _app_agent_unresolved = bool(slot._app) and not bindings.requested_resolved
         except Exception:
             logger.warning(
                 "Side turn: failed to resolve agent bindings for slot=%s; "
                 "falling back to raw slot.agent",
                 slot.key,
                 exc_info=True,
+            )
+
+        # FAIL-LOUD, exactly as the main chat does: an app-owned slot whose agent
+        # STILL did not resolve must NOT run the default agent. Substituting it
+        # here is worse than the main chat's version of the same bug, because a
+        # side answer carries no turn card the user would scrutinise — it reads as
+        # this app's assistant answering, while actually being the generic default
+        # with none of the app's MCP tools. Raised before get_or_create, so the
+        # turn aborts without ever creating a session or dispatching an agent.
+        if _app_agent_unresolved:
+            raise _AppAgentNotLoaded(
+                f"The app agent '{slot.agent or ''}' isn't loaded yet — "
+                "try again in a moment, or restart the gateway."
             )
 
         provider, _is_new, _resumed = await state.sessions.get_or_create(
@@ -447,6 +506,28 @@ async def _run_side_turn(
         from kiro_crew.dashboard.chat_runner import _mark_kiro_signed_out
 
         _mark_kiro_signed_out(state)
+        broadcast_side_result(
+            state,
+            slot_key=slot.key,
+            run_id=run_id,
+            role="assistant",
+            content=str(exc),
+            is_error=True,
+            final=True,
+        )
+    except _AppAgentNotLoaded as exc:
+        # Terminal for this turn and deliberately not a generic failure: the
+        # message names the agent and says what to do, which the catch-all below
+        # would replace with "see server logs". No session was created, so there
+        # is nothing to release. The queue is NOT held (unlike the auth arm
+        # above): the self-heal rungs re-run per turn, so the next queued
+        # question is a real retry rather than a repeat of a settled refusal.
+        logger.warning(
+            "Side turn: app agent not loaded for slot=%s run_id=%s: %s",
+            slot.key,
+            run_id,
+            exc,
+        )
         broadcast_side_result(
             state,
             slot_key=slot.key,

--- a/test/test_side.py
+++ b/test/test_side.py
@@ -590,3 +590,216 @@ async def test_side_stream_redacts_credential_split_across_chunks(tmp_path, monk
     assert raw_cred not in stored[-1]["content"]
     assert exfil_payload not in stored[-1]["content"]
     assert "[REDACTED" in stored[-1]["content"]
+
+
+def _app_slot(state, *, app: str = "notes", agent: str = "notes--assistant"):
+    """A slot owned by an app, with an open sidecar and one pending run."""
+    slot = state.get_or_create_slot("app-parent")
+    slot._app = app
+    slot.agent = agent
+    slot._side = SideState(open=True, created_at="2026-01-01T00:00:00Z")
+    slot._side.append_user("q")
+    slot._side.last_run_id = "run-1"
+    slot._side.is_complete = False
+    return slot
+
+
+def _side_errors(events: list[tuple[str, Any]]) -> list[str]:
+    return [
+        d.get("content", "")
+        for _t, d in events
+        if isinstance(d, dict) and d.get("is_error") and d.get("kind") == "side"
+    ]
+
+
+def _dispatch_recorder(state) -> list[str]:
+    dispatched: list[str] = []
+
+    async def _fake_get_or_create(key, **kwargs):
+        dispatched.append(kwargs.get("agent") or "")
+        return MagicMock(), True, False
+
+    state.sessions.get_or_create = _fake_get_or_create
+    state.sessions.release = MagicMock()
+    return dispatched
+
+
+@pytest.mark.asyncio
+async def test_side_turn_refuses_to_substitute_the_default_for_an_app_agent(
+    tmp_path, monkeypatch
+):
+    """An app slot whose agent never materialized must not answer as the default.
+
+    An app's agents live only in ``~/.kiro/agents/<app>--<agent>.json``, so
+    ``resolve_agent_bindings`` can honor them only through the materialized-agent
+    snapshot -- COLD on the event loop until a warm lands. A cold read falls back
+    to the default agent with ``requested_resolved=False``, and dispatching that
+    silently runs the generic assistant with none of the app's MCP tools.
+
+    The main chat closed this in #4995 / #4983; the side path was the counted
+    unfixed sibling, carrying none of the three rungs. A side answer is the worse
+    place for it: there is no turn card to scrutinise, so it simply reads as this
+    app's assistant answering.
+
+    Here BOTH self-heal rungs fail, so the turn must end without ever creating a
+    session, and must say why.
+    """
+    state = _make_state(tmp_path)
+    events = _capture_broadcasts(state)
+    slot = _app_slot(state)
+    dispatched = _dispatch_recorder(state)
+    warms: list[int] = []
+
+    async def _recover_fails(cfg, _slot, *, project=None):
+        # Mirrors the real coroutine's contract: a recovery failure only logs and
+        # hands back the still-cold bindings.
+        return MagicMock(kiro_agent="kirocrew", requested_resolved=False)
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.KiroCrewConfig.load", lambda: MagicMock()
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.resolve_agent_bindings",
+        lambda cfg, agent, project_dir=None: MagicMock(
+            kiro_agent="kirocrew", requested_resolved=False
+        ),
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.refresh_materialized_agents",
+        lambda: warms.append(1),
+        # raising=False so this asserts the CONTRACT rather than where the rescan
+        # happens to live. Against a build that has no such rung the test still
+        # RUNS, and fails on the dispatch below -- the actual defect -- instead of
+        # erroring because a name was missing from the module.
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_runner._recover_app_agent_binding",
+        _recover_fails,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.stream_and_collect",
+        AsyncMock(return_value="ok"),
+    )
+
+    await _run_side_turn(state, slot, "run-1", "q", is_first_turn=True)
+
+    assert dispatched == [], (
+        "the side turn dispatched an agent for an app slot whose agent never "
+        "resolved -- it would have answered as %r, not the app's agent" % (dispatched,)
+    )
+    assert warms == [1], "the snapshot-rescan rung did not run exactly once: %r" % (warms,)
+    errors = _side_errors(events)
+    assert errors, "the refusal was silent; the side panel has no other channel"
+    assert "notes--assistant" in errors[0], (
+        "the error does not name the agent the user asked for: %r" % (errors[0],)
+    )
+    assert "see server logs" not in errors[0], (
+        "the actionable message was flattened into the generic failure text"
+    )
+
+
+@pytest.mark.asyncio
+async def test_side_turn_self_heals_a_cold_app_agent_and_then_dispatches_it(
+    tmp_path, monkeypatch
+):
+    """When a rung succeeds, the turn proceeds on the app's own agent.
+
+    The refusal above must not be the only outcome: a cold snapshot is the common
+    case and it is recoverable, so the fix has to heal it rather than only refuse.
+    Ordering is deterministic rather than raced -- the rescan flips the resolver
+    stub's answer, so the second resolve is guaranteed to see the warm one.
+    """
+    state = _make_state(tmp_path)
+    _capture_broadcasts(state)
+    slot = _app_slot(state)
+    dispatched = _dispatch_recorder(state)
+    warmed: list[int] = []
+    recovered: list[int] = []
+
+    def _resolve(cfg, agent, project_dir=None):
+        if warmed:
+            return MagicMock(kiro_agent="notes--assistant", requested_resolved=True)
+        return MagicMock(kiro_agent="kirocrew", requested_resolved=False)
+
+    async def _recover(cfg, _slot, *, project=None):
+        recovered.append(1)
+        return MagicMock(kiro_agent="kirocrew", requested_resolved=False)
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.KiroCrewConfig.load", lambda: MagicMock()
+    )
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.side.resolve_agent_bindings", _resolve)
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.refresh_materialized_agents",
+        lambda: warmed.append(1),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_runner._recover_app_agent_binding", _recover, raising=False
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.stream_and_collect",
+        AsyncMock(return_value="ok"),
+    )
+
+    await _run_side_turn(state, slot, "run-1", "q", is_first_turn=True)
+
+    assert dispatched == ["notes--assistant"], (
+        "the healed app agent did not reach get_or_create: %r" % (dispatched,)
+    )
+    assert recovered == [], (
+        "the expensive register-from-source rung ran even though the rescan had "
+        "already resolved the agent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_side_turn_self_heal_is_scoped_to_app_slots(tmp_path, monkeypatch):
+    """A non-app slot never pays for the self-heal, and is never refused.
+
+    ``requested_resolved`` is False for any unknown agent name, not only a cold
+    app one. Gating on ``slot._app`` is what keeps an ordinary slot on its
+    existing best-effort behaviour -- it still dispatches -- and keeps the common
+    path free of the rescan's I/O.
+    """
+    state = _make_state(tmp_path)
+    events = _capture_broadcasts(state)
+    slot = state.get_or_create_slot("plain-parent")
+    slot.agent = "default"
+    slot._side = SideState(open=True, created_at="2026-01-01T00:00:00Z")
+    slot._side.append_user("q")
+    slot._side.last_run_id = "run-1"
+    slot._side.is_complete = False
+    dispatched = _dispatch_recorder(state)
+    warms: list[int] = []
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.KiroCrewConfig.load", lambda: MagicMock()
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.resolve_agent_bindings",
+        lambda cfg, agent, project_dir=None: MagicMock(
+            kiro_agent="kirocrew", requested_resolved=False
+        ),
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.refresh_materialized_agents",
+        lambda: warms.append(1),
+        # raising=False so this asserts the CONTRACT rather than where the rescan
+        # happens to live. Against a build that has no such rung the test still
+        # RUNS, and fails on the dispatch below -- the actual defect -- instead of
+        # erroring because a name was missing from the module.
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.side.stream_and_collect",
+        AsyncMock(return_value="ok"),
+    )
+
+    await _run_side_turn(state, slot, "run-1", "q", is_first_turn=True)
+
+    assert dispatched == ["kirocrew"], "a non-app slot stopped dispatching: %r" % (dispatched,)
+    assert warms == [], "a non-app slot paid for the app-only snapshot rescan"
+    assert not _side_errors(events), "a non-app slot was refused by the app-only guard"


### PR DESCRIPTION
## Problem / Motivation

A `/side` turn on an **app-owned slot** whose agent has not materialized yet silently answers as the **default** agent — with none of the app's MCP tools, and no error anywhere.

`dashboard/handlers/side.py` resolved bindings and took `.kiro_agent` off the result without ever consulting `requested_resolved`:

```python
kiro_agent = resolve_agent_bindings(
    cfg, slot.agent or None, slot.project or None
).kiro_agent
```

An app's agents live only in `~/.kiro/agents/<app>--<agent>.json`, never in `config.agents`, so `resolve_agent_bindings` can honor them only through the materialized-agent snapshot. That snapshot is **cold on the event loop** until a boot or registration warm lands — both of which run off it. A cold read makes the resolver fall back to the default agent and set `requested_resolved=False`, which this call site discarded.

## Why it matters

This is the same defect #4995 and #4983 removed from the main chat, on the one dispatch site neither of them reached. Both PRs' First Principles reviews counted it explicitly as the remaining unfixed sibling:

> Grepped `resolve_agent_bindings` dispatch sites: `chat_runner.py` (2, fixed here), `crew_chat.py:1053` (already fail-closed), and `handlers/side.py:348-361` (0 of the three rungs). A side turn on a cold app slot resolves the default binding and dispatches it silently — the defect this PR exists to remove. The shared coroutine now exists; wiring side.py to it is small.

> Of the other dispatching callers, `crew_chat.py:1054` fails closed and `chat_handlers.py:1805` logs deliberately, but `dashboard/handlers/side.py:348` dispatches the resolver's fallback unchecked — 1 unfixed sibling where an app-owned slot's side turn still silently runs the default.

**The side panel is the worse surface for that substitution than the main chat was.** There is no turn card to scrutinise and no agent attribution in the side panel, so the reply simply reads as this app's assistant answering — while it is actually the generic default, unable to see the app's tools. The user gets a confidently wrong answer with no signal at all.

It also cannot ride on the main chat healing first. A side turn creates its **own** `side:{slot.key}` session, and the panel can be opened on an app slot that has never taken a main turn.

## What changed (motivation → approach → change)

**Motivation** — close the last dispatch site that can silently substitute the default agent for an app's own.

**Approach** — no new mechanism. #4995 already established the pattern and shipped the shared coroutine; this wires the fourth site to it in the same order, for the same reasons, reading the same signal.

**Change** — the three rungs, gated on `slot._app`:

```
resolve -> requested_resolved?
  no  -> rescan the materialized-agent snapshot off the loop, re-resolve
  no  -> re-register the app from source (_recover_app_agent_binding), re-resolve
  no  -> refuse; never dispatch
```

**The refusal is the point, not the recovery.** Rungs 1 and 2 are best-effort and each only logs on failure; what must hold is that a slot whose agent never resolved does not reach `get_or_create`. The raise sits after the resolve `try` (so it is not swallowed by that block's `except Exception`) and before `get_or_create`, so the turn aborts without creating a session or dispatching anything.

`_AppAgentNotLoaded` is reused rather than re-invented, and gets **its own `except` arm** beside the `AcpAuthRequired` arm it mirrors. Without that arm the catch-all below would replace a message naming the requested agent with `(side conversation failed — see server logs)`, and the side panel has no other channel to tell the user what to do.

**The queue is deliberately NOT held**, unlike the auth arm directly above it. A signed-out CLI is non-retryable until the user acts externally, so draining would spend the whole queue on identical failures. This case is the opposite: the rungs re-run per turn, so the next queued question is a genuine retry — which also matches the main chat, where this exception is terminal for its turn and nothing special happens to the queue.

Both `chat_runner` imports are **function-local** (`chat_runner` imports this package, so a module-level import would close a cycle) and bound at the top of `_run_side_turn` rather than inside the `try`, because the `except` clause has to name the exception.

Gated on `slot._app` throughout, so a non-app slot keeps its existing best-effort behaviour and the common path does zero extra work and no extra I/O — `requested_resolved` is False for any unknown agent name, not only a cold app one.

One production file.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_side_turn_refuses_to_substitute_the_default_for_an_app_agent` | both rungs fail ⇒ **nothing is dispatched**, and the error names the requested agent rather than the generic failure text |
| `test_side_turn_self_heals_a_cold_app_agent_and_then_dispatches_it` | the rescan resolves it ⇒ the turn runs on the app's own agent, and the expensive from-source rung is **not** reached |
| `test_side_turn_self_heal_is_scoped_to_app_slots` | a non-app slot still dispatches, pays for no rescan, and is never refused |

Fail-before / pass-after, with **only** `side.py` reverted and the tests left in place:

```
AssertionError: the side turn dispatched an agent for an app slot whose agent
never resolved -- it would have answered as ['kirocrew'], not the app's agent

AssertionError: the healed app agent did not reach get_or_create: ['kirocrew']

2 failed, 12 passed
```

That is the reported defect exactly: the default agent dispatched for an app slot.

**The first control attempt was not valid, and was fixed rather than kept.** Patching `refresh_materialized_agents` on the module made the reverted build fail with `AttributeError: ... has no attribute 'refresh_materialized_agents'` — a missing patch target, not the defect. The rescan and recovery patches now use `raising=False`, so the tests assert the **contract** independently of where the rungs live: against a build with no such rung they still run, and fail on the dispatch.

The third test passes on both trees by design — it is preservation coverage for the gate, not evidence of a defect, and is reported as such rather than folded into the fail-before count.

```
pytest test/test_side.py test/test_side_context.py \
       test/test_side_context_cov80.py test/test_side_steer_queue.py -q     60 passed

# every module touching the app-agent binding surface
pytest test/test_chat_runner_coverage.py test/test_config_loader.py \
       test/test_crew_chat.py test/test_dashboard_chat.py \
       test/test_side.py -q                              1377 passed, 3 skipped
```

Gates: `flake8` · `isort --check-only` · `mypy` (no issues in the changed module) · `scripts/check_black_formatting.py` (2 files in scope, both pre-existing baseline entries, neither reformatted).

## Manual verification

N/A — unit coverage sufficient: the tests drive the real `_run_side_turn` end to end and assert at the dispatch boundary (`get_or_create`), which is the exact place the substitution happened. Reproducing by hand needs the materialized-agent snapshot to be cold at the instant a side turn resolves — a startup-timing window, not something that can be staged reliably.

## Related Issues

Fixes #5042.

Completes the sibling counted by the First Principles reviews on #4995 and #4983.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no documented behaviour changes. The rungs and the queue decision are explained at the call site and in the new `except` arm.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
