### PR TITLE
fix(memory): run the config read-modify-write off the gateway loop

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -899,10 +899,12 @@ def update_config_locked(
 
     The locked primitive for the converted config.json writers and the required
     path for new config.json mutations.  Legacy writers that pre-date this
-    function (dashboard agents endpoint, updates.py, memory.py, security.py,
+    function (dashboard agents endpoint, updates.py, security.py,
     messaging.py, mcp.py, core.py STT) still use
     :func:`write_config_atomically` directly and rely on the in-process asyncio
-    ``_get_config_lock()`` only.
+    ``_get_config_lock()`` only.  ``memory.py`` was in that list and has been
+    converted; it now reaches this function through
+    ``dashboard/chat_utils.run_config_write``.
 
     Contract:
 

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -72,9 +72,11 @@ async def run_config_write(fn, /, *args, **kwargs):
     takes (covering CLI / boot-refresh / other-process writers), and the
     loop-side :func:`_get_config_lock` asyncio lock that the dashboard's legacy
     handlers still rely on *alone* (bare ``read_config_for_update`` +
-    ``write_config_atomically`` — e.g. the memory-settings PUT). A writer that
-    holds only one of the two can interleave with the other family and silently
-    revert its settings from a stale snapshot.
+    ``write_config_atomically``). A writer that holds only one of the two can
+    interleave with the other family and silently revert its settings from a
+    stale snapshot. The memory-settings PUT was such a writer and is not one
+    any more: ``handlers/memory.py`` routes every config mutation through this
+    helper.
 
     This helper is the one async entry point that holds both: the asyncio lock
     is acquired on the event loop, then ``fn`` (a sync callable that itself
@@ -85,7 +87,39 @@ async def run_config_write(fn, /, *args, **kwargs):
     from kiro_crew.dashboard.handlers.agents import _get_config_lock  # lazy: import cycle
 
     async with _get_config_lock():
-        return await asyncio.to_thread(fn, *args, **kwargs)
+        # The worker is SHIELDED and drained before the lock is released. A
+        # thread cannot be cancelled, so cancelling this coroutine -- a gateway
+        # shutdown cancelling the boot migration, a client disconnecting mid-PUT
+        # -- would otherwise unwind the `async with` while ``fn`` is still inside
+        # its read-modify-write. The next writer would then enter the critical
+        # section against a file the previous one is still rewriting, and land a
+        # config derived from a snapshot taken before it: the earlier caller's
+        # settings silently revert.
+        #
+        # The invariant is NOT "drain once after a cancellation": it is that once
+        # a cancellation has been observed, the lock cannot leave this block until
+        # the worker is done. A single drain does not give that -- awaiting the
+        # drain is itself a suspension point, so a SECOND cancel (a graceful
+        # shutdown escalating after its timeout, which is exactly when a config
+        # write is most likely to be in flight) unwinds the `async with` with the
+        # thread still writing. Hence the loop: every cancellation is absorbed,
+        # and only a finished future ends it.
+        #
+        # Draining cannot change WHETHER the write happens -- the thread runs to
+        # completion either way -- so this only decides whether the lock outlives
+        # it. The cancellation is re-raised once, never swallowed.
+        fut = asyncio.ensure_future(asyncio.to_thread(fn, *args, **kwargs))
+        cancelled = False
+        while True:
+            try:
+                result = await asyncio.shield(fut)
+            except asyncio.CancelledError:
+                cancelled = True
+                continue
+            break
+        if cancelled:
+            raise asyncio.CancelledError
+        return result
 
 
 # Per-turn compaction-failure backoff. See

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -16,10 +16,9 @@ from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
     config_path,
-    read_config_for_update,
-    write_config_atomically,
+    update_config_locked,
 )
-from kiro_crew.dashboard.handlers.agents import _get_config_lock
+from kiro_crew.dashboard.chat_utils import run_config_write
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.embeddings import (
     DOWNLOAD_ATTEMPTS_INTERACTIVE,
@@ -154,31 +153,44 @@ async def api_memory_settings(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         # Read existing config, update memory section only
-        async with _get_config_lock():
-            path = config_path()
+        # Validated BEFORE the transaction: none of it reads the config, and a
+        # 400 should not have taken the lock or occupied a worker.
+        updates: dict[str, Any] = {}
+        if "history_idle_hours" in body:
             try:
-                data = read_config_for_update(path)
-            except ConfigReadError:
-                # Fail closed: writing back a {} baseline would drop every other setting.
-                logger.exception("Refusing to save memory settings: config unreadable")
-                return web.json_response(
-                    {"error": "failed to read config file", "code": "config_unreadable"},
-                    status=500,
-                )
-            mem = data.setdefault("memory", {})
-            if "history_idle_hours" in body:
-                try:
-                    mem["history_idle_hours"] = max(0.5, float(body["history_idle_hours"]))
-                except (ValueError, TypeError):
-                    return web.json_response({"error": "history_idle_hours must be numeric"}, status=400)
-            if "history_max_days" in body:
-                try:
-                    mem["history_max_days"] = max(7, int(body["history_max_days"]))
-                except (ValueError, TypeError):
-                    return web.json_response({"error": "history_max_days must be an integer"}, status=400)
-            if "migrated" in body:
-                mem["migrated"] = bool(body["migrated"])
-            write_config_atomically(path, data)
+                updates["history_idle_hours"] = max(0.5, float(body["history_idle_hours"]))
+            except (ValueError, TypeError):
+                return web.json_response({"error": "history_idle_hours must be numeric"}, status=400)
+        if "history_max_days" in body:
+            try:
+                updates["history_max_days"] = max(7, int(body["history_max_days"]))
+            except (ValueError, TypeError):
+                return web.json_response({"error": "history_max_days must be an integer"}, status=400)
+        if "migrated" in body:
+            updates["migrated"] = bool(body["migrated"])
+
+        def _apply(data: dict) -> dict | None:
+            # Nothing recognised in the body: skip the write rather than reach
+            # into the memory section at all. A config whose `memory` is not an
+            # object (`{"memory": []}` -- the top level is all
+            # read_config_for_update validates) would otherwise raise
+            # AttributeError from `.update` and 500 a request that answered a
+            # successful no-op before. `None` tells update_config_locked there
+            # is no change to persist.
+            if not updates:
+                return None
+            data.setdefault("memory", {}).update(updates)
+            return data
+
+        try:
+            await run_config_write(update_config_locked, config_path(), mutate=_apply)
+        except ConfigReadError:
+            # Fail closed: writing back a {} baseline would drop every other setting.
+            logger.exception("Refusing to save memory settings: config unreadable")
+            return web.json_response(
+                {"error": "failed to read config file", "code": "config_unreadable"},
+                status=500,
+            )
         # Apply to running consolidator
         state: DashboardState = request.app["state"]
         if state.consolidator:
@@ -416,28 +428,33 @@ _migrate_lock = LoopBoundLock()
 async def _set_migrated(value: bool) -> None:
     """Set memory.migrated in config.json.
 
-    If an existing config.json can't be parsed, do NOT write — overwriting it
-    with only the migration flag would destroy every other recoverable setting
-    (provider, Slack, dashboard, ...). Boot-time auto-migration calls this on
-    every startup while migrated is false, so a malformed config must fail
-    closed (skip the flag, keep the file) and let a later boot retry once the
-    user has repaired it, rather than silently clobbering their config.
+    Routed through the repo's designated config-write path: ``run_config_write``
+    holds the loop-side asyncio lock while ``update_config_locked`` performs the
+    read-modify-write on a worker under the sidecar advisory flock, so this
+    serializes against BOTH writer generations -- the dashboard's other handlers
+    and the CLI / boot-refresh / other-process writers -- and none of it runs on
+    the gateway loop.
+
+    If an existing config.json can't be parsed, do NOT write -- overwriting it
+    with only the migration flag would destroy every other recoverable setting.
+    Boot-time auto-migration calls this on every startup while migrated is false,
+    so a malformed config must fail closed (skip the flag, keep the file) and let
+    a later boot retry once the user has repaired it, rather than silently
+    clobbering their config. ``update_config_locked`` defaults to
+    ``on_corrupt="fail"``, which is exactly that contract.
     """
-    async with _get_config_lock():
-        path = config_path()
-        if path.exists():
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-            except Exception:
-                logger.warning(
-                    "config.json is unparseable; skipping memory.migrated write to "
-                    "avoid clobbering other settings — will retry next boot"
-                )
-                return
-        else:
-            data = {}
+
+    def _apply(data: dict) -> dict:
         data.setdefault("memory", {})["migrated"] = value
-        write_config_atomically(path, data)
+        return data
+
+    try:
+        await run_config_write(update_config_locked, config_path(), mutate=_apply)
+    except ConfigReadError:
+        logger.warning(
+            "config.json is unparseable; skipping memory.migrated write to "
+            "avoid clobbering other settings — will retry next boot"
+        )
 
 
 # ModelDownloadManager.status steps → the setup_step vocabulary the shipped
@@ -460,21 +477,7 @@ async def _write_embed_model_config(path: str, dim: int) -> None:
     config.json is left alone rather than clobbered with only these two keys,
     which would destroy every other recoverable setting.
     """
-    async with _get_config_lock():
-        cfg_path = config_path()
-        if cfg_path.exists():
-            try:
-                data = json.loads(cfg_path.read_text(encoding="utf-8"))
-            except Exception:
-                logger.warning(
-                    "config.json is unparseable; refusing to write the embedding "
-                    "model path to avoid clobbering other settings"
-                )
-                raise ValueError(
-                    "config.json could not be parsed — fix it before changing the model"
-                )
-        else:
-            data = {}
+    def _apply(data: dict) -> dict:
         memory = data.setdefault("memory", {})
         if path:
             memory["embed_model_path"] = path
@@ -492,7 +495,18 @@ async def _write_embed_model_config(path: str, dim: int) -> None:
         memory.pop("embed_model_id", None)
         if dim > 0:
             memory["embedding_dim"] = dim
-        write_config_atomically(cfg_path, data)
+        return data
+
+    try:
+        await run_config_write(update_config_locked, config_path(), mutate=_apply)
+    except ConfigReadError as exc:
+        logger.warning(
+            "config.json is unparseable; refusing to write the embedding "
+            "model path to avoid clobbering other settings"
+        )
+        raise ValueError(
+            "config.json could not be parsed — fix it before changing the model"
+        ) from exc
 
 
 def _apply_embedding_model(store: object, raw: str, loop: "asyncio.AbstractEventLoop") -> None:
@@ -1075,21 +1089,23 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
         )
 
     # Persist config
-    path = config_path()
-    async with _get_config_lock():
-        try:
-            data = read_config_for_update(path)
-        except ConfigReadError:
-            # Fail closed: writing back a {} baseline would drop every other setting.
-            logger.exception("Refusing to persist embedding config: config unreadable")
-            _embedding_setup_status = {"step": "error", "error": "config unreadable"}
-            return web.json_response(
-                {"error": "failed to read config file", "code": "config_unreadable"}, status=500
-            )
-        data.setdefault("memory", {})["embedding_provider"] = "llama_cpp"
-        data["memory"]["embedding_dim"] = 1024
-        data["memory"]["migrated"] = True
-        write_config_atomically(path, data)
+
+    def _apply(data: dict) -> dict:
+        memory = data.setdefault("memory", {})
+        memory["embedding_provider"] = "llama_cpp"
+        memory["embedding_dim"] = 1024
+        memory["migrated"] = True
+        return data
+
+    try:
+        await run_config_write(update_config_locked, config_path(), mutate=_apply)
+    except ConfigReadError:
+        # Fail closed: writing back a {} baseline would drop every other setting.
+        logger.exception("Refusing to persist embedding config: config unreadable")
+        _embedding_setup_status = {"step": "error", "error": "config unreadable"}
+        return web.json_response(
+            {"error": "failed to read config file", "code": "config_unreadable"}, status=500
+        )
 
     # Apply migrated to running consolidator
     state = request.app["state"]

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import contextlib
 import inspect
 import json
 import threading
@@ -273,6 +274,99 @@ def _cfg(idle: float = 6.0, days: int = 30, migrated: bool = False) -> Any:
     cfg.memory.history_max_days = days
     cfg.memory.migrated = migrated
     return cfg
+
+
+class TestRunConfigWriteCancellation:
+    """``run_config_write`` must not hand the config lock on mid-write.
+
+    The worker is a thread and cannot be cancelled, so the only question is
+    whether the lock outlives it. Ordering is forced with events, never slept
+    for.
+    """
+
+    @staticmethod
+    def _run(coro):
+        return asyncio.run(coro)
+
+    def test_a_repeated_cancellation_still_drains_before_unlocking(self):
+        """A SECOND cancel while draining must not release the lock either.
+
+        Awaiting the drain is itself a suspension point. A graceful shutdown
+        that escalates after its timeout cancels twice -- and that is exactly
+        when a config write is most likely to be in flight -- so a drain that
+        absorbs only the first cancellation unwinds the ``async with`` with
+        the thread still inside its read-modify-write.
+
+        The assertion is on ORDER, not on the number of cancels: the second
+        writer must not enter the critical section until the worker returns.
+        """
+        from kiro_crew.dashboard.chat_utils import run_config_write
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        in_write = threading.Event()
+        finish = threading.Event()
+        order: list[str] = []
+
+        def _slow_write(*_a, **_k):
+            order.append("worker-start")
+            in_write.set()
+            finish.wait(timeout=10)
+            order.append("worker-end")
+
+        async def _first():
+            # `run_config_write` acquires the lock itself; wrapping the call in a
+            # second acquire would deadlock on a non-reentrant asyncio.Lock.
+            await run_config_write(_slow_write)
+
+        async def _second():
+            async with _get_config_lock():
+                order.append("second-ran")
+
+        async def _drive():
+            first = asyncio.create_task(_first())
+            assert await asyncio.to_thread(in_write.wait, 10), "worker never entered"
+
+            # Cancel TWICE: the second lands while the drain is awaiting.
+            first.cancel()
+            for _ in range(5):
+                await asyncio.sleep(0)
+            first.cancel()
+
+            second = asyncio.create_task(_second())
+            # Yield generously rather than sleeping: had the lock been released,
+            # the second writer would have run by now.
+            for _ in range(200):
+                await asyncio.sleep(0)
+            early = "second-ran" in order
+
+            finish.set()
+            cancelled = False
+            try:
+                await first
+            except asyncio.CancelledError:
+                cancelled = True
+            await asyncio.wait_for(second, timeout=10)
+            return early, cancelled, list(order)
+
+        early, cancelled, seen = self._run(_drive())
+
+        assert not early, (
+            "the config lock was handed to the next writer while the twice-cancelled "
+            "one's worker was still writing: %r" % (seen,)
+        )
+        assert seen.index("worker-end") < seen.index("second-ran"), (
+            "the second writer entered before the worker finished: %r" % (seen,)
+        )
+        assert cancelled, "the cancellation must propagate, not be swallowed"
+
+    def test_an_uncancelled_call_returns_the_worker_result(self):
+        """The loop must not change the ordinary path: the value still comes back."""
+        from kiro_crew.dashboard.chat_utils import run_config_write
+
+        async def _drive():
+            return await run_config_write(lambda a, b=0: a + b, 40, b=2)
+
+        assert self._run(_drive()) == 42
 
 
 class TestMemorySettings:
@@ -1747,3 +1841,280 @@ class TestMemoryGraphFailure:
         resp = await mem_mod.api_memory_graph(_make_request(state))
         assert resp.status == 500
         assert _body(resp) == {"error": "failed to build memory graph"}
+
+
+class TestConfigWritesRunOffTheEventLoop:
+    """The config read-modify-write must not run on the gateway loop.
+
+    Reading ``config.json``, parsing it, and writing it back through
+    ``write_config_atomically`` (a tmp-file write plus a rename, which can
+    fsync) is all synchronous file I/O. Inline it stalls every other session for
+    its duration -- the class the repo has been closing site by site (#4118,
+    #3803, #4550).
+
+    The load-bearing property is not merely "off the loop" but **the whole
+    transaction on ONE worker**. Offloading only the read would put a suspension
+    point between the read and the write-back while the file is unguarded on
+    disk, so an external editor or CLI landing in that gap would be silently
+    overwritten by a write derived from state nobody re-checked. The gap is zero
+    today because the sequence is synchronous, and these tests are what keep it
+    zero.
+
+    Every seam here is one BOTH shapes reach -- ``write_config_atomically`` is
+    called by the hand-rolled version too -- and each wrapper delegates to the
+    real function, so the assertions are about where real work ran rather than
+    about which helper happens to be patched.
+    """
+
+    def _instrument(self, monkeypatch, tmp_path, initial: str = '{"existing": "kept"}'):
+        """Record which thread each half of the transaction runs on.
+
+        Wrapped at ``update_config_locked`` -- the designated locked primitive --
+        and at the ``write_config_atomically`` it calls internally, so both the
+        read and the write are observed inside the SAME critical section. Both
+        wrappers delegate to the real function, so the file really is written.
+        """
+        import threading
+
+        from kiro_crew.config import loader as loader_mod
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text(initial, encoding="utf-8")
+
+        seen: dict[str, Any] = {"read": [], "write": [], "data": None}
+        real_locked = mem_mod.update_config_locked
+        real_write = loader_mod.write_config_atomically
+
+        def _locked(path=None, **kwargs):
+            seen["read"].append(threading.get_ident())
+            return real_locked(path, **kwargs)
+
+        def _write(path, data, **kwargs):
+            seen["write"].append(threading.get_ident())
+            seen["data"] = data
+            return real_write(path, data, **kwargs)
+
+        monkeypatch.setattr(mem_mod, "update_config_locked", _locked)
+        monkeypatch.setattr(loader_mod, "write_config_atomically", _write)
+        monkeypatch.setattr(mem_mod, "config_path", lambda: cfg)
+        return seen, cfg
+
+    @staticmethod
+    def _assert_one_worker(seen, loop_thread) -> None:
+        assert seen["write"], "the config write never ran"
+        assert seen["write"][0] != loop_thread, (
+            "the config write ran on the gateway loop, stalling every other "
+            "session for a tmp-write plus rename"
+        )
+        assert seen["read"], "the transaction did not go through update_config_locked"
+        assert seen["read"][0] != loop_thread, "the config read ran on the gateway loop"
+        assert seen["read"][0] == seen["write"][0], (
+            "the read and the write ran on different threads, so the file was "
+            "unguarded between them -- an external writer landing in that gap "
+            "would be silently overwritten"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_migrated_runs_its_whole_transaction_on_one_worker(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        import threading
+
+        seen, cfg = self._instrument(monkeypatch, tmp_path)
+
+        await mem_mod._set_migrated(True)
+
+        self._assert_one_worker(seen, threading.get_ident())
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert on_disk["memory"]["migrated"] is True
+        assert on_disk["existing"] == "kept", "the rest of the config was dropped"
+
+    @pytest.mark.asyncio
+    async def test_settings_put_runs_its_whole_transaction_on_one_worker(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        import threading
+
+        seen, cfg = self._instrument(monkeypatch, tmp_path)
+        monkeypatch.setattr(mem_mod.KiroCrewConfig, "load", staticmethod(lambda: MagicMock()))
+
+        state = _make_state(consolidator=None)
+        req = _make_request(state, method="PUT", json_body={"history_max_days": 30})
+        resp = await mem_mod.api_memory_settings(req)
+
+        assert resp.status == 200
+        self._assert_one_worker(seen, threading.get_ident())
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert on_disk["memory"]["history_max_days"] == 30
+        assert on_disk["existing"] == "kept"
+
+    @pytest.mark.asyncio
+    async def test_embed_model_config_runs_its_whole_transaction_on_one_worker(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        import threading
+
+        seen, cfg = self._instrument(monkeypatch, tmp_path)
+
+        await mem_mod._write_embed_model_config("/models/e5.gguf", 768)
+
+        self._assert_one_worker(seen, threading.get_ident())
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert on_disk["memory"]["embed_model_path"] == "/models/e5.gguf"
+        assert on_disk["memory"]["embedding_dim"] == 768
+        assert on_disk["existing"] == "kept"
+
+    # ── fail-closed contracts: preservation, green on both shapes ────────────
+
+    @pytest.mark.asyncio
+    async def test_set_migrated_still_refuses_to_write_an_unreadable_config(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """A ``{}`` baseline written back would destroy every other setting.
+
+        Driven with a genuinely unparseable file rather than a raising stub, so
+        it exercises the same refusal in either shape.
+        """
+        seen, cfg = self._instrument(monkeypatch, tmp_path, initial="{oops")
+
+        await mem_mod._set_migrated(True)  # must not raise: boot retries next time
+
+        assert seen["write"] == [], "an unreadable config was overwritten anyway"
+        assert cfg.read_text(encoding="utf-8") == "{oops", "the file was modified"
+
+    @pytest.mark.asyncio
+    async def test_settings_put_still_fails_closed_on_an_unreadable_config(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        seen, cfg = self._instrument(monkeypatch, tmp_path, initial="{oops")
+        monkeypatch.setattr(mem_mod.KiroCrewConfig, "load", staticmethod(lambda: MagicMock()))
+
+        state = _make_state(consolidator=None)
+        req = _make_request(state, method="PUT", json_body={"history_max_days": 30})
+        resp = await mem_mod.api_memory_settings(req)
+
+        assert resp.status == 500
+        assert json.loads(resp.body)["code"] == "config_unreadable"
+        assert seen["write"] == []
+        assert cfg.read_text(encoding="utf-8") == "{oops"
+
+    @pytest.mark.asyncio
+    async def test_embed_model_config_still_raises_on_an_unreadable_config(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        seen, cfg = self._instrument(monkeypatch, tmp_path, initial="{oops")
+
+        with pytest.raises(ValueError, match="could not be parsed"):
+            await mem_mod._write_embed_model_config("/models/e5.gguf", 768)
+
+        assert seen["write"] == []
+        assert cfg.read_text(encoding="utf-8") == "{oops"
+
+    @pytest.mark.asyncio
+    async def test_settings_put_rejects_a_bad_body_without_touching_the_config(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Validation runs ahead of the transaction; a 400 must not write."""
+        seen, cfg = self._instrument(monkeypatch, tmp_path)
+        monkeypatch.setattr(mem_mod.KiroCrewConfig, "load", staticmethod(lambda: MagicMock()))
+
+        state = _make_state(consolidator=None)
+        req = _make_request(state, method="PUT", json_body={"history_max_days": "abc"})
+        resp = await mem_mod.api_memory_settings(req)
+
+        assert resp.status == 400
+        assert seen["write"] == [], "a rejected body still wrote the config"
+        assert cfg.read_text(encoding="utf-8") == '{"existing": "kept"}'
+
+    @pytest.mark.asyncio
+    async def test_cancelling_the_caller_does_not_release_the_lock_early(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """A cancelled caller must not hand the lock over mid-transaction.
+
+        A thread cannot be cancelled. Without the shield, cancelling this
+        coroutine unwinds ``async with _get_config_lock()`` while the worker is
+        still inside its read-modify-write, so the next writer enters the
+        critical section against a file the previous one is still rewriting and
+        lands a config derived from a pre-write snapshot -- the first caller's
+        settings silently revert.
+
+        Ordering is forced with events, never slept for: the worker parks inside
+        the transaction, the caller is cancelled while it is parked, and a second
+        writer then tries to take the lock. It must not get it until the first
+        worker has finished.
+        """
+        import threading
+
+        from kiro_crew.dashboard.chat_utils import run_config_write
+
+        in_txn = threading.Event()
+        finish = threading.Event()
+        order: list[str] = []
+
+        def _slow_writer():
+            order.append("worker-start")
+            in_txn.set()
+            finish.wait(timeout=10)
+            order.append("worker-end")
+
+        async def _second_writer():
+            order.append("second-waiting")
+            await run_config_write(lambda: order.append("second-ran"))
+
+        first = asyncio.create_task(run_config_write(_slow_writer))
+        assert await asyncio.to_thread(in_txn.wait, 10), "the worker never entered"
+
+        first.cancel()
+        second = asyncio.create_task(_second_writer())
+        # Yield generously rather than sleeping: if the lock had been released
+        # the second writer would have run by now.
+        for _ in range(200):
+            await asyncio.sleep(0)
+
+        assert "second-ran" not in order, (
+            "the config lock was handed to the next writer while the cancelled "
+            "caller's worker was still inside the transaction: %r" % (order,)
+        )
+
+        finish.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await first
+        await asyncio.wait_for(second, timeout=10)
+
+        assert order.index("worker-end") < order.index("second-ran"), (
+            "the second writer entered before the first worker finished: %r" % (order,)
+        )
+        assert first.cancelled(), "the cancellation must be re-raised, never swallowed"
+
+    @pytest.mark.asyncio
+    async def test_an_empty_settings_body_does_not_crash_on_a_non_object_section(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """``{"memory": []}`` plus ``PUT {}`` stays a successful no-op.
+
+        ``read_config_for_update`` validates only that the TOP level is an
+        object, so a hand-edited ``memory`` that is a list reaches the mutate.
+        Reaching into it unconditionally calls ``list.update`` -> AttributeError
+        -> 500, where the pre-existing contract answered 200 and changed nothing.
+
+        Scope note: a NON-empty update against the same malformed section still
+        raises, exactly as it did before this PR. That is pre-existing and is
+        deliberately not papered over here -- fixing it would hide which
+        behaviour this change is responsible for.
+        """
+        seen, cfg = self._instrument(monkeypatch, tmp_path, initial='{"memory": []}')
+        monkeypatch.setattr(mem_mod.KiroCrewConfig, "load", staticmethod(lambda: MagicMock()))
+
+        state = _make_state(consolidator=None)
+        req = _make_request(state, method="PUT", json_body={})
+        resp = await mem_mod.api_memory_settings(req)
+
+        assert resp.status == 200, (
+            "an empty body against a non-object memory section stopped being a "
+            "no-op: %r" % (resp.body,)
+        )
+        assert seen["write"] == [], "a no-op PUT rewrote the config"
+        assert json.loads(cfg.read_text(encoding="utf-8")) == {"memory": []}, (
+            "the malformed section was rewritten"
+        )


### PR DESCRIPTION
## Problem / Motivation

Every `config.json` update in `dashboard/handlers/memory.py` reads the file, changes one key, and writes the whole thing back — **on the gateway event loop**. All three parts block: the read, the JSON parse, and `write_config_atomically`, which is a tmp-file write plus a rename and can fsync. While it runs, every other session on the gateway is stalled.

Three sites, all under `_get_config_lock()`, none offloaded:

- `api_memory_settings` (PUT `/api/memory/settings`)
- `_set_migrated` — called on **every boot** while `migrated` is false, and from the Slack gateway
- `_write_embed_model_config`

This is the class the repo has been closing site by site (#4118, #3803, #4550), and #4946's First Principles review named `handlers/memory.py` in its counted list of remaining sites.

## Why it matters

The boot path is the sharp end: `_set_migrated` runs on every startup while the flag is false, so the stall lands exactly when the gateway is trying to bring sessions up.

Two of the three sites also hand-roll a reader the module already imports. `read_config_for_update` is documented as the companion to `write_config_atomically` and has 27 call sites; `api_memory_settings` already uses it 200 lines above. `_set_migrated` and `_write_embed_model_config` instead do `try: json.loads(path.read_text()) except Exception:`.

Two behaviours follow from that divergence. The shared helper raises `ConfigReadError` for a **non-object** top level (`[]`, `"x"`, `3`); the hand-rolled version accepts it and then calls `data.setdefault(...)`, which raises `AttributeError` on a list — an uncaught crash where the intent was a fail-closed refusal. The helper also names `UnicodeDecodeError` explicitly, which is a `ValueError` and not an `OSError`.

## What changed (motivation → approach → change)

**Motivation** — take the file I/O off the shared loop without widening any window.

**Approach** — route every config read-modify-write in this module through the
repo's **designated** path. `update_config_locked` documents itself as "the
required path for new config.json mutations" and names `memory.py` in its list of
legacy writers to convert; `run_config_write` is the async entry point holding
BOTH locks — the loop-side asyncio lock and the sidecar advisory flock — and names
"the memory-settings PUT" as a bare writer holding only one of them.

```python
await run_config_write(update_config_locked, config_path(), mutate=_apply)
```

**Change** — four sites converted: `api_memory_settings`, `_set_migrated`,
`_write_embed_model_config`, and the embedding-enable persist, which was a bare
on-loop read-modify-write holding only the asyncio lock.

**An earlier revision of this PR added its own helper, and that was wrong.** It
was a fourth spelling of a path the repo had already designated, and — the part
that matters — it held only the in-process asyncio lock while this PR's own body
claimed it protected against "an external editor, a CLI command, or another
process". Those writers serialize on the flock, which that helper never took, so
the stated guarantee was not the implemented one. Routing through
`update_config_locked` makes the claim true instead of restating it.

**Cancellation now drains the worker before the lock is released.** A thread
cannot be cancelled, so cancelling the caller — gateway shutdown cancelling the
boot migration, a client disconnecting mid-PUT — unwound `async with` while the
worker was still inside its read-modify-write, letting the next writer enter
against a file still being rewritten and land a config derived from a pre-write
snapshot. Fixed in `run_config_write` itself rather than at a call site, so every
consumer gets it. Draining cannot change *whether* the write happens — the thread
runs to completion either way — so it only decides whether the lock outlives it;
the cancellation is re-raised, never swallowed.

**A no-op settings PUT no longer reaches into the memory section.**
`read_config_for_update` validates only the top level, so a hand-edited
`{"memory": []}` reaches the mutate; with an empty body the previous revision
called `list.update` and 500'd a request that answered 200 before. The mutate now
returns `None` — which `update_config_locked` reads as "no change to persist" —
when there is nothing to apply. A NON-empty update against the same malformed
section still raises, exactly as before this PR: pre-existing, and deliberately
not papered over here.

Two production files: this module, and the drain in `run_config_write`.



## Tests

| Test | Behavior locked in |
|---|---|
| `test_set_migrated_runs_its_whole_transaction_on_one_worker` | read and write both off-loop **and on the same thread**, config content preserved |
| `test_settings_put_runs_its_whole_transaction_on_one_worker` | same, through the real PUT handler |
| `test_embed_model_config_runs_its_whole_transaction_on_one_worker` | same, and the model keys land |
| `test_set_migrated_still_refuses_to_write_an_unreadable_config` | fail-closed: no write, file untouched, no raise |
| `test_settings_put_still_fails_closed_on_an_unreadable_config` | 500 + `config_unreadable`, no write |
| `test_embed_model_config_still_raises_on_an_unreadable_config` | `ValueError`, no write |
| `test_settings_put_rejects_a_bad_body_without_touching_the_config` | a 400 writes nothing |
| `test_cancelling_the_caller_does_not_release_the_lock_early` | a cancelled caller's worker is drained **before** the lock is handed on, and the cancellation is re-raised |
| `test_an_empty_settings_body_does_not_crash_on_a_non_object_section` | `{"memory": []}` + `PUT {}` stays a 200 no-op |

The same-thread assertion is the point, not a detail: "off the loop" alone would also be satisfied by a build that offloaded the halves separately, which is the shape that widens the clobber window.

Fail-before / pass-after, with only `memory.py` reverted:

```
AssertionError: the config write ran on the gateway loop, stalling every other
session for a tmp-write plus rename

3 failed, 4 passed
```

The two review findings have their own controls, each reverting one thing:

```
# shield removed from run_config_write
AssertionError: the config lock was handed to the next writer while the
cancelled caller's worker was still inside the transaction:
  ['worker-start', 'second-waiting', 'second-ran']

# empty-updates guard removed
AttributeError: 'list' object has no attribute 'update'
```

The four fail-closed / validation tests pass on **both** trees by design — those contracts are unchanged by this PR, so they are preservation coverage and are reported as such rather than folded into the fail-before count.

**The first version of this control was invalid and was fixed rather than kept.** It patched `read_config_for_update`, which the hand-rolled sites never call, so the reverted build failed with "the transaction did not run" and an `IndexError` — a missing patch target, not the defect. Every seam is now one **both** shapes reach (`write_config_atomically` is called by the old code too), each wrapper delegates to the real function, the config file is real, and the unreadable cases use a genuinely unparseable file instead of a raising stub.

```
pytest test/test_run_config_write.py test/test_handlers_memory_coverage.py \
       test/test_embedding_model_apply.py test/test_enable_embeddings_faiss.py \
       test/test_slack_gateway_more_coverage.py test/test_config_loader.py -q
                                                    626 passed, 3 skipped

# run_config_write has 20 other call sites across the Slack modules and the
# drain changes behaviour for all of them, so they were run too
pytest test/test_slack_events_coverage.py test/test_slack_handler.py \
       test/test_slack_handler_coverage.py test/test_slack_interactions_coverage.py -q
                                                                867 passed
```

216 of those existed before this change and are untouched by it.

Gates: `flake8` · `isort --check-only` · `mypy --platform linux` (no issues) · `scripts/check_black_formatting.py` (2 files in scope, both pre-existing baseline entries, neither reformatted).

## Manual verification

N/A — unit coverage sufficient: the assertion is on which thread the real `write_config_atomically` and `read_config_for_update` executed on, driven through the real handler and the real boot-path coroutine. A loop stall is not observable by hand without a slow filesystem, which is exactly what the thread assertion replaces.

## Related Issues

Fixes #5057.

One of the sites counted by the First Principles review on #4946; continues #4118 / #3803 / #4550.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no documented behaviour changes. Why the whole transaction moves together is explained on the helper.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
