### PR TITLE
perf(dashboard): cache SPA shell HTML to avoid per-request disk read

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -53,6 +53,17 @@ logger = logging.getLogger(__name__)
 _STATIC_DIR = Path(__file__).resolve().parent.parent.parent / "static"
 _DIST_DIR = _STATIC_DIR / "dist"
 _DIST_INDEX = _DIST_DIR / "index.html"
+# mtime-keyed cache of the SPA shell HTML.  Each request stat()s _DIST_INDEX
+# (cheap) and re-reads the file only when its mtime_ns differs from the cached
+# key, so a Vite rebuild that rewrites index.html (new hashed asset refs) is
+# picked up on the very next request WITHOUT a gateway restart — the cache
+# never pins a pre-rebuild shell.  A missing-then-present bundle also self-heals
+# because a FileNotFoundError is never cached.  The stat replaces a full
+# read_text of the bundle on the hot path, which is the win.
+# SECURITY CONTRACT: the cached value must stay ``None`` or equal the static,
+# secret-free bundle — never inject per-request/dynamic data.  Pinned by
+# test_served_shell_is_auth_independent.
+_INDEX_HTML_CACHE: tuple[int, str] | None = None
 _SSE_INTERVAL_SECS = 5
 
 # Sentinel returned in place of sensitive config values in API responses. Kept
@@ -146,6 +157,29 @@ def _sel():
 # ── Page ──
 
 
+def _resolve_index_html() -> str:
+    """Return the SPA shell HTML, using the mtime-keyed cache.
+
+    Runs entirely in a worker thread (see ``index``): performs the blocking
+    ``stat()`` and, only on first load or after a rebuild changed the mtime, the
+    blocking ``read_text()``. A ``FileNotFoundError`` returns the static fallback
+    and is never cached, so a transiently-absent dist self-heals on the next
+    request (e.g. after a dev build). SECURITY CONTRACT: the cached value is
+    solely the on-disk bundle — never per-request/dynamic data.
+    """
+    global _INDEX_HTML_CACHE
+    try:
+        mtime = _DIST_INDEX.stat().st_mtime_ns
+        cached = _INDEX_HTML_CACHE
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
+        html = _DIST_INDEX.read_text(encoding="utf-8")
+        _INDEX_HTML_CACHE = (mtime, html)
+        return html
+    except FileNotFoundError:
+        return _DASHBOARD_HTML_NOT_FOUND
+
+
 async def index(request: web.Request) -> web.Response:
     """Serve the React dashboard SPA shell (``static/dist/index.html``).
 
@@ -164,10 +198,16 @@ async def index(request: web.Request) -> web.Response:
     would leak it across the auth boundary. Keep dynamic data behind gated
     ``/api/*`` routes. Pinned by test_served_shell_is_auth_independent.
     """
-    try:
-        html = _DIST_INDEX.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        html = _DASHBOARD_HTML_NOT_FOUND
+    # Resolve the shell entirely off the event loop: the stat() + conditional
+    # read_text() are the only blocking calls, and even a bare stat() can stall
+    # the loop on slow/network-backed storage. Route through the dedicated
+    # discovery_executor rather than the shared default thread pool: index() is
+    # served UNAUTHENTICATED on the cold-start path, so a remote SPA GET flood on
+    # slow storage must not be able to saturate the pool other gateway work
+    # (DNS, etc.) depends on. The mtime cache still serves repeat requests
+    # without a read.
+    loop = asyncio.get_running_loop()
+    html = await loop.run_in_executor(discovery_executor(), _resolve_index_html)
     return web.Response(text=html, content_type="text/html")
 
 

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -2408,6 +2408,102 @@ async def test_index_serves_guidance_when_bundle_missing(tmp_path, monkeypatch) 
     assert "someminted.token.value" not in body
 
 
+# -- index() SPA shell caching (issue #5087) -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_caches_html_and_rerereads_only_on_rebuild(
+    tmp_path, monkeypatch
+) -> None:
+    """The shell is cached keyed by index.html's mtime: repeated requests with
+    an UNCHANGED file read disk once; a rebuild (mtime change) is picked up on
+    the next request WITHOUT a restart.
+
+    Regression test for #5087 (unnecessary per-request read of a static bundle)
+    AND for the review finding that a process-lifetime cache would pin a
+    pre-rebuild shell after a Vite rebuild rewrote the hashed asset refs.
+    """
+    import kiro_crew.dashboard.handlers.core as core
+
+    fake_index = tmp_path / "index.html"
+    fake_index.write_text("<html>spa-shell-v1</html>", encoding="utf-8")
+
+    monkeypatch.setattr(core, "_INDEX_HTML_CACHE", None)
+    monkeypatch.setattr(core, "_DIST_INDEX", fake_index)
+
+    call_count = 0
+    original_read_text = fake_index.__class__.read_text
+
+    def counting_read_text(self, *args, **kwargs):
+        nonlocal call_count
+        if self == fake_index:
+            call_count += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(fake_index.__class__, "read_text", counting_read_text)
+
+    # Two requests with the file unchanged → one disk read, cache serves the 2nd.
+    resp1 = await core.index(_make_request(path="/", remote="127.0.0.1"))
+    resp2 = await core.index(_make_request(path="/", remote="127.0.0.1"))
+    assert resp1.text == "<html>spa-shell-v1</html>"
+    assert resp2.text == resp1.text
+    assert call_count == 1, (
+        f"_DIST_INDEX.read_text was called {call_count} times across two "
+        "unchanged requests; expected 1 (second must hit the mtime cache)"
+    )
+
+    # Simulate a rebuild: new content AND a strictly newer mtime.
+    stale = fake_index.stat().st_mtime_ns
+    fake_index.write_text("<html>spa-shell-v2</html>", encoding="utf-8")
+    os.utime(fake_index, ns=(stale + 1_000_000_000, stale + 1_000_000_000))
+
+    resp3 = await core.index(_make_request(path="/", remote="127.0.0.1"))
+    assert resp3.text == "<html>spa-shell-v2</html>", (
+        "a rebuilt bundle (changed mtime) must be re-read, not served stale"
+    )
+    assert call_count == 2, (
+        f"expected a re-read after the mtime changed; read_text calls={call_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_missing_bundle_not_cached_recovers_when_dist_appears(
+    tmp_path, monkeypatch
+) -> None:
+    """A FileNotFoundError must NOT be cached: once the bundle appears on disk
+    the next request should serve it (self-healing after a dev build).
+    """
+    import kiro_crew.dashboard.handlers.core as core
+
+    fake_index = tmp_path / "index.html"
+    # Do NOT create the file yet — first request should get the fallback.
+
+    monkeypatch.setattr(core, "_INDEX_HTML_CACHE", None)
+    monkeypatch.setattr(core, "_DIST_INDEX", fake_index)
+
+    req = _make_request(path="/", remote="127.0.0.1")
+
+    # First request: bundle absent → fallback, cache stays None.
+    resp_missing = await core.index(req)
+    assert core.DASHBOARD_HTML_NOT_FOUND_MARKER in resp_missing.text
+    assert core._INDEX_HTML_CACHE is None, (
+        "FileNotFoundError path must NOT populate the cache"
+    )
+
+    # Bundle appears (e.g. dev build completed).
+    fake_index.write_text("<html>now-built</html>", encoding="utf-8")
+
+    # Second request: bundle present → real shell served and cached.
+    resp_recovered = await core.index(req)
+    assert resp_recovered.text == "<html>now-built</html>"
+    assert core._INDEX_HTML_CACHE is not None
+    assert core._INDEX_HTML_CACHE[1] == "<html>now-built</html>"
+
+    # Third request: still the cached value, no further disk read.
+    resp_cached = await core.index(req)
+    assert resp_cached.text == "<html>now-built</html>"
+
+
 # -- extract_numeric_claim (round-2 bugfix: api_auth_me session_exp=0) ---------
 
 


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

On every unauthenticated `GET /`, the `index()` SPA handler synchronously reads
`static/dist/index.html` from disk on the aiohttp event loop:

```python
html = _DIST_INDEX.read_text(encoding="utf-8")
```

The SPA bundle is a static, runtime-constant file — it cannot change while the
gateway process is running. There is no reason to re-read it from disk on every
cold-start-path request.

## Why it matters

Every dashboard page load that hits the cold-start auth bypass path (no/expired
token, `GET`/`HEAD` `/`) pays an unnecessary synchronous disk I/O on the event
loop. At high request rates or on slow storage this blocks the event loop and
adds latency to every unauthenticated page load, including the initial bootstrap.
The fix caches the shell keyed by the file's mtime, so it stays correct across a
rebuild that rewrites `index.html` (new hashed asset references) — the cache is
never allowed to pin a pre-rebuild shell.

## What changed (motivation → approach → change)

Root cause: `index()` calls `_DIST_INDEX.read_text()` unconditionally on every
request, with no caching of the result.

Approach: an mtime-keyed module-level cache. `_INDEX_HTML_CACHE: tuple[int, str] |
None` starts as `None`. The resolve path lives in a sync helper
`_resolve_index_html()` that `index()` runs via `loop.run_in_executor(discovery_executor(), ...)` — the
dedicated discovery thread pool, NOT the shared default executor — so no
filesystem call touches the event loop and an unauthenticated SPA GET flood
cannot starve the shared pool other gateway work depends on. In the thread it `stat()`s
`_DIST_INDEX` and serves the cached body only when its `st_mtime_ns` matches the
cached key; otherwise it re-reads the file and re-caches under the new mtime. The
per-request work drops from a full `read_text()` of the bundle to a single
`stat()`, and neither the `stat()` nor the occasional `read_text()` runs on the
loop.

Why mtime rather than a one-time memoize: in the dev / DevFleet workflow the
gateway serves `dist` in place while a Vite rebuild rewrites `index.html` with
new hashed asset filenames. A process-lifetime cache would keep serving the old
shell (referencing deleted assets) until a restart. Keying on mtime means the
rebuild is picked up on the very next request with no restart.

Critical constraint preserved: `FileNotFoundError` is deliberately NOT cached.
The fallback guidance page is served for the current request, but the cache stays
`None` so a transiently-missing bundle self-heals once the dist is built and
present (e.g. after `npm run build` in a dev workflow).

The static, secret-free security contract on `index()` is unchanged: the cached
value is solely the on-disk bundle content — no per-request data, user state,
credentials, or feature flags can enter it. `test_served_shell_is_auth_independent`
continues to pass unmodified.

## Tests

Two regression tests in `test/test_token_auth.py`:

- **`test_index_caches_html_and_rerereads_only_on_rebuild`** — patches
  `Path.read_text` with a call counter; asserts two back-to-back requests on an
  UNCHANGED file read disk only once (second hits the mtime cache), then bumps
  the file's content and mtime (simulating a rebuild) and asserts the next
  request re-reads and serves the NEW body — proving a rebuilt bundle is never
  served stale.
- **`test_index_missing_bundle_not_cached_recovers_when_dist_appears`** — starts
  with the bundle absent (first request serves the fallback, cache stays `None`),
  then writes the bundle and verifies the next request serves the real shell and
  populates the cache.

Both existing tests (`test_served_shell_is_auth_independent` and
`test_index_serves_guidance_when_bundle_missing`) pass unchanged.

## Manual verification

N/A — unit coverage sufficient. The change is a pure Python module-level
mtime-keyed cache; the behaviour is fully captured by the tests above
(two pre-existing + two new), and there is no UI or external-service path to
exercise manually.

<!-- no-visual-delta -->
**Why no screenshot:** this change only modifies the Python `index()` handler
caching logic — no HTML, CSS, JS, or rendered UI surface changes. The SPA shell
served to the browser is byte-identical to before.

## Related Issues

Fixes #5087

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->



