### PR TITLE
fix(mcp): only report a search path where a search actually happened

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -3454,6 +3454,18 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         # that declares its own ``env.PATH`` is searched against a DIFFERENT path
         # than one that does not, so a caller reporting ``mcp_search_path("")``
         # would name directories that were never searched.
+        if os.path.dirname(cmd):
+            # ...and neither were these. ``shutil.which`` looks a command with a
+            # directory component up DIRECTLY and never consults ``path`` (see
+            # its first branch), so an absolute or ``./relative`` command that
+            # fails to resolve searched no directories at all. Reporting
+            # ``_search`` here would name every directory on the spec's PATH for
+            # a command that was only ever checked at one location, which is the
+            # inverse of what the report is for: it turns "this exact path does
+            # not exist" into "not found in any of N directories". The absolute
+            # branch above already returned for the ones that DO resolve, so
+            # this is the failing tail of the same case, plus its relative form.
+            return shutil.which(cmd), ""
         return shutil.which(cmd, path=_search), _search
 
     valid_servers: dict[str, Any] = {}
@@ -3605,13 +3617,33 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             # against a different path, so recomputing one here would name
             # directories that were never consulted. The candidate list stays at
             # DEBUG: that is about which spec won, not about why none resolved.
-            logger.warning(
-                "Dropping MCP server %r: command not found: %s — %s; %s",
-                name,
-                spec.get("command", ""),
-                describe_search_path(dedup_path(os.pathsep.join(searched))),
-                MCP_PATH_HINT,
-            )
+            if searched:
+                logger.warning(
+                    "Dropping MCP server %r: command not found: %s — %s; %s",
+                    name,
+                    spec.get("command", ""),
+                    describe_search_path(dedup_path(os.pathsep.join(searched))),
+                    MCP_PATH_HINT,
+                )
+            else:
+                # No candidate was PATH-searched at all -- every one carried a
+                # directory component, which ``shutil.which`` looks up directly.
+                # There is no search to describe, and describe_search_path("")
+                # would report "searched no directories (empty PATH)", naming a
+                # cause that is not this one: the PATH was fine, it was simply
+                # never consulted.
+                #
+                # MCP_PATH_HINT is dropped here for the same reason. It reads
+                # "if it is installed elsewhere, add that directory to
+                # mcp.extra_path_dirs" -- a remedy that cannot work for a
+                # command nothing looked up on the search path. Extending
+                # extra_path_dirs would not change this lookup, so offering it
+                # sends the reader to fix the one thing that was not wrong.
+                logger.warning(
+                    "Dropping MCP server %r: command not found: %s",
+                    name,
+                    spec.get("command", ""),
+                )
             logger.debug("MCP %r resolution failed; tried %s", name, "; ".join(tried))
     config["mcpServers"] = valid_servers
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -152,13 +152,26 @@ def _warn_unresolvable_once(name: str, command: str, search_path: str = "") -> N
         )
         return
     _unresolvable_warned.add(key)
-    logger.warning(
-        "MCP probe failed [%s]: command not found: %s%s; %s",
-        name,
-        command,
-        searched,
-        MCP_PATH_HINT,
-    )
+    if search_path:
+        logger.warning(
+            "MCP probe failed [%s]: command not found: %s%s; %s",
+            name,
+            command,
+            searched,
+            MCP_PATH_HINT,
+        )
+    else:
+        # Nothing was PATH-searched: the command carried a directory component,
+        # so ``shutil.which`` looked it up directly. MCP_PATH_HINT reads "if it
+        # is installed elsewhere, add that directory to mcp.extra_path_dirs" --
+        # a remedy that cannot change this lookup, so offering it here points
+        # the reader at the one thing that was not wrong. Same reason the
+        # searched-directory list is omitted above.
+        logger.warning(
+            "MCP probe failed [%s]: command not found: %s",
+            name,
+            command,
+        )
 
 
 #: Servers whose probe has already reported a missing sandbox backend. Keyed by
@@ -1557,6 +1570,13 @@ async def probe_server(
     # FileNotFoundError handler can name the searched directories regardless of
     # how far the attempt got.
     effective_path = ""
+    # What was ACTUALLY searched, which is not the same thing: ``shutil.which``
+    # ignores ``path`` for a command carrying a directory component, so only a
+    # BARE command is ever looked up across ``effective_path``. Reported
+    # separately so a failing ``/opt/vendor/bin/foo`` does not claim it was
+    # missing from every directory on the PATH. Bound before the try for the
+    # same reason ``effective_path`` is.
+    searched_path = ""
     # Stamped at probe START so the early error returns below (which skip the
     # cache) still carry an honest "when": the probe DID run at this time.
     # _cache_probe overwrites it with completion time on the paths it covers.
@@ -1595,11 +1615,12 @@ async def probe_server(
 
         # Resolve command to absolute path using the merged env PATH
         effective_path = env.get("PATH") or ""
+        searched_path = "" if os.path.dirname(server.command) else effective_path
         resolved = shutil.which(server.command, path=effective_path)
         if not resolved:
             server.status = "error"
-            server.error = _unresolved_error(server.command, effective_path)
-            _warn_unresolvable_once(server.name, server.command, effective_path)
+            server.error = _unresolved_error(server.command, searched_path)
+            _warn_unresolvable_once(server.name, server.command, searched_path)
             return server
 
         # The command resolved, so forget any prior "not found" report — keyed on
@@ -1867,10 +1888,11 @@ async def probe_server(
         )
     except FileNotFoundError:
         server.status = "error"
-        server.error = _unresolved_error(server.command, effective_path)
-        # ``effective_path`` was bound before the try, so it is always safe to
-        # read here even if the failure preceded PATH resolution.
-        _warn_unresolvable_once(server.name, server.command, effective_path)
+        server.error = _unresolved_error(server.command, searched_path)
+        # ``searched_path`` was bound before the try, so it is always safe to
+        # read here even if the failure preceded PATH resolution -- and it is
+        # already "" for a directory-qualified command, which never had one.
+        _warn_unresolvable_once(server.name, server.command, searched_path)
     except SandboxUnavailableError as exc:
         # The PROBE could not run — this says nothing about the server, and the
         # two must not be reported alike. Ahead of the generic clause, which would

--- a/test/test_unresolved_command_message.py
+++ b/test/test_unresolved_command_message.py
@@ -101,3 +101,148 @@ def test_probe_warning_repeats_are_still_demoted(caplog):
         caplog.clear()
         mcp_discovery._warn_unresolvable_once("srv", "ghost", BASE_PATH)
         assert "command not found" not in caplog.text  # repeat demoted to DEBUG
+
+
+# ── a directory-qualified command searched no directories at all ──────────────
+#
+# ``shutil.which`` looks a command carrying a directory component up DIRECTLY
+# and never consults ``path``: its first branch is
+# ``if os.path.dirname(cmd): ... return None``. So an absolute (or ``./``
+# relative) command that fails to resolve was checked at exactly ONE location.
+# Reporting the spec's PATH for it inverts the distinction these messages exist
+# to draw -- "this exact path does not exist" is rendered as "not found in any
+# of the N directories searched", pointing the reader at a search that never
+# happened.
+
+
+ABSENT_ABS = _abs("opt", "vendor", "bin", "ghost")
+
+
+def test_shutil_which_really_ignores_path_for_a_qualified_command():
+    """The premise, pinned. Everything below rests on it."""
+    import shutil
+
+    assert os.path.dirname(ABSENT_ABS)
+    assert shutil.which(ABSENT_ABS, path=BASE_PATH) is None
+
+
+def test_probe_error_for_an_absolute_command_claims_no_directories():
+    from kiro_crew.mcp_discovery import _unresolved_error
+
+    assert _unresolved_error(ABSENT_ABS, "") == "command not found: %s" % ABSENT_ABS
+    assert "directories" not in _unresolved_error(ABSENT_ABS, "")
+
+
+# ── the dashboard probe ───────────────────────────────────────────────────────
+
+
+def _probe(monkeypatch, command: str):
+    """Drive the real ``probe_server`` and capture what it reported.
+
+    Asserted at the reporting boundary rather than on an internal local: the
+    defect is what the reader is told, and ``probe_server`` reaches the same two
+    helpers from two different exits.
+    """
+    import asyncio
+
+    from kiro_crew import mcp_discovery
+
+    seen: list[tuple[str, str]] = []
+
+    def _record(name, cmd, search_path=""):
+        seen.append((cmd, search_path))
+
+    monkeypatch.setattr(mcp_discovery, "_warn_unresolvable_once", _record)
+    monkeypatch.setenv("PATH", BASE_PATH)
+    server = mcp_discovery.McpServerInfo(name="vendor", command=command)
+    result = asyncio.run(mcp_discovery.probe_server(server))
+    return result, seen
+
+
+def test_probe_reports_no_search_path_for_a_directory_qualified_command(monkeypatch):
+    result, seen = _probe(monkeypatch, ABSENT_ABS)
+
+    assert result.status == "error"
+    assert seen, "the probe never reported the unresolvable command"
+    command, search_path = seen[-1]
+    assert command == ABSENT_ABS
+    assert search_path == "", (
+        "the probe told the reader it searched %r for a command shutil.which "
+        "only ever checked at one location" % (search_path,)
+    )
+    assert "directories" not in (
+        result.error or ""
+    ), "the dashboard string still claims a directory search: %r" % (result.error,)
+
+
+def test_probe_still_reports_the_search_path_for_a_bare_command(monkeypatch):
+    """Preservation: #4954's behaviour is untouched where a search DID happen."""
+    result, seen = _probe(monkeypatch, "ghost-bare-command")
+
+    assert result.status == "error"
+    assert seen
+    _command, search_path = seen[-1]
+    assert search_path, "a bare command must still name what it searched"
+    assert "directories" in (result.error or "")
+
+
+# ── the agent config rebuild ──────────────────────────────────────────────────
+
+
+def _rebuild_with_command(tmp_path, monkeypatch, command: str, caplog):
+    """Run the real ``rebuild_agent_config`` over one unresolvable server."""
+    import json
+
+    from kiro_crew.agent import rebuild_agent_config
+
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
+    (agent_dir / "defaults.json").write_text(json.dumps({"name": "kirocrew"}))
+    (agent_dir / "prompt.md").write_text("prompt")
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+
+    kiro_dir = tmp_path / ".kiro" / "agents"
+    kiro_dir.mkdir(parents=True)
+    settings_dir = tmp_path / ".kiro" / "settings"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"vendor": {"command": command, "env": {"PATH": BASE_PATH}}}})
+    )
+
+    monkeypatch.setattr("kiro_crew.agent.KIRO_AGENTS_DIR", kiro_dir)
+    monkeypatch.setattr("kiro_crew.agent._KIRO_MCP_JSON", settings_dir / "mcp.json")
+    monkeypatch.setattr("kiro_crew.agent._CC_MCP_JSON", tmp_path / "nonexistent_cc.json")
+    monkeypatch.setattr("kiro_crew.agent._KIROCREW_BIN", "/usr/bin/kirocrew")
+
+    with caplog.at_level("WARNING"):
+        rebuild_agent_config()
+    return caplog.text
+
+
+def test_rebuild_drop_warning_names_no_directories_for_an_absolute_command(
+    tmp_path, monkeypatch, caplog
+):
+    text = _rebuild_with_command(tmp_path, monkeypatch, ABSENT_ABS, caplog)
+
+    assert "command not found" in text, "the server was not reported as dropped"
+    assert USR_BIN not in text, (
+        "the drop warning named a directory that shutil.which never consulted "
+        "for a command carrying a directory component"
+    )
+    assert "directories searched" not in text
+    # And not the wrong cause either: the PATH was fine, it was never consulted.
+    assert (
+        "empty PATH" not in text
+    ), "the warning blamed an empty PATH for a command that was never " "PATH-searched: %r" % (
+        text,
+    )
+
+
+def test_rebuild_drop_warning_still_names_directories_for_a_bare_command(
+    tmp_path, monkeypatch, caplog
+):
+    """Preservation: the whole point of #4954 survives for bare commands."""
+    text = _rebuild_with_command(tmp_path, monkeypatch, "ghost-bare-command", caplog)
+
+    assert "command not found" in text
+    assert USR_BIN in text, "a bare command must still name the directories searched"


### PR DESCRIPTION
## Problem / Motivation

When an MCP server's `command` carries a directory component — an absolute `/opt/vendor/bin/foo`, or a relative `./tool` — and it does not resolve, both report surfaces tell the reader it was searched for across the spec's whole `PATH`. It was not searched anywhere: `shutil.which` checked exactly one location.

CPython's `shutil.which` returns before `path` is ever read:

```python
# If we're given a path with a directory part, look it up directly rather
# than referring to PATH directories.
if os.path.dirname(cmd):
    if _access_check(cmd, mode):
        return cmd
    return None
```

Both sites added by #4954 passed the search path through unconditionally — `agent._resolve_command` returning it beside a `which()` that ignored it, and `probe_server` handing `effective_path` to `_unresolved_error` / `_warn_unresolvable_once` at two exits.

## Why it matters

This is backwards for the distinction #4954 exists to draw. Its purpose was to separate *"not installed"* from *"installed outside the search path"*. For a directory-qualified command the truth is neither — it is **"this exact path does not exist"** — and the report converts that into "not found in any of the 9 directories searched", sending the reader to audit a `PATH` that was never consulted and is not the problem.

Raised on #4954 itself by the Opus review, and deferred:

> `return shutil.which(cmd, path=_search), _search` returns the full declared search path even for an absolute `cmd`, but `shutil.which` ignores `path=` when `cmd` has a directory component and only checks the absolute location; a spec whose `command` is a non-existent absolute path (e.g. `/opt/vendor/bin/foo`) then drops with `describe_search_path(...)` naming directories that were never consulted — the exact "installed elsewhere" vs "not installed" distinction this change exists to fix, reported backwards. Same holds in `probe_server`.

## What changed (motivation → approach → change)

**Motivation** — never claim a search that did not happen.

**Approach** — no new mechanism and no helper change: `_unresolved_error` and `_warn_unresolvable_once` already degrade to a plain `command not found: <cmd>` on an empty search path. The fix is to stop feeding them a path when nothing was searched.

**Change**

- `agent._resolve_command` returns `""` when `os.path.dirname(cmd)` is truthy. Resolution itself is untouched: the call becomes `shutil.which(cmd)`, which is what `shutil.which(cmd, path=...)` already did for that input, and the absolute-and-executable fast path above still returns first.
- `probe_server` gains `searched_path`, separate from `effective_path` — the `which()` call still needs the real PATH, only the *report* changes. Bound before the `try` for the same reason `effective_path` is, so the `FileNotFoundError` exit reads it safely.

**One case the review did not name.** With no candidate PATH-searched, the rebuild's `searched` list is empty and `describe_search_path("")` renders `searched no directories (empty PATH)` — also the wrong cause, since the PATH was fine and merely unconsulted. The drop warning now omits the clause entirely rather than blaming an empty PATH.

Bare commands are unchanged: they *are* searched across the path, so they still say so.

**Rebased onto current `main` (2026-08-23), which changed what ships here.** `main` has since added `MCP_PATH_HINT` to both warnings this PR splits: *"if it is installed elsewhere, add that directory to `mcp.extra_path_dirs`"*. That is a **search-path remedy**, so it now follows the same rule as the directory list — kept where a search happened, dropped where none did.

For a command carrying a directory component `shutil.which` never consults the search path, so extending `extra_path_dirs` cannot change the lookup. Offering the hint there sends the reader to fix the one thing that was not wrong; it is the same defect this PR exists to remove, in remedy form rather than in directory-list form. Both sites are now consistent on it:

- `agent.rebuild_agent_config` — hint on the `if searched:` branch, omitted on the `else:` branch.
- `mcp_discovery._warn_unresolvable_once` — hint when `search_path` is non-empty, omitted when it is `""` (which is set precisely for a directory-qualified command).

Two production files, 74 insertions / 20 deletions.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_shutil_which_really_ignores_path_for_a_qualified_command` | the premise everything else rests on, pinned against the stdlib |
| `test_probe_reports_no_search_path_for_a_directory_qualified_command` | the real `probe_server` reports no directories, and the dashboard string claims none |
| `test_rebuild_drop_warning_names_no_directories_for_an_absolute_command` | the real `rebuild_agent_config` warning names no directory — **and does not blame an empty PATH** |
| `test_probe_still_reports_the_search_path_for_a_bare_command` | preservation: #4954's behaviour intact where a search happened |
| `test_rebuild_drop_warning_still_names_directories_for_a_bare_command` | preservation, rebuild side |
| `test_probe_error_for_an_absolute_command_claims_no_directories` | the dashboard string degrades to the plain form |

Both are asserted at the **reporting boundary** — what the reader is actually told — driving the real `probe_server` and the real `rebuild_agent_config`, not the nested `_resolve_command` (which is not importable, and would have meant adding a test-only export to production).

Fail-before / pass-after, with both production files reverted and the tests left in place:

```
AssertionError: the probe told the reader it searched
'...\.local\bin;...\.toolbox\bin;...\.npm-packages\bin;...\mise\shims;
 ...\.volta\bin;/opt/homebrew/bin;C:\usr\bin;C:\bin;...\.venv\Scripts'
for a command shutil.which only ever checked at one location

AssertionError: the drop warning named a directory that shutil.which never
consulted for a command carrying a directory component

2 failed, 12 passed
```

The four preservation tests pass on **both** trees by design — they are the guard against over-correcting into silence, not evidence of a defect, and are reported as such rather than folded into the fail-before count.

```
pytest test/test_unresolved_command_message.py -q                    14 passed
pytest test/test_mcp_discovery.py test/test_unresolved_command_message.py \
       test/test_agent.py -q                     331 passed, 10 failed, 19 skipped
```

Those 10 are pre-existing: the identical 10 fail on pristine `main` with this branch stashed (317 passed there vs 331 here — the delta is exactly the 14 new tests).

**Re-verified after the rebase**, at head `a26dc8e30`: the two negative controls still fail with both production files reverted (`2 failed`), the four preservation tests still pass on **both** trees (`4 passed` each), and the file is `14 passed`. `test_env.py` + `test_config_mcp_section.py` are `18 failed, 111 passed` **identically on both trees** — pre-existing POSIX-only (`os.getuid`) and Windows path cases, not this change.

Gates: `flake8` · `isort --check-only` · `mypy --platform linux` (no issues in either changed module) · `scripts/check_black_formatting.py` (3 files in scope; `test_unresolved_command_message.py` is NOT baselined, so it is held to `black` and formatted).

## Manual verification

N/A — unit coverage sufficient: the assertion is on the exact operator-facing warning and dashboard string, produced by the real probe and the real config rebuild. Reproducing by hand means pointing a spec at an absent absolute path and reading a log line, which is what these tests assert directly.

## Related Issues

Fixes #5053.

Closes the second hand-off from the Opus review on #4954. The first (the two ACP spawn sites that named no directories at all) is #5048 — a different contract, so it is a separate PR.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no documented behaviour changes. Why a directory-qualified command reports no search path is explained at both sites.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

