### PR TITLE
test: assert the property, not the host's shell, clock or RSS

### DIFF
--- a/test/test_history_coverage.py
+++ b/test/test_history_coverage.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1430,8 +1431,21 @@ class TestSidecarSummariesSurviveMtimePreservingRewrites:
         log.append(key, "user", "first message")
         log.append(key, "assistant", "first reply")
         log.append(key, "user", "second message")
+        # Age the transcript BEFORE stamping the sidecars against its mtime.
+        # Filesystem mtime resolution is not the clock's: tmpfs and ext4 stamp from
+        # the kernel's cached wall time, which advances on a timer tick rather than
+        # per write, so these appends and a later one can share a single
+        # ``st_mtime_ns`` (measured: 200 rapid writes to /tmp on a 6.12 kernel
+        # produced ONE distinct value). Every test in this class turns on telling
+        # "the mtime moved" apart from "the mtime was preserved", so that gap has to
+        # be REPRESENTABLE. Backdating states the precondition outright; a sleep
+        # would express the same thing by guessing how long a tick is.
+        now = log.session_mtime(key)
+        assert now is not None
+        aged = now - 60.0
+        os.utime(log._path(key), (aged, aged))
         sig = log.session_mtime(key)
-        assert sig is not None
+        assert sig == aged
         log.set_cached_summary(key, "describes the PRE-rewrite conversation", sig)
         log.set_cached_intent_summary(key, {"intents": [{"text": "pre-rewrite"}]}, sig)
         assert log.get_cached_summary(key) == "describes the PRE-rewrite conversation"

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -526,14 +526,26 @@ class TestResourceShims:
         # The peak, by contrast, is not allowed to fall.
         assert pc.proc_peak_rss_bytes() >= peak_while_held
 
-    def test_proc_peak_rss_bytes_is_never_below_the_current_reading(self):
-        # The high-water mark of a quantity cannot be under the quantity. A
-        # mismatched unit on either side (ru_maxrss is KiB on Linux, bytes on
-        # macOS) shows up here as a 1024x violation.
+    def test_proc_peak_rss_bytes_reads_the_same_unit_as_the_current_reading(self):
+        # The property under test is the UNIT, not the ordering: ru_maxrss is KiB on
+        # Linux and bytes on macOS, so a missing or spurious conversion puts the two
+        # readings 1024x apart. Asserted as a bounded ratio rather than
+        # `peak >= current`, which reads as the tighter and more obvious invariant but
+        # is not atomically observable on Linux: the two come from DIFFERENT kernel
+        # accounting paths. proc_rss_bytes reads /proc/self/statm, recomputed on
+        # read, while proc_peak_rss_bytes reads getrusage's high-water mark, which
+        # the kernel maintains from per-CPU RSS deltas it syncs in batches. So while
+        # the process is allocating, the live reading legitimately sits a little
+        # above the last-synced peak -- measured up to 1.02x on this 32-core host,
+        # which is what made the strict form fail under a loaded full-suite run.
+        # 4x leaves that mechanism ~250x of headroom before a real unit error passes.
         current = pc.proc_rss_bytes()
         peak = pc.proc_peak_rss_bytes()
         assert peak > 0
-        assert peak >= current
+        assert peak * 4 >= current, (
+            f"peak {peak} is more than 4x under the live reading {current} -- too far "
+            "apart to be counter-sync lag, so one side is in the wrong unit"
+        )
 
     def test_proc_rss_bytes_for_pid_self_positive(self):
         rss = pc.proc_rss_bytes_for_pid(os.getpid())

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -2140,6 +2140,60 @@ def _make_app(registry=None, cfg=None, user="testuser"):
     return app
 
 
+async def _recv_matching(ws, predicate, what: str, *, frames: int = 40, timeout: float = 3):
+    """Return the first frame satisfying *predicate*, skipping the ones it does not.
+
+    The socket carries three interleaved things, and only one of them is what any given
+    test is about: the reply to what the test just sent, raw binary PTY output the shell
+    produced on its own, and a ``ready`` control frame.
+
+    ``ready``'s arrival is NOT ordered against the test's own send. When the resolved
+    shell has no ready-marker to inject, ``api_terminal_ws`` sets ``shell_ready`` and
+    emits ``ready`` while still setting the connection up, so it precedes any reply;
+    when the marker IS injected (Bash), ``ready`` waits for the marker to appear in PTY
+    output and so usually arrives after. Taking the first TEXT frame, or assuming the
+    first frame is BINARY, therefore asserts on which shell the host resolved rather
+    than on the behaviour under test -- and fails on a host whose shell is not Bash.
+
+    Bounded by a frame COUNT, not a sleep: every iteration consumes a real frame, so
+    this cannot pass by waiting.
+    """
+    for _ in range(frames):
+        msg = await ws.receive(timeout=timeout)
+        if msg.type in (
+            web.WSMsgType.CLOSE,
+            web.WSMsgType.CLOSING,
+            web.WSMsgType.CLOSED,
+            web.WSMsgType.ERROR,
+        ):
+            raise AssertionError(f"socket closed ({msg.type!r}) before {what} arrived")
+        if predicate(msg):
+            return msg
+    raise AssertionError(f"{what} did not arrive within {frames} frames")
+
+
+async def _recv_control(ws, wanted: str, **kw):
+    """The JSON control frame whose ``type`` is *wanted*. See :func:`_recv_matching`."""
+
+    def _is_wanted(msg) -> bool:
+        if msg.type is not web.WSMsgType.TEXT:
+            return False
+        try:
+            return json.loads(msg.data).get("type") == wanted
+        except (ValueError, AttributeError):
+            return False
+
+    return json.loads((await _recv_matching(ws, _is_wanted, f"a {wanted!r} frame", **kw)).data)
+
+
+async def _recv_pty_output(ws, **kw) -> bytes:
+    """The first BINARY frame — bytes the PTY itself produced. See :func:`_recv_matching`."""
+    msg = await _recv_matching(
+        ws, lambda m: m.type is web.WSMsgType.BINARY, "binary PTY output", **kw
+    )
+    return msg.data
+
+
 @pytest.mark.xdist_group("pty_integration")
 class TestTerminalWsIntegration:
     """Integration tests that exercise the full WebSocket PTY lifecycle.
@@ -2198,13 +2252,7 @@ class TestTerminalWsIntegration:
         async with TestClient(TestServer(app)) as client:
             async with client.ws_connect("/api/ws/terminal/ping-sess") as ws:
                 await ws.send_str(json.dumps({"type": "ping"}))
-                # Drain binary PTY frames until we get the text pong
-                for _ in range(20):
-                    msg = await ws.receive(timeout=2)
-                    if msg.type == web.WSMsgType.TEXT:
-                        break
-                data = json.loads(msg.data)
-                assert data == {"type": "pong"}
+                assert await _recv_control(ws, "pong") == {"type": "pong"}
                 await ws.close()
 
             await terminal._kill_session(registry["ping-sess"])
@@ -2259,10 +2307,7 @@ class TestTerminalWsIntegration:
             async with client.ws_connect("/api/ws/terminal/io-sess") as ws:
                 # Send a command — the PTY should echo something back
                 await ws.send_bytes(b"echo hello\n")
-                # Read at least one binary frame back (PTY output)
-                msg = await ws.receive(timeout=3)
-                assert msg.type == web.WSMsgType.BINARY
-                assert len(msg.data) > 0
+                assert len(await _recv_pty_output(ws)) > 0
                 await ws.close()
 
             await terminal._kill_session(registry["io-sess"])
@@ -2544,13 +2589,7 @@ class TestTerminalWsIntegration:
                 await ws.send_str("not valid json")
                 # Should not crash — send a ping to verify connection alive
                 await ws.send_str(json.dumps({"type": "ping"}))
-                # Drain binary PTY frames until we get the text pong
-                for _ in range(20):
-                    msg = await ws.receive(timeout=2)
-                    if msg.type == web.WSMsgType.TEXT:
-                        break
-                data = json.loads(msg.data)
-                assert data == {"type": "pong"}
+                assert await _recv_control(ws, "pong") == {"type": "pong"}
                 await ws.close()
 
             await terminal._kill_session(registry["json-sess"])


### PR DESCRIPTION
Three tests encoded a property of the machine they were written on and fail on a host that differs. None is a flake in the retry sense — each fails **deterministically** once the host's shell, filesystem or core count changes, which is why they have read as environmental noise rather than as wrong assertions. All three fixes narrow what is asserted to the property under test; none adds a sleep, a rerun, or a weaker claim.

## Before / after, same host, idle, venv bin on `PATH`

| | `origin/main` | this branch |
|---|---|---|
| `test_terminal_handler.py` + `test_history_coverage.py` + `test_platform_compat.py` | **5 failed**, 601 passed | **0 failed**, 606 passed |
| Full suite, unsharded | — | **0 failed**, 60,981 passed |

## 1. Three `TestTerminalWsIntegration` cases asserted which shell the host resolved

They took the first TEXT frame as the reply to what they had just sent, or the first frame as binary PTY output. The socket carries a third thing: a `ready` control frame, whose arrival is **not ordered against the test's own send**.

- When the resolved shell has no ready-marker to inject, `api_terminal_ws` sets `shell_ready` and emits `ready` while still setting the connection up (`terminal.py:825-834`), so it *precedes* any reply.
- When the marker **is** injected (Bash), `ready` waits for the marker to appear in PTY output (`terminal.py:386-390`), so it usually arrives after.

So `assert {'type': 'ready'} == {'type': 'pong'}` was the test reporting the host's shell, not a protocol violation. They now match on the frame under test and skip the ones they are not about, bounded by a **frame count** rather than a sleep — every iteration consumes a real frame, so no iteration can pass by waiting.

## 2. `test_a_genuine_append_still_invalidates_by_signature` outran the filesystem clock

It seeded three appends, stamped the summary sidecars against the transcript's mtime, appended once more, and expected the sidecar to be invalid. All four writes land inside one filesystem mtime tick: tmpfs and ext4 stamp from the kernel's cached wall time, which advances on a **timer tick rather than per write**. Measured on this host — 200 rapid writes to `/tmp` produce **one** distinct `st_mtime_ns`. The recorded signature therefore still matched and the control failed.

The seed helper now backdates the transcript before stamping the sidecars, so the gap the whole class reasons about — "the mtime moved" versus "the mtime was preserved" — is representable at any granularity, including FAT's two seconds.

**I considered fixing this in production and rejected it.** Widening the sidecar signature with the file size looks right and is wrong: `mark_consolidated` rewrites the metadata line, which changes the size, and keeping the summary across a bookkeeping-only write is a *deliberate documented exclusion* ("discarding an LLM-generated summary here would be a pure cost with no correctness gain"). A size-based signature breaks it. A correct content signature — message-region length or a line count — costs a readline per session inside `list_sessions(summarize=true)`'s loop, and the window it would close needs two appends inside one tick of the snapshot, where the snapshot sits before a multi-second model call. Not proportionate. The residual limitation is real but narrow, and is now stated where the next reader meets it.

## 3. `test_proc_peak_rss_bytes…` compared two different kernel accounting paths

It asserted `peak >= current`. That reads as the tighter invariant — a high-water mark cannot be under the quantity — but it is not atomically observable on Linux:

- `proc_rss_bytes` reads `/proc/self/statm`, recomputed on read.
- `proc_peak_rss_bytes` reads `getrusage`'s high-water mark, which the kernel maintains from per-CPU RSS deltas it syncs **in batches**.

While the process allocates, the live reading legitimately sits above the last-synced peak — measured up to **1.02x** on this 32-core host, and it fails on `origin/main` even with the host idle. The property the test's own comment documents is the **unit** (`ru_maxrss` is KiB on Linux, bytes on macOS, so a missing conversion is 1024x); that is now asserted as a bounded ratio leaving the sync mechanism ~250x of headroom.

## Not in this branch

**16 `test/test_file_sheet.py` failures were a stale venv, not a repo bug.** `openpyxl>=3.1,<4` is in `install_requires`; a venv predating it reds 13 tests as `ModuleNotFoundError` and 3 more as `assert 501 == 4xx` (the handler maps the missing import to 501, so the pre-parse rejection tests see 501 instead of 413/415/422). Reinstalling fixed all 16 with no code change.

**Two further failures were my own invocation.** Running `<venv>/bin/python -m pytest` by absolute path leaves `<venv>/bin` off `PATH`, so `shutil.which("kirocrew")` misses the installed console script and production takes its `python -m` fallback — which `test_agent.py::TestRefreshDynamicFieldsStripsStaleUrl` and `test_computer_use_api.py::TestPermissionProbe` assert against. Both pass with the venv's bin on `PATH`, as CI has it. No change warranted.

**A 121-failure run was pure host load.** A concurrent scheduled sweep pushed load average to 236 on 32 cores; 119 of the 121 were the sandbox/spawn class failing closed, none in a file this branch touches, and all 121 vanished on an idle re-run.

---

no linked issue: these surfaced while verifying #5039's full-suite run on this host, not from a filed issue.
