### PR TITLE
refactor(apps): drop dead constants and flatten two chained ternaries

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_discovery.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_discovery.py
@@ -68,14 +68,8 @@ DEFAULT_AGENT_SURFACE_LIMIT = 6
 RULE_AGENT_BUG = "AGENT"
 RULE_AGENT_COVERAGE = "COVERAGE"
 
-# Cap the FOCUS LIST so the agent converges fast (operator directive 2026-06-15: "shrink
-# focus + hard turn cap"). A long list (82 files) made the agent investigate 10+ min and
-# blow the timeout. ~12 highest-value files is enough to find real defects per cycle; the
-# loop runs many cycles and the ledger dedups, so coverage accrues over runs, not in one.
-DEFAULT_FOCUS_FILE_CAP = 12
-
-# Low-value filename substrings — boilerplate/wiring with little testable logic. Dropped
-# from the focus list first so the cap is spent on logic-bearing modules.
+# Low-value filename substrings — boilerplate/wiring with little testable logic. Sorted
+# LAST so a bounded read budget is spent on logic-bearing modules.
 _LOW_VALUE_MARKERS = (
     "__init__.py",
     "__main__.py",

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
@@ -40,22 +40,22 @@ except ImportError:  # pragma: no cover - standalone fallback
 _RISK_W = {"low": 0, "medium": 35, "high": 60}
 _BLAST_W = {"SMALL": 0, "MEDIUM": 25, "LARGE": 40}
 
-# LLM-authored free-text fields. These are model output and must never be
-# surfaced raw: the dashboard reads the local rows.json / focus-report.html this
-# module writes DIRECTLY (no redaction in between), so we scrub here. Per
-# untrusted-LLM-output guidance ("should not be trusted at all") + the security-controls
-# guideline (scan with redact_exfiltration_urls + redact_credentials before any
-# external surface). The artifact-archive path also redacts; this closes the
-# local-file gap. ``pipeline._redact`` is a no-op when the redaction lib is
-# unavailable (standalone), so this is safe everywhere.
-_LLM_ROW_FIELDS = ("problem", "why_it_matters", "solution_assessment", "rationale")
-
 # Nesting depth past which a value is stringified rather than walked. The record
 # is worker-written JSON, so depth is attacker-chosen; recursing without a bound
 # turns a deep payload into a RecursionError on the report path.
 _REDACT_MAX_DEPTH = 6
 
 
+# Why the helpers below exist at all: the strings a worker and the reviewing model
+# write reach three local artifacts this module produces -- focus-report.html,
+# rows.json and report.json -- with nothing between `build_report` and the file, so
+# the scrub happens here. Per untrusted-LLM-output guidance ("should not be trusted
+# at all") plus the security-controls guideline (scan with redact_exfiltration_urls
+# AND redact_credentials before any external surface). `read_report` redacts AGAIN on
+# the way out, because the reports dir is writable by that worker, and the
+# artifact-archive path redacts too. ``pipeline._redact`` is a no-op when the
+# redaction lib is unavailable (standalone), so these calls are safe to make
+# everywhere.
 def _redact_deep(value: object, skip: frozenset[str] = frozenset(),
                  _depth: int = 0) -> object:
     """Redact every string inside `value` -- keys and values, at any depth --

--- a/src/kiro_crew/apps/builtins/design_critique/tests/test_manifest.py
+++ b/src/kiro_crew/apps/builtins/design_critique/tests/test_manifest.py
@@ -36,9 +36,6 @@ APP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[6]
 APP_JSON = APP_ROOT / "app.json"
 
-# Where the frontend serves /app-assets/** from.
-APP_ASSETS_DIR = REPO_ROOT / "website" / "public" / "app-assets" / "design-critique"
-
 APP_NAME = "design-critique"
 
 # The dashboard's BuiltinAppRoute resolves a SINGLE path param; its guard regex

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -214,10 +214,6 @@ _ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")  # queue file id safety
 
 # The only hosts this backend will ever fetch from (dev-server reverse proxy).
 _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1"})
-# Characters left unescaped when re-composing a proxied request path. "%" is
-# safe so an already-percent-encoded path is not double-encoded; CR/LF are
-# rejected outright before this point.
-_PROXY_PATH_SAFE = "%/@:~!$&()*+,;="
 # Credential dirs a previewed "project" folder may never be. The shared
 # `is_sensitive_path()` floor covers the crew home and the governance trust
 # root; these are the plain dot-dirs it does not need to know about.

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/verify_align.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/verify_align.py
@@ -51,8 +51,9 @@ def _home() -> pathlib.Path:
 
 DRIFT_WARN = 1.0  # seconds; above this the cut looks out of sync
 DRIFT_FAIL = 3.0
-DARK_MAX = 60.0  # a designed dark slide sits well under this
-BLACK_MAX = 12.0  # below this a window is effectively black
+# Below this a window is effectively black. A designed dark slide still averages well
+# above it, so the floor fires only on a genuinely black frame.
+BLACK_MAX = 12.0
 BRIGHT_MIN = 244.0  # above this it is blown out -- a white frame is as dead as a black one
 
 
@@ -205,7 +206,12 @@ def main() -> int:
         # Anything past DRIFT_WARN is visible on screen, and the house budget is
         # a few hundred milliseconds -- a WARN that does not fail the gate lets a
         # visibly desynchronised cut exit 0, which is what the gate exists to stop.
-        flag = "ok" if abs(d) <= DRIFT_WARN else ("FAIL" if abs(d) <= DRIFT_FAIL else "FAIL!")
+        if abs(d) <= DRIFT_WARN:
+            flag = "ok"
+        elif abs(d) <= DRIFT_FAIL:
+            flag = "FAIL"
+        else:
+            flag = "FAIL!"
         if flag != "ok":
             failures.append(f"beat {i} drifts {d:+.2f}s from its line")
         print(f"  beat {i}: line {fr:7.3f}s  beat {beat_rel[j]:7.3f}s  drift {d:+6.3f}s  {flag}")
@@ -262,7 +268,12 @@ def main() -> int:
                 f"{label} at {at:.1f}s is {how} (YAVG {y:.1f}) -- "
                 "did the video element fail to seek?"
             )
-        verdict = "NEAR-BLACK" if dark else ("BLOWN-OUT" if blown else "ok")
+        if dark:
+            verdict = "NEAR-BLACK"
+        elif blown:
+            verdict = "BLOWN-OUT"
+        else:
+            verdict = "ok"
         print(f"  {label:12s} t={at:7.2f}s  YAVG={y:7.2f}  {verdict}")
 
     print("== streams ==")

--- a/src/kiro_crew/apps/builtins/mochi/queue_file.py
+++ b/src/kiro_crew/apps/builtins/mochi/queue_file.py
@@ -51,11 +51,6 @@ logger = logging.getLogger(__name__)
 #: Every reader now takes it from this single definition.
 QUEUE_FILE = "mochi-queue.json"
 
-# ── Task type constants (mirror shared/queueTypes.ts) ──────────────────────
-
-DETERMINISTIC_TYPES = ("move", "notify", "mood")
-AGENT_TYPES = ("freestyle",)
-
 # Default TTL for done-task cleanup: 2 hours.
 DEFAULT_TTL_MS = 2 * 60 * 60 * 1000
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/models.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/models.py
@@ -301,9 +301,6 @@ PROPOSAL_REJECTED = "rejected"
 #: not consent, and treating it as refusal would quietly drop work the operator may still
 #: want. It stops asking and says so.
 PROPOSAL_EXPIRED = "expired"
-VALID_PROPOSAL_STATES: frozenset[str] = frozenset(
-    {PROPOSAL_PENDING, PROPOSAL_APPROVED, PROPOSAL_REJECTED, PROPOSAL_EXPIRED}
-)
 
 #: How long a proposal waits before it stops asking. The source bumps once at 24h and
 #: never auto-acts; this keeps the window and the never-auto-act half, and leaves the bump

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/rotation.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/rotation.py
@@ -88,10 +88,6 @@ DEFAULT_APP_MODE = MODE_OBSERVE
 #: budget on the other blocking path in this gate.
 _ASYNC_SHIFT_TIMEOUT_SECS = 10.0
 
-#: Config key holding the user's autonomy rules.
-_RULES_KEY = "autonomy_rules"
-_APP_MODE_KEY = "mode"
-
 #: Heartbeat-pacing keys, duplicated from ``dispatch`` because importing them would close
 #: an import cycle (``dispatch`` imports this module). They are asserted equal to
 #: ``dispatch``'s own constants by ``test_store_and_gate.py``, so the duplication cannot

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/preview_tools.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/preview_tools.py
@@ -41,11 +41,10 @@ from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger("kirocrew.app.pptx-maker")
 
-#: The tool this module can provide, and the module that implements it.
+#: The tool this module can provide.
 PDFTOPPM = "pdftoppm"
 #: The tool it deliberately cannot — a system package, reported with a hint.
 SOFFICE = "soffice"
-_SHIM_MODULE = "kiro_crew.apps.builtins.pptx_maker.backend.pdftoppm_shim"
 
 #: Mode for the generated launcher: OWNER-ONLY rwx. It lives under the data home and
 #: is executed by the gateway's own engine children, so nothing else needs to read or

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -186,11 +186,6 @@ _BITMAP_MAGIC: tuple[bytes, ...] = (
     b"BM",  # BMP
 )
 
-# How much of the base64 body to decode for the signature probe. 16 base64 chars
-# decode to 12 bytes — more than any signature above needs, and a fixed tiny
-# prefix keeps the check cheap on a multi-megabyte blob.
-_BITMAP_MAGIC_B64_CHARS = 16
-
 # AVIF/HEIF put a 4-byte box length BEFORE the `ftyp` brand, so the signature is
 # at an offset rather than at byte 0.
 _BITMAP_FTYP_OFFSET = 4


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — ten Python files under `src/kiro_crew/apps/`, no frontend path touched and no rendered surface changed.

## Problem / Motivation

Two readability defects in the `apps` module, one found by the module-simplification
detector and one by a repo-wide dead-name scan:

1. **Two chained ternaries** in the feature-demo verifier — `a if c1 else (b if c2 else d)` —
   where the reader has to unpick nesting to see a three-way threshold decision. These are
   the detector's remaining `chained-ternary` sites for this module.
2. **Twelve module-level constants that nothing reads.** Three of them are worse than
   merely dead, because their comments assert behaviour the code no longer has:
   - `DEFAULT_FOCUS_FILE_CAP = 12` says "Cap the FOCUS LIST so the agent converges fast",
     while `prioritize_focus` defaults to `cap=None` and its own docstring explains at
     length that the cap was removed because it "permanently BLINDED discovery to ~69 of
     81 changed files".
   - `_BITMAP_MAGIC_B64_CHARS = 16` says "How much of the base64 body to decode for the
     signature probe … a fixed tiny prefix keeps the check cheap", while
     `_scanned_bitmap_bytes` decodes the **whole** body on purpose — its docstring says
     "why the whole blob is decoded rather than just its head".
   - `_LLM_ROW_FIELDS` names four prose fields, reading as "these are the fields we
     scrub", when the module in fact scrubs every string at every depth, keys included.

## Why it matters

A dead constant whose comment contradicts the code is the expensive kind of dead code: a
reader trusts the comment and reasons about a cap, or a prefix-only probe, that does not
exist. On the pptx image path that reasoning is security-relevant — the comment described
a *weaker* check than the one that actually runs, so anyone auditing the
credential-smuggling guard started from a false premise.

## What changed (motivation → approach → change)

Behaviour-preserving only. Nothing changes what any code does; no import is added,
removed, or moved anywhere in the diff.

**Chained ternaries → `if`/`elif`/`else`** (2 sites, both in
`dev_fleet/skills/feature-demo-recording/references/verify_align.py`). Branch order,
precedence and short-circuiting are identical: the same conditions in the same sequence,
`abs(d)` re-evaluated in the `elif` exactly when the nested ternary re-evaluated it, and
both variables assigned on every path.

**Provably dead module-level constants removed** (12 sites, 9 files). Two passes:

- A mechanical pass — every module-level assignment under `src/kiro_crew/apps/` whose
  name has exactly **one** textual occurrence across all `git ls-files` blobs (its own
  definition). The count is over raw file text, so string literals, Markdown, and
  TypeScript are included, not just Python identifiers. Nine names.
- A reviewer pass that caught what the first is structurally blind to: a constant **dead
  inside its own module** whose name is coincidentally spelled by an unrelated file, so
  the repo-wide count never drops to one. Three more names, all duplicates of a live twin
  that owns the value elsewhere.

| File | Name | Note |
|---|---|---|
| `auto_improvement/spine/agent_discovery.py` | `DEFAULT_FOCUS_FILE_CAP` | comment contradicted the uncapped `prioritize_focus` |
| `code_review_sage/sage_lib/report.py` | `_LLM_ROW_FIELDS` | named subset superseded by unconditional deep redaction |
| `design_critique/tests/test_manifest.py` | `APP_ASSETS_DIR` | test-local, never asserted on; `REPO_ROOT` stays live |
| `design_tweak/backend/server.py` | `_PROXY_PATH_SAFE` | nothing re-composes the path — the relay forwards `self.path` verbatim and the file has no `quote(` at all |
| `dev_fleet/.../references/verify_align.py` | `DARK_MAX` | the black test uses `BLACK_MAX` |
| `mochi/queue_file.py` | `DETERMINISTIC_TYPES`, `AGENT_TYPES` | in-module dead; verbatim duplicates of `queue_poller.py:98-99`, which are the copies actually read |
| `ops_mission_control/backend/models.py` | `VALID_PROPOSAL_STATES` | no validator consumed it; the four state constants stay and `store.py` compares against them individually |
| `ops_mission_control/backend/rotation.py` | `_APP_MODE_KEY`, `_RULES_KEY` | in-module dead; both keys are owned and read by `policy_store` (`_MODE_KEY`, `_RULES_KEY`), which `rotation.py` goes through |
| `pptx_maker/backend/preview_tools.py` | `_SHIM_MODULE` | the launcher resolves `pdftoppm_shim.py` by path, never by dotted module |
| `pptx_maker/backend/routes.py` | `_BITMAP_MAGIC_B64_CHARS` | comment contradicted the whole-body decode |

`rotation.py`'s two removals are the reason the second pass matters: `_APP_MODE_KEY` and
`_RULES_KEY` are adjacent lines with identical deadness, and a purely repo-wide count
would have taken one and left the other — the kind of half-applied criterion that costs a
review round.

**Comments retargeted rather than dropped**, where the deletion would otherwise have made
one false or lost a load-bearing rationale:

- `agent_discovery.py`: the `_LOW_VALUE_MARKERS` comment said low-value files are
  "Dropped from the focus list first". They are not dropped — `tier()` returns `2` for
  them and the sort key is `(tier, path)`, so they sort **last**, and `prioritize_focus`
  truncates only when a caller passes `cap`. Now says so.
- `report.py`: `_LLM_ROW_FIELDS`' comment carried the module's *why-we-redact-at-all*
  rationale. That rationale now sits on `_redact_deep`, the helper it actually justifies,
  instead of floating between two unrelated constants where a reader would attach it to
  the depth cap. Its claims were re-checked against the code and two were corrected: it
  had said *every* row field is model-written (`score`, `band`, `red`, `yellow` are
  computed) and that the dashboard reads `rows.json` / `focus-report.html` "with no
  redaction in between" (the dashboard's inline view reads `report.json` through
  `read_report`, which redacts **again** on the way out). **No redaction call, skip set,
  or code path is touched** — each of the four fields the dead tuple named still goes
  through `pipeline._redact` explicitly in `build_report` and again through
  `_redact_deep_map`, which has no skip set.
- `preview_tools.py`: the comment said "The tool this module can provide, **and the
  module that implements it**"; with `_SHIM_MODULE` gone it covers only the tool.
- `verify_align.py`: `DARK_MAX`'s comment was the only note calibrating the luminance
  scale — why the failure floor is `12.0` and not something higher. That reference point
  is folded into `BLACK_MAX`'s comment rather than lost.

**Where the criterion stops, stated so the next round does not "restore consistency" by
breaking something:**

- **pytest-magic module attributes are excluded.**
  `code_review_sage/tests/conftest.py`'s `collect_ignore_glob` has exactly one repo-wide
  occurrence and is the one name matching the mechanical criterion that is deliberately
  kept: pytest reads it off the conftest module by attribute during collection, so
  deleting it would silently un-gate that suite on Windows.
- **A mention in a shipped system spec counts as a reference.** Two constants are
  code-dead but named in `docs/system-specs/` —
  `ops_mission_control/backend/models.py`'s `VALID_VERIFICATIONS` and
  `meetings/backend/constants.py`'s `MAX_CONCURRENT_MEETINGS`. Removing either requires a
  same-commit spec edit, which is a docs change with its own review surface, so both stay
  here. (`VALID_PROPOSAL_STATES` is removed because no doc names it — that is the rule
  applied, not an accident.)
- **`_APP_MODE_KEY` is deleted rather than wired up.** The literal `"mode"` does appear
  inline in `rotation.py`, but as a *rule* field in `AutonomyRule.from_dict` (whose
  sibling reads `"source"`, `"resource_glob"`, `"label_match"` are literals too) and as an
  output payload key — not as the app-mode config read the name implies. That config key
  already has an owner in `policy_store._MODE_KEY`. Picking one of the three call sites
  would be a semantic guess; removing an unread duplicate is not.
- **No keystone security file is reshaped and no lazy import is hoisted.** No in-function
  `from X import Y` is touched, and removing module-level constants can only reduce
  import-time work.

`agent_discovery.py` still carries twelve `operator directive <date>` comment citations
that `AGENTS.md` forbids as task-log entries. They are left alone: rewriting twelve
rationale comments is its own pass, and folding it in would bury this diff.

## Tests

No new tests — this is a subtraction of unreferenced names plus a local control-flow
rewrite, so there is no new behaviour to lock in, and the existing suites already cover
every touched code path (`_has_bitmap_signature` / `_scanned_bitmap_bytes`,
`prioritize_focus`, proposal-state transitions in `store.py`, the design-tweak relay, the
mochi queue file, and the design-critique manifest assertions). Coverage of the removed
names' *surviving* behaviour is unaffected: `test_report.py::test_build_report_redacts_all_llm_fields`
enumerates the four field names as literals rather than through the deleted tuple, and
`test_pptx_maker_preview_tools.py` asserts on the shim's **filename**, not the dotted
module string.

The one file with no test coverage at all, `verify_align.py`, is a standalone reference
script a skill runs by hand; its two rewritten hunks are argued equivalent above and were
independently re-derived truth-table-for-truth-table by a reviewer pass.

## Manual verification

N/A — unit coverage sufficient. What this change needed instead of manual steps was
**proof of non-reference**, which is mechanical: an AST pass over all 355 `.py` files under
`src/kiro_crew/apps/` enumerating every module-level assignment (all casings,
`_`-prefixed included), cross-referenced against a single-pass identifier-token count over
every `git ls-files` blob. Re-running it after the change leaves only the
`collect_ignore_glob` exception named above. Each removed name was additionally checked for
reachability a text search misses — `getattr` / `globals()` / `vars()`, prefix-filtered
`__all__`, `import *`, and source-text-grepping tests — with none found.

Gates run from the worktree on the Python 3.12 CI-parity venv, all exit 0:
`flake8`, `isort --check-only`, `mypy` (1012 files, clean), `check_brand_name.py`,
`check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`.

Targeted tests for every touched app: 2727 passed in the app-local suites and 1502 in the
matching `test/` suites. The 18 failures in `auto_improvement/tests` are **pre-existing
and environmental** — the failure set is byte-identical on a pristine `origin/main`
worktree run under the same interpreter (those tests spawn a nested pytest that cannot
resolve its interpreter on this host). Backend-only diff, so CI's `changes` job reports
`only_backend=true` and the frontend suites cannot newly fail.

One **pre-existing** defect surfaced while proving `_PROXY_PATH_SAFE` unwired, recorded
here so removing the constant does not bury it — it is **not** fixed in this PR, which is
scoped to behaviour-preserving cleanup: in `design_tweak/backend/server.py`,
`conn.request(self.command, self.path, …)` forwards the request target verbatim, and a raw
non-ASCII byte in the path makes `http.client`'s ASCII encode raise `UnicodeEncodeError`,
which is neither `OSError` nor `HTTPException` and so escapes the handler's `except`
instead of returning the 502 every other upstream failure returns. Reachable only from a
local non-browser client on the ephemeral loopback dev-proxy port (browsers percent-encode
path bytes); it resets one connection and prints a traceback, with no state change and no
header or credential bypass. Resurrecting the constant is **not** the fix — its safe set
omits `?` and `#`, so quoting with it would percent-encode the query separator and break
every dev-server request.

## Related Issues

no linked issue: routine module-simplification sweep, nothing filed.
