### PR TITLE
fix: forward validated mode on chat auto-create path (#5101)

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -204,11 +204,33 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     if requested_memory_mode not in ("persistent", "incognito", "temporary"):
         requested_memory_mode = None
 
+    # Honor mode from the body when auto-creating a slot, mirroring memory_mode
+    # above: an app whose worker slot lives only in gateway memory (e.g. Design
+    # Critique) repeats mode on send(), so a slot recreated here after a
+    # gateway restart keeps its non-"" surface and stays out of the chat
+    # sidebar's surface allowlist. Only creation-allowlisted values pass;
+    # anything else is dropped so get_or_create_slot uses its default. Unlike
+    # memory_mode there is no mismatch error: get_or_create_slot ignores mode
+    # for an already-existing slot.
+    requested_mode = body.get("mode")
+    if not isinstance(requested_mode, str) or requested_mode not in _CREATABLE_MODES:
+        requested_mode = ""
+    if requested_mode == "crew" and slot_name:
+        # Same boundary as api_chat_slot_create: a caller-supplied name whose
+        # normalized key cannot host a crew store must not become a crew slot
+        # (its first crew message would 500). Dropped rather than refused —
+        # auto-create is a convenience path, not the crew entry point.
+        from kiro_crew.crew_chat import is_crew_capable_slot_key
+
+        if not is_crew_capable_slot_key(_normalize_slot_key(slot_name)):
+            requested_mode = ""
+
     try:
         slot = state.get_or_create_slot(
             slot_name,
             app=request.get("app", ""),
             origin=request_slot_origin(request.get("app", "")),
+            mode=requested_mode,
             memory_mode=requested_memory_mode,
         )
     except ValueError as exc:

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -866,6 +866,119 @@ class TestApiChatMemoryModeForwarding:
 
 
 @pytest.mark.asyncio
+class TestApiChatModeForwarding:
+    """api_chat propagates a validated body.mode to the auto-created slot.
+
+    The Design Critique app's worker slot (mode="design-critique") lives only
+    in gateway memory. After a gateway restart the app's next send() recreates
+    the slot through this auto-create path; without mode forwarding the slot
+    is reborn with mode="" — it then serializes surface="" and passes the chat
+    sidebar's surface allowlist, leaking the throwaway worker session into the
+    user's chat list. Mirrors TestApiChatMemoryModeForwarding above.
+    """
+
+    async def _post_chat(self, state, body):
+        async def fake_run_chat(st, sl, msg):
+            sl.append("chunk", "ack", "chunk")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat)
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.post("/api/chat", json=body, timeout=None)
+                assert resp.status == 200
+                async for _chunk in resp.content.iter_any():
+                    break  # only need to drive slot creation
+                resp.close()
+                await asyncio.sleep(0.05)
+
+    async def test_design_critique_mode_propagates_to_new_slot(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+
+        await self._post_chat(
+            state,
+            {
+                "message": "critique this",
+                "slot": "dc-12345",
+                "memory_mode": "temporary",
+                "mode": "design-critique",
+            },
+        )
+
+        slot = state._slots.get("dc-12345")
+        assert slot is not None
+        assert slot.mode == "design-critique"
+        # The leak this guards against: the sidebar allowlist admits surfaces
+        # "", "orchestrator" and "crew" — the recreated worker must not
+        # serialize one of those.
+        assert slot.mode not in ("", "orchestrator", "crew")
+
+    async def test_bogus_mode_is_dropped(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+
+        await self._post_chat(
+            state,
+            {"message": "hello", "slot": "bogus-mode-slot", "mode": "not-a-mode"},
+        )
+
+        slot = state._slots.get("bogus-mode-slot")
+        assert slot is not None
+        assert slot.mode == ""
+
+    async def test_non_string_mode_is_dropped(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+
+        await self._post_chat(
+            state,
+            {"message": "hello", "slot": "nonstring-mode-slot", "mode": 42},
+        )
+
+        slot = state._slots.get("nonstring-mode-slot")
+        assert slot is not None
+        assert slot.mode == ""
+
+    async def test_crew_mode_dropped_for_crew_incapable_name(self, tmp_path, monkeypatch):
+        """Same boundary api_chat_slot_create enforces with a 400: a name whose
+        normalized key cannot host a crew store (e.g. a Win32 device basename)
+        must not become a crew slot via auto-create. Here it is dropped, not
+        refused — the slot is created with the default mode instead."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+
+        await self._post_chat(
+            state,
+            {"message": "hello", "slot": "CON", "mode": "crew"},
+        )
+
+        created = [s for k, s in state._slots.items() if k.lower() == "con"]
+        assert created, "slot should still be created, just without crew mode"
+        assert created[0].mode == ""
+
+    async def test_mode_ignored_for_existing_slot(self, tmp_path, monkeypatch):
+        """Repeating mode on send() must be safe when the slot survived: an
+        existing slot keeps its stored mode and no error is raised."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("dc-alive", mode="design-critique", memory_mode="temporary")
+
+        await self._post_chat(
+            state,
+            {
+                "message": "hello again",
+                "slot": "dc-alive",
+                "memory_mode": "temporary",
+                "mode": "design-critique",
+            },
+        )
+
+        slot = state._slots.get("dc-alive")
+        assert slot is not None
+        assert slot.mode == "design-critique"
+
+
+@pytest.mark.asyncio
 class TestApiChatNoBrowseMarker:
     """Browse is gated by tool AVAILABILITY, not a per-message marker: the chat
     handler injects nothing into the user message, and the agent itself decides

--- a/website/src/apps/design-critique/api.ts
+++ b/website/src/apps/design-critique/api.ts
@@ -41,14 +41,18 @@ export const designCritiqueApi = {
     jsonFetch<void>('/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      // memory_mode must be repeated here, not only at slot creation. POST
-      // /api/chat auto-creates a missing slot, and with no memory_mode in the body
-      // it falls back to the persistent default — so if the gateway restarts
-      // mid-run (the slot is in memory, not on disk) the next send would silently
-      // recreate this critique slot with memory reads and writes ENABLED. Passing
-      // it is also safe when the slot exists: get_or_create_slot only raises on a
-      // mismatch, and this matches what openSlot() asked for.
-      body: JSON.stringify({ message, slot: slotKey, agent: AGENT, memory_mode: 'temporary' }),
+      // memory_mode AND mode must be repeated here, not only at slot creation.
+      // POST /api/chat auto-creates a missing slot, and with neither in the body
+      // it falls back to the persistent default with surface '' — so if the
+      // gateway restarts mid-run (the slot is in memory, not on disk) the next
+      // send would silently recreate this critique slot with memory reads and
+      // writes ENABLED and visible in the chat sidebar (whose allowlist admits
+      // surface ''). Passing them is also safe when the slot exists:
+      // get_or_create_slot only raises on a memory_mode mismatch and ignores
+      // mode for existing slots, and both match what openSlot() asked for.
+      body: JSON.stringify({
+        message, slot: slotKey, agent: AGENT, memory_mode: 'temporary', mode: 'design-critique',
+      }),
     }).catch((e: unknown) => {
       if (e instanceof SyntaxError) return
       throw e


### PR DESCRIPTION
## Problem / Motivation

A Design Critique worker slot (`mode="design-critique"`, `memory_mode="temporary"`) exists only in gateway memory. After a gateway restart mid-critique, the app's next `send()` recreates the slot through the `POST /api/chat` auto-create path — but that path forwards only `memory_mode` to `get_or_create_slot`, so the recreated slot comes back with `mode=""`. It then serializes `surface=""` and passes the chat sidebar's surface allowlist (`filteredSlots` admits `''`, `'orchestrator'`, `'crew'`), so the throwaway worker session appears in the user's chat list — exactly the leak the custom mode exists to prevent. The frontend already repeats `memory_mode` in `send()` for this same restart scenario, but repeating `mode` there was inert because the auto-create path never read it.

## Why it matters

Anyone running a Design Critique when the gateway restarts gets a phantom "dc-…" session in their chat sidebar: an internal worker transcript surfacing as a user conversation. Beyond the clutter, it breaks the app's isolation contract — the worker slot was deliberately given a non-`''` surface so it never renders as a user chat.

## What changed (motivation → approach → change)

Symptom: worker slot leaks into the sidebar after restart → root cause: `POST /api/chat` auto-create forwards `memory_mode` but not `mode` → change: read `mode` from the request body on the auto-create path with the **same validated-or-dropped pattern** the handler already applies to `memory_mode`:

- **Backend** (`src/kiro_crew/dashboard/chat_handlers.py`): a body `mode` is validated against the creation allowlist `_CREATABLE_MODES`; an absent, non-string, or not-allowlisted value is dropped (falls back to today's behavior), never an error. A `"crew"` request whose caller-supplied name cannot host a crew store is likewise dropped — the same boundary `api_chat_slot_create` enforces with a 400, in drop form because auto-create is a convenience path. Existing slots are unaffected: `get_or_create_slot` ignores `mode` for a slot that already exists, so repeating it on `send()` is a no-op for live slots. No non-auto-create path changed.
- **Frontend** (`website/src/apps/design-critique/api.ts`): `send()` now repeats `mode: 'design-critique'` in the request body, co-located with the existing `memory_mode` repetition and its restart-scenario comment.

## Tests

`test/test_dashboard_chat.py` — new `TestApiChatModeForwarding` (mirrors the existing `TestApiChatMemoryModeForwarding`):

- `test_design_critique_mode_propagates_to_new_slot` — auto-create with `mode="design-critique"` yields a slot whose `mode` (serialized as `surface`) is not in the sidebar allowlist (`""`/`"orchestrator"`/`"crew"`). **Mutation-verified**: reverting the handler change fails this test.
- `test_bogus_mode_is_dropped` / `test_non_string_mode_is_dropped` — reject paths behave like today (slot created with `mode=""`).
- `test_crew_mode_dropped_for_crew_incapable_name` — a Win32-device slot name with `mode="crew"` creates a plain slot, never a crew slot that would 500 on its first message.
- `test_mode_ignored_for_existing_slot` — repeating `mode` on `send()` against a surviving slot is a safe no-op.

## Manual verification

N/A — unit coverage sufficient: the leak is a pure request-body → slot-field propagation, locked end-to-end by the auto-create tests above; the frontend hunk is a one-field body addition with no rendered output.

<!-- no-visual-delta -->
**Why no screenshot:** the frontend change adds one field to a fetch request body in `api.ts`; no component, layout, or rendered pixel changes.

## Related Issues

Closes #5101

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no doc describes the `POST /api/chat` body contract
- [x] No secrets, credentials, or internal references in the diff
