### PR TITLE
refactor(doctor): collapse duplicated branches in the doctor report

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -225,17 +225,18 @@ def _doctor_effective_model(cfg: KiroCrewConfig, project_dir: str, issues: list[
     tiers.append(("global agent.model", normalize_agent_model(cfg.agent.model)))
     tiers.append(("default spec pin", default_model))
 
-    decided_by = next((label for label, value in tiers if value), "bundled defaults.json")
-    if any(value for _, value in tiers):
-        decided_value = next(value for _, value in tiers if value)
-    elif default_readable:
-        # Nothing pinned anything, so the bundled default answered and the
-        # resolver's value is legitimately ours.
-        decided_value = effective
+    # Label and value come out of the SAME tier by construction; a second lookup
+    # for the value could be filtered differently and mis-attribute the decision.
+    decided = next(((label, value) for label, value in tiers if value), None)
+    if decided is not None:
+        decided_by, decided_value = decided
     else:
-        # A spec read was REFUSED, so the resolver may have followed a link this
-        # report would not. Adopting its answer here would hide exactly that.
-        decided_value = ""
+        decided_by = "bundled defaults.json"
+        # Nothing pinned anything, so the bundled default answered and the
+        # resolver's value is legitimately ours -- unless a spec read was
+        # REFUSED, in which case the resolver may have followed a link this
+        # report would not, and adopting its answer would hide exactly that.
+        decided_value = effective if default_readable else ""
 
     print(f"  effective:   {_safe_display(effective) if effective else 'auto (backend picks)'}")
     print(f"  decided by:  {decided_by}")
@@ -292,19 +293,20 @@ def _doctor_effective_model(cfg: KiroCrewConfig, project_dir: str, issues: list[
         # Resolved the way kiro-cli itself resolves --agent, via the existing
         # helper: the DECLARED name wins and the filename is only the fallback,
         # so a project spec that declares this agent under some other filename is
-        # still found. Checking `<bound>.json` alone missed exactly that and
-        # under-reported the shadow.
+        # still found. Matching on `<bound>.json` alone would miss exactly that
+        # and under-report the shadow.
         proj_spec = next(
             (p for p in project_agent_files(project_dir) if project_agent_name(p) == bound),
             None,
         )
         if proj_spec is not None:
             proj_model, proj_usable = _spec_model(proj_spec)
-            shown = (
-                _safe_display(proj_model)
-                if proj_model
-                else ("(unreadable)" if not proj_usable else "(no model)")
-            )
+            if proj_model:
+                shown = _safe_display(proj_model)
+            elif not proj_usable:
+                shown = "(unreadable)"
+            else:
+                shown = "(no model)"
             print(f"  project spec: ⚠️  {_safe_display(str(proj_spec))} -> {shown}")
             print("                kiro-cli loads this one first; not read above")
             issues.append("project-local agent spec shadows the user-level one")
@@ -326,7 +328,7 @@ def _os_fix_hint(mac: str, linux: str, windows: str | None = None) -> str:
     """Return the OS-appropriate Fix hint (brew on macOS, winget on Windows,
     else Linux guidance).
 
-    Without a Windows arm, Windows fell through to the Linux text — telling a
+    Without a Windows arm Windows would fall through to the Linux text, telling a
     Windows user to ``pipx``/drop a static build in ``~/.local/bin``, neither of
     which applies. When *windows* is omitted the Linux text is still used, so
     callers only pass it where a Windows-specific remedy exists.
@@ -443,8 +445,8 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
             # ungoverned — and leaving it in place means the ceiling applies only
             # to installs that were governed before their first launch. Every
             # other writer of this list revokes here too (agent.py's shared sync,
-            # both dashboard enable paths); doctor was the one that only declined
-            # to mint, which left `kirocrew doctor` reporting a repaired config
+            # both dashboard enable paths); declining to MINT without also
+            # revoking would leave `kirocrew doctor` reporting a repaired config
             # that still carried the exemption.
             #
             # This is the one case where doctor removes something from
@@ -1016,7 +1018,7 @@ _WINDOWS_GIT_DIRS = (
 def _windows_git_bin() -> str | None:
     """``git.exe`` from the fixed Git for Windows install roots, else ``None``.
 
-    Without this, every supported Windows source install reported "could not
+    Without this, every supported Windows source install reports "could not
     check" — :func:`platform_compat.trusted_system_bin` only probes the system
     directories, where git never is. A non-default-drive install still misses
     and degrades to "could not check", which is honest: this fallback widens
@@ -1108,8 +1110,11 @@ def _doctor_source_checkout(repo: Path) -> None:
         print(f"  branch:      ⚠️  {branch} (could not determine default branch)")
         return
 
+    # One count for both arms below; they ask git the same question and only
+    # differ in how they render the answer.
+    behind = _git_line(repo, "rev-list", "--count", f"HEAD..origin/{default_branch}")
+
     if branch == default_branch:
-        behind = _git_line(repo, "rev-list", "--count", f"HEAD..origin/{default_branch}")
         if behind is None or not behind.isdigit():
             # A failed count must not masquerade as a verified-fresh checkout:
             # "up to date" is a claim this probe could not actually establish.
@@ -1123,7 +1128,6 @@ def _doctor_source_checkout(repo: Path) -> None:
             print(f"  branch:      ✅ {default_branch} (up to date as of last fetch)")
         return
 
-    behind = _git_line(repo, "rev-list", "--count", f"HEAD..origin/{default_branch}")
     detail = (
         f", {behind} commit(s) behind origin/{default_branch}"
         if behind and behind.isdigit() and int(behind) > 0
@@ -1692,12 +1696,11 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # Report the composed profile, and surface a boot-composition failure as a
     # blocking issue with the remediation hint rather than letting it abort the
     # whole CLI before the doctor can run.
+    print("Platform")
     if platform_boot_error is not None:
-        print("Platform")
         print(f"  edition:     ❌ composition failed: {platform_boot_error}")
         issues.append(f"platform composition failed: {platform_boot_error}")
     else:
-        print("Platform")
         # Bind the context ONCE for the whole block so the edition line and the
         # jail line describe the same PlatformContext.  A late
         # PlatformCompositionError (boot succeeded, but a lazily-composing adapter
@@ -1798,12 +1801,13 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # venv detection — used by the runtime section below. Windows venvs put the
     # interpreter under .venv\Scripts\python.exe, not .venv/bin/python3, so a
-    # hardcoded POSIX layout misreported the venv (and the runtime section) on
+    # hardcoded POSIX layout misreports the venv (and the runtime section) on
     # every Windows install.
+    venv_root = Path(__file__).resolve().parents[2] / ".venv"
     if platform_compat.IS_WINDOWS:
-        venv_py = Path(__file__).resolve().parents[2] / ".venv" / "Scripts" / "python.exe"
+        venv_py = venv_root / "Scripts" / "python.exe"
     else:
-        venv_py = Path(__file__).resolve().parents[2] / ".venv" / "bin" / "python3"
+        venv_py = venv_root / "bin" / "python3"
     is_venv_install = venv_py.is_file()
 
     # ── Project ──
@@ -1865,7 +1869,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     if _port:
         print(f"  dashboard:   http://{_display_host}:{_port}")
 
-    # Dashboard auth mode
+    # Dashboard auth mode. Both this section and the Slack section below key off
+    # the SAME credential read and the same token pair, so the two can never
+    # disagree about whether Slack is configured.
     creds = cfg.load_credentials()
     _has_slack = bool(creds.get("SLACK_APP_TOKEN") and creds.get("SLACK_BOT_TOKEN"))
     _local = is_local_only(_host, _has_slack)
@@ -2092,8 +2098,8 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # STT ships enabled-by-default, but neither whisper nor ffmpeg is on a stock
     # Windows box and neither is a KiroCrew dependency there. Reporting them as
-    # hard issues made `kirocrew doctor` exit 1 on a healthy first install, and
-    # the guide's `kirocrew doctor && kirocrew gateway` then never launched the
+    # hard issues makes `kirocrew doctor` exit 1 on a healthy first install, so
+    # the guide's `kirocrew doctor && kirocrew gateway` never launches the
     # gateway. On Windows treat them as non-fatal notes; POSIX keeps failing so
     # a real STT setup gap is still surfaced.
     stt_fatal = not platform_compat.IS_WINDOWS
@@ -2173,9 +2179,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── Slack (optional) ──
     print("\nSlack Integration")
-    creds = cfg.load_credentials()
-    has_slack = bool(creds.get("SLACK_APP_TOKEN") and creds.get("SLACK_BOT_TOKEN"))
-    if has_slack:
+    if _has_slack:
         has_owner = bool(creds.get("KIROCREW_OWNER_ID"))
         print("  tokens:      ✅ configured")
         if has_owner:


### PR DESCRIPTION
## Problem / Motivation

`kirocrew doctor` — `src/kiro_crew/cli_doctor.py` — had accumulated several
places where two arms of a branch did the same work, and one place where a
chained ternary encoded a three-way choice as a nested expression:

- The model-precedence report resolved "which tier decided the model" **three
  times** over the same `if value` predicate: `next(...)` for the label,
  `any(...)` as a guard, `next(...)` again for the value. Three copies of one
  predicate that must stay in agreement.
- `_doctor_source_checkout` issued the identical `git rev-list --count
  HEAD..origin/<default>` as the first statement of **both** arms of its
  `branch == default_branch` split.
- `print("Platform")` was the first statement of both arms of the boot-error
  branch.
- The `.venv` root path was spelled out in full twice, once per arm of the
  Windows/POSIX interpreter split.
- The Slack section re-read credentials and re-derived "is Slack configured"
  from the same two token keys the Configuration section had already read
  ~300 lines earlier — two independent derivations of one fact.
- The project-spec fallback rendered a three-way choice as a chained ternary
  (`A if x else (B if not y else C)`).

Several comments in these hunks were also written as past-tense narration about
defects that had already been fixed ("Windows fell through to the Linux text",
"reported could not check", "made `kirocrew doctor` exit 1") rather than as the
present-tense constraint they were actually describing.

## Why it matters

Doctor is the command someone runs *because something is already broken*, so it
is read under pressure and its output is quoted in bug reports. Duplicated
branch arms make that reading slower — you have to compare two blocks
character by character to establish they agree — and they are the shape where a
later one-arm edit diverges silently, because nothing fails when the twin is
left behind. The three-times-resolved tier predicate is the sharpest example: a
future edit to the label lookup but not the value lookup would attribute a
model pin to the wrong tier, which is exactly the misattribution that report
exists to prevent.

The past-tense comments cost a different kind of time: they describe a state of
the code that no longer exists, so a reader has to work out whether the
sentence is a live constraint or an archaeology note.

## What changed (motivation → approach → change)

Behavior-preserving simplification of one module, scoped to `cli_doctor.py`.
This is one module's pass in the module-by-module simplification campaign
(`refactor/simplify-<module>`); the mechanical detector reports **0 actionable
sites** in this module afterwards.

**Mechanical class (detector-reported): 1 site**

- `_doctor_effective_model` — chained ternary for the project-spec `shown`
  label rewritten as `if`/`elif`/`else`. Python binds a conditional
  expression's `else` branch as a whole, so the original precedence was
  already `proj_model` → `not proj_usable` → fallback; the new form is that
  order written out. The untrusted `proj_model` still routes through
  `_safe_display`, and `"(unreadable)"` / `"(no model)"` stay bare literals.

**Judgment class: duplicated branch arms**

- `_doctor_effective_model` — one `next(((label, value) for ...), None)`
  replaces the `next` / `any` / `next` triple. `tiers` is a concrete
  `list[tuple[str, str]]` built by `.append`, never an iterator, so the three
  old passes and the one new pass see the same list; `any(value for _, value
  in tiers)` is true exactly when the new `next(..., None)` is not `None`.
  `decided_by` / `decided_value` are unchanged for every input, which the
  reviewers below confirmed by brute force rather than by argument.
- `_doctor_source_checkout` — the duplicated `git rev-list --count` call is
  hoisted above the branch. It sits **after** all three early returns
  (`.git` missing, `branch is None`, `default_branch is None`), and both
  surviving arms already invoked it unconditionally as their first action, so
  the process still makes exactly three `git` calls in the same order.
- `_doctor` — `print("Platform")` hoisted out of both arms (it was the first
  statement of each, and the new site is after the `--bundle` early return, so
  the bundle path still does not print it); `venv_root` factored out of the
  Windows/POSIX split (`(a / ".venv") / "Scripts"` is the same `PurePath` as
  `a / ".venv" / "Scripts"`).
- `_doctor` — the Slack section's duplicate `cfg.load_credentials()` and its
  duplicate `has_slack` derivation are removed; both sections now key off the
  single snapshot taken in the Configuration section. Nothing reachable from
  `_doctor` writes `~/.kiro/crew/.env` or a credential env var in between (the
  only writers in the tree are `cli_setup.py` and two dashboard handlers, none
  of them reachable here), and `creds` is never mutated. The dropped call's own
  side effects are all first-call-only: the `0600` enforcement is a no-op once
  the mode is tight, the unknown-key warning is gated on a module global the
  first call already populated, and `os.environ.setdefault` is idempotent — and
  the surviving read still precedes every subprocess spawn, so child-process
  credential inheritance is untouched.

**Comment hygiene**, only in hunks already being touched for a structural
reason, per `AGENTS.md` → Code style → Comments: six comments/docstrings move
from past-tense narration to the present-tense constraint. Every rewritten
claim was audited against the adjacent code; no load-bearing invariant, unit,
or security rationale was dropped.

### One disclosed behavior divergence

An adversarial verification pass found exactly one input on which old and new
differ, and it is worth naming rather than burying, because a cleanup PR is the
worst place for an undocumented behavior change:

`load_credentials()` `setdefault`s **every** key from `.env`, not only the
recognised credential keys. So if the data home's own `.env` contains
`KIROCREW_HOME=/alt` while the shell variable is unset, the first read injects
it, `config_dir()`'s memo (keyed on the raw value) misses, and `env_path()`
thereafter resolves `/alt/.env`. The **old** second read therefore read a
different file than the first, and doctor contradicted itself: "Configuration"
reported Slack configured while "Slack Integration" reported it not configured.

Reusing the first read makes the Slack line agree with the credentials the
gateway actually authenticates with, because `slack/gateway.py` resolves its
home *before* its own single credential read and so runs on the default home's
tokens for the whole process. What that pathological case loses is a duplicate
`0600` repair on `/alt/.env` during this one doctor run (re-applied at every
gateway boot) and unknown-key warnings for keys unique to that file. The
direction is toward correctness, and the affected verdict was a display line —
every security decision (`is_local_only`, the token-auth checks, the enterprise
gate) already keyed off the first read both before and after.

Not done deliberately: `safety_override.py`'s three chained ternaries are in
this module but are excluded as a keystone security file (they feed audit
labels and an expiry field), so they are left verbose. No import was added,
removed, or hoisted; no lazy import moved; no keystone matcher, guard, audit
emit, redaction call, or governance intersection changed shape — the
`_doctor_mcp_tools` hunk is comment prose only, with every executable line in
the `may_skip_gate_now` / `allowed.remove` / `sel().log_api_access` block
byte-identical.

## Tests

No new tests: this is a behavior-preserving refactor, so the existing suite is
the specification it must not move. The relevant existing coverage that locks
each rewritten hunk in place:

- `test/test_cli_doctor.py::TestSourceCheckout` — 9 tests drive
  `_doctor_source_checkout` through the `_git_line` seam and pin every arm the
  hoist touches: on-default up-to-date, on-default behind with a count,
  on-default with a **failed** count (must not read as verified-fresh),
  feature-branch behind, feature-branch with an unknown distance, missing
  `origin/HEAD`, not-a-checkout, and the hostile-ref-name test that forbids
  rendering a branch name into a pasteable command.
- `test/test_cli.py::TestDoctor` — end-to-end `_doctor()` runs including
  `test_doctor_reports_platform_boot_error_without_crashing` (the hoisted
  `print("Platform")` arm), the Slack-configured paths at lines 281/307 (the
  reused credential snapshot, with `validate_enterprise` still asserted called
  exactly once), and the Windows non-fatal STT path.
- `test/test_cli_doctor.py::TestFixHint` — the four `_os_fix_hint` arms whose
  docstring was reworded.
- `test/test_app_mcp_scoping.py` — source-text scanners over the
  `allowed.remove(ref)` / `mcp_auto_approve_withheld` audit block, which the
  comment-only hunk leaves intact.

Suites run green locally on the Python 3.12 CI-parity venv (1081 passed, 6
skipped, 0 failed): `test_cli_doctor.py`, `test_cli.py`, `test_doctor_deadpath.py`,
`test_doctor_sandbox_verdict.py`, plus every other file that references
`cli_doctor` (`test_app_mcp_scoping.py`, `test_computer_use_registration.py`,
`test_mcp_dashboard_registration.py`, `test_mcp_registry_governance.py`,
`test_mcp_discovery.py`, `test_platform_cpp_seam_coverage.py`,
`test_spawn_audit.py`, `test_service.py`).

Gates, all exit 0: `flake8`, `isort --check-only`, `mypy src/kiro_crew`,
`check_black_formatting.py`, `check_brand_name.py`, `check_harness_parity.py`,
`docs_lint.py --test`, `docs-lint.sh`, `check_per_file_coverage.py --test`,
`verify_vendor_manifest.py`, `scrub-lint.sh --no-history`, and
`push_guard.py --require-single-on-base`.

### Pre-submission review fleet

Six independent read-only reviewers ran on the diff before this PR opened, each
with a distinct lens, then an adversarial pass tried to refute the riskiest
finding.

- **AUTOSDE + blocking rules** — no findings. Established from the YAML rather
  than by assumption that `no-new-work-on-gateway-boot-path` does **not** match
  `cli_doctor.py` (its patterns are `slack/gateway.py`,
  `dashboard/server.py`, `dashboard/handlers/**`, `cli.py` exactly), and that
  the hoisted `subprocess.run` is on the one-shot CLI path the
  `no-blocking-call-on-event-loop` rule explicitly allows.
- **Behavior preservation** — equivalent. Brute-forced the tier collapse across
  all tier lists of length 0–4 over value shapes including `"0"` (to catch a
  truthiness flip), crossed with both `default_readable` values: 0 divergences.
- **Import semantics / test-patch observability** — no findings. The diff
  deletes and hoists **zero** imports. No test asserts a call count, a call
  order, or printed line order for the affected sections.
- **Security keystone + boot path** — no findings. `cli_doctor.py` is in
  neither the keystone set nor the boot-path patterns; it is imported at
  `cli.py` module scope, so the reviewer additionally confirmed the diff adds
  no module-scope statement.
- **Comment accuracy** — all ten audited comments true of the current code,
  with both halves of every merged rationale preserved.
- **Adversarial refutation of the credential dedup** — could not refute it. It
  is the pass that surfaced the `KIROCREW_HOME`-inside-`.env` divergence
  documented above, and concluded the new behavior is the correct one.

**Acted on:** one advisory note — the new comment above the tier lookup leaned
on restating the code and overstated a hazard that the old two-`next` form did
not have either. Tightened to name the actual constraint. **Dropped:** nothing;
no finding was refuted as a false positive, because none was raised as a
blocker.

## Manual verification

N/A — unit coverage sufficient. Every hunk is an output-identical restructuring
of `print` sequencing or of local resolution, and the existing doctor tests
assert on captured stdout, which is the entire user-visible surface of this
module.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — one Python CLI module under
`src/kiro_crew/`, nothing under `website/`, so there is no rendered delta.
A backend-only diff also narrows CI (`only_backend=true`), so the frontend
suites cannot newly fail and were not run locally.

## Related Issues

no linked issue: routine module simplification with no filed issue behind it.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
