### PR TITLE
chore(release): stamp release/0.4.0 as 0.4.0-rc.5 for the insider.5 cut

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.4.0-rc.4"
+version = "0.4.0-rc.5"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.4.0-rc.4"
+__version__ = "0.4.0-rc.5"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0-rc.4",
+  "version": "0.4.0-rc.5",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
Three-file version stamp `0.4.0-rc.4` -> `0.4.0-rc.5` (dual-valid spelling, per docs/build/release.md: in-code RC number matches the tag). Companion to the #5039 cherry-pick (PR #5058); the next candidate is `v0.4.0-insider.5` since insider.4's RC gate failed on the record-factory class.

Kept separate from #5058 because the cherry-pick must stay a pure single commit (PR Hygiene + byte-identical property).

**Why no screenshot:** version-declaration change; no UI surface.