### PR TITLE
feat(mcp): make the MCP binary search path extensible

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -62,10 +62,11 @@ from kiro_crew.config.paths import (
     kiro_agents_dir,
 )
 from kiro_crew.env import (
+    MCP_PATH_HINT,
     dedup_path,
     describe_search_path,
     emit_env,
-    spec_env_path,
+    mcp_search_path,
     spec_path_key,
 )
 from kiro_crew.mcp_cleanup import purge_deleted_proxy_from_config
@@ -3418,12 +3419,16 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         executable — shutil.which can fail inside user-namespace sandboxes
         even when the file is fine.
 
-        Searches the server's own env.PATH first, then the same augmented
-        PATH the MCP probe uses — both via :func:`spec_env_path`, which is
-        also the value emitted into the spec, so resolution, the probe and the
-        launched child all agree. A divergence would let a server probe healthy
+        Searches the server's own env.PATH first, then the contributed MCP
+        directories, then the same augmented PATH the MCP probe uses — all via
+        :func:`mcp_search_path`, so resolution, the probe and the rewriter all
+        agree. A divergence would let a server probe healthy
         on the dashboard while being silently dropped from the generated agent
-        config ("command not found: kirocrew"). augmented_path
+        config ("command not found: kirocrew"). The value EMITTED into the spec
+        is :func:`spec_env_path` instead, which omits the contributed
+        directories: an emitted PATH is persisted and read back as an authored
+        entry, so a contributed directory written there could never be removed
+        again. augmented_path
         covers ~/.aim/mcp-servers and ~/.toolbox/bin and appends the running
         interpreter's console-scripts dir
         (venv ``Scripts\\`` on Windows, ``bin/`` on POSIX) as a last-resort
@@ -3439,10 +3444,10 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         _env = env or {}
         _key = spec_path_key(_env)
         _declared = _env.get(_key, "") if _key else ""
-        _search = spec_env_path(_declared if isinstance(_declared, str) else "")
+        _search = mcp_search_path(_declared if isinstance(_declared, str) else "")
         # The search path is returned, not recomputed by the caller: a candidate
         # that declares its own ``env.PATH`` is searched against a DIFFERENT path
-        # than one that does not, so a caller reporting ``spec_env_path("")``
+        # than one that does not, so a caller reporting ``mcp_search_path("")``
         # would name directories that were never searched.
         return shutil.which(cmd, path=_search), _search
 
@@ -3596,10 +3601,11 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             # directories that were never consulted. The candidate list stays at
             # DEBUG: that is about which spec won, not about why none resolved.
             logger.warning(
-                "Dropping MCP server %r: command not found: %s — %s",
+                "Dropping MCP server %r: command not found: %s — %s; %s",
                 name,
                 spec.get("command", ""),
                 describe_search_path(dedup_path(os.pathsep.join(searched))),
+                MCP_PATH_HINT,
             )
             logger.debug("MCP %r resolution failed; tried %s", name, "; ".join(tried))
     config["mcpServers"] = valid_servers

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -163,6 +163,7 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "computer_use",
         "instances",
         "mcp_gateway",
+        "mcp",
         "taskrunner",
         "orchestrator",
         "watchdog",
@@ -4630,6 +4631,34 @@ FORWARD_DECLARED_ENV_DEFAULT = bool(
 
 
 @dataclass
+class McpConfig:
+    """MCP server settings that apply whether or not the broker is enabled.
+
+    Distinct from :class:`McpGatewayConfig`, which configures the sharing broker
+    itself: these settings govern how MCP servers are FOUND and launched, so
+    they matter equally with the broker off.
+    """
+
+    extra_path_dirs: list[str] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Extra MCP Binary Directories",
+            "Additional directories to search for MCP server binaries, ahead of "
+            "the built-in locations. Add one when a package manager installs its "
+            "MCP launchers somewhere Kiro Crew does not know about: a server "
+            "declared by bare name that resolves nowhere never starts, and the "
+            "session just comes up short of tools. Each entry must be a single "
+            "absolute directory (``~`` is expanded); anything else is ignored "
+            "with a warning. These directories are prepended to the search path "
+            "used by the MCP probe, the agent-config command resolver, and the "
+            "broker's rewriter alike, so a binary found here is found "
+            "everywhere. They do NOT join the search for the agent runtime "
+            "itself, which must not be shadowable by a configured directory.",
+        ),
+    )
+
+
+@dataclass
 class InstancesConfig:
     """Multi-instance management (the *Instances* feature).
 
@@ -5895,6 +5924,13 @@ class KiroCrewConfig:
         default_factory=McpGatewayConfig,
         metadata=_meta("MCP Gateway", "Sidecar MCP broker that shares backends across sessions."),
     )
+    mcp: McpConfig = field(
+        default_factory=McpConfig,
+        metadata=_meta(
+            "MCP",
+            "How MCP servers are found and launched — applies with the broker off too.",
+        ),
+    )
     instances: InstancesConfig = field(
         default_factory=InstancesConfig,
         metadata=_meta(
@@ -6071,6 +6107,33 @@ class KiroCrewConfig:
         The overlay is applied at load time but NOT persisted back by
         ``save()`` — only the base config is written to ``config.json``.
         """
+        cfg = cls._load_resolved()
+        # Push the MCP search-path setting to its consumer. It is PUSHED rather
+        # than read there because kiro_crew.env.mcp_search_path is reached from
+        # the event loop by every MCP probe and by the agent-config resolver, so
+        # a config read on that side would stat/read/validate config.json on the
+        # loop. Done here rather than inside _load_resolved so EVERY return path
+        # publishes -- including the defaults path taken when neither config file
+        # could be read, which must CLEAR a previously published snapshot rather
+        # than leave a deleted directory resolving commands. Lazy import: env
+        # must stay off this module's import graph.
+        try:
+            from kiro_crew.env import publish_config_path_dirs
+
+            publish_config_path_dirs(cfg.mcp.extra_path_dirs)
+        except Exception as e:  # pragma: no cover - defensive
+            # A publish failure must never make the config unloadable; the
+            # search path simply keeps its previous (or empty) contribution.
+            logger.warning("Publishing mcp.extra_path_dirs failed: %s", e)
+        return cfg
+
+    @classmethod
+    def _load_resolved(cls) -> KiroCrewConfig:
+        """Resolve the config from disk (or defaults). See :meth:`load`.
+
+        Split out so :meth:`load` owns the post-resolution publication on every
+        return path; this method may return from more than one place.
+        """
         path = config_path()
 
         # Hot-path cache: reuse the validated, merged dict when neither config
@@ -6220,6 +6283,9 @@ class KiroCrewConfig:
         mcp_gateway_data = data.get("mcp_gateway", {})
         if not isinstance(mcp_gateway_data, dict):
             mcp_gateway_data = {}
+        mcp_data = data.get("mcp", {})
+        if not isinstance(mcp_data, dict):
+            mcp_data = {}
         heartbeat_data = data.get("heartbeat", {})
         if not isinstance(heartbeat_data, dict):
             heartbeat_data = {}
@@ -7024,6 +7090,18 @@ class KiroCrewConfig:
                     ),
                 ),
             ),
+            mcp=McpConfig(
+                # Kept as authored strings — validation (absolute-only, ``~``
+                # expansion, dedup) belongs to the consumer,
+                # kiro_crew.env.augmented_path, so the ONE gate the built-in
+                # directories already pass applies to these too instead of a
+                # second rule drifting here. Non-strings ARE dropped now: the
+                # field is typed list[str] and to_dict() round-trips it verbatim
+                # into the saved config.
+                extra_path_dirs=[
+                    d for d in _safe_list(mcp_data.get("extra_path_dirs", [])) if isinstance(d, str)
+                ],
+            ),
             instances=InstancesConfig(
                 enabled=bool(instances_data.get("enabled", False)),
                 warm_set_cap=_safe_int(
@@ -7183,6 +7261,7 @@ class KiroCrewConfig:
             "computer_use": asdict(self.computer_use),
             "instances": asdict(self.instances),
             "mcp_gateway": asdict(self.mcp_gateway),
+            "mcp": asdict(self.mcp),
             "taskrunner": asdict(self.taskrunner),
             "orchestrator": asdict(self.orchestrator),
             "watchdog": asdict(self.watchdog),

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import threading
 from collections.abc import Iterable, Mapping, MutableMapping
 from pathlib import Path
 
@@ -33,6 +34,161 @@ _EXTRA_PATH_DIRS = (
     "{home}/.volta/bin",
     "/opt/homebrew/bin",  # Apple Silicon Homebrew node / global npm bins
 )
+
+
+# --- extending the MCP binary search path -------------------------------------
+#
+# ``_EXTRA_PATH_DIRS`` above is a fixed set of guesses and can never be
+# complete: WHICH directory a package manager drops an MCP launcher into is
+# ecosystem-, distribution- and site-specific. A launcher installed outside that
+# list is invisible to every consumer of :func:`augmented_path` — the MCP probe,
+# the agent-config command resolver, and gatewayd's rewriter — so a server
+# declared by bare name never launches and the session simply comes up short of
+# tools, which reads as a missing capability rather than a launch failure.
+#
+# So the list is extensible from two sides, merged in :func:`mcp_search_path`
+# (issue #5083). Fixing it at that one function is deliberate: it is the path all
+# three of those consumers resolve against, so one contributed directory reaches
+# all of them without any of them knowing it exists.
+#
+# * ``mcp.extra_path_dirs`` in the config — an operator on one host.
+# * :func:`register_mcp_path_dirs` — a packaged/downstream build or an embedding
+#   runtime, which has no per-user config file to edit.
+#
+# Both go through the same absolute-only :func:`_validated_bin_dir` gate as this
+# module's own entries, and both rank ahead of :func:`augmented_path`'s guesses:
+# a directory somebody named explicitly is more specific than a built-in guess,
+# so it must win when the same command name exists in both. A spec's own
+# ``env.PATH`` still outranks everything -- an operator pin cannot be displaced.
+#
+# The contribution reaches ONLY the resolution path, never
+# :func:`spec_env_path` (whose result :func:`emit_env` persists into consumed
+# config files) and never :func:`augmented_path` (the generic composition). Both
+# exclusions are load-bearing and are argued at :func:`mcp_search_path`.
+#
+# The config value is PUSHED here by the loader (:func:`publish_config_path_dirs`,
+# called from ``KiroCrewConfig.load``) rather than read here. That is not
+# indirection for its own sake: :func:`mcp_search_path` is reached from the event
+# loop by every MCP probe (``probe_server``) and by the agent-config resolver, so
+# pulling the config here would stat/read/validate ``config.json`` on the loop.
+# Pushing keeps this module's whole search-path construction free of IO, and
+# costs nothing: every process that spawns an MCP server loads the config at
+# startup, and each later ``load()`` refreshes the snapshot, so an edited setting
+# takes effect without a restart.
+_registered_path_dirs: tuple[str, ...] = ()
+_config_path_dirs: object = ()
+_path_dirs_lock = threading.Lock()
+
+#: Rejected operator-supplied bin dirs already logged, so a per-spawn call site
+#: does not re-log the same bad entry on every subprocess launch. Bounded by the
+#: number of distinct bad values an operator authored.
+_warned_bad_bin_dirs: set[str] = set()
+
+
+def _warn_rejected_bin_dir(raw: object, source: str) -> None:
+    """Log a rejected bin dir once per distinct value.
+
+    Silently dropping it would reproduce the failure this seam exists to fix:
+    a directory that looks configured but contributes nothing, with no trace.
+    """
+    key = f"{source}\0{raw!r}"
+    if key in _warned_bad_bin_dirs:
+        return
+    _warned_bad_bin_dirs.add(key)
+    logger.warning(
+        "%s: ignoring %r — expected a single absolute directory path",
+        source,
+        raw,
+    )
+
+
+def _validated_bin_dirs(values: object, source: str) -> list[str]:
+    """Validate an operator-supplied LIST of bin directories, dropping bad ones.
+
+    ``~`` is expanded first (a config file is where a human writes
+    ``~/.pixi/bin``), then each entry passes the same
+    :func:`_validated_bin_dir` gate as this module's own well-known dirs — one
+    absolute directory, no path separator, no NUL. A rejected entry is dropped
+    rather than failing the whole list: one typo must not cost an operator every
+    other directory they declared, nor abort PATH construction for every spawn.
+
+    *values* is typed ``object`` because both sources are hand-editable and can
+    legally parse as something other than a list of strings.
+    """
+    if not isinstance(values, (list, tuple)):
+        if values not in (None, ""):
+            _warn_rejected_bin_dir(values, source)
+        return []
+    out: list[str] = []
+    for raw in values:
+        entry = _validated_bin_dir(os.path.expanduser(raw)) if isinstance(raw, str) else None
+        if entry is None:
+            _warn_rejected_bin_dir(raw, source)
+            continue
+        out.append(entry)
+    return out
+
+
+def register_mcp_path_dirs(*dirs: str) -> tuple[str, ...]:
+    """Contribute directories to the MCP binary search path. Returns the accepted ones.
+
+    The programmatic half of the seam described above: a downstream build, a
+    packaged distribution, or a host embedding Kiro Crew can name the directories
+    ITS package manager installs MCP launchers into, without forking this module
+    and without a per-user config file. Call it during startup, before the first
+    session or MCP probe; :func:`augmented_path` reads the registry on every
+    call, so a later registration still takes effect (nothing is cached).
+
+    Entries are validated (:func:`_validated_bin_dirs`) and deduped, so calling
+    this twice with the same directory is a no-op rather than a doubled PATH
+    entry — an idempotent installer hook can just call it again. Registration
+    order is precedence order, and the whole registry ranks behind
+    ``mcp.extra_path_dirs``: an operator's own host setting outranks a
+    distribution default.
+    """
+    global _registered_path_dirs
+    accepted = _validated_bin_dirs(list(dirs), "register_mcp_path_dirs")
+    with _path_dirs_lock:
+        merged = _dedup_dirs([*_registered_path_dirs, *accepted])
+        _registered_path_dirs = tuple(merged)
+    return tuple(accepted)
+
+
+def publish_config_path_dirs(values: object) -> None:
+    """Record ``mcp.extra_path_dirs`` for :func:`augmented_path` to merge.
+
+    Called by ``KiroCrewConfig.load`` on every load, which is what keeps the
+    snapshot current without this module ever reading the config -- see the
+    section comment above for why the direction matters. Stores the value AS
+    AUTHORED and validates it at use: validation is pure string work, so keeping
+    it out of here keeps the load path's cost to one tuple assignment.
+
+    Idempotent and safe from any thread; a load that reports no setting clears
+    the snapshot, so removing the setting takes effect too. A malformed value is
+    stored as-is and rejected (with a warning) at use, so this cannot turn a
+    scalar into a directory entry.
+    """
+    global _config_path_dirs
+    # Copied to a tuple so a caller mutating its list afterwards cannot mutate
+    # the search path; a non-sequence is kept as-is for _validated_bin_dirs to
+    # reject and report.
+    snapshot: object = tuple(values) if isinstance(values, (list, tuple)) else values
+    with _path_dirs_lock:
+        _config_path_dirs = snapshot
+
+
+def _extra_mcp_path_dirs() -> list[str]:
+    """Operator/downstream-contributed MCP bin dirs, highest precedence first.
+
+    Pure: no IO and no config read, so it is safe on the event loop (the MCP
+    probe and the agent-config resolver both reach it from there). Validation of
+    the config-supplied entries happens here rather than at publish time because
+    it is string-only work.
+    """
+    return [
+        *_validated_bin_dirs(_config_path_dirs, "mcp.extra_path_dirs"),
+        *_registered_path_dirs,
+    ]
 
 
 # --- node build toolchain -----------------------------------------------------
@@ -489,6 +645,13 @@ def augmented_path(base_path: str = "") -> str:
     agent's own ``python``/``pip`` shell calls) to the gateway's venv
     interpreter. As a pure fallback it resolves only names found nowhere
     else — exactly the console-script-wrapper case.
+
+    Deliberately NOT extended by ``mcp.extra_path_dirs`` /
+    :func:`register_mcp_path_dirs`: callers here include the resolvers for the
+    trusted agent runtime (``kiro_cli.known_kiro_cli_dirs``,
+    ``acp.client``'s claude-backend resolvers), which must not consume a
+    contributed directory. That contribution lives on :func:`mcp_search_path` —
+    see the section comment near ``_registered_path_dirs``.
     """
     home = os.path.expanduser("~")
     mise_data = mise_data_dir(home)
@@ -514,6 +677,12 @@ def augmented_path(base_path: str = "") -> str:
 #: view.
 _SEARCH_PATH_REPORT_LIMIT = 40
 
+#: Appended to "MCP command not found" warnings. Naming the directories searched
+#: tells a reader the binary is installed somewhere uncovered; this tells them
+#: what to do about it, so the diagnosis and the remedy arrive together instead
+#: of the remedy living only in the source (issue #5083).
+MCP_PATH_HINT = "if it is installed elsewhere, add that directory to mcp.extra_path_dirs"
+
 
 def describe_search_path(path: str) -> str:
     """Render *path* as a human-readable list of searched directories.
@@ -536,25 +705,20 @@ def describe_search_path(path: str) -> str:
     return f"searched {len(dirs)} directories: {', '.join(shown)}{suffix}"
 
 
-def dedup_path(path: str) -> str:
-    """Drop repeated entries from a ``PATH`` string, keeping the first of each.
-
-    First-wins so precedence is preserved, and so :func:`spec_env_path` is
-    idempotent: feeding an already-expanded value back in contributes only
-    duplicates, which collapse to the same string.
+def _dedup_dirs(dirs: Iterable[str]) -> list[str]:
+    """Drop repeated (and empty) directory entries, keeping the first of each.
 
     Entries are compared through ``normcase(normpath(...))`` but emitted in
-    their original spelling. On Windows ``os.path`` IS ``ntpath``, so that
-    folds case and separator flavour together -- ``C:\\Tools`` and
-    ``C:/tools`` name one directory, and emitting both would put two spellings
-    of it on the child's PATH. Matches the normalization
-    :func:`node_bin_dirs` applies for the same reason. The original spelling is
-    kept rather than the normalized one so the value stays byte-comparable
-    against what a caller authored.
+    their original spelling. On Windows ``os.path`` IS ``ntpath``, so that folds
+    case and separator flavour together -- ``C:\\Tools`` and ``C:/tools`` name
+    one directory, and emitting both would put two spellings of it on the
+    child's PATH. Matches the normalization :func:`node_bin_dirs` applies for
+    the same reason. The original spelling is kept rather than the normalized
+    one so the value stays byte-comparable against what a caller authored.
     """
     seen: set[str] = set()
     out: list[str] = []
-    for entry in path.split(os.pathsep):
+    for entry in dirs:
         if not entry:
             continue
         key = os.path.normcase(os.path.normpath(entry))
@@ -562,7 +726,18 @@ def dedup_path(path: str) -> str:
             continue
         seen.add(key)
         out.append(entry)
-    return os.pathsep.join(out)
+    return out
+
+
+def dedup_path(path: str) -> str:
+    """Drop repeated entries from a ``PATH`` string, keeping the first of each.
+
+    First-wins so precedence is preserved, and so :func:`spec_env_path` is
+    idempotent: feeding an already-expanded value back in contributes only
+    duplicates, which collapse to the same string. Comparison rules are
+    :func:`_dedup_dirs`'.
+    """
+    return os.pathsep.join(_dedup_dirs(path.split(os.pathsep)))
 
 
 def _spec_path_entries(env_path: str) -> list[str]:
@@ -612,7 +787,7 @@ def spec_env_path(env_path: str) -> str:
     Expanding the value before it is written into the agent config closes the
     gap: the child is launched with the PATH the probe validates and the command
     resolves against, so "probes healthy" and "works in a session" cannot
-    diverge. The spec's own entries stay FIRST, ahead of both the inherited PATH
+    diverge.     The spec's own entries stay FIRST, ahead of both the inherited PATH
     and the augmentation, so a spec that pins a toolchain still wins.
 
     Idempotent: re-expanding an already-expanded value contributes only
@@ -641,6 +816,49 @@ def spec_env_path(env_path: str) -> str:
         logger.debug("ignoring non-string MCP spec PATH: %s", type(env_path).__name__)
         env_path = ""
     parts = [*_spec_path_entries(env_path), augmented_path(os.environ.get("PATH", ""))]
+    return dedup_path(os.pathsep.join(filter(None, parts)))
+
+
+def mcp_search_path(env_path: str) -> str:
+    """:func:`spec_env_path` plus the contributed MCP directories (issue #5083).
+
+    The path an MCP command is RESOLVED against -- the probe, the agent-config
+    command resolver, and gatewayd's rewriter all use this one. Separate from
+    :func:`spec_env_path` on purpose, and the separation is the whole safety
+    argument for the feature, on two counts:
+
+    * :func:`spec_env_path`'s result is PERSISTED. :func:`emit_env` writes it into
+      consumed config files (the agent config, the kiro-global ``mcp.json``, the
+      Claude Code sidecar), and those files are read back as a spec's authored
+      ``env.PATH`` on the next rebuild -- which is why that function documents
+      being idempotent under re-expansion. A contributed directory written there
+      would become indistinguishable from an authored entry, so clearing
+      ``mcp.extra_path_dirs`` could never remove it again. Resolution is
+      recomputed every time and stored nowhere, so a removed directory stops
+      being searched immediately.
+    * It also keeps the contribution off :func:`augmented_path`, whose callers
+      include the resolvers for the trusted agent runtime -- see the section
+      comment near ``_registered_path_dirs``.
+
+    Contributed dirs sit BETWEEN the spec's own entries and the generic
+    augmentation: a spec that pins a toolchain still wins, while a directory an
+    operator or a packaged build named explicitly outranks this module's built-in
+    guesses. ``dedup_path`` collapses the overlap a contributed directory has
+    with the built-in list.
+    """
+    extra = _extra_mcp_path_dirs()
+    if not extra:
+        # Byte-identical to the unextended path when nothing is contributed, so
+        # an install that never uses the setting cannot be perturbed by it.
+        return spec_env_path(env_path)
+    if not isinstance(env_path, str):
+        logger.debug("ignoring non-string MCP spec PATH: %s", type(env_path).__name__)
+        env_path = ""
+    parts = [
+        *_spec_path_entries(env_path),
+        *extra,
+        augmented_path(os.environ.get("PATH", "")),
+    ]
     return dedup_path(os.pathsep.join(filter(None, parts)))
 
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -32,9 +32,11 @@ import aiohttp
 from kiro_crew import platform_compat
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.env import (
+    MCP_PATH_HINT,
     denied_spec_env_keys,
     describe_search_path,
     emit_env,
+    mcp_search_path,
     sanitize_spec_env,
     spec_env_path,
     spec_path_key,
@@ -150,7 +152,13 @@ def _warn_unresolvable_once(name: str, command: str, search_path: str = "") -> N
         )
         return
     _unresolvable_warned.add(key)
-    logger.warning("MCP probe failed [%s]: command not found: %s%s", name, command, searched)
+    logger.warning(
+        "MCP probe failed [%s]: command not found: %s%s; %s",
+        name,
+        command,
+        searched,
+        MCP_PATH_HINT,
+    )
 
 
 #: Servers whose probe has already reported a missing sandbox backend. Keyed by
@@ -1572,7 +1580,7 @@ async def probe_server(
         # "PATH" here would probe with a different path than the session gets.
         _path_key = spec_path_key(server.env)
         _declared_path = server.env.get(_path_key, "") if _path_key else ""
-        env["PATH"] = spec_env_path(_declared_path if isinstance(_declared_path, str) else "")
+        env["PATH"] = mcp_search_path(_declared_path if isinstance(_declared_path, str) else "")
         # The declared env is untrusted config text applied to the environment
         # the SANDBOX LAUNCHER starts under, so loader/interpreter injection
         # keys must not pass through — they would execute before confinement

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -38,7 +38,7 @@ from typing import Any, Collection, Mapping
 from kiro_crew import __version__, platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
-from kiro_crew.env import spec_env_path, spec_path_key
+from kiro_crew.env import mcp_search_path, spec_path_key
 from kiro_crew.mcp_gateway import STUB_MODULE
 from kiro_crew.mcp_gateway.hashing import hash_command, is_secret_env_key
 from kiro_crew.mcp_gateway.manager import is_credential_env_key
@@ -151,7 +151,7 @@ def _resolve_target_command(
     ``PATH`` lacks the toolbox / user-local bin dirs a login shell has — so a
     bare command that resolves fine for the SESSION's own exec ENOENTs on
     every pooled spawn: 79% of all measured fallbacks. The search is
-    :func:`kiro_crew.env.spec_env_path` — literally the same composition the
+    :func:`kiro_crew.env.mcp_search_path` — literally the same composition the
     MCP probe and the agent-config resolver use (spec ``env.PATH`` first, then
     the augmented host PATH) — so a server that probes healthy on the
     dashboard can never ENOENT in gatewayd.
@@ -182,12 +182,12 @@ def _resolve_target_command(
     # legitimately spell it "Path" and the child's loader honours it.
     path_key = spec_path_key(env_pairs) if isinstance(env_pairs, dict) else None
     env_path = env_pairs.get(path_key, "") if path_key else ""
-    # spec_env_path is the canonical composition the MCP probe and the
-    # agent-config resolver also use: the spec's own env.PATH entries FIRST
-    # (an operator pin must win), then the augmented host PATH. It also
-    # degrades a non-string PATH and dedups, so one malformed hand-edited
-    # spec cannot abort the rewrite pass.
-    search_path = spec_env_path(env_path)
+    # mcp_search_path is the canonical RESOLUTION composition the MCP probe and
+    # the agent-config resolver also use: the spec's own env.PATH entries FIRST
+    # (an operator pin must win), then the contributed MCP directories, then the
+    # augmented host PATH. It also degrades a non-string PATH and dedups, so one
+    # malformed hand-edited spec cannot abort the rewrite pass.
+    search_path = mcp_search_path(env_path)
     resolved = shutil.which(target_command, path=search_path)
     if notes is not None:
         notes.which_results[
@@ -966,9 +966,11 @@ def _rewrite_inputs_fingerprint(
       so a moved/upgraded interpreter must regenerate the overlays.
     * ``path_env`` / ``pathext`` / ``path_augment`` — feed the
       ``shutil.which`` resolution of bare command names (``path_augment`` is
-      :func:`kiro_crew.env.spec_env_path` over an empty spec PATH — the
+      :func:`kiro_crew.env.mcp_search_path` over an empty spec PATH — the
       augmentation-and-dedup half of the search, which depends on ambient
-      state like ``MISE_DATA_DIR`` that ``path_env`` cannot see). The
+      state like ``MISE_DATA_DIR`` and on ``mcp.extra_path_dirs`` that
+      ``path_env`` cannot see, so editing that setting invalidates the
+      cache instead of reusing a stale resolution). The
       other half of which()'s input — the CONTENTS of the searched
       directories — is not stat-able here; it is covered by the stored
       per-probe results, which the cache-hit path re-runs and compares (see
@@ -993,7 +995,7 @@ def _rewrite_inputs_fingerprint(
         "python": sys.executable,
         "path_env": os.environ.get("PATH", ""),
         "pathext": os.environ.get("PATHEXT", ""),
-        "path_augment": spec_env_path(""),
+        "path_augment": mcp_search_path(""),
         "forward_declared_env": bool(forward_env),
         "pool_identity_env": sorted(frozenset(identity_keys)),
         "source_dir": str(source_dir),

--- a/test/test_config_mcp_section.py
+++ b/test/test_config_mcp_section.py
@@ -1,0 +1,131 @@
+"""The ``mcp`` config section that carries ``extra_path_dirs`` (issue #5083).
+
+Separate from ``mcp_gateway``, which configures the sharing broker: these
+settings govern how MCP servers are FOUND and launched, so they apply with the
+broker off too. Validation of the directories themselves belongs to the
+consumer (``kiro_crew.env.augmented_path``) -- see ``test_env.py`` -- so what is
+pinned here is only that the section parses, survives the save round-trip, and
+degrades instead of raising on a hand-edited value.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from kiro_crew.config import loader as L
+from kiro_crew.config.loader import KiroCrewConfig, McpConfig
+
+
+def _load_from(tmp_path, monkeypatch, data: dict) -> KiroCrewConfig:
+    cfgp = tmp_path / "config.json"
+    cfgp.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+    return KiroCrewConfig.load()
+
+
+def test_defaults_to_empty_list():
+    assert KiroCrewConfig().mcp.extra_path_dirs == []
+
+
+def test_parses_and_preserves_order(tmp_path, monkeypatch):
+    """Order is precedence order downstream, so the loader must not reorder it."""
+    cfg = _load_from(
+        tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/a/bin", "/opt/b/bin"]}}
+    )
+    assert cfg.mcp.extra_path_dirs == ["/opt/a/bin", "/opt/b/bin"]
+
+
+def test_round_trips_through_to_dict(tmp_path, monkeypatch):
+    """A setting dropped by to_dict() would be lost the next time anything saves."""
+    cfg = _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/a/bin"]}})
+    assert cfg.to_dict()["mcp"] == {"extra_path_dirs": ["/opt/a/bin"]}
+
+
+def test_non_string_entries_dropped(tmp_path, monkeypatch):
+    """The field is typed list[str] and to_dict() re-emits it verbatim, so a
+    non-string must not survive the load into the saved config."""
+    cfg = _load_from(
+        tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/a/bin", 42, None, {}]}}
+    )
+    assert cfg.mcp.extra_path_dirs == ["/opt/a/bin"]
+
+
+def test_malformed_section_degrades_to_default(tmp_path, monkeypatch):
+    """config.json is hand-editable; a non-dict section must not abort the load."""
+    cfg = _load_from(tmp_path, monkeypatch, {"mcp": "yes please"})
+    assert cfg.mcp.extra_path_dirs == []
+
+
+def test_malformed_value_degrades_to_default(tmp_path, monkeypatch):
+    cfg = _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": "/opt/a/bin"}})
+    assert cfg.mcp.extra_path_dirs == []
+
+
+def test_load_publishes_the_setting_to_the_search_path(tmp_path, monkeypatch):
+    """The setting only works because ``load()`` pushes it into
+    ``kiro_crew.env``. Pinned end-to-end: without this call the config field
+    parses correctly and changes nothing."""
+    import kiro_crew.env as env_mod
+
+    monkeypatch.setattr(env_mod, "_config_path_dirs", ())
+    _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/pixi/bin"]}})
+    assert "/opt/pixi/bin" in env_mod.mcp_search_path("").split(os.pathsep)
+
+
+def test_load_republishes_so_a_removed_setting_clears(tmp_path, monkeypatch):
+    import kiro_crew.env as env_mod
+
+    monkeypatch.setattr(env_mod, "_config_path_dirs", ())
+    _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/pixi/bin"]}})
+    _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": []}})
+    assert "/opt/pixi/bin" not in env_mod.mcp_search_path("").split(os.pathsep)
+
+
+def test_defaults_path_also_clears_a_stale_snapshot(tmp_path, monkeypatch):
+    """The load path taken when NEITHER config file can be read returns early.
+
+    It must still publish. Otherwise a config that is later deleted or made
+    unreadable leaves the last-published directory resolving MCP commands
+    forever, with nothing on disk that explains why.
+    """
+    import kiro_crew.env as env_mod
+
+    monkeypatch.setattr(env_mod, "_config_path_dirs", ())
+    _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/pixi/bin"]}})
+    assert "/opt/pixi/bin" in env_mod.mcp_search_path("").split(os.pathsep)
+
+    # Now point the loader at a home with no config files at all.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setattr(L, "config_path", lambda: empty / "config.json")
+    monkeypatch.setattr(L, "config_dir", lambda: empty)
+    monkeypatch.setattr(L, "config_local_path", lambda: empty / "config.local.json")
+    KiroCrewConfig.load()
+    assert "/opt/pixi/bin" not in env_mod.mcp_search_path("").split(os.pathsep)
+
+
+def test_section_is_in_the_schema_registry():
+    """The setting must be reachable from the settings UI / config API, not just
+    from a hand-edited file -- that is the whole point of making it a setting."""
+    from kiro_crew.config import schema
+
+    entry = next(e for e in schema.SCHEMA_REGISTRY if e.path == "mcp.extra_path_dirs")
+    assert entry.type == "array"
+    assert entry.label
+
+
+def test_mcp_is_not_captured_as_an_unknown_section(tmp_path, monkeypatch):
+    """Being absent from _KNOWN_CONFIG_SECTIONS would round-trip a stale copy
+    alongside the parsed one."""
+    cfg = _load_from(tmp_path, monkeypatch, {"mcp": {"extra_path_dirs": ["/opt/a/bin"]}})
+    assert "mcp" not in cfg._extra_sections
+
+
+def test_distinct_from_mcp_gateway():
+    """These settings apply with the broker off, so they must not live on the
+    broker's own section."""
+    assert not hasattr(KiroCrewConfig().mcp_gateway, "extra_path_dirs")
+    assert isinstance(KiroCrewConfig().mcp, McpConfig)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -17,6 +17,7 @@ from kiro_crew.env import (
     augmented_path,
     ensure_node,
     node_all_bin_dirs,
+    register_mcp_path_dirs,
     resolve_krb5_ccname,
 )
 
@@ -173,6 +174,266 @@ class TestAugmentedPath:
             env_mod._node_all_bin_dirs.cache_clear()
         for d in dirs:
             assert os.path.isabs(d), f"relative PATH entry leaked: {d!r}"
+
+
+class TestExtraMcpPathDirs:
+    """The MCP binary search path must be extensible (issue #5083).
+
+    A launcher installed into a directory ``_EXTRA_PATH_DIRS`` does not guess
+    resolves nowhere on a systemd gateway's PATH, so the server never starts and
+    the session merely comes up short of tools. Both seams -- the
+    ``mcp.extra_path_dirs`` setting and :func:`register_mcp_path_dirs` -- are
+    merged in ``mcp_search_path``, the path the MCP probe, the agent-config
+    resolver and gatewayd's rewriter all RESOLVE against, so one contributed
+    directory reaches all three. It is deliberately NOT ``spec_env_path``, whose
+    result is persisted -- see ``TestContributedDirsAreNeverPersisted``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self, monkeypatch):
+        # Module-global snapshots + warn-once memo: isolate all three so ordering
+        # between tests cannot leak a directory or swallow an expected warning.
+        monkeypatch.setattr(env_mod, "_registered_path_dirs", ())
+        monkeypatch.setattr(env_mod, "_config_path_dirs", ())
+        monkeypatch.setattr(env_mod, "_warned_bad_bin_dirs", set())
+        yield
+
+    @staticmethod
+    def _set_configured(monkeypatch, value):
+        """Publish *value* as the config's ``mcp.extra_path_dirs``.
+
+        Goes through the real publish entry point rather than assigning the
+        global, so a rename or a change of stored shape breaks these tests
+        instead of silently passing against a stale field.
+        """
+        env_mod.publish_config_path_dirs(value)
+
+    @staticmethod
+    def _mcp_dirs(declared: str = "") -> list[str]:
+        """The search path an MCP server's command is resolved against."""
+        return env_mod.mcp_search_path(declared).split(os.pathsep)
+
+    def test_configured_dir_outranks_builtin_guesses(self, monkeypatch) -> None:
+        """An explicitly named directory must win over a built-in guess.
+
+        Ordering is the whole point: when the same command name exists in both,
+        the directory the operator named is the one they meant.
+        """
+        self._set_configured(monkeypatch, ["/opt/pixi/bin"])
+        dirs = self._mcp_dirs()
+        local_idx = next(i for i, d in enumerate(dirs) if ".local/bin" in d)
+        assert dirs.index("/opt/pixi/bin") < local_idx
+
+    def test_spec_declared_path_still_outranks_a_configured_dir(self, monkeypatch) -> None:
+        """An operator pin on the spec must not be displaceable by this setting."""
+        self._set_configured(monkeypatch, ["/opt/pixi/bin"])
+        dirs = self._mcp_dirs("/opt/pinned/bin")
+        assert dirs.index("/opt/pinned/bin") < dirs.index("/opt/pixi/bin")
+
+    def test_configured_dir_expands_tilde(self, monkeypatch, tmp_path) -> None:
+        """``~/x/bin`` is what a human writes in a config file."""
+        monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path), 1))
+        self._set_configured(monkeypatch, ["~/pixi/bin"])
+        dirs = self._mcp_dirs()
+        assert str(tmp_path / "pixi" / "bin") in dirs
+        assert "~/pixi/bin" not in dirs
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "relative/bin",  # re-resolved against the CHILD's cwd
+            f"/opt/a{os.pathsep}/opt/b",  # smuggles two entries into one
+            "/opt/\0bin",  # cannot survive exec
+            "",
+            42,  # hand-edited config / a caller passing junk
+            None,
+        ],
+    )
+    def test_bad_entry_is_dropped_not_fatal(self, monkeypatch, bad, caplog) -> None:
+        """One bad entry must cost only itself -- never the whole list.
+
+        Failing the list would take out every other directory the operator
+        declared; failing the call would take out every MCP probe and rewrite.
+        """
+        self._set_configured(monkeypatch, [bad, "/opt/good/bin"])
+        with caplog.at_level("WARNING"):
+            dirs = self._mcp_dirs()
+        assert "/opt/good/bin" in dirs
+        assert all(os.path.isabs(d) and os.pathsep not in d for d in dirs)
+        assert any("mcp.extra_path_dirs" in r.message for r in caplog.records)
+
+    def test_rejected_entry_is_warned_once(self, monkeypatch, caplog) -> None:
+        """This runs once per candidate per rebuild; warning every time is spam."""
+        self._set_configured(monkeypatch, ["relative/bin"])
+        with caplog.at_level("WARNING"):
+            self._mcp_dirs()
+            self._mcp_dirs()
+        warnings = [r for r in caplog.records if "mcp.extra_path_dirs" in r.message]
+        assert len(warnings) == 1
+
+    def test_non_list_setting_is_ignored(self, monkeypatch) -> None:
+        self._set_configured(monkeypatch, "/opt/pixi/bin")  # a bare string, not a list
+        dirs = self._mcp_dirs()
+        assert "/opt/pixi/bin" not in dirs
+        assert any(".local/bin" in d for d in dirs)  # the rest still built
+
+    def test_reads_no_config(self, monkeypatch) -> None:
+        """The whole reason the value is pushed: this composition is reached from
+        the event loop by every MCP probe (probe_server), so it must not
+        stat/read/validate config.json."""
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        def _boom(cls):
+            raise AssertionError("the search path must not load the config")
+
+        monkeypatch.setattr(KiroCrewConfig, "load", classmethod(_boom))
+        self._set_configured(monkeypatch, ["/opt/pixi/bin"])
+        assert "/opt/pixi/bin" in self._mcp_dirs()
+
+    def test_publish_clears_a_removed_setting(self, monkeypatch) -> None:
+        """Every load republishes, so deleting the setting must take effect too --
+        not leave the last value pinned for the process lifetime."""
+        self._set_configured(monkeypatch, ["/opt/pixi/bin"])
+        assert "/opt/pixi/bin" in self._mcp_dirs()
+        self._set_configured(monkeypatch, [])
+        assert "/opt/pixi/bin" not in self._mcp_dirs()
+
+    def test_register_contributes_and_is_idempotent(self) -> None:
+        """A packaged build's installer hook may run more than once."""
+        assert register_mcp_path_dirs("/opt/dist/bin") == ("/opt/dist/bin",)
+        register_mcp_path_dirs("/opt/dist/bin")
+        assert self._mcp_dirs().count("/opt/dist/bin") == 1
+
+    def test_register_returns_only_accepted_entries(self) -> None:
+        """The caller needs to see that a value was rejected."""
+        assert register_mcp_path_dirs("relative/bin", "/opt/dist/bin") == ("/opt/dist/bin",)
+        assert "relative/bin" not in self._mcp_dirs()
+
+    def test_config_outranks_registered(self, monkeypatch) -> None:
+        """An operator's own host setting beats a distribution default."""
+        self._set_configured(monkeypatch, ["/opt/operator/bin"])
+        register_mcp_path_dirs("/opt/dist/bin")
+        dirs = self._mcp_dirs()
+        assert dirs.index("/opt/operator/bin") < dirs.index("/opt/dist/bin")
+
+    def test_registration_order_is_precedence_order(self) -> None:
+        register_mcp_path_dirs("/opt/first/bin")
+        register_mcp_path_dirs("/opt/second/bin")
+        dirs = self._mcp_dirs()
+        assert dirs.index("/opt/first/bin") < dirs.index("/opt/second/bin")
+
+    def test_contributed_duplicate_of_builtin_appears_once(self, monkeypatch, tmp_path) -> None:
+        """Contributing a directory the built-in list already covers must not
+        lengthen every child's PATH with a second copy of it."""
+        monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path) if p == "~" else p)
+        local_bin = str(tmp_path / ".local" / "bin")
+        self._set_configured(monkeypatch, [local_bin])
+        env_mod._node_all_bin_dirs.cache_clear()
+        try:
+            dirs = self._mcp_dirs()
+        finally:
+            env_mod._node_all_bin_dirs.cache_clear()
+        assert dirs.count(local_bin) == 1
+        assert dirs.index(local_bin) == 0
+
+    def test_default_config_changes_nothing(self, monkeypatch) -> None:
+        """With the setting untouched the emitted PATH is byte-identical to before,
+        so the seam cannot perturb an install that never uses it."""
+        self._set_configured(monkeypatch, [])
+        assert env_mod.mcp_search_path("/opt/pinned/bin") == env_mod.spec_env_path(
+            "/opt/pinned/bin"
+        )
+
+
+class TestContributedDirsAreNeverPersisted:
+    """A contributed directory must never be written into a consumed config file.
+
+    ``emit_env`` writes ``spec_env_path``'s result into the agent config, the
+    kiro-global ``mcp.json`` and the Claude Code sidecar, and those files are read
+    back as a spec's AUTHORED ``env.PATH`` on the next rebuild -- which is why
+    ``spec_env_path`` documents being idempotent under re-expansion. A contributed
+    directory rendered there would become indistinguishable from an authored
+    entry, so clearing ``mcp.extra_path_dirs`` could never remove it again.
+    Resolution is recomputed every time and stored nowhere, which is why the
+    contribution lives only on ``mcp_search_path``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _contributed(self, monkeypatch):
+        monkeypatch.setattr(env_mod, "_registered_path_dirs", ())
+        monkeypatch.setattr(env_mod, "_config_path_dirs", ())
+        monkeypatch.setattr(env_mod, "_warned_bad_bin_dirs", set())
+        env_mod.publish_config_path_dirs(["/opt/contributed/bin"])
+        register_mcp_path_dirs("/opt/contributed-registered/bin")
+        yield
+
+    def test_spec_env_path_excludes_contributed_dirs(self) -> None:
+        entries = env_mod.spec_env_path("/opt/pinned/bin").split(os.pathsep)
+        assert "/opt/contributed/bin" not in entries
+        assert "/opt/contributed-registered/bin" not in entries
+
+    def test_emit_env_excludes_contributed_dirs(self) -> None:
+        """The persisted surface. ``emit_env`` is the single writer for every
+        consumed config file, so excluding it here covers all of them."""
+        emitted = env_mod.emit_env({"PATH": "/opt/pinned/bin"})["PATH"]
+        assert "/opt/contributed/bin" not in emitted.split(os.pathsep)
+        assert "/opt/contributed-registered/bin" not in emitted.split(os.pathsep)
+
+    def test_a_removed_setting_stops_being_searched(self) -> None:
+        """The consequence the exclusion buys: clearing the setting takes effect
+        even for a spec whose PATH was rendered while it was set."""
+        rendered = env_mod.emit_env({"PATH": "/opt/pinned/bin"})["PATH"]
+        env_mod.publish_config_path_dirs([])
+        monkeyed = env_mod.mcp_search_path(rendered).split(os.pathsep)
+        assert "/opt/contributed/bin" not in monkeyed
+
+    def test_contributed_dir_still_reaches_the_mcp_search_path(self) -> None:
+        """The negative assertions above must not pass by the feature being broken."""
+        entries = env_mod.mcp_search_path("").split(os.pathsep)
+        assert "/opt/contributed/bin" in entries
+        assert "/opt/contributed-registered/bin" in entries
+
+
+class TestContributedDirsNeverReachTheTrustedRuntime:
+    """A contributed MCP directory must not be able to shadow the agent runtime.
+
+    ``kiro_cli.known_kiro_cli_dirs`` appends ``augmented_path`` when looking for
+    ``kiro-cli`` itself, and ``resolve_kiro_cli`` takes the FIRST executable
+    candidate. On an install whose CLI is reachable only that way -- a toolbox
+    install, found via ``~/.toolbox/bin`` -- a contributed directory ranked ahead
+    of it would let a forged ``kiro-cli`` win. Where ``agent.sandbox="off"``
+    delegates confinement to the CLI's own sandbox, that forged binary IS the
+    sandbox, so this is a credential-exposure path and not merely a wrong
+    binary. The contribution therefore lives on the MCP-only composition; these
+    tests are the ratchet on that boundary.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _contributed(self, monkeypatch):
+        monkeypatch.setattr(env_mod, "_registered_path_dirs", ())
+        monkeypatch.setattr(env_mod, "_config_path_dirs", ())
+        monkeypatch.setattr(env_mod, "_warned_bad_bin_dirs", set())
+        env_mod.publish_config_path_dirs(["/opt/attacker/bin"])
+        register_mcp_path_dirs("/opt/attacker-registered/bin")
+        yield
+
+    def test_augmented_path_excludes_contributed_dirs(self) -> None:
+        dirs = augmented_path("/usr/bin").split(os.pathsep)
+        assert "/opt/attacker/bin" not in dirs
+        assert "/opt/attacker-registered/bin" not in dirs
+
+    def test_kiro_cli_search_dirs_exclude_contributed_dirs(self, tmp_path) -> None:
+        from kiro_crew.kiro_cli import known_kiro_cli_dirs
+
+        dirs = known_kiro_cli_dirs("linux", tmp_path, {"PATH": "/usr/bin"})
+        assert "/opt/attacker/bin" not in dirs
+        assert "/opt/attacker-registered/bin" not in dirs
+
+    def test_contributed_dir_still_reaches_the_mcp_search_path(self) -> None:
+        """The negative tests above must not pass by the feature being broken."""
+        dirs = env_mod.mcp_search_path("").split(os.pathsep)
+        assert "/opt/attacker/bin" in dirs
+        assert "/opt/attacker-registered/bin" in dirs
 
 
 class TestNodeAllBinDirs:

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -404,13 +404,14 @@ def test_spec_env_path_wins_over_augmented_host_path(
     tmp_path: Path, monkeypatch
 ) -> None:
     """The spec's declared env.PATH is the operator's explicit intent: the
-    search is composed by the canonical ``env.spec_env_path`` (spec entries
-    FIRST, augmented host PATH behind), so a well-known dir can never shadow a
-    same-named binary the spec deliberately points elsewhere.
+    search is composed by the canonical ``env.mcp_search_path`` (spec entries
+    FIRST, contributed MCP dirs then the augmented host PATH behind), so a
+    well-known dir can never shadow a same-named binary the spec deliberately
+    points elsewhere.
 
     ``shutil.which`` is faked (first matching dir in path order wins) so the
     ordering assertion is platform-independent; the search string itself
-    comes from the REAL ``spec_env_path``, spied to prove the resolver
+    comes from the REAL ``mcp_search_path``, spied to prove the resolver
     delegates to it rather than hand-rolling the composition."""
     import os as _os
 
@@ -428,14 +429,14 @@ def test_spec_env_path_wins_over_augmented_host_path(
         return None
 
     seen: list[str] = []
-    real = _rw.spec_env_path
+    real = _rw.mcp_search_path
 
     def _spy(env_path: str) -> str:
         seen.append(env_path)
         return real(env_path)
 
     monkeypatch.setattr(_rw.shutil, "which", _fake_which)
-    monkeypatch.setattr(_rw, "spec_env_path", _spy)
+    monkeypatch.setattr(_rw, "mcp_search_path", _spy)
     monkeypatch.setenv("PATH", str(host_dir))
 
     resolved = _rw._resolve_target_command(


### PR DESCRIPTION
## 1. What is the problem?

`augmented_path()` in `src/kiro_crew/env.py` built the MCP binary search path
from a hardcoded private tuple, `_EXTRA_PATH_DIRS`. Its own comment called it
"a broad 'where might an MCP binary live' search path", but it listed a fixed
set of directories with **no config setting and no extension point** to add one.

Which directory a package manager drops an MCP launcher into is ecosystem-,
distribution- and site-specific, so that tuple can never be complete. A launcher
installed outside it is invisible, and the failure is silent: the gateway
typically runs under `systemd --user` with a minimal PATH, so an agent spec
declaring a server by bare name (`"command": "some-mcp"`) resolves nowhere,
`execvp` ENOENTs, and the session simply comes up short of tools. The agent then
tells the user it lacks that capability -- which reads as a missing feature
rather than a launch failure.

The existing guard does not save it. `mcp_gateway/rewriter.py`'s
`_resolve_target_command` detects the unresolvable command, logs a warning, and
leaves the entry unwrapped on the reasoning that "kiro-cli's own spawn
environment may still resolve it" -- but under a systemd-launched gateway the
session inherits the *same* minimal PATH, so that fallback is a guaranteed
no-op. The only trace is one log line.

## 2. Why this issue matters to the user

It is not a one-binary papercut. On the host in the issue, 13 distinct MCP
servers were declared as bare command names, all installed by a single package
manager into one directory outside `_EXTRA_PATH_DIRS`. All 13 launchers exist
and are executable on disk; all 13 are unresolvable on the gateway's PATH;
therefore none of them ever start. Several agents lost effectively their whole
toolset with no user-visible error.

Because `_EXTRA_PATH_DIRS` is a module-level private constant read directly
inside `augmented_path()`, a user's only options today are patching core or
symlinking every launcher (per binary, and every new install re-breaks it), or
widening the service unit's PATH (per host, outside the app's own configuration,
easy to lose on reinstall).

## 3. How our fix solves it

The search path is extensible from two sides, and both are merged in one new
function, `env.mcp_search_path()` -- the path an MCP command is **resolved**
against. The three consumers that do that resolution (the probe via
`probe_server`, the agent-config command resolver, and gatewayd's
`_resolve_target_command`) all call it, so one contributed directory reaches all
three without any of them knowing it exists. It also feeds the rewriter's
`path_augment` fingerprint input, so editing the setting invalidates the rewrite
cache instead of reusing a stale resolution.

**A user-facing setting.** New `mcp` config section (distinct from
`mcp_gateway`, which configures the sharing broker -- these settings govern how
servers are *found and launched*, so they apply with the broker off too) with
`mcp.extra_path_dirs: ["~/some/launcher/dir"]`. A normal dataclass field, so it
appears in the JSON schema, the config API and the settings UI, and round-trips
through `to_dict()`.

**A programmatic extension point.** `env.register_mcp_path_dirs(*dirs)` for a
packaged/downstream build or an embedding runtime that has no per-user config
file to edit. Validated and deduped, so an idempotent installer hook can just
call it again; nothing is cached, so a later registration still takes effect.

Both sources pass the same absolute-only `_validated_bin_dir` gate this module
already applies to its own entries (one absolute directory, no path separator,
no NUL) after `~` expansion, and a rejected entry is dropped rather than failing
the list -- one typo must not cost the operator every other directory they
declared, nor abort path construction for every probe. A rejected entry is
logged once per distinct value, because silently dropping it would reproduce the
very failure this seam exists to fix: a directory that looks configured and
contributes nothing.

Precedence, outermost first: a spec's own `env.PATH` (an operator pin must never
be displaceable), then the config dirs, then the registered dirs, then
`augmented_path()`'s built-in guesses and node version-manager bins. A directory
somebody named explicitly is more specific than a built-in guess; an operator's
own host setting outranks a distribution default. With nothing contributed,
`mcp_search_path()` returns `spec_env_path()` verbatim, so an install that never
uses the setting cannot be perturbed by it.

### Where the contribution deliberately does NOT go

Both exclusions are load-bearing, argued in the code, and ratcheted by tests.

**Not `spec_env_path()`, because its result is persisted.** `emit_env` is the
single writer for every surface some other process launches MCP servers from --
the agent config, the kiro-global `mcp.json`, the Claude Code sidecar -- and it
writes `spec_env_path()`'s output into those files. Those files are read back as
a spec's *authored* `env.PATH` on the next rebuild, which is exactly why
`spec_env_path` documents being idempotent under re-expansion. A contributed
directory rendered there would stop being a contribution and become an authored
entry, so clearing `mcp.extra_path_dirs` could never remove it again. Resolution,
by contrast, is recomputed every time and stored nowhere, so a removed directory
stops being searched immediately.

**Not `augmented_path()`, because its callers include the trusted runtime.**
`kiro_cli.known_kiro_cli_dirs` appends the augmented PATH when looking for
`kiro-cli` itself (and `acp.client` does the same for the claude backends), and
`resolve_kiro_cli` takes the first executable candidate. The explicit well-known
dirs it checks first do not include `~/.toolbox/bin`, so on a toolbox install the
real CLI is reachable only through that tail -- and a contributed directory ranked
ahead of it could shadow the real binary with a forged one. Where
`agent.sandbox="off"` delegates confinement to the CLI's own internal sandbox,
that forged binary *is* the sandbox. `augmented_path()` is byte-identical to main.

This is the same distinction the file already draws one constant lower down:
`_NODE_MANAGER_GLOBS` is "deliberately NARROW and separate from
`_EXTRA_PATH_DIRS`" because a build caller must not consume the broad list.

The scoping has one honest consequence: the contribution reaches **command
resolution** (which is what the issue reports -- 13 launchers that resolve
nowhere), not the runtime PATH of a resolved server that then shells out to a
sibling binary without declaring `env.PATH`. That boundary is deliberate; see
section 5.

### The config value is pushed, not pulled

`KiroCrewConfig.load` calls `env.publish_config_path_dirs(...)`; `env` reads only
that in-memory snapshot and never touches the config itself. `mcp_search_path()`
is reached from the event loop by every MCP probe, so a config read on that side
would stat, re-read and revalidate `config.json` on the loop -- a blocking call
there stalls every other task, including the watchdog heartbeat. Pushing keeps the
whole search-path construction free of IO, so this change adds no blocking work to
any caller and needs no offload anywhere.

`load()` now resolves via `_load_resolved()` and owns the publication once, after
it, so **every** return path publishes -- including the defaults path taken when
neither config file could be read, which publishes `[]` and clears. Without that,
a config later deleted or made unreadable would leave the last-published directory
resolving commands with nothing on disk to explain why. Publishing after
resolution rather than at each `return` is deliberate: a second call site is the
same bug one refactor later.

Because every `load()` republishes, an edited setting takes effect without a
restart, and removing it clears the contribution rather than pinning the last
value for the process lifetime. A process that never loads the config gets no
contribution -- documented, and true of nothing that spawns MCP servers.

Finally, the diagnosis and the remedy now arrive together. Both "MCP command not
found" warnings already named the directories they searched, which tells a reader
the binary is installed somewhere uncovered; they now also name what to do about
it (`mcp.extra_path_dirs`).

## 4. What tests we did

37 new tests: 16 in `test/test_env.py::TestExtraMcpPathDirs`, 4 in
`TestContributedDirsAreNeverPersisted`, 3 in
`TestContributedDirsNeverReachTheTrustedRuntime`, 11 in the new
`test/test_config_mcp_section.py`. Plus three more behaviours pinned inside the
existing classes.

Behaviour: a configured dir outranks the built-in guesses; a spec's own declared
`env.PATH` outranks a configured dir; `~` is expanded; each rejected shape
(relative, path-separator-bearing, NUL-bearing, empty, non-string) is dropped
without taking the rest of the list or the call with it; a rejected entry warns
exactly once across repeated calls; a non-list setting is ignored; registration is
idempotent, returns only the accepted entries, and is precedence-ordered; config
outranks registration; a contributed duplicate of a built-in appears once; and
with nothing contributed the result equals `spec_env_path` exactly.

The two exclusions are ratcheted, not just documented:

- `TestContributedDirsAreNeverPersisted` -- neither a configured nor a registered
  directory appears in `spec_env_path(...)` or in `emit_env(...)["PATH"]`, and a
  directory removed *after* a spec was rendered stops being searched (the
  user-visible consequence).
- `TestContributedDirsNeverReachTheTrustedRuntime` -- neither appears in
  `augmented_path()` nor in `kiro_cli.known_kiro_cli_dirs(...)`.

Each of those classes also asserts the directories *do* still reach
`mcp_search_path`, so the negative assertions cannot pass by the feature being
broken.

Push-design tests: the MCP search path still contributes the configured directory
with `KiroCrewConfig.load` patched to raise (proving the composition never loads
the config); a republish with an empty list clears a previously published
directory; loading a config file with the setting makes `mcp_search_path()`
include it, and loading one without it clears the contribution; and
`test_defaults_path_also_clears_a_stale_snapshot` publishes a directory, then
points the loader at a home with no config files, and asserts the directory is
gone.

Mutation-verified, each reverted after: neutering the merge in `mcp_search_path()`
fails 17; re-adding the merge to `spec_env_path()` fails all three persistence
ratchets; re-adding it to `augmented_path()` fails both trusted-runtime ratchets
(including through `known_kiro_cli_dirs`, i.e. it reproduces the reported attack
path); making the publish conditional on a non-empty value fails the defaults-path
test; dropping the publish call entirely fails the end-to-end loader test.

One existing test was updated rather than worked around:
`test_spec_env_path_wins_over_augmented_host_path` spied on `_rw.spec_env_path` to
prove the resolver delegates instead of hand-rolling the composition; it now spies
on `mcp_search_path`, the helper it delegates to. The contract it pins is
unchanged.

Full backend suite: 57165 passed, 15 failed. All 15 were confirmed pre-existing on
this host by stashing the change and re-running them (artifact_source /
artifacts_handlers `/tmp` classification, a `~/.local/bin/gh` symlink in
dev_fleet_app, a stray flock holder, and imessage_rpc bridge timeouts).

Gates: flake8 clean, mypy clean (1028 files), isort clean, black gate passed,
brand-name gate clean.

Three review rounds shaped this and every finding was real -- none overridden.
Round 1: `test_acp_spawn_offload.py` caught an on-loop config read, and GPT found
the caller the offload hops did not cover (`probe_server`), producing the push
design. Round 2: GPT found the trusted-runtime shadowing path, producing the split
from `augmented_path()`. Round 3: GPT found that the rendered-spec round-trip made
a contributed directory unremovable, and that the defaults return path skipped
publication -- producing `mcp_search_path()` and the `_load_resolved()` split.

## 5. Any other suggestions on the work

- `config-baseline.json` is deliberately untouched. It is already stale on main
  by ~1175 lines (fields added since without regenerating), so regenerating it
  here would bury this change under unrelated drift. There is no CI gate on it.
- The issue's optional follow-on -- surfacing unresolved MCP commands on the
  dashboard MCP page or as a startup warning list -- is **not** in this PR. This
  one adds the seam and closes the log-line gap; a user-visible surface for
  "servers whose command could not be resolved" is separate UI work.
- The runtime-PATH boundary in section 3 is deliberate. Closing it would mean
  putting the contribution on either of the two compositions this PR spent two
  review rounds establishing must not carry it: the persisted one or the generic
  one. If it turns out to matter in practice, the right shape is a third,
  explicitly ephemeral MCP-spawn path -- not widening either of these.
- Worth knowing for future changes here: `augmented_path()` already globs the
  Node version-manager roots on its first call per process, and
  `_resolve_claude_code_executable()` runs a `mise which` subprocess on the loop
  in `AcpClient._spawn`. Both pre-existing and out of scope, but they are the
  same class of on-loop blocking work this PR was careful not to add to.
