### PR TITLE
test: freeze the clock in the home-targets TTL cache test (#5056)

### DIFF
--- a/test/test_security.py
+++ b/test/test_security.py
@@ -3490,7 +3490,25 @@ class TestHomeDirTargetsCache:
         )
 
     def test_second_call_does_not_rebuild(self, monkeypatch, tmp_path) -> None:
-        """Within the TTL the expensive builder runs once, not per call."""
+        """Within the TTL the expensive builder runs once, not per call.
+
+        The cache compares ``time.monotonic()`` against a stored deadline
+        (``_home_dir_targets`` reads the clock exactly once per call), so the
+        clock is FROZEN here rather than raced: with a constant monotonic
+        source, "every call is inside the TTL" is a fact of the test instead
+        of a bet that the loop outruns ``_HOME_TARGETS_TTL_SECS`` (0.1s) on
+        the slowest runner in the matrix. That removes the only
+        platform-dependent input — before this, the assertion held only while
+        50 iterations plus one ~1.4ms rebuild finished inside 100ms, which the
+        Windows shards do not guarantee.
+
+        The second half advances the fake clock past the TTL and requires a
+        rebuild. That direction pins the TTL behavior itself AND proves the
+        freeze took effect: were the patch silently a no-op, the +0.11s jump
+        would not have happened in real time and the rebuild would not occur,
+        failing the final assertion instead of degrading back into a timing
+        race.
+        """
         from kiro_crew import security
 
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -3503,9 +3521,16 @@ class TestHomeDirTargetsCache:
             return real(home_dirs, roots)
 
         monkeypatch.setattr(security, "_home_dir_targets_uncached", counting)
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(security.time, "monotonic", lambda: clock["now"])
         for _ in range(50):
             security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
         assert len(calls) == 1
+
+        # Guard: advancing the frozen clock past the TTL MUST rebuild.
+        clock["now"] += security._HOME_TARGETS_TTL_SECS + 0.01
+        security._home_dir_targets(security._SENSITIVE_HOME_DIRS)
+        assert len(calls) == 2
 
     def test_kirocrew_home_change_is_not_deferred_by_ttl(self, monkeypatch, tmp_path) -> None:
         """A changed KIROCREW_HOME must re-key immediately, not after the TTL.


### PR DESCRIPTION
## Problem

`test/test_security.py::TestHomeDirTargetsCache::test_second_call_does_not_rebuild` fails intermittently on the Windows CI shards with `assert 2 == 1 where 2 = len([1, 1])`, landing a red on whichever unrelated PR happens to be running — on a security-relevant test file, where the reflex to "just re-run the shard" is exactly the reflex we don't want to train.

## Why it matters

Every false red burns a CI round on an innocent PR and erodes trust in `test_security.py` failures specifically. Production code is correct; only the test is racing.

## Fix (symptom → root cause → change)

- **Symptom:** the builder-call counter reads 2 instead of 1 on slow (Windows) runners.
- **Root cause:** the test raced a real wall clock. `_home_dir_targets` caches against a `time.monotonic()` deadline with `_HOME_TARGETS_TTL_SECS = 0.1`, and the test called it 50 times asserting the uncached builder ran once — which only holds while all 50 iterations plus one ~1.4 ms rebuild finish inside 100 ms. Windows runners don't guarantee that; a second recorded call is the TTL legitimately expiring mid-loop, not a cache defect.
- **Change (test-only):** freeze the clock the cache actually reads. `_home_dir_targets` calls `time.monotonic()` exactly once per call (verified at the call site), so the test monkeypatches `security.time.monotonic` to a constant dict-backed fake. "Every call is inside the TTL" becomes a fact of the test rather than a bet on runner speed. Then the test advances the fake clock past `_HOME_TARGETS_TTL_SECS + 0.01` and asserts a rebuild — pinning the TTL behavior itself *and* proving the freeze took effect (a silently no-op patch would fail this assertion instead of degrading back into a timing race).
- No production change: `src/kiro_crew/security.py`, `_HOME_TARGETS_TTL_SECS`, and the cache implementation are untouched per the issue's scope note.
- Explicitly rejected: raising the TTL, shrinking the loop, retries, or relaxing to `<= 2` — each only moves the threshold while leaving the test racing a wall clock, and a relaxed assertion would stop pinning the property.

## Why the fixed test is platform-independent

With `time.monotonic` frozen, runner speed no longer appears anywhere in the assertion: the first 50 calls observe a constant clock strictly inside the stored deadline (`1000.0 < 1000.1`), and the guard call observes `1000.11 ≥ 1000.1` — both comparisons are exact float facts, independent of how long the loop takes on any OS. The class's `_clear()` empties the module-global cache before the calls, so the first call is a guaranteed miss regardless of prior tests.

## Sibling sweep (issue step 5)

Swept `test/` for other tests asserting a call/hit count across a loop while the code under test keys on real time. **Clean** — no sibling carries the same shape:
- `test_skills.py` (skills `_iter` cache): 60 s TTL with a tolerant `assert calls <= 1` — not raceable in practice and not an exact-count pin.
- `test_external_registry.py`: 1 h TTL; the `call_count` uses are retry-shaped stubs, not loop-raced cache counters.
- `test_eager_spawn.py`: its `range(50)` is a bounded readiness poll, not a call-count assertion; its TTL tests pin the TTL to 0 deterministically.
- `test_security.py` was the only sub-second-TTL cache with an exact call-count assert across a loop.

## Tests

- `test_second_call_does_not_rebuild` (updated): frozen clock + 50 calls → builder ran exactly once; then fake-clock advance past the TTL → builder ran exactly twice.
- Mutation-verified in both directions: removing the freeze (or making the cache rebuild unconditionally) fails the test; unmodified main-plus-fix passes.
- Siblings `test_cached_result_matches_uncached` and `test_kirocrew_home_change_is_not_deferred_by_ttl` are untouched and still pass (monkeypatch is per-test scoped; each sibling re-clears the cache).

## Manual verification

Honest note: a CI-style shard run on this (Linux) host did **not** reproduce the original flake directly — the loop comfortably fits inside 100 ms here; Windows is where the margin collapses. The fix was therefore validated structurally (frozen-clock determinism + both-direction mutation checks) rather than by observed repro.

Local gates on the rebased head (base 7e9feaaa6): isort, flake8, mypy (1028 files clean), full pytest (failures on the previous base were all confirmed pre-existing on clean main via a throwaway worktree), and the touched class 7/7.

## Screenshots

N/A — test-only change, no user-visible surface.

Closes #5056
