### PR TITLE
fix(dev-fleet): boot the platform context in the app backend entry point

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -754,6 +754,35 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         # without this forward the documented override silently never reaches
         # the backend and the fleet renders empty. A path, not a secret.
         _platform_extra["KIROCREW_DEVFLEET_REPO"] = os.environ["KIROCREW_DEVFLEET_REPO"]
+    if os.environ.get("KIROCREW_PROFILE"):
+        # Forward the edition-profile override to the backend subprocess.
+        # minimal_env() strips it otherwise, so a gateway launched with an
+        # explicit KIROCREW_PROFILE (e.g. =standalone to override an installed
+        # companion) would have the child re-resolve the profile from on-disk
+        # markers and diverge from the parent. Since the backend now boots the
+        # platform context at startup (fail-closed), that divergence would make
+        # the subprocess refuse to start rather than fail lazily. Forwarding it
+        # keeps the child on the SAME profile the gateway resolved. A profile
+        # name, not a secret.
+        _platform_extra["KIROCREW_PROFILE"] = os.environ["KIROCREW_PROFILE"]
+    for _policy_env in ("KIROCREW_SECURITY_POLICY", "KIROCREW_ADMISSION_POLICY"):
+        # Forward the governance trust-root path overrides alongside the profile.
+        # These are the fleet operator's highest-priority policy sources
+        # (governance.load_security_policy / admission), and minimal_env() strips
+        # them. Now that the backend boots the platform context itself, dropping
+        # them would make the child resolve its ceiling from the on-disk /
+        # packaged default instead of the administrator-pinned policy — a looser
+        # ceiling for governed app commands.
+        #
+        # Absolutize against THIS process's cwd before forwarding: the loaders
+        # read the value as a bare Path() with no resolve()/expanduser(), and the
+        # backend subprocess runs with a different cwd (the package root, set
+        # below), so forwarding a RELATIVE override verbatim would make the child
+        # look in the wrong directory and fail closed. Resolving here binds the
+        # child to the exact file the gateway resolved. A path, not a secret.
+        _policy_val = os.environ.get(_policy_env)
+        if _policy_val:
+            _platform_extra[_policy_env] = os.path.abspath(os.path.expanduser(_policy_val))
     for _k, _v in os.environ.items():
         # Operator-declared trusted-binary overrides (unit-file owned):
         # backends resolve credential-bearing tools through these instead of

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -54,9 +54,11 @@ from aiohttp import web
 from kiro_crew import dep_sync, frontend, hooks, platform_compat
 from kiro_crew.apps.builtins.dev_fleet import gateway_service
 from kiro_crew.apps.proxy_auth import raw_request_target
+from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.instances import run_marker
+from kiro_crew.platform import boot_platform
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
     create_subprocess_limited,
@@ -5914,7 +5916,21 @@ def create_app() -> web.Application:
 
 
 def main() -> int:
-    """Entry point when run as a module by the app backend system."""
+    """Entry point when run as a module by the app backend system.
+
+    Install the platform context FIRST. This runs as its own subprocess
+    (``python -m ...`` spawned by the app backend launcher), so unlike an
+    in-gateway import it inherits no installed context. Without this, the first
+    code path that reads the context -- e.g. the sandbox floor resolved while
+    wrapping this app's own ``git worktree`` scan -- calls ``current_context()``
+    cold. On a non-standalone edition that raises ``PlatformCompositionError``
+    ("no installed context but profile resolved to ..."), whose message then
+    surfaces verbatim in the UI as an opaque sandbox error. ``boot_platform`` is
+    idempotent and, like the CLI entry point, fails CLOSED: a non-standalone
+    profile that cannot compose its companion aborts here rather than serving a
+    backend with no security overlay or credential redaction.
+    """
+    boot_platform(KiroCrewConfig.load())
     app = create_app()
     logger.info("Dev Fleet backend starting on 127.0.0.1:%d", PORT)
     web.run_app(app, host="127.0.0.1", port=PORT, print=None)

--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -43,7 +43,9 @@ from pathlib import Path
 
 from kiro_crew import platform_compat
 from kiro_crew.apps.proxy_auth import verify_proxy_request
+from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.hooks import safe_read_file_bytes
+from kiro_crew.platform import boot_platform
 from kiro_crew.sandbox import cgroup_scope_argv, run_limited, wrap_argv
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
@@ -1185,6 +1187,13 @@ class FileExplorerHandler(BaseHTTPRequestHandler):
 
 
 def main() -> int:
+    # Install the platform context before serving. This backend is spawned as
+    # its own subprocess by the app backend launcher, so it inherits no context;
+    # its git-command sandbox wrapping reads the governed sandbox floor, which
+    # resolves the context cold and raises PlatformCompositionError on a
+    # non-standalone edition. Idempotent and fail-closed, mirroring the CLI and
+    # gateway entry points (and Dev Fleet's backend).
+    boot_platform(KiroCrewConfig.load())
     server = ThreadingHTTPServer(("127.0.0.1", PORT), FileExplorerHandler)
     logger.info(
         "listening on http://127.0.0.1:%d  rg=%s  allowed=%s",

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -1846,3 +1846,52 @@ async def test_worktree_detail_survives_pod_probe_failure(monkeypatch, tmp_path)
     assert detail["pod_running"] is False
     assert detail["disk_mb"] is None
     assert detail["commits"] == []
+
+
+def test_main_boots_platform_before_serving(monkeypatch):
+    """main() must install the platform context BEFORE create_app/run_app.
+
+    The app backend launches this module as its own subprocess, which inherits
+    no installed platform context. If it served without booting, the first read
+    of current_context() (e.g. the sandbox floor resolved while wrapping the
+    app's own git worktree scan) would raise on a non-standalone edition and the
+    error would surface verbatim in the UI. The ORDER is the invariant: boot
+    resolves the profile and installs the context, so create_app never runs
+    against a cold context.
+    """
+    calls: list[str] = []
+
+    def _fake_boot(_cfg):
+        calls.append("boot")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(mod, "boot_platform", _fake_boot)
+    monkeypatch.setattr(mod.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
+    monkeypatch.setattr(mod, "create_app", lambda: calls.append("create_app") or MagicMock())
+    monkeypatch.setattr(mod.web, "run_app", lambda *a, **k: calls.append("run_app"))
+
+    assert mod.main() == 0
+    assert calls == ["boot", "create_app", "run_app"]
+
+
+def test_main_fails_closed_when_platform_cannot_compose(monkeypatch):
+    """A composition failure must ABORT main(), never serve a cold backend.
+
+    Mirrors the CLI entry point's fail-closed posture: a non-standalone profile
+    whose companion cannot compose must not fall through to serving the backend
+    with no security overlay.
+    """
+    from kiro_crew.platform.context import PlatformCompositionError
+
+    def _boom(_cfg):
+        raise PlatformCompositionError("companion missing")
+
+    served: list[str] = []
+    monkeypatch.setattr(mod, "boot_platform", _boom)
+    monkeypatch.setattr(mod.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
+    monkeypatch.setattr(mod, "create_app", lambda: served.append("create_app") or MagicMock())
+    monkeypatch.setattr(mod.web, "run_app", lambda *a, **k: served.append("run_app"))
+
+    with pytest.raises(PlatformCompositionError):
+        mod.main()
+    assert served == []

--- a/test/test_file_explorer_app.py
+++ b/test/test_file_explorer_app.py
@@ -822,3 +822,39 @@ class TestAutoSdeRound1Findings:
             assert not any(
                 server._is_within(expanded, root) for root in server.ALLOWED_ROOTS
             ), "attacker dir should NOT be within ALLOWED_ROOTS"
+
+
+def test_main_boots_platform_before_serving(monkeypatch):
+    """main() must install the platform context BEFORE binding the server.
+
+    The File Explorer backend runs as its own subprocess (spawned by the app
+    backend launcher) and inherits no platform context. Its git-command sandbox
+    wrapping reads the governed sandbox floor via current_context(), which
+    raises PlatformCompositionError cold on a non-standalone edition. Booting
+    first (idempotent, fail-closed) is the fix; the ORDER is the invariant.
+    """
+    from types import SimpleNamespace
+
+    calls: list[str] = []
+
+    def _fake_boot(_cfg):
+        calls.append("boot")
+        return SimpleNamespace()
+
+    class _FakeServer:
+        def __init__(self, *a, **k):
+            calls.append("bind")
+
+        def serve_forever(self):
+            calls.append("serve")
+
+        def server_close(self):
+            pass
+
+    monkeypatch.setattr(server, "boot_platform", _fake_boot)
+    monkeypatch.setattr(server.KiroCrewConfig, "load", classmethod(lambda cls: SimpleNamespace()))
+    monkeypatch.setattr(server, "ThreadingHTTPServer", _FakeServer)
+
+    assert server.main() == 0
+    assert calls[0] == "boot", "boot_platform must run before the server binds"
+    assert "bind" in calls


### PR DESCRIPTION
## Summary

The Dev Fleet app backend runs as its own subprocess (`python -m kiro_crew.apps.builtins.dev_fleet.server`, spawned by the app backend launcher). Its `main()` served the aiohttp app without ever calling `boot_platform()`, so the backend process had **no installed platform context**.

- On the **standalone** edition this is harmless: `current_context()` lazily composes the all-defaults context.
- On a **non-standalone** edition it is fatal. The first code path that reads the context raises `PlatformCompositionError` — *"current_context() reached with no installed context but profile resolved to '...'; refusing to compose open-source defaults (fail-closed)"*.

The trigger in practice is the backend wrapping its **own** `git worktree list` scan: on a host with no user-namespace sandbox backend, `sandbox.wrap_argv` reads the governed `sandbox.min_level` floor, which resolves the context cold. The `PlatformCompositionError` message then surfaces **verbatim in the Dev Fleet UI** as an opaque "sandbox unavailable" error, instead of the actionable no-backend guidance the sandbox layer would otherwise return.

## Fix

Call `boot_platform(KiroCrewConfig.load())` at the top of `main()`, before `create_app()`, mirroring the CLI entry point (`cli.py`) and the gateway (`slack/gateway.py`). It is:

- **idempotent** — safe if a context is somehow already installed;
- **fail-closed** — a non-standalone profile whose companion cannot compose aborts the backend rather than serving with no security overlay or credential redaction.

## Tests

Two regression tests in `test/test_dev_fleet_server_coverage.py`:

- `test_main_boots_platform_before_serving` — pins the boot → create_app → run_app ORDER.
- `test_main_fails_closed_when_platform_cannot_compose` — pins that a composition failure aborts `main()` and never serves.

Both **fail against the unmodified entry point** (verified) and pass with the fix.

## Verification

- `pytest test/test_dev_fleet_server_coverage.py` — 171 passed (2 new + 169 existing, no regression)
- black (repo change-scoped gate) / isort / flake8 / mypy — clean on the changed files
