### PR TITLE
fix(channels): close the aiohttp session even when the background task died

### DIFF
--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -606,24 +606,27 @@ class DiscordClient:
                 await self._ws.close()
             except Exception:
                 pass
-        if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
-        # Snapshot first: a cancelled handler's done-callback mutates the set.
-        handlers = list(self._handler_tasks)
-        for handler in handlers:
-            handler.cancel()
-        if handlers:
-            # return_exceptions so one handler raising during unwind cannot
-            # abandon the others or skip the session close below.
-            await asyncio.gather(*handlers, return_exceptions=True)
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        try:
+            if self._task:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    self._task = None
+        finally:
+            # Snapshot first: a cancelled handler's done-callback mutates the set.
+            handlers = list(self._handler_tasks)
+            for handler in handlers:
+                handler.cancel()
+            if handlers:
+                # return_exceptions so one handler raising during unwind cannot
+                # abandon the others or skip the session close below.
+                await asyncio.gather(*handlers, return_exceptions=True)
+            if self._session and not self._session.closed:
+                await self._session.close()
+                self._session = None
 
     def set_message_handler(self, on_message: Callable[[DiscordInbound], Awaitable[None]]) -> None:
         """Set/replace the inbound-message handler after construction.

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -723,16 +723,19 @@ class TelegramClient:
         # exactly as a plain message arriving at shutdown already is today. It
         # costs nothing, sometimes wins, and drains the buffer either way.
         self._flush_all_albums()
-        if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        try:
+            if self._task:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    self._task = None
+        finally:
+            if self._session and not self._session.closed:
+                await self._session.close()
+                self._session = None
 
     def set_message_handler(self, on_message: Callable[[TelegramInbound], Awaitable[None]]) -> None:
         """Set/replace the inbound-message handler after construction.

--- a/src/kiro_crew/webex/client.py
+++ b/src/kiro_crew/webex/client.py
@@ -389,21 +389,24 @@ class WebexClient:
     async def close(self) -> None:
         """Gracefully shut down."""
         self._closed = True
-        if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
-        if self._handler_tasks:
-            for t in list(self._handler_tasks):
-                t.cancel()
-            await asyncio.gather(*self._handler_tasks, return_exceptions=True)
-            self._handler_tasks.clear()
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        try:
+            if self._task:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    self._task = None
+        finally:
+            if self._handler_tasks:
+                for t in list(self._handler_tasks):
+                    t.cancel()
+                await asyncio.gather(*self._handler_tasks, return_exceptions=True)
+                self._handler_tasks.clear()
+            if self._session and not self._session.closed:
+                await self._session.close()
+                self._session = None
 
     def set_message_handler(self, on_message: Callable[[WebexInbound], Awaitable[None]]) -> None:
         """Set/replace the inbound-message handler after construction.

--- a/src/kiro_crew/wecom/client.py
+++ b/src/kiro_crew/wecom/client.py
@@ -247,25 +247,31 @@ class WeComClient:
         """
         self._closed = True
         if self._ws and not self._ws.closed:
-            await self._ws.close()
-        if self._task:
-            self._task.cancel()
             try:
-                await self._task
-            except asyncio.CancelledError:
+                await self._ws.close()
+            except Exception:
                 pass
-            self._task = None
-        # Fail any push still waiting on an ACK: the socket is going away, so the
-        # answer is "not delivered", and leaving the future pending would hang the
-        # caller until its timeout for no reason.
-        for waiter in list(self._pending_acks.values()):
-            if not waiter.done():
-                waiter.set_result(-1)
-        self._pending_acks.clear()
-        await self._drain_handler_tasks()
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        try:
+            if self._task:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    self._task = None
+        finally:
+            # Fail any push still waiting on an ACK: the socket is going away, so the
+            # answer is "not delivered", and leaving the future pending would hang the
+            # caller until its timeout for no reason.
+            for waiter in list(self._pending_acks.values()):
+                if not waiter.done():
+                    waiter.set_result(-1)
+            self._pending_acks.clear()
+            await self._drain_handler_tasks()
+            if self._session and not self._session.closed:
+                await self._session.close()
+                self._session = None
 
     async def _drain_handler_tasks(self) -> None:
         """Cancel and await the in-flight turn tasks.

--- a/test/test_discord_client_coverage.py
+++ b/test/test_discord_client_coverage.py
@@ -324,6 +324,28 @@ class TestLifecycle:
         await client.close()
         assert ws.close_calls == 0
 
+    @pytest.mark.asyncio
+    async def test_close_closes_session_even_when_task_died_with_a_bug(self) -> None:
+        """A task already dead from an uncaught, non-CancelledError exception
+        makes ``task.cancel()`` a no-op, and re-``await``ing it re-raises that
+        exception -- which must not skip the session close (issue #4627)."""
+        client = _make_client()
+        session = FakeSession()
+        client._session = session  # type: ignore[assignment]
+
+        async def _buggy_loop() -> None:
+            raise ValueError("malformed frame")
+
+        client._task = asyncio.create_task(_buggy_loop())
+        await _REAL_SLEEP(0)  # let the task actually finish before close()
+
+        with pytest.raises(ValueError, match="malformed frame"):
+            await client.close()
+
+        assert client._task is None
+        assert session.close_calls == 1
+        assert client._session is None
+
     def test_set_message_handler_replaces_the_handler(self) -> None:
         client = _make_client()
 

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -4979,3 +4979,43 @@ class TestContextThresholdNotices:
         asyncio.run(d._maybe_notice(7, ("direct", "7"), "key", object()))
 
         assert cli.sent == []
+
+
+class TestClientClose:
+    def test_close_closes_session_even_when_task_died_with_a_bug(self) -> None:
+        """A polling task already dead from an uncaught, non-CancelledError
+        exception makes ``task.cancel()`` a no-op, and re-``await``ing it
+        re-raises that exception -- which must not skip the session close
+        (issue #4627)."""
+
+        class _FakeSession:
+            def __init__(self) -> None:
+                self.closed = False
+                self.close_calls = 0
+
+            async def close(self) -> None:
+                self.close_calls += 1
+                self.closed = True
+
+        async def _run() -> None:
+            client = TelegramClient(token="t")
+            session = _FakeSession()
+            client._session = session  # type: ignore[assignment]
+
+            async def _buggy_loop() -> None:
+                raise ValueError("malformed update")
+
+            client._task = asyncio.create_task(_buggy_loop())
+            await asyncio.sleep(0)  # let the task actually finish before close()
+
+            try:
+                await client.close()
+                raise AssertionError("close() must propagate the task's exception")
+            except ValueError as exc:
+                assert "malformed update" in str(exc)
+
+            assert client._task is None
+            assert session.close_calls == 1
+            assert client._session is None
+
+        asyncio.run(_run())

--- a/test/test_webex_client.py
+++ b/test/test_webex_client.py
@@ -347,6 +347,39 @@ class TestLifecycle:
         assert task.cancelled()
         assert c._handler_tasks == set()
 
+    @pytest.mark.asyncio
+    async def test_close_drains_handlers_and_session_even_when_run_loop_died(self) -> None:
+        """``_run_loop`` dying from an uncaught, non-CancelledError exception
+        makes ``self._task.cancel()`` a no-op, and re-``await``ing it re-raises
+        that exception -- which must not skip the handler-task drain or the
+        session close (issue #4627)."""
+
+        class _FakeSession:
+            def __init__(self) -> None:
+                self.closed = False
+
+            async def close(self) -> None:
+                self.closed = True
+
+        c = _client()
+        c._session = _FakeSession()  # type: ignore[assignment]
+        handler_task: asyncio.Task[Any] = asyncio.ensure_future(asyncio.sleep(100))
+        c._handler_tasks.add(handler_task)
+
+        async def _buggy_loop() -> None:
+            raise ValueError("malformed frame")
+
+        c._task = asyncio.create_task(_buggy_loop())
+        await asyncio.sleep(0)  # let the task actually finish before close()
+
+        with pytest.raises(ValueError, match="malformed frame"):
+            await c.close()
+
+        assert c._task is None
+        assert handler_task.cancelled()
+        assert c._handler_tasks == set()
+        assert c._session is None
+
 
 class TestRedeliveryHandling:
     """Acks and dedup, together.

--- a/test/test_wecom_client_cov80.py
+++ b/test/test_wecom_client_cov80.py
@@ -101,6 +101,43 @@ class TestLifecycle:
         assert client._closed is True
         assert client._task is None
 
+    @pytest.mark.asyncio
+    async def test_close_closes_session_even_when_ws_close_raises(self, client) -> None:
+        """A websocket whose transport is already broken raises on close();
+        that must not take the session close down with it (issue #4627)."""
+
+        class _BadWS(_FakeWS):
+            async def close(self) -> None:
+                raise RuntimeError("transport already broken")
+
+        ws = _BadWS()
+        session = _FakeSession()
+        client._ws = ws  # type: ignore[assignment]
+        client._session = session  # type: ignore[assignment]
+        await client.close()
+        assert client._closed is True
+        assert session.closed is True
+
+    @pytest.mark.asyncio
+    async def test_close_closes_session_even_when_task_died_with_a_bug(self, client) -> None:
+        """A task already dead from an uncaught, non-CancelledError exception
+        makes ``task.cancel()`` a no-op, and re-``await``ing it re-raises that
+        exception -- which must not skip the session close (issue #4627)."""
+        session = _FakeSession()
+        client._session = session  # type: ignore[assignment]
+
+        async def _buggy_loop() -> None:
+            raise ValueError("malformed frame")
+
+        client._task = asyncio.create_task(_buggy_loop())
+        await asyncio.sleep(0)  # let the task actually finish before close()
+
+        with pytest.raises(ValueError, match="malformed frame"):
+            await client.close()
+
+        assert client._task is None
+        assert session.closed is True
+
 
 class _FakeSession:
     def __init__(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

`DiscordClient`, `TelegramClient`, `WeComClient`, and `WebexClient` each own one long-lived `aiohttp.ClientSession` and one background reconnect/polling task. Every `close()` has the same sequential shape:

```python
if self._task:
    self._task.cancel()
    try:
        await self._task
    except asyncio.CancelledError:
        pass
    self._task = None
if self._session and not self._session.closed:
    await self._session.close()
    self._session = None
```

`task.cancel()` on a task that has **already finished with an exception** is a no-op, and the following `await self._task` re-raises that exception. `except asyncio.CancelledError` does not catch it (nor does a `CancelledError` delivered into `close()` itself while it's awaiting that task, since `CancelledError` is a `BaseException`), so the exception escapes `close()` and the session close below is never reached.

## Reachable, not theoretical

The reconnect/polling loops don't catch every exception type — `WeComClient._run_loop` handles `aiohttp.ClientError`, `asyncio.TimeoutError`, `OSError`, and `asyncio.CancelledError`; a `ValueError` from a malformed frame, a `KeyError`, or a `RuntimeError` escapes and kills the task. The transport then shuts down (gateway stop, config change, reconnect teardown), `close()` runs, and the session close is skipped.

## Why it matters

The `ClientSession`'s connector and open sockets are held for the process lifetime; aiohttp surfaces this as `Unclosed client session` / `Unclosed connector` at GC. `self._session` is also left non-`None`, so a later `close()` believes it was already handled and nothing ever retries.

## Second, narrower defect in `WeComClient`

```python
if self._ws and not self._ws.closed:
    await self._ws.close()
```

`DiscordClient.close()` has wrapped the equivalent call in `try/except Exception: pass` all along — closing a websocket whose transport is already broken raises. `WeComClient` didn't, so that raise also took the session close down with it, one step earlier than the task path above.

## What changed

`src/kiro_crew/{discord,telegram,wecom,webex}/client.py::close()`: moved the session close (and, for Webex, its `_handler_tasks` drain) into a `finally` around the task-cancel block, so it runs regardless of how that block exits, while the task's own exception still propagates to the caller afterward — matching the fix already landed for `AcpSessionProvider.shutdown` and `AcpRuntime.terminate_session`. Also gave WeComClient's websocket close the same `try/except Exception: pass` DiscordClient already has. `self._task = None` moved into its own `finally` too, so a second `close()` doesn't try to re-await an already-consumed, already-raised task.

## Tests

One new regression test per client reproducing the exact scenario from the issue (a background task that dies from an uncaught non-`CancelledError` exception, asserting the session is still closed and the original exception still propagates):

- `test/test_discord_client_coverage.py::TestLifecycle::test_close_closes_session_even_when_task_died_with_a_bug`
- `test/test_telegram.py::TestClientClose::test_close_closes_session_even_when_task_died_with_a_bug`
- `test/test_wecom_client_cov80.py::TestLifecycle::test_close_closes_session_even_when_task_died_with_a_bug` (plus `test_close_closes_session_even_when_ws_close_raises` for the second defect)
- `test/test_webex_client.py::TestLifecycle::test_close_drains_handlers_and_session_even_when_run_loop_died`

`python -m pytest test/test_discord.py test/test_discord_client_coverage.py test/test_telegram.py test/test_telegram_album.py test/test_wecom_client.py test/test_wecom_client_cov80.py test/test_wecom_transport.py test/test_webex_client.py test/test_webex_transport.py -q` — 684 passed, plus the 4 new tests above (1 pre-existing, unrelated fixture error in `test_wecom_client_cov80.py::TestRunLoop::test_long_lived_connection_resets_the_backoff` reproduces identically on `main`, confirmed via `git stash`).

`isort`/`flake8`/`mypy` clean on all touched files; `black --target-version py310` applied to `test/test_webex_client.py` during the rebase (the new test needed a blank line after its docstring to satisfy the repo's black-baseline gate).

## Manual verification

N/A — unit coverage sufficient; this is a pure async lifecycle-ordering fix around mocked background tasks, fully exercised by the async unit tests above.

## Related Issues

Fixes #4627.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec documents this internal close()-ordering detail for these per-channel clients
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
