### PR TITLE
refactor: swap the two remaining greedy-regex JSON span-scanners for the shared extractor (#5082)

### DIFF
--- a/src/kiro_crew/crew_chat.py
+++ b/src/kiro_crew/crew_chat.py
@@ -35,7 +35,7 @@ from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.history import append_if_absent_off_loop
-from kiro_crew.llm_helpers import run_bg_oneliner
+from kiro_crew.llm_helpers import _extract_json_of_type, run_bg_oneliner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.spawn_warm import warm_project_agents_for_spawn
 from kiro_crew.subagent_persistence import _agent_dir, read_state
@@ -71,6 +71,16 @@ _SUB_TASK_SUFFIX = (
     "with a summary of the result (<=150 words) wrapped EXACTLY as: "
     "<<<SUMMARY your summary here >>>"
 )
+
+
+def _decision_shaped(value: object) -> bool:
+    """Prefer predicate: a dict carrying the decision payload's ``actions`` list.
+
+    Disambiguates the payload from stray braced JSON in surrounding prose (an
+    inline worked example, a ``{placeholder}`` aside) -- those parse as dicts
+    but never carry the schema the executor consumes."""
+    return isinstance(value, dict) and isinstance(value.get("actions"), list)
+
 
 _DECISION_PROMPT = """You are the routing decision function for a multi-topic chat. \
 Decide what to do with each PENDING message. Reply with ONLY a JSON object, no prose.
@@ -1411,8 +1421,15 @@ class CrewOrchestrator:
                     self._sessions, prompt, model=self._decision_model,
                     sel_source="crew_decision", timeout=_DECISION_TIMEOUT,
                 )
-                m = re.search(r"\{.*\}", raw, re.DOTALL)
-                actions = json.loads(m.group(0))["actions"] if m else []
+                data = _extract_json_of_type(raw, dict, prefer=_decision_shaped)
+                if not isinstance(data, dict):
+                    # No usable JSON object: nothing parseable, or two
+                    # DIFFERENT actions-shaped dicts (the shared contract
+                    # refuses to guess which is the real payload). The prompt
+                    # demands a JSON-only reply, so all of these are model
+                    # failures -- take the retry-then-defer path.
+                    raise ValueError("decision reply carried no usable JSON object")
+                actions = data["actions"]
                 break
             except Exception:
                 if attempt == 2:

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import time as _time
 from collections.abc import Callable
 from datetime import datetime, timedelta
@@ -15,6 +14,7 @@ from pathlib import Path
 from typing import TypeVar
 from uuid import uuid4
 
+from kiro_crew.llm_helpers import _extract_json_of_type
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -234,6 +234,19 @@ def _first_line_title(content: str) -> str:
         if line:
             return line[:80]
     return ""
+
+
+_SUMMARY_PAYLOAD_KEYS = frozenset({"topic", "themes"})
+
+
+def _summary_shaped(value: object) -> bool:
+    """Prefer predicate: a dict carrying at least one source-summary field.
+
+    Disambiguates the payload from stray braced JSON in the surrounding prose
+    or in the untrusted section summaries echoed back by the model -- those
+    parse as dicts but never carry the ``topic``/``themes`` fields this
+    caller consumes."""
+    return isinstance(value, dict) and not _SUMMARY_PAYLOAD_KEYS.isdisjoint(value)
 
 
 class IngestionPipeline:
@@ -1012,10 +1025,12 @@ class IngestionPipeline:
         )
         try:
             response = await self.extractor._pool.send(prompt, timeout=30.0)
-            # Parse JSON from response
-            m = re.search(r'\{[\s\S]*\}', response)
-            if m:
-                data = json.loads(m.group())
+            data = _extract_json_of_type(response, dict, prefer=_summary_shaped)
+            # The shape check guards the WRITE, not just the preference: the
+            # scanner falls back to the first dict when nothing is
+            # payload-shaped (e.g. a bare "{}" echo), and storing that would
+            # overwrite an existing summary with empty values.
+            if isinstance(data, dict) and _summary_shaped(data):
                 topic = _redact(data.get("topic", ""))
                 themes = json.dumps([r for t in data.get("themes", [])[:5] if (r := _redact(t))])
                 self.store.db.execute(

--- a/test/test_crew_chat.py
+++ b/test/test_crew_chat.py
@@ -2987,3 +2987,74 @@ class TestUnknownCrewNameStaysFailClosed:
         with cfg_patch, bind_patch:
             resolved = await orch._dispatch_agent(_slot(agent="default"))
         assert resolved == "kirocrew"
+
+
+class TestDecisionJsonExtraction:
+    """The decision reply is parsed by the shared scanner, not a greedy regex."""
+
+    @pytest.mark.asyncio
+    async def test_stray_brace_in_prose_still_routes(self) -> None:
+        # The old greedy first-'{'-to-last-'}' regex spanned from the
+        # {placeholder} aside to the trailing "{}" echo, so a valid decision
+        # payload wrapped in prose never parsed and every entry was deferred.
+        orch = _orch()
+        slot = _slot()
+        st = orch._store("s1")
+        e = st.add_msg("do the thing")
+        reply = (
+            'Routing per the {msg_id, topic_id} schema: '
+            '{"actions": [{"do": "meta", "msg_id": "%s"}]} -- use {} if unsure.'
+            % e["msg_id"]
+        )
+
+        async def _reply(*a, **kw):
+            return reply
+
+        with patch.object(crew_mod, "run_bg_oneliner", side_effect=_reply), \
+                patch.object(orch, "_apply", new=AsyncMock()) as apply:
+            await orch._decide_once(slot)
+        apply.assert_awaited_once()
+        assert apply.await_args.args[2] == {"do": "meta", "msg_id": e["msg_id"]}
+
+    @pytest.mark.asyncio
+    async def test_two_different_payloads_defer_not_guess(self) -> None:
+        # Two DIFFERENT actions-shaped dicts (e.g. a worked example echoed
+        # before the real payload) are ambiguous: the shared contract refuses
+        # to guess, so the pass takes the retry-then-defer path instead of
+        # executing whichever dict a scanner happened to land on.
+        orch = _orch()
+        slot = _slot()
+        st = orch._store("s1")
+        st.add_msg("do the thing")
+
+        async def _reply(*a, **kw):
+            return ('{"actions": [{"do": "meta", "msg_id": "a"}]} or '
+                    '{"actions": [{"do": "meta", "msg_id": "b"}]}')
+
+        with patch.object(crew_mod, "run_bg_oneliner", side_effect=_reply) as llm, \
+                patch.object(orch, "_apply", new=AsyncMock()) as apply:
+            await orch._decide_once(slot)
+        apply.assert_not_awaited()
+        assert llm.call_count == 2  # retried once, then deferred
+
+    @pytest.mark.asyncio
+    async def test_braceless_reply_takes_the_retry_path(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        # The prompt demands a JSON-only reply, so a reply with no JSON object
+        # at all is a model failure: it gets the same retry-then-defer
+        # treatment as garbage braces (the old code silently treated it as
+        # "no actions" and never logged).
+        orch = _orch()
+        slot = _slot()
+        st = orch._store("s1")
+        st.add_msg("do the thing")
+
+        async def _reply(*a, **kw):
+            return "I cannot decide right now."
+
+        with caplog.at_level(logging.WARNING):
+            with patch.object(crew_mod, "run_bg_oneliner", side_effect=_reply) as llm, \
+                    patch.object(orch, "_apply", new=AsyncMock()) as apply:
+                await orch._decide_once(slot)
+        apply.assert_not_awaited()
+        assert llm.call_count == 2
+        assert "unparseable decision" in caplog.text

--- a/test/test_source_summary.py
+++ b/test/test_source_summary.py
@@ -118,3 +118,53 @@ class TestGenerateSourceSummary:
         row = store.db.execute("SELECT summary_themes FROM sources WHERE id = ?", (sid,)).fetchone()
         themes = json.loads(row["summary_themes"])
         assert len(themes) <= 5
+
+    @pytest.mark.asyncio
+    async def test_stray_brace_in_prose_still_parses(self, pipeline, store):
+        # The old greedy first-'{'-to-last-'}' regex spanned from the
+        # {topic, themes} aside to the trailing "{}" echo, so the slice never
+        # parsed and a valid payload was silently lost.
+        sid = store.add_source("test", "local_file", "/tmp/test.md")
+        store.add_item("title", "content", "doc", source_id=sid, summary="A summary")
+        pipeline.extractor._pool.send.return_value = (
+            'Per the {topic, themes} shape: {"topic": "AI overview", '
+            '"themes": ["AI"]} -- use {} when unsure.'
+        )
+        await pipeline.generate_source_summary(sid)
+        row = store.db.execute(
+            "SELECT summary_topic, summary_themes FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["summary_topic"] == "AI overview"
+        assert json.loads(row["summary_themes"]) == ["AI"]
+
+    @pytest.mark.asyncio
+    async def test_two_different_payloads_refuse_the_guess(self, pipeline, store):
+        # The shared extractor's ambiguity contract: two DIFFERENT
+        # payload-shaped dicts mean the caller cannot know which is real, so
+        # nothing is stored (the pre-swap behavior for such a reply was also
+        # a no-op -- the greedy span across both never parsed).
+        sid = store.add_source("test", "local_file", "/tmp/test.md")
+        store.add_item("title", "content", "doc", source_id=sid, summary="A summary")
+        pipeline.extractor._pool.send.return_value = (
+            '{"topic": "first"} or maybe {"topic": "second"}'
+        )
+        await pipeline.generate_source_summary(sid)
+        row = store.db.execute(
+            "SELECT summary_topic FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["summary_topic"] is None
+
+    @pytest.mark.asyncio
+    async def test_unshaped_fallback_does_not_erase_an_existing_summary(self, pipeline, store):
+        # The scanner falls back to the first dict when nothing is
+        # payload-shaped; a bare "{}" echo in the reply must not overwrite a
+        # previously stored summary with empty topic/themes on re-ingestion.
+        sid = store.add_source("test", "local_file", "/tmp/test.md")
+        store.add_item("title", "content", "doc", source_id=sid, summary="A summary")
+        pipeline.extractor._pool.send.return_value = (
+            '{"topic": "AI overview", "themes": ["AI"]}'
+        )
+        await pipeline.generate_source_summary(sid)
+        pipeline.extractor._pool.send.return_value = 'Use {placeholder} style, or {} when unsure.'
+        await pipeline.generate_source_summary(sid)
+        row = store.db.execute(
+            "SELECT summary_topic FROM sources WHERE id = ?", (sid,)).fetchone()
+        assert row["summary_topic"] == "AI overview"


### PR DESCRIPTION
## Problem / Motivation

Two prose-tolerant JSON extractors still parse LLM replies with the documented-buggy greedy first-`{`-to-last-`}` regex — the byte-identical pattern that PR #5079 (#5071) deleted from `knowledge/extractor.py`:

1. `src/kiro_crew/knowledge/ingestion.py` `generate_source_summary`: `re.search(r'{[\s\S]*}', response)` + `json.loads`, fed by the same `extractor._pool`.
2. `src/kiro_crew/crew_chat.py` `_decide_once`: `re.search(r"{.*}", raw, re.DOTALL)` on the `run_bg_oneliner` routing-decision reply. (The issue also mentions a missing-DOTALL multi-line failure; on current main the flag is present, so only the greedy-span defect applies.)

Any stray brace in surrounding prose (a `{placeholder}` aside, a trailing `{}` echo) corrupts the span, the parse fails, and a valid payload is silently lost.

## Why it matters

For ingestion, a source that got a valid summary reply silently ends up with no `summary_topic`/`summary_themes` — degraded knowledge search with no signal anything went wrong. For crew chat, a valid routing decision wrapped in prose is discarded, so every pending message is needlessly deferred and, after the straggler cap, visibly failed back to the user ("I could not work out how to route this request").

## What changed (motivation → approach → change)

Same mechanical call-site treatment as PR #5079 (#5071) and PR #5066 (#4974): each site now calls the shared `llm_helpers._extract_json_of_type` (stdlib `raw_decode` over successive delimiter offsets — robust to stray braces, refuses to guess between two different payload-shaped candidates) with a prefer predicate matching that caller's payload shape:

- `ingestion.py`: `_summary_shaped` (dict carrying `topic`/`themes`). Failure contract preserved exactly — any unusable reply means no DB write, debug log, as before. `_redact` still runs on everything stored.
- `crew_chat.py`: `_decision_shaped` (dict carrying an `actions` list). Parse failures keep the existing retry-then-defer path (one in-pass retry, then a redacted warning). One deliberate contract unification: a reply with **no JSON object at all** — previously treated silently as "no actions" — now takes that same retry-then-defer path, since `_DECISION_PROMPT` demands a JSON-only reply, making a brace-less reply a model failure, not a decision. The `_settle_stragglers` backstop (bounded re-passes, then a visible failure) is unchanged either way.

Out of scope, per the issue: `agent_discovery.py` (owned by #4974 / PR #5066) and the shared extractor itself are untouched.

The unused `import re` in `ingestion.py` is removed (no other `re.` use remained).

## Tests

- `test_source_summary.py::test_stray_brace_in_prose_still_parses` — **mutation-verified** (fails against the old greedy regex): payload wrapped in prose with brace asides now stores topic + themes.
- `test_source_summary.py::test_two_different_payloads_refuse_the_guess` — ambiguity refusal locks the no-write contract.
- `test_crew_chat.py::TestDecisionJsonExtraction::test_stray_brace_in_prose_still_routes` — **mutation-verified**: a decision payload wrapped in prose is now executed.
- `test_crew_chat.py::TestDecisionJsonExtraction::test_two_different_payloads_defer_not_guess` — ambiguity takes retry-then-defer, never executes a guessed dict.
- `test_crew_chat.py::TestDecisionJsonExtraction::test_braceless_reply_takes_the_retry_path` — **mutation-verified**: locks the deliberate contract unification (retry + redacted warning).

The pre-existing redaction test (`test_an_unparseable_decision_is_redacted_before_logging`) passes unchanged — garbage-brace replies still hit the redacted-warning path.

Local gates: pytest full suite (60,971 passed; the 20 failures are byte-identical on pristine `origin/main` — host-environment issues in `test_xdist_host_budget`/`test_pr_readiness_publish`/etc., verified by re-running those files with this diff reverted), isort, flake8, mypy (1,028 files) all green. Frontend untouched.

## Manual verification

N/A — unit coverage sufficient: both call sites are exercised end-to-end through their public entry points (`generate_source_summary`, `_decide_once`) with mocked LLM replies, which is the only variable this change touches.

## Related Issues

Closes #5082

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff
