### PR TITLE
fix(mcp): include inject-role breadcrumbs in get_chat_session

### DIFF
--- a/src/kiro_crew/mcp_tools/sessions.py
+++ b/src/kiro_crew/mcp_tools/sessions.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from typing import Any
 
 from kiro_crew import mcp_core
+from kiro_crew.context import RECALL_ROLES
 from kiro_crew.history import ConversationLog
 from kiro_crew.validation import (
     GET_CHAT_SESSION_SCHEMA,
@@ -317,7 +318,17 @@ def get_chat_session(name: str, args: dict[str, Any]) -> str:
             )
             return "Access denied: that conversation belongs to a different workspace."
 
-    messages = cl.recent(key, max_messages=max_messages, roles={"user", "assistant"})
+    # RECALL_ROLES rather than a literal, because this is the one surface whose
+    # whole purpose is reading a past session: a breadcrumb appended with
+    # role="inject" (a /note, a cron result) is precisely a message meant to
+    # survive the session boundary being crossed here, and a hardcoded
+    # {"user", "assistant"} dropped it. The constant already governs replay and
+    # compression in context.py, so sharing it keeps the fetch from drifting
+    # from them. Note it is narrowING as well as widening: "system" is absent
+    # from RECALL_ROLES, so passing no roles at all would not be equivalent --
+    # recent() treats a falsy roles as "no filter" and would admit internal
+    # rows here.
+    messages = cl.recent(key, max_messages=max_messages, roles=RECALL_ROLES)
     if not messages:
         mcp_core.sel().log_tool_invocation(
             session_key=mcp_core._resolve_session_key(),

--- a/test/test_search_chat_history.py
+++ b/test/test_search_chat_history.py
@@ -147,6 +147,32 @@ class TestSearchChatHistoryHandler:
         out = mcp_core._call_tool_inner("get_chat_session", {"session_key": "dashboard_chat-1"})
         assert "redis.timeout" in out
 
+    def test_get_chat_session_reads_recall_roles(self, tmp_path, monkeypatch):
+        """An inject-role breadcrumb is readable here, and a system-role one is not.
+
+        A ``/note`` breadcrumb is appended with ``role="inject"``, and reading a
+        past session is the clearest case of crossing the boundary those notes
+        exist to survive -- so a handler that filtered on a hardcoded
+        ``{"user", "assistant"}`` dropped exactly the messages it was asked for.
+        ``RECALL_ROLES`` already governs replay and compression; this asserts the
+        same constant governs the fetch.
+
+        The system-role half is the negative direction, and it is what makes the
+        test measure the CONSTANT rather than merely the absence of a filter:
+        ``ConversationLog.recent`` guards with ``if roles:``, so deleting the
+        argument is permissive and would satisfy the inject assertion on its own
+        while quietly admitting internal system rows into the transcript.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        cl = _seed_sessions(tmp_path)
+        cl.append("dashboard_chat-1", "inject", "note breadcrumb: rotate the staging key")
+        cl.append("dashboard_chat-1", "system", "internal marker, not for recall")
+
+        out = mcp_core._call_tool_inner("get_chat_session", {"session_key": "dashboard_chat-1"})
+
+        assert "rotate the staging key" in out, "an inject breadcrumb must be readable here"
+        assert "internal marker, not for recall" not in out, "system is absent from RECALL_ROLES"
+
     def test_legacy_metadataless_session_still_surfaces(self, tmp_path, monkeypatch):
         # A legacy session file whose first line is a message (predates the
         # metadata line) yields {} from get_metadata. Search must NOT drop it:


### PR DESCRIPTION
## Problem / Motivation

`get_chat_session` filtered its fetch on a hardcoded `{"user", "assistant"}`, so a
message appended with `role="inject"` was invisible there. Those inject rows are
exactly the breadcrumbs meant to outlive a session: a note written through
`POST /api/chat/slots/{slot}/note`, or a cron result reported back into a chat.

The observable effect is that an agent asked to read a past session gets a
transcript with those rows silently missing — from the one surface whose whole
purpose is reading a past session, which is the clearest case of crossing the
boundary the breadcrumbs exist to survive.

## Why it matters

`RECALL_ROLES` in `context.py` is documented as the single source of truth for
which roles survive recall, and replay and compression already read it
(`context.py:1519`, `:1566`). This handler was the last recall path still
carrying a literal, so the constant was not actually authoritative: adding a role
to it would silently fail to reach `get_chat_session`.

Concretely, a caller writes a note, later asks the agent what happened, and the
agent reads the session back without it — a quiet omission rather than an error,
which is the hard kind to notice.

## What changed (motivation → approach → change)

Root cause: the literal at `src/kiro_crew/mcp_tools/sessions.py:320` predates
`RECALL_ROLES` and was never converted with the other recall paths.

Approach: share the existing constant rather than extend the literal, so the
fetch cannot drift from the paths that already govern recall, and a future role
added to `RECALL_ROLES` is picked up without touching this handler. No new
constant and no change to `RECALL_ROLES` itself.

Change: import `RECALL_ROLES` and pass it as `roles`. One line plus the import,
with a comment recording why the constant rather than a literal.

Worth noting the conversion **narrows** as well as widens. `"system"` is absent
from `RECALL_ROLES`, and `ConversationLog.recent` guards with `if roles:` — so
simply dropping the argument would be permissive, not equivalent, and would admit
internal system rows into the transcript. Passing the constant keeps them out.

## Tests

`test_get_chat_session_reads_recall_roles` (in `test/test_search_chat_history.py`)
asserts **both** directions against the real handler through
`mcp_core._call_tool_inner`:

- an `inject` row **is** readable — the behaviour being fixed;
- a `system` row is **not** — which is what makes the test measure the constant
  rather than merely the absence of a filter.

Both halves are load-bearing, and each fails for a different wrong
implementation:

| Implementation under test | Result |
| ------------------------------------------- | ------------------------------------------------------------- |
| `roles=RECALL_ROLES` (this PR) | passes |
| `roles={"user", "assistant"}` (pre-fix) | fails: `an inject breadcrumb must be readable here` |
| `roles` argument deleted (permissive) | fails: `system is absent from RECALL_ROLES` |

Verified in that order: red at the parent commit for the first reason, green
after the change, and red again for the second reason when the argument is
removed — so the test cannot pass vacuously by the filter simply being gone.

Suites run locally: `test_search_chat_history.py`, `test_history_race.py`,
`test_mcp_tool_registry.py`, `test_dashboard_sessions_summarize.py`,
`test_dashboard_sessions_search.py` — 138 passed. `isort`, `flake8`, `mypy` and
`black --check` clean on both changed files.

## Manual verification

N/A — unit coverage is sufficient: the test drives the real tool handler end to
end against an on-disk conversation log, which is the whole code path.

## Related Issues

None.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changes
- [x] No secrets, credentials, or internal references in the diff
