### PR TITLE
fix(channels): drain the .env write before releasing the config lock

### DIFF
--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2656,6 +2656,34 @@ def _clean_id_list(raw: object, is_valid: Callable[[str], bool], label: str) -> 
     return out
 
 
+async def _write_env_off_loop(updates: dict[str, str | None]) -> None:
+    """Run the blocking ``.env`` write on a worker, drained under the config lock.
+
+    Every caller holds ``_get_config_lock()`` across this, and a thread cannot be
+    cancelled -- so a bare ``await asyncio.to_thread(...)`` lets a cancelled
+    request (a client disconnecting mid-save, gateway shutdown) unwind the
+    ``async with`` while the worker is still rewriting ``.env``. The next channel
+    save then enters the critical section against a file still being replaced and
+    writes it back from lines it read before the first write landed, discarding
+    whichever credential the other save was persisting.
+
+    Shielding and draining puts the lock release after the worker instead. It
+    cannot change WHETHER the write happens -- the thread runs to completion
+    either way -- so the only thing it decides is whether the lock outlives it.
+    The cancellation is re-raised, never swallowed.
+
+    All six channel saves go through here. The offload itself is already in
+    place on every one of them; the bare offload is what leaves the hole, so
+    covering a subset would leave the same window open in the rest.
+    """
+    fut = asyncio.ensure_future(asyncio.to_thread(_write_env_updates, updates))
+    try:
+        await asyncio.shield(fut)
+    except asyncio.CancelledError:
+        await asyncio.wait([fut])
+        raise
+
+
 def _write_env_updates(updates: dict[str, str | None]) -> None:
     """Update select keys in config_dir/.env, preserving comments and order.
 
@@ -2669,6 +2697,16 @@ def _write_env_updates(updates: dict[str, str | None]) -> None:
     lockdown fails. ``restrict_on_error="warn"`` keeps this writer's contract:
     a host where the lockdown cannot be applied must not abort a token save
     that already succeeded.
+
+    CALLER CONTRACT: blocking, and every caller is an async request handler
+    holding ``_get_config_lock()``, so each one must reach this through
+    ``_write_env_off_loop`` rather than ``asyncio.to_thread`` directly --
+    the drain there is what keeps the lock from being released mid-write.
+    Offload the WHOLE call, never a part of it: the read-modify-write is one
+    transaction, and a suspension point between the read and the rename would
+    let a concurrent writer's keys be dropped by a write derived from lines
+    nobody re-read. ``test/test_channel_env_write_off_loop.py`` pins both
+    properties for all six channels.
     """
     from kiro_crew.config.loader import env_path  # noqa: F811
 
@@ -2940,7 +2978,7 @@ async def _slack_config_save_locked(request: web.Request) -> web.Response:
     if env_updates:
         # Off-loop: on Windows the owner-only lockdown shells out to icacls,
         # which must not block the event loop.
-        await asyncio.to_thread(_write_env_updates, env_updates)
+        await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state.
         # load_credentials() lets os.environ win over .env, so without this a
         # replaced/cleared token would keep being reported as installed by GET
@@ -3357,7 +3395,7 @@ async def _discord_config_save_locked(request: web.Request) -> web.Response:
     if env_updates:
         # Off-loop: on Windows the owner-only lockdown shells out to icacls,
         # which must not block the event loop.
-        await asyncio.to_thread(_write_env_updates, env_updates)
+        await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
         # save handler for the full rationale).
@@ -3697,7 +3735,7 @@ async def _telegram_config_save_locked(request: web.Request) -> web.Response:
     if env_updates:
         # Off-loop: on Windows the owner-only lockdown shells out to icacls,
         # which must not block the event loop.
-        await asyncio.to_thread(_write_env_updates, env_updates)
+        await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
         # save handler for the full rationale).
@@ -4294,7 +4332,7 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
         if env_updates:
             # Off-loop: restrict_to_owner spawns whoami/icacls subprocesses on
             # Windows, which would stall the gateway loop if run inline.
-            await asyncio.to_thread(_write_env_updates, env_updates)
+            await _write_env_off_loop(env_updates)
             for key, new_val in env_updates.items():
                 if new_val is None:
                     os.environ.pop(key, None)
@@ -4507,7 +4545,7 @@ async def api_webex_config_save(request: web.Request) -> web.Response:
         if env_updates:
             # Off-loop: on Windows the owner-only lockdown shells out to icacls,
             # which must not block the event loop.
-            await asyncio.to_thread(_write_env_updates, env_updates)
+            await _write_env_off_loop(env_updates)
             # Keep the live process environment in sync (see the Slack save path).
             for key, new_val in env_updates.items():
                 if new_val is None:
@@ -5051,7 +5089,7 @@ async def _wecom_config_save_locked(request: web.Request) -> web.Response:
     if env_updates:
         # Off-loop: on Windows the owner-only lockdown shells out to icacls,
         # which must not block the event loop.
-        await asyncio.to_thread(_write_env_updates, env_updates)
+        await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
         # save handler for the full rationale).

--- a/test/test_channel_env_write_off_loop.py
+++ b/test/test_channel_env_write_off_loop.py
@@ -1,0 +1,189 @@
+"""Every channel token save writes ``.env`` off the loop AND drains before unlocking.
+
+``_write_env_updates`` stats and reads the whole ``.env``, re-parses it line by
+line, then writes an owner-locked temp file and renames it. All of it is
+synchronous file I/O, and all six channel config-save handlers are ``async``
+request handlers on the shared gateway loop.
+
+Two separate properties are pinned here, because the offload alone is not the
+whole contract:
+
+1. the write runs on a worker, not on the gateway loop -- asserted on the
+   thread the write ACTUALLY ran on, captured by wrapping
+   ``_write_env_updates`` itself, so it holds regardless of how a caller
+   reaches it;
+2. a cancelled save drains that worker before releasing ``_get_config_lock()``
+   -- the property a bare ``await asyncio.to_thread(...)`` does not have, and
+   the one the last test in this module covers.
+
+``.env`` and ``config.json`` are redirected into ``tmp_path`` and every token
+validator is stubbed to accept, so nothing here touches the network or a real
+credential file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import kiro_crew.config.loader as loader
+import kiro_crew.dashboard.handlers.messaging as mod
+
+# Shapes each validator accepts. Real-looking because the handlers reject on
+# format before they ever reach the write, and a rejected body would make this
+# pass for the wrong reason.
+TELEGRAM_TOKEN = "110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw"
+DISCORD_TOKEN = ".".join(
+    ["MTA5OTk5OTk5OTk5OTk5OTk5OQ", "GhIjKl", "MnOpQrStUvWxYz0123456789_-AbCdEfGhIj"]
+)
+
+# route, handler attribute, validator attribute, body — one row per channel.
+CHANNELS = [
+    ("slack", "api_slack_config_save", "_validate_slack_token", {"bot_token": "xoxb-NEW"}),
+    ("discord", "api_discord_config_save", "_validate_discord_token", {"bot_token": DISCORD_TOKEN}),
+    ("webex", "api_webex_config_save", "_validate_webex_token", {"bot_token": "webex-tok-1234"}),
+    (
+        "telegram",
+        "api_telegram_config_save",
+        "_validate_telegram_token",
+        {"bot_token": TELEGRAM_TOKEN},
+    ),
+]
+
+#: The channels whose saves are driven end to end here. Named so a
+#: parametrisation that silently loses one is a failure, not a smaller run.
+PINNED = {"slack", "discord", "webex", "telegram"}
+
+
+def _drive(channel: str, monkeypatch, tmp_path: Path) -> list[int]:
+    """Save one channel's token; return the threads the .env write ran on."""
+    name, handler_attr, validator_attr, body = next(c for c in CHANNELS if c[0] == channel)
+
+    env = tmp_path / ".env"
+    env.write_text("", encoding="utf-8")
+    monkeypatch.setattr(loader, "env_path", lambda: env)
+    monkeypatch.setattr(loader, "config_path", lambda: tmp_path / "config.json")
+    monkeypatch.setattr(mod, "is_direct_local_request", lambda req: True)
+
+    async def _accept(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(mod, validator_attr, _accept, raising=False)
+
+    threads: list[int] = []
+    real_write = mod._write_env_updates
+
+    def _record(updates):
+        threads.append(threading.get_ident())
+        return real_write(updates)
+
+    monkeypatch.setattr(mod, "_write_env_updates", _record)
+
+    async def _run() -> int:
+        app = web.Application()
+        app.router.add_put(f"/api/{name}/config", getattr(mod, handler_attr))
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.put(f"/api/{name}/config", json=body)
+            return resp.status
+
+    status = asyncio.run(_run())
+    assert status == 200, f"{name} save did not succeed ({status}); the write was never reached"
+    return threads
+
+
+@pytest.mark.parametrize("channel", sorted(c[0] for c in CHANNELS))
+def test_channel_token_save_writes_env_off_the_loop(channel, monkeypatch, tmp_path: Path) -> None:
+    loop_thread = threading.get_ident()
+    threads = _drive(channel, monkeypatch, tmp_path)
+
+    assert threads, f"the {channel} save never wrote .env"
+    assert threads[0] != loop_thread, (
+        f"the {channel} token save wrote .env on the gateway loop: a stat, a full "
+        "read and re-parse, then a temp-file create + chmod + rename, with every "
+        "other session blocked for the duration"
+    )
+
+
+def test_the_family_is_covered_here(monkeypatch, tmp_path: Path) -> None:
+    """Every channel this module claims to pin is still parametrised.
+
+    A parametrisation that quietly lost a channel would keep passing while
+    that channel regressed to a bare offload, which is the exact way a
+    per-site convention drifts back apart.
+    """
+    covered = {c[0] for c in CHANNELS}
+    assert PINNED <= covered, f"channels dropped from the table: {PINNED - covered}"
+
+
+def test_cancelling_a_save_drains_the_env_write_before_releasing_the_lock(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A cancelled save must not hand the config lock on mid-write.
+
+    Every channel save holds ``_get_config_lock()`` across the ``.env`` write, and
+    a thread cannot be cancelled. Without the drain, cancelling the request
+    unwinds the ``async with`` while the worker is still rewriting the file, so
+    the next channel save enters the critical section against a file still being
+    replaced and writes it back from lines it read before the first write landed
+    -- discarding whichever credential that save was persisting.
+
+    Ordering is forced with events, never slept for: the worker parks inside the
+    write, the caller is cancelled while it is parked, and a second writer then
+    tries to proceed. It must not get through until the first worker finishes.
+    """
+    from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+    in_write = threading.Event()
+    finish = threading.Event()
+    order: list[str] = []
+
+    def _slow_write(_updates):
+        order.append("worker-start")
+        in_write.set()
+        finish.wait(timeout=10)
+        order.append("worker-end")
+
+    monkeypatch.setattr(mod, "_write_env_updates", _slow_write)
+
+    async def _first():
+        async with _get_config_lock():
+            await mod._write_env_off_loop({"A": "1"})
+
+    async def _second():
+        async with _get_config_lock():
+            order.append("second-ran")
+
+    async def _run() -> tuple[bool, list[str]]:
+        first = asyncio.create_task(_first())
+        assert await asyncio.to_thread(in_write.wait, 10), "the worker never entered"
+
+        first.cancel()
+        second = asyncio.create_task(_second())
+        # Yield generously rather than sleeping: if the lock had been released the
+        # second writer would have run by now.
+        for _ in range(200):
+            await asyncio.sleep(0)
+        early = "second-ran" in order
+
+        finish.set()
+        try:
+            await first
+        except asyncio.CancelledError:
+            pass
+        await asyncio.wait_for(second, timeout=10)
+        return early, order
+
+    early, seen = asyncio.run(_run())
+
+    assert not early, (
+        "the config lock was handed to the next channel save while the cancelled "
+        "one's worker was still rewriting .env: %r" % (seen,)
+    )
+    assert seen.index("worker-end") < seen.index(
+        "second-ran"
+    ), "the second save entered before the first write finished: %r" % (seen,)


### PR DESCRIPTION
> **Rescoped on 2026-08-24.** The defect this PR originally opened against — three of six channel saves calling `_write_env_updates` inline on the gateway loop — was fixed upstream by #5269 and siblings. That half is **dropped, not re-landed**: `main` already offloads all six. What remains is the part the offload did not bring with it, described below.

## Problem / Motivation

Every channel token save runs its `.env` write inside `async with _get_config_lock()`, and on current `main` all six reach it as a bare offload:

```python
async with _get_config_lock():
    ...
    await asyncio.to_thread(_write_env_updates, env_updates)
```

A thread cannot be cancelled. When the request is cancelled — a client disconnecting mid-save, a gateway shutdown — the `await` raises `CancelledError` and the `async with` unwinds **while the worker is still rewriting `.env`**. The lock is released; the worker is not.

The next channel save then enters the critical section against a file that is still being replaced, and writes it back from lines it read before the first write landed. Whichever credential the cancelled save was persisting is discarded. Both saves answer `200`.

All six call sites on `main` have this shape: `_slack_config_save_locked`, `_discord_config_save_locked`, `_telegram_config_save_locked`, `api_teams_config_save`, `api_webex_config_save`, `_wecom_config_save_locked`.

## Why it matters

The lost write is a **credential**, and the loss is silent — the save that gets clobbered has already returned success to the user, so the dashboard shows the token as installed while `.env` holds the other one. Recovery requires noticing that a channel stopped authenticating and re-entering a token by hand.

Cancellation here is ordinary, not exotic: an aiohttp client disconnect during a save that is validating a token against a remote API (which is what makes the save slow enough to overlap another) is enough.

## What changed (motivation → approach → change)

**Motivation** — keep the lock's guarantee intact across the hop the offload introduced.

**Approach** — do not widen the lock or make the write cancellable; put the lock *release* after the worker. Shield the future so the cancellation does not propagate into it, drain it, then re-raise. This is the same shape `run_config_write` uses in `dashboard/chat_utils.py`, so the two config-write paths behave alike.

**Change** — one helper, `_write_env_off_loop`, and all six call sites route through it:

```python
async def _write_env_off_loop(updates: dict[str, str | None]) -> None:
    fut = asyncio.ensure_future(asyncio.to_thread(_write_env_updates, updates))
    try:
        await asyncio.shield(fut)
    except asyncio.CancelledError:
        await asyncio.wait([fut])
        raise
```

Draining cannot change **whether** the write happens — the thread runs to completion either way — so the only thing it decides is whether the lock outlives it. The `CancelledError` is re-raised, never swallowed.

**All six, not a subset.** The bare offload is the hole, so the three sites that were already offloading before this PR carry it too. Covering only some would leave the same window open in the rest and re-create a per-site split.

The caller contract is now stated on `_write_env_updates` itself, so the next channel inherits the reason and not just the shape.

## Tests

`test/test_channel_env_write_off_loop.py` (new) pins two distinct properties:

1. **Cancellation drain** — `test_cancelling_a_save_drains_the_env_write_before_releasing_the_lock`. Ordering is forced with events, never slept for: the worker parks inside the write, the caller is cancelled while it is parked, a second writer then tries to take the lock, and must not get through until the first worker finishes.

   **Fail-before, verified on this same tree** by replacing the helper body with a bare `await asyncio.to_thread(...)`:

   ```
   FAILED test_cancelling_a_save_drains_the_env_write_before_releasing_the_lock
     AssertionError: the config lock was handed to the next channel save while
     the cancelled one's worker was still rewriting .env
   1 failed, 5 passed
   ```

   Restored: `6 passed`.

2. **Off-loop guard** — four parametrised cases (slack, discord, webex, telegram) drive each save over a real HTTP client and assert on the thread the real `_write_env_updates` executed on. These **pass on `main` as it stands and are a guard, not a fail-before**: they exist so the next channel cannot reintroduce an inline write, plus a meta-test that fails if a channel is quietly dropped from the table.

Gates run locally on the rebased head: `flake8` · `isort --check-only` · `scripts/check_black_formatting.py` (2 files in scope, passed) · `scripts/check_loop_bound_locks.py` (passed).

## Manual verification

N/A — unit coverage sufficient: the regression turns on the interleaving of a cancellation and a worker thread, which the event-forced ordering reproduces deterministically and a hand test cannot.

## Related Issues

#5065 reported the inline-write half. That half is already fixed on `main` by #5269 and siblings, so this PR does not claim to close it — the issue can be closed independently of this change.

Same family as #4118 / #3803 / #4550, and the `run_config_write` drain in #5059.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: no documented behaviour changes. The caller contract is stated on `_write_env_updates` itself.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
