### PR TITLE
fix(channels): stop deleting a reply's [OPTIONS:] choices, and bring WeChat up

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -177,7 +177,6 @@ src/kiro_crew/apps/teardown.py
 src/kiro_crew/artifact_source.py
 src/kiro_crew/artifacts.py
 src/kiro_crew/atomic_write.py
-src/kiro_crew/autonudge.py
 src/kiro_crew/autonudge_authz.py
 src/kiro_crew/beacon.py
 src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
@@ -448,8 +447,6 @@ src/kiro_crew/vector_memory.py
 src/kiro_crew/voice_reply.py
 src/kiro_crew/webhooks.py
 src/kiro_crew/weixin/client.py
-src/kiro_crew/weixin/transport_dispatch.py
-src/kiro_crew/weixin/turn_renderer.py
 src/kiro_crew/workflows/agent_exec.py
 src/kiro_crew/workflows/context.py
 src/kiro_crew/workflows/runner.py
@@ -552,7 +549,6 @@ test/test_auto_approve.py
 test/test_auto_research.py
 test/test_auto_research_handlers_coverage.py
 test/test_auto_research_onloop_db.py
-test/test_autonudge.py
 test/test_autonudge_dashboard_fire.py
 test/test_autonudge_stop_auth.py
 test/test_background_approval_routing.py
@@ -617,7 +613,6 @@ test/test_channel_transcript_migration.py
 test/test_chat_backfill.py
 test/test_chat_folder_app_isolation.py
 test/test_chat_folder_suggest.py
-test/test_chat_mirror.py
 test/test_chat_nav.py
 test/test_chat_regenerate_cov80.py
 test/test_chat_runner_coverage.py
@@ -650,7 +645,6 @@ test/test_computer_use_apps.py
 test/test_computer_use_overlay.py
 test/test_computer_use_skylight.py
 test/test_computer_use_snapshot_macos.py
-test/test_config_loader.py
 test/test_config_meta_stamp.py
 test/test_config_patch.py
 test/test_config_rmw_preserves_settings.py
@@ -1085,7 +1079,6 @@ test/test_pptx_maker_library.py
 test/test_pptx_maker_paths.py
 test/test_pptx_maker_provision.py
 test/test_pptx_maker_routes.py
-test/test_pr_quality_gates.py
 test/test_pr_readiness_evaluate.py
 test/test_pr_readiness_publish.py
 test/test_pr_readiness_sweep.py
@@ -1130,7 +1123,6 @@ test/test_restart_command.py
 test/test_reveal_in_file_manager.py
 test/test_reveal_path.py
 test/test_review_driver_loopback.py
-test/test_review_fixes.py
 test/test_role_models.py
 test/test_route_registry.py
 test/test_run_config_write.py
@@ -1338,7 +1330,6 @@ test/test_webhooks_store.py
 test/test_website_build_heap.py
 test/test_wecom_config_handlers.py
 test/test_wecom_wire.py
-test/test_weixin_dispatch.py
 test/test_weixin_media.py
 test/test_weixin_qr.py
 test/test_weixin_wire.py

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -746,6 +746,26 @@ Wraps `SlackClientOps` in the Layer-1 contract; declares Slack's real (rich-end)
 
 Full new-path dispatch: fires the ack reaction + working status immediately (constructing the `SlackRenderer` before the potentially slow session acquisition), acquires/creates the session, builds the message with context, then drives `TurnDriver.run()`. Agent resolution: thread override (`!agent`) → per-channel `agent_override` → configured default → the canonical `_DEFAULT_KIROCREW_AGENT = "kirocrew"` fallback (so the session loads kirocrew-core / `spawn_run` rather than kiro-cli's bare built-in default). It injects `auto_approve_tool=lambda title: _should_auto_approve_spawn(context_builder, title)` and `auto_approve_session=lambda: is_slack_session_trusted(session_key)`. Post-turn bookkeeping (context-usage accounting, conversation logging, success SEL audit) is each isolated in its own `try/except` so a bookkeeping failure never re-records a successful turn as a failure; `sessions.release()` runs in `finally`.
 
+### Two Slack features are deliberately NOT the reference
+
+Slack is the reference for the LAYERS — transport contract, renderer, turn
+dispatch — not for its feature list. Two of its features are decisions against
+replication rather than parity gaps, so an audit that finds another channel
+lacking them should close the finding, not file it:
+
+- **A channel-local auto-approve switch** (`is_slack_session_trusted`, the
+  `mc_tool_trust_` button). Approval posture is a property of the agent, not of
+  the surface a message arrived on: a second place to turn approvals off is a
+  second place to forget one is off, and it makes a session's ceiling depend on
+  which app the user typed into. Every other channel routes `/yolo` through the
+  one `safety_override` grant — see "There is ONE auto-approve grant" under
+  [Invariants](#invariants).
+- **A channel-local reply redirect.** Reply routing is owned by the session's
+  origin binding that every channel already shares through `drive_turn`. A
+  second router for the same question disagrees with the first the moment either
+  changes, and the disagreement surfaces as a reply delivered to the wrong
+  conversation.
+
 ## Cron output delivery: one run, one surface
 
 An unattended cron run has no inbound message to answer, so its output is
@@ -1252,7 +1272,8 @@ start, tool-progress status edits are throttled and budgeted to 6 of the 10
 edits (an edit failure burns the remaining budget so the final-answer edit
 can never race the cap), and the final answer lands as one placeholder edit
 with a fresh-message fallback plus chunked follow-ups past the 7000-char cap.
-Trailing `[OPTIONS:]` markup is stripped (`max_buttons=0`); interactive tool
+A trailing `[OPTIONS:]` trailer becomes a numbered text list (`max_buttons=0`,
+via the shared `render_options_as_text`); interactive tool
 approvals run decider-less, so under INTERACTIVE mode the only rung that can
 approve a tool here is `ChannelTurn.auto_approve_session`, wired to the
 process-global safety-override grant (see [Approval ladder](#approval-ladder)).
@@ -2894,8 +2915,11 @@ current key — with the session key re-derived afterwards. The turn carries a
 marker the driver leaves inert while still reporting success to the model;
 dashboard-only directives stay refused for a channel turn (`slot=None`,
 fail-closed). The dispatcher runs decider-less (no interactive buttons); an
-`[OPTIONS:]` trailer is stripped. The renderer buffers the complete turn and sends it as one reply on
-`on_done` — no streaming, no edit-in-place.
+`[OPTIONS:]` trailer degrades to a numbered text list through the shared
+`render_options_as_text`. The renderer buffers the complete turn and sends it as
+one reply on `on_done` — no streaming, no edit-in-place. Because nothing is shown
+before `on_done`, an UNFINISHED `[OPTIONS` tail is kept rather than cut: there is
+no partial frame for it to flash in, so it can only be the assistant's own prose.
 
 **Session identity.** A p2p turn keys on `open_id` under the `DIRECT` chat
 type; a group turn keys on the group's `chat_id` under the non-direct

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1382,
+    "missing_code": 1378,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 939,
+  "_compliant": 966,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -43,7 +43,7 @@
       "missing_code": 67
     },
     "dashboard/chat_mirror.py": {
-      "missing_code": 11
+      "missing_code": 7
     },
     "dashboard/chat_nav.py": {
       "missing_code": 3

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -87,12 +87,67 @@ _TERMINAL_BOUND_REASONS = frozenset({"cycle_cap", "runtime_budget", APPROVAL_STA
 # dashboard turn-lifecycle hooks (notify_turn_complete / notify_user_input),
 # so they run on a fixed interval instead of an idle timer: the timer re-arms
 # itself right after every delivered fire.
-_CHANNEL_KEY_PREFIXES = ("slack:", "discord:", "telegram:", "whatsapp:", "unified:")
+#
+# This mirrors ``messaging.link.CHANNEL_SESSION_NAMESPACES``, spelled out here
+# rather than derived from it, for two independent reasons:
+#
+# 1. IMPORT WEIGHT. ``autonudge`` is imported at module scope by ``mcp_core``
+#    (i.e. by every MCP server process) and by the dashboard chat layer, and it
+#    depends only on config/security/platform_compat today. Naming
+#    ``kiro_crew.messaging.link`` runs ``messaging/__init__``, which pulls the
+#    driver/renderer/transport layer and, transitively, the ACP client, agent,
+#    hooks, artifacts, metrics and sqlite — measured at 48 additional
+#    ``kiro_crew`` modules to obtain one tuple of string literals.
+# 2. THIS IS A KEY-SHAPE QUESTION, NOT A LIVE-CAPABILITY ONE. ``is_channel_key``
+#    selects the RE-ARM STRATEGY and the expiry-notification metadata, so it has
+#    to answer identically whether or not the transport happens to be registered
+#    at this instant. Deriving it from a runtime ``supports_proactive_send``
+#    lookup fails toward the WRONG branch: a loop whose transport is momentarily
+#    absent would read as a dashboard slot, so ``_run_fire_cycle`` would stop
+#    self-re-arming it — and nothing else ever will, since
+#    ``notify_turn_complete`` never fires for a channel key — while the expiry
+#    notice would synthesize a ``dashboard:<namespace>:<id>`` jump link pointing
+#    at no slot.
+#
+# Membership therefore does NOT assert deliverability; it asserts "this key names
+# a conversation rather than a chat slot". Whether a nudge can actually be
+# delivered stays with the fail-closed ladder in ``dashboard/chat_runner.py``
+# (``_resolve_channel_target``: governance, then a REGISTERED transport, then
+# ``supports_proactive_send``), which logs its reason and degrades to a no-op.
+# So a namespace is listed even when nothing can currently be delivered to it,
+# and the two clearest cases are both here: ``whatsapp`` has no transport package
+# in this fork at all, and ``feishu`` ships one that declares
+# ``supports_proactive_send=False`` (its renderer only replies to an inbound
+# message id, so a nudge cycle has nowhere to put the answer). Both still classify
+# as channel keys, because the alternative is worse than a refusal: an unlisted key
+# is read as a dashboard slot and silently stops being re-armed, whereas a listed
+# one reaches the ladder and is refused with a logged reason. Being listed is
+# likewise not an arming permission — that is ``binding_key_for``, which is
+# narrower still and gated on an ownership check and a fire route.
+_CHANNEL_KEY_PREFIXES = (
+    "slack:",
+    "discord:",
+    "telegram:",
+    "wecom:",
+    "whatsapp:",
+    "webex:",
+    "teams:",
+    "weixin:",
+    "imessage:",
+    "feishu:",
+    "unified:",
+)
 
 
 def is_channel_key(key: str) -> bool:
     """True when *key* names a messaging-channel session (``slack:<ts>``,
-    ``discord:{agent}:direct:{user}`` ...) rather than a dashboard chat slot."""
+    ``discord:{agent}:direct:{user}`` ...) rather than a dashboard chat slot.
+
+    A CLASSIFICATION, not a permission: see :data:`_CHANNEL_KEY_PREFIXES` for why
+    the set is spelled out, and why membership says nothing about whether a nudge
+    can be delivered. Callers asking "may this session be armed?" want
+    :func:`binding_key_for` instead.
+    """
     return key.startswith(_CHANNEL_KEY_PREFIXES)
 
 
@@ -107,6 +162,18 @@ def binding_key_for(session_key: str) -> str | None:
 
     Single source of truth shared by the ``monitor_start`` MCP tool and the
     workflow ``ctx.nudge`` port so both agree on what "nudge-able" means.
+
+    NARROWER THAN :data:`_CHANNEL_KEY_PREFIXES` ON PURPOSE, and for a different
+    reason than that tuple's own exclusions. ``is_channel_key`` classifies a key's
+    SHAPE; this function answers whether an arm request can be honoured, which
+    additionally requires an ownership check in ``autonudge_authz`` and a fire
+    route in the gateway's ``_fire`` dispatcher — both implemented for ``slack:``
+    and ``discord:`` only. Passing a namespace through ahead of those two would
+    arm a loop that is denied at the chokepoint (or removed on its first fire
+    with "unsupported channel key"), which is strictly worse than refusing it
+    here: a clean "not supported from this session type" instead of a loop that
+    appears to exist and then dies. Widen this set only together with the
+    matching ownership check and fire route.
     """
     if not session_key:
         return None
@@ -675,9 +742,7 @@ class AutoNudgeService:
             # worker thread, and await it so a persistence failure still
             # propagates to the caller before the loop is reported armed.
             payload = self._serialize_state()
-            await asyncio.get_running_loop().run_in_executor(
-                None, self._write_state, payload
-            )
+            await asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
             self._arm_from_deadline(loop)
         self._emit("added", loop)
         logger.info("AutoNudge: added loop %s on slot %s (idle=%ds)", loop.id, slot_key, idle_secs)
@@ -795,11 +860,7 @@ class AutoNudgeService:
                         "reasonless inactive update",
                         loop.id,
                     )
-                elif (
-                    stopped_reason in _TERMINAL_BOUND_REASONS
-                    and not active
-                    and not loop.active
-                ):
+                elif stopped_reason in _TERMINAL_BOUND_REASONS and not active and not loop.active:
                     logger.info(
                         "AutoNudge: loop %s already deactivated (%s) — %s bound "
                         "not overwriting it",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -7163,13 +7163,17 @@ class KiroCrewConfig:
             ),
             wecom=WeComConfig(
                 session_folder=_coerce_session_folder(wecom_data.get("session_folder")),
-                enabled=bool(wecom_data.get("enabled", False)),
+                # _safe_bool, not bool(): `bool("false")` is True, so a JSON string
+                # would read the operator's "off" as "on" -- enabling a channel,
+                # or opening it to every org member, from a config value that says the
+                # opposite. A non-bool must read as the default, not as truthy.
+                enabled=_safe_bool(wecom_data.get("enabled"), False),
                 allowed_users=[
                     u
-                    for u in wecom_data.get("allowed_users", [])
+                    for u in _safe_list(wecom_data.get("allowed_users"))
                     if isinstance(u, dict) and u.get("userid")
                 ],
-                allow_all_users=bool(wecom_data.get("allow_all_users", False)),
+                allow_all_users=_safe_bool(wecom_data.get("allow_all_users"), False),
                 ws_url=str(wecom_data.get("ws_url", "wss://openws.work.weixin.qq.com")),
                 soft_threshold_pct=_threshold_pct(wecom_data.get("soft_threshold_pct"), 80),
                 hard_threshold_pct=_threshold_pct(wecom_data.get("hard_threshold_pct"), 95),

--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -124,7 +124,9 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
     conversation id is never accepted as a send target, so a session's transcript
     can only be anchored into a channel the user has actually configured. The
     target channel's transport must be registered at boot AND
-    ``supports_proactive_send`` — Telegram and WeCom both qualify. WeCom's
+    ``supports_proactive_send``, which every shipped channel declares except
+    Feishu, whose v1 renderer can only reply to an inbound ``message_id``. WeCom
+    shows why that flag is necessary but not sufficient — its
     availability is per-TARGET rather than blanket: ``aibot_send_msg`` needs no
     token, but the platform only delivers into a conversation the user has already
     written to, so ``configured_targets`` lists an allow-listed userid that has
@@ -180,7 +182,13 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         if target is None:
             existing = state.sessions.get_mirror_link(session_key)
             if existing is None:
-                return web.json_response({"error": "channel_type required"}, status=400)
+                # Same condition, and so the same code, as the explicit-body
+                # check below: nothing names a channel. Two sites emitting one
+                # sentence must not carry two different machine contracts.
+                return web.json_response(
+                    {"error": "channel_type required", "code": "channel_type_required"},
+                    status=400,
+                )
             return web.json_response({"error": "mirror channel is not live"}, status=503)
         link, transport = target
         try:
@@ -204,9 +212,13 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         )
 
     if not channel_type:
-        return web.json_response({"error": "channel_type required"}, status=400)
+        return web.json_response(
+            {"error": "channel_type required", "code": "channel_type_required"}, status=400
+        )
     if channel_type == SLACK_NAMESPACE:
-        return web.json_response({"error": "use /slack-link for Slack"}, status=400)
+        return web.json_response(
+            {"error": "use /slack-link for Slack", "code": "use_slack_link"}, status=400
+        )
     if not target_id:
         return web.json_response(
             {"error": "target_id required", "code": "target_id_required"}, status=400
@@ -218,8 +230,14 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
             status=503,
         )
     if not transport.capabilities.supports_proactive_send:
+        # The channel type stays in the advisory prose only. ``code`` is the
+        # stable contract, so it names the CONDITION and never interpolates a
+        # request value a client would have to parse back out.
         return web.json_response(
-            {"error": f"channel '{channel_type}' cannot mirror (no proactive send)"},
+            {
+                "error": f"channel '{channel_type}' cannot mirror (no proactive send)",
+                "code": "channel_not_proactive",
+            },
             status=400,
         )
     session_key = effective_session_key(slot)

--- a/src/kiro_crew/docs/feishu-integration.md
+++ b/src/kiro_crew/docs/feishu-integration.md
@@ -121,8 +121,9 @@ Anything else is a prompt.
 
 Feishu v1 is deliberately single-shot: the agent's answer is buffered and sent
 as **one reply** when the turn completes, rather than streamed. There are no
-interactive buttons, so an `[OPTIONS: …]` trailer is stripped and the choices
-arrive as plain text.
+interactive buttons, so when the agent offers a choice, the `[OPTIONS: …]`
+trailer arrives as a numbered list and you answer by typing one — which is an
+ordinary message, so nothing extra has to be configured.
 
 Known gaps, all follow-up work rather than defects:
 

--- a/src/kiro_crew/docs/weixin-integration.md
+++ b/src/kiro_crew/docs/weixin-integration.md
@@ -53,6 +53,8 @@ the id from the gateway log.
 |---|---|
 | `/new`, `新对话`, `清空` | Start a fresh session |
 | `/compact` | Compact the session context in place |
+| `/stop`, `/cancel`, `停止` | Stop the reply that is currently generating |
+| `/help`, `帮助` | List the commands |
 
 Context length is managed automatically: at `weixin.soft_threshold_pct` (80%) the
 bot suggests `/compact` or `/new`; at `weixin.hard_threshold_pct` (95%) it
@@ -97,7 +99,7 @@ credential store) and overrides `weixin.token`.
 | `errcode -2` | iLink rate limit; the poller backs off automatically |
 | Bot ignores DMs | Check `dm_policy` — under `allowlist` the sender must be listed |
 | Group messages ignored | Expected: iLink bot identities do not receive group events |
-| Images / voice / files ignored | Expected: media is not supported yet (text only) |
+| An image, voice note or file isn't read | The message arrived but the file was skipped — the gateway log shows `attachment_skip` with the reason. Video is never read; send a screenshot instead |
 | Startup error about `aiohttp` | Install the messaging extra |
 
 ## Attribution

--- a/src/kiro_crew/feishu/renderer.py
+++ b/src/kiro_crew/feishu/renderer.py
@@ -4,7 +4,8 @@ Maps the channel-neutral ``OutputEvent`` stream onto a single Feishu REST
 reply anchored to the inbound message_id:
 
 * ``on_turn_start``   -- no-op (no streaming placeholder in v1).
-* ``on_text_chunk``   -- buffers text; trailing ``[OPTIONS:]`` stripped.
+* ``on_text_chunk``   -- buffers text; a trailing ``[OPTIONS:]`` trailer
+  becomes a numbered text list (Feishu renders no tappable chips).
 * ``on_tool_call``    -- updates a transient tool-footer in the buffer.
 * ``on_prompt_choice``-- no-op: Feishu has no interactive buttons in v1
   (the driver only dispatches this for INTERACTIVE + a decider, and
@@ -21,32 +22,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
-from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.messaging.renderer import Renderer, render_options_as_text
 from kiro_crew.messaging.transport import TransportCapabilities
 
 if TYPE_CHECKING:
     from kiro_crew.feishu.client import LarkClient
 
 logger = logging.getLogger(__name__)
-
-# Trailing "[OPTIONS: a | b | c]" chip trailer -- Feishu can't render tappable
-# chips, so we strip it entirely.  Shared with every other surface via
-# constants.py so the ReDoS-hardened grammar never drifts.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
-
-def _strip_options(text: str) -> str:
-    """Remove a trailing ``[OPTIONS: …]`` chip trailer."""
-    m = _OPTIONS_RE.search(text)
-    if m:
-        return text[: m.start()].rstrip()
-    # Also strip a still-streaming partial ``[OPTIONS…`` fragment so raw
-    # markup never flashes to the user.
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip()
-    return text
 
 
 class FeishuRenderer(Renderer):
@@ -148,9 +130,11 @@ class FeishuRenderer(Renderer):
     # -- Helpers ------------------------------------------------------------
 
     def text(self) -> str:
-        """The complete visible answer so far (OPTIONS stripped).
+        """The complete answer so far, with ``[OPTIONS:]`` as numbered text.
 
-        Used both by ``on_done`` (final send) and by the dispatcher to persist
-        the reply to history.
+        This is what ``on_done`` sends. History is persisted separately by
+        ``messaging.dispatch`` from the driver's own accumulated text, so the two
+        are not guaranteed to agree — a difference that only shows up in what the
+        transcript records, never in what the user is shown.
         """
-        return _strip_options("".join(self._buf).strip())
+        return render_options_as_text("".join(self._buf).strip(), self.capabilities)

--- a/src/kiro_crew/imessage/renderer.py
+++ b/src/kiro_crew/imessage/renderer.py
@@ -23,12 +23,11 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.imessage.client import redact_handle
 from kiro_crew.imessage.plaintext import chunk_plaintext, to_plaintext
 from kiro_crew.imessage.rpc import RpcError, RpcTransportError
 from kiro_crew.messaging.display_safety import redact_for_display
-from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.messaging.renderer import Renderer, render_options_as_text
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -44,13 +43,6 @@ _TYPING_THROTTLE_S = 4.0
 
 _ERROR_TEXT = "⚠️ Something went wrong — please try again."
 
-#: Trailing "[OPTIONS: a | b | c]" chip trailer (a dashboard convention with no
-#: iMessage equivalent -- there are no tappable choices). Matched only at the
-#: very END of the message, so use the DOTALL/trailer canonical parser defined
-#: once in constants.py; see OPTIONS_RE_TRAILER for the ReDoS-hardening
-#: rationale.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
 
 def _default_redactor(text: str) -> str:
     """The same pair ``TurnDriver`` streams provider text through.
@@ -63,22 +55,6 @@ def _default_redactor(text: str) -> str:
     out, _ = redact_exfiltration_urls(text or "")
     out, _ = redact_credentials(out)
     return out
-
-
-def _strip_options(text: str) -> str:
-    """Remove a trailing ``[OPTIONS: a | b | c]`` chip trailer.
-
-    iMessage has no tappable chips, so the trailer is dropped entirely -- the
-    user just replies naturally. Also hides a partial ``[OPTIONS...`` fragment
-    (no closing ``]``) so it never lands as raw text.
-    """
-    m = _OPTIONS_RE.search(text)
-    if m:
-        return text[: m.start()].rstrip()
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip()
-    return text
 
 
 class IMessageRenderer(Renderer):
@@ -201,8 +177,8 @@ class IMessageRenderer(Renderer):
 
     # -- helpers ------------------------------------------------------------
     def text(self) -> str:
-        """The turn's visible answer so far, as markdown with OPTIONS stripped."""
-        return _strip_options("".join(self._buf).strip())
+        """The turn's answer as markdown, with ``[OPTIONS:]`` as numbered text."""
+        return render_options_as_text("".join(self._buf).strip(), self.capabilities)
 
     def delivery_text(self) -> str:
         """The answer flattened for a surface that renders no markup.

--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -35,7 +35,10 @@ from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import HOOK_REPLY, TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import DirectiveConsumer, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
-from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
+from kiro_crew.messaging.link import (
+    channel_namespace_of,
+    is_channel_session_key,
+)
 from kiro_crew.messaging.renderer import SilentRenderer
 from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -14,9 +14,10 @@ degrades to a numbered text list the user can answer by typing. The cap is
 ENFORCED (see ``test/test_capability_ledger.py``) and pinned per channel by
 the cross-channel contract test in ``test/test_options_cap_contract.py`` —
 a widget-capable renderer that skips the helper fails that test.
-Channels declaring ``max_buttons=0`` render no widget and today strip the
-trailer entirely; the numbered-text fallback for them lands with the
-approval-ladder work.
+Channels declaring ``max_buttons=0`` render no widget and route the whole
+trailer through :func:`render_options_as_text`, which reaches the same helper
+with zero widget slots: every choice becomes a numbered line the user answers by
+typing, rather than being deleted along with the trailer.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.tables import render_tables, render_tables_with_metadata
 from kiro_crew.messaging.transport import TransportCapabilities
@@ -98,10 +100,11 @@ def cap_choices(
 ) -> tuple[list[str], list[str]]:
     """Split a parsed ``[OPTIONS:]`` list at ``capabilities.max_buttons``.
 
-    Returns ``(kept, overflow)``. ``max_buttons <= 0`` keeps nothing (the
-    zero-widget channels own their trailer handling). Pure — callers that
-    must transform choices before display (Slack redacts at the sink) split
-    here and format overflow themselves via :func:`format_overflow`.
+    Returns ``(kept, overflow)``. ``max_buttons <= 0`` keeps nothing and
+    overflows everything, which is what makes a zero-widget channel the
+    all-overflow case rather than a special case. Pure — callers that must
+    transform choices before display (Slack redacts at the sink) split here and
+    format overflow themselves via :func:`format_overflow`.
     """
     n = capabilities.max_buttons
     if n <= 0:
@@ -201,29 +204,59 @@ def apply_options_cap(
     widget, so the cap lives in shared code and the per-channel contract
     test can pin it.
 
-    Returns ``(body, kept_choices)``:
+    Returns ``(body, kept_choices)``: the first ``max_buttons`` choices are kept
+    for the widget and the remainder is appended to ``body`` as a numbered text
+    list, numbering continued after the widget slots, rather than dropped — so
+    the user still learns those choices exist. A list that fits is a
+    byte-identical pass-through.
 
-    * ``len(choices) <= max_buttons`` — byte-identical pass-through.
-    * overflow — the first ``max_buttons`` choices are kept for the widget;
-      the remainder is appended to ``body`` as a numbered text list
-      (numbering continues after the widget slots) rather than dropped, so
-      the user still learns those choices exist.
-    * ``max_buttons <= 0`` — returns ``(body, [])``; zero-widget channels
-      own their trailer handling (today: strip).
+    ``max_buttons <= 0`` needs no branch of its own: :func:`cap_choices` keeps
+    nothing and overflows everything, so a button-less channel is the
+    all-overflow case and every choice becomes a numbered line through the same
+    sanitising sink. Dropping the list there would delete the answers to a
+    question the agent just asked and leave the user no way to see what was
+    offered.
     """
-    if capabilities.max_buttons <= 0:
-        return body, []
     kept, overflow = cap_choices(choices, capabilities)
     if not overflow:
         return body, kept
     lines = format_overflow(overflow, start=len(kept))
-    if not body:
-        sep = ""
-    elif body.endswith("\n"):
-        sep = "\n"
-    else:
-        sep = "\n\n"
+    sep = "" if not body else ("\n" if body.endswith("\n") else "\n\n")
     return f"{body}{sep}{lines}", kept
+
+
+def render_options_as_text(text: str, capabilities: TransportCapabilities) -> str:
+    """Rewrite a trailing ``[OPTIONS:]`` trailer in *text* as numbered text.
+
+    The whole trailer handling for a channel that renders no widget, so every
+    channel that renders none shares one implementation instead of a copy each.
+    Returns the body only; the widget half of :func:`apply_options_cap` has
+    nothing to keep at ``max_buttons == 0``.
+
+    Only a COMPLETE marker at the very end is recognised, via the shared
+    ``OPTIONS_RE_TRAILER``. Everything else is returned untouched, and both halves
+    of that matter:
+
+    * A quoted ``[OPTIONS:`` mid-answer cannot swallow the body between it and
+      some later ``]`` — the end-of-buffer anchor is what prevents that.
+    * An UNFINISHED ``[OPTIONS`` tail is left alone rather than stripped. It reads
+      like a marker still arriving, but this helper cannot tell a live frame from
+      a sealed answer, and its callers here do not stream at all — they buffer a
+      whole turn and send once — so for them such a tail is simply the assistant's
+      prose and cutting it is permanent data loss. A reply ending
+      ``see the [OPTIONS section`` keeps its last four words. The one zero-widget
+      channel that DOES stream (WeCom) trades the other way and hides the tail,
+      in its own ``wecom.renderer._render_options_as_text``: there the cost is a
+      transient cosmetic flash whose next frame replaces the bubble anyway.
+
+    Stripping a genuine steering frame is ``TurnDriver``'s job and happens before
+    a renderer sees the text.
+    """
+    match = OPTIONS_RE_TRAILER.search(text)
+    if not match:
+        return text
+    choices = [c.strip() for c in match.group(1).split("|") if c.strip()]
+    return apply_options_cap(text[: match.start()].rstrip(), choices, capabilities)[0]
 
 
 class Renderer(ABC):

--- a/src/kiro_crew/messaging/transport.py
+++ b/src/kiro_crew/messaging/transport.py
@@ -69,8 +69,10 @@ class TransportCapabilities:
       stays channel-internal). Widget-capable renderers route the parsed
       list through ``messaging.renderer.apply_options_cap``, which keeps the
       first N for the widget and degrades the remainder to a numbered text
-      list in the body. Channels declaring 0 render no widget (trailer
-      stripped; text fallback arrives with the approval-ladder work).
+      list in the body. Channels declaring 0 render no widget and route the
+      WHOLE list through ``messaging.renderer.render_options_as_text``, which is
+      the same helper with zero widget slots, so every choice arrives as a
+      numbered line rather than being deleted with the trailer.
 
     * ``files_outbound`` — gates whether a renderer pulls local image
       references out of a sealed segment and uploads them. Discord's renderer

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -766,6 +766,22 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "approval prompt) that `whatsapp/turn_renderer.py` puts on the wire.",
     ),
     (
+        "Weixin steer receipts",
+        "weixin/turn_renderer.py",
+        "The in-answer steer chip (`> \u21aa\ufe0f {summary}`). A steer arrives "
+        "separately from the provider stream, so it never passes `TurnDriver`'s "
+        "rolling redactor, and it is interpolated into the message BODY -- which "
+        "the platform markdown-parses, so a credential split by a code span or "
+        "emphasis is whole on screen while a byte-level scan saw it broken. The "
+        "summary therefore goes through the shared DISPLAY-form redactor at the "
+        "point of interpolation: `Renderer.redact_for_target`, which is only the "
+        "`redact_for_display` pass -- it re-scans the markdown-rendered form with "
+        "the credential + exfiltration-URL chain, and deliberately does not repeat "
+        "the driver's rolling stream scan, which a one-shot summary has no split "
+        "chunks to need. The ANSWER text needs no pass here at all: it reaches this "
+        "renderer already redacted by the driver.",
+    ),
+    (
         "Slack render pipeline",
         "slack/format.py",
         "The Slack RENDERING boundary: text that is converted to mrkdwn goes "

--- a/src/kiro_crew/webex/renderer.py
+++ b/src/kiro_crew/webex/renderer.py
@@ -9,8 +9,8 @@ Maps the channel-neutral ``OutputEvent`` stream (routed by the base
   updates spend at most ``_TOOL_EDIT_BUDGET`` edits and the final answer
   always has one left.
 * ``on_text_chunk`` -- buffered only (no typewriter streaming; see the
-  edit cap), with any trailing ``[OPTIONS:]`` markup stripped (Webex has
-  no tappable chips here).
+  edit cap); a trailing ``[OPTIONS:]`` trailer becomes a numbered text list
+  (Webex renders no tappable chips).
 * ``on_prompt_choice`` -- no-op: the driver only dispatches this for
   INTERACTIVE + a decider; Webex runs decider-less (deny-by-default).
 * ``on_compaction`` -- logged only; the dispatcher surfaces threshold
@@ -28,8 +28,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
-from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.messaging.renderer import Renderer, render_options_as_text
 from kiro_crew.messaging.tables import TABLE_POLICY_CARDS
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.webex.client import WEBEX_MAX_TEXT, chunk_utf8
@@ -50,30 +49,6 @@ _STATUS_THROTTLE_S = 2.0
 _THINKING = "🤔 Thinking…"
 
 _ERROR_TEXT = "⚠️ Something went wrong — please try again."
-
-# Trailing "[OPTIONS: a | b | c]" chip trailer (a dashboard convention Webex
-# can't render as tappable chips). Matched only at the very END of the message,
-# so use the DOTALL/trailer canonical parser. Defined once in constants.py
-# (shared with the Slack/dashboard/Discord/Telegram/WeCom surfaces) so the
-# ReDoS-hardened grammar can never drift; see OPTIONS_RE_TRAILER for the full
-# rationale. Per-choice whitespace is stripped by the caller.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
-
-def _strip_options(text: str) -> str:
-    """Remove a trailing ``[OPTIONS: a | b | c]`` chip trailer.
-
-    Webex has no tappable chips, so we drop the trailer entirely -- the user
-    just replies naturally. Also hides a partial ``[OPTIONS…`` fragment (no
-    closing ``]``) so it never lands as raw text.
-    """
-    m = _OPTIONS_RE.search(text)
-    if m:
-        return text[: m.start()].rstrip()
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip()
-    return text
 
 
 class WebexRenderer(Renderer):
@@ -179,7 +154,7 @@ class WebexRenderer(Renderer):
         # Byte-aware, lossless split: Webex caps messages in UTF-8 BYTES, so
         # the neutral character-based chunk_text could hand the client an
         # oversized chunk that gets tail-truncated (silent data loss).
-        chunks = chunk_utf8(content) or ["…"]
+        chunks = chunk_utf8(content, WEBEX_MAX_TEXT) or ["…"]
         first, rest = chunks[0], chunks[1:]
         delivered = False
         if self._placeholder_id is not None:
@@ -217,8 +192,8 @@ class WebexRenderer(Renderer):
 
     # -- helpers ------------------------------------------------------------
     def text(self) -> str:
-        """The turn's visible answer so far (OPTIONS stripped).
+        """The turn's answer so far, with ``[OPTIONS:]`` as numbered text.
 
         Used both for the final message and to persist the reply to history.
         """
-        return _strip_options("".join(self._buf).strip())
+        return render_options_as_text("".join(self._buf).strip(), self.capabilities)

--- a/src/kiro_crew/webex/transport.py
+++ b/src/kiro_crew/webex/transport.py
@@ -41,9 +41,9 @@ logger = logging.getLogger(__name__)
 DispatchFn = Callable[[WebexInbound], Awaitable[None]]
 
 # Webex capabilities: no streaming (10-edit cap per message), but edits exist
-# (budgeted status placeholder), no tappable chips (max_buttons=0 records the
-# fact; the renderer's [OPTIONS:] drop is unconditional and does not read it),
-# and proactive send is fine (a bot may post to a room / person at any time).
+# (budgeted status placeholder), no tappable chips (max_buttons=0, so the
+# renderer routes [OPTIONS:] through the shared numbered-text fallback), and
+# proactive send is fine (a bot may post to a room / person at any time).
 #
 # max_message_chars is a CHARACTER count, but Webex caps messages in UTF-8
 # BYTES (WEBEX_MAX_TEXT = 7000 bytes; see chunk_utf8's docstring on why the

--- a/src/kiro_crew/weixin/commands.py
+++ b/src/kiro_crew/weixin/commands.py
@@ -1,8 +1,7 @@
 """Weixin command parsing.
 
-Commands:
-  /new (or 新对话 / 清空)  — start a fresh session (advances the generation counter)
-  /compact               — trigger context compaction
+The vocabulary is DATA — :data:`COMMANDS` — and both the matcher and the
+`/help` card read it, so a command cannot be added without appearing in help.
 
 Per-conversation generation + awaiting-compact state lives in the shared
 ``messaging.conversation.ConversationState`` (re-exported so callers can import
@@ -11,18 +10,101 @@ it from this module, mirroring ``wecom.commands``).
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from kiro_crew.messaging.conversation import ConversationState  # noqa: F401
 
-_NEW_ALIASES = frozenset(("/new", "新对话", "清空"))
-_COMPACT_ALIASES = frozenset(("/compact",))
+#: Weixin's command vocabulary. No `/link` row: iLink is DM-only and the channel
+#: has no dashboard-mirror command, so listing one would advertise a capability
+#: that does not exist here.
+# ── Command grammar ───────────────────────────────────────────────────────────
+# Kept LOCAL rather than shared. WeCom grew its own ``build_help_text`` in #5105,
+# so Weixin is the only caller these three would have, and a shared module with one
+# consumer is a guess about the second. The day a second channel wants this table
+# shape, this is the block to move -- with two callers to shape it, instead of one.
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """One command: its canonical name, what it does, and how it is spelled.
+
+    ``name`` is the value a dispatcher switches on; the displayed form adds the
+    ``/``. ``aliases`` are EXTRA spellings beyond ``f"/{name}"``, which is always
+    accepted: native-language words (`新对话`), and short forms (`cancel` for
+    `stop`).
+    """
+
+    name: str
+    help_text: str
+    aliases: tuple[str, ...] = field(default=())
+
+
+def match_command(text: str, specs: tuple[CommandSpec, ...]) -> str | None:
+    """Return the ``name`` of the command *text* invokes, else ``None``.
+
+    Matching is EXACT against the whole stripped message, so a message that
+    merely begins with a command word stays ordinary prose the model answers.
+    ``f"/{name}"`` is matched case-insensitively (a phone keyboard capitalises),
+    while a non-ASCII alias is compared as written because casing is meaningless
+    for it and ``str.lower()`` on some scripts is not a no-op.
+
+    The ``/`` is hardcoded because both adopters use it. Discord prefixes with
+    ``!`` (its client swallows a bare ``/``) but does not consume this module; the
+    day it migrates is the day a prefix parameter earns its place.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+    lowered = stripped.lower()
+    for spec in specs:
+        if lowered == f"/{spec.name}":
+            return spec.name
+        for alias in spec.aliases:
+            if stripped == alias or lowered == alias.lower():
+                return spec.name
+    return None
+
+
+def build_help_text(header: str, specs: tuple[CommandSpec, ...], footer: str = "") -> str:
+    """Render a help card from *specs*.
+
+    Aliases are shown beside their command, because a user who was taught `新对话`
+    needs to see it is the same thing as `/new` rather than discovering two
+    commands. The caller puts anything else it needs to explain into *footer*.
+    """
+    lines = [header, ""]
+    for spec in specs:
+        spelled = f"/{spec.name}"
+        if spec.aliases:
+            spelled += " (" + " / ".join(spec.aliases) + ")"
+        lines.append(f"{spelled} — {spec.help_text}")
+    if footer:
+        lines += ["", footer]
+    return "\n".join(lines)
+
+
+# Named ``COMMANDS`` (not ``COMMAND_SPEC``) because the shared cancel-drift
+# tripwire in ``test/test_messaging_dispatch.py`` discovers a channel's table by
+# EXPORT NAME: ``COMMAND_SPEC`` is its ``(canonical, aliases, description)``
+# 3-tuple shape (teams), while ``COMMANDS`` is its dataclass-row shape carrying
+# ``.name``/``.aliases`` (whatsapp), which is what these rows are. Exporting
+# dataclass rows as ``COMMAND_SPEC`` makes that tripwire call ``len()`` on one.
+COMMANDS: tuple[CommandSpec, ...] = (
+    CommandSpec("new", "开始新对话", aliases=("新对话", "清空")),
+    CommandSpec("compact", "压缩上下文，腾出空间"),
+    CommandSpec("stop", "停止当前回复", aliases=("/cancel", "停止")),
+    CommandSpec("help", "显示命令列表", aliases=("帮助",)),
+)
+
+_HELP_HEADER = "🦞 Kiro Crew — 微信"
+_HELP_FOOTER = "直接发消息即可对话。较长的回复会分成多条消息。"
+
+
+def build_help() -> str:
+    """The `/help` card, rendered from :data:`COMMANDS`."""
+    return build_help_text(_HELP_HEADER, COMMANDS, _HELP_FOOTER)
 
 
 def parse_command(text: str) -> str | None:
-    """Return 'new', 'compact', or None."""
-    stripped = (text or "").strip()
-    lower = stripped.lower()
-    if lower in _NEW_ALIASES or stripped in _NEW_ALIASES:
-        return "new"
-    if lower in _COMPACT_ALIASES:
-        return "compact"
-    return None
+    """Return the command name *text* invokes, else ``None``."""
+    return match_command(text, COMMANDS)

--- a/src/kiro_crew/weixin/transport.py
+++ b/src/kiro_crew/weixin/transport.py
@@ -13,9 +13,10 @@ authorizes nobody.
 SCAFFOLD NOTES / TODO:
   * Inbound media (image/voice/file) IS decrypted and ingested -- see
     ``weixin/media.py`` (CDN + AES-128-ECB) and ``weixin/attachments.py``
-    (shared ingest adapter). Inbound VIDEO is downloaded-then-rejected by the
-    shared pipeline with a visible note; outbound media is still unimplemented
-    (``getuploadurl`` + encrypted CDN PUT).
+    (shared ingest adapter). Inbound VIDEO is rejected with a visible note
+    BEFORE any download (``messaging/attachments.py`` classifies and refuses it
+    ahead of the fetch), so it costs no CDN round trip; outbound media is still
+    unimplemented (``getuploadurl`` + encrypted CDN PUT).
   * Outbound chunking uses a naive splitter; swap for ``renderer`` once the
     Markdown block splitter lands.
   * Group delivery is intentionally unsupported for now (iLink bot identities

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -47,7 +47,7 @@ from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.safety_override import safety_override
 from kiro_crew.weixin.attachments import process_weixin_attachments
-from kiro_crew.weixin.commands import ConversationState, parse_command
+from kiro_crew.weixin.commands import ConversationState, build_help, parse_command
 from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
 from kiro_crew.weixin.turn_renderer import WeixinRenderer
 
@@ -64,6 +64,31 @@ logger = logging.getLogger(__name__)
 # (spawn_run etc.) instead of kiro-cli's bare built-in default. Mirrors the
 # Slack / Telegram / WeCom paths.
 _DEFAULT_KIROCREW_AGENT = "kirocrew"
+
+# ── Bot-facing strings, owned here rather than inline at each send ──
+# One block so the channel's whole voice is visible at once and a wording change
+# is one edit. These are CHINESE because iLink addresses WeChat users in it;
+# backend-owned strings have no catalog path yet (AGENTS.md), so the owning module
+# is the unit of ownership.
+_ATTACHMENT_WITH_COMMAND = "📎 附件未读取：这条是命令消息，请把附件单独发送。"
+_NEW_SESSION = "✅ 已开始新对话"
+# Three states, not two. The cancel is COOPERATIVE: the ack goes out after only
+# writing session/cancel, so the turn stops at its next safe point and the bubble
+# may still move for a moment -- "正在停止" is what the user will actually observe.
+# And a busy session whose cancel FAILED must not be told nothing was running: that
+# is the case /stop exists for, and cancel failures cluster on exactly those turns.
+_STOPPING = "⏹ 正在停止当前回复…"
+_STOP_FAILED = "⚠️ 停止失败，请重试。"
+_NOTHING_RUNNING = "ℹ️ 当前没有正在生成的回复。"
+_RESEND_AFTER_TURN = "⏳ 上一条消息还在处理中，附件无法在这轮读取，请等回复结束后重新发送。"
+_STEER_MERGED = "⏳ 已合并到当前回复"
+_STEER_UNAVAILABLE = "⏳ 正在处理上一条，请稍后重发"
+_AUTO_COMPACTED = "🗜️ 上下文接近上限，已自动压缩。"
+_SOFT_THRESHOLD = "⚠️ 对话上下文已较长，回复 /compact 压缩，或 /new 开始新对话。"
+_COMPACT_BUSY = "⏳ 正在处理上一条消息，请稍后再试 /compact。"
+_COMPACT_NOTHING = "ℹ️ 当前没有可压缩的对话。"
+_COMPACT_DONE = "🗜️ 已压缩上下文。"
+_COMPACT_FAILED = "⚠️ 压缩失败，请重试。"
 
 
 class WeixinDispatcher:
@@ -124,10 +149,18 @@ class WeixinDispatcher:
         cmd = parse_command(text)
         if cmd is not None:
             if inbound.attachments:
-                await self._say(user_id, "📎 附件未读取：这条是命令消息，请把附件单独发送。")
+                await self._say(user_id, _ATTACHMENT_WITH_COMMAND)
             if cmd == "new":
                 self._conv.bump_gen(user_id)
-                await self._say(user_id, "✅ 已开始新对话")
+                await self._say(user_id, _NEW_SESSION)
+                return
+            if cmd == "help":
+                await self._say(user_id, build_help())
+                return
+            if cmd == "stop":
+                # Before any turn dispatch: /stop is the one message that must not
+                # be folded into the running turn it exists to abort.
+                await self._handle_stop(user_id)
                 return
             self._conv.clear_awaiting(user_id)
             await self._handle_compact(user_id)
@@ -144,9 +177,7 @@ class WeixinDispatcher:
         # still reaches the turn via steer.
         attachment_temp_paths: list[str] = []
         if inbound.attachments:
-            ingested, attachment_temp_paths = await self._ingest_or_refuse(
-                inbound, user_id, text
-            )
+            ingested, attachment_temp_paths = await self._ingest_or_refuse(inbound, user_id, text)
             if ingested is None:
                 return
             text = ingested
@@ -206,10 +237,7 @@ class WeixinDispatcher:
 
     async def _say_resend_after_turn(self, user_id: str) -> None:
         """Tell a mid-turn sender their attachment needs resending."""
-        await self._say(
-            user_id,
-            "⏳ 上一条消息还在处理中，附件无法在这轮读取，请等回复结束后重新发送。",
-        )
+        await self._say(user_id, _RESEND_AFTER_TURN)
 
     async def _drive(self, inbound: InboundMessage, user_id: str, text: str) -> None:
         """Session acquisition + turn dispatch for one already-ingested message."""
@@ -310,11 +338,60 @@ class WeixinDispatcher:
             and await steer(inbound.text)
         )
         if steered:
-            await self._say(inbound.user_id, "⏳ 已合并到当前回复")
+            await self._say(inbound.user_id, _STEER_MERGED)
         else:
-            await self._say(inbound.user_id, "⏳ 正在处理上一条，请稍后重发")
+            await self._say(inbound.user_id, _STEER_UNAVAILABLE)
 
     # ── Helpers ────────────────────────────────────────────────────────────
+
+    async def _handle_stop(self, user_id: str) -> None:
+        """Hard cancel: abort the in-flight turn for this conversation.
+
+        Cooperative before it is fatal -- ``cancel(wait_ack_timeout=0)`` writes
+        the ACP ``session/cancel`` notification and returns, so the ack to the
+        user is immediate and the turn stops at its next safe point. Waiting here
+        would hold the reply behind the very turn being stopped.
+
+        The semaphore is deliberately NOT touched: ``drive_turn``'s ``finally``
+        owns the release, and releasing one this method never acquired would free
+        the session while its turn is still unwinding.
+        """
+        session_key = self._session_key(user_id)
+        # Three states. A busy session whose cancel could not run must NOT be told
+        # nothing was running -- that is the wedged turn /stop exists for, and the
+        # is_busy check one line up already proved otherwise.
+        ack = _NOTHING_RUNNING
+        if self.sessions.is_busy(session_key):
+            # Branch on the RETURNED outcome, not on whether the call raised.
+            # ``cancel`` is typed ``CancelOutcome`` and swallows its own failures --
+            # ``AcpRuntimeDead`` and any other exception come back as ``"error"``
+            # rather than propagating -- so a try/except alone reports "stopping"
+            # for a cancel that never happened, which is the same lie as telling
+            # someone watching a live reply that nothing is running.
+            ack = _STOP_FAILED
+            provider = self.sessions.get_provider(session_key)
+            cancel = getattr(provider, "cancel", None)
+            if cancel is not None:
+                try:
+                    outcome = await cancel(wait_ack_timeout=0)
+                except Exception:
+                    # A provider that raises instead of returning an outcome (the
+                    # contract allows either shape to reach here) stays a failure.
+                    logger.warning("weixin /stop: cancel failed for %s", session_key, exc_info=True)
+                else:
+                    if outcome in ("acked", "timeout"):
+                        # timeout means the cancel WAS written and the ack has not
+                        # landed yet, which is what "正在停止" already describes.
+                        ack = _STOPPING
+                    elif outcome == "no_turn":
+                        # The provider disagrees with is_busy: the turn finished in
+                        # between. Nothing is running, and saying so is accurate.
+                        ack = _NOTHING_RUNNING
+                    else:
+                        logger.warning(
+                            "weixin /stop: cancel returned %r for %s", outcome, session_key
+                        )
+        await self._say(user_id, ack)
 
     async def _say(self, user_id: str, text: str) -> None:
         """One-shot out-of-band message (command ack / notice)."""
@@ -390,12 +467,12 @@ class WeixinDispatcher:
             try:
                 await provider.compact()
                 await provider.wait_for_compaction()
-                await self._say(user_id, "🗜️ 上下文接近上限，已自动压缩。")
+                await self._say(user_id, _AUTO_COMPACTED)
             except Exception:
                 logger.debug("weixin hard-threshold compaction failed", exc_info=True)
         elif pct >= soft and not self._conv.is_awaiting(user_id):
             self._conv.set_awaiting(user_id)
-            await self._say(user_id, "⚠️ 对话上下文已较长，回复 /compact 压缩，或 /new 开始新对话。")
+            await self._say(user_id, _SOFT_THRESHOLD)
 
     async def _handle_compact(self, user_id: str) -> None:
         """In-place ACP ``/compact`` on the user's current session."""
@@ -404,20 +481,20 @@ class WeixinDispatcher:
         # turn is mutating the same session races the transcript.
         if not await self.sessions.try_acquire(session_key):
             if self.sessions.has_session(session_key):
-                await self._say(user_id, "⏳ 正在处理上一条消息，请稍后再试 /compact。")
+                await self._say(user_id, _COMPACT_BUSY)
             else:
-                await self._say(user_id, "ℹ️ 当前没有可压缩的对话。")
+                await self._say(user_id, _COMPACT_NOTHING)
             return
         try:
             provider = self.sessions.get_provider(session_key)
             if provider is None:
-                await self._say(user_id, "ℹ️ 当前没有可压缩的对话。")
+                await self._say(user_id, _COMPACT_NOTHING)
                 return
             await provider.compact()
             await provider.wait_for_compaction()
-            await self._say(user_id, "🗜️ 已压缩上下文。")
+            await self._say(user_id, _COMPACT_DONE)
         except Exception:
             logger.exception("weixin /compact failed for %s", session_key)
-            await self._say(user_id, "⚠️ 压缩失败，请重试。")
+            await self._say(user_id, _COMPACT_FAILED)
         finally:
             self.sessions.release(session_key)

--- a/src/kiro_crew/weixin/turn_renderer.py
+++ b/src/kiro_crew/weixin/turn_renderer.py
@@ -17,8 +17,7 @@ import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
-from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.messaging.renderer import Renderer, render_options_as_text
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.weixin.client import TYPING_START, TYPING_STOP
 from kiro_crew.weixin.renderer import render_chunks
@@ -33,21 +32,7 @@ _CHUNK_DELAY_S = 0.3
 # Refresh the typing indicator on this cadence; iLink expires it on its own.
 _TYPING_REFRESH_S = 8.0
 
-# Trailing "[OPTIONS: a | b | c]" chip trailer (a dashboard convention iLink
-# can't render as tappable chips). Matched only at the very END of the message
-# via the canonical trailer parser, defined once in constants.py and shared with
-# the Slack/dashboard/Discord/Telegram/WeCom/Webex/Teams surfaces so the
-# ReDoS-hardened grammar can never drift. A hand-rolled MULTILINE|DOTALL variant
-# is unsafe here: `.*?` spans newlines, so a quoted "[OPTIONS:" earlier in a
-# reply could match a "]" far below it and silently delete everything between.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
 _ERROR_TEXT = "⚠️ 出错了，请重试"
-
-
-def _strip_options(text: str) -> str:
-    """Drop the dashboard-only [OPTIONS: …] affordance — iLink has no buttons."""
-    return _OPTIONS_RE.sub("", text).strip()
 
 
 class WeixinRenderer(Renderer):
@@ -79,6 +64,8 @@ class WeixinRenderer(Renderer):
         self._typing = typing_cache
         self._session_key = session_key
         self._buf: list[str] = []
+        # Steer chip awaiting the text it heads (see on_steer_consumed).
+        self._pending_chip = ""
         self._started = False
         self._finalized = False
         self._typing_task: asyncio.Task[None] | None = None
@@ -91,7 +78,38 @@ class WeixinRenderer(Renderer):
         self._typing_task = asyncio.create_task(self._hold_typing())
 
     async def on_text_chunk(self, text: str) -> None:
+        self._materialize_chip()
         self._buf.append(text)
+
+    async def on_steer_consumed(self, summary: str = "") -> None:
+        """Record that kiro-cli folded a mid-turn steer, for an in-answer receipt.
+
+        The dispatcher already acked the steer out of band, but that ack is its own
+        message: the answer itself showed no sign of where the fold happened, so a
+        reader could not tell which half answered what. iLink cannot edit or rotate
+        a message, so the boundary is marked inline with a quote chip.
+
+        Materialized LAZILY, on the next text chunk. A steer folded at the very end
+        of a stream (the answer already covered it) would otherwise leave a chip
+        with nothing under it, and the out-of-band ack is receipt enough.
+        """
+        self._pending_chip = (summary or "").strip()
+
+    def _materialize_chip(self) -> None:
+        """Emit the pending steer chip, once, ahead of the text that follows it.
+
+        The summary is redacted in DISPLAY form, not merely inherited from the
+        driver's raw-stream scan. It lands in the message BODY, which the platform
+        markdown-parses, so a credential split by a code span or emphasis is whole
+        on screen while the byte-level scan saw it broken -- the same reassembly
+        hazard ``format_overflow`` redacts LLM-authored choice text for. A steer is
+        untrusted text arriving mid-turn, so it gets the same sink.
+        """
+        if not self._pending_chip:
+            return
+        prefix = "\n\n" if self._buf else ""
+        self._buf.append(f"{prefix}> ↪️ {self.redact_for_target(self._pending_chip)}\n\n")
+        self._pending_chip = ""
 
     async def on_thinking(self, text: str) -> None:
         # iLink surfaces one bubble per turn; reasoning would double the noise.
@@ -148,8 +166,8 @@ class WeixinRenderer(Renderer):
 
     # -- helpers ------------------------------------------------------------
     def text(self) -> str:
-        """The turn's visible answer (OPTIONS stripped). Also persisted to history."""
-        return _strip_options("".join(self._buf).strip())
+        """The turn's answer, with ``[OPTIONS:]`` as numbered text. Also persisted."""
+        return render_options_as_text("".join(self._buf).strip(), self.capabilities)
 
     async def _send(self, body: str) -> None:
         """Deliver the answer as one or more chat messages.
@@ -217,9 +235,7 @@ class WeixinRenderer(Renderer):
                     self._typing.set(self._to, ticket)
             if not ticket:
                 return
-            await self._client.send_typing(
-                to_user_id=self._to, typing_ticket=ticket, status=status
-            )
+            await self._client.send_typing(to_user_id=self._to, typing_ticket=ticket, status=status)
         except Exception:
             # Typing is cosmetic — never let it break a turn.
             logger.debug("weixin: typing signal failed", exc_info=True)

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -266,9 +266,7 @@ async def test_runtime_budget_unspent_fires_normally(svc, monkeypatch):
     events: list[str] = []
     svc.subscribe(lambda ev, lp: events.append(ev))
     await svc.start()
-    loop = await svc.add(
-        slot_key="chat-1-123", message="go", idle_secs=15, max_runtime_secs=86400
-    )
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=15, max_runtime_secs=86400)
     await svc._timers[loop.id]
     assert len(fired) == 1
     assert "expired" not in events
@@ -309,9 +307,7 @@ async def test_runtime_budget_persists_across_restart(tmp_path):
     both max_runtime_secs and the created_ts anchor round-trip the store."""
     svc1 = AutoNudgeService(base_dir=tmp_path)
     await svc1.start()
-    loop = await svc1.add(
-        slot_key="chat-1-123", message="go", idle_secs=15, max_runtime_secs=3600
-    )
+    loop = await svc1.add(slot_key="chat-1-123", message="go", idle_secs=15, max_runtime_secs=3600)
     created = svc1._loops[loop.id].created_ts
     svc1.stop()
 
@@ -373,9 +369,9 @@ async def test_bound_deactivation_never_overwrites_a_manual_pause(svc):
     assert svc._loops[loop.id].stopped_reason == "manual"
     # The timer's shielded update arrives second with the bound tag.
     await svc.update(loop.id, active=False, stopped_reason="runtime_budget")
-    assert svc._loops[loop.id].stopped_reason == "manual", (
-        "a terminal bound must never overwrite an existing deactivation"
-    )
+    assert (
+        svc._loops[loop.id].stopped_reason == "manual"
+    ), "a terminal bound must never overwrite an existing deactivation"
     assert svc._loops[loop.id].active is False
     svc.stop()
 
@@ -838,6 +834,203 @@ def test_is_channel_key():
     # Fully-qualified dashboard keys never appear as binding keys, but must
     # not be misclassified either.
     assert not is_channel_key("dashboard:chat-1-123")
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "telegram:kirocrew:direct:4242",
+        "webex:kirocrew:direct:user@example.com",
+        "teams:kirocrew:direct:29:1abcdef",
+        "weixin:kirocrew:direct:oUserOpenId",
+        "imessage:kirocrew:direct:+15550100",
+    ],
+)
+def test_proactive_channel_namespaces_are_channel_keys(key):
+    """Every transport that CAN send unattended classifies as a channel session.
+
+    ``is_channel_key`` selects the re-arm strategy and the expiry-notification
+    metadata: a channel loop self-re-arms, while a dashboard loop waits for
+    ``notify_turn_complete``, which never fires for a channel key. Leaving
+    webex/teams/weixin/imessage out therefore made those sessions structurally
+    unrunnable rather than merely unsupported — misread as dashboard slots they
+    would stall with no armed timer and carry a ``dashboard:<namespace>:<id>``
+    jump link pointing at no slot — even though each of those transports declares
+    ``supports_proactive_send=True``.
+    """
+    from kiro_crew.autonudge import is_channel_key
+
+    assert is_channel_key(key)
+
+
+def test_wecom_is_classified_because_it_gained_a_proactive_send_path():
+    """The classifier and the capability are asserted TOGETHER so they cannot drift.
+
+    WeCom was excluded while its reply was bound to the inbound request's own reply
+    token: a nudge cycle there would wake, spend a turn and have nowhere to put the
+    answer. #5105 gave the channel a proactive path over its long connection and
+    flipped the capability, so the exclusion's own stated condition fired and the
+    namespace is now classified like every other channel.
+
+    Keeping both halves in one test is the point. Either alone can go stale
+    silently: a classifier entry for a channel that cannot send unattended arms
+    loops with nowhere to deliver, and a flipped capability with no entry leaves a
+    channel that CAN be nudged unreachable.
+    """
+    from kiro_crew.autonudge import is_channel_key
+    from kiro_crew.wecom.transport import WECOM_CAPABILITIES
+
+    assert WECOM_CAPABILITIES.supports_proactive_send is True
+    assert is_channel_key("wecom:kirocrew:direct:oUserOpenId")
+
+
+def test_channel_key_prefixes_mirror_the_shipped_namespaces():
+    """The tuple is spelled out in ``autonudge``, so pin it against drift.
+
+    Deriving it would make ``autonudge`` — imported at module scope by
+    ``mcp_core`` (every MCP server process) and by the dashboard chat layer —
+    name ``kiro_crew.messaging.link``, whose package ``__init__`` pulls the
+    driver/renderer/transport layer and with it the ACP client, agent, hooks,
+    artifacts, metrics and sqlite: 48 extra ``kiro_crew`` modules to obtain one
+    tuple of string literals. This assertion buys the drift protection that
+    import would have bought, at no import cost.
+
+    Equality, not containment: a namespace added to ``CHANNEL_SESSION_NAMESPACES``
+    must be classified here too, with no escape hatch for "excluded on purpose".
+    The exclusion that looks tempting — a channel nothing can currently deliver a
+    nudge to — is precisely the misclassification this guards against, because an
+    unlisted key reads as a dashboard slot and stops being re-armed silently.
+    Undeliverability belongs to the ladder; see ``_CHANNEL_KEY_PREFIXES``.
+    """
+    from kiro_crew.autonudge import _CHANNEL_KEY_PREFIXES
+    from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES
+
+    assert {p.rstrip(":") for p in _CHANNEL_KEY_PREFIXES} == set(CHANNEL_SESSION_NAMESPACES)
+
+
+@pytest.mark.asyncio
+async def test_unrouted_channel_namespace_degrades_instead_of_raising(svc, monkeypatch):
+    """A classified namespace with no fire route degrades; it never raises.
+
+    ``whatsapp`` is in the prefix tuple but has no transport package in this fork
+    at all, so the gateway's ``_fire`` dispatcher reaches its "unsupported channel
+    key" arm: it logs the reason, removes the loop and returns False. The service
+    must treat that as a TERMINAL non-delivery — no backoff re-arm, no
+    resurrection, no exception escaping the timer — so classifying a namespace can
+    never turn an undeliverable session into a loop that hot-polls forever.
+    """
+    import asyncio as _asyncio
+
+    import kiro_crew.autonudge as _an
+
+    real_sleep = _asyncio.sleep  # capture before patching
+    sleep_calls: list[float] = []
+
+    async def _sleep(secs):
+        sleep_calls.append(secs)
+        return None
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _sleep)
+
+    removed = _asyncio.Event()
+
+    async def on_fire_unsupported(loop):
+        # Mirrors slack/gateway.py::_fire's else-branch for a channel key with
+        # no implemented fire route.
+        await svc.remove(loop.id)
+        removed.set()
+        return False
+
+    svc._on_fire = on_fire_unsupported
+    await svc.start()
+    loop = await svc.add(
+        slot_key="whatsapp:kirocrew:direct:15550100", message="watch", idle_secs=60
+    )
+    for _ in range(500):
+        if removed.is_set() and loop.id not in svc._timers:
+            break
+        await real_sleep(0.005)
+    assert loop.id not in svc._loops
+    assert loop.id not in svc._timers
+    assert loop.id not in svc._rearm_fail_count
+    # Only the initial idle sleep ran — no backoff re-arm was scheduled.
+    assert sleep_calls == [pytest.approx(60, abs=1)]
+    svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_cross_surface_ladder_still_refuses_unroutable_channels(tmp_path):
+    """The delivery ladder, not the key classifier, is the enforcement point.
+
+    Membership in ``_CHANNEL_KEY_PREFIXES`` asserts "this key names a
+    conversation", never "a send will succeed", so the fail-closed ladder in
+    ``dashboard/chat_runner.py`` (``_resolve_channel_target``: governance → a
+    REGISTERED transport → ``supports_proactive_send``) has to keep refusing on
+    its own. Both of its transport arms are pinned here: a namespace with no
+    registered transport (``whatsapp``) and a registered transport that declares
+    no proactive send (a SYNTHETIC capability — every shipped channel now declares
+    True, and the arm still has to refuse). Each logs its reason and degrades to a
+    no-op rather than raising into the turn.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from chat_test_helpers import _make_state
+
+    from kiro_crew.dashboard.chat_runner import _deliver_cross_surface_reply
+    from kiro_crew.messaging.link import ChannelLink
+    from kiro_crew.messaging.transport import TransportCapabilities
+
+    state = _make_state(tmp_path)
+
+    # (a) Nothing registered for the namespace — the ladder's transport arm.
+    state.sessions.get_mirror_link = MagicMock(
+        return_value=ChannelLink("whatsapp", channel_id="15550100", thread_id=None)
+    )
+    assert state.get_channel_transport("whatsapp") is None
+    await _deliver_cross_surface_reply(state, "whatsapp:kirocrew:direct:15550100", "cycle 1 output")
+
+    # (b) Registered, but declaring no unattended send — the
+    # ``supports_proactive_send`` arm. SYNTHETIC on purpose: every shipped channel
+    # declares True now, and this arm must keep refusing regardless, or a future
+    # transport that cannot send unattended would be handed a nudge to deliver.
+    bound = SimpleNamespace(
+        channel_type="telegram",
+        capabilities=TransportCapabilities(supports_proactive_send=False),
+        send_message=AsyncMock(return_value="mid-1"),
+    )
+    state.register_channel_transport(bound)
+    state.sessions.get_mirror_link = MagicMock(
+        return_value=ChannelLink("telegram", channel_id="4242", thread_id=None)
+    )
+    await _deliver_cross_surface_reply(state, "telegram:kirocrew:direct:4242", "cycle 1 output")
+    bound.send_message.assert_not_awaited()
+
+
+def test_binding_key_for_does_not_widen_with_the_classifier():
+    """Classifying a namespace must NOT make it armable ahead of its arm path.
+
+    ``binding_key_for`` is the "may this session be armed?" answer, and honouring
+    it additionally needs an ownership check in ``autonudge_authz`` and a fire
+    route in the gateway's ``_fire`` dispatcher — both implemented for ``slack:``
+    and ``discord:`` only. Passing weixin/webex/teams/imessage through here ahead
+    of those two would arm a loop that the chokepoint denies (or that is removed
+    on its first fire), which is strictly worse than the clean "not supported from
+    this session type" refusal it replaces.
+    """
+    from kiro_crew.autonudge import binding_key_for, is_channel_key
+
+    for key in (
+        "weixin:kirocrew:direct:oUserOpenId",
+        "webex:kirocrew:direct:user@example.com",
+        "teams:kirocrew:direct:29:1abcdef",
+        "imessage:kirocrew:direct:+15550100",
+    ):
+        assert is_channel_key(key)
+        assert binding_key_for(key) is None
+    # The two namespaces that DO have both halves still pass through.
+    assert binding_key_for("slack:1700000000.123456") == "slack:1700000000.123456"
+    assert binding_key_for("discord:kirocrew:direct:42") == "discord:kirocrew:direct:42"
 
 
 @pytest.mark.asyncio
@@ -1603,8 +1796,8 @@ class TestAutonudgeUpdateConcurrency:
             timer = svc._timers[loop_obj.id]
             await asyncio.sleep(0.15)  # delivered; parked inside the persist
             assert loop_obj.id in svc._firing
-            svc.notify_turn_complete("chat-9-7")   # queues a deferred re-arm
-            svc.notify_user_input("chat-9-7")      # user takes priority
+            svc.notify_turn_complete("chat-9-7")  # queues a deferred re-arm
+            svc.notify_user_input("chat-9-7")  # user takes priority
             assert not timer.cancelled(), "user input cancelled the firing task"
             gate.set()
             await asyncio.wait_for(asyncio.shield(timer), timeout=5)
@@ -1657,9 +1850,7 @@ class TestAutonudgeUpdateConcurrency:
         svc = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
         await svc.start()
         try:
-            loop_obj = await svc.add(
-                slot_key="slack:1700000000.1", message="go", idle_secs=15
-            )
+            loop_obj = await svc.add(slot_key="slack:1700000000.1", message="go", idle_secs=15)
             # Re-arm with a zero delay so exactly ONE fire starts promptly; the
             # channel self-re-arm afterwards uses the real 15s idle gap, so the
             # test observes a single, deterministic fire window.
@@ -1895,10 +2086,18 @@ class TestSentinelPathRepair:
                 {
                     "version": 1,
                     "loops": [
-                        {"id": "bad", "slot_key": "chat-1-1", "message": "m",
-                         "stop_sentinel_path": 12345},
-                        {"id": "good", "slot_key": "chat-2-2", "message": "m",
-                         "stop_sentinel_path": str(current / "workspace" / ".stop-ok")},
+                        {
+                            "id": "bad",
+                            "slot_key": "chat-1-1",
+                            "message": "m",
+                            "stop_sentinel_path": 12345,
+                        },
+                        {
+                            "id": "good",
+                            "slot_key": "chat-2-2",
+                            "message": "m",
+                            "stop_sentinel_path": str(current / "workspace" / ".stop-ok"),
+                        },
                     ],
                 }
             ),
@@ -2084,9 +2283,7 @@ class TestPersistenceIsOffLoopAndOrdered:
     @pytest.mark.asyncio
     async def test_remove_persists_off_the_loop(self, tmp_path):
         svc = AutoNudgeService(base_dir=tmp_path)
-        loop = await svc.add(
-            slot_key="dashboard:x", message="go", idle_secs=60, max_cycles=1
-        )
+        loop = await svc.add(slot_key="dashboard:x", message="go", idle_secs=60, max_cycles=1)
 
         writes: list[str] = []
         real_write = svc._write_state
@@ -2109,9 +2306,7 @@ class TestPersistenceIsOffLoopAndOrdered:
     @pytest.mark.asyncio
     async def test_cancelled_removal_holds_the_lock_until_the_write_settles(self, tmp_path):
         svc = AutoNudgeService(base_dir=tmp_path)
-        doomed = await svc.add(
-            slot_key="dashboard:a", message="a", idle_secs=60, max_cycles=1
-        )
+        doomed = await svc.add(slot_key="dashboard:a", message="a", idle_secs=60, max_cycles=1)
 
         order: list[str] = []
         release = threading.Event()

--- a/test/test_autonudge_authz_cov80.py
+++ b/test/test_autonudge_authz_cov80.py
@@ -273,13 +273,32 @@ async def test_add_denies_discord_when_the_current_session_lookup_raises(
     assert svc.added == []
 
 
-async def test_add_rejects_a_channel_transport_it_cannot_authorize(audits: list[dict]) -> None:
-    """``is_channel_key`` accepts telegram/whatsapp/unified prefixes too, but only
+@pytest.mark.parametrize(
+    "slot_key",
+    [
+        "telegram:9001",
+        "whatsapp:kirocrew:direct:15550100",
+        "unified:kirocrew",
+        "webex:kirocrew:direct:user@example.com",
+        "teams:kirocrew:direct:29:1abcdef",
+        "weixin:kirocrew:direct:oUserOpenId",
+        "imessage:kirocrew:direct:+15550100",
+    ],
+)
+async def test_add_rejects_a_channel_transport_it_cannot_authorize(
+    audits: list[dict], slot_key: str
+) -> None:
+    """``is_channel_key`` classifies every proactive-capable namespace, but only
     Slack and Discord have ownership checks here — anything else must be refused
-    rather than falling through to an unvalidated arm."""
+    rather than falling through to an unvalidated arm.
+
+    Widening the classifier deliberately does NOT widen this chokepoint: a
+    namespace becomes armable only together with an ownership check here and a
+    fire route in the gateway's ``_fire`` dispatcher.
+    """
     svc = RecordingSvc()
     loop, error, status = await authorize_and_add_nudge(
-        svc=svc, state=_state(), slot_key="telegram:9001", message="watch", source="dashboard"
+        svc=svc, state=_state(), slot_key=slot_key, message="watch", source="dashboard"
     )
     assert loop is None and status == 400 and "unsupported channel session" in error
     assert svc.added == []

--- a/test/test_channel_wire_conformance.py
+++ b/test/test_channel_wire_conformance.py
@@ -87,3 +87,31 @@ class TestWeixinConformance:
             "qrcode_img_content is no longer a URL -- the QR render path "
             "(server-side encode to PNG data URI) assumes it is"
         )
+
+
+# WeCom has NO live probe, and that is a decision rather than a gap.
+#
+# Every WeCom frame worth probing requires SUBSCRIBING with the bot's credentials,
+# and WeCom allows one subscription per bot: a second one replaces the incumbent, so
+# the running gateway is disconnected and its reconnect loop stops on
+# `disconnected_event`. Env-gating that is not a defence -- `no-test-side-effects` is
+# about the side effect existing at all, not how hard it is to reach -- and the
+# blast radius lands on a production channel, not on the test.
+#
+# Nothing is lost by omitting it, because none of the assertions needed the wire:
+#
+# * Frame SHAPES are asserted against the recorded fixtures on a fake socket in
+#   `test_wecom_wire.py`, which is where a shape assertion belongs.
+# * The cmd-less ACK's req_id echo -- the only thing that tells a pong from a
+#   stream-reply receipt -- is pinned by
+#   `test_the_same_shape_clears_a_pending_pong_when_the_req_id_was_a_ping`.
+# * The unverified vendor semantics that a probe WOULD settle are recorded as such
+#   in each fixture's `_provenance`, including the load-bearing one: whether a
+#   non-empty `body.chatid` really means "group", which `wecom/transport.py::receive`
+#   and `wecom/transport_dispatch.py::_route` both assume. Naming an assumption in
+#   the fixture that carries it is what keeps it from being forgotten; a probe nobody
+#   may safely run would not have settled it either.
+#
+# If a throwaway bot with its own credentials ever exists, the honest place for a
+# WeCom probe is against THAT, with the incumbent-subscription hazard stated in the
+# opt-in instructions.

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,8 +12,47 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 from chat_test_helpers import _make_state
 
-from kiro_crew.messaging.link import ChannelLink
+# The shipped capability objects, imported from the file that already owns the
+# eight-channel roster so there is one place a new channel has to be added.
+from test_options_cap_contract import _all_channel_capabilities
+
+from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink
 from kiro_crew.messaging.transport import ConfiguredChannelTarget
+
+#: Channels whose REAL capabilities refuse a proactive send, so the mirror-link
+#: gate must reject them. Pinned as a set as well as derived below, so unlocking
+#: one is a NAMED failure in ``test_the_proactive_split_matches_the_shipped_caps``
+#: rather than a parametrized suite that quietly stops driving anything.
+#:
+#: Membership tracks a capability declaration, not a policy: WeCom left when it
+#: gained a proactive path over its long connection, and Feishu arrived declaring
+#: ``supports_proactive_send=False`` because its v1 renderer only ever replies to
+#: an inbound ``message_id``. The rejection branch below is nonetheless driven by a
+#: SYNTHETIC capability rather than by whoever happens to be in this set: the set
+#: has been empty before and will be again, and a branch whose only coverage is a
+#: roster entry stops being covered the moment that entry graduates.
+NON_PROACTIVE_CHANNELS: set[str] = {"feishu"}
+
+
+def _mirror_gate_capabilities() -> dict[str, Any]:
+    """Real capabilities per channel, minus Slack.
+
+    Slack is refused on channel TYPE before any capability is read — its
+    dedicated ``slack-link`` endpoint owns the rich thread plus streaming mirror
+    — so its proactive flag never reaches the gate under test here.
+    """
+    caps = dict(_all_channel_capabilities())
+    caps.pop(SLACK_NAMESPACE, None)
+    return caps
+
+
+def _channels_declaring_proactive(supported: bool) -> list[str]:
+    """Channel types whose shipped capabilities declare (or refuse) proactive send."""
+    return sorted(
+        name
+        for name, caps in _mirror_gate_capabilities().items()
+        if caps.supports_proactive_send is supported
+    )
 
 
 def _make_mirror_app(state):
@@ -30,11 +71,16 @@ def _make_mirror_app(state):
 
 
 def _fake_transport(
-    channel_type="telegram", proactive=True, max_message_chars=4096, session_resume=False
+    channel_type="telegram",
+    proactive=True,
+    max_message_chars=4096,
+    session_resume=False,
+    capabilities=None,
 ):
     return SimpleNamespace(
         channel_type=channel_type,
-        capabilities=SimpleNamespace(
+        capabilities=capabilities
+        or SimpleNamespace(
             supports_proactive_send=proactive,
             # The real TransportCapabilities always carries this; the mirror
             # backfill chunks to it instead of truncating, so the fake needs it
@@ -48,6 +94,39 @@ def _fake_transport(
         ),
         resolve_configured_target=AsyncMock(return_value=("123", None)),
     )
+
+
+def _real_caps_transport(channel_type: str):
+    """A fake transport carrying the channel's SHIPPED ``TransportCapabilities``.
+
+    The proactive gate is a capability read, so a test that hands it a
+    hand-built ``SimpleNamespace`` pins the fake and not the declaration:
+    flipping ``WECOM_CAPABILITIES.supports_proactive_send`` left the refusal
+    green while the endpoint began accepting a channel that cannot send. Only
+    the network methods stay faked.
+
+    Copied rather than aliased: ``TransportCapabilities`` is a MUTABLE dataclass
+    and the module-level object is shared process-wide, so a test that tweaked a
+    field in place would silently rewrite every later test's idea of the channel.
+    """
+    return _fake_transport(
+        channel_type, capabilities=dataclasses.replace(_mirror_gate_capabilities()[channel_type])
+    )
+
+
+def _caps_transport(channel_type: str, **overrides):
+    """A fake transport whose capabilities are SYNTHETIC, for a branch no shipped
+    channel exercises any more.
+
+    Deliberately separate from :func:`_real_caps_transport`: that one exists so the
+    gate is pinned against the real declaration and an unlock is observable, and
+    this one must not be reachable from it. Every shipped channel now declares
+    ``supports_proactive_send=True``, so the refusing branch has no real subject —
+    but the gate still has to refuse, and this is the only honest way to say so.
+    """
+    from kiro_crew.messaging.transport import TransportCapabilities
+
+    return _fake_transport(channel_type, capabilities=TransportCapabilities(**overrides))
 
 
 def _prep(tmp_path, monkeypatch):
@@ -184,10 +263,14 @@ class TestMirrorLink:
 
     @pytest.mark.asyncio
     async def test_missing_channel_type(self, tmp_path, monkeypatch):
+        # An empty JSON object is reminder mode with nothing to remind, so this
+        # lands on the reminder path's own required-field refusal — the twin of
+        # the explicit-body one, and it must answer with the same code.
         state = _prep(tmp_path, monkeypatch)
         async with TestClient(TestServer(_make_mirror_app(state))) as client:
             resp = await client.post("/api/chat/slots/s1/mirror-link", json={})
             assert resp.status == 400
+            assert (await resp.json())["code"] == "channel_type_required"
 
     @pytest.mark.asyncio
     async def test_slack_rejected(self, tmp_path, monkeypatch):
@@ -198,7 +281,11 @@ class TestMirrorLink:
                 json={"channel_type": "slack", "conversation_id": "C1"},
             )
             assert resp.status == 400
-            assert "slack-link" in (await resp.json())["error"]
+            body = await resp.json()
+            assert "slack-link" in body["error"]
+            # Slack is not unsupported, it is handled elsewhere; the code has to
+            # say which, because that is the only part a localized client reads.
+            assert body["code"] == "use_slack_link"
 
     @pytest.mark.asyncio
     async def test_missing_target_id(self, tmp_path, monkeypatch):
@@ -220,17 +307,79 @@ class TestMirrorLink:
             )
             assert resp.status == 503
 
+    def test_the_proactive_split_matches_the_shipped_caps(self):
+        """The two suites below are only as honest as this roster.
+
+        Derived from the shipped objects, so a channel that starts or stops
+        declaring ``supports_proactive_send`` fails HERE, named, instead of
+        migrating between the suites without a word. The acceptance half is
+        checked for non-vacuity too: an empty parametrize list is a green test
+        that drives nothing.
+        """
+        assert _channels_declaring_proactive(False) == sorted(NON_PROACTIVE_CHANNELS), (
+            "A channel's supports_proactive_send declaration changed. The mirror-link "
+            "gate rejects exactly the non-proactive channels, so update "
+            "NON_PROACTIVE_CHANNELS — and check the endpoint's docstring, which names "
+            "the channels it can and cannot mirror. "
+            f"newly_locked={set(_channels_declaring_proactive(False)) - NON_PROACTIVE_CHANNELS} "
+            f"newly_unlocked={NON_PROACTIVE_CHANNELS - set(_channels_declaring_proactive(False))}"
+        )
+        assert _channels_declaring_proactive(True), (
+            "no shipped channel declares supports_proactive_send=True, so the "
+            "acceptance suite drives nothing"
+        )
+
     @pytest.mark.asyncio
     async def test_non_proactive_channel_rejected(self, tmp_path, monkeypatch):
+        """The gate must refuse a transport that declares no proactive send.
+
+        Driven by a SYNTHETIC capability rather than by a shipped channel that
+        declares ``False``, so this branch keeps its coverage across a roster that
+        churns: ``NON_PROACTIVE_CHANNELS`` has been empty before, and a test
+        parametrized over it would have gone vacuously green instead of red. The
+        real-capability version is `test_proactive_channel_accepted`, which covers
+        every shipped channel; this one keeps the refusing branch alive, because a
+        mirror binding on a transport that cannot send unattended promises a
+        delivery it will never make.
+        """
+        channel = "synthetic"
         state = _prep(tmp_path, monkeypatch)
-        state.register_channel_transport(_fake_transport("wecom", proactive=False))
+        state.register_channel_transport(_caps_transport(channel, supports_proactive_send=False))
         async with TestClient(TestServer(_make_mirror_app(state))) as client:
             resp = await client.post(
                 "/api/chat/slots/s1/mirror-link",
-                json={"channel_type": "wecom", "target_id": "user:u1"},
+                json={"channel_type": channel, "target_id": "user:u1"},
             )
             assert resp.status == 400
-            assert "proactive" in (await resp.json())["error"]
+            body = await resp.json()
+            assert "proactive" in body["error"]
+            # The dashboard renders `error` verbatim into a localized UI, so the
+            # machine contract is the code, and the code is what a client that
+            # cannot read English has to switch on.
+            assert body["code"] == "channel_not_proactive"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("channel", _channels_declaring_proactive(True))
+    async def test_proactive_channel_accepted(self, tmp_path, monkeypatch, channel):
+        """The positive counterpart, and what makes a future unlock observable.
+
+        Weixin ships ``supports_proactive_send=True``, so it must LINK. Without
+        this half the suite only ever proved the gate says no, and a gate that
+        refuses everything would pass it — including the day WeCom's declaration
+        flips and the endpoint is supposed to start accepting it.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(_real_caps_transport(channel))
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": channel, "target_id": "user:123"},
+            )
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+        link = state.sessions.set_mirror_link.call_args.args[1]
+        assert link == ChannelLink(channel, channel_id="123", thread_id=None)
 
     @pytest.mark.asyncio
     async def test_link_success(self, tmp_path, monkeypatch):
@@ -417,7 +566,9 @@ class TestMirrorReminder:
                 "/api/chat/slots/s1/mirror-link", json={"thread_id": "unexpected"}
             )
             assert resp.status == 400
-            assert (await resp.json())["error"] == "channel_type required"
+            body = await resp.json()
+            assert body["error"] == "channel_type required"
+            assert body["code"] == "channel_type_required"
 
         transport.send_message.assert_not_awaited()
 
@@ -510,9 +661,7 @@ class TestMirrorPause:
         def _build(state):
             app = web.Application()
             app["state"] = state
-            app.router.add_post(
-                "/api/chat/slots/{name}/mirror-pause", api_chat_slot_mirror_pause
-            )
+            app.router.add_post("/api/chat/slots/{name}/mirror-pause", api_chat_slot_mirror_pause)
             return app
 
         return _build
@@ -534,9 +683,7 @@ class TestMirrorPause:
         )
         state.sessions.set_mirror_paused = MagicMock(return_value=False)
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": True}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": True})
             assert resp.status == 200
             data = await resp.json()
             assert data["ok"] is True
@@ -552,9 +699,7 @@ class TestMirrorPause:
         )
         state.sessions.set_mirror_paused = MagicMock(return_value=True)
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": False}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": False})
             assert resp.status == 200
             data = await resp.json()
             assert data["paused"] is False
@@ -567,9 +712,7 @@ class TestMirrorPause:
         # get_mirror_link returns None → no explicit mirror, and session key is
         # not a channel key → not origin-connected either.
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": True}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": True})
             assert resp.status == 409
             assert (await resp.json())["code"] == "mirror_not_linked"
 
@@ -590,9 +733,7 @@ class TestMirrorPause:
         state.sessions.set_mirror_paused = MagicMock(return_value=False)
 
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": True}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": True})
             assert resp.status == 200
 
         # The disconnect note was delivered to the mirror channel.
@@ -619,9 +760,7 @@ class TestMirrorPause:
         state.sessions.set_mirror_paused = MagicMock(return_value=False)
 
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": True}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": True})
             assert resp.status == 200
 
         transport.send_message.assert_not_awaited()
@@ -654,9 +793,7 @@ class TestMirrorPause:
         transport.send_message.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_pause_noop_when_already_paused(
-        self, tmp_path, monkeypatch, mirror_pause_app
-    ):
+    async def test_pause_noop_when_already_paused(self, tmp_path, monkeypatch, mirror_pause_app):
         """No disconnect note when already paused (not a transition)."""
         monkeypatch.setattr(
             "kiro_crew.platform.governance_profiles.governance_permits",
@@ -671,9 +808,7 @@ class TestMirrorPause:
         state.sessions.set_mirror_paused = MagicMock(return_value=True)
 
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": True}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": True})
             assert resp.status == 200
             data = await resp.json()
             assert data["was_paused"] is True
@@ -700,15 +835,11 @@ class TestMirrorPause:
         state.sessions.set_mirror_paused = MagicMock(return_value=False)
 
         async with TestClient(TestServer(mirror_pause_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/s1/mirror-pause", json={"paused": True}
-            )
+            resp = await client.post("/api/chat/slots/s1/mirror-pause", json={"paused": True})
             assert resp.status == 200
 
     @pytest.mark.asyncio
-    async def test_invalid_body_defaults_to_pause(
-        self, tmp_path, monkeypatch, mirror_pause_app
-    ):
+    async def test_invalid_body_defaults_to_pause(self, tmp_path, monkeypatch, mirror_pause_app):
         """Non-JSON or non-dict body defaults to paused=True."""
         state = _prep(tmp_path, monkeypatch)
         state.sessions.get_mirror_link = MagicMock(
@@ -1154,9 +1285,9 @@ class TestMirrorBackfillFidelity:
 
         await self._link(state)
         sent = self._sent(transport)
-        assert len(sent) <= self._BOUND_CEILING, (
-            f"inline delivery sent {len(sent)} units, over the budget"
-        )
+        assert (
+            len(sent) <= self._BOUND_CEILING
+        ), f"inline delivery sent {len(sent)} units, over the budget"
         # Priority order: the newest turn is irreducible, then the marker, then
         # the opening turn, then older turns. Here each turn costs ~6 units, so
         # the opening turn cannot be afforded and is folded into the count.
@@ -1165,9 +1296,7 @@ class TestMirrorBackfillFidelity:
         assert any("earlier turn" in t for t in sent), "trim happened with no marker"
 
     @pytest.mark.asyncio
-    async def test_delivery_scales_with_the_budget_not_with_history(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_delivery_scales_with_the_budget_not_with_history(self, tmp_path, monkeypatch):
         """Ten times the history must not mean ten times the request duration."""
 
         counts = []
@@ -1182,9 +1311,9 @@ class TestMirrorBackfillFidelity:
             counts.append(len(self._sent(transport)))
 
         assert all(c <= self._BOUND_CEILING for c in counts), counts
-        assert counts[0] == counts[1], (
-            f"unit count tracked history length ({counts}) instead of the budget"
-        )
+        assert (
+            counts[0] == counts[1]
+        ), f"unit count tracked history length ({counts}) instead of the budget"
 
     @pytest.mark.asyncio
     async def test_no_slack_mrkdwn_conversion_on_a_non_slack_channel(self, tmp_path, monkeypatch):
@@ -1250,13 +1379,15 @@ class TestMirrorBackfillFidelity:
             return await original_send(*args, **kwargs)
 
         transport.send_message = _tracked_send
-        state.sessions.set_mirror_link = MagicMock(side_effect=lambda *a, **k: order.append("persist"))
+        state.sessions.set_mirror_link = MagicMock(
+            side_effect=lambda *a, **k: order.append("persist")
+        )
 
         await self._link(state)
         assert "persist" in order, "link was never persisted"
-        assert order.index("persist") == len(order) - 1, (
-            "the link was persisted before delivery finished"
-        )
+        assert (
+            order.index("persist") == len(order) - 1
+        ), "the link was persisted before delivery finished"
         assert order.count("send") >= 3, "announcement + both messages should have been sent"
 
 
@@ -1269,9 +1400,7 @@ class TestInboundClaimFollowsTheCapability:
     """
 
     @pytest.mark.asyncio
-    async def test_a_resume_capable_transport_gets_an_inbound_binding(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_resume_capable_transport_gets_an_inbound_binding(self, tmp_path, monkeypatch):
         state = _prep(tmp_path, monkeypatch)
         state.register_channel_transport(_fake_transport("discord", session_resume=True))
         state.sessions.set_mirror_link = MagicMock()
@@ -1284,9 +1413,7 @@ class TestInboundClaimFollowsTheCapability:
         assert state.sessions.set_mirror_link.call_args.kwargs["accepts_inbound"] is True
 
     @pytest.mark.asyncio
-    async def test_a_transport_that_cannot_resume_stays_outbound_only(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_transport_that_cannot_resume_stays_outbound_only(self, tmp_path, monkeypatch):
         """Degrade, never over-promise.
 
         Telegram builds its session key from the route and never consults the
@@ -1337,15 +1464,13 @@ class TestInboundClaimFollowsTheCapability:
             assert resp.status == 409
             assert (await resp.json())["code"] == "conversation_occupied"
 
-        assert transport.send_message.await_count == 0, (
-            "the transcript was delivered into a conversation another session owns"
-        )
+        assert (
+            transport.send_message.await_count == 0
+        ), "the transcript was delivered into a conversation another session owns"
         state.sessions.set_mirror_link.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_a_stubbed_session_manager_does_not_read_as_occupied(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_stubbed_session_manager_does_not_read_as_occupied(self, tmp_path, monkeypatch):
         """A Mock is truthy, and truthy must not mean "taken".
 
         Read as a rival list, a stubbed accessor's Mock would refuse every connect

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -3085,9 +3085,7 @@ class TestFeishuConfigCoercionFailsClosed:
     def test_null_id_lists_do_not_crash_config_load(self) -> None:
         # A null or non-list value must yield the deny-everybody default rather
         # than reaching an iteration that would raise during gateway startup.
-        cfg = _load_from_dict(
-            {"feishu": {"allowed_open_ids": None, "allowed_group_ids": "oc_g1"}}
-        )
+        cfg = _load_from_dict({"feishu": {"allowed_open_ids": None, "allowed_group_ids": "oc_g1"}})
         assert cfg.feishu.allowed_open_ids == []
         assert cfg.feishu.allowed_group_ids == []
 
@@ -3600,9 +3598,7 @@ class TestOrchestratorWatchdogThemeAreParsed:
                 captured.append(kwargs)
 
         monkeypatch.setattr(acp_mod, "AcpProvider", _FakeProvider)
-        cfg = _load_from_dict(
-            {"agents": {"pr-reviewer": {"kiro_agent": "pr-reviewer-kiro"}}}
-        )
+        cfg = _load_from_dict({"agents": {"pr-reviewer": {"kiro_agent": "pr-reviewer-kiro"}}})
         factory = cfg.create_provider_factory()
 
         factory("k1", agent="pr-reviewer-kiro", crew_agent="pr-reviewer")
@@ -5022,10 +5018,9 @@ class TestMigrationBackupContainment:
     _LEGACY = {"telegram": {"allow_forum": True}}
 
     def _load_with(self, home: Path, cfg_file: Path) -> KiroCrewConfig:
-        with unittest.mock.patch(
-            "kiro_crew.config.loader.config_dir", return_value=home
-        ), unittest.mock.patch(
-            "kiro_crew.config.loader.config_path", return_value=cfg_file
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=home),
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_file),
         ):
             return KiroCrewConfig.load()
 
@@ -5045,8 +5040,8 @@ class TestMigrationBackupContainment:
         # Guard the guard: assert the migration branch actually ran, otherwise
         # this test would pass for the wrong reason if that branch stops firing.
         assert cfg.agents, "migration write-back did not run, test is vacuous"
-        assert after == before, (
-            "load() left orphans beside the caller's config: %s" % sorted(after - before)
+        assert after == before, "load() left orphans beside the caller's config: %s" % sorted(
+            after - before
         )
 
     def test_real_config_in_the_data_home_is_still_backed_up(self, tmp_path: Path) -> None:
@@ -5153,9 +5148,7 @@ class TestTransportThresholdConsistency:
         # An inverted pair (soft=90, hard=50) would make the soft nudge
         # unreachable -- the transports check pct >= hard first.
         section = self._section(
-            _load_from_dict(
-                {transport: {"soft_threshold_pct": 90, "hard_threshold_pct": 50}}
-            ),
+            _load_from_dict({transport: {"soft_threshold_pct": 90, "hard_threshold_pct": 50}}),
             transport,
         )
         assert section.hard_threshold_pct == 50
@@ -5235,10 +5228,79 @@ class TestTransportThresholdConsistency:
         cfg = _load_from_dict(
             {
                 "telegram": {
-                    "accounts": {
-                        "acct-1": {"bot_token": "123:abc", "soft_threshold_pct": 400}
-                    }
+                    "accounts": {"acct-1": {"bot_token": "123:abc", "soft_threshold_pct": 400}}
                 }
             }
         )
         assert cfg.telegram.accounts["acct-1"].soft_threshold_pct == 100
+
+
+#: One non-default sample per ``WeComConfig`` field, keyed by field name. The map
+#: must cover EVERY field: ``load()`` enumerates the section's keys by hand, so a
+#: field added to the dataclass but forgotten there loads as its default and is
+#: then written back as its default — the operator's setting is both ignored and
+#: erased, with nothing failing — a key that looks wired (it appears in the config
+#: schema, which IS derived from the dataclass) while being discarded at load. This
+#: map is the ratchet: a new field fails the test below until a sample is added,
+#: which forces the author through the load path.
+_WECOM_FIELD_SAMPLES: dict[str, object] = {
+    "enabled": True,
+    "allowed_users": [{"userid": "zhangsan", "name": "Z"}],
+    "allow_all_users": True,
+    "ws_url": "wss://example.invalid/ws",
+    "soft_threshold_pct": 71,
+    "hard_threshold_pct": 91,
+    "session_folder": "wecom-folder",
+}
+
+
+class TestWeComSectionSurvivesLoad:
+    def test_the_sample_map_covers_every_field(self) -> None:
+        import dataclasses
+
+        declared = {f.name for f in dataclasses.fields(loader_module.WeComConfig)}
+        missing = declared - set(_WECOM_FIELD_SAMPLES)
+        assert not missing, (
+            f"WeComConfig gained field(s) {sorted(missing)} with no sample here. Add one, "
+            "and check KiroCrewConfig.load() actually reads the key -- it enumerates them "
+            "by hand, so an omission silently discards the operator's value."
+        )
+        assert not set(_WECOM_FIELD_SAMPLES) - declared, "sample for a field that no longer exists"
+
+    @pytest.mark.parametrize("field_name", sorted(_WECOM_FIELD_SAMPLES))
+    def test_each_configured_value_survives_load(self, field_name: str) -> None:
+        sample = _WECOM_FIELD_SAMPLES[field_name]
+        cfg = _load_from_dict({"wecom": {field_name: sample}})
+        loaded = getattr(cfg.wecom, field_name)
+        default = getattr(loader_module.WeComConfig(), field_name)
+        assert loaded != default, (
+            f"wecom.{field_name} loaded as its default {default!r} despite being configured "
+            f"as {sample!r} -- KiroCrewConfig.load() is not reading the key"
+        )
+
+    @pytest.mark.parametrize("junk", [None, 7, "zhangsan", {"a": 1}, True])
+    def test_a_non_list_allow_list_degrades_to_empty_rather_than_crashing_load(
+        self, junk: object
+    ) -> None:
+        # An explicit `null`, or any non-list, must not raise out of load(): a
+        # config file the operator can write is not a trusted type, and a TypeError
+        # here prevents STARTUP rather than degrading one setting. A bare string is
+        # the subtle one -- iterating it would char-split into single-letter userids.
+        cfg = _load_from_dict({"wecom": {"allowed_users": junk}})
+        assert cfg.wecom.allowed_users == []
+
+    @pytest.mark.parametrize("field", ["enabled", "allow_all_users"])
+    @pytest.mark.parametrize("junk", ["false", "off", "0", 0, 1, [], {}, None, "true"])
+    def test_a_non_bool_never_turns_a_switch_ON(self, field: str, junk: object) -> None:
+        # `bool("false")` is True, so a JSON string would invert the operator's
+        # intent -- enabling the channel, or opening it to every org member, from a
+        # value that says the opposite. Even the "helpfully" correct-looking "true"
+        # must not enable it: a parse that guesses at a string is the same parse that
+        # cannot refuse "false".
+        cfg = _load_from_dict({"wecom": {field: junk}})
+        assert getattr(cfg.wecom, field) is False
+
+    @pytest.mark.parametrize("field", ["enabled", "allow_all_users"])
+    def test_a_real_bool_still_works(self, field: str) -> None:
+        cfg = _load_from_dict({"wecom": {field: True}})
+        assert getattr(cfg.wecom, field) is True

--- a/test/test_cross_surface_mirror.py
+++ b/test/test_cross_surface_mirror.py
@@ -16,6 +16,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from chat_test_helpers import _make_state
 
+# Both legs gate on the SHIPPED capability objects, so the refusal cases below
+# read them instead of a matching fake. Same roster the mirror-link suite uses.
+from test_chat_mirror import (
+    NON_PROACTIVE_CHANNELS,
+    _channels_declaring_proactive,
+    _real_caps_transport,
+)
+
 from kiro_crew.dashboard.chat_runner import (
     _deliver_cross_surface_reply,
     _deliver_cross_surface_user_message,
@@ -27,6 +35,11 @@ from kiro_crew.security import (
     redact_exfiltration_urls,
 )
 
+#: A channel whose REAL capabilities permit a proactive send, so both legs must
+#: DELIVER to it. Named rather than derived: if Weixin's declaration is ever
+#: locked down, this fails loudly here instead of quietly moving suites.
+PROACTIVE_CHANNEL = "weixin"
+
 
 def _fake_transport(channel_type: str = "telegram", proactive: bool = True):
     return SimpleNamespace(
@@ -34,6 +47,17 @@ def _fake_transport(channel_type: str = "telegram", proactive: bool = True):
         capabilities=SimpleNamespace(supports_proactive_send=proactive, max_message_chars=4096),
         send_message=AsyncMock(return_value="mid-1"),
     )
+
+
+def test_the_pinned_proactive_channel_still_declares_proactive_send() -> None:
+    """Guards the two delivery assertions below from becoming vacuous.
+
+    They prove the legs deliver where the capability allows it. Pointing them at
+    a channel that had since been locked would turn both into tests of the skip
+    path wearing a delivery test's name.
+    """
+    assert PROACTIVE_CHANNEL in _channels_declaring_proactive(True)
+    assert PROACTIVE_CHANNEL not in NON_PROACTIVE_CHANNELS
 
 
 class TestGovernanceDegradationFailsClosed:
@@ -185,14 +209,35 @@ class TestDeliverCrossSurfaceReply:
 
     @pytest.mark.asyncio
     async def test_skips_when_not_proactive(self, tmp_path):
+        """The leg must honour a False ``supports_proactive_send``.
+
+        SYNTHETIC capability, so this branch is covered whatever
+        ``NON_PROACTIVE_CHANNELS`` holds this week: it has been empty, and a suite
+        parametrized over an empty set drives NOTHING while still reporting green.
+        Real-capability coverage is the accepting counterpart below; this keeps the
+        refusing branch alive.
+        """
+        channel = "synthetic"
         state = _make_state(tmp_path)
-        tp = _fake_transport("wecom", proactive=False)
+        tp = _fake_transport(channel, proactive=False)
         state.register_channel_transport(tp)
         state.sessions.get_mirror_link = MagicMock(
-            return_value=ChannelLink("wecom", channel_id="u1")
+            return_value=ChannelLink(channel, channel_id="u1")
         )
         await _deliver_cross_surface_reply(state, "k", "hi")
         tp.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delivers_when_real_capabilities_allow_it(self, tmp_path):
+        """The positive counterpart, on real capabilities rather than a fake."""
+        state = _make_state(tmp_path)
+        tp = _real_caps_transport(PROACTIVE_CHANNEL)
+        state.register_channel_transport(tp)
+        state.sessions.get_mirror_link = MagicMock(
+            return_value=ChannelLink(PROACTIVE_CHANNEL, channel_id="u1")
+        )
+        await _deliver_cross_surface_reply(state, "k", "hi")
+        tp.send_message.assert_awaited_once_with("u1", "hi", thread_id=None)
 
     @pytest.mark.asyncio
     async def test_skips_empty_text(self, tmp_path):
@@ -300,14 +345,27 @@ class TestDeliverCrossSurfaceUserMessage:
 
     @pytest.mark.asyncio
     async def test_skips_when_not_proactive(self, tmp_path):
+        """Synthetic capability, for the same reason as the reply leg's twin."""
+        channel = "synthetic"
         state = _make_state(tmp_path)
-        tp = _fake_transport("wecom", proactive=False)
+        tp = _fake_transport(channel, proactive=False)
         state.register_channel_transport(tp)
         state.sessions.get_mirror_link = MagicMock(
-            return_value=ChannelLink("wecom", channel_id="u1")
+            return_value=ChannelLink(channel, channel_id="u1")
         )
         await _deliver_cross_surface_user_message(state, "k", "hi")
         tp.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delivers_when_real_capabilities_allow_it(self, tmp_path):
+        state = _make_state(tmp_path)
+        tp = _real_caps_transport(PROACTIVE_CHANNEL)
+        state.register_channel_transport(tp)
+        state.sessions.get_mirror_link = MagicMock(
+            return_value=ChannelLink(PROACTIVE_CHANNEL, channel_id="u1")
+        )
+        await _deliver_cross_surface_user_message(state, "k", "hi")
+        tp.send_message.assert_awaited_once_with("u1", "💬 hi", thread_id=None)
 
     @pytest.mark.asyncio
     async def test_skips_empty_message(self, tmp_path):

--- a/test/test_feishu_renderer.py
+++ b/test/test_feishu_renderer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from kiro_crew.feishu.renderer import FeishuRenderer, _strip_options
+from kiro_crew.feishu.renderer import FeishuRenderer
 from kiro_crew.messaging.transport import TransportCapabilities
 
 
@@ -54,22 +54,6 @@ class TestTextAccumulation:
         assert c.replies[0] == ("msg1", "Hello world")
 
     @pytest.mark.asyncio
-    async def test_options_trailer_stripped(self) -> None:
-        c = FakeClient()
-        r = _renderer(c)
-        await r.on_text_chunk("Pick one\n\n[OPTIONS: A | B | C]")
-        await r.on_done()
-        assert c.replies[0][1] == "Pick one"
-
-    @pytest.mark.asyncio
-    async def test_unterminated_options_stripped(self) -> None:
-        c = FakeClient()
-        r = _renderer(c)
-        await r.on_text_chunk("Answer text\n\n[OPTIONS: A | B")
-        await r.on_done()
-        assert c.replies[0][1] == "Answer text"
-
-    @pytest.mark.asyncio
     async def test_empty_buffer_sends_ellipsis(self) -> None:
         c = FakeClient()
         r = _renderer(c)
@@ -78,15 +62,44 @@ class TestTextAccumulation:
         assert c.replies[0] == ("msg1", "…")
 
 
-class TestStripOptions:
-    def test_complete_options_tag(self) -> None:
-        assert _strip_options("Hi\n[OPTIONS: a | b]") == "Hi"
+class TestOptionsTrailer:
+    """Feishu renders no tappable chip, so the trailer degrades to numbered text.
 
-    def test_unterminated_options_tag(self) -> None:
-        assert _strip_options("Hi\n[OPTIONS: a | b") == "Hi"
+    Deleting it left the user unable to learn the choices existed at all. The
+    grammar itself is pinned once in ``test_options_cap_contract.py`` against the
+    shared helper; what these drive is that ``text()`` — the string that both
+    reaches the user and is persisted to history — actually goes through it.
+    """
 
-    def test_no_options_passthrough(self) -> None:
-        assert _strip_options("plain text") == "plain text"
+    @pytest.mark.asyncio
+    async def test_a_complete_trailer_becomes_a_numbered_list(self) -> None:
+        c = FakeClient()
+        r = _renderer(c)
+        await r.on_text_chunk("Hi\n\n[OPTIONS: a | b]")
+        await r.on_done()
+        assert c.replies[0][1] == "Hi\n\n1. a\n2. b"
+
+    @pytest.mark.asyncio
+    async def test_an_unfinished_marker_is_kept(self) -> None:
+        """Feishu buffers the whole turn and replies once, so it never streams.
+
+        There is no partial frame for a half-arrived marker to flash in: text
+        reaches the user only from ``on_done``. So a dangling ``[OPTIONS`` is the
+        assistant's own prose, and cutting it is silent, permanent data loss.
+        """
+        c = FakeClient()
+        r = _renderer(c)
+        await r.on_text_chunk("see the [OPTIONS section")
+        await r.on_done()
+        assert c.replies[0][1] == "see the [OPTIONS section"
+
+    @pytest.mark.asyncio
+    async def test_plain_text_passes_through(self) -> None:
+        c = FakeClient()
+        r = _renderer(c)
+        await r.on_text_chunk("plain text")
+        await r.on_done()
+        assert c.replies[0][1] == "plain text"
 
 
 class TestErrorDone:

--- a/test/test_imessage_renderer.py
+++ b/test/test_imessage_renderer.py
@@ -233,20 +233,26 @@ class TestDelivery:
         assert all(len(text) <= IMESSAGE_CAPABILITIES.max_message_chars for text in client.sent)
 
     @pytest.mark.asyncio
-    async def test_an_options_trailer_is_stripped(self) -> None:
+    async def test_an_options_trailer_becomes_numbered_text(self) -> None:
+        # iMessage has no tappable choices, but the choices are the answers to the
+        # question the body just asked -- dropping them left the user with no way
+        # to see what was offered.
         client = FakeClient()
         renderer = _renderer(client)
         await renderer.on_text_chunk("Pick one.\n\n[OPTIONS: a | b | c]")
         await renderer.on_done()
-        assert client.sent == ["Pick one."]
+        assert client.sent == ["Pick one.\n\n1. a\n2. b\n3. c"]
 
     @pytest.mark.asyncio
-    async def test_a_truncated_options_fragment_never_lands_as_raw_text(self) -> None:
+    async def test_an_incomplete_options_fragment_is_not_cut_off_the_answer(self) -> None:
+        # iMessage never streams, so an incomplete marker at finalization is not a
+        # marker still arriving -- it is the assistant's text, and deleting it to
+        # tidy up protocol would lose authored content.
         client = FakeClient()
         renderer = _renderer(client)
         await renderer.on_text_chunk("Pick one.\n\n[OPTIONS: a | b")
         await renderer.on_done()
-        assert client.sent == ["Pick one."]
+        assert client.sent == ["Pick one.\n\n[OPTIONS: a | b"]
 
     @pytest.mark.asyncio
     async def test_an_empty_answer_still_sends_something(self) -> None:

--- a/test/test_options_cap_contract.py
+++ b/test/test_options_cap_contract.py
@@ -10,19 +10,89 @@ over-cap list and pins:
    the widget slots) instead of being silently dropped — the pre-enforcement
    behavior lost choices without any user-visible signal.
 
-``test_every_widget_channel_is_pinned_here`` is the ratchet: a channel that
-starts declaring ``max_buttons > 0`` without a pin in this file fails it.
+A channel declaring ``max_buttons == 0`` renders no widget, and the same helper
+answers it with zero widget slots: EVERY choice becomes a numbered line. That
+half is pinned here too, because dropping the list deletes the answers to a
+question the agent just asked and the user is left with a prompt and no way to
+see what it offered.
+
+Two ratchets keep both halves exhaustive: a channel that starts declaring
+``max_buttons > 0`` without a pin in this file fails
+``test_every_widget_channel_is_pinned_here``, and a zero-widget channel absent
+from ``ZERO_WIDGET_RENDERERS`` fails
+``test_every_zero_widget_channel_is_pinned_here``. The second is keyed on a
+renderer FACTORY rather than a name, because ``text()`` is not on the ``Renderer``
+ABC — nothing in code forces a zero-widget renderer to call the helper, so the
+ratchet has to demand something it can actually drive.
 """
 
 from __future__ import annotations
 
 import asyncio
+import time
+from typing import Any, Callable
 
-from kiro_crew.messaging.renderer import apply_options_cap, cap_choices
+import pytest
+
+from kiro_crew.messaging.renderer import (
+    apply_options_cap,
+    cap_choices,
+    render_options_as_text,
+)
 from kiro_crew.messaging.transport import TransportCapabilities
 
 #: channel_type -> the test class below that pins its enforcement.
 PINNED_WIDGET_CHANNELS = {"slack", "discord", "telegram", "teams"}
+
+
+def _wecom_renderer() -> Any:
+    from kiro_crew.wecom.renderer import WeComRenderer
+    from kiro_crew.wecom.transport import WECOM_CAPABILITIES
+
+    return WeComRenderer(object(), "rq1", "https://r", WECOM_CAPABILITIES)
+
+
+def _weixin_renderer() -> Any:
+    from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
+    from kiro_crew.weixin.turn_renderer import WeixinRenderer
+
+    return WeixinRenderer(
+        object(), "peer", WEIXIN_CAPABILITIES, ctx_store=object(), account_id="acct"
+    )
+
+
+def _webex_renderer() -> Any:
+    from kiro_crew.webex.renderer import WebexRenderer
+    from kiro_crew.webex.transport import WEBEX_CAPABILITIES
+
+    return WebexRenderer(object(), "room", WEBEX_CAPABILITIES)
+
+
+def _imessage_renderer() -> Any:
+    from kiro_crew.imessage.renderer import IMessageRenderer
+    from kiro_crew.imessage.transport import IMESSAGE_CAPABILITIES
+
+    return IMessageRenderer(object(), "+61400000000", IMESSAGE_CAPABILITIES)
+
+
+def _feishu_renderer() -> Any:
+    from kiro_crew.feishu.renderer import FeishuRenderer
+    from kiro_crew.feishu.transport import FEISHU_CAPABILITIES
+
+    return FeishuRenderer(object(), "om_msg", FEISHU_CAPABILITIES)
+
+
+#: Channels rendering no widget, each with a factory driving its REAL renderer
+#: against its REAL capabilities. Keyed this way rather than as a set of names so
+#: the ratchet below cannot be satisfied by adding a string: a new zero-widget
+#: channel has to supply something this file can actually drive.
+ZERO_WIDGET_RENDERERS: dict[str, Callable[[], Any]] = {
+    "wecom": _wecom_renderer,
+    "weixin": _weixin_renderer,
+    "webex": _webex_renderer,
+    "imessage": _imessage_renderer,
+    "feishu": _feishu_renderer,
+}
 
 
 def _all_channel_capabilities() -> dict[str, TransportCapabilities]:
@@ -61,6 +131,29 @@ class TestRatchet:
             f"stale={PINNED_WIDGET_CHANNELS - widget_channels}"
         )
 
+    def test_every_zero_widget_channel_is_pinned_here(self) -> None:
+        # Keyed on the FACTORY map, not a set of names: a name could be added to
+        # a bare set to make this green, which would leave the channel with no
+        # actual pin -- nothing in code forces a renderer to call the helper.
+        zero_widget = {
+            name for name, caps in _all_channel_capabilities().items() if caps.max_buttons == 0
+        }
+        assert zero_widget == set(ZERO_WIDGET_RENDERERS), (
+            "A channel's max_buttons declaration changed. Every channel "
+            "declaring max_buttons == 0 needs a renderer factory in "
+            "ZERO_WIDGET_RENDERERS so its numbered-text fallback is driven here. "
+            f"unpinned={zero_widget - set(ZERO_WIDGET_RENDERERS)} "
+            f"stale={set(ZERO_WIDGET_RENDERERS) - zero_widget}"
+        )
+
+    def test_the_two_pinned_sets_cover_every_channel(self) -> None:
+        # A channel is widget-capable or not, so the union must be the whole
+        # shipped set. A NEGATIVE max_buttons would land in neither and is the
+        # only way to sit in the gap between the two ratchets above.
+        assert set(_all_channel_capabilities()) == (
+            PINNED_WIDGET_CHANNELS | set(ZERO_WIDGET_RENDERERS)
+        )
+
 
 class TestSharedHelper:
     def test_under_cap_is_byte_identical(self) -> None:
@@ -75,11 +168,32 @@ class TestSharedHelper:
         assert kept == ["A", "B"]
         assert body == "Pick one.\n\n3. C\n4. D"
 
-    def test_zero_cap_keeps_nothing_and_leaves_body_alone(self) -> None:
+    def test_zero_cap_keeps_nothing_and_numbers_every_choice(self) -> None:
+        # A button-less channel is the overflow case with zero widget slots, not
+        # a channel with nothing to say. Returning the body alone deleted the
+        # answers to the question the body just asked.
         caps = TransportCapabilities(max_buttons=0)
         body, kept = apply_options_cap("Text.", ["A", "B"], caps)
+        assert body == "Text.\n\n1. A\n2. B"
+        assert kept == []
+
+    def test_zero_cap_with_no_choices_is_byte_identical(self) -> None:
+        caps = TransportCapabilities(max_buttons=0)
+        body, kept = apply_options_cap("Text.", [], caps)
         assert body == "Text."
         assert kept == []
+
+    def test_zero_cap_renders_one_blank_line_however_the_body_ends(self) -> None:
+        # A body that already ends in a newline needs one fewer, so both spellings
+        # render as exactly one blank line between the prompt and the list.
+        caps = TransportCapabilities(max_buttons=0)
+        assert apply_options_cap("Pick.", ["A"], caps)[0] == "Pick.\n\n1. A"
+        assert apply_options_cap("Pick.\n", ["A"], caps)[0] == "Pick.\n\n1. A"
+
+    def test_zero_cap_with_empty_body_is_just_the_list(self) -> None:
+        caps = TransportCapabilities(max_buttons=0)
+        body, _ = apply_options_cap("", ["A", "B"], caps)
+        assert body == "1. A\n2. B"
 
     def test_cap_choices_splits_without_formatting(self) -> None:
         caps = TransportCapabilities(max_buttons=1)
@@ -183,6 +297,182 @@ class TestSharedHelper:
 
         out = format_overflow(["Rebase onto main", "Skip the `--force` flag"], start=2)
         assert out == "3. Rebase onto main\n4. Skip the `--force` flag"
+
+
+class TestRenderOptionsAsText:
+    """The whole trailer path for a zero-widget channel, in one place.
+
+    Left to themselves the channels drifted: several carried a byte-identical
+    ``_strip_options``, Weixin a looser ``sub()`` variant that suppressed nothing,
+    and each pinned these properties in its own file — including its own copy of
+    the ReDoS regression. They are pinned once here, against the helper they all
+    call, so a new zero-widget channel inherits the properties instead of
+    re-deriving them.
+    """
+
+    CAPS = TransportCapabilities(max_buttons=0)
+
+    def test_a_complete_trailer_becomes_a_numbered_list(self) -> None:
+        out = render_options_as_text("Pick one.\n\n[OPTIONS: a | b | c]", self.CAPS)
+        assert out == "Pick one.\n\n1. a\n2. b\n3. c"
+
+    def test_an_unfinished_marker_is_left_alone(self) -> None:
+        # It LOOKS like a marker still arriving, but this helper cannot tell a live
+        # frame from a sealed answer, and the channels calling it buffer a whole turn
+        # and send once — so for them such a tail is the assistant's prose, and
+        # cutting it is permanent data loss. The one zero-widget channel that does
+        # stream (WeCom) trades the other way in its own helper, where the cost is a
+        # transient flash whose next frame replaces the bubble anyway.
+        assert (
+            render_options_as_text("answer [OPTIONS: a | b", self.CAPS) == "answer [OPTIONS: a | b"
+        )
+
+    def test_prose_ending_in_a_bare_marker_word_keeps_its_last_words(self) -> None:
+        text = "see the [OPTIONS section"
+        assert render_options_as_text(text, self.CAPS) == text
+
+    def test_plain_text_is_returned_unchanged(self) -> None:
+        assert render_options_as_text("just an answer", self.CAPS) == "just an answer"
+
+    def test_empty_text_is_returned_unchanged(self) -> None:
+        assert render_options_as_text("", self.CAPS) == ""
+
+    def test_prose_that_merely_MENTIONS_a_marker_is_never_deleted(self) -> None:
+        # Only a COMPLETE trailer at the very END is ours. Anything else is the
+        # assistant's answer: deleting it to be tidy about protocol would lose the
+        # user's content, which is worse than leaving a marker visible.
+        assert (
+            render_options_as_text("See the [STEERING design doc", self.CAPS)
+            == "See the [STEERING design doc"
+        )
+        # A steering frame reaching a renderer at all means TurnDriver did not
+        # strip it; this sink is not the place to guess. Left intact.
+        raw = "answer\n[OPTIONS: a | b]\n[STEERING steer-1234"
+        assert render_options_as_text(raw, self.CAPS) == raw
+
+    def test_choice_whitespace_is_stripped_and_blanks_dropped(self) -> None:
+        out = render_options_as_text("Q\n[OPTIONS:  a  |   | b ]", self.CAPS)
+        assert out == "Q\n\n1. a\n2. b"
+
+    def test_body_text_before_the_trailer_keeps_its_own_newlines(self) -> None:
+        out = render_options_as_text("line one\nline two\n[OPTIONS: a]", self.CAPS)
+        assert out == "line one\nline two\n\n1. a"
+
+    #: Samples per size, taking the MINIMUM. Even in CPU time a single sample can
+    #: absorb a GC pause; the fastest of a few is the machine's best effort, which
+    #: is the quantity that reflects the algorithm rather than the host.
+    _SAMPLES = 3
+
+    #: Calls per timed batch. ONE call is single-digit milliseconds, and Windows'
+    #: ``process_time`` granularity is ~15.6 ms — so a single call measures as
+    #: exactly 0.0 there and any ratio built from it is noise, not signal (a
+    #: Windows shard produced "ratio 15625.0x" against a provably linear regex,
+    #: which is 1/1e-6, i.e. the divide-by-zero floor rather than a measurement).
+    #: 20 calls puts the batch 5-11x above that tick on measured hardware.
+    _REPS = 20
+
+    #: A batch must clear this to be a measurement at all. Belt-and-braces against
+    #: the failure above recurring on a platform whose clock is coarser still, or a
+    #: machine fast enough to drop back under the tick: fail LOUDLY asking for more
+    #: reps rather than silently comparing two zeroes.
+    _MIN_BATCH_SECONDS = 0.02
+
+    def _growth_ratio(self, build: Callable[[int], str], n: int) -> float:
+        """CPU-time ratio for *build* at ``n`` and ``2n``, min-of-N batches.
+
+        Three choices make this a COMPLEXITY assertion rather than a performance
+        one, which is what keeps it from false-reddening a loaded shard:
+
+        * **The ratio, not a duration.** An absolute budget passes or fails on how
+          busy the host is and on whether coverage is enabled. Linear matching
+          stays near 2x per doubling on any machine; polynomial backtracking blows
+          past it on every machine.
+        * **``process_time``, not ``perf_counter``.** Wall clock counts the time
+          this process spent DESCHEDULED, so under the CPU oversubscription an
+          ``-n auto`` shard creates, one sample can absorb another worker's slice
+          and invent a 6x ratio out of a linear regex.
+        * **A batch, not one call.** CPU time is scheduler-immune but COARSE on
+          Windows; see ``_REPS``.
+        """
+
+        def best(size: int) -> float:
+            text = build(size)
+            render_options_as_text(text, self.CAPS)  # warm: exclude the first call
+            return min(self._cpu_per_call(text) for _ in range(self._SAMPLES))
+
+        # Smaller size FIRST: a cold cache or a page fault charged to whichever
+        # size runs first must not be charged to the numerator.
+        small = best(n)
+        return best(2 * n) / small
+
+    def _cpu_per_call(self, text: str) -> float:
+        """Mean CPU seconds per call, measured over a batch above the clock's tick."""
+        start = time.process_time()
+        for _ in range(self._REPS):
+            render_options_as_text(text, self.CAPS)
+        batch = time.process_time() - start
+        assert batch >= self._MIN_BATCH_SECONDS, (
+            f"batch of {self._REPS} measured {batch:.4f}s, under the "
+            f"{self._MIN_BATCH_SECONDS}s floor — the clock cannot resolve it, so "
+            "any ratio would be noise. Raise _REPS."
+        )
+        return batch / self._REPS
+
+    def test_an_unterminated_options_tag_is_not_redos(self) -> None:
+        # Regression (py/polynomial-redos), consolidated from the wecom, webex
+        # and teams renderer suites: a greedy ``.*`` body could consume a "["
+        # that ALSO starts the outer "[OPTIONS:" literal, so over text with many
+        # "[OPTIONS:" prefixes search() re-explored the body from each position —
+        # polynomial. The tempered body in OPTIONS_RE_TRAILER forbids only a
+        # re-occurring "[OPTIONS:", so the match is linear.
+        # Returned unchanged (no complete trailer), which is the point of the
+        # timing check below: the regex must REJECT this in linear time, not
+        # backtrack over it.
+        evil = "[OPTIONS:" + ("\t" * 200_000) + "x"
+        assert render_options_as_text(evil, self.CAPS) == evil
+        ratio = self._growth_ratio(lambda n: "[OPTIONS:" + ("\t" * n) + "x", 100_000)
+        assert ratio < 8.0, f"superlinear in input length (ratio {ratio:.1f}x)"
+
+    def test_many_repeated_options_prefixes_are_not_redos(self) -> None:
+        # The real polynomial pump: each "[OPTIONS:" is another position the body
+        # could be re-explored from.
+        ratio = self._growth_ratio(lambda n: "[OPTIONS:" * n + "x", 50_000)
+        assert ratio < 8.0, f"superlinear in prefix count (ratio {ratio:.1f}x)"
+
+
+class TestZeroWidgetChannelEnforcement:
+    """Each zero-widget renderer's own text path, driven through its real
+    capabilities object.
+
+    ``TestRenderOptionsAsText`` pins the helper; this pins that each channel
+    actually routes through it — the thing a renderer can silently stop doing,
+    since ``text()`` is not on the ``Renderer`` ABC and nothing forces the call.
+    """
+
+    TRAILER = "Deploy now?\n\n[OPTIONS: yes | no]"
+    EXPECTED = "Deploy now?\n\n1. yes\n2. no"
+
+    @pytest.mark.parametrize("channel", sorted(ZERO_WIDGET_RENDERERS))
+    def test_the_trailer_becomes_numbered_text(self, channel: str) -> None:
+        renderer = ZERO_WIDGET_RENDERERS[channel]()
+        renderer._buf = [self.TRAILER]
+        assert renderer.text() == self.EXPECTED
+
+    #: WeCom keeps a LOCAL variant of the helper and hides an unfinished marker
+    #: instead of keeping it. That is a defensible choice for the one zero-widget
+    #: channel that STREAMS — its next frame replaces the bubble, so a partial
+    #: marker is a transient flash rather than the permanent loss it would be for
+    #: a channel that only ever sends the sealed answer. The shared helper keeps
+    #: the tail for exactly that reason, so this assertion covers the callers of
+    #: the shared helper and names WeCom's divergence rather than hiding it.
+    _KEEPS_AN_UNFINISHED_TAIL = sorted(set(ZERO_WIDGET_RENDERERS) - {"wecom"})
+
+    @pytest.mark.parametrize("channel", _KEEPS_AN_UNFINISHED_TAIL)
+    def test_an_unfinished_marker_is_left_alone(self, channel: str) -> None:
+        # No channel may delete authored text to tidy up an incomplete marker.
+        renderer = ZERO_WIDGET_RENDERERS[channel]()
+        renderer._buf = ["Deploy now? [OPTIONS: yes | n"]
+        assert renderer.text() == "Deploy now? [OPTIONS: yes | n"
 
 
 class TestSlackEnforcement:

--- a/test/test_pr_quality_gates.py
+++ b/test/test_pr_quality_gates.py
@@ -115,13 +115,25 @@ class TestScreenshotEvidenceBodyLogic:
         gh.chmod(0o755)
         summary = tmp_path / "summary.md"
         summary.touch()
+        # HERMETIC env, not `**os.environ`. The step's outcome is decided entirely
+        # by environment variables, and inheriting the ambient one made that
+        # outcome depend on whatever else the process had been doing: `BASH_ENV`
+        # would make `bash -c` source a file before the script runs, and a stray
+        # `PATH`, `EXEMPT`, `LC_*` or `GH_*` value reaches the same branches the
+        # assertions read. Enumerating what the script needs is also self-documenting
+        # -- anything absent here is something the step must not depend on.
         env = {
-            **os.environ,
-            "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+            # tmp_path first so the `gh` stub wins; the system dirs follow because
+            # the script needs printf/grep/cat and the stub's shell.
+            "PATH": f"{tmp_path}{os.pathsep}/usr/local/bin{os.pathsep}/usr/bin{os.pathsep}/bin",
             # Starve any real gh of credentials so a stub-resolution failure
             # can never turn into a live API call.
             "GH_TOKEN": "",
             "GITHUB_TOKEN": "",
+            # The patterns are ASCII and every fixture body is ASCII, so pin the
+            # collation rather than inheriting a locale that changes what `grep -i`
+            # and the `[[:space:]]` class match.
+            "LC_ALL": "C",
             "EXEMPT": exempt,
             "REPO": "example/repo",
             "PR": "1",
@@ -217,10 +229,7 @@ class TestCrossPlatform:
         wf = _read("cross-platform.yml")
         assert "deliberately NO" in wf, "the absence must stay documented"
         # No rule may actually grep for the encoding kwarg.
-        rule_lines = [
-            ln for ln in wf.splitlines()
-            if ln.lstrip().startswith("hits=")
-        ]
+        rule_lines = [ln for ln in wf.splitlines() if ln.lstrip().startswith("hits=")]
         assert rule_lines, "expected at least one scan rule"
         for ln in rule_lines:
             assert "encoding" not in ln, f"encoding rule reintroduced: {ln.strip()[:80]}"
@@ -246,7 +255,7 @@ class TestPrScope:
         # combination reviews badly.
         wf = _read("pr-scope.yml")
         assert '-gt "$MAX_AREAS" ] && [' in wf
-        assert 'MAX_LINES' in wf
+        assert "MAX_LINES" in wf
 
     def test_excludes_vendor_and_screenshots(self):
         wf = _read("pr-scope.yml")
@@ -267,9 +276,9 @@ class TestDesignReviewBlocks:
         # force-pass UX and First Principles (and once Design too) is gone, so
         # a red opinion lane now produces a red PR Readiness.
         wf = _read("pr-readiness.yml")
-        assert 'passed+=("$label (advisory)")' not in wf, (
-            "no opinion lane may be force-passed; a BLOCK must reach readiness"
-        )
+        assert (
+            'passed+=("$label (advisory)")' not in wf
+        ), "no opinion lane may be force-passed; a BLOCK must reach readiness"
         assert 'failed+=("$label (BLOCK)")' in wf
 
     def test_all_three_lanes_share_the_one_blocking_branch(self):

--- a/test/test_review_fixes.py
+++ b/test/test_review_fixes.py
@@ -65,6 +65,7 @@ class TestYoloExpiry:
     def _reset_yolo(self):
         from kiro_crew.safety_override import reset_singleton
         from kiro_crew.slack.handler import disable_yolo
+
         disable_yolo()
         yield
         reset_singleton()
@@ -163,6 +164,13 @@ class TestEnvPermissions:
         # module-global warned-keys set, a residue no fixture resets.
         env_file.write_text("SLACK_BOT_TOKEN=xoxb-test\n")
         env_file.chmod(0o644)
+        # Read the FILE, not a leftover environ value. `load_credentials` ends by
+        # propagating credentials into os.environ so spawned children inherit them,
+        # and its own override loop prefers os.environ over the file — so ANY earlier
+        # test in this worker that triggered a credential read leaves a value here
+        # that monkeypatch cannot revert (the production code set it, not the test).
+        # Without this the assertion below reads that leak and fails on test ORDER.
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
 
         monkeypatch.setattr(loader_mod.platform_compat, "IS_POSIX", False)
         chmods: list[int] = []
@@ -331,9 +339,7 @@ class TestLoadCredentialsEnvPropagation:
         tmp = Path(str(tmp_path))
         env_file = tmp / ".env"
         env_file.write_text(
-            "SLACK_BOT_TOKEN=xoxb-test\n"
-            "SLACK_APP_TOKEN=xapp-test\n"
-            "KIROCREW_OWNER_ID=U123\n"
+            "SLACK_BOT_TOKEN=xoxb-test\n" "SLACK_APP_TOKEN=xapp-test\n" "KIROCREW_OWNER_ID=U123\n"
         )
         env_file.chmod(0o600)
 
@@ -345,9 +351,7 @@ class TestLoadCredentialsEnvPropagation:
         assert os.environ.get("SLACK_APP_TOKEN") == "xapp-test"
         assert os.environ.get("KIROCREW_OWNER_ID") == "U123"
 
-    def test_existing_env_value_preserved(
-        self, tmp_path: object, monkeypatch
-    ) -> None:
+    def test_existing_env_value_preserved(self, tmp_path: object, monkeypatch) -> None:
         """setdefault() must not clobber a value the caller set explicitly
         (e.g. systemd Environment= block, wrapper script export)."""
         import os
@@ -371,9 +375,7 @@ class TestLoadCredentialsEnvPropagation:
         # …and the env var is unchanged (setdefault is a no-op when set).
         assert os.environ["SLACK_BOT_TOKEN"] == "xoxb-from-systemd"
 
-    def test_empty_env_file_does_not_clobber_environ(
-        self, tmp_path: object, monkeypatch
-    ) -> None:
+    def test_empty_env_file_does_not_clobber_environ(self, tmp_path: object, monkeypatch) -> None:
         """When ~/.kirocrew/.env is bind-mounted empty inside a sandbox child,
         load_credentials() must not overwrite an env var the caller already
         propagated via os.environ.setdefault() in the parent."""
@@ -473,9 +475,7 @@ class TestLoadCredentialsEnvPropagation:
 
         tmp = Path(str(tmp_path))
         env_file = tmp / ".env"
-        env_file.write_text(
-            "".join(f"{key}=placeholder-value\n" for key in fixture_keys)
-        )
+        env_file.write_text("".join(f"{key}=placeholder-value\n" for key in fixture_keys))
         env_file.chmod(0o600)
 
         with patch("kiro_crew.config.loader.env_path", return_value=env_file):
@@ -496,6 +496,7 @@ class TestYoloFromConfigGuard:
     @pytest.fixture(autouse=True)
     def _reset_yolo(self):
         from kiro_crew.safety_override import reset_singleton
+
         reset_singleton()
         yield
         reset_singleton()
@@ -562,6 +563,7 @@ class TestYoloFromConfigSlackGuards:
     @pytest.fixture(autouse=True)
     def _reset_yolo(self):
         from kiro_crew.safety_override import reset_singleton
+
         reset_singleton()
         yield
         reset_singleton()
@@ -580,7 +582,10 @@ class TestYoloFromConfigSlackGuards:
 
         from kiro_crew.slack.events import _handle_yolo
 
-        with patch("kiro_crew.slack.events.sel") as mock_sel, patch("kiro_crew.slack.events.is_owner", return_value=True):
+        with (
+            patch("kiro_crew.slack.events.sel") as mock_sel,
+            patch("kiro_crew.slack.events.is_owner", return_value=True),
+        ):
             await _handle_yolo(orch, "UOWNER", "on", respond)
 
         respond.assert_awaited_once()
@@ -600,13 +605,22 @@ class TestYoloFromConfigSlackGuards:
         slack = AsyncMock()
         sessions = MagicMock()
 
-        with patch("kiro_crew.slack.handler.sel") as mock_sel, patch("kiro_crew.slack.handler.is_owner", return_value=True):
-            result = await _handle_slash_command("!yolo on", slack, sessions, "C123", "ts1", "ts2", "key1", "UOWNER")
+        with (
+            patch("kiro_crew.slack.handler.sel") as mock_sel,
+            patch("kiro_crew.slack.handler.is_owner", return_value=True),
+        ):
+            result = await _handle_slash_command(
+                "!yolo on", slack, sessions, "C123", "ts1", "ts2", "key1", "UOWNER"
+            )
 
         assert result is not None
         slack.post_message.assert_awaited()
         msg = slack.post_message.call_args[0][1]
         assert "already" in msg.lower()
         # No noop_config_permanent log; the already-on path logs nothing in this case
-        noop_calls = [c for c in mock_sel.return_value.log_api_access.call_args_list if c.kwargs.get("outcome") == "noop_config_permanent"]
+        noop_calls = [
+            c
+            for c in mock_sel.return_value.log_api_access.call_args_list
+            if c.kwargs.get("outcome") == "noop_config_permanent"
+        ]
         assert len(noop_calls) == 0

--- a/test/test_webex_renderer.py
+++ b/test/test_webex_renderer.py
@@ -5,32 +5,13 @@ from __future__ import annotations
 import pytest
 
 from kiro_crew.webex.client import WEBEX_MAX_TEXT
-from kiro_crew.webex.renderer import _TOOL_EDIT_BUDGET, WebexRenderer, _strip_options
+from kiro_crew.webex.renderer import _TOOL_EDIT_BUDGET, WebexRenderer
 from kiro_crew.webex.transport import WEBEX_CAPABILITIES
 
-
-class TestStripOptionsRedos:
-    def test_unterminated_options_tag_is_not_redos(self) -> None:
-        # Regression (py/polynomial-redos): the old lazy ``\s*(.*?)`` body could
-        # consume a "[" that ALSO starts the outer "[OPTIONS:" literal, so over
-        # text with many "[OPTIONS:" prefixes search() re-explored the body from
-        # each position — polynomial. Webex now shares the tempered
-        # OPTIONS_RE_TRAILER (forbids only a re-occurring "[OPTIONS:"), so the
-        # body is unambiguous (linear). A whitespace-padded unterminated tag and
-        # many repeated "[OPTIONS:" prefixes (the real pump) must both return
-        # promptly.
-        import time
-
-        evil = "[OPTIONS:" + ("\t" * 200_000) + "x"
-        start = time.perf_counter()
-        result = _strip_options(evil)
-        assert time.perf_counter() - start < 1.0, "possible ReDoS"
-        assert result == ""
-
-        evil = "[OPTIONS:" * 100_000 + "x"
-        start = time.perf_counter()
-        _strip_options(evil)
-        assert time.perf_counter() - start < 1.0, "possible ReDoS"
+# The trailer grammar, its ReDoS hardening and the numbered-text fallback are
+# shared by every zero-widget channel and pinned once in
+# test_options_cap_contract.py (TestRenderOptionsAsText +
+# TestZeroWidgetChannelEnforcement::test_webex).
 
 
 class FakeClient:
@@ -128,13 +109,13 @@ class TestFinalAnswer:
         assert delivered == text  # nothing lost
 
     @pytest.mark.asyncio
-    async def test_options_trailer_stripped(self) -> None:
+    async def test_options_trailer_becomes_numbered_text(self) -> None:
         c = FakeClient()
         r = _renderer(c)
         await r.on_turn_start()
         await r.on_text_chunk("Pick one\n\n[OPTIONS: A | B | C]")
         await r.on_done()
-        assert c.edits[-1][2] == "Pick one"
+        assert c.edits[-1][2] == "Pick one\n\n1. A\n2. B\n3. C"
 
     @pytest.mark.asyncio
     async def test_error_done_shows_error_text(self) -> None:

--- a/test/test_weixin.py
+++ b/test/test_weixin.py
@@ -502,13 +502,7 @@ def test_allowed_sender_still_gets_context_persisted(tmp_path):
     assert t._ctx.get("acct1", "friend") == "ctx-keep"
 
 
-def test_options_trailer_is_stripped_from_the_end():
-    from kiro_crew.weixin.turn_renderer import _strip_options
-
-    assert _strip_options("Here you go.\n\n[OPTIONS: Yes | No]") == "Here you go."
-
-
-def test_options_stripping_never_deletes_mid_response_content():
+def test_a_mid_response_options_mention_never_deletes_the_body():
     """Regression: a non-trailing "[OPTIONS:" must not swallow the body.
 
     The hand-rolled MULTILINE|DOTALL pattern let ``.*?`` span newlines, so an
@@ -516,23 +510,20 @@ def test_options_stripping_never_deletes_mid_response_content():
     between was silently deleted from the user's reply. The shared
     OPTIONS_RE_TRAILER anchors to end-of-string instead.
     """
-    from kiro_crew.weixin.turn_renderer import _strip_options
-
     body = (
         "The dashboard renders `[OPTIONS: a | b]` as tappable chips.\n"
         "Important paragraph that must survive.\n"
         "A list: [1] first [2] second\n"
     )
-    out = _strip_options(body + "\n[OPTIONS: Keep | Discard]")
+    from kiro_crew.messaging.renderer import render_options_as_text
+    from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
+
+    out = render_options_as_text(body + "\n[OPTIONS: Keep | Discard]", WEIXIN_CAPABILITIES)
     assert "Important paragraph that must survive." in out
     assert "[1] first [2] second" in out
     assert "Keep | Discard" not in out
-
-
-def test_text_without_a_trailer_is_untouched():
-    from kiro_crew.weixin.turn_renderer import _strip_options
-
-    assert _strip_options("just an answer") == "just an answer"
+    # The trailer's own choices still reach the user, now as numbered lines.
+    assert out.endswith("1. Keep\n2. Discard")
 
 
 def test_poll_loop_backs_off_on_ret_keyed_session_expiry(tmp_path, monkeypatch):

--- a/test/test_weixin_commands.py
+++ b/test/test_weixin_commands.py
@@ -1,0 +1,64 @@
+"""Contract tests for Weixin's command GRAMMAR (``weixin/commands.py``).
+
+The module's whole point is that the matcher and the help card read ONE table, so
+a command cannot exist without being discoverable. The per-channel half of that
+promise — every alias in a channel's spec really is reachable, and really does
+appear in its help — is pinned in each channel's own suite.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.weixin.commands import CommandSpec, build_help_text, match_command
+
+SPECS = (
+    CommandSpec("new", "Start fresh", aliases=("新对话", "清空")),
+    CommandSpec("stop", "Stop the reply", aliases=("/cancel",)),
+)
+
+
+class TestMatchCommand:
+    def test_the_canonical_spelling_matches(self) -> None:
+        assert match_command("/new", SPECS) == "new"
+
+    def test_an_alias_matches(self) -> None:
+        assert match_command("新对话", SPECS) == "new"
+        assert match_command("/cancel", SPECS) == "stop"
+
+    def test_matching_is_case_insensitive_for_the_ascii_form(self) -> None:
+        # A phone keyboard capitalises the first letter unprompted.
+        assert match_command("/New", SPECS) == "new"
+        assert match_command("/CANCEL", SPECS) == "stop"
+
+    def test_surrounding_whitespace_is_ignored(self) -> None:
+        assert match_command("  /new \n", SPECS) == "new"
+
+    def test_a_message_that_merely_STARTS_with_a_command_is_not_one(self) -> None:
+        # The whole message must be the command, or "/new plan for the migration"
+        # would silently wipe the session instead of being answered.
+        assert match_command("/new plan for the migration", SPECS) is None
+        assert match_command("新对话的想法", SPECS) is None
+
+    def test_unknown_and_empty_text_match_nothing(self) -> None:
+        assert match_command("hello", SPECS) is None
+        assert match_command("", SPECS) is None
+        assert match_command("   ", SPECS) is None
+
+    def test_only_the_slash_prefix_matches(self) -> None:
+        # The prefix is hardcoded: both adopters use "/". Discord's "!" forms are
+        # its own module's business until it migrates onto this one.
+        assert match_command("!new", SPECS) is None
+
+
+class TestBuildHelpText:
+    def test_every_visible_command_appears_with_its_aliases(self) -> None:
+        out = build_help_text("HEADER", SPECS, "FOOTER")
+        assert out.startswith("HEADER")
+        assert out.endswith("FOOTER")
+        assert "/new (新对话 / 清空) — Start fresh" in out
+        assert "/stop (/cancel) — Stop the reply" in out
+
+    def test_the_footer_is_optional(self) -> None:
+        assert build_help_text("H", SPECS).rstrip().endswith("Stop the reply")
+
+    def test_the_rendered_names_carry_the_slash(self) -> None:
+        assert "/new" in build_help_text("H", SPECS)

--- a/test/test_weixin_dispatch.py
+++ b/test/test_weixin_dispatch.py
@@ -10,13 +10,15 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
+
 from kiro_crew.messaging.driver import APPROVAL_AUTO
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.weixin.client import ContextTokenStore, TypingTicketCache
 from kiro_crew.weixin.commands import parse_command
 from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
 from kiro_crew.weixin.transport_dispatch import WeixinDispatcher
-from kiro_crew.weixin.turn_renderer import WeixinRenderer, _strip_options
+from kiro_crew.weixin.turn_renderer import WeixinRenderer
 
 
 # ── fakes ─────────────────────────────────────────────────────────────────────
@@ -68,6 +70,7 @@ class FakeProvider:
         self.reply = reply
         self.prompts: list[str] = []
         self.compacted = False
+        self.cancelled: list = []
 
     async def stream(self, message):
         self.prompts.append(message)
@@ -78,6 +81,13 @@ class FakeProvider:
 
     def has_active_turn(self):
         return False
+
+    async def cancel(self, *, wait_ack_timeout: float = 0.0) -> str:
+        # Returns a CancelOutcome, like the real provider. A fake that returned
+        # None modelled the SHAPE of the call but not its contract, which is how
+        # "did it raise" passed for "did it work".
+        self.cancelled.append(wait_ack_timeout)
+        return "acked"
 
     async def compact(self):
         self.compacted = True
@@ -95,6 +105,8 @@ class FakeSessions:
         self.failures = 0
         self.channels: dict[str, str] = {}
         self.acquired = False
+        self.mirror_links: dict[str, object] = {}
+        self.opted_out = False
 
     def is_busy(self, key):
         return self._busy
@@ -131,6 +143,16 @@ class FakeSessions:
         # seed_generation() probes for the highest existing generation; a fresh
         # fake has none.
         return 0
+
+    # ── outbound mirror binding (drive_turn binds the conversation to itself) ──
+    def mirror_opt_out(self, key):
+        return self.opted_out
+
+    def get_mirror_link(self, key):
+        return self.mirror_links.get(key)
+
+    def set_mirror_link(self, key, location):
+        self.mirror_links[key] = location
 
 
 class FakeHooks:
@@ -183,16 +205,10 @@ def _make(tmp_path, provider=None, busy=False):
 
 
 def _msg(text="hi", user="userA"):
-    return InboundMessage(
-        channel_type="weixin", user_id=user, conversation_id=user, text=text
-    )
+    return InboundMessage(channel_type="weixin", user_id=user, conversation_id=user, text=text)
 
 
 # ── renderer ──────────────────────────────────────────────────────────────────
-def test_strip_options_removes_dashboard_only_affordance():
-    assert _strip_options("answer\n[OPTIONS: a | b]") == "answer"
-
-
 def test_renderer_buffers_and_sends_once_on_done(tmp_path):
     client = FakeClient()
     r = WeixinRenderer(
@@ -218,8 +234,11 @@ def test_renderer_buffers_and_sends_once_on_done(tmp_path):
 def test_renderer_on_done_is_idempotent(tmp_path):
     client = FakeClient()
     r = WeixinRenderer(
-        client, "userA", WEIXIN_CAPABILITIES,
-        ctx_store=ContextTokenStore(str(tmp_path)), account_id="acct1",
+        client,
+        "userA",
+        WEIXIN_CAPABILITIES,
+        ctx_store=ContextTokenStore(str(tmp_path)),
+        account_id="acct1",
     )
 
     async def go():
@@ -235,19 +254,25 @@ def test_renderer_on_done_is_idempotent(tmp_path):
 def test_renderer_close_without_done_emits_error_text(tmp_path):
     client = FakeClient()
     r = WeixinRenderer(
-        client, "userA", WEIXIN_CAPABILITIES,
-        ctx_store=ContextTokenStore(str(tmp_path)), account_id="acct1",
+        client,
+        "userA",
+        WEIXIN_CAPABILITIES,
+        ctx_store=ContextTokenStore(str(tmp_path)),
+        account_id="acct1",
     )
     asyncio.run(r.close())
     assert len(client.sent) == 1
     assert "出错" in client.sent[0]["text"]
 
 
-def test_renderer_strips_options_from_the_reply(tmp_path):
+def test_renderer_renders_options_as_numbered_text_in_the_reply(tmp_path):
     client = FakeClient()
     r = WeixinRenderer(
-        client, "userA", WEIXIN_CAPABILITIES,
-        ctx_store=ContextTokenStore(str(tmp_path)), account_id="acct1",
+        client,
+        "userA",
+        WEIXIN_CAPABILITIES,
+        ctx_store=ContextTokenStore(str(tmp_path)),
+        account_id="acct1",
     )
 
     async def go():
@@ -255,16 +280,14 @@ def test_renderer_strips_options_from_the_reply(tmp_path):
         await r.on_done()
 
     asyncio.run(go())
-    assert client.sent[0]["text"] == "answer"
+    assert client.sent[0]["text"] == "answer\n\n1. a\n2. b"
 
 
 def test_renderer_echoes_the_stored_context_token(tmp_path):
     client = FakeClient()
     store = ContextTokenStore(str(tmp_path))
     store.set("acct1", "userA", "ctx-42")
-    r = WeixinRenderer(
-        client, "userA", WEIXIN_CAPABILITIES, ctx_store=store, account_id="acct1"
-    )
+    r = WeixinRenderer(client, "userA", WEIXIN_CAPABILITIES, ctx_store=store, account_id="acct1")
 
     async def go():
         await r.on_text_chunk("hi")
@@ -277,8 +300,11 @@ def test_renderer_echoes_the_stored_context_token(tmp_path):
 def test_renderer_chunks_an_oversized_answer(tmp_path):
     client = FakeClient()
     r = WeixinRenderer(
-        client, "userA", WEIXIN_CAPABILITIES,
-        ctx_store=ContextTokenStore(str(tmp_path)), account_id="acct1",
+        client,
+        "userA",
+        WEIXIN_CAPABILITIES,
+        ctx_store=ContextTokenStore(str(tmp_path)),
+        account_id="acct1",
     )
 
     async def go():
@@ -293,8 +319,11 @@ def test_renderer_chunks_an_oversized_answer(tmp_path):
 def test_renderer_tool_and_thinking_events_emit_nothing(tmp_path):
     client = FakeClient()
     r = WeixinRenderer(
-        client, "userA", WEIXIN_CAPABILITIES,
-        ctx_store=ContextTokenStore(str(tmp_path)), account_id="acct1",
+        client,
+        "userA",
+        WEIXIN_CAPABILITIES,
+        ctx_store=ContextTokenStore(str(tmp_path)),
+        account_id="acct1",
     )
 
     async def go():
@@ -767,3 +796,158 @@ def test_tool_gate_denies_when_hooks_deny(tmp_path):
     gate = captured.get("tool_gate")
     assert gate is not None
     assert gate(FakeEvent("permission")) == "deny"
+
+
+# ── command vocabulary ────────────────────────────────────────────────────────
+def test_every_alias_in_the_weixin_spec_is_reachable():
+    """A command that parses but is missing from help is a feature nobody finds;
+    one listed but unreachable is a lie. Both derive from COMMANDS."""
+    from kiro_crew.weixin.commands import COMMANDS
+
+    for spec in COMMANDS:
+        assert parse_command(f"/{spec.name}") == spec.name
+        for alias in spec.aliases:
+            assert parse_command(alias) == spec.name, f"{alias} unreachable"
+
+
+def test_every_visible_weixin_command_appears_in_help():
+    from kiro_crew.weixin.commands import COMMANDS, build_help
+
+    body = build_help()
+    for spec in COMMANDS:
+        assert f"/{spec.name}" in body
+        for alias in spec.aliases:
+            assert alias in body
+
+
+def test_weixin_help_lists_no_link_command():
+    """iLink is DM-only with no dashboard-mirror command, so advertising one
+    would promise a capability this channel does not have."""
+    from kiro_crew.weixin.commands import build_help
+
+    assert "/link" not in build_help()
+
+
+def test_help_replies_with_the_card_and_runs_no_turn(tmp_path):
+    provider = FakeProvider()
+    d, client, sessions = _make(tmp_path, provider=provider)
+
+    asyncio.run(d.handle_message(_msg("/help")))
+
+    assert provider.prompts == [], "help must not spend a turn"
+    assert any("/stop" in m["text"] for m in client.sent)
+
+
+def test_stop_cancels_a_live_turn_cooperatively(tmp_path):
+    provider = FakeProvider()
+    d, client, sessions = _make(tmp_path, provider=provider, busy=True)
+
+    asyncio.run(d.handle_message(_msg("/stop")))
+
+    # Fire-and-forget: waiting for the ack would hold the reply behind the very
+    # turn being stopped.
+    assert provider.cancelled == [0]
+    assert any("正在停止" in m["text"] for m in client.sent)
+
+
+def test_stop_with_nothing_running_says_so(tmp_path):
+    provider = FakeProvider()
+    d, client, sessions = _make(tmp_path, provider=provider, busy=False)
+
+    asyncio.run(d.handle_message(_msg("/stop")))
+
+    assert provider.cancelled == []
+    assert any("没有正在生成" in m["text"] for m in client.sent)
+
+
+@pytest.mark.parametrize(
+    "outcome,expected",
+    [
+        ("acked", "正在停止"),
+        # The cancel WAS written; only the ack is outstanding, which is what
+        # "stopping" already describes.
+        ("timeout", "正在停止"),
+        # The provider disagrees with is_busy -- the turn finished in between --
+        # so "nothing running" is the accurate answer, not a failure.
+        ("no_turn", "没有正在生成"),
+        # AcpRuntimeDead and any other internal failure come back as "error"
+        # rather than raising, so a try/except alone would have reported
+        # "stopping" for a cancel that never happened.
+        ("error", "停止失败"),
+    ],
+)
+def test_stop_reports_the_cancel_OUTCOME_not_merely_that_the_call_returned(
+    tmp_path, outcome, expected
+):
+    """``cancel`` is typed ``CancelOutcome`` and swallows its own failures.
+
+    It returns ``"error"`` for ``AcpRuntimeDead`` and for any unexpected
+    exception, so branching on "did the call raise" reports success for a cancel
+    that did not happen -- the same class of lie as telling someone watching a
+    live reply that nothing is running.
+    """
+
+    class Outcome(FakeProvider):
+        async def cancel(self, *, wait_ack_timeout: float = 0.0):
+            self.cancelled.append(wait_ack_timeout)
+            return outcome
+
+    d, client, sessions = _make(tmp_path, provider=Outcome(), busy=True)
+
+    asyncio.run(d.handle_message(_msg("/stop")))
+
+    assert any(expected in m["text"] for m in client.sent), [m["text"] for m in client.sent]
+
+
+def test_stop_reports_failure_when_the_provider_raises(tmp_path):
+    # The other shape the contract allows to reach here: a provider that raises
+    # instead of returning an outcome must still not read as success.
+    class Raising(FakeProvider):
+        async def cancel(self, *, wait_ack_timeout: float = 0.0):
+            raise RuntimeError("transport gone")
+
+    d, client, sessions = _make(tmp_path, provider=Raising(), busy=True)
+
+    asyncio.run(d.handle_message(_msg("/stop")))
+
+    assert any("停止失败" in m["text"] for m in client.sent)
+
+
+def test_stop_never_releases_a_semaphore_it_did_not_acquire(tmp_path):
+    provider = FakeProvider()
+    d, client, sessions = _make(tmp_path, provider=provider, busy=True)
+
+    asyncio.run(d.handle_message(_msg("/stop")))
+
+    assert sessions.released == 0, "drive_turn's finally owns the release"
+
+
+# ── origin-mirror binding: deliberately NOT automatic ─────────────────────────
+def test_a_turn_does_not_auto_bind_the_conversation_as_a_mirror(tmp_path):
+    """An inbound turn must NOT bind its conversation as the session's mirror.
+
+    Binding it would be convenient -- a cron result or subagent reply for a
+    channel-born session reaches nobody unless the user ran ``/link`` -- but the
+    mirror is PERSISTED and the outbound path never re-checks the channel's
+    allow-list. ``chat_runner._resolve_channel_target`` gates on governance, a
+    registered transport and ``supports_proactive_send``, and none of those answers
+    "is this recipient still allowed?". A user removed from ``weixin.allowed_users``
+    would keep receiving session content through a binding their first message
+    created.
+
+    The gap is not created by an auto-bind -- it is a property of mirror bindings,
+    and ``/link`` and Discord's own auto-bind share it -- but auto-binding WIDENS
+    who is exposed from "users who linked" to "everyone who ever sent a message",
+    and that is not a widening to ship without the recipient check.
+
+    Pinned as a test rather than left as an absence, so re-adding the bind is a
+    deliberate act: the fix is an authorization re-check at the outbound send
+    boundary, alongside the other channels that share the gap.
+    """
+    d, client, sessions = _make(tmp_path, provider=FakeProvider())
+    asyncio.run(d.handle_message(_msg("hi", "userA")))
+    assert sessions.mirror_links == {}, (
+        "an inbound turn bound a mirror; see this test's docstring -- the outbound "
+        "path does not re-check the allow-list, so a revoked user would keep "
+        "receiving session content"
+    )

--- a/website/capture/thinking-block-align.tsx
+++ b/website/capture/thinking-block-align.tsx
@@ -12,6 +12,12 @@
  * class strings are copied verbatim from ToolCallLine.tsx.
  *
  * Query params: ?theme=dark|light
+ *
+ * i18n is pinned to English rather than booted bare. A bare `initI18n()` resolves
+ * the language from `readStoredLanguage()`, so the same capture would render
+ * different chrome on two machines and a before/after pair would no longer isolate
+ * the layout change it exists to show. The sample content below is deliberately
+ * Chinese -- that is the CJK line-height case being captured, not a locale setting.
  */
 import { createRoot } from 'react-dom/client'
 import { CircleDot } from 'lucide-react'
@@ -22,7 +28,7 @@ import ThinkingBlock from '../src/pages/chat/ThinkingBlock'
 import { PanelRightSolid } from '../src/components/icons/panels'
 import { ROW_PILL_BUTTON_CLASS, ROW_PILL_WRAPPER_CLASS } from '../src/pages/chat/rowPill'
 
-initI18n()
+initI18n('en')
 
 const params = new URLSearchParams(location.search)
 const theme = params.get('theme') === 'light' ? 'light' : 'dark'


### PR DESCRIPTION
## What this fixes

Four fixes that survive **#5105**. That PR closed the WeCom platform gaps this branch originally targeted — the byte cap, splitting, `/help`, `/stop`, ACK reliability, media ingest — and went further on several. Everything it now owns has been **dropped from here**; what remains is the shared-layer work it did not touch, plus the WeChat (Weixin) half.

Scope before: 64 files, +6 012/−722. Now: **31 files, +1 660/−384.**

### Choices were deleted, not degraded

A trailing `[OPTIONS: a | b | c]` trailer was removed outright by every channel that renders no tappable chip — the user read a question whose answers had been deleted. Webex, iMessage and Weixin each carried their own `_strip_options` for it, and #5105 added a fourth spelling in WeCom that degrades instead.

`cap_choices` already overflows everything at zero widget slots, so `apply_options_cap` needs no zero-widget branch: one `render_options_as_text` puts every choice through the same numbered-list sink that already redacts credentials in **display** form and defangs mentions, and the three deleting channels now call it.

An unfinished `[OPTIONS` tail is **kept** rather than cut: those three never stream, so for them the cut was permanent loss of authored prose. WeCom keeps its local variant precisely because it *does* stream, and `test_options_cap_contract.py` names that divergence rather than hiding it.

### WeChat could not be steered or stopped

- **`/stop`** (with `/cancel`, `停止`) sends the cooperative ACP `session/cancel`, intercepted **before** the steer path — otherwise the message is folded into the very turn it exists to stop. It reports three states, because "nothing is running" told to someone watching a live reply is a lie.
- **`/help`** lists commands from the same table the matcher reads, so a command cannot exist without being discoverable.
- **A folded mid-turn steer** now leaves a quote chip at the boundary, materialized lazily so a steer folded at the very end adds no empty chip, and **display-redacted** — a steer is untrusted text landing in a markdown-parsed body, where a credential split by a code span is whole on screen while a byte-level scan saw it broken. Registered in `_REDACTION_SINKS` with its single-pass coverage disclosed.

### Channel sessions reach nobody — and this PR no longer tries to fix that

**Withdrawn.** The fix was to have `drive_turn` bind the conversation it is reading as that session's own mirror. GPT 5.6 blocked it, correctly: the mirror is **persisted**, and the outbound path never re-checks the channel's allow-list — `chat_runner._resolve_channel_target` gates on governance, a registered transport and `supports_proactive_send`, none of which answers *"is this recipient still allowed?"*. A user removed from `weixin.allowed_users` would keep receiving session content through a binding their first message created.

That gap is **not created** by an auto-bind — `/link` and Discord's own auto-bind (`discord/transport_dispatch.py:597`) both have it — but auto-binding widens who is exposed from "users who linked" to "everyone who ever sent a message", and that is not a widening to ship without the recipient check.

So `ChannelTurn.origin_location` and the `drive_turn` bind branch are both gone (zero suppliers, so the field went with them), and `test_a_turn_does_not_auto_bind_the_conversation_as_a_mirror` pins the decision with the reasoning, so re-adding it is deliberate. **The real fix is an authorization re-check at the outbound send boundary**, which belongs with the other channels that share the gap rather than in this PR.

### Config could say "off" and mean "on"

`bool("false")` is `True`, so a JSON string in `wecom.enabled` or `wecom.allow_all_users` enabled a channel — or opened it to a whole org — from a value that said the opposite. Both read through `_safe_bool`; `allowed_users` reads through `_safe_list` so an explicit `null` degrades instead of raising out of config load at **startup**.

### WeCom is nudge-able now

Its exclusion from the auto-nudge classifier named its own condition — *"add it here on the day WeCom gains a proactive send path"*. #5105 flipped that capability, so `wecom:` is classified like every other namespace. The mirror and cross-surface suites read **real** capabilities rather than fakes, which is what made the flip observable. With every shipped channel now declaring proactive send, their refusing branches are driven by a **synthetic** capability so they keep testing the gate instead of quietly driving nothing.

## Deliberately NOT in this PR

- **WeCom per-group sessions and a group allow-list.** `WeComTransport._chat_is_direct` refuses group traffic outright and says *"until per-group sessions and a group allow-list exist"* — this is that follow-up, and it is its own change. The bug I originally found (a group message keyed to the sender's **private DM** session) is already closed by that refusal.
- **Deduping WeCom's local `_render_options_as_text` onto the shared helper.** It differs deliberately — it hides an unfinished marker because it streams — and reversing that in a brand-new file is not this PR's call.
- **Moving `chunk_utf8` into `messaging/split.py`.** Cosmetic consolidation, and #5105 moved only `truncate_utf8`.
- **Migrating the other channels' command parsers.** Weixin's grammar stays local: WeCom grew its own `build_help_text`, so a shared module would have exactly one consumer, and that is a guess about the second.

## Pre-existing CI failures fixed

All three were failing before this branch and are unrelated to its subject:

- `capture/thinking-block-align.tsx` booted i18n from the English-only entry, so 12 locales fell back silently. Pinned to `initI18n('en')` — an evidence capture must be reproducible, not dependent on `readStoredLanguage()`.
- `test_pr_quality_gates.py` inherited the entire ambient environment into a subprocess whose outcome is decided by environment variables (`BASH_ENV` alone is sufficient). Now hermetic.
- `test_review_fixes.py` read a `SLACK_BOT_TOKEN` that `load_credentials` had propagated into `os.environ` for child processes — behind `monkeypatch`'s back, so nothing reverted it and the test passed or failed on order.

## Linked issues

No linked issue: this is a follow-on to **#5105**, which merged mid-review and
superseded the WeCom half. It references that PR for context but closes nothing —
the group-session work #5105's `_chat_is_direct` gate defers to is a separate
change, not closed here.

## Verification

- Full backend suite: **63 494 passed**, 155 skipped, 6 xfailed.
- `mypy` clean (1 049 files); `flake8`, `black` baseline, `docs-lint`, `scrub-lint`, harness-parity and brand gates all clean.
- `.github/black-baseline.txt` pruned only for files this PR touches (re-checked after each rebase).
- One unrelated flake seen once under heavy local load: `test_telegram.py::test_concurrent_queue_adds_share_one_receipt` (`assert 2 == 3`), not in this diff, passes 3/3 in isolation.


