### PR TITLE
refactor(knowledge): drop dead migration DDL and dedupe repeated blocks

### DIFF
--- a/src/kiro_crew/knowledge/chunker.py
+++ b/src/kiro_crew/knowledge/chunker.py
@@ -182,52 +182,15 @@ class HeadingAwareChunker:
                 sections.insert(0, (None, 1, preamble))
 
         # Merge small sections, split oversized ones
-        results = []
+        results: list[dict] = []
         idx = 0
         current_title: str | None = None
         current_body = ""
         current_start = 1
 
-        for title, line_start, body in sections:
-            if not current_body:
-                current_title = title
-                current_body = body
-                current_start = line_start
-            elif _word_count(current_body + body) <= self.target_size:
-                current_body += "\n" + body
-                if current_title is None and title is not None:
-                    current_title = title
-            else:
-                # Flush current
-                if _word_count(current_body) > self.target_size:
-                    offset = 0
-                    for sub in self._recursive_split(current_body, _SEPARATORS):
-                        sub_line_start = current_start + offset
-                        results.append({
-                            "content": sub,
-                            "section_title": current_title,
-                            "chunk_index": idx,
-                            "line_start": sub_line_start,
-                            "line_end": sub_line_start + sub.count("\n"),
-                        })
-                        offset += sub.count("\n") + 1
-                        idx += 1
-                else:
-                    stripped = current_body.strip()
-                    results.append({
-                        "content": stripped,
-                        "section_title": current_title,
-                        "chunk_index": idx,
-                        "line_start": current_start,
-                        "line_end": current_start + stripped.count("\n"),
-                    })
-                    idx += 1
-                current_title = title
-                current_body = body
-                current_start = line_start
-
-        # Flush last
-        if current_body.strip():
+        def _flush() -> None:
+            """Emit the accumulated section, sub-splitting it if oversized."""
+            nonlocal idx
             if _word_count(current_body) > self.target_size:
                 offset = 0
                 for sub in self._recursive_split(current_body, _SEPARATORS):
@@ -250,6 +213,25 @@ class HeadingAwareChunker:
                     "line_start": current_start,
                     "line_end": current_start + stripped.count("\n"),
                 })
+                idx += 1
+
+        for title, line_start, body in sections:
+            if not current_body:
+                current_title = title
+                current_body = body
+                current_start = line_start
+            elif _word_count(current_body + body) <= self.target_size:
+                current_body += "\n" + body
+                if current_title is None and title is not None:
+                    current_title = title
+            else:
+                _flush()
+                current_title = title
+                current_body = body
+                current_start = line_start
+
+        if current_body.strip():
+            _flush()
 
         return results[:MAX_CHUNKS_PER_FILE]
 

--- a/src/kiro_crew/knowledge/readers.py
+++ b/src/kiro_crew/knowledge/readers.py
@@ -55,6 +55,28 @@ def _decode_text_bytes(raw: bytes) -> str:
     return text.replace('\r\n', '\n').replace('\r', '\n')
 
 
+def _read_error(exc: Exception) -> tuple[str, dict]:
+    """The reader result for a file that could not be read.
+
+    ``format: 'error'`` is the sentinel ``IngestionPipeline.ingest_file`` tests:
+    it raises rather than indexing, so the file is recorded as failed against its
+    source and the surrounding scan continues. The returned text is diagnostic and
+    never becomes an item.
+    """
+    return f'Error reading file: {exc}', {'format': 'error', 'error': str(exc)}
+
+
+def _missing_dep(fmt: str, package: str) -> tuple[str, dict]:
+    """The reader result when an optional extraction dependency is absent.
+
+    Carries the same ``format: 'error'`` sentinel as :func:`_read_error`. ``.pptx``
+    has no declared dependency, so this is the normal path for that format rather
+    than an anomaly.
+    """
+    message = f'{fmt} support requires {package}: pip install {package}'
+    return message, {'format': 'error', 'error': f'{fmt} support requires {package}'}
+
+
 class FileReader:
     # Binary formats need optional runtime deps: .pdf -> pdfplumber and .docx ->
     # python-docx (both declared in setup.cfg). .pptx -> python-pptx is NOT declared,
@@ -88,10 +110,9 @@ class FileReader:
         method_name = self._DISPATCH.get(ext)
         if method_name:
             text, meta = getattr(self, method_name)(path)
-            base_meta.update(meta)
         else:
             text, meta = self._read_text(path, ext.lstrip('.'))
-            base_meta.update(meta)
+        base_meta.update(meta)
         base_meta['line_count'] = text.count('\n') + 1 if text else 0
         return text, base_meta
 
@@ -104,23 +125,21 @@ class FileReader:
                 raw = f.read()
             return _decode_text_bytes(raw), {'format': fmt}
         except Exception as e:
-            return f'Error reading file: {e}', {'format': 'error', 'error': str(e)}
+            return _read_error(e)
 
     def _read_pdf(self, path: str) -> tuple[str, dict]:
         if pdfplumber is None:
-            return ('PDF support requires pdfplumber: pip install pdfplumber',
-                    {'format': 'error', 'error': 'PDF support requires pdfplumber'})
+            return _missing_dep('PDF', 'pdfplumber')
         try:
             with pdfplumber.open(path) as pdf:
                 pages = [p.extract_text() or '' for p in pdf.pages]
                 return '\n'.join(pages), {'format': 'pdf', 'page_count': len(pages)}
         except Exception as e:
-            return f'Error reading file: {e}', {'format': 'error', 'error': str(e)}
+            return _read_error(e)
 
     def _read_pptx(self, path: str) -> tuple[str, dict]:
         if Presentation is None:
-            return ('PPTX support requires python-pptx: pip install python-pptx',
-                    {'format': 'error', 'error': 'PPTX support requires python-pptx'})
+            return _missing_dep('PPTX', 'python-pptx')
         try:
             prs = Presentation(path)
             parts = []
@@ -143,12 +162,11 @@ class FileReader:
                 parts.append(section)
             return '\n\n'.join(parts), {'format': 'pptx', 'slide_count': len(prs.slides)}
         except Exception as e:
-            return f'Error reading file: {e}', {'format': 'error', 'error': str(e)}
+            return _read_error(e)
 
     def _read_docx(self, path: str) -> tuple[str, dict]:
         if Document is None:
-            return ('DOCX support requires python-docx: pip install python-docx',
-                    {'format': 'error', 'error': 'DOCX support requires python-docx'})
+            return _missing_dep('DOCX', 'python-docx')
         try:
             doc = Document(path)
             lines = []
@@ -165,7 +183,7 @@ class FileReader:
                     lines.append(text)
             return '\n'.join(lines), {'format': 'docx', 'content_type': 'markdown', 'paragraph_count': len(doc.paragraphs)}
         except Exception as e:
-            return f'Error reading file: {e}', {'format': 'error', 'error': str(e)}
+            return _read_error(e)
 
     def _read_html(self, path: str) -> tuple[str, dict]:
         try:
@@ -174,7 +192,7 @@ class FileReader:
             with open(path, 'rb') as f:
                 html = _decode_text_bytes(f.read())
         except Exception as e:
-            return f'Error reading file: {e}', {'format': 'error', 'error': str(e)}
+            return _read_error(e)
         if _html2text_mod is not None:
             h = _html2text_mod.HTML2Text()
             h.ignore_links = False

--- a/src/kiro_crew/knowledge/retrieval.py
+++ b/src/kiro_crew/knowledge/retrieval.py
@@ -7,6 +7,7 @@ import logging
 import math
 import struct
 from collections import defaultdict
+from typing import Any
 
 try:
     import pysqlite3 as sqlite3
@@ -32,6 +33,22 @@ _STOPWORDS = frozenset({
 # Weight applied to the vector leg in RRF fusion so semantically-strong matches
 # dominate when the keyword leg returns weak/literal junk.
 VECTOR_RRF_WEIGHT = 2.0
+
+
+def _stored_item_ids(raw: str | bytes | None) -> Any:
+    """A state row's ``item_ids`` JSON column, decoded as stored.
+
+    An empty column, or one whose value ``json`` reports as malformed, yields
+    ``[]`` so a single bad row costs its own citation locator rather than the
+    whole enrichment pass. The decoded value is handed back unchecked -- callers
+    only iterate it.
+    """
+    if not raw:
+        return []
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
 
 
 class HybridRetriever:
@@ -60,7 +77,8 @@ class HybridRetriever:
         # with (kw, gr, vec).
         fused = self._rrf_fuse(kw, gr, vec, weights=(1.0, 1.0, VECTOR_RRF_WEIGHT))
 
-        # Batch-fetch all candidate items once
+        # Resolve every fused candidate up front: both the recency tie-break below
+        # and the result rows read the same item, so one lookup per id serves both.
         all_ids = [item_id for item_id, _ in fused]
         items_cache: dict[str, dict] = {}
         for item_id in all_ids:
@@ -175,15 +193,10 @@ class HybridRetriever:
         except sqlite3.OperationalError:
             return
 
-        folder_sids = [
-            sid for sid in sid_list
-            if meta.get(sid) is not None
-            and meta[sid]["source_type"] in ("local_folder", "obsidian_vault")
-        ]
-        artifact_sids = [
-            sid for sid in sid_list
-            if meta.get(sid) is not None and meta[sid]["source_type"] == "artifact"
-        ]
+        folder_sids = [sid for sid in sid_list if sid in meta
+                       and meta[sid]["source_type"] in ("local_folder", "obsidian_vault")]
+        artifact_sids = [sid for sid in sid_list if sid in meta
+                         and meta[sid]["source_type"] == "artifact"]
 
         item_to_file: dict[str, str] = {}
         for sid in folder_sids:
@@ -191,11 +204,7 @@ class HybridRetriever:
                 "SELECT file_path, item_ids FROM folder_file_state WHERE source_id = ?",
                 (sid,),
             ).fetchall():
-                try:
-                    ids = json.loads(row["item_ids"]) if row["item_ids"] else []
-                except (json.JSONDecodeError, TypeError):
-                    continue
-                for item_id in ids:
+                for item_id in _stored_item_ids(row["item_ids"]):
                     item_to_file[item_id] = row["file_path"]
 
         item_to_artifact: dict[str, tuple] = {}
@@ -204,11 +213,7 @@ class HybridRetriever:
                 "SELECT slug, name, item_ids FROM artifact_item_state WHERE source_id = ?",
                 (sid,),
             ).fetchall():
-                try:
-                    ids = json.loads(row["item_ids"]) if row["item_ids"] else []
-                except (json.JSONDecodeError, TypeError):
-                    continue
-                for item_id in ids:
+                for item_id in _stored_item_ids(row["item_ids"]):
                     item_to_artifact[item_id] = (row["slug"], row["name"])
 
         for result in results:

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -486,115 +486,69 @@ class KnowledgeStore:
             self.db.execute("ALTER TABLE sources ADD COLUMN summary_topic TEXT")
         if "summary_themes" not in src_cols:
             self.db.execute("ALTER TABLE sources ADD COLUMN summary_themes TEXT")
-        # Migrate: folder_file_state table
-        tables = {r[0] for r in self.db.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
-        if "folder_file_state" not in tables:
-            self.db.execute("""
-                CREATE TABLE IF NOT EXISTS folder_file_state (
-                    source_id TEXT NOT NULL REFERENCES sources(id),
-                    file_path TEXT NOT NULL,
-                    content_hash TEXT,
-                    text_hash TEXT,
-                    mtime REAL,
-                    item_ids TEXT DEFAULT '[]',
-                    last_seen TEXT NOT NULL,
-                    status TEXT DEFAULT 'pending',
-                    error_message TEXT,
-                    merged_into_source_id TEXT,
-                    attempts INTEGER NOT NULL DEFAULT 0,
-                    PRIMARY KEY (source_id, file_path)
-                )
-            """)
-        else:
-            ffs_cols = {r[1] for r in self.db.execute("PRAGMA table_info(folder_file_state)").fetchall()}
-            if "status" not in ffs_cols:
-                self.db.execute("ALTER TABLE folder_file_state ADD COLUMN status TEXT DEFAULT 'pending'")
-            if "error_message" not in ffs_cols:
-                self.db.execute("ALTER TABLE folder_file_state ADD COLUMN error_message TEXT")
-            if "merged_into_source_id" not in ffs_cols:
-                self.db.execute(
-                    "ALTER TABLE folder_file_state ADD COLUMN merged_into_source_id TEXT")
-            # The extracted-text hash, in the same domain as items.content_hash --
-            # see _OWNERSHIP_HASH_COL. Deliberately NOT backfilled: it can only be
-            # derived from a row's own items, and a legacy row that owns nothing has
-            # nothing to derive it from. Left NULL, such a row behaves exactly as it
-            # does today (its ownership lookups match nothing) and is populated the
-            # next time the file is scanned. A backfill that guessed instead would be
-            # the data-loss shape this feature already had to remove once.
-            if "text_hash" not in ffs_cols:
-                self.db.execute("ALTER TABLE folder_file_state ADD COLUMN text_hash TEXT")
-            # Consecutive non-terminal attempt count, the bound on crash recovery --
-            # see the CREATE TABLE comment. Existing rows start at 0, including any
-            # already stuck in 'scanning': that is deliberate, so a database carrying
-            # a file that cannot be ingested spends the same small retry budget as a
-            # fresh one and then retires the row, instead of re-ingesting it (and
-            # paying for its extraction calls) on every sweep for as long as the
-            # source exists.
-            if "attempts" not in ffs_cols:
-                self.db.execute(
-                    "ALTER TABLE folder_file_state "
-                    "ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0")
-        # Migrate: artifact_item_state table -- per-artifact item-group tracking
-        # for the aggregate "Artifacts" KB source, keyed by artifact slug.
-        if "artifact_item_state" not in tables:
-            self.db.execute("""
-                CREATE TABLE IF NOT EXISTS artifact_item_state (
-                    source_id TEXT NOT NULL REFERENCES sources(id),
-                    slug TEXT NOT NULL,
-                    content_hash TEXT,
-                    item_ids TEXT DEFAULT '[]',
-                    updated_at TEXT NOT NULL,
-                    name TEXT,
-                    merged_into_source_id TEXT,
-                    kind TEXT,
-                    PRIMARY KEY (source_id, slug)
-                )
-            """)
-        else:
-            ais_cols = {r[1] for r in self.db.execute(
-                "PRAGMA table_info(artifact_item_state)").fetchall()}
-            if "name" not in ais_cols:
-                self.db.execute("ALTER TABLE artifact_item_state ADD COLUMN name TEXT")
-            if "status" not in ais_cols:
-                self.db.execute(
-                    "ALTER TABLE artifact_item_state ADD COLUMN status TEXT DEFAULT 'active'")
-            if "merged_into_source_id" not in ais_cols:
-                self.db.execute(
-                    "ALTER TABLE artifact_item_state ADD COLUMN merged_into_source_id TEXT")
-            # The artifact kind AS INGESTED. Reconcile needs it to tell an
-            # artifact whose kind changed while sync was off (stale chunks, must
-            # be reaped) from one the user merely excluded by narrowing
-            # `auto_ingest_artifact_kinds` (still live, must NOT be reaped).
-            # Legacy rows carry NULL, which reconcile treats as "cannot tell"
-            # and leaves alone; the next ingest of that artifact backfills it.
-            if "kind" not in ais_cols:
-                self.db.execute("ALTER TABLE artifact_item_state ADD COLUMN kind TEXT")
-        # Migrate: agent_item_state table -- per-document item-group tracking for
-        # the aggregate "Auto-added" KB source the agent writes to.
-        if "agent_item_state" not in tables:
-            self.db.execute("""
-                CREATE TABLE IF NOT EXISTS agent_item_state (
-                    source_id TEXT NOT NULL REFERENCES sources(id),
-                    slug TEXT NOT NULL,
-                    content_hash TEXT,
-                    item_ids TEXT DEFAULT '[]',
-                    updated_at TEXT NOT NULL,
-                    name TEXT,
-                    status TEXT DEFAULT 'active',
-                    merged_into_source_id TEXT,
-                    PRIMARY KEY (source_id, slug)
-                )
-            """)
-        else:
-            agent_cols = {r[1] for r in self.db.execute(
-                "PRAGMA table_info(agent_item_state)").fetchall()}
-            if "status" not in agent_cols:
-                self.db.execute(
-                    "ALTER TABLE agent_item_state ADD COLUMN status TEXT DEFAULT 'active'")
-            if "merged_into_source_id" not in agent_cols:
-                self.db.execute(
-                    "ALTER TABLE agent_item_state ADD COLUMN merged_into_source_id TEXT")
+        # Backfill columns on the document-state tables. Each table itself is
+        # created by ``_init_schema``, which runs first on every construction, so
+        # only the per-column ALTERs belong here.
+        ffs_cols = {r[1] for r in self.db.execute(
+            "PRAGMA table_info(folder_file_state)").fetchall()}
+        if "status" not in ffs_cols:
+            self.db.execute(
+                "ALTER TABLE folder_file_state ADD COLUMN status TEXT DEFAULT 'pending'")
+        if "error_message" not in ffs_cols:
+            self.db.execute("ALTER TABLE folder_file_state ADD COLUMN error_message TEXT")
+        if "merged_into_source_id" not in ffs_cols:
+            self.db.execute(
+                "ALTER TABLE folder_file_state ADD COLUMN merged_into_source_id TEXT")
+        # The extracted-text hash, in the same domain as items.content_hash --
+        # see _OWNERSHIP_HASH_COL. Deliberately NOT backfilled: it can only be
+        # derived from a row's own items, and a legacy row that owns nothing has
+        # nothing to derive it from. Left NULL, such a row behaves exactly as it
+        # does today (its ownership lookups match nothing) and is populated the
+        # next time the file is scanned. A backfill that guessed instead would be
+        # the data-loss shape this feature already had to remove once.
+        if "text_hash" not in ffs_cols:
+            self.db.execute("ALTER TABLE folder_file_state ADD COLUMN text_hash TEXT")
+        # Consecutive non-terminal attempt count, the bound on crash recovery --
+        # see the CREATE TABLE comment. Existing rows start at 0, including any
+        # already stuck in 'scanning': that is deliberate, so a database carrying
+        # a file that cannot be ingested spends the same small retry budget as a
+        # fresh one and then retires the row, instead of re-ingesting it (and
+        # paying for its extraction calls) on every sweep for as long as the
+        # source exists.
+        if "attempts" not in ffs_cols:
+            self.db.execute(
+                "ALTER TABLE folder_file_state "
+                "ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0")
+        # artifact_item_state -- per-artifact item-group tracking for the
+        # aggregate "Artifacts" KB source, keyed by artifact slug.
+        ais_cols = {r[1] for r in self.db.execute(
+            "PRAGMA table_info(artifact_item_state)").fetchall()}
+        if "name" not in ais_cols:
+            self.db.execute("ALTER TABLE artifact_item_state ADD COLUMN name TEXT")
+        if "status" not in ais_cols:
+            self.db.execute(
+                "ALTER TABLE artifact_item_state ADD COLUMN status TEXT DEFAULT 'active'")
+        if "merged_into_source_id" not in ais_cols:
+            self.db.execute(
+                "ALTER TABLE artifact_item_state ADD COLUMN merged_into_source_id TEXT")
+        # The artifact kind AS INGESTED. Reconcile needs it to tell an
+        # artifact whose kind changed while sync was off (stale chunks, must
+        # be reaped) from one the user merely excluded by narrowing
+        # `auto_ingest_artifact_kinds` (still live, must NOT be reaped).
+        # Legacy rows carry NULL, which reconcile treats as "cannot tell"
+        # and leaves alone; the next ingest of that artifact backfills it.
+        if "kind" not in ais_cols:
+            self.db.execute("ALTER TABLE artifact_item_state ADD COLUMN kind TEXT")
+        # agent_item_state -- per-document item-group tracking for the aggregate
+        # "Auto-added" KB source the agent writes to.
+        agent_cols = {r[1] for r in self.db.execute(
+            "PRAGMA table_info(agent_item_state)").fetchall()}
+        if "status" not in agent_cols:
+            self.db.execute(
+                "ALTER TABLE agent_item_state ADD COLUMN status TEXT DEFAULT 'active'")
+        if "merged_into_source_id" not in agent_cols:
+            self.db.execute(
+                "ALTER TABLE agent_item_state ADD COLUMN merged_into_source_id TEXT")
         # Clean orphan sources (no items), entities (no mentions/relations), and stale relations
         #
         # Folder sources are EXCLUDED: a watched folder with zero discovered
@@ -622,15 +576,27 @@ class KnowledgeStore:
             self.db.execute(f"DELETE FROM ingestion_jobs WHERE source_id IN ({orphan_sources_q})")
             self.db.execute(f"DELETE FROM sources WHERE id IN ({orphan_sources_q})")
             self.db.execute("DELETE FROM entity_relations WHERE source_id NOT IN (SELECT id FROM entities) OR target_id NOT IN (SELECT id FROM entities)")
-            self.db.execute("""
-                DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM mentions)
-                AND id NOT IN (SELECT source_id FROM entity_relations)
-                AND id NOT IN (SELECT target_id FROM entity_relations)
-            """)
+            self._prune_orphan_entities()
             self.db.execute("COMMIT")
         except Exception:
             self.db.execute("ROLLBACK")
             raise
+
+    def _prune_orphan_entities(self) -> None:
+        """Delete entities nothing references any more -- no mention, no relation.
+
+        Every path that removes items or a source has to run this, because an
+        entity is only reachable through the rows those paths delete. It takes no
+        transaction of its own -- each call site is already inside an open write
+        transaction -- and it does not reload the in-memory graph, which the sweep
+        can leave holding dropped entities; that stays with whoever owns the
+        transaction.
+        """
+        self.db.execute("""
+            DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM mentions)
+            AND id NOT IN (SELECT source_id FROM entity_relations)
+            AND id NOT IN (SELECT target_id FROM entity_relations)
+        """)
 
     def find_doc_by_content_hash(
         self, content_hash: str, exclude_source_id: str | None = None
@@ -750,12 +716,7 @@ class KnowledgeStore:
         self.db.execute("BEGIN")
         try:
             self._delete_item_cascade(item_id)
-            # Remove orphan entities (no mentions and no relations)
-            self.db.execute("""
-                DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM mentions)
-                AND id NOT IN (SELECT source_id FROM entity_relations)
-                AND id NOT IN (SELECT target_id FROM entity_relations)
-            """)
+            self._prune_orphan_entities()
             self.db.execute("COMMIT")
         except Exception:
             self.db.execute("ROLLBACK")
@@ -938,11 +899,7 @@ class KnowledgeStore:
                         (item_id, owner_source_id))
                     continue
             self._delete_item_cascade(item_id)
-        self.db.execute("""
-            DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM mentions)
-            AND id NOT IN (SELECT source_id FROM entity_relations)
-            AND id NOT IN (SELECT target_id FROM entity_relations)
-        """)
+        self._prune_orphan_entities()
 
     def reload_graph(self) -> None:
         """Rebuild the in-memory entity graph from the tables.
@@ -1197,12 +1154,7 @@ class KnowledgeStore:
             self.db.execute("DELETE FROM artifact_item_state WHERE source_id = ?", (source_id,))
             self.db.execute("DELETE FROM agent_item_state WHERE source_id = ?", (source_id,))
             self.db.execute("DELETE FROM sources WHERE id = ?", (source_id,))
-            # Remove orphan entities
-            self.db.execute("""
-                DELETE FROM entities WHERE id NOT IN (SELECT entity_id FROM mentions)
-                AND id NOT IN (SELECT source_id FROM entity_relations)
-                AND id NOT IN (SELECT target_id FROM entity_relations)
-            """)
+            self._prune_orphan_entities()
             self.db.execute("COMMIT")
         except Exception:
             self.db.execute("ROLLBACK")
@@ -1362,13 +1314,9 @@ class KnowledgeStore:
         exists is a no-op. Attaching a second source is what keeps the item alive when
         the first is deleted -- see ``sources_holding_item``.
         """
-        lid = str(uuid4())
-        now = datetime.now().isoformat()
-        self.db.execute(
-            "INSERT OR IGNORE INTO source_locations "
-            "(id, item_id, source_id, chunk_range, section_title, anchor, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (lid, item_id, source_id, chunk_range, section_title, anchor, now))
+        self.add_source_location_in_txn(
+            item_id, source_id, chunk_range=chunk_range,
+            section_title=section_title, anchor=anchor)
         self.db.commit()
 
     def add_source_location_in_txn(self, item_id, source_id, chunk_range=None,

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -128,7 +128,7 @@ class KnowledgeWatcher:
             # every interval, and an unanticipated persistent error would
             # otherwise emit a full traceback forever.
             sig = f"{type(exc).__name__}:{exc}"
-            if sig != getattr(self, "_discover_error_sig", None):
+            if sig != self._discover_error_sig:
                 self._discover_error_sig = sig
                 logger.warning("Knowledge drop-folder discovery failed", exc_info=True)
             else:
@@ -173,7 +173,7 @@ class KnowledgeWatcher:
                 )
         except Exception as exc:
             sig = f"{type(exc).__name__}:{exc}"
-            if sig != getattr(self, "_project_docs_error_sig", None):
+            if sig != self._project_docs_error_sig:
                 self._project_docs_error_sig = sig
                 logger.warning("Knowledge project-docs discovery failed", exc_info=True)
             else:

--- a/test/test_folder_watcher.py
+++ b/test/test_folder_watcher.py
@@ -1248,3 +1248,44 @@ class TestFolderFileStateAttemptsMigration:
             assert row["attempts"] == 0
         finally:
             store.close()
+
+
+class TestDocumentStateTableSchema:
+    """``_migrate`` backfills COLUMNS; ``_init_schema`` owns creating the tables."""
+
+    _STATE_TABLES = ("folder_file_state", "artifact_item_state", "agent_item_state")
+
+    @staticmethod
+    def _columns(store, table: str) -> set[str]:
+        return {r[1] for r in store.db.execute(
+            "SELECT * FROM pragma_table_info(?)", (table,)).fetchall()}
+
+    def test_absent_state_tables_come_back_with_their_full_shape(self, tmp_path):
+        """Opening a database whose document-state tables are gone recreates them.
+
+        ``_migrate`` runs ``PRAGMA table_info`` and then ``ALTER TABLE`` on all
+        three unconditionally, and an ALTER against a missing table raises
+        ``no such table`` -- so what keeps the column backfill safe is
+        ``__init__`` running ``_init_schema`` (whose ``CREATE TABLE IF NOT
+        EXISTS`` carries every column) FIRST. This pins that ordering, which is
+        otherwise only a comment.
+        """
+        db_path = tmp_path / "dropped.db"
+        store = KnowledgeStore(str(db_path))
+        expected = {t: self._columns(store, t) for t in self._STATE_TABLES}
+        store.close()
+        assert all(expected.values()), "fresh schema must define all three tables"
+
+        conn = sqlite3.connect(str(db_path))
+        for table in self._STATE_TABLES:
+            conn.execute(f"DROP TABLE {table}")  # noqa: S608
+        conn.commit()
+        conn.close()
+
+        store = KnowledgeStore(str(db_path))
+        try:
+            for table in self._STATE_TABLES:
+                assert self._columns(store, table) == expected[table], (
+                    f"{table} did not come back with its full column set")
+        finally:
+            store.close()


### PR DESCRIPTION
## Problem / Motivation

Five files under `src/kiro_crew/knowledge/` carry code that says the same thing more than once, and one block that cannot run at all:

- **`store.py::_migrate` holds ~50 lines of unreachable DDL.** Each of the three document-state tables is guarded by `if "<table>" not in tables: CREATE TABLE … else: <column ALTERs>`. The CREATE branch can never execute: `KnowledgeStore.__init__` calls `_init_schema()` — whose `executescript` creates all three with `CREATE TABLE IF NOT EXISTS` — at line 207, immediately before `_migrate()` at line 208, on the same connection. `_migrate` has exactly two callers and neither can reach it with a table missing.
- **That dead copy has already drifted, and the drift is the proof.** The deleted `artifact_item_state` CREATE lacks the `status` column that `_init_schema` defines and that `artifact_ingest.py:237` writes on **every** artifact ingest. Had the branch ever fired it would have produced a table making artifact ingestion fail with `no column named status` for the life of the process. Nobody has ever reported that, and `git` shows both copies were added in the same commit — the branch was dead from birth.
- **The orphan-entity sweep is written out four times**, byte-identically, in `_migrate`, `delete_item`, `delete_items_batch_in_txn` and `delete_source_cascade`. `add_source_location` likewise duplicates the exact `INSERT OR IGNORE` of its own `_in_txn` sibling.
- **`chunker.py::chunk_markdown` duplicates its flush block verbatim** — 23 lines repeated between the loop body and the tail.
- **`readers.py` writes the same two return values eight times** — the `format: 'error'` result five times and the missing-optional-dependency result three.
- **A comment in `retrieval.py` is false**: `# Batch-fetch all candidate items once` sits above a per-id `get_item` loop, which is N queries, not a batch.

## Why it matters

Duplicated logic is where the next divergence lands, and `store.py` already demonstrates the cost: a copy nobody could reach drifted away from its twin and nothing caught it, because there is no test that can exercise a branch that never runs. A reader auditing the knowledge store's migration path today has to read two schemas for each table and work out which one wins.

`chunk_markdown`'s duplicate is the same hazard in the hot path: the two copies had *already* diverged by one statement (`idx += 1`), which happens to be unobservable — but the next edit to one copy has no reason to be.

## What changed (motivation → approach → change)

Behaviour-preserving refactor only. **No API, schema, config or observable behaviour change**, and no new capability. One module, one commit, per the module-simplification campaign's scope rule.

**`store.py`**
- Both branches of all three table guards collapse to the unconditional column backfill (the old `else` body). The `SELECT name FROM sqlite_master` that fed the guards goes with them, so the steady-state path issues one fewer query. A comment records the load-bearing coupling: the tables are `_init_schema`'s to create.
- The four inline orphan-entity `DELETE`s become `_prune_orphan_entities()`, whose docstring states precisely what the call sites guarantee — it takes no transaction of its own because each site is already inside an open write transaction, and it does not reload the in-memory graph, which stays with whoever owns that transaction.
- `add_source_location` delegates to `add_source_location_in_txn` and keeps its trailing `commit()`.

**`chunker.py`** — one nested `_flush()` closure replaces both copies. It reads `current_body` / `current_title` / `current_start` (never binds them), so no `nonlocal` is needed for those and there is no `UnboundLocalError`; only `idx` is declared `nonlocal`.

**`readers.py`** — `_read_error(exc)` and `_missing_dep(fmt, package)` produce byte-identical strings and meta dicts at all eight sites. `base_meta.update(meta)` was identical in both dispatch branches and is hoisted below them.

**`retrieval.py`** — `_stored_item_ids()` replaces the two copies of the `item_ids` JSON decode, catching exactly what the originals caught. The false batch-fetch comment now states what the cache is actually for (the recency tie-break *and* the result rows both read it).

**`watcher.py`** — two `getattr(self, "_…", None)` reads of attributes `__init__` always sets become plain attribute reads.

### Deliberately NOT done

- **`retrieval._bytes_to_floats` is left alone** even though `embedder.bytes_to_floats` looks like the same function. They differ on corrupt input in both directions (element-type validation; a `>= 16` byte floor), so consolidating them would change behaviour on malformed rows. A test also imports the private name directly.
- **`_stored_item_ids` does not gain an `isinstance(parsed, list)` guard**, and its `except` is not widened to `ValueError`, even though both would be improvements. Either changes what a malformed column does. That is a behaviour fix and belongs in its own PR, not in a cleanup; the docstring says exactly what the code does instead of what it should do.

## Tests

**One test added** — `TestDocumentStateTableSchema::test_absent_state_tables_come_back_with_their_full_shape` in `test/test_folder_watcher.py`.

It locks in the invariant this diff now leans on. The column backfill runs `PRAGMA table_info` and then `ALTER TABLE` on all three tables unconditionally, and an `ALTER` against a missing table raises `no such table`; what keeps that unreachable is `_init_schema` running first. The test opens a database whose three state tables have been dropped and asserts each comes back with its full column set — so the ordering is enforced rather than merely commented.

It is a **ratchet, not a regression test**: it passes on `origin/main` too. Its value is that it fails if someone later swaps or removes the two `__init__` steps. Verified by mutation — inverting `_init_schema()` / `_migrate()` in `__init__` makes it fail; restoring makes it pass.

No other test changed, which is the point: 1,997 existing tests across the knowledge surface pass unmodified.

## Manual verification

Beyond the suite, the migration hunk was exercised directly against real SQLite databases, because it runs on every gateway start against the user's own data:

| Database shape | Result |
|---|---|
| Fresh | All three tables created with the full column set |
| All three state tables **dropped**, then reopened | Recreated intact by `_init_schema`; every `ALTER` correctly skipped |
| State tables present in their **pre-column shapes** | Exactly the column sets the old `else` branches produced |
| `PRAGMA table_info` on a missing table | Returns `[]` (no raise); the following `ALTER` raises `no such table` — confirming the failure mode is real, and unreachable |

`chunk_markdown` was checked by differential run: `origin/main`'s implementation vs the refactored one over 1,600 randomised markdown inputs × 4 `target_size` values — **0 mismatches**.

Gates, all green on the Python 3.12 CI-parity venv: `flake8`, `isort --check-only`, `mypy` (1030 files), `check_black_formatting.py`, `check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`, `scrub-lint.sh --no-history`.

### Pre-open review

Four independent read-only reviewers ran over the finished diff before it was pushed — AUTOSDE + deterministic `code-review.yml` greps, behaviour preservation, import/name + comment accuracy, and security-keystone/data-safety.

- **Found and fixed (2), both in comments this PR itself introduced.** `_read_error`'s docstring claimed the message "becomes the item's text"; it does not — `ingestion.py:533` raises on the `format: 'error'` sentinel, so the file is recorded as failed and nothing is indexed. `_stored_item_ids`'s docstring justified its `except TypeError` with SQLite storage-class variance (wrong for a TEXT-affinity column) and promised `[]` for any unparseable value (an invalid-UTF-8 BLOB raises `UnicodeDecodeError`, which escapes). Both now describe the actual code, and its return type is `Any` rather than a `list` it cannot guarantee.
- **Dropped as out of scope (1).** The same reviewer proposed *fixing* `_stored_item_ids` — widen the `except`, add an `isinstance` guard. Correct in the abstract, but it changes behaviour on malformed data, which this PR must not do. See "Deliberately NOT done".
- **No findings** on AUTOSDE blocking rules (`backend-security-controls` and `no-blocking-call-on-event-loop` match the changed files and comply; `no-new-work-on-gateway-boot-path` does not match `knowledge/`), on behaviour preservation, or on security. No keystone file is touched, and no matcher, guard, audit emit, redaction call or governance intersection changed shape, order or reachability.
- **Accepted and acted on (1 advisory).** The security reviewer noted the new `_init_schema`-before-`_migrate` dependency was documented but not pinned by any test. That is the test described above.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — five files under `src/kiro_crew/knowledge/` plus one test; nothing under `website/`, so no rendered surface changes and the Screenshot Evidence gate does not fire.

## Related Issues

no linked issue: campaign-driven cleanup of one backend module, with no filed issue behind it.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass; one test added pinning the invariant the refactor relies on
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: `docs/system-specs/modules/knowledge.md` documents no API, schema or behaviour this diff changes; its one reference to the migrate step (§ "per-call schema DDL / migrate / graph-load") remains accurate
- [x] No secrets, credentials, or internal references in the diff
