### PR TITLE
feat(mcp-gateway): contain spawned backends' temp output under a managed per-process dir

### DIFF
--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -1559,6 +1559,7 @@ async def probe_server(
     server.probe_mode = "handshake"
     proc = None
     sandbox_cleanup: str | None = None
+    probe_tmp: "Path | None" = None
     try:
         env = dict(os.environ)
         # The same expression backs command resolution and the PATH emitted into
@@ -1625,19 +1626,82 @@ async def probe_server(
                 server.name, server.command, server.args or [], server.env or {}
             ),
         )
-        proc = await create_subprocess_limited(
-            *wrapped_argv,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-            limit=1024 * 1024,  # 1 MB — some MCP servers return large responses
-            # POSIX: setsid so the probe owns a dedicated process group and
-            # teardown can killpg launcher grandchildren (a leader-only kill
-            # leaked ``npx @playwright/mcp`` -> node trees). Windows: silently
-            # ignored (mirrors AcpRuntime / AcpClient._spawn).
-            start_new_session=platform_compat.IS_POSIX,
-        )
+        # Probe temp containment (#5064): each probe gets its OWN private dir
+        # under the managed root, cleaned in this function's finally -- unlike
+        # a backend, a probe knows exactly when its lifecycle ends, so no
+        # shared directory and no sweep race exist. Lazily imported
+        # (mcp_gateway.preflight imports this module, so a module-level import
+        # would cycle), created off-loop, and fail-open: a probe must run even
+        # when containment cannot be set up.
+        #
+        # Mirrors the backend chokepoint: a spec-DECLARED temp wins -- the
+        # operator pointed this server at chosen storage, and overriding it
+        # would trade litter for ENOSPC on the data-home volume. Checked
+        # case-insensitively (Windows env keys are case-insensitive and the
+        # sanitized spec preserves the author's spelling).
+        try:
+            _declared_temp_upper = {
+                key.upper()
+                for key in (server.env or {})
+                if key.upper() in ("TMPDIR", "TMP", "TEMP")
+            }
+            if not _declared_temp_upper:
+                from kiro_crew.mcp_gateway.backend_tmp import allocate_probe_tmp, tmp_env
+
+                probe_tmp = await asyncio.to_thread(allocate_probe_tmp)
+                env = {**env, **tmp_env(probe_tmp)}
+            else:
+                # Yielding alone is not enough: ambient temp keys are still in
+                # ``env`` and ``tempfile`` consults TMPDIR before TMP, so a
+                # spec declaring only TMP would silently write through the
+                # inherited ambient TMPDIR. Strip the canonical keys the spec
+                # did NOT declare (mirrors the backend chokepoint).
+                env = {
+                    key: value
+                    for key, value in env.items()
+                    if not (
+                        key in ("TMPDIR", "TMP", "TEMP")
+                        and key not in _declared_temp_upper
+                    )
+                }
+        except Exception:
+            logger.debug("probe temp containment unavailable", exc_info=True)
+        try:
+            proc = await create_subprocess_limited(
+                *wrapped_argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                limit=1024 * 1024,  # 1 MB — some MCP servers return large responses
+                # POSIX: setsid so the probe owns a dedicated process group and
+                # teardown can killpg launcher grandchildren (a leader-only kill
+                # leaked ``npx @playwright/mcp`` -> node trees). Windows: silently
+                # ignored (mirrors AcpRuntime / AcpClient._spawn).
+                start_new_session=platform_compat.IS_POSIX,
+            )
+        except BaseException:
+            # Spawn failed: the probe never existed, so reclaim its fresh dir
+            # here and now -- ownerless-or-provisional dirs are deliberately
+            # never deleted by the sweeps, making this the ONLY reclamation
+            # point for it (mirrors spawn_backend's failure path).
+            if probe_tmp is not None:
+                from kiro_crew.mcp_gateway.backend_tmp import sweep_backend_tmp
+
+                await asyncio.to_thread(sweep_backend_tmp, probe_tmp)
+            raise
+        if probe_tmp is not None:
+            # Re-record the owner as the PROBE's pid. The provisional owner
+            # written at allocation is THIS gateway process, which stays alive
+            # indefinitely -- on the Windows path (finally-sweep deferred) the
+            # daemon sweep would then retain the dir forever, accumulating one
+            # per probe. The probe pid dies with the probe, so owner-dead+idle
+            # reclamation works there. Off-loop, fail-open (record_owner
+            # swallows OSError; a stale provisional owner then keeps the dir
+            # until this gateway exits, bounded by gateway lifetime).
+            from kiro_crew.mcp_gateway.backend_tmp import record_owner
+
+            await asyncio.to_thread(record_owner, probe_tmp, proc.pid)
 
         # Send initialize request
         init_req = (
@@ -1960,6 +2024,37 @@ async def probe_server(
                     )
         if sandbox_cleanup:
             Path(sandbox_cleanup).unlink(missing_ok=True)
+        if probe_tmp is not None:
+            if platform_compat.IS_POSIX:
+                # POSIX: the probe's dedicated process GROUP was reaped above
+                # (killpg is tree-faithful), so its private temp dir dies with
+                # it. Off-loop, fail-open (a failed cleanup is picked up by
+                # the daemon sweep once the dir is owner-dead and idle).
+                try:
+                    from kiro_crew.mcp_gateway.backend_tmp import sweep_backend_tmp
+
+                    await asyncio.to_thread(sweep_backend_tmp, probe_tmp)
+                except Exception:
+                    logger.debug("probe temp cleanup failed", exc_info=True)
+            else:
+                # Windows: taskkill /T walks PPID links and can miss a child
+                # whose wrapper already exited, so tree death is UNPROVABLE
+                # here. Deleting THIS dir now could remove temp storage under
+                # a live survivor -- instead run the root-wide dual-condition
+                # sweep (owner dead AND 1h+ whole-tree idle) from THIS
+                # process: it reclaims prior probes' dead dirs while never
+                # touching the fresh one (its tree is seconds old). Running
+                # it here, not only in the mcp-tmp daemon, matters because a
+                # topology with no stub servers never starts that daemon --
+                # probes must not depend on it for reclamation. Concurrent
+                # with a daemon sweep it is benign: both sides lstat-recheck
+                # and rmtree(ignore_errors=True).
+                try:
+                    from kiro_crew.mcp_gateway.backend_tmp import sweep_all_backend_tmp
+
+                    await asyncio.to_thread(sweep_all_backend_tmp)
+                except Exception:
+                    logger.debug("probe-side backend-tmp sweep failed", exc_info=True)
 
     # A probe run under a SYNTHETIC identity must not become the cached truth:
     # the per-name cache is what ``GET /api/mcp`` renders, and a pre-flight's

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -23,6 +23,7 @@ import os
 import re
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from kiro_crew import platform_compat
@@ -42,6 +43,12 @@ from kiro_crew.mcp_gateway.apps import (
     extract_ui_resource_uri,
     strip_model_hidden_tools,
     write_spool,
+)
+from kiro_crew.mcp_gateway.backend_tmp import (
+    allocate_backend_tmp,
+    record_owner,
+    sweep_backend_tmp,
+    tmp_env,
 )
 from kiro_crew.mcp_gateway.image_budget import (
     line_may_carry_image_block,
@@ -2183,6 +2190,11 @@ class Backend:
             await self._cancel_background_tasks()
             if self._dead_reason is None:
                 self._dead_reason = f"shutdown rc={self.process.returncode}"
+        # Deliberately NO temp sweep here: the launcher's exit is not proof
+        # its process TREE is gone (a wrapper launcher exits while its server
+        # child lives on and keeps using the dir). The single deletion
+        # authority is backend_tmp.sweep_all_backend_tmp, which requires the
+        # recorded owner to be dead AND the directory to be idle.
 
 
 # --- Spawn / handshake ------------------------------------------------------
@@ -2194,8 +2206,15 @@ async def spawn_backend(
     args: list[str],
     env: Mapping[str, str],
     work_dir: str,
+    declared_temp_keys: tuple[str, ...] = (),
 ) -> Backend:
     """Spawn a real MCP subprocess and wrap it in a :class:`Backend`.
+
+    ``declared_temp_keys`` are the temp-key names (``TMPDIR``/``TMP``/``TEMP``,
+    any casing) the operator's agent spec DECLARES for this server -- the
+    caller knows the declared-env set and this function does not (``env``
+    also carries the daemon's ambient values, which must not suppress
+    containment; see the containment block below).
 
     ``env`` is passed verbatim — callers MUST NOT rely on parent process
     env inheritance. The rewriter layer computes the effective env for
@@ -2235,17 +2254,72 @@ async def spawn_backend(
     # identity (unlike a per-session value, which would be a correctness bug).
     spawn_env = dict(env)
     spawn_env[KIROCREW_SPAWNED_ENV] = KIROCREW_SPAWNED_VALUE
-    process = await asyncio.create_subprocess_exec(
-        command,
-        *args,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=work_dir,
-        env=spawn_env,
-        start_new_session=True,
-        limit=READ_BUFFER_LIMIT_BYTES,
-    )
+    # Per-process temp containment (#5064). Safe re: the pooled-backend
+    # PoolKey invariant for the same reason as the marker above -- the value
+    # is derived from the key's own digest plus a token generated AFTER
+    # pool-identity resolution and is never folded into the hash, so it can
+    # neither split nor collapse pool identity. Allocated off-loop (mkdir is
+    # filesystem work), and fail-open: containment is hygiene, not a spawn
+    # prerequisite -- a host where the dir cannot be created still gets a
+    # working backend with today's inherited-temp behavior.
+    #
+    # An OPERATOR-DECLARED temp wins: a spec that sets any of TMPDIR/TMP/TEMP
+    # deliberately points a heavy server at chosen storage (e.g. a capacity
+    # volume), and overriding it would trade litter for ENOSPC. No allocation
+    # happens at all in that case -- no empty dir, nothing to sweep.
+    #
+    # Declaration is signalled by the CALLER (``declared_temp_keys``), not
+    # read off ``spawn_env``: the resolver folds the daemon's own inherited
+    # environment into ``env``, and macOS always exports TMPDIR (Windows
+    # always exports TMP/TEMP), so an env-membership test would read the
+    # ambient value as a declaration and silently disable containment on
+    # those platforms. Ambient keys are OVERRIDDEN by the managed triple on
+    # success, left untouched on allocation failure (the documented fail-open
+    # "inherited temp" fallback), and PRUNED down to the declared set when
+    # the operator declared a temp (see the else branch).
+    backend_tmp: Optional[Path] = None
+    _declared_upper = {key.upper() for key in declared_temp_keys}
+    if not _declared_upper:
+        try:
+            backend_tmp = await asyncio.to_thread(
+                allocate_backend_tmp, pool_key.stable_hash()
+            )
+            spawn_env.update(tmp_env(backend_tmp))
+        except OSError:
+            logger.warning(
+                "backend-tmp: could not allocate a contained temp dir; spawning "
+                "with inherited temp",
+                exc_info=True,
+            )
+    else:
+        # Yielding is not enough on its own: the daemon's AMBIENT temp keys
+        # are still in ``spawn_env``, and ``tempfile`` consults TMPDIR before
+        # TMP -- a spec declaring only ``TMP`` on macOS would silently write
+        # through the inherited ambient TMPDIR. Strip the canonical keys the
+        # operator did NOT declare so the declared one actually governs.
+        for key in ("TMPDIR", "TMP", "TEMP"):
+            if key not in _declared_upper:
+                spawn_env.pop(key, None)
+    try:
+        process = await asyncio.create_subprocess_exec(
+            command,
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=work_dir,
+            env=spawn_env,
+            start_new_session=True,
+            limit=READ_BUFFER_LIMIT_BYTES,
+        )
+    except BaseException:
+        # The spawn itself failed: reclaim the just-allocated dir here and
+        # now. Unowned directories are deliberately never deleted by the
+        # sweeps (an owner record can fail on a live backend), so this is
+        # the ONLY reclamation point for a dir whose process never existed.
+        if backend_tmp is not None:
+            await asyncio.to_thread(sweep_backend_tmp, backend_tmp)
+        raise
     if process.stdin is None or process.stdout is None:
         # asyncio.create_subprocess_exec populates these whenever PIPE was
         # requested; the guard exists for type checkers. Kill the child on
@@ -2277,6 +2351,12 @@ async def spawn_backend(
     )
     backend._last_ping_response_mono = now  # cold-start: not insta-stale
     backend._stderr_task = stderr_task
+    if backend_tmp is not None:
+        # Liveness anchor for the daemon-boot sweep: a SIGKILL'd daemon can
+        # leave this backend running (start_new_session), and the next boot
+        # must not delete temp storage under a survivor. Off-loop, fail-open
+        # (an unowned dir falls under the sweep's grace-window rule instead).
+        await asyncio.to_thread(record_owner, backend_tmp, process.pid)
     return backend
 
 

--- a/src/kiro_crew/mcp_gateway/backend_tmp.py
+++ b/src/kiro_crew/mcp_gateway/backend_tmp.py
@@ -1,0 +1,274 @@
+"""Per-process temp-dir containment for gateway-spawned MCP servers.
+
+Third-party MCP servers write telemetry, caches, and scratch files into
+whatever temp directory their process sees. Spawned with an inherited
+default, that is the shared system temp dir -- which nothing ever cleans, so
+their output accumulates for as long as the host lives (issue #5064). Setting
+``TMPDIR``/``TMP``/``TEMP`` at the spawn chokepoint contains every
+well-behaved server without touching any server's code. A server that
+hardcodes ``/tmp`` ignores the variables and keeps today's behavior: this is
+containment, not a sandbox guarantee.
+
+Layout: ``<data home>/run/mcp-tmp/<digest12>-<token8>/`` -- one directory per
+spawned PROCESS, not per PoolKey. Two live processes can share a PoolKey (a
+connection-private backend spawned beside the shared one), so a sweep keyed
+on the digest alone would delete the temp dir out from under the survivor.
+The digest prefix keeps the directory attributable to its server config; the
+fresh token makes the shutdown sweep single-owner by construction.
+
+PoolKey invariant (same reasoning as the ``KIROCREW_SPAWNED_ENV`` marker in
+:func:`kiro_crew.mcp_gateway.backend.spawn_backend`): the injected value is
+derived from the key's own digest plus a token generated AFTER pool-identity
+resolution, and is never folded into the PoolKey hash -- so it can neither
+split nor collapse pooled-backend identity.
+
+Sweep hygiene follows the house rules established by
+:mod:`kiro_crew.agents_janitor`: ``os.lstat`` snapshots, symlinks are never
+followed (a symlink where a directory is expected is skipped entirely),
+deletion happens only for direct children of the managed root, and every
+failure is tolerated per entry (fail-open -- hygiene must never take the
+daemon down).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import shutil
+import stat
+import time
+from pathlib import Path
+
+from kiro_crew import platform_compat
+from kiro_crew.config.loader import config_dir
+
+logger = logging.getLogger(__name__)
+
+#: Subdirectory of ``<data home>/run`` that holds every per-process temp dir.
+_SUBDIR = "mcp-tmp"
+
+
+def backend_tmp_root() -> Path:
+    """The managed root: ``<data home>/run/mcp-tmp``."""
+    return config_dir() / "run" / _SUBDIR
+
+
+def allocate_backend_tmp(pool_digest: str) -> Path:
+    """Create and return a fresh private temp dir for ONE backend process.
+
+    ``0o700`` like the rest of ``<data home>/run``. A PROVISIONAL owner (the
+    spawning process) is recorded inside the same allocation step: deletion is
+    permitted only for owned-and-dead directories, so a dir that cannot get an
+    owner must not exist at all -- if the owner write fails (ENOSPC, inode
+    exhaustion), the dir is removed and the failure propagates, degrading the
+    spawn to inherited temp instead of leaving an unreclaimable orphan.
+    :func:`record_owner` later replaces the provisional pid with the child's.
+    """
+    root = backend_tmp_root()
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # ``mode=0o700`` is a POSIX-bits no-op on Windows: under a permissive
+    # custom data home the dir would inherit a readable DACL, exposing any
+    # token-bearing temp file a backend writes. The shim applies an
+    # owner-only DACL with (OI)(CI) inheritance there (0o700 on POSIX), so
+    # children created inside are covered as well.
+    platform_compat.restrict_dir_to_owner(root)
+    name = f"{pool_digest[:12]}-{secrets.token_hex(4)}"
+    path = root / name
+    path.mkdir(mode=0o700)
+    platform_compat.restrict_dir_to_owner(path)
+    try:
+        (path / OWNER_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
+    except OSError:
+        shutil.rmtree(path, ignore_errors=True)
+        raise
+    return path
+
+
+def allocate_probe_tmp() -> Path:
+    """Create and return a fresh private temp dir for ONE probe spawn.
+
+    Same allocation contract as :func:`allocate_backend_tmp` (provisional
+    owner written atomically, raise-and-remove on failure). The probe cleans
+    its own dir in its ``finally`` -- unlike a backend, a probe knows exactly
+    when its lifecycle ends -- and a cleanup that never ran (crash) leaves an
+    owner-dead dir the daemon sweep reclaims once idle.
+    """
+    return allocate_backend_tmp("probe")
+
+
+def tmp_env(path: Path) -> dict[str, str]:
+    """The ``TMPDIR``/``TMP``/``TEMP`` triple pointing a child at *path*.
+
+    All three deliberately: ``tempfile`` honors ``TMPDIR`` on POSIX but
+    ``TMP``/``TEMP`` on Windows, and shell ``mktemp`` reads ``TMPDIR`` --
+    setting the triple covers every well-behaved consumer on both platforms.
+    """
+    value = str(path)
+    return {"TMPDIR": value, "TMP": value, "TEMP": value}
+
+
+def _is_plain_dir(path: Path) -> bool:
+    """A real directory -- not a symlink, not a file, not absent.
+
+    ``os.lstat``, never ``stat``: a symlink planted where a directory is
+    expected must classify as a symlink so the sweep skips it instead of
+    following it out of the managed root.
+    """
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return False
+    return stat.S_ISDIR(info.st_mode)
+
+
+#: Owner-pid marker written right after the backend process spawns.
+OWNER_FILENAME = ".owner"
+
+#: A token dir younger than this with no ``.owner`` yet is mid-spawn, not an
+#: orphan.
+_UNOWNED_GRACE_SECONDS = 3600.0
+
+
+def record_owner(path: Path, pid: int) -> None:
+    """Record the spawned backend's pid so the boot sweep can check liveness."""
+    try:
+        (path / OWNER_FILENAME).write_text(str(pid), encoding="utf-8")
+    except OSError:
+        # Fail-open: an unowned dir falls under the grace-window rule instead.
+        logger.debug("backend-tmp: could not record owner for %r", path.name, exc_info=True)
+
+
+def _pgroup_alive(pid: int) -> bool:
+    """Whether any member of *pid*'s PROCESS GROUP is still alive.
+
+    The recorded owner is the launcher pid, and ``spawn_backend`` uses
+    ``start_new_session=True`` -- so the launcher's pid IS the group id and
+    ordinary descendants keep it even after the launcher exits. Probing the
+    GROUP (:func:`platform_compat.pgroup_exists`) is therefore the
+    tree-faithful liveness signal: a live child holding an open file
+    descriptor produces no directory-mtime evidence at all, while the group
+    probe still sees it. A descendant that setsid()s OUT of the group evades
+    this probe -- and equally evades ``kill_process_tree`` -- so it is owned
+    by the spawn-marker orphan reaper, not by this sweep; the sweep's
+    liveness boundary deliberately matches the kill path's tree boundary.
+    """
+    if pid <= 0:
+        return False
+    return platform_compat.pgroup_exists(pid)
+
+
+def sweep_backend_tmp(path: Path) -> None:
+    """Remove ONE backend's temp dir after its process is gone (fail-open).
+
+    Containment guard: only a direct child of the managed root is ever
+    removed -- a path from anywhere else (bug, stale attribute) is refused
+    and logged rather than deleted.
+    """
+    if path.parent != backend_tmp_root():
+        logger.warning(
+            "backend-tmp: refusing to sweep a path outside the managed root: %r",
+            path.name,
+        )
+        return
+    if not _is_plain_dir(path):
+        # Already gone, or replaced by something that is not a plain
+        # directory (e.g. a planted symlink) -- never followed, never removed.
+        return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _tree_newest_mtime(root: Path, fallback: float) -> float:
+    """The newest mtime anywhere in *root*'s tree (lstat, symlinks never followed).
+
+    A live process writing through an already-open file descriptor never
+    touches the top DIRECTORY's mtime, but every write refreshes the FILE's
+    own mtime -- so tree-newest is the faithful idle signal on every
+    platform, and the only one available on Windows (no process groups).
+    Fail-safe: an unreadable entry returns *fallback* (reads as active, the
+    sweep keeps the dir).
+
+    Deliberately UNCAPPED: an entry cap that bails to *fallback* turns every
+    tree larger than the cap into a permanently active-looking one, so a dead
+    backend that wrote enough entries could never be reclaimed and repeated
+    runs would exhaust storage -- the exact defect this module exists to fix.
+    The walk runs off the event loop (``asyncio.to_thread`` / daemon thread)
+    on an hourly cadence, and its size is bounded by what one backend wrote
+    into its OWN temp dir, so a full metadata walk is the right trade.
+    """
+    newest = 0.0
+    try:
+        newest = os.lstat(root).st_mtime
+        stack = [root]
+        while stack:
+            current = stack.pop()
+            for entry in os.scandir(current):
+                info = os.lstat(entry.path)
+                if info.st_mtime > newest:
+                    newest = info.st_mtime
+                if stat.S_ISDIR(info.st_mode):  # lstat: symlinks never descend
+                    stack.append(Path(entry.path))
+    except OSError:
+        return fallback
+    return newest
+
+
+def sweep_all_backend_tmp() -> int:
+    """Sweep (boot + periodic): remove dirs whose owner is DEAD and whose
+    content is IDLE.
+
+    Deletion needs BOTH signals, because each alone is an unfaithful proxy
+    for "no process is using this":
+
+    * The recorded owner is the LAUNCHER pid, and a wrapper launcher (npx ->
+      node) can exit while its server child lives on and keeps writing temp
+      files -- ``tempfile`` creates entries directly under ``$TMPDIR``, so a
+      live user keeps the dir's mtime fresh. Dead owner + fresh mtime reads
+      as "still in use": kept.
+    * A dir with NO owner record is NEVER deleted here. Allocation writes a
+      provisional owner atomically-with-creation and fails the allocation
+      otherwise, so an ownerless dir indicates a state this code did not
+      produce -- deleting on absence-of-evidence is how live data gets lost.
+    * A garbled owner file is left for a human.
+
+    Probe dirs are allocated with the same contract and normally removed by
+    the probe's own ``finally``; one whose cleanup never ran is reclaimed by
+    the generic owner-dead + idle path above.
+
+    Returns the number of directories removed.
+    """
+    root = backend_tmp_root()
+    try:
+        entries = list(os.scandir(root))
+    except FileNotFoundError:
+        return 0
+    except OSError:
+        logger.debug("backend-tmp: could not list %s; skipping sweep", root, exc_info=True)
+        return 0
+    reference = time.time()
+    removed = 0
+    for entry in entries:
+        # Name-composed child path: nothing here can traverse outside root.
+        child = root / entry.name
+        if not _is_plain_dir(child):
+            # Symlinks and stray files are never swept.
+            continue
+        try:
+            idle = reference - _tree_newest_mtime(child, fallback=reference)
+        except OSError:
+            continue
+        if idle < _UNOWNED_GRACE_SECONDS:
+            continue  # recently active anywhere in the tree, whoever owns it
+        owner_file = child / OWNER_FILENAME
+        try:
+            pid = int(owner_file.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            # Unowned or garbled: never delete on absence of evidence.
+            continue
+        if _pgroup_alive(pid):
+            continue
+        shutil.rmtree(child, ignore_errors=True)
+        removed += 1
+    if removed:
+        logger.info("backend-tmp: sweep removed %d dead idle dir(s)", removed)
+    return removed

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -49,6 +49,7 @@ from kiro_crew.mcp_caller import _parent_pid as _ppid_fn
 from kiro_crew.mcp_gateway import credwatch, hazards, socketsec, transport
 from kiro_crew.mcp_gateway.apps import sweep_spool as apps_sweep_spool
 from kiro_crew.mcp_gateway.backend import Backend, BackendGone, spawn_backend
+from kiro_crew.mcp_gateway.backend_tmp import sweep_all_backend_tmp
 from kiro_crew.mcp_gateway.breaker import CircuitBreaker
 from kiro_crew.mcp_gateway.hashing import hash_effective_env, non_secret_env
 from kiro_crew.mcp_gateway.manager import _scrub_sensitive_env, is_credential_env_key
@@ -436,6 +437,7 @@ async def run_gatewayd(
     # a dangling socket that confuses the next startup probe.
     server: Optional[transport.TransportServer] = None
     sweeper: Optional[asyncio.Task[None]] = None
+    tmp_sweeper: Optional[asyncio.Task[None]] = None
     socket_liveness: Optional[asyncio.Task[None]] = None
     diagnostic: Optional[asyncio.Task[None]] = None
     heartbeat: Optional[asyncio.Task[None]] = None
@@ -484,6 +486,22 @@ async def run_gatewayd(
             _idle_sweeper(pool, idle_timeout_secs, sweep_interval, stop_event),
             name="mcp-gateway-idle-sweeper",
         )
+
+        # Backend temp containment (#5064): reclaim per-process temp dirs
+        # whose owner is dead AND whose content is idle (see backend_tmp --
+        # deletion deliberately lives ONLY here, never on a shutdown path,
+        # because a launcher's exit is not proof its process tree is gone).
+        # First pass at task start (same boot posture as the spool sweep),
+        # then hourly; offloaded and best-effort.
+        async def _backend_tmp_sweeper() -> None:
+            while True:
+                try:
+                    await asyncio.to_thread(sweep_all_backend_tmp)
+                except Exception:
+                    logger.debug("backend-tmp: sweep failed", exc_info=True)
+                await asyncio.sleep(3600)
+
+        tmp_sweeper = asyncio.create_task(_backend_tmp_sweeper(), name="mcp-gateway-tmp-sweeper")
 
         # Socket-liveness self-exit: the daemon is its own session/group
         # leader, so a launcher that dies without signalling it (pytest
@@ -692,6 +710,11 @@ async def run_gatewayd(
             sweeper.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await sweeper
+
+        if tmp_sweeper is not None:
+            tmp_sweeper.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await tmp_sweeper
 
         if socket_liveness is not None:
             socket_liveness.cancel()
@@ -2831,6 +2854,17 @@ async def _acquire_backend(
             args=list(args),
             env=spawn_env,
             work_dir=work_dir,
+            # Containment yields ONLY to a spec-declared temp. ``spawn_env``
+            # also carries the daemon's ambient TMPDIR/TMP/TEMP (macOS and
+            # Windows always export one), so spawn_backend cannot infer
+            # declaration from env membership -- this closure is the one
+            # place that still knows the declared set. Key NAMES are passed
+            # (matched case-insensitively inside; Windows env keys are
+            # case-insensitive) so spawn_backend can also prune the ambient
+            # keys the operator did NOT declare.
+            declared_temp_keys=tuple(
+                key for key in declared if key.upper() in ("TMPDIR", "TMP", "TEMP")
+            ),
         )
         # Security note: resolved secrets exist ONLY in the local spawn_env
         # dict passed to the child via Popen(env=...).  They are NEVER written

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -2065,6 +2065,36 @@ def pid_liveness(pid: int) -> str:
     return PID_ALIVE if pid_exists(pid) else PID_DEAD
 
 
+def pgroup_exists(pgid: int) -> bool:
+    """Return True iff any member of process GROUP ``pgid`` is alive (best-effort).
+
+    The tree-faithful liveness probe for a child spawned with
+    ``start_new_session=True``: the launcher's pid doubles as the group id and
+    ordinary descendants keep it after the launcher exits, so the group
+    outlives the launcher exactly as long as any member does. A descendant
+    that ``setsid()``s out of the group evades this probe precisely as it
+    evades ``kill_process_tree`` -- callers that must catch those use the
+    escaped-children reapers, not this.
+
+    POSIX: ``os.killpg(pgid, 0)`` -- conservative on EPERM (unsignalable
+    reads as alive). Windows: process groups in this sense do not exist and
+    ``kill_process_tree`` already walks the whole child tree via
+    ``taskkill /T``, so the group id (== the launcher pid) is probed as a
+    plain pid via :func:`pid_exists`.
+    """
+    if not IS_POSIX:
+        return pid_exists(pgid)
+    if pgid <= 0:
+        return False
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True  # exists but we can't signal it
+    return True
+
+
 def pid_exists(pid: int) -> bool:
     """Return True iff ``pid`` currently exists (best-effort).
 

--- a/test/test_backend_tmp.py
+++ b/test/test_backend_tmp.py
@@ -1,0 +1,269 @@
+"""Tests for :mod:`kiro_crew.mcp_gateway.backend_tmp` (issue #5064).
+
+Everything runs against a monkeypatched data home under ``tmp_path``; the
+real ``<data home>/run`` is never touched.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_gateway import backend_tmp as bt
+
+
+@pytest.fixture
+def tmp_root(monkeypatch, tmp_path: Path) -> Path:
+    """Point the module's data home at a fabricated directory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(bt, "config_dir", lambda: home)
+    return home / "run" / "mcp-tmp"
+
+
+DIGEST = "a" * 64
+
+
+class TestAllocate:
+    def test_creates_private_dir_under_managed_root(self, tmp_root: Path) -> None:
+        path = bt.allocate_backend_tmp(DIGEST)
+
+        assert path.parent == tmp_root
+        assert path.is_dir()
+        assert path.name.startswith(DIGEST[:12] + "-")
+        # Provisional owner recorded atomically-with-allocation: deletion is
+        # only ever permitted for owned-and-dead dirs, so a dir must never
+        # exist without an owner record.
+        assert (path / bt.OWNER_FILENAME).read_text() == str(os.getpid())
+        if sys.platform != "win32":
+            assert stat.S_IMODE(os.stat(path).st_mode) == 0o700
+            assert stat.S_IMODE(os.stat(tmp_root).st_mode) == 0o700
+
+    def test_allocation_applies_platform_dacl_lockdown(self, tmp_root: Path, monkeypatch) -> None:
+        # ``mode=0o700`` is a POSIX-bits no-op on Windows: under a permissive
+        # custom data home the dir would inherit a readable DACL, exposing
+        # token-bearing temp files. Allocation must route through the shim
+        # (owner-only DACL with inheritance on Windows, chmod 0o700 on
+        # POSIX) for BOTH the root and the fresh child dir.
+        from kiro_crew import platform_compat as pc
+
+        calls: list[str] = []
+        real = pc.restrict_dir_to_owner
+
+        def _spy(path):
+            calls.append(str(path))
+            real(path)
+
+        monkeypatch.setattr(pc, "restrict_dir_to_owner", _spy)
+
+        path = bt.allocate_backend_tmp(DIGEST)
+
+        assert str(tmp_root) in calls
+        assert str(path) in calls
+
+    def test_two_allocations_of_one_digest_are_distinct(self, tmp_root: Path) -> None:
+        # Per PROCESS, not per PoolKey: a connection-private backend can run
+        # beside the shared one on the same key, and a digest-keyed dir would
+        # let one process's shutdown sweep delete the other's live temp.
+        a = bt.allocate_backend_tmp(DIGEST)
+        b = bt.allocate_backend_tmp(DIGEST)
+        assert a != b
+
+    def test_probe_dirs_are_private_and_owned(self, tmp_root: Path) -> None:
+        # Per-probe, never shared: a shared dir invites a sweep-vs-acquire
+        # race; a private dir dies in the probe's own finally.
+        a = bt.allocate_probe_tmp()
+        b = bt.allocate_probe_tmp()
+        assert a != b
+        assert a.parent == b.parent == tmp_root
+        assert (a / bt.OWNER_FILENAME).read_text() == str(os.getpid())
+
+
+class TestTmpEnv:
+    def test_triple_points_at_the_dir(self, tmp_path: Path) -> None:
+        env = bt.tmp_env(tmp_path)
+        assert env == {"TMPDIR": str(tmp_path), "TMP": str(tmp_path), "TEMP": str(tmp_path)}
+
+
+class TestSweepOne:
+    def test_removes_own_dir_with_contents(self, tmp_root: Path) -> None:
+        path = bt.allocate_backend_tmp(DIGEST)
+        (path / "litter").mkdir()
+        (path / "litter" / "cache.bin").write_bytes(b"x")
+
+        bt.sweep_backend_tmp(path)
+
+        assert not path.exists()
+
+    def test_refuses_a_path_outside_the_managed_root(self, tmp_root: Path, tmp_path: Path) -> None:
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        (victim / "keep.txt").write_text("keep")
+
+        bt.sweep_backend_tmp(victim)
+
+        assert victim.exists() and (victim / "keep.txt").exists()
+
+    def test_missing_dir_is_a_noop(self, tmp_root: Path) -> None:
+        bt.sweep_backend_tmp(tmp_root / "gone-already")  # must not raise
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege")
+    def test_symlink_in_place_of_dir_is_never_followed(
+        self, tmp_root: Path, tmp_path: Path
+    ) -> None:
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        (victim / "keep.txt").write_text("keep")
+        path = bt.allocate_backend_tmp(DIGEST)
+        (path / bt.OWNER_FILENAME).unlink()
+        path.rmdir()
+        path.symlink_to(victim)
+
+        bt.sweep_backend_tmp(path)
+
+        assert victim.exists() and (victim / "keep.txt").exists()
+
+
+def _age(path: Path, seconds: float) -> None:
+    import time
+
+    past = time.time() - seconds
+    os.utime(path, (past, past))
+
+
+class TestBootSweep:
+    def test_dead_and_idle_reclaimed_dead_but_active_kept(self, tmp_root: Path) -> None:
+        # Deletion needs BOTH signals: the recorded owner is the LAUNCHER
+        # pid, and a wrapper launcher can exit while its server child lives
+        # on writing temp files (which keeps the dir mtime fresh).
+        dead_idle = bt.allocate_backend_tmp(DIGEST)
+        bt.record_owner(dead_idle, 2**22 - 1)  # almost surely dead
+        _age(dead_idle, 2 * bt._UNOWNED_GRACE_SECONDS)
+        _age(dead_idle / bt.OWNER_FILENAME, 2 * bt._UNOWNED_GRACE_SECONDS)
+        dead_active = bt.allocate_backend_tmp("b" * 64)
+        bt.record_owner(dead_active, 2**22 - 1)  # dead owner, fresh mtime
+
+        removed = bt.sweep_all_backend_tmp()
+
+        assert not dead_idle.exists()
+        assert dead_active.exists(), "fresh mtime reads as in-use: kept"
+        assert removed == 1
+
+    def test_oversized_dead_tree_is_still_reclaimed(self, tmp_root: Path) -> None:
+        # Regression: an entry cap in the tree-idle walk that bailed to
+        # ``fallback`` (= now) made every tree larger than the cap read as
+        # permanently ACTIVE, so a dead backend that wrote enough entries
+        # could never be reclaimed -- the exact storage-exhaustion defect
+        # this module exists to fix. 10,050 entries exceeds the removed
+        # 10,000 cap; the walk is uncapped now and must find the true
+        # (ancient) newest mtime.
+        import time
+
+        big = bt.allocate_backend_tmp(DIGEST)
+        bt.record_owner(big, 2**22 - 1)  # almost surely dead
+        past = time.time() - 2 * bt._UNOWNED_GRACE_SECONDS
+        for d in range(10):
+            sub = big / f"d{d}"
+            sub.mkdir()
+            for f in range(1005):
+                p = sub / f"f{f}"
+                p.touch()
+                os.utime(p, (past, past))
+            os.utime(sub, (past, past))
+        _age(big, 2 * bt._UNOWNED_GRACE_SECONDS)
+        _age(big / bt.OWNER_FILENAME, 2 * bt._UNOWNED_GRACE_SECONDS)
+
+        removed = bt.sweep_all_backend_tmp()
+
+        assert not big.exists()
+        assert removed == 1
+
+    def test_deep_fresh_write_keeps_the_dir(self, tmp_root: Path) -> None:
+        # A live process writing through an already-open fd never touches the
+        # top DIRECTORY's mtime -- the idle signal must be tree-newest, so a
+        # fresh file deep inside keeps the dir even when the top is aged and
+        # the recorded owner is dead (the Windows-reachable wrapper case,
+        # where no group probe exists).
+        path = bt.allocate_backend_tmp(DIGEST)
+        bt.record_owner(path, 2**22 - 1)  # dead owner
+        nested = path / "cache" / "blobs"
+        nested.mkdir(parents=True)
+        (nested / "live.bin").write_bytes(b"x")
+        for p in (path, path / "cache", nested, path / bt.OWNER_FILENAME):
+            _age(p, 2 * bt._UNOWNED_GRACE_SECONDS)
+        os.utime(nested / "live.bin")  # the one fresh entry
+
+        assert bt.sweep_all_backend_tmp() == 0
+        assert path.exists()
+
+    def test_live_owner_is_kept_even_when_idle(self, tmp_root: Path) -> None:
+        live = bt.allocate_backend_tmp(DIGEST)
+        # POSIX: our own process GROUP id -- the probe is group-scoped (the
+        # launcher pid doubles as the pgid under start_new_session), and
+        # under pytest-xdist os.getpid() is not a group leader. Windows: the
+        # probe routes through pid_exists, so a live PID is the right ref.
+        live_ref = os.getpid() if sys.platform == "win32" else os.getpgrp()
+        bt.record_owner(live, live_ref)
+        _age(live, 2 * bt._UNOWNED_GRACE_SECONDS)
+
+        assert bt.sweep_all_backend_tmp() == 0
+        assert live.exists()
+
+    def test_unowned_dir_is_never_deleted(self, tmp_root: Path) -> None:
+        # Allocation writes a provisional owner atomically-with-creation, so
+        # an ownerless dir indicates a state this code did not produce --
+        # deleting on absence of evidence is how live data gets lost.
+        path = bt.allocate_backend_tmp(DIGEST)
+        (path / bt.OWNER_FILENAME).unlink()
+        _age(path, 10 * bt._UNOWNED_GRACE_SECONDS)
+
+        assert bt.sweep_all_backend_tmp() == 0
+        assert path.exists()
+
+    def test_garbled_owner_is_left_for_a_human(self, tmp_root: Path) -> None:
+        path = bt.allocate_backend_tmp(DIGEST)
+        (path / bt.OWNER_FILENAME).write_text("not-a-pid")
+        _age(path, 2 * bt._UNOWNED_GRACE_SECONDS)
+
+        assert bt.sweep_all_backend_tmp() == 0
+        assert path.exists()
+
+    def test_crashed_probe_dir_is_reclaimed_when_dead_and_idle(self, tmp_root: Path) -> None:
+        # A probe normally cleans its own dir in its finally; one whose
+        # cleanup never ran (crash) is reclaimed by the generic owner-dead +
+        # idle path once its recording process is gone.
+        probe = bt.allocate_probe_tmp()
+        (probe / bt.OWNER_FILENAME).write_text(str(2**22 - 1))
+        _age(probe, 2 * bt._UNOWNED_GRACE_SECONDS)
+        _age(probe / bt.OWNER_FILENAME, 2 * bt._UNOWNED_GRACE_SECONDS)
+        assert bt.sweep_all_backend_tmp() == 1
+        assert not probe.exists()
+
+    def test_missing_root_returns_zero(self, tmp_root: Path) -> None:
+        assert bt.sweep_all_backend_tmp() == 0
+
+    def test_stray_file_is_left_alone(self, tmp_root: Path) -> None:
+        tmp_root.mkdir(parents=True)
+        stray = tmp_root / "not-a-dir.txt"
+        stray.write_text("stray")
+
+        removed = bt.sweep_all_backend_tmp()
+
+        assert removed == 0 and stray.exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege")
+    def test_symlink_child_is_never_followed(self, tmp_root: Path, tmp_path: Path) -> None:
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        (victim / "keep.txt").write_text("keep")
+        tmp_root.mkdir(parents=True)
+        (tmp_root / "evil-link").symlink_to(victim)
+
+        removed = bt.sweep_all_backend_tmp()
+
+        assert removed == 0
+        assert victim.exists() and (victim / "keep.txt").exists()

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -1997,6 +1997,198 @@ class TestProbeServerConsentGate:
         assert result.error == ""
 
 
+class TestProbeTempContainment:
+    """#5064 probe wiring: spec-declared temp yields; Windows defers cleanup.
+
+    Both tests assert ONLY on the containment calls and tolerate any probe
+    outcome -- the probe command is a real interpreter that exits instantly,
+    so the handshake fails, which is irrelevant to the temp lifecycle.
+    """
+
+    def setup_method(self) -> None:
+        _probe_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_spec_declared_temp_suppresses_probe_containment(self, tmp_path) -> None:
+        # Mirror of the backend chokepoint: an operator-declared temp key in
+        # the SPEC (any casing -- Windows env keys are case-insensitive)
+        # means no allocation at all, so a storage-heavy probe honors the
+        # configured volume instead of ENOSPC-ing the data home.
+        import sys
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        server = McpServerInfo(
+            name="declared-temp",
+            command=sys.executable,
+            args=["-c", "pass"],
+            env={"tmpdir": str(tmp_path / "chosen")},
+        )
+        alloc_spy = MagicMock(side_effect=AssertionError("must not allocate"))
+        with patch.object(bt, "allocate_probe_tmp", alloc_spy):
+            await probe_server(server)
+        alloc_spy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_windows_probe_cleanup_defers_to_daemon_sweep(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # On Windows tree death is unprovable (taskkill /T loses orphaned
+        # children), so the probe's finally must NOT delete -- the daemon's
+        # dual-condition sweep is the single deletion authority there. The
+        # probe command exits on its own, so skipping the POSIX reap branch
+        # (a side effect of patching IS_POSIX) leaks nothing.
+        import sys
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        # The IS_POSIX patch also flips restrict_dir_to_owner onto its icacls
+        # branch, which cannot run on the POSIX host executing this test --
+        # shim it to POSIX behavior so ALLOCATION survives and the test
+        # exercises the logic it targets.
+        monkeypatch.setattr(
+            platform_compat,
+            "restrict_dir_to_owner",
+            # 0o700 is the RESTRICTIVE mode for a directory (see the identical
+            # suppression in platform_compat.restrict_dir_to_owner itself).
+            # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501
+            lambda p: os.chmod(p, 0o700),
+        )
+
+        # Pre-seed a PRIOR probe's dead+idle dir: the deferral path must run
+        # the root-wide dual-condition sweep from THIS (gateway) process, so
+        # reclamation exists even in a topology that never starts the mcp-tmp
+        # daemon (no stub servers). Owner pid 2**22+5 is far above any live
+        # pid on CI runners; mtimes aged beyond the grace window.
+        stale = bt.backend_tmp_root() / "probe-deadbeef-old"
+        stale.mkdir(parents=True)
+        (stale / bt.OWNER_FILENAME).write_text(str(2**22 + 5), encoding="utf-8")
+        old = time.time() - 7200
+        os.utime(stale / bt.OWNER_FILENAME, (old, old))
+        os.utime(stale, (old, old))
+        os.utime(bt.backend_tmp_root(), (old, old))
+
+        server = McpServerInfo(name="win-probe", command=sys.executable, args=["-c", "pass"])
+        await probe_server(server)
+
+        # The prior dead dir was reclaimed by the probe-side sweep...
+        assert not stale.exists()
+        # ...while the fresh probe's own dir (seconds-old tree) was kept.
+        root = home / "run" / "mcp-tmp"
+        assert root.exists() and any(root.iterdir())
+        owners = [
+            int((child / bt.OWNER_FILENAME).read_text(encoding="utf-8").strip())
+            for child in root.iterdir()
+            if (child / bt.OWNER_FILENAME).is_file()
+        ]
+        assert owners and all(pid != os.getpid() for pid in owners)
+
+    @pytest.mark.asyncio
+    async def test_probe_spawn_failure_reclaims_the_fresh_dir(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A dir whose probe never existed has no dead-owner future: the sweeps
+        # never delete provisional/ownerless dirs, so the spawn-failure path
+        # is its only reclamation point (mirrors spawn_backend). Exercised on
+        # the WINDOWS path (IS_POSIX=False) where the finally-sweep defers to
+        # the daemon -- there the except-block reclamation is the ONLY one;
+        # on POSIX the finally would double-cover it and mask a regression.
+        import sys
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        # The IS_POSIX patch also flips restrict_dir_to_owner onto its icacls
+        # branch, which cannot run on the POSIX host executing this test --
+        # shim it to POSIX behavior so ALLOCATION survives and the test
+        # exercises the logic it targets.
+        monkeypatch.setattr(
+            platform_compat,
+            "restrict_dir_to_owner",
+            # 0o700 is the RESTRICTIVE mode for a directory (see the identical
+            # suppression in platform_compat.restrict_dir_to_owner itself).
+            # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501
+            lambda p: os.chmod(p, 0o700),
+        )
+
+        server = McpServerInfo(name="spawnfail", command=sys.executable, args=["-c", "pass"])
+        with patch(
+            "kiro_crew.mcp_discovery.create_subprocess_limited",
+            new_callable=AsyncMock,
+            side_effect=OSError("spawn failed"),
+        ):
+            result = await probe_server(server)
+
+        assert result.status == "error"
+        root = home / "run" / "mcp-tmp"
+        assert not root.exists() or not any(root.iterdir())
+
+    @pytest.mark.asyncio
+    async def test_partial_spec_declaration_strips_ambient_tmpdir(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Spec declares only TMP: the probe env must not keep the ambient
+        # TMPDIR (tempfile consults it first), and no managed dir may be
+        # allocated. Mirrors the backend chokepoint's pruning.
+        import sys
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "ambient"))
+
+        server = McpServerInfo(
+            name="partial-temp",
+            command=sys.executable,
+            args=["-c", "pass"],
+            env={"TMP": str(tmp_path / "chosen")},
+        )
+        with patch(
+            "kiro_crew.mcp_discovery.create_subprocess_limited",
+            new_callable=AsyncMock,
+            side_effect=OSError("stop after env capture"),
+        ) as spawn_mock:
+            await probe_server(server)
+
+        captured = spawn_mock.call_args.kwargs["env"]
+        assert "TMPDIR" not in captured
+        assert captured["TMP"] == str(tmp_path / "chosen")
+        root = home / "run" / "mcp-tmp"
+        assert not root.exists() or not any(root.iterdir())
+
+    @pytest.mark.skipif(
+        not platform_compat.IS_POSIX,
+        reason="POSIX-only control: on Windows the finally-path deferral to the "
+        "daemon sweep is the designed behavior (see the deferral test above)",
+    )
+    @pytest.mark.asyncio
+    async def test_posix_probe_cleanup_sweeps_its_own_dir(self, tmp_path, monkeypatch) -> None:
+        # Control for the Windows deferral: on POSIX the group reap is
+        # tree-faithful, so the probe's finally DOES reclaim its private dir.
+        import sys
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        server = McpServerInfo(name="posix-probe", command=sys.executable, args=["-c", "pass"])
+        await probe_server(server)
+
+        root = home / "run" / "mcp-tmp"
+        assert not root.exists() or not any(root.iterdir())
+
+
 class TestProbeServerProcessCleanup:
     """Tests for the finally block that tears down the probed subprocess."""
 

--- a/test/test_mcp_gateway_backend_coverage.py
+++ b/test/test_mcp_gateway_backend_coverage.py
@@ -2057,3 +2057,195 @@ class TestCallMetrics:
         await _settle(backend)
         assert backend._metric_tasks == set()
         assert json.loads(path.read_text(encoding="utf-8").strip())["method"] == "ping"
+
+
+class TestBackendTmpContainment:
+    """Issue #5064: spawn injects a contained temp dir; shutdown reclaims it."""
+
+    @pytest.mark.asyncio
+    async def test_spawn_contains_temp_under_managed_root(
+        self, fake_spawn, monkeypatch, tmp_path
+    ) -> None:
+        from pathlib import Path
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        await spawn_backend(
+            _pool_key(), "/usr/bin/example-mcp", [], {}, "/nonexistent-work-dir"
+        )
+
+        env = fake_spawn["kwargs"]["env"]
+        root = home / "run" / "mcp-tmp"
+        for key in ("TMPDIR", "TMP", "TEMP"):
+            assert Path(env[key]).parent == root, key
+        assert env["TMPDIR"] == env["TMP"] == env["TEMP"]
+        contained = Path(env["TMPDIR"])
+        assert contained.is_dir()
+        # Liveness anchor for the sweep: allocation + spawn leave an owner
+        # record on disk -- the sweep's ONLY state (no in-memory field).
+        assert (contained / bt.OWNER_FILENAME).is_file()
+
+    @pytest.mark.asyncio
+    async def test_operator_declared_temp_wins(self, fake_spawn, monkeypatch, tmp_path) -> None:
+        # A spec that sets TMPDIR deliberately points a heavy server at
+        # chosen storage; containment must not trade litter for ENOSPC.
+        # Declaration is the CALLER's signal (declared_temp_keys), carried
+        # from the gatewayd closure that knows the declared-env set.
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        await spawn_backend(
+            _pool_key(),
+            "/usr/bin/example-mcp",
+            [],
+            {"TMPDIR": "/mnt/bigdisk/tmp"},
+            "/nonexistent-work-dir",
+            declared_temp_keys=("TMPDIR",),
+        )
+
+        env = fake_spawn["kwargs"]["env"]
+        assert env["TMPDIR"] == "/mnt/bigdisk/tmp"
+        assert not (home / "run" / "mcp-tmp").exists() or not any(
+            (home / "run" / "mcp-tmp").iterdir()
+        )
+
+    @pytest.mark.asyncio
+    async def test_partial_declaration_strips_competing_ambient_keys(
+        self, fake_spawn, monkeypatch, tmp_path
+    ) -> None:
+        # A spec declaring only TMP must actually govern the child: tempfile
+        # consults TMPDIR before TMP, so leaving the daemon's ambient TMPDIR
+        # in place would silently defeat the declaration (macOS always
+        # exports one). Yield = declared keys kept, undeclared canonical
+        # keys pruned.
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        await spawn_backend(
+            _pool_key(),
+            "/usr/bin/example-mcp",
+            [],
+            {"TMPDIR": "/var/folders/xy/ambient", "TMP": "/mnt/bigdisk/tmp"},
+            "/nonexistent-work-dir",
+            declared_temp_keys=("TMP",),
+        )
+
+        env = fake_spawn["kwargs"]["env"]
+        assert "TMPDIR" not in env
+        assert env["TMP"] == "/mnt/bigdisk/tmp"
+        assert not (home / "run" / "mcp-tmp").exists() or not any(
+            (home / "run" / "mcp-tmp").iterdir()
+        )
+
+    @pytest.mark.asyncio
+    async def test_ambient_temp_does_not_suppress_containment(
+        self, fake_spawn, monkeypatch, tmp_path
+    ) -> None:
+        # Regression: the resolver folds the daemon's own inherited environ
+        # into the spawn env, and macOS always exports TMPDIR (Windows: TMP /
+        # TEMP). An env-membership gate read that ambient value as an operator
+        # declaration and disabled containment on those platforms entirely.
+        # Ambient keys must be OVERRIDDEN by the managed triple.
+        from pathlib import Path
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        await spawn_backend(
+            _pool_key(),
+            "/usr/bin/example-mcp",
+            [],
+            {"TMPDIR": "/var/folders/xy/ambient", "TMP": r"C:\Users\x\tmp"},
+            "/nonexistent-work-dir",
+            declared_temp_keys=(),
+        )
+
+        env = fake_spawn["kwargs"]["env"]
+        root = home / "run" / "mcp-tmp"
+        for key in ("TMPDIR", "TMP", "TEMP"):
+            assert Path(env[key]).parent == root, key
+        assert Path(env["TMPDIR"]).is_dir()
+
+    @pytest.mark.asyncio
+    async def test_spawn_survives_allocation_failure(self, fake_spawn, monkeypatch) -> None:
+        # Fail-open: containment is hygiene, not a spawn prerequisite. The
+        # allocate step raises when the dir or its owner record cannot be
+        # written (ENOSPC / inode exhaustion) -- the spawn proceeds with
+        # inherited temp and nothing is left on disk to reclaim.
+        from kiro_crew.mcp_gateway import backend as backend_mod
+
+        def _boom(_digest: str):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(backend_mod, "allocate_backend_tmp", _boom)
+
+        await spawn_backend(
+            _pool_key(), "/usr/bin/example-mcp", [], {"PATH": "/usr/bin"}, "/nonexistent-work-dir"
+        )
+
+        env = fake_spawn["kwargs"]["env"]
+        assert "TMPDIR" not in env
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_reclaims_the_fresh_dir(self, monkeypatch, tmp_path) -> None:
+        # Unowned-by-a-live-process dirs are never deleted by the sweeps, so
+        # the spawn-failure path is the ONLY reclamation point for a dir
+        # whose process never existed.
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        async def _boom(*_args, **_kwargs):
+            raise OSError("exec failed")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _boom)
+
+        with pytest.raises(OSError):
+            await spawn_backend(
+                _pool_key(), "/usr/bin/example-mcp", [], {}, "/nonexistent-work-dir"
+            )
+
+        root = home / "run" / "mcp-tmp"
+        assert not root.exists() or list(root.iterdir()) == []
+
+    @pytest.mark.asyncio
+    async def test_shutdown_leaves_the_dir_for_the_sweep(
+        self, fake_spawn, monkeypatch, tmp_path
+    ) -> None:
+        # Deliberately NO deletion on shutdown: the launcher's exit is not
+        # proof its process TREE is gone (a wrapper exits while its server
+        # child lives on). The sweep's dual condition (owner dead AND idle)
+        # is the single deletion authority.
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        from pathlib import Path
+
+        backend = await spawn_backend(
+            _pool_key(), "/usr/bin/example-mcp", [], {}, "/nonexistent-work-dir"
+        )
+        tmp_dir = Path(fake_spawn["kwargs"]["env"]["TMPDIR"])
+        assert tmp_dir.is_dir()
+
+        fake_spawn["process"].returncode = 0
+        await backend.shutdown()
+
+        assert tmp_dir.is_dir(), "shutdown must not delete; the sweep owns deletion"


### PR DESCRIPTION
## What is the problem?

Third-party MCP servers spawned by the gateway inherit the host's shared system temp dir and litter it without bound -- one telemetry-heavy server family alone produced ~3,400 directories per day, and profiling probes (which spawn each server twice per pass) multiplied it. Nothing ever reclaimed these: the gateway cannot patch third-party code, and the system tmp sweeper ages files with zero liveness checking, so it both misses fresh litter for days and can delete files under a live process.

## Why this issue matters to the user

A grown /tmp slows every process that scans it (the sandbox hardlink scan has a hard budget it can blow through), fills tmpfs at the expense of RAM, and mixes KiroCrew-caused litter into a shared system directory the operator has to clean by hand.

## How our fix solves it

The spawn chokepoint (`spawn_backend`) allocates a private per-process dir under `<data home>/run/mcp-tmp/<pool-digest>-<token>/` (0o700) and exports the `TMPDIR`/`TMP`/`TEMP` triple pointing at it, so everything the child's `tempfile`/`mktemp` machinery creates lands in a directory we own. From there:

- **Reclamation is a daemon sweep with a dual condition** -- a dir is removed only when its recorded owner PROCESS GROUP is dead (`platform_compat.pgroup_exists`, the same tree boundary the kill path uses) AND the whole tree has been mtime-idle for over an hour. Each signal alone is an unfaithful proxy: a wrapper launcher can exit while its server child lives on (group probe catches that), and a SIGKILL'd daemon can leave backends running into the next boot (idle window plus owner probe catches that). The sweep runs at daemon boot (after an initial sleep, off the boot path) and hourly thereafter.
- **`Backend.shutdown` deliberately does NOT sweep** -- the launcher's exit is not proof its process tree is gone. The sweep above is the single deletion authority. (Earlier revisions swept on shutdown; review rounds showed every shutdown-time signal lies for some real topology, so deletion authority was consolidated.)
- **Ownership is on-disk only**: allocation atomically writes a provisional `.owner` record and fails the allocation otherwise; spawn success re-records the real pid. An ownerless or garbled dir is never deleted (absence of evidence). The one exception is spawn FAILURE, which reclaims the just-allocated dir immediately -- the only reclamation point for a dir whose process never existed.
- **Probes get their own private dirs**, not a shared one: each preflight probe allocates under the same contract and removes its dir in its own `finally` (a probe, unlike a backend, knows when it is done). One whose cleanup never ran falls under the generic sweep.
- **An operator-declared temp wins**: a spec that sets any of `TMPDIR`/`TMP`/`TEMP` deliberately points a heavy server at chosen storage, so containment yields entirely (no allocation, nothing to sweep). The declaration signal is carried from the gatewayd spawn closure (`operator_declared_tmp`) rather than read off the merged env, because the resolver folds the daemon's own inherited environment in and macOS always exports `TMPDIR` (Windows: `TMP`/`TEMP`) -- an env-membership test would silently disable containment on those platforms.
- **Fail-open**: allocation failure (ENOSPC, unwritable home) degrades to today's inherited-temp behavior; containment is hygiene, not a spawn prerequisite.
- `platform_compat.pgroup_exists` is new and lives in the shim table per that module's invariant (raw `os.killpg` is ratcheted: on Windows it does not exist, and raw `os.kill(pid, 0)` can terminate the probed process).

## What tests we did

16 unit tests across `test_backend_tmp.py` and `test_mcp_gateway_backend_coverage.py::TestBackendTmpContainment`: containment under the managed root with an on-disk owner record; ambient `TMPDIR`/`TMP` never suppressing containment (regression for the macOS/Windows gate bug, mutation-verified); operator-declared temp yielding; allocation-failure fail-open; spawn-failure immediate reclamation; shutdown leaving the dir in place for the sweep (`"shutdown must not delete; the sweep owns deletion"`); the dual-condition sweep keeping owner-alive dirs and fresh-tree dirs, never deleting ownerless/garbled dirs, and reclaiming dead+idle ones; symlinks never swept nor descended; whole-tree mtime scan behavior. The sweep's group-probe line and the spawn's injection line are mutation-verified (reverting each fails its pinning test). Full affected suites: 196 passed.

## Any other suggestions on the work

The same containment pattern applies to agent-session scratch (#5063, PR #5070). The two PRs each carry a copy of the `pgroup_exists` shim; whichever merges second rebases and deduplicates.

Closes #5064
