### PR TITLE
fix: App Store Open routes external apps through appNavTarget

### DIFF
--- a/website/src/pages/AppsPage.tsx
+++ b/website/src/pages/AppsPage.tsx
@@ -23,6 +23,7 @@ import {
   AlertTriangle, PowerOff,
 } from 'lucide-react'
 import { api } from '../api/client'
+import { appNavTarget } from '../appNav'
 import { Btn, EmptyState, PageHeader, SearchInput } from '../components/ui'
 import SimpleSelect from '../components/SimpleSelect'
 import { recordEvent } from '../rum'
@@ -1203,7 +1204,7 @@ export default function AppsPage() {
                       app={app}
                       actionLoading={updatingAll ? `${app.name}:update` : actionLoading}
                       onAction={handleAction}
-                      onOpen={() => navigate(app.manifest?.ui?.pages?.[0]?.route || `/apps/${app.name}`)}
+                      onOpen={() => navigate(appNavTarget(app)?.route || `/apps/${app.name}`)}
                       onDetail={() => openDetail(app.name)}
                     />
                   </ErrorBoundary>

--- a/website/src/test/AppsPageW3Coverage.test.tsx
+++ b/website/src/test/AppsPageW3Coverage.test.tsx
@@ -120,7 +120,6 @@ function renderPage() {
           <Route path="/apps" element={<AppsPage />} />
           <Route path="/apps/detail/:name" element={<DetailProbe />} />
           <Route path="/apps/:name" element={<DetailProbe />} />
-          <Route path="/secretary-ui" element={<div data-testid="app-ui-route" />} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -372,12 +371,17 @@ describe('AppsPage — query failures and empty states', () => {
 })
 
 describe('AppsPage — Library actions', () => {
-  it('opens the app UI page from the card and the detail page from its name', async () => {
+  it('opens the app at its AppHost route from the card, and the detail page from its name', async () => {
     renderPage()
     await catalogReady()
     goLibrary()
+    // Open must resolve through the same appNavTarget derivation the sidebar and
+    // command palette use: a third-party (non-builtin) app is AppHost-routed at
+    // /apps/<name>, NOT its raw manifest page route (which only a native builtin
+    // serves, and which otherwise dead-ends at BuiltinAppRoute -> /chat).
     fireEvent.click(await screen.findByRole('button', { name: 'Open' }))
-    expect(await screen.findByTestId('app-ui-route')).toBeInTheDocument()
+    const probe = await screen.findByTestId('detail-route')
+    expect(probe).toHaveAttribute('data-path', '/apps/secretary')
   })
 
   it('routes to the detail page when the card name is clicked', async () => {


### PR DESCRIPTION
## Problem
Clicking **Open** on an installed app's Library card did nothing for external
(third-party) apps — the app page never opened.

## Root cause
`AppsPage` built the Open handler as:

```tsx
onOpen={() => navigate(app.manifest?.ui?.pages?.[0]?.route || `/apps/${app.name}`)}
```

It navigates to the app's **raw manifest page route**. That is only the correct
destination for a *native builtin* (no `ui.entry`), whose compiled surface is
registered at that route. An installed **external** app — or any app that ships
`ui.entry` — is **AppHost-routed at `/apps/<name>`** (see `appNavTarget` in
`appNav.ts`). Navigating to its raw route (e.g. `/endless-worlds`) hits the
`/:builtinApp` catch-all → `BuiltinAppRoute` → `getBuiltinComponent` finds no
builtin → `<Navigate to="/chat" replace />`. The click looked inert.

The left-nav rail and the command palette both already resolve destinations
through `appNavTarget`; the App Store Open button was the one surface that
bypassed it, so it could send a user somewhere different from the sidebar for
the same app — exactly the drift `appNav.ts` was written to prevent.

## Fix
Resolve Open through `appNavTarget(app)` (with the AppHost route as the
fallback), so it matches the rail/palette exactly:

```tsx
onOpen={() => navigate(appNavTarget(app)?.route || `/apps/${app.name}`)}
```

## Test
Updated the Library-actions test in `AppsPageW3Coverage.test.tsx`: the
third-party `secretary` app's Open now asserts navigation to its AppHost route
`/apps/secretary` (previously it asserted the raw `/secretary-ui`, a destination
that in production dead-ends at `/chat`). `tsc -b` clean, ESLint/Prettier clean,
`AppsPageW3Coverage` 51/51 green, `npm run build` clean. (The unrelated
electron/desktop `node --test` suites fail only for lack of an Electron runtime
in the dev sandbox; they do not touch this change.)
