### PR TITLE
refactor(doctor): derive the STT severity marker once (#5096)

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -2097,12 +2097,13 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # gateway. On Windows treat them as non-fatal notes; POSIX keeps failing so
     # a real STT setup gap is still surfaced.
     stt_fatal = not platform_compat.IS_WINDOWS
+    stt_mark = "❌" if stt_fatal else "⚠️ "
 
     whisper_bin = _find_whisper(cfg.stt.whisper_path)
     if whisper_bin:
         print(f"  whisper:     ✅ {whisper_bin}")
     elif needs_whisper:
-        mark = "❌" if stt_fatal else "⚠️ "
+        mark = stt_mark
         print(f"  whisper:     {mark} not found")
         print(
             "               Fix: "
@@ -2122,7 +2123,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     if ffmpeg_bin:
         print(f"  ffmpeg:      ✅ {ffmpeg_bin}")
     elif needs_ffmpeg:
-        mark = "❌" if stt_fatal else "⚠️ "
+        mark = stt_mark
         print(f"  ffmpeg:      {mark} not found")
         print(
             "               Fix: "
@@ -2165,7 +2166,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
         if parakeet_bin:
             print(f"  parakeet:    ✅ {parakeet_bin}")
         else:
-            mark = "❌" if stt_fatal else "⚠️ "
+            mark = stt_mark
             print(f"  parakeet:    {mark} parakeet-mlx not found")
             print("               Fix: pipx install parakeet-mlx  (Apple Silicon only)")
             if stt_fatal:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -193,6 +193,68 @@ class TestDoctor:
             # Must NOT raise SystemExit(1): the two STT gaps are notes on Windows.
             _doctor()
 
+    @pytest.mark.parametrize(
+        "is_windows, expected_mark",
+        [(False, "❌"), (True, "⚠️ ")],
+        ids=["posix-fatal", "windows-note"],
+    )
+    def test_doctor_stt_marker_arms_match_platform(
+        self, tmp_path, capsys, monkeypatch, is_windows, expected_mark
+    ):
+        """The whisper/ffmpeg severity marker is derived once (stt_mark) from
+        stt_fatal: a hard-issue mark on POSIX, a note mark on Windows. Pins
+        both arms byte-for-byte — including the note mark's trailing pad
+        space, which keeps the report columns aligned — AND that the twin
+        report lines can never disagree, so a one-arm edit to either site
+        fails here (issue #5096)."""
+        import kiro_crew.cli_doctor as _doc
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        agent_file = tmp_path / "kirocrew.json"
+        _healthy_agent_file(agent_file)
+        mock_run = MagicMock(returncode=0, stdout="kiro-cli 1.0.0", stderr="")
+        monkeypatch.setattr(_doc.platform_compat, "IS_WINDOWS", is_windows)
+
+        # STT enabled with whisper provider, neither binary present — the
+        # autouse fixture pins STT OFF, so re-enable here.
+        def _cfg_with_stt() -> KiroCrewConfig:
+            cfg = KiroCrewConfig()
+            cfg.stt.enabled = True
+            cfg.stt.provider = "whisper"
+            return cfg
+
+        monkeypatch.setattr(KiroCrewConfig, "load", classmethod(lambda cls: _cfg_with_stt()))
+        monkeypatch.setattr(_doc, "_find_whisper", lambda path=None: None)
+        monkeypatch.setattr(_doc, "ensure_ffmpeg_in_path", lambda: None)
+
+        def _which(binary, **_kw):
+            # Everything resolves EXCEPT the two STT binaries.
+            if binary in ("whisper", "ffmpeg"):
+                return None
+            return f"/usr/local/bin/{binary}"
+
+        with (
+            patch("kiro_crew.cli_doctor.shutil.which", side_effect=_which),
+            patch("kiro_crew.cli_doctor.KIRO_AGENTS_DIR", tmp_path),
+            patch("kiro_crew.cli_doctor.subprocess.run", return_value=mock_run),
+            patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no gateway")),
+            patch("kiro_crew.cli_doctor.is_local_only", return_value=True),
+            patch("kiro_crew.cli_doctor.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_doctor.probe_server", side_effect=_noop_probe_server),
+        ):
+            # On POSIX the two gaps are hard issues and doctor exits 1; on
+            # Windows they are notes. Exit semantics are pinned elsewhere —
+            # here only the printed markers matter.
+            try:
+                _doctor()
+            except SystemExit:
+                pass
+        out = capsys.readouterr().out
+        # Exact literals from the production f-strings: any drift in glyph,
+        # variation selector, or the note arm's padding space fails here.
+        assert f"  whisper:     {expected_mark} not found" in out
+        assert f"  ffmpeg:      {expected_mark} not found" in out
+
     def test_doctor_reports_platform_boot_error_without_crashing(self, tmp_path, capsys):
         """A PlatformCompositionError from boot must be REPORTED by the doctor,
         not crash it — the doctor is the tool that diagnoses a broken setup, so


### PR DESCRIPTION
## What is the problem?

In `src/kiro_crew/cli_doctor.py`, the STT section binds `stt_fatal = not platform_compat.IS_WINDOWS` once and never reassigns it, then re-derives the identical severity marker ternary at three separate report sites (whisper, ffmpeg, parakeet). Since `stt_fatal` cannot change between those sites, the three ternaries always produce the same string - three copies of one fact.

## Why this issue matters to the user

The doctor report's severity glyphs are a user-facing contract: the hard-issue mark (U+274C) means "this will fail your install" and the note mark (U+26A0) means "informational on this platform". With three independent copies, a later one-arm edit to any single site would silently make the twin report lines disagree - one binary reported as fatal, its sibling as a note, on the same platform - with nothing failing. PR #5094 collapsed the same shape elsewhere in this module; these three sites are pre-existing code its diff does not touch.

## How our fix solves it

Chain from symptom to root cause: the duplication exists because each report branch derived its own `mark` from `stt_fatal` at the point of use. The fix derives the marker exactly once - `stt_mark` bound directly beneath `stt_fatal` - and the three sites now read `mark = stt_mark`. A one-arm drift is no longer expressible: there is one arm to edit. The ternary was copied byte-for-byte from the original sites (verified via hexdump: U+274C for the fatal arm; U+26A0 followed by variation selector U+FE0F and a trailing pad space for the note arm), so report output is byte-identical on both platforms. Pure refactor, no behaviour change.

## What tests we did

- New parametrized test `test_doctor_stt_marker_arms_match_platform` (posix-fatal / windows-note) pins both marker arms byte-for-byte by asserting the exact rendered report lines - including the note mark's trailing pad space that keeps the report columns aligned - and that the whisper/ffmpeg twins agree. No existing test asserted either glyph.
- Mutation-verified twice: (a) diverging one twin site (a literal fatal mark at the ffmpeg site) fails the windows-note case; (b) dropping the note arm's trailing pad space fails it too. Both probes reverted before commit.
- Spec-named regression test `test_doctor_windows_missing_whisper_ffmpeg_is_non_fatal` still passes (Windows exit-0 semantics untouched).
- Local gates: isort and flake8 clean; `pytest test/test_cli_doctor.py test/test_cli.py` 355 passed; full suite run with the only failures (46) reproduced identically on pristine origin/main (environment-dependent: xdist host-budget, iMessage RPC timeouts, docker entrypoint, etc.), zero introduced by this diff. Local mypy's 4 errors are pre-existing on main (stub version skew in `transcribe.py` / `cloudwatch.py`), untouched files.
- Pre-push model-pinned reviews: GPT 5.6 lane - CLEAN. Opus lane - nothing blocking, 4 Low/Nit findings on the test: the unpinned pad space was fixed (mutation-verified above); the arrangement-duplication and alias-style suggestions were declined as matching the file's established local style and the minimal-diff choice (the reviewer itself called the latter defensible); the parakeet-site note needs no action since after this change a one-arm drift there is no longer expressible.

## Any other suggestions on the work

None - the change is deliberately minimal. The parakeet site is exercised only under `provider="parakeet"` on Apple Silicon; it now reads the same single source, which is the point of the fix.

Closes #5096
