### PR TITLE
cherry-pick(#5039): stop a leaked record factory reddening the full suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,7 @@ doubling ratio only where it does not: absolute ceilings split by Python version
 enables coverage on 3.12 only), and tight timed ratios false-red on shared runners.
 
 **A test must not touch the operator's machine, and the floor you stand on is not the
-same in every testpath.** `testpaths` collects three trees, and only `test/` gets
+same in every testpath.** `testpaths` collects two trees, and only `test/` gets
 `test/conftest.py`; the ~108 test modules under `src/kiro_crew/apps/builtins/*/tests/`
 see the **rootdir** `conftest.py`, plus that app's own `tests/conftest.py` where one
 exists (three of the eight apps ship one). So the rootdir conftest carries the

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -233,8 +233,8 @@ custom-rules:
       never checked.
 
       Know which floor you are standing on — it is NOT the same everywhere:
-      - The ROOTDIR `conftest.py` is the HOST-MUTATION FLOOR and applies to all
-        three testpaths. It pins $XDG_CONFIG_HOME and the launchd paths, blocks
+      - The ROOTDIR `conftest.py` is the HOST-MUTATION FLOOR and applies to both
+        testpaths. It pins $XDG_CONFIG_HOME and the launchd paths, blocks
         host service mutation, pins KIROCREW_HOME per test (with
         `config.paths._resolved_home` reset, since resolving the home CREATES it
         and can run the legacy migration), pins the import-time `~/.kiro`

--- a/conftest.py
+++ b/conftest.py
@@ -81,6 +81,7 @@ import gc
 import getpass
 import importlib
 import linecache
+import logging
 import os
 import pathlib
 import shutil
@@ -771,6 +772,67 @@ def _no_leaked_telemetry_exporter():
         "to it -- see "
         "conftest._no_leaked_telemetry_exporter."
     )
+
+
+# ── the logging record factory goes back after every test ─────────────
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_record_factory():
+    """Put ``logging``'s record factory back, so one test cannot rewrite every later record.
+
+    ``logging.setLogRecordFactory`` is ONE process-global slot. The wrapper the suite
+    reaches -- ``log_redaction``'s, installed by ``cli._setup_cli_logging`` for a
+    long-lived command -- is deliberately destructive to every record it then creates: it
+    materializes ``msg`` and clears ``args`` so a handler cannot re-format, and it renders
+    ``exc_info`` into ``exc_text`` and clears ``exc_info`` so a handler cannot re-render an
+    unredacted traceback. Correct for redaction, and invisible to the test that leaves it
+    installed, because the damage lands on whatever unrelated test later asserts on
+    ``record.exc_info``, ``record.args``, or a deferred ``%s``.
+
+    Measured: two tests failed this way in a release run and neither is a logging test --
+    ``test_pid_lifecycle.py::TestFindOrphanMcpCandidates::
+    test_unexpected_probe_error_keeps_traceback`` asserting a probe failure kept its
+    traceback, and ``test_log_redaction`` itself hitting ``RecursionError`` because
+    installing over the already-installed wrapper captured it as its own base factory.
+
+    **Sharding hides this class, so the floor cannot rely on a full-suite run to find it.**
+    ``ci.yml`` slices the suite into duration-balanced pytest-split groups and a leak only
+    damages tests in the SAME process, so PR CI usually cannot observe it at all; the
+    release job runs the suite whole and is otherwise the first place it appears -- as
+    failures in files unrelated to the cause, long after the diff merged. Restoring here
+    removes the class outright rather than improving the odds of noticing it.
+
+    Restoring rather than failing is deliberate, for the same reason the CWD restore in
+    ``pytest_runtest_teardown`` above does not blame either: installing this factory is a
+    legitimate, unavoidable side effect of every test that drives the real ``cli.main()``
+    or ``_setup_cli_logging`` in-process, which production does once per process and never
+    undoes. Blaming them would demand pure bookkeeping with no test value, and the damage
+    is to OTHER tests, so stopping it propagating is the whole job.
+    ``log_redaction.uninstall_log_redaction()`` is there for a test that wants to assert on
+    the uninstalled state itself; the install/uninstall contract is pinned by
+    ``test_log_redaction.py``, not by this floor.
+
+    The restore target is what this test INHERITED, not a pristine ``LogRecord``. That is
+    what lets a higher-scoped fixture install one for the whole class or module without
+    this floor tearing it out from under the second test, and it is also why this is a
+    fixture rather than the cheaper ``pytest_runtest_teardown`` hookimpl the CWD restore
+    uses: a conftest ``pytest_runtest_setup`` runs BEFORE the item's own fixtures, so its
+    snapshot would miss such an installer and the teardown would then rip it out after the
+    class's FIRST test. Measured cost of the fixture protocol over the hookimpl: ~50us per
+    test, ~3s of CPU across the suite, spread over the xdist workers.
+
+    The BOUNDARY that follows from the same choice: a class-, module- or session-scoped
+    fixture that installs a factory and never removes it leaks PAST its own scope, because
+    every later test inherits it and so restores to it. No fixture in this repo does that
+    -- every installer sits in a test body, which is inside this fixture's window -- but a
+    new higher-scoped one has to uninstall itself; the floor cannot tell that case from a
+    deliberate one.
+    """
+    before = logging.getLogRecordFactory()
+    yield
+    if logging.getLogRecordFactory() is not before:
+        logging.setLogRecordFactory(before)
 
 
 # ── the sandbox probe cache is warm for every test, in every testpath ──

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -106,7 +106,7 @@ test). The sweep's own behavior belongs in its own module's tests.
 
 ## Which conftest you are standing on
 
-There are **three** testpaths (`setup.cfg`'s `testpaths = test transfer
+There are **two** testpaths (`setup.cfg`'s `testpaths = test
 src/kiro_crew/apps/builtins`) and they do **not** get the same fixtures. Know which
 floor is under your file before you decide what to isolate yourself:
 
@@ -125,7 +125,7 @@ It also pins the other real host paths a test must not reach: the subagent regis
 running gateway sweeps stray entries there as orphans), the 610MB embedding-model
 download, and the agent-state sidecar.
 
-Two members are there for a different reason — a **process-global** that any testpath
+Three members are there for a different reason — a **process-global** that any testpath
 can poison for every test after it, which is the same failure shape as host mutation
 one scope down:
 
@@ -139,6 +139,18 @@ one scope down:
   running. See the Rules entry — that thread makes the sandbox probe's fork child
   multithreaded, which the kernel answers with an EINVAL the probe used to cache as
   "this host has no sandbox backend".
+* `_restore_log_record_factory` puts `logging`'s record factory back. There is one such
+  slot per process, and `log_redaction`'s wrapper deliberately clears `args` and
+  `exc_info` on every record it creates, so leaving it installed reds whatever unrelated
+  test later asserts on either field. `cli._setup_cli_logging` installs it for a
+  long-lived command, so grepping `cli.main()` finds only some of the tests that reach
+  it — most call that helper directly, and they are in `test_cli_logging.py`, whose own
+  `_pristine_logging` fixture restores handlers and levels but not the factory, which is
+  why that file looks like it already handles this. Restored rather than blamed, for the
+  same reason the CWD restore is: production installs it once per process and never
+  undoes it, so a test driving that code cannot avoid it.
+  `log_redaction.uninstall_log_redaction()` exists for a test that wants to assert on
+  the uninstalled state itself.
 
 It registers the xdist worker budget too — the policy is in the repo-root
 `xdist_budget.py`, a plain module rather than a second conftest, because the module
@@ -154,8 +166,8 @@ When you add isolation, put it in the rootdir conftest **only** if a test in any
 testpath could damage the host, poison a process global for every later test, or
 consume enough of a shared *resource* — memory, cores, disk — to take the machine down
 with it. Otherwise it belongs in `test/conftest.py`, where it costs the in-package
-suites nothing. Both of the entries above started life in `test/conftest.py` and were
-silently absent from the in-package tests, which is how each was found.
+suites nothing. The first two of those entries started life in `test/conftest.py` and
+were silently absent from the in-package tests, which is how each was found.
 
 Resource consumption belongs on that list for the same reason damage does: a guard
 that only covers `test/` is invisibly absent from the other two testpaths, and the
@@ -225,7 +237,7 @@ which testpath asked for the workers.
 - **Never leave the process working directory somewhere else.** The CWD is
   per-PROCESS, so under xdist one test's `os.chdir` becomes every later test's starting
   directory on that worker. Use `monkeypatch.chdir`, which reverts on its own; the
-  rootdir conftest's `_restore_cwd` puts it back either way.
+  rootdir conftest's `pytest_runtest_teardown` puts it back either way.
 
   This was survivable only while the directory outlived the run. With
   `tmp_path_retention_policy = failed` pytest removes a passing test's `tmp_path` at
@@ -703,6 +715,26 @@ mark is the tool for a test that genuinely cannot share a worker.
 
 Mutate process globals through `monkeypatch`, which reverts on teardown even when the
 test fails. Raw assignment does not.
+
+**Sharding does not just scatter this class, it hides it — so a full-suite run is the wrong
+place to be finding it.** `ci.yml` slices the suite into duration-balanced `pytest-split`
+groups, and a leaker only damages tests that land in the *same process*, so a leak whose
+victim sits in another shard is not observable in PR CI at all. The release job runs the
+suite whole and is therefore the first place it appears — as failures in files that have
+nothing to do with the cause, at a point where the diff that introduced it is long merged.
+Running the full suite more often narrows that window; it does not close it, because which
+tests share a worker still varies run to run.
+
+What closes it is a floor fixture per process-global chokepoint: snapshot at setup, compare
+at teardown, restore to **what the test inherited** (not to a pristine value, so a leak from
+an earlier test is not re-reported against every test after it). So when you introduce a new
+process-global, ship its floor entry with it rather than relying on a full-suite run to
+notice. Whether that entry also *fails* the test depends on whether reaching the global is a
+defect: `_no_leaked_telemetry_exporter` fails, because nothing legitimately leaves an
+exporter running; the CWD restore and `_restore_log_record_factory` restore silently, because
+production really does `chdir` and really does install a record factory, and a test driving
+that code cannot avoid inheriting it. Restore either way — the damage is to other tests, and
+stopping it propagating is the part that is never optional.
 
 ### 5. Absolute time budgets on instrumented runs
 

--- a/src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
+++ b/src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
@@ -152,17 +152,24 @@ def main(argv: list[str] | None = None) -> int:
         "settleMs": args.settle_ms,
         "tailMs": args.tail_ms,
     }
+    # delete=False because the driver is a separate process that opens this by name,
+    # so the handle has to be closed before the spawn. The driver reads it once at
+    # startup, so nothing needs it after the run returns; the unlink is a finally
+    # because the timeout below raises past a trailing statement.
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
         json.dump(cfg, f)
         cfg_path = f.name
 
-    proc = subprocess.run(
-        [node, str(DRIVER), cfg_path],
-        cwd=str(project),
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
+    try:
+        proc = subprocess.run(
+            [node, str(DRIVER), cfg_path],
+            cwd=str(project),
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    finally:
+        Path(cfg_path).unlink(missing_ok=True)
     sys.stderr.write(proc.stderr)
     if proc.returncode != 0:
         _fail(f"driver failed (exit {proc.returncode})", proc.returncode)

--- a/src/kiro_crew/log_redaction.py
+++ b/src/kiro_crew/log_redaction.py
@@ -61,45 +61,81 @@ class SecretRedactionFilter:
         return text
 
 
-# Module-level singleton set by install_log_redaction
-_active_filter: Optional[SecretRedactionFilter] = None
-_original_factory: Optional[Callable[..., logging.LogRecord]] = None
+#: Marks an installed factory as a redacting wrapper, and carries the two things it
+#: needs: ``base`` (the factory it displaced, to call and to give back) and ``filter``
+#: (the live :class:`SecretRedactionFilter`, or ``None`` to pass records through).
+#:
+#: Both live ON THE INSTALLED FUNCTION rather than in a module global, and that is the
+#: invariant the whole module rests on. A module global is resolved at CALL time and can
+#: be rewritten — or zeroed by a reload — while the wrapper stays in ``logging``'s slot,
+#: so the two disagree and the wrapper ends up calling something other than what it
+#: displaced. Held on the function, each wrapper's base is fixed at install:
+#:
+#: * A CYCLE IS UNREPRESENTABLE. Wrapping our own wrapper makes it the inner link of a
+#:   finite chain whose base is still the real original, so the worst case is redacting
+#:   twice. Resolved through a global, the same wrap made the wrapper its own base and
+#:   every later record recursed until ``RecursionError`` — on a PROCESS-GLOBAL slot, so
+#:   no record was emitted again, redacted or not.
+#: * OWNERSHIP IS READ OFF THE SLOT. ``install``/``uninstall`` ask the installed object
+#:   what it is instead of consulting a sentinel that anything replacing the slot (a test
+#:   floor, a reload, another copy of this module) silently invalidates.
+_FACTORY_BASE = "_kirocrew_redaction_base"
+_FACTORY_FILTER = "_kirocrew_redaction_filter"
 
 
-def _redacting_record_factory(*args, **kwargs) -> logging.LogRecord:  # type: ignore[no-untyped-def]
-    """Wrap the standard LogRecord factory to redact msg at creation time.
+def _redacting_factory(base: Callable[..., logging.LogRecord]) -> Callable[..., logging.LogRecord]:
+    """Build a record factory that redacts everything *base* produces.
 
-    This runs BEFORE any handler sees the record, covering all handlers
-    including those added after installation.  We materialize the final
-    message (msg % args) and redact it, then clear args so the handler
-    cannot re-format and leak.  Exception info is also redacted.
+    The wrapper runs at record CREATION, before any handler sees it, which is what
+    covers handlers added after installation. It materializes the final message
+    (``msg % args``) and clears ``args`` so a handler cannot re-format and leak, and it
+    renders ``exc_info`` into ``exc_text`` and clears it so a handler cannot re-render
+    an unredacted traceback.
     """
-    record = (
-        _original_factory(*args, **kwargs)
-        if _original_factory is not None
-        else logging.LogRecord(*args, **kwargs)
-    )
-    if _active_filter is not None:
-        # Materialize the full formatted message so deferred %s args
-        # cannot bypass redaction at handler-format time.
+
+    def factory(*args, **kwargs) -> logging.LogRecord:  # type: ignore[no-untyped-def]
+        record = base(*args, **kwargs)
+        filt: Optional[SecretRedactionFilter] = getattr(factory, _FACTORY_FILTER, None)
+        if filt is None:
+            return record
+
+        # Materialize the full formatted message so deferred %s args cannot
+        # bypass redaction at handler-format time.
         try:
             materialized = record.getMessage()
         except Exception:
             materialized = str(record.msg) if record.msg else ""
-        record.msg = _active_filter.redact(materialized)
+        record.msg = filt.redact(materialized)
         record.args = None  # Already materialized — prevent double-format
 
-        # Redact exc_text if already rendered, and format exc_info now
-        # so Bearer tokens in tracebacks are caught.
         if record.exc_text:
-            record.exc_text = _active_filter.redact(record.exc_text)
+            record.exc_text = filt.redact(record.exc_text)
         if record.exc_info:
             import traceback
 
             tb_lines = traceback.format_exception(*record.exc_info)
-            record.exc_text = _active_filter.redact("".join(tb_lines))
+            record.exc_text = filt.redact("".join(tb_lines))
             record.exc_info = None  # Prevent handler from re-formatting
-    return record
+        return record
+
+    setattr(factory, _FACTORY_BASE, base)
+    setattr(factory, _FACTORY_FILTER, None)
+    return factory
+
+
+def _installed_factory() -> Optional[Callable[..., logging.LogRecord]]:
+    """The redacting wrapper currently in ``logging``'s slot, or ``None``.
+
+    Only the TOP of the chain is inspected. A third party that wrapped ours answers
+    ``None``, which is the right answer for both callers: the slot is not theirs to hand
+    back, and installing a second wrapper over it is safe because chains terminate.
+
+    Marker-based rather than identity-based so it survives this module being reloaded or
+    imported a second time — either of which produces a new function object for a
+    wrapper that is already installed and working.
+    """
+    factory = logging.getLogRecordFactory()
+    return factory if hasattr(factory, _FACTORY_BASE) else None
 
 
 def install_log_redaction(patterns: list[str]) -> SecretRedactionFilter:
@@ -110,20 +146,46 @@ def install_log_redaction(patterns: list[str]) -> SecretRedactionFilter:
     performs ZERO vault I/O — the caller resolves secret values and passes
     them as *patterns*.
 
+    Idempotent: when a redacting wrapper is already installed, its filter is
+    re-pointed at *patterns* and the slot is left alone. Re-pointing the INSTALLED
+    wrapper, rather than a global only this copy of the module can see, is what keeps
+    the new patterns in force after a reload or a second import.
+
     Parameters
     ----------
     patterns:
         Literal secret values to redact from log output. Values shorter
         than 4 chars are ignored (too likely to cause false positives).
     """
-    global _active_filter, _original_factory
-
     filt = SecretRedactionFilter(patterns)
-    _active_filter = filt
 
-    # Wrap the record factory only once
-    if _original_factory is None:
-        _original_factory = logging.getLogRecordFactory()
-        logging.setLogRecordFactory(_redacting_record_factory)
+    installed = _installed_factory()
+    if installed is None:
+        installed = _redacting_factory(logging.getLogRecordFactory())
+        logging.setLogRecordFactory(installed)
+    setattr(installed, _FACTORY_FILTER, filt)
 
     return filt
+
+
+def uninstall_log_redaction() -> None:
+    """Stop redacting, and give the record factory back.
+
+    ``install_log_redaction`` needs a counterpart because the record factory is
+    process-global: a caller that installs one and cannot remove it has changed
+    every ``LogRecord`` for the life of the process, including dropping
+    ``exc_info``, which the wrapper does on purpose so a handler cannot re-render
+    an unredacted traceback.
+
+    Idempotent, and it reverts only the wrapper at the TOP of the slot. If a third
+    party wrapped ours, theirs is what the slot holds and ours is unreachable behind
+    their closure, so nothing is touched and redaction CONTINUES until they remove
+    their own wrapper. That is the safe direction for a control whose job is to keep
+    secrets out of the log: the alternative is reaching into a chain this module does
+    not own and unlinking whatever they added.
+    """
+    installed = _installed_factory()
+    if installed is None:
+        return
+    setattr(installed, _FACTORY_FILTER, None)
+    logging.setLogRecordFactory(getattr(installed, _FACTORY_BASE))

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -1136,8 +1136,6 @@ class TestRunScriptSandboxedErrorPaths:
             "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
         ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
             "subprocess.Popen", return_value=mock_proc
-        ), patch(
-            "pathlib.Path.unlink"
         ):
             result = run_script_sandboxed("/f.py:run", "j1", "")
         assert result["status"] == "error"
@@ -1152,8 +1150,6 @@ class TestRunScriptSandboxedErrorPaths:
             "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
         ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
             "subprocess.Popen", return_value=mock_proc
-        ), patch(
-            "pathlib.Path.unlink"
         ):
             result = run_script_sandboxed("/f.py:run", "j1", "")
         assert result["status"] == "error"
@@ -1325,9 +1321,7 @@ class TestRunScriptSandboxedTimeout:
             # TestKillBroadcastGuard.
             "kiro_crew.platform_compat.kill_process_tree",
             return_value=True,
-        ) as mock_tree, patch(
-            "pathlib.Path.unlink"
-        ):
+        ) as mock_tree:
             result = run_script_sandboxed("/f.py:run", "j1", "", timeout=30)
         assert result["status"] == "error"
         assert "timed out" in result["error"]
@@ -1528,8 +1522,6 @@ class TestResolveInternalSecret:
             "kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)
         ), patch(
             "subprocess.Popen", side_effect=fake_popen
-        ), patch(
-            "pathlib.Path.unlink"
         ):
             run_script_sandboxed("/f.py:run", "j1", "", timeout=30)
         assert captured["secret"] == "realsecret"

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -25,12 +25,15 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import logging
 import os
 import pathlib
 import sys
 import tempfile
 
 import pytest
+
+from kiro_crew.log_redaction import install_log_redaction
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _ROOT_CONFTEST = _REPO_ROOT / "conftest.py"
@@ -764,6 +767,54 @@ class TestTheWorkingDirectoryIsRestored:
             f"CWD at fixture-finalizer time was {_CWD_ORDER.get('at_finalizer')!r}, "
             f"expected {_CWD_ORDER.get('expected')!r} -- the restore ran too late, so "
             "tmp_path cleanup would be asked to delete the process's own directory"
+        )
+
+
+# ── the logging record factory ─────────────────────────────────────────────
+
+
+#: Written by one test and asserted by the next, for the same reason as ``_CWD_ORDER``:
+#: the restore this pins runs during teardown, so no finalizer of the leaking test can
+#: observe it -- the rootdir floor is the OUTER fixture and finalizes after them all.
+_FACTORY_ORDER: dict[str, object] = {}
+
+
+@pytest.mark.xdist_group(name="log_record_factory_floor")
+class TestTheLogRecordFactoryIsRestored:
+    """``logging.setLogRecordFactory`` is ONE process-global slot, per worker.
+
+    ``log_redaction``'s wrapper clears ``args`` and ``exc_info`` on every record created
+    after it, so a test that leaves it installed reds whatever unrelated test later
+    asserts on either field -- and because PR CI shards, the victim usually lands in a
+    different process and the pollution is invisible until an unsharded release run.
+    ``conftest._restore_log_record_factory`` is what removes the class; without a test,
+    an edit to it reverts silently and the failures reappear in files that have nothing
+    to do with the cause.
+
+    Grouped with ``xdist_group`` so the leaker and the observer stay on ONE worker:
+    ``--dist loadgroup`` honours that, and without it the two are distributed
+    independently and the observation passes vacuously.
+    """
+
+    def test_this_test_starts_with_the_stdlib_factory(self) -> None:
+        """Which is only true if no earlier test on this worker left a wrapper installed."""
+        assert logging.getLogRecordFactory() is logging.LogRecord
+
+    def test_a_leaked_wrapper_does_not_reach_the_next_test(self) -> None:
+        """Installs one and deliberately does NOT remove it -- the floor's job, not ours."""
+        install_log_redaction([])
+        _FACTORY_ORDER["installed"] = logging.getLogRecordFactory()
+        assert logging.getLogRecordFactory() is not logging.LogRecord
+
+    def test_the_next_test_sees_the_slot_restored(self) -> None:
+        """Reads what the previous test recorded. Ordered by definition order in the file."""
+        assert _FACTORY_ORDER.get("installed") is not None, (
+            "the installing test did not run on this worker, so this assertion proves "
+            "nothing -- the xdist_group mark on the class is what keeps them together"
+        )
+        assert logging.getLogRecordFactory() is logging.LogRecord, (
+            f"the record factory is still {logging.getLogRecordFactory()!r} -- a wrapper "
+            "left installed by an earlier test now rewrites every record on this worker"
         )
 
 

--- a/test/test_log_redaction.py
+++ b/test/test_log_redaction.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
+import sys
 
-from kiro_crew.log_redaction import SecretRedactionFilter, install_log_redaction
+import pytest
+
+from kiro_crew.log_redaction import (
+    SecretRedactionFilter,
+    install_log_redaction,
+    uninstall_log_redaction,
+)
 
 
 class TestSecretRedactionFilter:
@@ -63,84 +71,183 @@ class TestSecretRedactionFilter:
         assert "eyJhbGciOiJSUzI1NiJ9" not in result
 
 
+def _make_record(msg: str, exc_info: object = None) -> logging.LogRecord:
+    """Create a record through the LIVE factory — how ``logging`` itself does it."""
+    return logging.getLogRecordFactory()("kiro_crew.test", logging.INFO, "", 0, msg, None, exc_info)
+
+
 class TestInstallLogRedaction:
     """Tests for the install_log_redaction convenience function."""
 
-    def test_installs_record_factory(self) -> None:
-        import kiro_crew.log_redaction as mod
+    @pytest.fixture(autouse=True)
+    def _no_redaction_installed(self):
+        """Start and end each test with no redacting factory installed.
 
-        old_factory = logging.getLogRecordFactory()
-        old_active = mod._active_filter
-        old_orig = mod._original_factory
-        try:
-            mod._active_filter = None
-            mod._original_factory = None
-            filt = install_log_redaction([])
-            assert mod._active_filter is filt
-            assert logging.getLogRecordFactory() is not old_factory
-        finally:
-            # Restore
-            mod._active_filter = old_active
-            mod._original_factory = old_orig
-            logging.setLogRecordFactory(old_factory)
+        The record factory is a single process-global slot, and these tests assert on
+        the install contract itself, so each one owns its precondition rather than
+        inheriting whatever ran before it on this worker.
+        ``conftest._restore_log_record_factory`` puts the slot back after every test in
+        the suite; uninstalling on both sides here is what makes these tests
+        independent of that.
+        """
+        uninstall_log_redaction()
+        yield
+        uninstall_log_redaction()
+
+    def test_installs_record_factory(self) -> None:
+        before = logging.getLogRecordFactory()
+        install_log_redaction([])
+        assert logging.getLogRecordFactory() is not before
+        # The wrapper is live, not merely constructed.
+        assert "Bearer [REDACTED]" in _make_record("h: Bearer eyJhbGciOiJSUzI1NiJ9.a.b").msg
 
     def test_returns_filter_instance(self) -> None:
-        import kiro_crew.log_redaction as mod
-
-        old_factory = logging.getLogRecordFactory()
-        old_active = mod._active_filter
-        old_orig = mod._original_factory
-        try:
-            mod._active_filter = None
-            mod._original_factory = None
-            filt = install_log_redaction(["test-secret"])
-            assert isinstance(filt, SecretRedactionFilter)
-        finally:
-            mod._active_filter = old_active
-            mod._original_factory = old_orig
-            logging.setLogRecordFactory(old_factory)
+        assert isinstance(install_log_redaction(["test-secret"]), SecretRedactionFilter)
 
     def test_redacts_via_record_factory(self) -> None:
         """Records created after install have secrets redacted."""
+        install_log_redaction(["sk-secret-key-12345"])
+        record = _make_record("key is sk-secret-key-12345 here")
+        assert "sk-secret-key-12345" not in record.msg
+        assert "[REDACTED]" in record.msg
+
+    def test_install_survives_a_module_reload(self) -> None:
+        """A reload must not orphan the installed wrapper or make it call itself.
+
+        ``importlib.reload`` re-executes this module in the SAME namespace, so every
+        module-level name the wrapper might read is reset while ``logging`` still holds
+        the wrapper. A design that resolved the base factory or the active filter
+        through one of those names would either recurse (the wrapper becomes its own
+        base — process-wide, so ALL logging dies, not just redaction) or silently stop
+        redacting. The wrapper carries both on itself, so a reload cannot reach them.
+        """
         import kiro_crew.log_redaction as mod
 
-        old_factory = logging.getLogRecordFactory()
-        old_active = mod._active_filter
-        old_orig = mod._original_factory
+        install_log_redaction(["sk-secret-key-12345"])
+        installed = logging.getLogRecordFactory()
         try:
-            mod._active_filter = None
-            mod._original_factory = None
-            install_log_redaction(["sk-secret-key-12345"])
+            importlib.reload(mod)
+            assert logging.getLogRecordFactory() is installed
+            assert "sk-secret-key-12345" not in _make_record("k=sk-secret-key-12345").msg
 
-            # Use the factory directly (how logging internally creates records)
-            factory = logging.getLogRecordFactory()
-            record = factory(
-                "kiro_crew.test",
-                logging.INFO,
-                "",
-                0,
-                "key is sk-secret-key-12345 here",
-                None,
-                None,
-            )
-            assert "sk-secret-key-12345" not in record.msg
-            assert "[REDACTED]" in record.msg
+            # And a post-reload install re-points the SAME live wrapper.
+            mod.install_log_redaction(["second-secret-value"])
+            assert logging.getLogRecordFactory() is installed
+            assert "second-secret-value" not in _make_record("k=second-secret-value").msg
         finally:
-            mod._active_filter = old_active
-            mod._original_factory = old_orig
-            logging.setLogRecordFactory(old_factory)
+            mod.uninstall_log_redaction()
 
-    def test_zero_vault_imports(self) -> None:
+    def test_reinstall_under_a_foreign_wrapper_never_cycles(self) -> None:
+        """A second install must not chain onto a third party's wrapper of ours.
+
+        The stdlib's own "Customizing LogRecord" recipe is to capture
+        ``getLogRecordFactory()`` and wrap it, which is what logging-instrumentation
+        libraries do. That wrapper reports as foreign, so capturing it as the base
+        factory would build ``ours -> theirs -> ours`` — and because the wrapper
+        resolves its base at call time on a process-global slot, the next log call
+        anywhere raises RecursionError and NO record is emitted again.
+        """
+        install_log_redaction(["sk-secret-key-12345"])
+        ours = logging.getLogRecordFactory()
+
+        def foreign_factory(*args, **kwargs):
+            record = ours(*args, **kwargs)
+            record.tenant = "acme"
+            return record
+
+        logging.setLogRecordFactory(foreign_factory)
+        try:
+            install_log_redaction(["sk-secret-key-12345"])
+            record = _make_record("key is sk-secret-key-12345 here")
+        finally:
+            logging.setLogRecordFactory(ours)
+
+        # Redaction still applies through the foreign wrapper, and the wrapper it
+        # added survived — the second install left the slot alone.
+        assert "sk-secret-key-12345" not in record.msg
+        assert record.tenant == "acme"
+
+    def test_uninstall_leaves_a_foreign_wrapper_alone(self) -> None:
+        """Uninstall must not reach into a chain it does not own.
+
+        Ours is unreachable behind a third party's closure, so uninstall is a no-op
+        and redaction CONTINUES — the safe direction for a control that keeps secrets
+        out of the log. Unlinking their wrapper to get at ours is the alternative, and
+        it silently costs every later record whatever they added.
+        """
+        install_log_redaction(["sk-secret-key-12345"])
+        ours = logging.getLogRecordFactory()
+
+        def foreign_factory(*args, **kwargs):
+            record = ours(*args, **kwargs)
+            record.tenant = "acme"
+            return record
+
+        logging.setLogRecordFactory(foreign_factory)
+        try:
+            uninstall_log_redaction()
+            assert logging.getLogRecordFactory() is foreign_factory
+            record = _make_record("key is sk-secret-key-12345 here")
+            assert "sk-secret-key-12345" not in record.msg
+            assert record.tenant == "acme"
+        finally:
+            logging.setLogRecordFactory(ours)
+            uninstall_log_redaction()
+
+    def test_reinstall_adopts_the_new_patterns(self) -> None:
+        """A second install re-points the active filter instead of being a no-op."""
+        install_log_redaction(["first-secret-value"])
+        install_log_redaction(["second-secret-value"])
+
+        record = _make_record("a=first-secret-value b=second-secret-value")
+        assert "second-secret-value" not in record.msg
+        # The first install's patterns are replaced, not merged — one active filter.
+        assert "first-secret-value" in record.msg
+
+    def test_uninstall_restores_the_previous_factory(self) -> None:
+        before = logging.getLogRecordFactory()
+        install_log_redaction(["sk-secret-key-12345"])
+        uninstall_log_redaction()
+
+        assert logging.getLogRecordFactory() is before
+        assert "sk-secret-key-12345" in _make_record("key is sk-secret-key-12345").msg
+
+    def test_uninstall_without_install_is_a_noop(self) -> None:
+        before = logging.getLogRecordFactory()
+        uninstall_log_redaction()
+        assert logging.getLogRecordFactory() is before
+
+    def test_installed_factory_renders_exc_info_into_exc_text(self) -> None:
+        """``exc_info`` is cleared once the traceback is rendered and redacted.
+
+        Pinned because it is the destructive half of the wrapper: a handler must not
+        be able to re-render an unredacted traceback, and clearing the field is what
+        guarantees that. It is also why leaking the wrapper reds tests that assert a
+        log record kept its ``exc_info``.
+        """
+        install_log_redaction([])
+        try:
+            raise ValueError("Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig")
+        except ValueError:
+            record = _make_record("boom", exc_info=sys.exc_info())
+
+        assert record.exc_info is None
+        assert record.exc_text is not None
+        assert "eyJhbGciOiJSUzI1NiJ9" not in record.exc_text
+
+    def test_zero_vault_imports(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """log_redaction module does NOT import kiro_crew.secrets."""
-        import importlib
-        import sys
+        import kiro_crew
 
-        # Ensure fresh import
         mod_name = "kiro_crew.log_redaction"
-        if mod_name in sys.modules:
-            del sys.modules[mod_name]
+        # A fresh import is the only way to observe what the module pulls in, and it
+        # rebinds BOTH sys.modules and the parent package attribute — so undo covers
+        # both, or `kiro_crew.log_redaction` keeps pointing at the duplicate and one
+        # process-global chokepoint has two module objects. monkeypatch reverts even
+        # when the assertion below fails.
+        monkeypatch.setattr(kiro_crew, "log_redaction", sys.modules[mod_name])
+        monkeypatch.delitem(sys.modules, mod_name)
 
-        # Track what gets imported
         imported_before = set(sys.modules.keys())
         importlib.import_module(mod_name)
         imported_after = set(sys.modules.keys())

--- a/test/test_no_open_browser.py
+++ b/test/test_no_open_browser.py
@@ -9,7 +9,6 @@ Covers:
 from __future__ import annotations
 
 import json
-import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,16 +17,14 @@ import pytest
 from kiro_crew.config.loader import DashboardConfig, KiroCrewConfig
 
 
-def _load_from_raw_string(content: str) -> KiroCrewConfig:
-    """Write raw string content to a temp file and load."""
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".json",
-        delete=False,
-        encoding="utf-8",
-    ) as f:
-        f.write(content)
-        tmp = Path(f.name)
+def _load_from_raw_string(content: str, tmp_path: Path) -> KiroCrewConfig:
+    """Write raw *content* under *tmp_path* and load the config from it.
+
+    ``config_path`` is patched, so the name is arbitrary — what matters is that the
+    file lives under ``tmp_path``, which pytest removes for us.
+    """
+    tmp = tmp_path / "config.json"
+    tmp.write_text(content, encoding="utf-8")
 
     with patch("kiro_crew.config.loader.config_path", return_value=tmp):
         return KiroCrewConfig.load()
@@ -41,32 +38,29 @@ class TestAutoOpenBrowserConfig:
         cfg = DashboardConfig()
         assert cfg.auto_open_browser is True
 
-    def test_from_json_false(self) -> None:
+    def test_from_json_false(self, tmp_path: Path) -> None:
         """Loading config with auto_open_browser=false reads the value."""
         content = json.dumps({"dashboard": {"auto_open_browser": False}})
-        cfg = _load_from_raw_string(content)
+        cfg = _load_from_raw_string(content, tmp_path)
         assert cfg.dashboard.auto_open_browser is False
 
-    def test_from_json_true(self) -> None:
+    def test_from_json_true(self, tmp_path: Path) -> None:
         """Loading config with auto_open_browser=true reads the value."""
         content = json.dumps({"dashboard": {"auto_open_browser": True}})
-        cfg = _load_from_raw_string(content)
+        cfg = _load_from_raw_string(content, tmp_path)
         assert cfg.dashboard.auto_open_browser is True
 
-    def test_missing_key_defaults_true(self) -> None:
+    def test_missing_key_defaults_true(self, tmp_path: Path) -> None:
         """Missing auto_open_browser key defaults to True."""
         content = json.dumps({"dashboard": {}})
-        cfg = _load_from_raw_string(content)
+        cfg = _load_from_raw_string(content, tmp_path)
         assert cfg.dashboard.auto_open_browser is True
 
-    def test_roundtrip_serialization(self) -> None:
+    def test_roundtrip_serialization(self, tmp_path: Path) -> None:
         """auto_open_browser survives save/load roundtrip."""
         cfg = KiroCrewConfig()
         cfg.dashboard.auto_open_browser = False
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False, encoding="utf-8"
-        ) as f:
-            tmp = Path(f.name)
+        tmp = tmp_path / "config.json"
         with patch("kiro_crew.config.loader.config_path", return_value=tmp):
             cfg.save()
             loaded = KiroCrewConfig.load()


### PR DESCRIPTION
## What

**Pure cherry-pick** of #5039's squash commit `24775e7ff` onto release/0.4.0 (`git cherry-pick -x`, byte-identical, single commit). No adaptation needed — applied with zero conflicts.

## Why this branch needs it — it IS the insider.4 RC-gate failure

The `v0.4.0-insider.4` RC gate ([run 32546035806](https://github.com/kirodotdev/KiroCrew/actions/runs/32546035806)) failed **2 failed / 60154 passed**, and both failures are exactly the leaked-record-factory class this PR fixes:

- `test/test_log_redaction.py::TestInstallLogRedaction::test_redacts_via_record_factory` — RecursionError (factory stacking)
- `test/test_pid_lifecycle.py::TestFindOrphanMcpCandidates::test_unexpected_probe_error_keeps_traceback` — `exc_info` swallowed (`assert None is not None`)

The two prior RC killers (#4891 min-version parse, worktree maintenance.lock race) did NOT recur — this was the sole remaining failure class. With this cherry-pick the next RC (`v0.4.0-insider.5`) carries the fix.

## Verification

- `test/test_log_redaction.py` + `test/test_pid_lifecycle.py`: **150 passed** locally on this branch (includes both RC-gate failures)
- Cherry-pick purity: single commit, `-x` trailer, no content changes

**Why no screenshot:** logging/test-infrastructure fix; no UI surface.