### PR TITLE
refactor(config): make kiro_agents_dir the single redirectable accessor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1506,33 +1506,14 @@ _AGENT_SPEC_HOOKS: tuple[tuple[str, str], ...] = (
     ("kiro_crew.doctor_deadpath", "KIRO_AGENTS_DIR"),
 )
 
-#: Modules that WRITE through a bound ``config.paths.kiro_agents_dir`` name, which no
-#: hook reaches. Deliberately short: this file's remit is the host-MUTATION floor, and
-#: redirecting a read-only consumer's bound name costs more than it protects -- the
-#: dominant isolation idiom in this suite is ``patch("<module>.Path.home", ...)`` and
-#: then reading through that module's own resolver, which a redirect silently overrides.
-#: Every read-only consumer is therefore listed as excluded, with that reason, in
-#: ``test_host_isolation_floor.py``'s ratchet rather than pinned here.
-#:
-#: ``kiro_crew.config.paths`` is the DEFINITION, and patching it is what reaches a writer
-#: that imports the name inside a function body -- ``auto_improvement.spine.agent_runner``
-#: copies agent specs that way, so no module-level binding exists to pin.
-#:
-#: ``kiro_crew.agent.kiro_agents_dir`` is deliberately ABSENT, and adding it would break
-#: the suite on the setup this repo mandates for development. That binding is not a
-#: write target -- ``agent`` writes exclusively through ``kiro_agents_dir_path()``, which
-#: reads the hook above -- it is the AMBIENT reference
-#: ``_decline_shared_agent_home`` compares the target against to decide whether the
-#: target is shared at all. Leaving it resolving the real home is what makes the pinned
-#: hook read as "a caller redirected this somewhere the ambient environment would never
-#: produce", which returns early and allows the write. Patch it too and target ==
-#: ambient, so the guard falls through to its ephemerality check and DECLINES from a
-#: linked git worktree -- every test that reaches ``rebuild_agent_config`` would then
-#: pass in CI and fail on a developer's machine.
-_AGENT_SPEC_RESOLVER_BINDINGS: tuple[tuple[str, str], ...] = (
-    ("kiro_crew.config.paths", "kiro_agents_dir"),
-    ("kiro_crew.dashboard.handlers.mcp", "kiro_agents_dir"),
-)
+#: The real user home, captured at IMPORT -- before any test can patch
+#: ``Path.home``. The pin below compares against it to tell "nobody redirected the
+#: home, so use the per-test dir" from "this test redirected it, so follow the test".
+#: ``patch("<module>.Path.home", ...)`` is the dominant isolation idiom in this suite
+#: and it is global by construction (``from pathlib import Path`` binds the same class
+#: object everywhere, so patching an attribute on it patches it for every module), which
+#: is why the pin can detect it at all.
+_REAL_USER_HOME = pathlib.Path.home()
 
 
 @pytest.fixture(scope="session")
@@ -1626,23 +1607,22 @@ def _isolate_agent_spec_home(_agent_spec_seam_modules, _isolation_dirs, monkeypa
     monkeypatch.delenv("KIRO_HOME", raising=False)
     root = _isolation_dirs("kiro-agents")
     paths = sys.modules.get("kiro_crew.config.paths")
-    real = getattr(paths, "kiro_agents_dir", None) if paths is not None else None
 
     def _pinned_agents_dir() -> pathlib.Path:
-        """The per-test dir, unless this test chose a kiro home of its own."""
-        if os.environ.get("KIRO_HOME") and real is not None:
-            return real()
+        """The per-test dir, unless this test redirected the home itself."""
+        if paths is None:  # pragma: no cover - defensive: package not importable
+            return root
+        if os.environ.get("KIRO_HOME") or pathlib.Path.home() != _REAL_USER_HOME:
+            return paths.ambient_agents_dir()
         return root
 
     for module, attr in _AGENT_SPEC_HOOKS:
         mod = sys.modules.get(module)
         if mod is not None:
             monkeypatch.setattr(mod, attr, root, raising=False)
-    for module, attr in _AGENT_SPEC_RESOLVER_BINDINGS:
-        mod = sys.modules.get(module)
-        if mod is not None:
-            monkeypatch.setattr(mod, attr, _pinned_agents_dir, raising=False)
-    return real
+    if paths is not None:
+        monkeypatch.setattr(paths, "_agents_dir_override", _pinned_agents_dir)
+    return paths.ambient_agents_dir if paths is not None else None
 
 
 @pytest.fixture
@@ -1665,10 +1645,9 @@ def unpinned_agent_spec_home(_isolate_agent_spec_home, monkeypatch):
         mod = sys.modules.get(module)
         if mod is not None:
             monkeypatch.setattr(mod, attr, None, raising=False)
-    for module, attr in _AGENT_SPEC_RESOLVER_BINDINGS:
-        mod = sys.modules.get(module)
-        if mod is not None and _isolate_agent_spec_home is not None:
-            monkeypatch.setattr(mod, attr, _isolate_agent_spec_home, raising=False)
+    paths = sys.modules.get("kiro_crew.config.paths")
+    if paths is not None:
+        monkeypatch.setattr(paths, "_agents_dir_override", None)
     return _isolate_agent_spec_home
 
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -57,6 +57,7 @@ from kiro_crew.config.paths import (
     _in_linked_git_worktree,
     _under_system_tmp,
     _valid_override_home,
+    ambient_agents_dir,
     isolated_agents_dir,
     kiro_agents_dir,
 )
@@ -2640,8 +2641,12 @@ def _decline_shared_agent_home(*, audit: bool = True) -> Path | None:
     * A globally exported ``KIRO_HOME`` moves the shared directory, so comparing
       against a hard-coded default reads "not the shared one" and waves the write
       straight through. The comparison is therefore against what the AMBIENT
-      environment resolves right now (``kiro_agents_dir()``), which is by
+      environment resolves right now (``ambient_agents_dir()``), which is by
       definition the directory every instance under this environment shares.
+      Deliberately the override-BLIND resolver, not ``kiro_agents_dir()``: the
+      latter follows ``config.paths._agents_dir_override``, so a redirect would
+      move both sides of this comparison together, read as "target is the shared
+      one", and refuse the write from any ephemeral checkout.
 
     A target is exempt only when it is **provably private**: either a caller
     redirected the write somewhere the ambient environment would never produce (a
@@ -2658,7 +2663,7 @@ def _decline_shared_agent_home(*, audit: bool = True) -> Path | None:
     (``KIROCREW_HOME=$HOME`` is enough).
     """
     target = kiro_agents_dir_path().resolve()
-    if target != kiro_agents_dir().resolve():
+    if target != ambient_agents_dir().resolve():
         # A caller pointed the write somewhere of its own choosing; nothing is
         # shared with the ambient install, so there is nothing to protect.
         return None

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -28,7 +28,7 @@ import logging
 import os
 import sys
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -544,6 +544,37 @@ def isolated_agents_dir(data_home: Path) -> Path:
     return data_home / "kiro" / "agents"
 
 
+#: Test/tooling redirect for :func:`kiro_agents_dir`, consulted on every call
+#: (``None`` = resolve from the environment). A CALLABLE rather than a path so a
+#: caller can decide per call — the suite's own redirect defers to a test that
+#: moved ``Path.home`` or ``$KIRO_HOME`` itself, which it cannot know in advance.
+#:
+#: Why it lives HERE rather than as a per-module hook: 16 modules bind
+#: ``kiro_agents_dir`` by name (``from ... import kiro_agents_dir``), and that
+#: copies the function OBJECT, so patching this module's attribute never reaches
+#: them. A value read inside the function BODY does reach them, because a
+#: function's globals are always its defining module's -- so one assignment here
+#: redirects every consumer, present and future, with no per-module registration
+#: to keep in sync.
+_agents_dir_override: Callable[[], Path] | None = None
+
+
+def ambient_agents_dir() -> Path:
+    """The agents dir the AMBIENT ENVIRONMENT resolves, ignoring any override.
+
+    Exists for exactly one caller: ``agent._decline_shared_agent_home`` asks "is
+    the target this instance is about to write the one every instance under this
+    environment shares?". That question is about the environment, so it must not
+    see a redirect — with the override applied to both sides the comparison is
+    trivially equal and the guard mistakes a privately redirected target for the
+    shared one, then refuses the write from any ephemeral checkout.
+
+    Not a general-purpose reader. Anything that WRITES or reads the specs in use
+    wants :func:`kiro_agents_dir`, which honours the redirect.
+    """
+    return kiro_home() / "agents"
+
+
 def kiro_agents_dir() -> Path:
     """Return the kiro agents directory (``<kiro home>/agents``).
 
@@ -557,8 +588,21 @@ def kiro_agents_dir() -> Path:
     to a search path would leave those writers without one obvious destination.
     Project-local discovery is a separate READ-only scope — see
     :func:`project_agents_dir`.
+
+    Honours :data:`_agents_dir_override` when one is installed, which is what
+    makes this the single accessor every consumer already routes through. See
+    :func:`ambient_agents_dir` for the one caller that must NOT follow it.
+
+    The no-override branch DELEGATES to that function rather than re-spelling
+    ``kiro_home() / "agents"``. Two hand-written copies of the default would let a
+    later change to the layout land in only one, and the write guard compares this
+    resolver's answer against that one -- a stale comparison there reads a shared
+    target as private and fails OPEN on the machine-wide home, which is the #4912
+    failure class this whole seam exists to prevent.
     """
-    return kiro_home() / "agents"
+    if _agents_dir_override is not None:
+        return _agents_dir_override()
+    return ambient_agents_dir()
 
 
 def project_agents_dir(project_dir: str | Path) -> Path:

--- a/test/test_agent_home_isolation.py
+++ b/test/test_agent_home_isolation.py
@@ -41,7 +41,13 @@ def _no_overrides(monkeypatch) -> None:
     monkeypatch.delenv("KIROCREW_POD", raising=False)
 
 
-def test_kiro_home_defaults_to_dot_kiro(monkeypatch):
+def test_kiro_home_defaults_to_dot_kiro(monkeypatch, unpinned_agent_spec_home):
+    """The shipped default, with the suite's agents-dir pin lifted.
+
+    ``kiro_agents_dir()`` honours ``config.paths._agents_dir_override``, which the
+    host-mutation floor installs for every test, so this assertion is about the
+    resolver's own default rather than what a test run resolves.
+    """
     _no_overrides(monkeypatch)
     assert kiro_home() == Path.home() / ".kiro"
     assert kiro_agents_dir() == Path.home() / ".kiro" / "agents"
@@ -170,9 +176,15 @@ def _pretend_target_is_shared(monkeypatch, agent_mod, agents_dir: Path) -> None:
     A target the ambient environment would never produce is by definition private
     to whoever redirected it, so a test must line the two up to exercise the
     guard.
+
+    The ambient side is ``config.paths.ambient_agents_dir``, patched at its
+    DEFINITION: it is the override-blind resolver the guard reads, and ``agent``
+    binds it by name so a module-attribute patch on ``agent`` would be a second
+    copy that the guard's own call still ignores. ``KIRO_AGENTS_DIR`` stays the
+    target side because ``kiro_agents_dir_path()`` prefers it.
     """
     monkeypatch.setattr(agent_mod, "KIRO_AGENTS_DIR", agents_dir)
-    monkeypatch.setattr(agent_mod, "kiro_agents_dir", lambda: agents_dir)
+    monkeypatch.setattr(agent_mod, "ambient_agents_dir", lambda: agents_dir)
 
 
 def test_private_target_is_never_declined(monkeypatch, tmp_path):
@@ -217,7 +229,7 @@ def test_symlinked_shared_home_still_declines(monkeypatch, tmp_path):
     # Same directory, two spellings: the target is reached through the symlink,
     # the machine-wide default through the real path.
     monkeypatch.setattr(agent, "KIRO_AGENTS_DIR", link / "agents")
-    monkeypatch.setattr(agent, "kiro_agents_dir", lambda: real)
+    monkeypatch.setattr(agent, "ambient_agents_dir", lambda: real)
 
     assert (
         agent._decline_shared_agent_home() is not None

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -149,11 +149,7 @@ class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
         )
 
     def test_every_seam_in_the_tables_is_actually_pinned(self) -> None:
-        """A table entry nobody patches is documentation, not isolation.
-
-        Resolver bindings are checked only when their module is loaded, matching the
-        fixture's own tolerance: an unimported module has no bound name to reach.
-        """
+        """A table entry nobody patches is documentation, not isolation."""
         unpinned = []
         for module, attr in _root._AGENT_SPEC_HOOKS:
             mod = sys.modules.get(module)
@@ -163,17 +159,30 @@ class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
             value = getattr(mod, attr, None)
             if value is None or _inside_a_guarded_root(pathlib.Path(value).resolve()):
                 unpinned.append(f"{module}.{attr} = {value!r}")
-        for module, attr in _root._AGENT_SPEC_RESOLVER_BINDINGS:
-            mod = sys.modules.get(module)
-            if mod is None:
-                continue
-            resolved = getattr(mod, attr)()
-            if _inside_a_guarded_root(pathlib.Path(resolved).resolve()):
-                unpinned.append(f"{module}.{attr}() -> {resolved}")
 
         assert not unpinned, "these agent-spec seams still resolve a real home:\n" + "\n".join(
             f"    {entry}" for entry in unpinned
         )
+
+    def test_the_resolver_itself_is_pinned_so_no_consumer_needs_registering(self) -> None:
+        """The single accessor: one override inside the function body covers everyone.
+
+        This is what replaced a per-module table. 16 modules bind ``kiro_agents_dir``
+        by name and that copies the function OBJECT, so patching this module's
+        attribute never reached them -- but a value the function BODY reads does,
+        because a function's globals are always its defining module's. Asserting on a
+        module that binds the name by hand is what proves the reach, not the
+        definition site.
+        """
+        from kiro_crew.config import paths
+        from kiro_crew.slack import handler
+
+        assert paths._agents_dir_override is not None, "the floor installed no override"
+        assert handler.kiro_agents_dir is paths.kiro_agents_dir, (
+            "slack.handler no longer binds the resolver by name, so this test has "
+            "stopped proving that a bound copy honours the override"
+        )
+        assert not _inside_a_guarded_root(handler.kiro_agents_dir().resolve())
 
     def test_the_hook_modules_are_imported_so_the_table_can_reach_them(self) -> None:
         """The session fixture's whole job: patching cannot precede importing.
@@ -188,6 +197,39 @@ class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
 
         assert not missing, f"hook modules never imported, so their seams leak: {missing}"
 
+    def test_a_test_that_redirects_the_home_itself_is_followed(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pin defers rather than overriding a test's own isolation.
+
+        ~35 tests isolate with ``patch("<module>.Path.home", ...)`` -- global by
+        construction, since ``from pathlib import Path`` binds the same class object
+        everywhere -- and then read through a module's own resolver. A pin that
+        answered a fixed tmp dir regardless would hand those tests an empty directory
+        instead of the tree they just built, which is how an earlier revision of this
+        floor broke five test groups at once.
+        """
+        from kiro_crew.config import paths
+
+        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+
+        assert paths.kiro_agents_dir() == tmp_path / ".kiro" / "agents"
+
+    def test_the_two_resolvers_cannot_drift_apart_on_the_default(
+        self, unpinned_agent_spec_home
+    ) -> None:
+        """With no override installed the two answers must be the SAME default.
+
+        They are compared against each other by the write guard, so a layout change
+        landing in only one of them would read a shared target as private and fail
+        OPEN on the machine-wide home. Delegation makes that impossible by
+        construction; this pins it so a future edit that re-spells the default in both
+        places still has to keep them equal.
+        """
+        from kiro_crew.config import paths
+
+        assert paths.kiro_agents_dir() == paths.ambient_agents_dir()
+
     def test_one_directory_is_shared_across_the_seams(self) -> None:
         """A spec written through one seam has to be readable through another."""
         from kiro_crew import agent, agent_discovery
@@ -195,103 +237,73 @@ class TestTheAgentSpecHomeIsPinnedForEveryTestpath:
         assert agent.KIRO_AGENTS_DIR == agent_discovery._KIRO_AGENTS_DIR
 
     def test_the_guards_ambient_reference_is_left_resolving_the_real_home(self) -> None:
-        """``agent.kiro_agents_dir`` must NOT be pinned, and this says why in a test.
+        """The write guard's AMBIENT reference must stay override-blind.
 
-        It is the AMBIENT reference ``_decline_shared_agent_home`` compares the target
-        against. Leaving it real is what makes the pinned hook read as a privately
-        redirected target, which returns early and allows the write. Pin it too and
-        target == ambient, so the guard falls through to its ephemerality check and
-        declines from a linked git worktree -- green in CI, red on a developer machine,
-        which is the setup this repo mandates.
+        ``_decline_shared_agent_home`` asks "is my target the one every instance under
+        this environment shares?", so it reads ``ambient_agents_dir()`` -- which
+        deliberately does NOT follow ``_agents_dir_override``. Point it at the honouring
+        resolver instead and the pin moves both sides of that comparison together: the
+        guard reads a privately redirected target as the shared one, then declines from
+        a linked git worktree -- green in CI, red on a developer machine, which is the
+        setup this repo mandates.
         """
+        from kiro_crew.config import paths
+
+        assert _inside_a_guarded_root(paths.ambient_agents_dir().resolve()), (
+            "ambient_agents_dir followed the override; the write guard can no longer "
+            "tell a redirected target from the shared one"
+        )
+        assert (
+            paths.kiro_agents_dir() != paths.ambient_agents_dir()
+        ), "the two resolvers agree, so the guard's comparison proves nothing"
+
         from kiro_crew import agent
 
-        assert _inside_a_guarded_root(agent.kiro_agents_dir().resolve()), (
-            "agent.kiro_agents_dir was pinned; the write guard can no longer tell a "
-            "redirected target from the shared one"
-        )
         assert agent._decline_shared_agent_home(audit=False) is None, (
             "the floor's pinned target is being treated as the shared agent home"
         )
 
-    def test_a_test_can_still_override_the_seams_itself(
-        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The floor is a safety net, not a cage."""
-        from kiro_crew import agent
+    def test_the_ambient_resolver_has_exactly_one_caller(self) -> None:
+        """``ambient_agents_dir`` is override-BLIND, so a second caller is a leak.
 
-        mine = tmp_path / "my-own-agents"
-        monkeypatch.setattr(agent, "KIRO_AGENTS_DIR", mine)
-
-        assert agent.kiro_agents_dir_path() == mine
-
-
-class TestTheAgentSpecSeamRatchet:
-    """A NEW agents-dir consumer must not land unpinned.
-
-    Same contract as the shared-path ratchet above: an entry is either pinned by one of
-    the two tables or excluded with a stated reason, so adding a consumer forces a
-    decision. Covers the two shapes that actually leak -- a module-level
-    ``KIRO_AGENTS_DIR`` hook, and a module-level ``from ... import kiro_agents_dir``
-    whose bound name the resolver patch cannot reach.
-    """
-
-    #: Agents-dir bindings that deliberately need no redirect.
-    #:
-    #: The large group is READ-ONLY consumers, excluded for one shared reason worth
-    #: stating once: this floor's remit is host MUTATION, and the dominant isolation
-    #: idiom in this suite is ``patch("<module>.Path.home", ...)`` followed by a read
-    #: through that same module's resolver. Redirecting the bound name silently
-    #: overrides that, so a test that carefully built its own tree reads an empty
-    #: directory instead -- the same trap ``_isolate_kirocrew_home`` documents for
-    #: ``KIRO_HOME``. A read that resolves the operator's real specs can still make a
-    #: test's outcome depend on the operator's machine; that is a determinism concern
-    #: rather than host mutation, and it is not what this file is for.
-    _EXCLUDED: dict[tuple[str, str], str] = {
-        # The guard's AMBIENT reference, not a write target: `agent` writes exclusively
-        # through `kiro_agents_dir_path()`, which reads the hook. Pinning this one makes
-        # target == ambient inside `_decline_shared_agent_home`, so the guard stops
-        # seeing a privately redirected target and declines from a linked worktree.
-        ("kiro_crew/agent.py", "kiro_agents_dir"): "the write guard's ambient reference",
-        # NOT a resolved path -- the RELATIVE string `.kiro/agents`, used as a security
-        # MATCHER. Same reasoning the home-binding ratchet applies to its anchors: a
-        # redirected value would make the guard stop matching the thing it protects.
-        # `test_a_security_matcher_is_not_mistaken_for_a_path_binding` pins the shape so
-        # an edit that turns it into a real path comes back through this table.
-        ("kiro_crew/security.py", "_KIRO_AGENTS_DIR"): "security matcher: a relative string",
-        # Covered by their own hook, which the fixture pins: every call site in these
-        # three routes through a private `_kiro_agents_dir()` that prefers it.
-        ("kiro_crew/agent_discovery.py", "kiro_agents_dir"): "covered by its own hook",
-        ("kiro_crew/apps/bridges.py", "kiro_agents_dir"): "covered by its own hook",
-        ("kiro_crew/cli_doctor.py", "kiro_agents_dir"): "covered by its own hook",
-        ("kiro_crew/doctor_deadpath.py", "kiro_agents_dir"): "covered by its own hook",
-        # Read-only consumers: see the note above this table.
-        ("kiro_crew/config/loader.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/context.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/cron_script.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/mcp_discovery.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/acp/runtime.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/dashboard/handlers/_shared.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/dashboard/handlers/sessions.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/slack/events.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/slack/gateway.py", "kiro_agents_dir"): "read-only consumer",
-        ("kiro_crew/slack/handler.py", "kiro_agents_dir"): "read-only consumer",
-        (
-            "kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py",
-            "kiro_agents_dir",
-        ): "read-only consumer",
-    }
-
-    @staticmethod
-    def _agents_dir_bindings() -> dict[tuple[str, str], int]:
-        """Module-level ``KIRO_AGENTS_DIR`` hooks and bound ``kiro_agents_dir`` names.
-
-        Parsed rather than grepped for the same reason as the home-binding ratchet: a
-        name imported inside a FUNCTION body is re-resolved per call and so already
-        follows the patched resolver, and only the module-level shape freezes a
-        reference a test can reach.
+        Its docstring says "not a general-purpose reader" -- this makes that
+        enforceable. Anything that reads it resolves the operator's REAL agents dir
+        even under the floor's pin, which is the leak this seam exists to close; the
+        write guard is the one caller whose question is genuinely about the
+        environment.
         """
-        found: dict[tuple[str, str], int] = {}
+        allowed = {"kiro_crew/config/paths.py", "kiro_crew/agent.py"}
+        callers = set()
+        for path in sorted(_SRC.rglob("*.py")):
+            if "_vendor" in path.parts:
+                continue
+            rel = path.relative_to(_REPO_ROOT / "src").as_posix()
+            if rel in allowed:
+                continue
+            try:
+                source = path.read_text(encoding="utf-8")
+            except OSError:  # pragma: no cover - unreadable source
+                continue
+            if "ambient_agents_dir" in source:
+                callers.add(rel)
+
+        assert not callers, (
+            "ambient_agents_dir is override-blind and gained new readers, each of "
+            f"which resolves the operator's real agents dir: {sorted(callers)}. Use "
+            "kiro_agents_dir() unless the question is genuinely about the environment."
+        )
+
+    def test_a_new_agents_dir_hook_is_an_opt_in_none_not_a_frozen_path(self) -> None:
+        """The half of the deleted ratchet that did NOT become obsolete.
+
+        Retiring the per-module table killed the bound-NAME half of that ratchet -- a
+        bound copy now honours the override by construction. This half survives: a
+        module-level ``*KIRO_AGENTS_DIR`` initialized to a RESOLVED path freezes the
+        answer at import, so it follows neither the override nor the hook table and
+        nothing goes red. ``None`` (the opt-in hook shape) and a plain string literal
+        (``security``'s ``.kiro/agents`` matcher) are the two legitimate shapes.
+        """
+        frozen: dict[str, int] = {}
         for path in sorted(_SRC.rglob("*.py")):
             if "_vendor" in path.parts or "/tests/" in path.as_posix():
                 continue
@@ -308,62 +320,40 @@ class TestTheAgentSpecSeamRatchet:
                 pending.extend(
                     child for child in ast.iter_child_nodes(node) if isinstance(child, ast.stmt)
                 )
-                if isinstance(node, ast.ImportFrom):
-                    for alias in node.names:
-                        if alias.name == "kiro_agents_dir":
-                            found[(rel, alias.asname or alias.name)] = node.lineno
-                    continue
-                if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
                     continue
                 targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-                for target in targets:
-                    if isinstance(target, ast.Name) and target.id.endswith("KIRO_AGENTS_DIR"):
-                        found[(rel, target.id)] = node.lineno
-        return found
+                named = [
+                    t
+                    for t in targets
+                    if isinstance(t, ast.Name) and t.id.endswith("KIRO_AGENTS_DIR")
+                ]
+                if not named:
+                    continue
+                if isinstance(node.value, ast.Constant) and (
+                    node.value.value is None or isinstance(node.value.value, str)
+                ):
+                    continue
+                for target in named:
+                    frozen[f"{rel} {target.id}"] = node.lineno
 
-    def test_every_agents_dir_binding_is_pinned_or_excluded(self) -> None:
-        pinned = {
-            (module.replace(".", "/") + ".py", attr)
-            for module, attr in _root._AGENT_SPEC_HOOKS + _root._AGENT_SPEC_RESOLVER_BINDINGS
-        }
-        # The definition itself is the resolver, not a consumer's frozen reference.
-        pinned.add(("kiro_crew/config/paths.py", "kiro_agents_dir"))
-        unhandled = {
-            key: line
-            for key, line in self._agents_dir_bindings().items()
-            if key not in pinned and key not in self._EXCLUDED
-        }
-
-        assert not unhandled, (
-            "these agents-dir bindings are neither pinned by the rootdir conftest's "
-            "_AGENT_SPEC_HOOKS / _AGENT_SPEC_RESOLVER_BINDINGS nor excluded with a "
-            "reason:\n"
-            + "\n".join(
-                f"    {mod}:{line} {attr}" for (mod, attr), line in sorted(unhandled.items())
-            )
-            + "\nA test that reaches one of these resolves the operator's real agent "
-            "specs. Pin it, or exclude it and say why."
+        assert not frozen, (
+            "these module-level agents-dir hooks are initialized to something other "
+            "than None or a string literal, so they freeze a path at import and follow "
+            "neither the resolver override nor the hook table:\n"
+            + "\n".join(f"    {where}:{line}" for where, line in sorted(frozen.items()))
         )
 
-    def test_the_exclusion_list_has_not_gone_stale(self) -> None:
-        """An exclusion for a binding that no longer exists hides the next one."""
-        bindings = self._agents_dir_bindings()
-        stale = [key for key in self._EXCLUDED if key not in bindings]
+    def test_a_test_can_still_override_the_seams_itself(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is a safety net, not a cage."""
+        from kiro_crew import agent
 
-        assert not stale, f"_EXCLUDED names bindings that no longer exist: {stale}"
+        mine = tmp_path / "my-own-agents"
+        monkeypatch.setattr(agent, "KIRO_AGENTS_DIR", mine)
 
-    def test_a_security_matcher_is_not_mistaken_for_a_path_binding(self) -> None:
-        """``security._KIRO_AGENTS_DIR`` is the relative string ``.kiro/agents``.
-
-        It is a MATCHER, not a resolved path, so it must never be redirected -- the
-        same reasoning the home-binding ratchet applies to its security anchors. Pinned
-        here because the name matches this ratchet's suffix rule, so a future edit that
-        turns it into a real path has to come back through this test.
-        """
-        from kiro_crew import security
-
-        assert security._KIRO_AGENTS_DIR == ".kiro/agents"
-        assert not isinstance(security._KIRO_AGENTS_DIR, pathlib.Path)
+        assert agent.kiro_agents_dir_path() == mine
 
 
 class TestTheSharedKiroPathsArePinned:


### PR DESCRIPTION
## What is the problem?

`kiro_agents_dir()` resolves the directory holding the agent specs -- the file that decides which MCP servers the operator's real agent has. 16 modules consume it, and every one binds it by name (`from kiro_crew.config.paths import kiro_agents_dir`), which copies the function OBJECT. Patching the definition site therefore reaches none of them.

The isolation floor #4969 added had to work around that with a per-module table, and the workaround has three costs:

- The table must grow with every new consumer. An AST ratchet was added to force that, so a new consumer fails loudly rather than leaking -- but the maintenance is real and the ratchet exists only to police a list.
- Only two writers could be redirected safely. The other 14 consumers are listed as excluded, because redirecting a bound name silently overrides the suite's dominant isolation idiom (`patch("<module>.Path.home", ...)` then reading through that module's own resolver) -- an earlier revision that redirected all 16 broke five test groups at once.
- So two consumers in one test can see different agents dirs, and the only record of which is which is a docstring plus a 16-entry exclusion table. Design Review flagged exactly this on #4969.

## Why this issue matters to the user

Nothing is broken for a user today; this is maintenance cost with a sharp edge. The edge is that "which consumers are isolated" is a hand-maintained list, and the failure it guards against is the one #4912 already cost: a test that reaches the write path rewrites the machine-wide `kirocrew.json` with a throwaway venv and data home, and every new session on the machine then fails `internal_auth_mismatch` once those are deleted. A list that is one entry behind reopens that.

## How our fix solves it

The chain is: consumers hold copies -> the definition cannot be patched -> a per-module table -> a table that must be policed. The fix cuts it at the second link.

A function's `__globals__` is always its DEFINING module's namespace. So a value the function BODY reads is shared by every copy of that function, even copies bound in other modules. `kiro_agents_dir()` now reads `config.paths._agents_dir_override` -- one assignment redirects all 16 consumers, and any consumer added later, with nothing to register.

The override is a callable, not a path, because the suite's redirect has to decide per call: it defers to a test that moved `Path.home` or `$KIRO_HOME` itself. That is what keeps the ~35 tests using the `Path.home` idiom working, and it is detectable precisely because that idiom is global by construction -- `from pathlib import Path` binds the same class object everywhere, so patching an attribute on it patches it for every module.

One caller must NOT follow the redirect. `agent._decline_shared_agent_home` asks "is my write target the one every instance under this environment shares?", so it now reads a new `ambient_agents_dir()` that skips the override. With the redirect applied to both sides that comparison is trivially equal, the guard mistakes a privately redirected target for the shared one, and refuses the write from any ephemeral checkout -- green in CI, red on a developer machine, which is the setup this repo mandates. A test asserts the two resolvers disagree, so the comparison cannot silently become vacuous.

What that deletes: the per-module resolver table, its 24 lines of caveats, the AST ratchet class, and its 16-entry exclusion list. Net -209/+137.

The four per-module `KIRO_AGENTS_DIR` hooks stay. They are a finer-grained seam production already offers ("a caller (test/tooling)"), around 30 tests use them directly, and removing them would be churn for no gain.

## What tests we did

- **Mutation-verified the mechanism**: neutering the override read in the resolver body turns two floor tests red, including the one that asserts through `slack.handler`'s bound copy rather than the definition -- which is what proves the reach.
- **New floor tests** replacing the ratchet: the resolver itself is pinned so no consumer needs registering (asserted via a hand-bound copy, plus an identity check that fails if that module stops binding the name and the test stops proving anything); a test that redirects the home itself is followed rather than overridden; the guard's ambient reference stays override-blind AND the two resolvers disagree.
- **129 affected test files** -- every file referencing `kiro_agents_dir` / `KIRO_AGENTS_DIR` / `rebuild_agent_config` / `_register_agents`, UNION every file patching `Path.home` (the idiom at risk): 10,596 passed, 29 skipped. The five test groups the earlier all-16 revision broke (`test_cc_agent_resolution`, `test_context`, `test_cron_script`, `test_skill_browser`, `test_slack_handler`) all pass here.
- 3 failures remain and are A/B verified as pre-existing on the unmodified base (two artifacts-handlers root checks, one `.local/bin/gh` symlink assertion -- host-specific, identical before and after).
- `black` / `flake8` / `mypy` clean on the touched files; brand gate passes.

Two test-side updates the refactor forced, both mechanical: `_pretend_target_is_shared` and the symlink regression now patch `ambient_agents_dir` (the name the guard actually reads) instead of the old bound `kiro_agents_dir`, and the shipped-default assertion takes `unpinned_agent_spec_home` because the floor's override is installed for every test.

## Any other suggestions on the work

- One correction to #4969's description, on the record: it claimed `test_list_merges_installed_config` had a latent defect because it patched `mcp_discovery.Path.home` while the branch under test resolves through `config.paths`. That was wrong -- the patch is global, so it did reach the resolver, and the test was correct as written. The line #4969 added to it is harmless (it pins the directory directly instead of relying on a global class patch) but it was not fixing a bug.
- `ambient_agents_dir()` has exactly one legitimate caller and its docstring says so. If a second appears, the honest reading is that something else needs an environment-only answer, and that is worth a look rather than a second import.
- The same shape exists elsewhere: any lazy resolver consumed via `from ... import` has the same "copies cannot be patched" property. This PR does not go looking; the pattern is written down in the resolver's docstring for whoever hits it next.

Refs #4912
