### PR TITLE
refactor: swap three bespoke JSON span-scanners for the shared extractor (#5071)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -43,6 +43,7 @@ from kiro_crew.dashboard.chat_utils import (
 )
 from kiro_crew.history import on_loop_persist_strict
 from kiro_crew.knowledge.llm_pool import LLMPool
+from kiro_crew.llm_helpers import _extract_json_of_type
 from kiro_crew.platform_compat import is_link_or_junction, unlink_link_or_junction
 
 try:
@@ -2546,14 +2547,36 @@ def _compact_tree(tree: list[dict]) -> str:
     return "\n".join(lines) if lines else "(empty — this is the first round)"
 
 
+def _grill_node_shaped(value: object) -> bool:
+    """Prefer predicate: an array carrying at least one node-shaped record.
+
+    Disambiguates the payload from stray bracketed PROSE that also parses as
+    an array (a "see item [1]:" marker, a trailing "[12]." citation) — those
+    decode to arrays of scalars and are never preferred."""
+    return isinstance(value, list) and any(
+        isinstance(item, dict) and "kind" in item and "text" in item for item in value
+    )
+
+
 def _parse_grill_nodes(raw: str) -> list[dict]:
-    """Extract child node dicts {kind, text, recommended?} from an LLM reply."""
-    start, end = raw.find("["), raw.rfind("]")
-    if start < 0 or end <= start:
-        return []
+    """Extract child node dicts {kind, text, recommended?} from an LLM reply.
+
+    Extraction delegates to the shared ``llm_helpers._extract_json_of_type``
+    scanner, so a stray bracket in surrounding prose no longer corrupts the
+    span the way the old outermost ``find('[') .. rfind(']')`` slice did.
+    Returns [] on any parse failure, or when two DIFFERENT node-shaped arrays
+    make the choice ambiguous (the shared contract refuses to guess)."""
     try:
-        items = json.loads(raw[start : end + 1])
-    except (json.JSONDecodeError, ValueError):
+        items = _extract_json_of_type(raw, list, prefer=_grill_node_shaped)
+    except RecursionError:
+        # The stdlib decoder recurses per nesting level, so a nesting bomb in
+        # the untrusted reply overflows long before any structural bound. This
+        # parser's callers are outside any exception envelope (the grill-expand
+        # handler would surface it as HTTP 500), so degrade to no-nodes here.
+        # PR #5066 makes the shared scanner fail closed on this centrally;
+        # this guard becomes redundant-but-harmless once that lands.
+        return []
+    if not isinstance(items, list):
         return []
     out = []
     for it in items:

--- a/src/kiro_crew/dashboard/chat_summary.py
+++ b/src/kiro_crew/dashboard/chat_summary.py
@@ -16,7 +16,6 @@ judgement calls the prompt has to name.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -25,7 +24,7 @@ from kiro_crew.acp.types import STOP_REASON_END_TURN
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.history import is_incognito_transcript
-from kiro_crew.llm_helpers import run_bg_oneliner
+from kiro_crew.llm_helpers import _extract_json_of_type, run_bg_oneliner
 from kiro_crew.session_summary import (
     count_user_turns,
     extract_turns,
@@ -201,24 +200,32 @@ def _should_summarize(
     return ""
 
 
+def _summary_shaped(value: object) -> bool:
+    """Prefer predicate: a dict that carries the summary payload's ``intents`` list.
+
+    Disambiguates the payload from stray braced JSON in surrounding prose (a
+    ``{placeholder}`` aside, an inline worked example) — those parse as dicts
+    but never carry the payload shape ``normalize_payload`` consumes."""
+    return isinstance(value, dict) and isinstance(value.get("intents"), list)
+
+
 def _parse_reply(text: str) -> object:
-    """Pull a JSON object out of a model reply, tolerating fenced output."""
+    """Pull a JSON object out of a model reply, tolerating fences and prose.
+
+    Delegates to the shared ``llm_helpers._extract_json_of_type`` scanner
+    (fence markers are just prose to it), so a stray brace in the prose no
+    longer corrupts the extracted span the way the old outermost
+    ``find('{') .. rfind('}')`` slice did. Returns None when nothing parses —
+    the caller then keeps the previous cached summary — or when two DIFFERENT
+    payload-shaped dicts make the choice ambiguous (the shared contract
+    refuses to guess)."""
     raw = (text or "").strip()
     if not raw:
         return None
-    if raw.startswith("```"):
-        # Strip a fence and any language tag, then the trailing fence.
-        raw = raw.split("\n", 1)[-1]
-        if raw.rstrip().endswith("```"):
-            raw = raw.rstrip()[: -len("```")]
-    start, end = raw.find("{"), raw.rfind("}")
-    if start == -1 or end <= start:
-        return None
-    try:
-        return json.loads(raw[start : end + 1])
-    except json.JSONDecodeError:
-        logger.debug("Session summary: reply was not valid JSON")
-        return None
+    data = _extract_json_of_type(raw, dict, prefer=_summary_shaped)
+    if data is None:
+        logger.debug("Session summary: reply carried no usable JSON object")
+    return data
 
 
 async def generate_session_summary(

--- a/src/kiro_crew/knowledge/extractor.py
+++ b/src/kiro_crew/knowledge/extractor.py
@@ -1,13 +1,25 @@
 """Entity extraction using the LLM pool."""
 from __future__ import annotations
 
-import json
-import re
 import uuid
 from typing import TYPE_CHECKING
 
+from kiro_crew.llm_helpers import _extract_json_of_type
+
 if TYPE_CHECKING:
     from kiro_crew.knowledge.llm_pool import LLMPool
+
+_PAYLOAD_KEYS = frozenset({"title", "entities", "relations", "category", "summary"})
+
+
+def _extraction_shaped(value: object) -> bool:
+    """Prefer predicate: a dict carrying at least one extraction payload field.
+
+    Disambiguates the payload from stray braced JSON in the surrounding prose
+    or in the untrusted chunk itself — those parse as dicts but never carry
+    the fields ``_validate`` consumes."""
+    return isinstance(value, dict) and not _PAYLOAD_KEYS.isdisjoint(value)
+
 
 EXTRACTION_PROMPT = """Extract structured information from this text chunk.
 
@@ -87,26 +99,20 @@ class EntityExtractor:
             return [_empty_result() for _ in chunks]
 
     def _parse_response(self, response: str) -> dict:
-        for text in (response, self._extract_code_block(response)):
-            if text:
-                try:
-                    data = json.loads(text)
-                    return self._validate(data)
-                except (json.JSONDecodeError, ValueError):
-                    pass
-        m = re.search(r'\{[\s\S]*\}', response)
-        if m:
-            try:
-                data = json.loads(m.group())
-                return self._validate(data)
-            except (json.JSONDecodeError, ValueError):
-                pass
-        return _empty_result()
+        """Pull the extraction payload dict out of an LLM reply.
 
-    @staticmethod
-    def _extract_code_block(response: str) -> str | None:
-        m = re.search(r'```(?:json)?\s*\n?([\s\S]*?)```', response)
-        return m.group(1).strip() if m else None
+        Delegates to the shared ``llm_helpers._extract_json_of_type`` scanner
+        (a bare JSON reply, a fenced block, and JSON wrapped in prose are all
+        the same to it), so a stray brace in surrounding prose no longer
+        corrupts the span the way the old greedy first-``{``-to-last-``}``
+        regex did. Returns the empty result on any parse failure, on a
+        non-dict reply, or when two DIFFERENT payload-shaped dicts make the
+        choice ambiguous (the shared contract refuses to guess).
+        """
+        data = _extract_json_of_type(response, dict, prefer=_extraction_shaped)
+        if isinstance(data, dict):
+            return self._validate(data)
+        return _empty_result()
 
     @staticmethod
     def _validate(data: dict) -> dict:

--- a/test/test_auto_research.py
+++ b/test/test_auto_research.py
@@ -3269,6 +3269,43 @@ class TestGrillParse:
 
         assert _parse_grill_nodes("no json here") == []
 
+    def test_stray_bracket_in_prose_does_not_corrupt_the_payload(self):
+        # The old outermost find('[') .. rfind(']') span ran from the "[1]:"
+        # marker to the trailing "[12]." citation, so the slice never parsed
+        # and a valid payload was silently lost.
+        from kiro_crew.apps.builtins.auto_research.handlers import _parse_grill_nodes
+
+        raw = (
+            'Expanding item [1]: [{"kind":"research","text":"How is it stored?"}] '
+            "as noted in [12]."
+        )
+        assert _parse_grill_nodes(raw) == [{"kind": "research", "text": "How is it stored?"}]
+
+    def test_two_different_node_arrays_refuse_the_guess(self):
+        # The shared extractor's ambiguity contract: two DIFFERENT node-shaped
+        # arrays mean the caller cannot know which is the real payload.
+        from kiro_crew.apps.builtins.auto_research.handlers import _parse_grill_nodes
+
+        raw = (
+            'For example [{"kind":"research","text":"Example?"}] but my answer is '
+            '[{"kind":"research","text":"Real?"}]'
+        )
+        assert _parse_grill_nodes(raw) == []
+
+    def test_fenced_reply_is_accepted(self):
+        # Fence markers are just prose to the shared scanner.
+        from kiro_crew.apps.builtins.auto_research.handlers import _parse_grill_nodes
+
+        raw = '```json\n[{"kind":"research","text":"How is it stored?"}]\n```'
+        assert _parse_grill_nodes(raw) == [{"kind": "research", "text": "How is it stored?"}]
+
+    def test_nesting_bomb_degrades_to_no_nodes(self):
+        # A RecursionError from the stdlib decoder must not escape into the
+        # grill-expand handler (it would surface as HTTP 500, not empty nodes).
+        from kiro_crew.apps.builtins.auto_research.handlers import _parse_grill_nodes
+
+        assert _parse_grill_nodes("[" * 100_000) == []
+
     def test_node_depth(self):
         from kiro_crew.apps.builtins.auto_research.handlers import _node_depth
 

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -1089,7 +1089,7 @@ class TestEntityExtractorExtended:
         result = asyncio.get_event_loop().run_until_complete(ext.extract("text"))
         assert result == {"title": "", "entities": [], "relations": [], "category": "document", "summary": ""}
 
-    def test_parse_response_regex_fallback(self):
+    def test_parse_response_prose_wrapped(self):
         ext = EntityExtractor()
         raw = 'Some preamble text {"entities": [], "relations": [], "category": "runbook", "summary": "ok"} trailing'
         result = ext._parse_response(raw)
@@ -1100,11 +1100,35 @@ class TestEntityExtractorExtended:
         result = ext._parse_response("totally invalid garbage")
         assert result == {"title": "", "entities": [], "relations": [], "category": "document", "summary": ""}
 
-    def test_extract_code_block(self):
+    def test_parse_response_stray_brace_in_prose(self):
+        # The old greedy first-'{'-to-last-'}' regex spanned from the
+        # {placeholder} aside to the trailing "{}" echo, so the slice never
+        # parsed and a valid payload was silently lost.
         ext = EntityExtractor()
-        assert ext._extract_code_block("no block here") is None
-        result = ext._extract_code_block('```\n{"a": 1}\n```')
-        assert result == '{"a": 1}'
+        raw = (
+            'Per the {name, type} shape: {"entities": [], "relations": [], '
+            '"category": "runbook", "summary": "ok"} — use {} when empty.'
+        )
+        result = ext._parse_response(raw)
+        assert result["category"] == "runbook"
+        assert result["summary"] == "ok"
+
+    def test_parse_response_non_dict_reply_is_empty(self):
+        # A top-level array reply must yield the empty result, not leak an
+        # AttributeError out of _validate (which nuked a whole extract_batch
+        # under the old direct json.loads path).
+        ext = EntityExtractor()
+        raw = '[{"entities": []}]'
+        result = ext._parse_response(raw)
+        assert result == {"title": "", "entities": [], "relations": [], "category": "document", "summary": ""}
+
+    def test_parse_response_two_different_payloads_refuse_the_guess(self):
+        # The shared extractor's ambiguity contract: two DIFFERENT
+        # payload-shaped dicts mean the caller cannot know which is real.
+        ext = EntityExtractor()
+        raw = '{"summary": "first"} or maybe {"summary": "second"}'
+        result = ext._parse_response(raw)
+        assert result == {"title": "", "entities": [], "relations": [], "category": "document", "summary": ""}
 
     def test_validate_partial_data(self):
         ext = EntityExtractor()

--- a/test/test_session_summary_generate.py
+++ b/test/test_session_summary_generate.py
@@ -589,6 +589,31 @@ class TestReplyParsing:
         _stub_llm(monkeypatch, f"Here you go:\n{_GOOD_REPLY}\nHope that helps.")
         assert await chat_summary.generate_session_summary(state, slot, cfg=_cfg()) is True
 
+    async def test_stray_brace_in_prose_does_not_corrupt_the_payload(self):
+        # The old outermost find('{') .. rfind('}') span started at the
+        # {placeholder} aside and swallowed the trailing "{}" echo, so the
+        # slice never parsed and a valid payload was silently lost.
+        reply = (
+            "Using the {title, ranges} shape as asked:\n"
+            f"{_GOOD_REPLY}\n"
+            'Emit {} if the transcript is empty.'
+        )
+        parsed = chat_summary._parse_reply(reply)
+        assert isinstance(parsed, dict)
+        assert parsed == json.loads(_GOOD_REPLY)
+
+    async def test_two_different_payloads_refuse_the_guess(self):
+        # The shared extractor's ambiguity contract: two DIFFERENT
+        # payload-shaped dicts mean the caller cannot know which is real.
+        a = json.dumps({"intents": [{"title": "a", "ranges": [[1, 1]], "status": "active"}]})
+        b = json.dumps({"intents": [{"title": "b", "ranges": [[2, 2]], "status": "active"}]})
+        assert chat_summary._parse_reply(f"Either:\n{a}\nor:\n{b}") is None
+
+    async def test_garbage_and_empty_replies_yield_none(self):
+        assert chat_summary._parse_reply("") is None
+        assert chat_summary._parse_reply("no json at all") is None
+        assert chat_summary._parse_reply("{not valid json}") is None
+
     async def test_caps_from_config_are_applied_to_the_reply(self, env, monkeypatch):
         state, slot = env
         many = {


### PR DESCRIPTION
## Summary

Follow-up from the First Principles review on PR #5066: consolidates the three remaining bespoke prose-tolerant JSON extractors onto the shared `llm_helpers._extract_json_of_type` scanner. Closes #5071.

| Call site | Old approach | Failure it caused |
|---|---|---|
| `dashboard/chat_summary.py` `_parse_reply` | outermost `find('{') .. rfind('}')` span | any stray brace in prose corrupts the span; a valid summary payload is silently dropped |
| `apps/builtins/auto_research/handlers.py` `_parse_grill_nodes` | outermost `find('[') .. rfind(']')` span | a `[1]:` marker or `[12].` citation in prose corrupts the span; valid grill nodes silently dropped |
| `knowledge/extractor.py` `_parse_response` | greedy first-`{`-to-last-`}` regex + fence helper | same failure mode; also a top-level-array reply raised `AttributeError` inside `extract_batch`'s single try, collapsing the WHOLE batch to empty results |

Each site now calls the shared scanner with a prefer predicate matching its consumer's payload shape (`_summary_shaped` ⊇ `normalize_payload`'s acceptance set, `_grill_node_shaped` ⊇ the downstream kind/text filter, `_extraction_shaped` = `_validate`'s key set), mirroring the call-site treatment PR #5066 applied for #4974. Failure contracts preserved: `None` / `[]` / `_empty_result` respectively. The scanner needs NO changes; `workflows/schema.py` and `agent_discovery.py` are untouched (owned by #4974 / PR #5066, files disjoint).

`_parse_grill_nodes` additionally guards `RecursionError` from a nesting bomb in the untrusted reply: unlike the other two sites (wrapped in `except Exception`), it runs outside any exception envelope and the escape would surface as HTTP 500 from the grill-expand handler. The base's scanner does not yet fail closed on this (that lands centrally in PR #5066); the guard becomes redundant-but-harmless once #5066 merges.

## Tests

- The three stray-delimiter-in-prose cases are **mutation-verified**: each fails against the old span code (verified by stashing src and running).
- Per site: ambiguity refusal (two different payload-shaped candidates → refuse), fenced reply, garbage/empty reply, and (grill) the nesting bomb.
- `test_parse_response_non_dict_reply_is_empty` locks the `extract_batch` AttributeError fix.
- Deleted `test_extract_code_block` with its subsumed helper; renamed `test_parse_response_regex_fallback` → `test_parse_response_prose_wrapped` (no regex fallback exists anymore).

## Verification

- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` clean.
- Full `python -m pytest`: 60844 passed; the 14 failures on the dev host (3 PTY terminal-integration, 11 artifact-source-root / xdist-host-budget) reproduce identically on unmodified origin/main — host-environment-sensitive (repo under /tmp, host CPU count), unrelated to this diff.
- Pre-push adversarial review, two model-pinned lanes (GPT, Opus): 1 converged finding (the RecursionError escape) fixed with a locking test; 1 fence-coverage finding adopted for the one genuinely uncovered site (grill) — the other two sites already had fenced-reply tests; 2 informational findings (superlinear worst-case scan bounded by reply size; ambiguity fail-closed on echoed untrusted chunk is the same outcome as the old regex and the correct direction).

No UI changes — no screenshots required.
