### PR TITLE
fix(config): lock and offload PUT config RMW to prevent lost-write race

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1383,
+    "missing_code": 1382,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 884,
+  "_compliant": 939,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -87,7 +87,7 @@
     },
     "dashboard/handlers/core.py": {
       "dynamic_status": 3,
-      "missing_code": 24
+      "missing_code": 23
     },
     "dashboard/handlers/cron.py": {
       "dynamic_status": 6,

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1382,132 +1382,185 @@ async def api_kirocrew_config(request: web.Request) -> web.Response:
         agent_settings = body.get("agent")
         if not isinstance(agent_settings, dict):
             return _deny("agent must be an object")
-        path = config_path()
+        cfg_path = config_path()
+        # Validate-only (CPU-bound) before acquiring the lock — fail fast on
+        # obviously-bad input so the lock hold is as short as possible.
+        # The actual read-modify-write is serialised under _get_config_lock and
+        # offloaded to a thread so it neither races concurrent writers (lost-write
+        # bug) nor blocks the event loop (event-loop-stall bug).  This mirrors the
+        # pattern used by the sibling PATCH handler (~line 2031).
+        from kiro_crew.config.loader import ConfigReadError, update_config_locked  # noqa: F811
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock  # noqa: F811
+
+        # Carry the validation error and result out of the mutate callback.
+        # Validation that depends on the *persisted* ceiling (max_subagents bound)
+        # runs inside the callback where it can read the current config; the
+        # callback also emits the "no recognized settings provided" 400, so no
+        # pre-lock key-recognition check is needed.
+        _validation_error: list[tuple[str, int]] = []
+        _result: dict[str, object] = {}
+
+        def _mutate_config_put(data: dict) -> dict | None:
+            if not isinstance(data.get("agent"), dict):
+                data["agent"] = {}
+            agent = data["agent"]
+            # Snapshot BEFORE mutation for the restart-hint truthfulness guard.
+            # The dashboard sends all settings on every save so "was applied" !=
+            # "was changed" — see the no-op-save comments in messaging.py.
+            before = dict(agent)
+
+            limits = {"subagent_max_turns": SUBAGENT_MAX_TURNS_CEILING}
+            applied: list[str] = []
+            for key, upper in limits.items():
+                if key in agent_settings:
+                    val = agent_settings[key]
+                    if isinstance(val, bool) or not isinstance(val, int) or val < 1 or val > upper:
+                        _validation_error.append(
+                            (f"{key} must be an integer between 1 and {upper}", 400)
+                        )
+                        return None
+                    agent[key] = val
+                    applied.append(key)
+
+            # Capture the hard cap from the *persisted* config BEFORE applying any
+            # subagent_auto_max from this request — deny-by-default prevents a
+            # same-request ceiling-raise+spend.
+            persisted_hard_cap = agent.get("subagent_auto_max", 16)
+            if (
+                not isinstance(persisted_hard_cap, int)
+                or isinstance(persisted_hard_cap, bool)
+                or persisted_hard_cap < 3
+            ):
+                persisted_hard_cap = 16
+            persisted_hard_cap = min(persisted_hard_cap, SUBAGENT_AUTO_MAX_CEILING)
+
+            if "subagent_auto_max" in agent_settings:
+                val = agent_settings["subagent_auto_max"]
+                if (
+                    isinstance(val, bool)
+                    or not isinstance(val, int)
+                    or val < 3
+                    or val > SUBAGENT_AUTO_MAX_CEILING
+                ):
+                    _validation_error.append(
+                        (
+                            "subagent_auto_max must be an integer between 3 and "
+                            f"{SUBAGENT_AUTO_MAX_CEILING}",
+                            400,
+                        )
+                    )
+                    return None
+                agent["subagent_auto_max"] = val
+                applied.append("subagent_auto_max")
+
+            if "max_subagents" in agent_settings:
+                val = agent_settings["max_subagents"]
+                hard_cap = persisted_hard_cap
+                if (
+                    isinstance(val, bool)
+                    or not isinstance(val, int)
+                    or (val != 0 and not (MAX_SUBAGENTS_FIXED_FLOOR <= val <= hard_cap))
+                ):
+                    _validation_error.append(
+                        (
+                            f"max_subagents must be 0 (auto) or an integer between "
+                            f"{MAX_SUBAGENTS_FIXED_FLOOR} and {hard_cap}",
+                            400,
+                        )
+                    )
+                    return None
+                agent["max_subagents"] = val
+                applied.append("max_subagents")
+
+            for key in ("conductor_skill",):
+                if key in agent_settings:
+                    val = agent_settings[key]
+                    if not isinstance(val, bool):
+                        _validation_error.append((f"{key} must be a boolean", 400))
+                        return None
+                    agent[key] = val
+                    applied.append(key)
+
+            if not applied:
+                _validation_error.append(("no recognized settings provided", 400))
+                return None
+
+            restart_required = any(
+                key in _STARTUP_READ_AGENT_KEYS and agent.get(key) != before.get(key)
+                for key in applied
+            )
+            _result["applied"] = applied
+            _result["restart_required"] = restart_required
+            return data
+
         try:
-            data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-        except Exception:
+            async with _get_config_lock():
+                try:
+                    # update_config_locked returns the final config dict (after
+                    # mutation); use it directly rather than re-reading from disk
+                    # (a blocking read on the loop, and it writes the callback's
+                    # output verbatim — there is no concurrent merge to observe).
+                    final = await asyncio.to_thread(
+                        update_config_locked, cfg_path, mutate=_mutate_config_put
+                    )
+                except ConfigReadError:
+                    _sel().log_api_access(
+                        caller=caller,
+                        operation="config.update",
+                        outcome="error",
+                        error="config.json is corrupt",
+                    )
+                    return web.json_response(
+                        {"error": "config.json is corrupt", "code": "config_corrupt"},
+                        status=500,
+                    )
+
+                if _validation_error:
+                    msg, status = _validation_error[0]
+                    return _deny(msg, status)
+
+                applied: list[str] = _result["applied"]  # type: ignore[assignment]
+                agent = final.get("agent") or {}
+                _sel().log_api_access(
+                    caller=caller,
+                    operation="config.update",
+                    outcome="ok",
+                    resources=",".join(applied),
+                )
+                # Regenerate or clean up conductor skill on toggle. Held INSIDE
+                # the lock so a concurrent enable/disable cannot interleave and
+                # leave the persisted flag disagreeing with the skill file on
+                # disk (config says enabled while SKILL.md is absent, or vice
+                # versa).
+                if "conductor_skill" in applied:
+                    if agent.get("conductor_skill"):
+                        from kiro_crew.dashboard.handlers.agents import (  # noqa: F811
+                            _regen_conductor,
+                        )
+
+                        _regen_conductor()
+                    else:
+                        try:
+                            from kiro_crew.skills import SkillsLoader  # noqa: F811
+
+                            p = SkillsLoader()._dir / "conductor" / "SKILL.md"
+                            if p.exists():
+                                p.unlink()
+                        except Exception:
+                            logger.exception("Failed to clean up conductor skill")
+        except OSError:
             _sel().log_api_access(
                 caller=caller,
                 operation="config.update",
                 outcome="error",
-                error="config.json is corrupt",
+                error="config.json write failed",
             )
-            return web.json_response({"error": "config.json is corrupt"}, status=500)
-        if not isinstance(data.get("agent"), dict):
-            data["agent"] = {}
-        agent = data["agent"]
-        # Snapshot the persisted values BEFORE any mutation. The dashboard sends
-        # all four settings on every save and enables Save whenever any one is
-        # dirty, so "was applied" is not "was changed" -- keying the restart hint
-        # off the raw applied list would flag a restart for a conductor-only save.
-        # Same truthfulness guard as handlers/messaging.py (see its no-op-save
-        # comments) so the flag stays trustworthy enough to act on.
-        before = dict(agent)
-        # subagent_max_turns keeps the generic 1..N validation; max_subagents is
-        # special — 0 is the "auto-size" sentinel and its upper bound is the
-        # configured hard cap (dynamic-subagent-sizing.md §5.5/§6).
-        limits = {"subagent_max_turns": SUBAGENT_MAX_TURNS_CEILING}
-        applied: list[str] = []
-        for key, upper in limits.items():
-            if key in agent_settings:
-                val = agent_settings[key]
-                if isinstance(val, bool) or not isinstance(val, int) or val < 1 or val > upper:
-                    return _deny(f"{key} must be an integer between 1 and {upper}")
-                agent[key] = val
-                applied.append(key)
-        # Capture the hard cap from the *persisted* config BEFORE applying any
-        # subagent_auto_max from this request. max_subagents is bounded by this
-        # persisted value only: a same-request raise of subagent_auto_max must NOT
-        # widen the bound (deny-by-default — prevents
-        # {subagent_auto_max: 9999, max_subagents: 9999} bypass). A higher ceiling
-        # only takes effect for max_subagents on a *subsequent* request.
-        persisted_hard_cap = agent.get("subagent_auto_max", 16)
-        if (
-            not isinstance(persisted_hard_cap, int)
-            or isinstance(persisted_hard_cap, bool)
-            or persisted_hard_cap < 3
-        ):
-            persisted_hard_cap = 16
-        # Clamp to the absolute ceiling even when read from persisted config: a
-        # corrupt or hand-edited config (e.g. {"subagent_auto_max": 9999}) must not
-        # be trusted to widen the concurrency bound (deny-by-default).
-        persisted_hard_cap = min(persisted_hard_cap, SUBAGENT_AUTO_MAX_CEILING)
-        # subagent_auto_max is now persistable (so the dashboard can raise/lower the
-        # auto-size ceiling), but carries its own absolute upper bound
-        # (SUBAGENT_AUTO_MAX_CEILING) so it can never be set arbitrarily high.
-        if "subagent_auto_max" in agent_settings:
-            val = agent_settings["subagent_auto_max"]
-            if (
-                isinstance(val, bool)
-                or not isinstance(val, int)
-                or val < 3
-                or val > SUBAGENT_AUTO_MAX_CEILING
-            ):
-                return _deny(
-                    "subagent_auto_max must be an integer between 3 and "
-                    f"{SUBAGENT_AUTO_MAX_CEILING}"
-                )
-            agent["subagent_auto_max"] = val
-            applied.append("subagent_auto_max")
-        # max_subagents: 0 = auto-size; otherwise a fixed pin in
-        # [MAX_SUBAGENTS_FIXED_FLOOR, persisted_hard_cap]. The bound is the
-        # persisted ceiling captured above, never this request's value. A pin of
-        # 1 or 2 is rejected — it would disable auto-sizing and run below the
-        # default (0 is the only way to request the host-safe auto cap).
-        if "max_subagents" in agent_settings:
-            val = agent_settings["max_subagents"]
-            hard_cap = persisted_hard_cap
-            if (
-                isinstance(val, bool)
-                or not isinstance(val, int)
-                or (val != 0 and not (MAX_SUBAGENTS_FIXED_FLOOR <= val <= hard_cap))
-            ):
-                return _deny(
-                    f"max_subagents must be 0 (auto) or an integer between "
-                    f"{MAX_SUBAGENTS_FIXED_FLOOR} and {hard_cap}"
-                )
-            agent["max_subagents"] = val
-            applied.append("max_subagents")
-        # Boolean toggles
-        for key in ("conductor_skill",):
-            if key in agent_settings:
-                val = agent_settings[key]
-                if not isinstance(val, bool):
-                    return _deny(f"{key} must be a boolean")
-                agent[key] = val
-                applied.append(key)
-        if not applied:
-            return _deny("no recognized settings provided")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, path)
-        _sel().log_api_access(
-            caller=caller,
-            operation="config.update",
-            outcome="ok",
-            resources=",".join(applied),
-        )
-        # Regenerate or clean up conductor skill on toggle.
-        if "conductor_skill" in applied:
-            if agent.get("conductor_skill"):
-                from kiro_crew.dashboard.handlers.agents import _regen_conductor  # noqa: F811
+            return web.json_response(
+                {"error": "failed to write config file", "code": "config_write_failed"},
+                status=500,
+            )
 
-                _regen_conductor()
-            else:
-                try:
-                    from kiro_crew.skills import SkillsLoader  # noqa: F811
-
-                    p = SkillsLoader()._dir / "conductor" / "SKILL.md"
-                    if p.exists():
-                        p.unlink()
-                except Exception:
-                    logger.exception("Failed to clean up conductor skill")
-        # A startup-read key that was merely re-sent with its existing value did
-        # not change the enforced cap, so it must not raise the hint.
-        restart_required = any(
-            key in _STARTUP_READ_AGENT_KEYS and agent.get(key) != before.get(key) for key in applied
-        )
+        restart_required: bool = _result["restart_required"]  # type: ignore[assignment]
         return web.json_response({"ok": True, "restart_required": restart_required})
 
     cfg = KiroCrewConfig.load()

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -1127,6 +1127,67 @@ class TestAgentSettingsPut:
         assert "agent" in body
 
 
+class TestAgentSettingsPutLockOffload:
+    """Regression tests for the locked + offloaded read-modify-write path.
+
+    Before the fix the PUT handler called ``path.read_text`` / ``os.replace``
+    directly on the event loop, racing concurrent writers (lost-write) and
+    blocking the loop.  After the fix the write goes through
+    ``update_config_locked`` under ``_get_config_lock``, making two
+    concurrent PUTs serialize rather than clobber each other.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_puts_serialize_not_clobber(
+        self, seeded_config, fake_sel
+    ) -> None:
+        """Two concurrent PUTs must both land — neither write clobbers the other.
+
+        We fire two coroutines simultaneously: one sets ``subagent_max_turns=3``
+        and one sets ``max_subagents=4``.  Because the RMW is now serialized
+        under the config lock, the config file must end up with BOTH values
+        after both coroutines complete, not just the last one written.
+        """
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            r1, r2 = await asyncio.gather(
+                _put_agent(client, {"subagent_max_turns": 3}),
+                _put_agent(client, {"max_subagents": 0}),
+            )
+        assert r1.status == 200
+        assert r2.status == 200
+        persisted = json.loads(seeded_config.read_text(encoding="utf-8"))["agent"]
+        # Both writes must have survived — a lost-write would drop one of them.
+        assert persisted.get("subagent_max_turns") == 3
+        assert persisted.get("max_subagents") == 0
+
+    @pytest.mark.asyncio
+    async def test_write_goes_through_atomic_helper(
+        self, seeded_config, fake_sel, monkeypatch
+    ) -> None:
+        """The write path must call ``update_config_locked``, not a bare
+        ``write_text`` / ``os.replace``.  Patching the helper to a spy lets us
+        assert it was invoked while still allowing the real write to complete."""
+        import kiro_crew.config.loader as _loader
+
+        calls: list[str] = []
+        _real = _loader.update_config_locked
+
+        def _spy(path=None, *, mutate, **kw):
+            calls.append("update_config_locked")
+            return _real(path, mutate=mutate, **kw)
+
+        monkeypatch.setattr(_loader, "update_config_locked", _spy)
+        async with TestClient(TestServer(_agent_cfg_app())) as client:
+            resp = await _put_agent(client, {"subagent_max_turns": 5})
+        assert resp.status == 200
+        assert calls == ["update_config_locked"], (
+            "PUT did not route through update_config_locked — lost-write race still present"
+        )
+        assert json.loads(seeded_config.read_text(encoding="utf-8"))["agent"][
+            "subagent_max_turns"
+        ] == 5
+
+
 # ── PATCH validators not reachable through the editable-field table ─────
 
 


### PR DESCRIPTION
## Problem / Motivation

`api_kirocrew_config` (PUT `/api/config/kirocrew`) reads `config.json` with
`path.read_text()`, mutates `data['agent']`, then writes back via
`tmp.write_text() + os.replace()` — all directly on the aiohttp event loop,
with no advisory lock and no `asyncio.to_thread` offload.

Two concrete defects result:

1. **Lost-write race.** Two concurrent dashboard saves (e.g. two browser tabs)
   interleave their read-modify-write cycles: both read the same baseline, each
   writes its own update, and the last `os.replace` silently discards the first
   write.
2. **Event-loop stall.** Synchronous disk I/O on the event loop blocks all
   other request processing for the duration of the write.

## Why it matters

Every dashboard "Save" button hit goes through this endpoint.  A user with two
tabs open, or a fast double-save, silently loses one of the writes with no
error reported.  The event-loop block degrades gateway responsiveness for every
concurrent request during a save.

## What changed (motivation → approach → change)

**Root cause:** the PUT handler predates `update_config_locked` and was never
migrated when the PATCH sibling (`api_kirocrew_config_patch`, ~line 2031) was
written with the correct pattern.

**Approach:** mirror the PATCH handler exactly —
`async with _get_config_lock(): await asyncio.to_thread(update_config_locked, cfg_path, mutate=...)`.

**Changes:**
- Moved the entire read-modify-write into a `_mutate_config_put` callback
  passed to `update_config_locked` under `_get_config_lock()`, serializing
  concurrent writes under both an in-process asyncio lock and the cross-process
  advisory file lock that `update_config_locked` holds.
- All validation runs inside the callback under the lock: persisted-state
  validation (the `max_subagents` ceiling from `subagent_auto_max`) reads the
  live config there, and the callback also emits the "no recognized settings
  provided" 400, so there is no separate pre-lock key-recognition check to drift
  out of sync.
- Added `ConfigReadError` and `OSError` handling to match the PATCH handler's
  error surface. Both new error responses carry a machine-readable `code`
  (`config_corrupt`, `config_write_failed`) per the repo's error-code contract
  (`test_no_new_error_response_without_a_code`), matching the `config_unreadable`
  convention already used in `agents.py`.
- Post-write side-effects use `update_config_locked`'s returned config dict
  (no second on-loop disk re-read), and the SEL log + `conductor_skill`
  regen/delete run INSIDE the lock so a concurrent enable/disable cannot
  interleave and leave the persisted flag disagreeing with the on-disk
  `SKILL.md`. The `restart_required` truthfulness guard is unchanged.

## Tests

Two regression tests added to `TestAgentSettingsPutLockOffload`:

- **`test_concurrent_puts_serialize_not_clobber`**: fires two PUTs concurrently
  via `asyncio.gather` — one sets `subagent_max_turns=3`, one sets
  `max_subagents=0` — and asserts both values are present in the persisted
  config after both complete.  This test fails on the pre-fix code because the
  second `os.replace` clobbers the first write.

- **`test_write_goes_through_atomic_helper`**: patches `update_config_locked` as
  a spy and asserts it is called exactly once per PUT.  This test fails on the
  pre-fix code because the old path bypasses `update_config_locked` entirely.

All 16 pre-existing `TestAgentSettingsPut` tests continue to pass (18 total).

## Manual verification

N/A — unit coverage sufficient.  The concurrent-clobber scenario is
deterministically reproduced by the new test via `asyncio.gather`.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — no rendered UI delta.

## Related Issues

Fixes #5085

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the project's open-source license and I have the right to submit
it under those terms.


