### PR TITLE
fix: accept design-critique as a creatable chat-slot mode (#5099)

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -1762,6 +1762,17 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     return web.Response(text=body, content_type="application/json")
 
 
+# Modes a slot may be CREATED with. A deliberate superset of the mode-SWITCH
+# allowlist (chat_folders._VALID_MODES) and the fork override allowlist
+# (chat_fork): "design-critique" is an app-worker mode assigned at birth by the
+# Design Critique app's openSlot() — the custom mode keeps its throwaway dc-*
+# slots off the chat sidebar, which renders only "", "orchestrator" and "crew"
+# (ChatPage.tsx filteredSlots). Switching an existing session INTO an app-worker
+# mode, or forking one with it as an override, is not a real flow, so those two
+# allowlists deliberately stay narrower — do not "sync" them to this one.
+_CREATABLE_MODES = ("", "orchestrator", "crew", "design-critique")
+
+
 async def api_chat_slot_create(request: web.Request) -> web.Response:
     """POST /api/chat/slots — create a new chat slot."""
     state: DashboardState = request.app["state"]
@@ -1830,7 +1841,7 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
             if memory_mode not in ("persistent", "incognito", "temporary"):
                 return web.json_response({"error": "invalid memory_mode"}, status=400)
             _mode = body.get("mode", "")
-            if _mode not in ("", "orchestrator", "crew"):
+            if _mode not in _CREATABLE_MODES:
                 return web.json_response(
                     {"error": "invalid mode", "code": "invalid_mode"}, status=400
                 )

--- a/test/test_crew_http.py
+++ b/test/test_crew_http.py
@@ -175,6 +175,37 @@ class TestCrewHttpFlow:
             assert r2.status in (200, 201)
 
     @pytest.mark.asyncio
+    async def test_create_endpoint_accepts_design_critique_mode(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """Regression for #5099: the Design Critique app opens throwaway worker
+        slots with mode="design-critique" (kept out of the chat sidebar by the
+        frontend's surface filter). The create allowlist never included the
+        mode, so every open of the app failed with 400 code=invalid_mode."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_create
+
+        state = _crew_state(tmp_path)
+        app = _make_app(state)
+        app.router.add_post("/api/chat/slots", api_chat_slot_create)
+        async with TestClient(TestServer(app)) as client:
+            r = await client.post(
+                "/api/chat/slots",
+                json={
+                    "name": "dc-1755892086",
+                    "mode": "design-critique",
+                    "memory_mode": "temporary",
+                },
+            )
+            assert r.status in (200, 201)
+            data = await r.json()
+            assert data.get("mode") == "design-critique"
+            # The forward-compat surface alias mirrors the mode — this is the
+            # field the sidebar filter reads, so it must not be "".
+            assert data.get("surface") == "design-critique"
+            # An unknown mode still returns the machine-readable rejection.
+            bad = await client.post("/api/chat/slots", json={"mode": "bogus-mode"})
+            assert bad.status == 400
+            assert (await bad.json()).get("code") == "invalid_mode"
+
+    @pytest.mark.asyncio
     async def test_crew_ingest_refusal_is_not_a_200(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         """`ingest` declines an app-owned session. Reporting 200 anyway told the
         caller its message was accepted for work that will never run — and an API


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The Design Critique builtin app is completely non-functional: opening the app and submitting any input immediately fails with HTTP 400 (`error "invalid mode"`, `code "invalid_mode"`) and no critique session is ever created. Reported on 0.4.0-insider (macOS arm64); the defect is platform-independent and present on main.

## Why it matters

Every user of the Design Critique app hits this on first use — the app cannot do anything at all. The failure is silent-adjacent (a raw 400 surfaced into the panel), so it reads as "the app is broken", not as a config problem the user could route around.

## What changed (motivation → approach → change)

- Symptom: `POST /api/chat/slots` returns 400 `invalid_mode` for every Design Critique open.
- Root cause: the app's frontend (`website/src/apps/design-critique/api.ts`, `openSlot`) deliberately creates its throwaway worker slots with `mode: 'design-critique'` — the custom mode is what keeps `dc-*` slots out of the chat sidebar. The backend slot-creation allowlist in `src/kiro_crew/dashboard/chat_handlers.py` was never taught that value, so creation always failed.
- Change: name the creation allowlist (`_CREATABLE_MODES`) directly above `api_chat_slot_create` and add `"design-critique"`; the validation now checks membership in that constant. The frontend is untouched — its mode value is load-bearing and correct.

Sibling allowlists were evaluated and deliberately NOT changed (the constant's comment records this so nobody "syncs" them later):

- `chat_folders.py` `_VALID_MODES` (PATCH `/api/chat/slots/{slot}/mode`): mode-switching an existing session INTO an app-worker mode is not a real flow — the app assigns the mode at creation, and `dc-*` slots are never rendered anywhere a switch could be initiated.
- `chat_fork.py` `mode_override` (fork endpoint): `dc-*` slots are `memory_mode="temporary"` and the fork endpoint rejects non-persistent slots before the mode check; forking a normal session into `design-critique` mode is likewise not a real flow.
- `chat_tags.py` `_VALID_MODES` is an unrelated constant (tag-filter match modes `any/all/none`).

Sidebar-leak verification (per the fix plan): the chat sidebar filter (`website/src/pages/ChatPage.tsx`, `filteredSlots`) renders only surface keys `''`, `'orchestrator'`, `'crew'`, and the backend serializes `surface = slot.mode` (`state.py` `serialize` / to-dict path). A `design-critique` slot therefore stays out of the chat list; the unread-count path (`dashboardSlice.ts` `countUnreadByMode`) applies the same allowlist logic.

Downstream mode-universe check: no reachable path assumes the mode universe is exactly `{"", "orchestrator", "crew"}` in a way the new value breaks — crew ingest gates on `== "crew"`, autopilot prompt selection on `== "orchestrator"`, persistence rehydrates the stored string verbatim.

## Tests

`test/test_crew_http.py::TestCrewHttpFlow::test_create_endpoint_accepts_design_critique_mode` (new):
- `POST /api/chat/slots` with `mode="design-critique"`, `memory_mode="temporary"`, `name="dc-…"` succeeds and serializes both `mode` and the sidebar-filter field `surface` as `design-critique`.
- An unknown mode still returns 400 with `code="invalid_mode"` (locks the machine-readable rejection the app's error handling keys on).

The adjacent existing test (`test_create_endpoint_rejects_bad_mode`) continues to lock the reject path.

## Manual verification

N/A — unit coverage sufficient: the regression test drives the exact request the app's `openSlot()` sends (same body shape), and the sidebar-exclusion claim is verified against the frontend filter source (see above); no rendered UI changed.

## Related Issues

Fixes #5099

Follow-up (deliberately out of scope, filed as #5101): a `dc-*` slot recreated by `POST /api/chat`'s auto-create path after a mid-critique gateway restart comes back with `mode=""` and would appear in the sidebar — raised as an advisory by pre-push review. Making the frontend's `send()` repeat the mode requires a new backend surface (validated `mode` forwarding on auto-create), which deserves its own review.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, behavior fix with in-code rationale comment
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
