### PR TITLE
refactor: consolidate JSON extractors onto the shared scanner (#4974)

### DIFF
--- a/docs/system-specs/modules/workflows.md
+++ b/docs/system-specs/modules/workflows.md
@@ -445,9 +445,15 @@ Unknown keywords are ignored, so a richer schema still validates on the parts th
 understands. `bool` is explicitly **not** an `integer` or `number`.
 
 `parse_json(text)` is tolerant of the two shapes a model actually returns: a
-fenced ` ```json ` block, and JSON wrapped in prose (it falls back to the
-outermost `{...}` / `[...]` span, trying whichever delimiter appears first so a
-prose-wrapped array yields the array, not an inner object). It never `eval`s.
+fenced ` ```json ` block, and JSON wrapped in prose. Prose recovery delegates to
+the shared `llm_helpers._extract_json_of_type` scanner (stdlib `raw_decode` over
+successive `{` / `[` offsets), so a stray brace or bracket in the prose no longer
+corrupts recovery, and a prose-wrapped array still yields the outer array, not an
+inner object. `coerce_and_validate` derives a prefer predicate from the schema's
+container `type`, so an object schema selects the object even when stray prose
+parses as an array first (and vice versa); two *different* candidates of the
+preferred shape refuse the guess and count as a parse failure, feeding the retry
+loop. It never `eval`s.
 
 `run_with_schema(produce, prompt, schema, retries=DEFAULT_SCHEMA_RETRIES)` drives
 the loop: the prompt is augmented with the serialized schema and a JSON-only

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_discovery.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_discovery.py
@@ -55,6 +55,8 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Callable
 
+from kiro_crew.llm_helpers import _extract_json_of_type
+
 from .git_safety import GIT_SAFE_CONFIG, require_pinned
 
 # How many agent-discovered surfaces to keep per cycle. The agent is asked for a small,
@@ -275,97 +277,66 @@ def _git_grep_imports(clone: Path, leaf: str) -> list[str]:
     return [ln.strip() for ln in out.splitlines() if ln.strip().endswith(".py")]
 
 
-def _iter_json_arrays(text: str):
-    """Yield every BALANCED JSON array (in source order) that parses to a ``list``.
+def _array_of_objects(value: Any) -> bool:
+    """Prefer predicate: a JSON array that carries at least one object record.
 
-    A bracket-matching scan that is aware of string literals (so a ``]`` inside a string
-    value does not close the span). This is robust to leading/trailing bracketed PROSE
-    (e.g. a trailing "see line [12]." note, or a leading "item [1]:"), which the old
-    ``text.find('[') .. text.rfind(']')`` span got wrong: any stray ``[``/``]`` in prose
-    corrupted the span, json.loads failed, and a perfectly good array was silently lost."""
-    n = len(text)
-    i = 0
-    while i < n:
-        if text[i] != "[":
-            i += 1
-            continue
-        depth = 0
-        in_str = False
-        esc = False
-        for j in range(i, n):
-            c = text[j]
-            if in_str:
-                if esc:
-                    esc = False
-                elif c == "\\":
-                    esc = True
-                elif c == '"':
-                    in_str = False
-                continue
-            if c == '"':
-                in_str = True
-            elif c == "[":
-                depth += 1
-            elif c == "]":
-                depth -= 1
-                if depth == 0:
-                    try:
-                        data = json.loads(text[i : j + 1])
-                    except json.JSONDecodeError:
-                        data = None
-                    if isinstance(data, list):
-                        yield data
-                    break
-        # Advance past this '[' (balanced or not) so a later valid array is still found.
-        i += 1
+    Disambiguates the findings payload from stray bracketed PROSE that also
+    parses as an array (a trailing "see line [12]." note, a leading "item [1]:"
+    marker) — those decode to arrays of scalars and are never preferred."""
+    return isinstance(value, list) and any(isinstance(item, dict) for item in value)
 
 
 def _extract_json_array(text: str) -> list[dict]:
     """Pull the first JSON array of objects out of an agent reply. The agent is asked to
-    emit ONLY a JSON array, but models often wrap it in prose or a ```json fence — so we
-    locate a balanced ``[ ... ]`` and parse that. Returns [] on any parse failure
-    (a malformed reply yields no surfaces, never an exception)."""
+    emit ONLY a JSON array, but models often wrap it in prose or a ```json fence —
+    extraction delegates to the shared ``llm_helpers._extract_json_of_type`` scanner
+    (fence markers are just prose to it), preferring an array that actually contains
+    object records. Returns [] on any parse failure, on an object-wrapped reply (the
+    tool-side forcing re-emit recovers those), or when two DIFFERENT object-bearing
+    arrays make the choice ambiguous (the shared contract refuses to guess — e.g.
+    a worked example preceding the real payload). Never raises."""
     if not text:
         return []
-    # Prefer a fenced block if present (```json ... ``` or ``` ... ```).
-    fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
-    if fence:
-        try:
-            data = json.loads(fence.group(1))
-        except json.JSONDecodeError:
-            data = None
-        if isinstance(data, list):
-            return [d for d in data if isinstance(d, dict)]
-    # Fall back to a balanced-bracket scan (string-literal aware) — prefer the first array
-    # that actually contains object records, but accept the first list otherwise.
-    first_list: list | None = None
-    for arr in _iter_json_arrays(text):
-        if first_list is None:
-            first_list = arr
-        if any(isinstance(d, dict) for d in arr):
-            return [d for d in arr if isinstance(d, dict)]
-    if first_list is not None:
-        return [d for d in first_list if isinstance(d, dict)]
-    return []
+    arr = _extract_json_of_type(text, list, prefer=_array_of_objects)
+    if not isinstance(arr, list):
+        return []
+    return [item for item in arr if isinstance(item, dict)]
+
+
+def _whole_reply_array(text: str) -> list | None:
+    """The reply parsed as a JSON array when the ENTIRE (fence-stripped) reply is
+    one. This is the only form in which an empty ``[]`` counts as the no-findings
+    answer: the agent is instructed to emit ONLY the array, so a conforming empty
+    answer is the whole reply — an ``[]`` embedded in prose ("Use [] when none")
+    is instruction-echo, not an answer, and must not suppress recovery."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        parts = stripped.split("```", 2)
+        stripped = parts[1] if len(parts) >= 2 else ""
+        if stripped.startswith("json"):
+            stripped = stripped[4:]
+        stripped = stripped.strip()
+    try:
+        data = json.loads(stripped)
+    except (json.JSONDecodeError, RecursionError):
+        return None
+    return data if isinstance(data, list) else None
 
 
 def _has_json_array(text: str) -> bool:
-    """True iff the reply CONTAINS a parseable JSON array (even an empty ``[]``). Used to
-    distinguish "the agent answered (possibly with no findings)" from "the agent never
-    emitted an array" — only the latter triggers the tool-side forcing re-emit. Without
-    this, a valid empty-result answer (``[]``) would wrongly trigger a second call."""
+    """True iff the reply carries an ANSWER: it IS a JSON array (bare or fenced —
+    covering the legitimate empty ``[]`` no-findings reply, which must not trigger
+    a second call), or prose scanning finds a top-level object-bearing array.
+    Position/form decides, not value shape: scalar prose fragments (``[12]``),
+    instruction-echo (``Use [] when none``), and object-wrapped replies all read
+    as unanswered, so the tool-side forcing re-emit fires and demands the bare
+    array (GPT review rounds 1-3, #4974)."""
     if not text:
         return False
-    fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
-    if fence:
-        try:
-            if isinstance(json.loads(fence.group(1)), list):
-                return True
-        except json.JSONDecodeError:
-            pass
-    for _arr in _iter_json_arrays(text):
+    if _whole_reply_array(text) is not None:
         return True
-    return False
+    found = _extract_json_of_type(text, list, prefer=_array_of_objects)
+    return _array_of_objects(found)
 
 
 def _normalize_surface(

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -1377,6 +1377,20 @@ def _extract_json_of_type(
             continue
         try:
             data, end = _JSON_DECODER.raw_decode(text, i)
+        except RecursionError:
+            # Adversarially deep nesting (e.g. "[" * 100_000 in prose): the
+            # stdlib decoder recurses per nesting level and overflows long
+            # before any structural bound. This text is untrusted model output,
+            # and callers handle only JSONDecodeError (parse_json's ValueError
+            # contract, the spine extractor's never-raises contract) — so the
+            # error must not escape. Fail the WHOLE scan closed: a truncated
+            # scan cannot certify a preferred match as unambiguous, so keeping
+            # candidates collected before the bomb would let a worked example
+            # launder past the ambiguity refusal (GPT review, #4974 round 4).
+            # Callers already have recovery paths for None (schema retry loop,
+            # the spine's forcing re-emit); salvaging a prefix of a reply that
+            # contains a nesting bomb is not worth defeating them.
+            return None
         except json.JSONDecodeError:
             i += 1
             continue

--- a/src/kiro_crew/workflows/schema.py
+++ b/src/kiro_crew/workflows/schema.py
@@ -12,9 +12,14 @@ validator for the JSON-Schema **subset** the workflow DSL actually uses
     array:  items
     any:    enum
 
-Leaf module (no intra-package imports) so it sits at the bottom of the layering
-(GATE F1); ``runner`` imports it. Pure functions + one async retry helper, all
-unit-testable against a stub text producer (never a real agent).
+Leaf module within the workflows package (no intra-package sibling imports) so
+it sits at the bottom of the layering (GATE F1); ``runner`` imports it. Prose
+recovery is delegated to the shared ``kiro_crew.llm_helpers`` extractor — an
+external import, like the optional adapters' — the same scanner the spine and
+task-planner call sites use (a few bespoke span-scans remain elsewhere, e.g.
+dashboard/chat_summary and knowledge/extractor; consolidating them is tracked
+separately). Pure functions + one async retry helper, all unit-testable against
+a stub text producer (never a real agent).
 
 Gates: C1 valid object returned · C2 malformed→retry→success, all-malformed→None ·
 C3 schema-violating object rejected. See ``docs/system-specs/modules/workflow-gates.md``.
@@ -24,6 +29,8 @@ from __future__ import annotations
 
 import json
 from typing import Any, Awaitable, Callable, Optional
+
+from kiro_crew.llm_helpers import _extract_json_of_type
 
 # Bounded retries before ``ctx.agent(schema=)`` gives up and returns None
 # (matches ``_SCHEMA_RETRIES`` in the module spec).
@@ -71,34 +78,47 @@ def validate_against_schema(value: Any, schema: dict, *, path: str = "$") -> lis
     if "enum" in schema and value not in schema["enum"]:
         errors.append(f"{path}: {value!r} not in enum {schema['enum']}")
 
-    if expected_type == "object" or (expected_type is None and isinstance(value, dict)):
-        if isinstance(value, dict):
-            for key in schema.get("required", []):
-                if key not in value:
-                    errors.append(f"{path}: missing required property '{key}'")
-            props = schema.get("properties", {})
-            for key, subschema in props.items():
-                if key in value:
-                    errors.extend(
-                        validate_against_schema(value[key], subschema, path=f"{path}.{key}")
-                    )
+    # Container sub-checks key on the VALUE's runtime type, not the ``type``
+    # spelling: any type mismatch already early-returned above, so a dict here
+    # is schema-admissible whether ``type`` said "object", a union list
+    # admitting object, or nothing. Keying on ``expected_type == "object"``
+    # missed the union spelling, so ``["object", "null"]`` skipped
+    # ``required``/``properties`` entirely and an invalid object validated
+    # (GPT review, #4974 round 2).
+    if isinstance(value, dict):
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append(f"{path}: missing required property '{key}'")
+        props = schema.get("properties", {})
+        for key, subschema in props.items():
+            if key in value:
+                errors.extend(validate_against_schema(value[key], subschema, path=f"{path}.{key}"))
 
-    if expected_type == "array" or (expected_type is None and isinstance(value, list)):
-        if isinstance(value, list):
-            item_schema = schema.get("items")
-            if isinstance(item_schema, dict):
-                for i, item in enumerate(value):
-                    errors.extend(validate_against_schema(item, item_schema, path=f"{path}[{i}]"))
+    if isinstance(value, list):
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for i, item in enumerate(value):
+                errors.extend(validate_against_schema(item, item_schema, path=f"{path}[{i}]"))
 
     return errors
 
 
-def parse_json(text: str) -> Any:
+def parse_json(text: str, *, prefer: Callable[[Any], bool] | None = None) -> Any:
     """Tolerantly parse model output as JSON; raises ``ValueError`` if not JSON.
 
-    Handles the common cases of a fenced ```json block or surrounding prose by
-    extracting the outermost ``{...}`` / ``[...]`` span. Never executes anything
-    (no ``eval``).
+    Handles the common cases of a fenced ```json block or surrounding prose.
+    Prose recovery delegates to the shared ``llm_helpers._extract_json_of_type``
+    scanner (stdlib ``raw_decode`` over successive ``{`` / ``[`` offsets), which
+    skips stray braces/brackets in the prose — the previous outermost-span
+    (``find``/``rfind``) approach corrupted the whole span on any stray
+    delimiter. Positional scanning preserves the old guarantee that a
+    prose-wrapped array yields the outer array, not an inner object.
+
+    *prefer* narrows prose recovery when the caller knows the expected shape
+    (see ``coerce_and_validate``); it is a disambiguator among prose-embedded
+    candidates, not a validator — the strict whole-text parse ignores it, and
+    schema validation stays the caller's job. Never executes anything (no
+    ``eval``).
     """
     if not isinstance(text, str):
         raise ValueError("model output is not text")
@@ -113,30 +133,59 @@ def parse_json(text: str) -> Any:
     try:
         return json.loads(stripped)
     except json.JSONDecodeError:
-        # Fall back to the outermost object/array span. Try whichever delimiter
-        # appears first so a prose-wrapped array containing an object yields the
-        # outer array, not the inner object.
-        candidates = []
-        for open_c, close_c in (("{", "}"), ("[", "]")):
-            start, end = stripped.find(open_c), stripped.rfind(close_c)
-            if 0 <= start < end:
-                candidates.append((start, end))
-        for start, end in sorted(candidates):
-            try:
-                return json.loads(stripped[start : end + 1])
-            except json.JSONDecodeError:
-                continue
-        raise ValueError("model output is not valid JSON")
+        result = _extract_json_of_type(stripped, (dict, list), prefer=prefer)
+        if result is None:
+            raise ValueError("model output is not valid JSON")
+        return result
+
+
+def _prefer_dict(value: Any) -> bool:
+    """Prefer predicate for ``schema.type == "object"``: select the dict."""
+    return isinstance(value, dict)
+
+
+def _prefer_list(value: Any) -> bool:
+    """Prefer predicate for ``schema.type == "array"``: select the list."""
+    return isinstance(value, list)
+
+
+# Schema ``type`` → prefer predicate for prose recovery. Only the two container
+# shapes matter: scalars never survive prose recovery anyway (the scanner only
+# decodes at ``{`` / ``[``).
+_SHAPE_PREFERENCE: dict[str, Callable[[Any], bool]] = {
+    "object": _prefer_dict,
+    "array": _prefer_list,
+}
+
+
+def _shape_preference(expected: Any) -> Callable[[Any], bool] | None:
+    """The prefer predicate a schema ``type`` implies: the single container shape
+    it admits. A union list counts only its container members — ``"null"`` and
+    scalar members add no prose-recoverable shape, so ``["object", "null"]``
+    still prefers the object (GPT review: routing unions to no-preference let a
+    worked example win first-match instead of triggering ambiguity refusal). A
+    union admitting BOTH containers has no single shape to prefer."""
+    if isinstance(expected, str):
+        return _SHAPE_PREFERENCE.get(expected)
+    if isinstance(expected, list):
+        containers = {t for t in expected if isinstance(t, str) and t in _SHAPE_PREFERENCE}
+        if len(containers) == 1:
+            return _SHAPE_PREFERENCE[containers.pop()]
+    return None
 
 
 def coerce_and_validate(text: str, schema: dict) -> tuple[Optional[Any], list[str]]:
     """Parse ``text`` as JSON and validate against ``schema``.
 
     Returns ``(value, [])`` on success or ``(None, errors)`` when parsing fails or
-    the value violates the schema.
+    the value violates the schema. When the schema names a container ``type``,
+    prose recovery prefers a value of that shape, so an object schema selects the
+    object even when stray prose parses as an array first (and vice versa).
     """
+    expected = schema.get("type")
+    prefer = _shape_preference(expected)
     try:
-        value = parse_json(text)
+        value = parse_json(text, prefer=prefer)
     except ValueError as exc:
         return None, [str(exc)]
     errors = validate_against_schema(value, schema)

--- a/test/test_spine_json_extraction.py
+++ b/test/test_spine_json_extraction.py
@@ -1,0 +1,192 @@
+"""The spine's agent-reply JSON extraction, consolidated onto the shared
+``llm_helpers._extract_json_of_type`` scanner (#4974).
+
+Locks the call-site behaviors ``_extract_json_array`` / ``_has_json_array``
+provide to ``_discover_surfaces_via_agent``: fenced replies, stray bracketed
+prose (the input class outermost-span scanners mishandle), object-record
+preference, the shared ambiguity refusal, and the top-level-only contract the
+tool-side forcing re-emit relies on. Pure-function tests — no agent, no I/O.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.apps.builtins.auto_improvement.spine.agent_discovery import (
+    _extract_json_array,
+    _has_json_array,
+    discover_surfaces_via_agent,
+)
+
+
+class TestExtractJsonArray:
+    def test_bare_array_of_objects(self) -> None:
+        assert _extract_json_array('[{"file": "a.py"}]') == [{"file": "a.py"}]
+
+    def test_fenced_array(self) -> None:
+        text = 'Here you go:\n```json\n[{"file": "a.py", "line": 3}]\n```\nDone.'
+        assert _extract_json_array(text) == [{"file": "a.py", "line": 3}]
+
+    def test_stray_bracketed_prose_before_array(self) -> None:
+        # "see line [12]" parses as a JSON array of ints and appears FIRST; the
+        # object-record preference selects the real findings array after it.
+        text = 'see line [12] for context. Findings: [{"file": "a.py"}]'
+        assert _extract_json_array(text) == [{"file": "a.py"}]
+
+    def test_stray_bracketed_prose_after_array(self) -> None:
+        text = '[{"file": "a.py"}] as noted in [3] above'
+        assert _extract_json_array(text) == [{"file": "a.py"}]
+
+    def test_non_dict_items_filtered(self) -> None:
+        assert _extract_json_array('["x", {"file": "a.py"}, 3]') == [{"file": "a.py"}]
+
+    def test_scalar_only_array_yields_empty(self) -> None:
+        assert _extract_json_array("[1, 2, 3]") == []
+
+    def test_empty_array_yields_empty(self) -> None:
+        assert _extract_json_array("[]") == []
+
+    def test_no_array_yields_empty(self) -> None:
+        assert _extract_json_array("no json here") == []
+        assert _extract_json_array("") == []
+
+    def test_malformed_array_yields_empty(self) -> None:
+        assert _extract_json_array('[{"file": "a.py"') == []
+
+    def test_restated_identical_array_is_not_ambiguous(self) -> None:
+        # Shared contract: equal preferred matches collapse to one.
+        text = '[{"file": "a.py"}]\nAs stated: [{"file": "a.py"}]'
+        assert _extract_json_array(text) == [{"file": "a.py"}]
+
+    def test_two_different_object_arrays_refuse_to_guess(self) -> None:
+        # Shared contract: two DIFFERENT preferred matches return None → [].
+        # A first-match scan would execute the worked example that precedes
+        # the real payload; refusing is the safer failure.
+        text = 'e.g. [{"file": "ex.py"}] ... final: [{"file": "real.py"}]'
+        assert _extract_json_array(text) == []
+
+    def test_array_inside_object_wrapper_not_dug_out(self) -> None:
+        # Top-level-only contract: an array nested in an object wrapper is not
+        # extracted, and _has_json_array is False for it — so the tool-side
+        # forcing re-emit fires and demands the bare array (the designed
+        # recovery for format deviations).
+        text = '{"findings": [{"file": "a.py"}]}'
+        assert _extract_json_array(text) == []
+        assert _has_json_array(text) is False
+
+
+class TestHasJsonArray:
+    def test_empty_array_counts_as_answered(self) -> None:
+        # `[]` is a legitimate "no findings" answer and must NOT trigger the
+        # forcing re-emit ([] is falsy — the check must be `is not None`).
+        assert _has_json_array("[]") is True
+
+    def test_fenced_empty_array_counts(self) -> None:
+        assert _has_json_array("```json\n[]\n```") is True
+
+    def test_array_after_prose_counts(self) -> None:
+        assert _has_json_array('analysis done. [{"file": "a.py"}]') is True
+
+    def test_prose_only_is_false(self) -> None:
+        assert _has_json_array("I could not finish reading the files") is False
+        assert _has_json_array("") is False
+
+    def test_object_only_reply_is_false(self) -> None:
+        assert _has_json_array('{"a": 1}') is False
+
+    def test_scalar_prose_array_is_not_an_answer(self) -> None:
+        # "see line [12]" parses as a JSON array but is prose, not an answer —
+        # counting it suppressed the forcing re-emit (pre-push review finding).
+        assert _has_json_array("see line [12] for details") is False
+
+    def test_wrapper_plus_prose_array_still_reads_unanswered(self) -> None:
+        # The convergent pre-push review finding (GPT + Opus): an object-wrapped
+        # reply next to stray bracketed prose must NOT read as answered, or the
+        # wrapped findings are silently dropped instead of recovered by the
+        # forcing re-emit.
+        text = '{"findings": [{"file": "a.py"}]} See line [12].'
+        assert _extract_json_array(text) == []
+        assert _has_json_array(text) is False
+
+    def test_wrapper_plus_instruction_echo_empty_array_reads_unanswered(self) -> None:
+        # GPT round 3: an empty [] embedded in prose is instruction-echo, not a
+        # no-findings answer — counting it suppressed the forcing re-emit and
+        # lost the wrapped findings. [] answers only as the whole reply.
+        text = '{"findings": [{"file": "a.py"}]} Use [] when none.'
+        assert _extract_json_array(text) == []
+        assert _has_json_array(text) is False
+
+    def test_whole_reply_scalar_array_counts_as_answered(self) -> None:
+        # The agent complied with the demanded form (the reply IS the array);
+        # re-asking cannot improve on it, so no forcing — extraction just
+        # filters the non-dict items away.
+        assert _extract_json_array("[1, 2, 3]") == []
+        assert _has_json_array("[1, 2, 3]") is True
+
+
+class TestAdversarialNesting:
+    # Untrusted model output can embed pathological nesting; the shared
+    # scanner must keep both call-site contracts (ValueError / never-raises)
+    # instead of letting RecursionError escape (pre-push review finding).
+
+    def test_unterminated_nesting_bomb_never_raises(self) -> None:
+        assert _extract_json_array("x " + "[" * 100_000) == []
+
+    def test_balanced_nesting_bomb_never_raises(self) -> None:
+        assert _extract_json_array("x " + "[" * 100_000 + "]" * 100_000) == []
+
+    def test_payload_before_bomb_fails_closed(self) -> None:
+        # A reply containing a nesting bomb yields nothing, even when a payload
+        # precedes the bomb: a truncated scan cannot certify the payload as
+        # unambiguous (a later DIFFERENT payload may follow the bomb), and the
+        # forcing re-emit is the designed recovery. GPT review round 4 — this
+        # flips the earlier keep-the-prefix behavior, which let a worked
+        # example launder past the ambiguity refusal.
+        text = '[{"file": "a.py"}] ' + "[" * 100_000
+        assert _extract_json_array(text) == []
+        assert _has_json_array(text) is False
+
+
+class TestForcingReemitWiring:
+    def test_wrapper_plus_prose_reply_triggers_forced_reemit(self, tmp_path) -> None:
+        # End-to-end through discover_surfaces_via_agent with a stub runner:
+        # call 1 returns the wrapper+prose reply, the forcing re-emit (call 2,
+        # no tools) returns the bare array, and the finding is recovered.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "x.py").write_text("x = 1\n", encoding="utf-8")
+
+        class _Res:
+            def __init__(self, text: str) -> None:
+                self.text = text
+                self.ok = True
+                self.error = ""
+
+        calls: list[dict] = []
+
+        class _Runner:
+            def run(self, prompt: str, **kwargs) -> _Res:
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    return _Res('{"findings": [{"file": "src/x.py"}]} See line [12].')
+                return _Res('[{"file": "src/x.py", "line": 1, "symbol": "x", "message": "m"}]')
+
+        out = discover_surfaces_via_agent(_Runner(), clone=tmp_path)
+        assert len(calls) == 2, "forcing re-emit must fire for a wrapper+prose reply"
+        assert calls[1].get("allowed_tools") == []  # the re-emit call carries no tools
+        assert [s["file"] for s in out] == ["src/x.py"]
+
+    def test_empty_array_answer_does_not_reemit(self, tmp_path) -> None:
+        # A bare [] is a completed no-findings answer: exactly one call.
+        calls: list[dict] = []
+
+        class _Res:
+            text = "[]"
+            ok = True
+            error = ""
+
+        class _Runner:
+            def run(self, prompt: str, **kwargs) -> _Res:
+                calls.append(kwargs)
+                return _Res()
+
+        out = discover_surfaces_via_agent(_Runner(), clone=tmp_path)
+        assert len(calls) == 1
+        assert out == []

--- a/test/test_workflows_schema.py
+++ b/test/test_workflows_schema.py
@@ -65,6 +65,32 @@ def test_c3_bool_is_not_integer() -> None:
     assert any("count" in e for e in errs)
 
 
+def test_union_type_still_enforces_required_and_properties() -> None:
+    # GPT review round 2: keying the object sub-checks on the literal string
+    # "object" skipped required/properties for union spellings, so an invalid
+    # object validated under ["object", "null"].
+    union = dict(FINDING_SCHEMA, type=["object", "null"])
+    assert any("required" in e for e in validate_against_schema({}, union))
+    assert validate_against_schema(None, union) == []
+    assert validate_against_schema({"title": "x", "severity": "low"}, union) == []
+
+
+def test_union_type_still_enforces_array_items() -> None:
+    schema = {"type": ["array", "null"], "items": {"type": "integer"}}
+    assert validate_against_schema([1, "two"], schema) != []
+    assert validate_against_schema([1, 2], schema) == []
+    assert validate_against_schema(None, schema) == []
+
+
+def test_coerce_union_preferred_object_is_still_schema_checked() -> None:
+    # The full round-2 chain: prefer steers the {} candidate in, and the
+    # validator must reject it (missing required) so the retry loop re-asks —
+    # not return an invalid object as validated.
+    union = dict(FINDING_SCHEMA, type=["object", "null"])
+    value, errs = coerce_and_validate("note [1] then {}", union)
+    assert value is None and errs
+
+
 def test_nested_array_items_validated() -> None:
     schema = {
         "type": "object",
@@ -94,6 +120,115 @@ def test_parse_json_with_surrounding_prose() -> None:
 def test_parse_non_json_raises() -> None:
     with pytest.raises(ValueError):
         parse_json("not json at all")
+
+
+def test_parse_json_nesting_bomb_keeps_valueerror_contract() -> None:
+    # Adversarially deep nesting must surface as the contract ValueError, not a
+    # RecursionError escaping the shared scanner (pre-push review finding). The
+    # balanced form overflowed even the old span fallback; both are contained now.
+    with pytest.raises(ValueError):
+        parse_json("x " + "[" * 100_000)
+    with pytest.raises(ValueError):
+        parse_json("x " + "[" * 100_000 + "]" * 100_000)
+
+
+def test_nesting_bomb_cannot_launder_a_candidate_past_refusal() -> None:
+    # GPT review round 4: a bomb between a worked example and the real payload
+    # truncated the scan after collecting only the example, defeating the
+    # ambiguity refusal. The scan now fails closed on overflow: nothing is
+    # returned, parsing errors, and the retry loop re-asks.
+    text = (
+        'Example: {"title": "example", "severity": "low"} '
+        + "[" * 100_000
+        + ' final: {"title": "real", "severity": "high"}'
+    )
+    value, errs = coerce_and_validate(text, FINDING_SCHEMA)
+    assert value is None and errs
+
+
+def test_parse_scalar_strict_path_preserved() -> None:
+    # Whole-text scalars parse via the strict path (prose recovery only
+    # decodes at container delimiters).
+    assert parse_json("42") == 42
+    assert parse_json("```json\ntrue\n```") is True
+
+
+def test_parse_json_stray_brace_in_preamble() -> None:
+    # The old outermost-span (find/rfind) fallback corrupted the span on any
+    # stray brace in prose ('{placeholder} … 1}' is not valid JSON) and raised.
+    # The shared scanner skips the failed offset and recovers the real object.
+    assert parse_json('use {placeholder} syntax: {"a": 1}') == {"a": 1}
+
+
+def test_parse_json_stray_brace_after_payload() -> None:
+    # find/rfind spanned '{"a": 1} and note {this}' — unparseable — and raised.
+    assert parse_json('{"a": 1} and note {this}') == {"a": 1}
+
+
+def test_parse_prose_array_yields_outer_array_not_inner_object() -> None:
+    # Preserved guarantee from the old fallback's delimiter ordering.
+    assert parse_json('Result: [{"a": 1}] done') == [{"a": 1}]
+
+
+def test_coerce_prefers_schema_shape_object_over_leading_array() -> None:
+    # Stray '[1, 2]' in prose parses as an array and appears FIRST; the object
+    # schema's prefer predicate selects the object payload anyway. (The old
+    # span fallback returned [1, 2] here and validation failed.)
+    text = 'steps [1, 2] then: {"title": "x", "severity": "high"}'
+    value, errs = coerce_and_validate(text, FINDING_SCHEMA)
+    assert errs == [] and value == {"title": "x", "severity": "high"}
+
+
+def test_coerce_prefers_schema_shape_array_over_leading_object() -> None:
+    schema = {"type": "array", "items": {"type": "integer"}}
+    text = 'config {"note": "x"} follows: [1, 2, 3]'
+    value, errs = coerce_and_validate(text, schema)
+    assert errs == [] and value == [1, 2, 3]
+
+
+def test_coerce_restated_identical_payload_is_not_ambiguous() -> None:
+    # A model restating the same payload twice is not ambiguity (shared
+    # extractor contract: equal preferred matches collapse to one).
+    payload = '{"title": "x", "severity": "low"}'
+    text = f"{payload}\nAs stated above: {payload}"
+    value, errs = coerce_and_validate(text, FINDING_SCHEMA)
+    assert errs == [] and value == {"title": "x", "severity": "low"}
+
+
+def test_coerce_two_different_shaped_candidates_refuse_to_guess() -> None:
+    # Two DIFFERENT object candidates under an object schema: the extractor
+    # refuses to guess, parsing fails, and the retry loop re-asks (returning
+    # either one would risk validating a worked example as the payload).
+    text = '{"title": "a", "severity": "low"} or {"title": "b", "severity": "high"}'
+    value, errs = coerce_and_validate(text, FINDING_SCHEMA)
+    assert value is None and errs
+
+
+def test_coerce_nullable_union_type_keeps_ambiguity_refusal() -> None:
+    # GPT review round 1: `type: ["object", "null"]` must derive the object
+    # preference — routing unions to no-preference let a worked example win
+    # first-match and validate as the payload instead of triggering refusal.
+    schema = dict(FINDING_SCHEMA, type=["object", "null"])
+    text = (
+        'Example: {"title": "example", "severity": "low"} ... '
+        'final: {"title": "real", "severity": "high"}'
+    )
+    value, errs = coerce_and_validate(text, schema)
+    assert value is None and errs
+
+
+def test_coerce_nullable_array_union_prefers_array() -> None:
+    schema = {"type": ["array", "null"], "items": {"type": "integer"}}
+    value, errs = coerce_and_validate('note {"a": 1} then: [1, 2]', schema)
+    assert errs == [] and value == [1, 2]
+
+
+def test_coerce_dual_container_union_has_no_single_preference() -> None:
+    # A union admitting BOTH containers accepts either shape, so recovery
+    # keeps first-match fallback semantics.
+    schema = {"type": ["object", "array"]}
+    value, errs = coerce_and_validate('pick [1, 2] or {"a": 1}', schema)
+    assert errs == [] and value == [1, 2]
 
 
 def test_coerce_and_validate_round() -> None:


### PR DESCRIPTION
## What is the problem?

Two bespoke prose-tolerant JSON scanners survived after #4964 introduced the shared `llm_helpers._extract_json_of_type` with prefer predicates. `workflows/schema.py parse_json` fell back to an outermost `find`/`rfind` span -- the documented-buggy approach: any stray brace in the prose corrupts the span and a perfectly good payload is lost (`use {placeholder} syntax: {"a": 1}` raised ValueError). The auto-improvement spine's `agent_discovery.py` carried its own fence regex plus a 45-line balanced-bracket scanner. Three implementations of the same job meant three places to harden and three sets of edge-case behavior.

## Why this issue matters to the user

`parse_json` sits behind `ctx.agent(schema=)` in the workflow engine: a stray brace in a model's prose preamble burned a bounded retry (or the whole call) on output that actually contained valid JSON. The spine's scanner decides whether an auto-improvement discovery cycle yields findings or silently returns none. Divergent bespoke scanners also meant fixes like #4947's did not reach these call sites.

## How our fix solves it

Both call sites delegate to the shared scanner; the bespoke scanners are deleted.

Schema path (`workflows/schema.py`):
- `parse_json` keeps its contract (fence strip, strict parse incl. scalars, ValueError on failure) and gains a keyword-only `prefer` parameter for prose recovery.
- `coerce_and_validate` derives the prefer predicate from the schema's container `type`, including union spellings admitting exactly one container (`["object", "null"]` prefers the object; a union admitting both containers keeps first-match fallback since either shape is schema-valid). Without the union handling, a worked example in the preamble could be selected and validated as the payload.
- Declared rider (entangled with the above): `validate_against_schema` container sub-checks now key on the value's runtime type instead of the literal `type` string. Previously ANY union spelling skipped `required`/`properties`/`items` entirely, so an invalid `{}` validated under `["object", "null"]` -- pre-existing on main, but this PR's shape preference widened the inputs reaching it, so it is fixed here at the root. Null members still validate.

Spine path (`agent_discovery.py`):
- `_extract_json_array` prefers a top-level array carrying object records over bracketed prose like `see line [12]`.
- `_has_json_array` (the forcing re-emit gate) keys on POSITION/FORM, not value shape: a reply counts as answered when it IS a JSON array (whole reply, bare or fenced -- the only form where the legitimate empty `[]` no-findings answer counts) or when prose scanning finds a top-level object-bearing array. Prose fragments (`[12]`), instruction-echo (`Use [] when none`), and object-wrapped replies all read as unanswered and route to the existing tool-side forcing re-emit (one bounded no-tools call), which recovers them.

Shared scanner (`llm_helpers._extract_json_of_type`):
- RecursionError from adversarially deep nesting (e.g. `"[" * 100_000` in prose) now fails the WHOLE scan closed instead of escaping. Escaping violated both call-site contracts; and keeping candidates collected before the bomb would let a worked example launder past the ambiguity refusal, since a truncated scan cannot certify unambiguity. Callers already have designed recovery for None (schema retry loop, spine forcing re-emit). This also heals a pre-existing balanced-bomb overflow reachable on main via `task_planner`.

Deliberate shared-contract deltas at the call sites: two DIFFERENT preferred candidates refuse the guess (a worked example is never executed as the payload), and nested values are not dug out of a surrounding container (the spine's re-emit covers object-wrapped replies).

`docs/system-specs/modules/workflows.md` is updated in the same commit. Three sibling bespoke span-scanners elsewhere in the repo (dashboard/chat_summary, auto_research handlers, knowledge/extractor) are out of scope here and tracked in #5071.

## What tests we did

- 40+ new/extended tests across `test_workflows_schema.py` and the new `test_spine_json_extraction.py`: the find/rfind-mishandled inputs, schema-shape preference both directions, union-type preference and union `required`/`properties`/`items` enforcement, restated-payload non-ambiguity, refuse-to-guess, answer-form gating (instruction-echo, scalar prose fragments, whole-reply arrays), nesting bombs (unterminated, balanced, and bomb-after-payload laundering), and two end-to-end stub-runner tests proving the forcing re-emit fires for a wrapper reply and does NOT fire for a bare `[]` answer.
- Mutation-verified every load-bearing piece (8 probes): shape-prefer wiring, union derivation, spine prefer predicate, answer-form gate, validator rekey, and RecursionError fail-closed each redden exactly the tests that pin them when reverted.
- Full suite: 60011 passed; zero deterministic branch-only failures (host-environmental families A/B-verified against unmodified main: /tmp contention from a concurrent run, RSS jitter, xdist-ordering flake passing standalone). isort/flake8/black/brand gates clean; mypy delta zero.
- Grep confirms no in-repo callers of the deleted `_iter_json_arrays` remain.

## Any other suggestions on the work

The refuse-to-guess and fail-closed semantics now protect all three shared-scanner call sites uniformly; a future caller needing first-match semantics should add an explicit predicate, not a fourth scanner. Consolidating the three remaining sibling span-scanners is #5071.

Closes #4974
