### PR TITLE
fix(messaging): consume session-directive markers in TurnDriver (#4540)

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -84,6 +84,8 @@ Consumes a provider's `AcpEvent` stream and emits abstract `OutputEvent`s to a p
 
 The dashboard does **not** flow through `TurnDriver`; it remains unchanged as the authoritative transcript surface. Direct channel paths that bypass the driver are sanitized at source: Discord's explicit five-message resume replay strips legacy steering frames and summary-bearing compaction notices, shortens each entry to the shared splitter's first (sealed) chunk so a replayed code block cannot arrive with its fence cut in half, and puts the role icon on its own line so the body's first line still starts where the fence grammar needs it; direct compact commands publish only terse receipts. Stored transcripts remain intact for audit.
 
+**Session-directive consumption** — an optional `directive_consumer` callback (`(kind, args) -> awaitable`) makes the driver the channel-side consumer of the stateless session-directive protocol (`session_directive.py`): the trusted `_meta.kiro` identity (`mcp_server_name == CORE_MCP_SERVER`, `match_tool(tool_name)`) is recorded at `EVENT_TOOL_CALL`, and the matching `EVENT_TOOL_RESULT`'s marker is decoded and handed to the consumer — single-consume across result frames, forged markers under any other tool ignored, `encode()` refusals logged, a lost marker on the final frame logged at WARNING. A tool call announced as a NATIVE sub-agent's (`EVENT_SUBAGENT_ACTIVITY` with a `tool_call_id`) is refused with a SEL `denied` audit rather than applied — a child session must never arm/mutate its parent, mirroring the dashboard consumer's isolation. Dispatchers inject `messaging.dispatch.build_directive_consumer(session_key=…, sessions=…, dispatcher=…)`, which funnels into the same `apply_session_directive` core the dashboard consumer uses with `slot=None` (so dashboard-only directives stay refused for channel turns). The monitor trio takes effect where the session is nudge-able (`slack:`/`discord:`); on the other six transports (Telegram, iMessage, Teams, Webex, WeCom, Weixin) the applier answers "not supported from this session type" — logged and SEL-audited instead of the old silent drop, but no loop is armed there until `autonudge.binding_key_for` admits those keys. Without a consumer, directive markers are inert exactly as before.
+
 **`run(message) -> str`** — calls `renderer.on_turn_start()`, then translates each provider event into a dispatched `OutputEvent` and returns the accumulated (redacted) assistant text:
 
 | Provider event | Emitted `OutputEvent` |
@@ -91,7 +93,8 @@ The dashboard does **not** flow through `TurnDriver`; it remains unchanged as th
 | `EVENT_TEXT_CHUNK` | `TEXT_CHUNK` (protocol-framed, redacted, accumulated); inline steering frames become `STEER_CONSUMED`, compaction summary notices become a terse receipt |
 | `EVENT_THINKING_CHUNK` | `THINKING` |
 | `EVENT_STEER_CONSUMED` | paired with the inline frame so exactly one `STEER_CONSUMED` boundary reaches the renderer |
-| `EVENT_TOOL_CALL` | `TOOL_CALL` (uniform — each call completes the prior task + starts a new one) |
+| `EVENT_TOOL_CALL` | `TOOL_CALL` (uniform — each call completes the prior task + starts a new one); records the directive-tool identity when a `directive_consumer` is injected |
+| `EVENT_TOOL_RESULT` | nothing rendered; decodes + applies a session-directive marker via the injected `directive_consumer` (inert without one) |
 | `EVENT_PERMISSION_REQUEST` | `PROMPT_CHOICE` (interactive w/ decider only) then approve/reject |
 | `EVENT_COMPACTION_STATUS` | `COMPACTION` |
 | `EVENT_COMPLETE` | `DONE` |

--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -1,12 +1,21 @@
 """Apply a decoded session directive against the consumer's OWN session.
 
 Called from ``dashboard/chat_runner.py``'s ``EVENT_TOOL_RESULT`` handler — the
-single shared turn loop for every interactive surface (dashboard, Slack,
-Discord, taskrunner, …). The caller supplies the AUTHORITATIVE ``slot`` and
-``session_key`` for the turn, so a stateless tool's directive is applied to the
-exact session that produced it. Effects run IN-PROCESS via the same cores the
-HTTP endpoints call (no loopback HTTP, no user-token dance): the consumer is
-the authoritative session, so cross-session misattribution is unrepresentable.
+shared turn loop for every dashboard-driven surface (dashboard, Slack mirror,
+taskrunner, …) — and from ``messaging/driver.py``'s ``TurnDriver`` directive
+consumer, which covers the standalone channel transports (Telegram, Discord,
+standalone Slack, iMessage, Teams, Webex, WeCom, Weixin). The caller supplies
+the AUTHORITATIVE ``session_key`` for the turn, so a stateless tool's directive
+is applied to the exact session that produced it. Effects run IN-PROCESS via
+the same cores the HTTP endpoints call (no loopback HTTP, no user-token dance):
+the consumer is the authoritative session, so cross-session misattribution is
+unrepresentable.
+
+``slot`` is the dashboard chat slot when the caller has one (chat_runner) and
+``None`` for a channel turn (TurnDriver). A missing slot NEVER weakens a
+boundary: the dashboard-only directives are refused outright for a slot-less
+caller (they act on a slot, so there is nothing to apply them to), and the
+monitor trio only reads ``slot`` through fail-safe ``getattr``.
 
 Every branch returns a human-readable confirmation string and NEVER raises into
 the runner. NOTE: gateway-off (the default), the MODEL already received the
@@ -51,8 +60,11 @@ _DASHBOARD_ONLY_DIRECTIVES = frozenset({"set_project", "suggest_followup", "ask_
 
 
 class _DirectiveDenied(Exception):
-    """Raised by an applier when it refuses on a permission decision (e.g. a
-    sensitive-path block). Audited as ``outcome="denied"`` by the wrapper."""
+    """Raised by an applier when the directive is REFUSED — a permission
+    decision (e.g. a sensitive-path block), an unsupported session type, or an
+    authorizer refusal. Audited as ``outcome="denied"`` by the wrapper. The
+    distinction from a plain returned string matters for the SEL chain: every
+    path where the effect was NOT applied must never audit ``success``."""
 
 
 def _audit(session_key: str, kind: str, outcome: str) -> None:
@@ -85,16 +97,22 @@ async def apply_session_directive(
 ) -> str:
     """Apply directive *kind* with *args* to *slot*/*session_key*; return a
     confirmation string for the model. Fail-soft: any error is returned as a
-    readable message, never raised. Every path emits a SEL audit event."""
-    if kind in _DASHBOARD_ONLY_DIRECTIVES and not has_dashboard_surface(session_key):
+    readable message, never raised. Every path emits a SEL audit event.
+    ``slot`` is ``None`` for a channel (TurnDriver) caller — see the module
+    docstring."""
+    if kind in _DASHBOARD_ONLY_DIRECTIVES and (
+        slot is None or not has_dashboard_surface(session_key)
+    ):
         # These three act on a dashboard chat SLOT (its project/CWD, its
         # follow-up card, its question card), so the boundary is whether an open
         # tab exists to receive the effect — not where the conversation started.
         # A channel-born session displayed in a tab qualifies; a cron, sub-agent
         # or otherwise tabless caller does not, and must not silently retarget a
-        # slot's project or address a card nothing will render. The consumer is
-        # the only layer that knows the authoritative session, so the check
-        # belongs HERE.
+        # slot's project or address a card nothing will render. A slot-less
+        # caller (a channel transport's TurnDriver) is refused for the same
+        # reason even when a tab happens to be open: the effect targets the
+        # SLOT, and this turn does not hold one. The consumer is the only layer
+        # that knows the authoritative session, so the check belongs HERE.
         _audit(session_key, kind, "denied")
         return (
             f"Error: {kind} only works from a dashboard chat session "
@@ -146,11 +164,14 @@ async def _monitor_start(state: Any, session_key: str, args: dict[str, Any]) -> 
     from kiro_crew.autonudge_authz import authorize_and_add_nudge
 
     svc = get_instance()
+    # Not-applied paths RAISE so the wrapper audits them as denied — a plain
+    # return here would be derived as ``success`` and corrupt the SEL chain
+    # for an effect that never happened (the loop was not armed).
     if svc is None:
-        return "Monitor loop NOT armed: auto-nudge is disabled on this host."
+        raise _DirectiveDenied("Monitor loop NOT armed: auto-nudge is disabled on this host.")
     binding = _binding(session_key)
     if not binding:
-        return "monitor_start is not supported from this session type."
+        raise _DirectiveDenied("monitor_start is not supported from this session type.")
     idle_secs = int(args.get("idle_secs") or 300)
     max_cycles = int(args.get("max_cycles") or 0)
     max_runtime_secs = int(args.get("max_runtime_secs") or 0)
@@ -167,7 +188,9 @@ async def _monitor_start(state: Any, session_key: str, args: dict[str, Any]) -> 
         caller="session-directive",
     )
     if error is not None:
-        return f"Failed to start monitor loop: {error}"
+        # The authorizer already audited its own refusal; the wrapper's record
+        # for THIS directive must agree (denied), not overwrite it as success.
+        raise _DirectiveDenied(f"Failed to start monitor loop: {error}")
     cap = f", stopping after {max_cycles} cycles" if max_cycles else ", with NO cycle cap"
     if max_runtime_secs:
         cap += f", wall-clock budget {max_runtime_secs}s"
@@ -185,14 +208,15 @@ async def _monitor_update(session_key: str, args: dict[str, Any]) -> str:
     from kiro_crew.autonudge_authz import authorize_and_update_nudge
 
     svc = get_instance()
+    # Not-applied paths raise (audited denied) — see _monitor_start.
     if svc is None:
-        return "Cannot update monitor loop: auto-nudge is disabled on this host."
+        raise _DirectiveDenied("Cannot update monitor loop: auto-nudge is disabled on this host.")
     binding = _binding(session_key)
     if not binding:
-        return "monitor_update is not supported from this session type."
+        raise _DirectiveDenied("monitor_update is not supported from this session type.")
     loop = svc.get_by_slot(binding)
     if not loop:
-        return "No active monitor loop on this session to update."
+        raise _DirectiveDenied("No active monitor loop on this session to update.")
     patch = dict(args.get("patch") or {})
     cycle_count = int(getattr(loop, "cycle_count", 0) or 0)
     current_cap = int(getattr(loop, "max_cycles", 0) or 0)
@@ -285,7 +309,8 @@ async def _monitor_update(session_key: str, args: dict[str, Any]) -> str:
         caller="session-directive",
     )
     if error is not None:
-        return f"Failed to update monitor loop: {error}"
+        # The authorizer already audited its own refusal; agree with it.
+        raise _DirectiveDenied(f"Failed to update monitor loop: {error}")
     fields = ", ".join(sorted(k for k in patch if k != "active"))
     return (
         f"Monitor loop {loop.id} updated on this session ({fields})."
@@ -297,11 +322,15 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
     from kiro_crew.autonudge import get_instance
 
     svc = get_instance()
+    # "Nothing to stop" is an IDEMPOTENT success — the goal (no loop running on
+    # this session) already holds — so the disabled-service and no-loop paths
+    # keep returning. The unsupported-session path is a refusal like its
+    # siblings: the caller asked for an effect this session can never carry.
     if svc is None:
         return "No auto-nudge loop to stop (auto-nudge is disabled on this host)."
     binding = _binding(session_key)
     if not binding:
-        return "autonudge_stop is not supported from this session type."
+        raise _DirectiveDenied("autonudge_stop is not supported from this session type.")
     loop = svc.get_by_slot(binding)
     if not loop:
         return "No active auto-nudge loop on this session — nothing to stop."

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -50,7 +50,7 @@ from kiro_crew.history import is_incognito_transcript
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.attachments import IngestLimits
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
-from kiro_crew.messaging.dispatch import delivery_is_muted
+from kiro_crew.messaging.dispatch import build_directive_consumer, delivery_is_muted
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import (
@@ -541,6 +541,13 @@ class DiscordDispatcher:
                     and title == "spawn_run"
                 ),
                 tool_gate=_tool_gate,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker the driver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
             )
             accumulated = await driver.run(full_message)
 

--- a/src/kiro_crew/imessage/transport_dispatch.py
+++ b/src/kiro_crew/imessage/transport_dispatch.py
@@ -31,7 +31,12 @@ from kiro_crew.imessage.commands import HELP_TEXT, ConversationState, parse_comm
 from kiro_crew.imessage.renderer import IMessageRenderer
 from kiro_crew.imessage.rpc import RpcError, RpcTransportError
 from kiro_crew.imessage.transport import IMESSAGE_CAPABILITIES
-from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.dispatch import (
+    ChannelTurn,
+    build_directive_consumer,
+    drive_turn,
+    inbound_permitted,
+)
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 
@@ -171,6 +176,13 @@ class IMessageDispatcher:
             ChannelTurn(
                 channel_type="imessage",
                 session_key=session_key,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker TurnDriver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
                 conversation_id=conversation_id,
                 agent=agent,
                 user_text=text,

--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -27,15 +27,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
-from kiro_crew.messaging.driver import TurnDriver
+from kiro_crew.messaging.driver import DirectiveConsumer, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
 from kiro_crew.messaging.renderer import SilentRenderer
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,10 @@ class ChannelTurn:
     after_persist: Optional[Callable[[], Awaitable[None]]] = None
     """Optional loop-side callback after persistence, such as dashboard surfacing."""
 
+    directive_consumer: Optional[DirectiveConsumer] = None
+    """Session-directive consumer for this turn (``build_directive_consumer``).
+    ``None`` leaves directive-tool results inert — the pre-consumer behavior."""
+
     audit_caller: str = ""
     """SEL audit caller label; defaults to ``<channel_type>:unknown``."""
 
@@ -151,6 +156,69 @@ def build_auto_approve(ctx_builder: Any) -> Callable[[str], bool]:
         )
 
     return _auto_approve
+
+
+@dataclass
+class _ChannelDirectiveState:
+    """Minimal ``NudgeAuthzState`` stand-in for a turn with no gateway state.
+
+    Carries the one thing the monitor-trio authorizer can validate for a
+    channel session — ``sessions`` (Slack routability). The empty ``_slots`` /
+    ``channel_transports`` make every other lookup fail CLOSED (deny), never
+    crash.
+    """
+
+    sessions: Any
+    channel_transports: dict[str, Any] = field(default_factory=dict)
+    _slots: dict[str, Any] = field(default_factory=dict)
+
+
+def build_directive_consumer(
+    *,
+    session_key: str,
+    sessions: Any,
+    dispatcher: Any = None,
+) -> DirectiveConsumer:
+    """Session-directive consumer for one channel turn (``TurnDriver`` injection).
+
+    Applies a decoded directive against THIS turn's *session_key* via the shared
+    ``apply_session_directive`` core — the same applier the dashboard's
+    ``chat_runner`` consumer uses, so the security boundaries (the
+    dashboard-only denial, the monitor-trio authorization chokepoint) live in
+    exactly one place. A channel turn has no dashboard chat slot, so
+    ``slot=None`` is passed and the dashboard-only directives are refused there
+    (fail-closed).
+
+    *dispatcher* supplies the live gateway state: each channel dispatcher gets
+    ``dashboard_state`` attached at boot (``register_channel_transport``), and
+    it is re-read per directive so a consumer built before that attachment
+    still sees it. Slack's function-style dispatch has no dispatcher object;
+    the minimal *sessions*-backed stand-in covers the Slack routability check,
+    and everything it cannot answer fails CLOSED in the authorizer.
+    """
+
+    async def _consume(kind: str, args: dict[str, Any]) -> None:
+        # Deferred import: the dashboard package imports every channel package
+        # at boot, and the channel packages import this module (cycle).
+        from kiro_crew.dashboard.session_directive_apply import apply_session_directive
+
+        state: Any = getattr(dispatcher, "dashboard_state", None)
+        if state is None:
+            state = _ChannelDirectiveState(sessions=sessions)
+        result = await apply_session_directive(state, None, session_key, kind, args)
+        # The channel surface never renders tool results, so the applier's
+        # confirmation has no user-facing sink here; this log is the operator's
+        # record (the applier itself SEL-audits every outcome). Failures log at
+        # WARNING because a silently dropped effect is the defect this consumer
+        # exists to remove. The string interpolates LLM-derived text (a stop
+        # reason, a rejected path, exception args), so scrub it like every
+        # other LLM-influenced output before it lands anywhere.
+        result, _ = redact_exfiltration_urls(result)
+        result, _ = redact_credentials(result)
+        log = logger.warning if result.startswith(("Error", "Failed")) else logger.info
+        log("session directive %s on %s: %s", kind, session_key, result)
+
+    return _consume
 
 
 def delivery_is_muted(sessions: Any, session_key: str, channel_type: str) -> bool:
@@ -260,6 +328,7 @@ async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> N
             decider=turn.decider,
             auto_approve_tool=build_auto_approve(ctx_builder),
             tool_gate=build_tool_gate(ctx_builder, session_key=session_key, agent=turn.agent),
+            directive_consumer=turn.directive_consumer,
         )
         accumulated = await driver.run(full_message)
 

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -7,8 +7,9 @@ redaction and the tool-approval decision -- so every channel inherits them
 once.
 
 This module stays dependency-neutral: it imports only the ``acp.types``
-event constants (a stdlib-only leaf) and the ``security`` redactors (also a
-leaf). It does NOT import ``kiro_crew.slack`` or ``kiro_crew.dashboard``.
+event constants (a stdlib-only leaf), the ``security`` redactors (also a
+leaf), and the ``session_directive`` codec (a third stdlib-only leaf). It
+does NOT import ``kiro_crew.slack`` or ``kiro_crew.dashboard``.
 
 This driver is the channel-neutral core shared by every transport;
 Slack-specific rendering lives in the Slack ``Renderer``
@@ -17,17 +18,21 @@ Slack-specific rendering lives in the Slack ``Renderer``
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any, Awaitable, Callable
 
+from kiro_crew import session_directive
 from kiro_crew.acp.types import (
     EVENT_COMPACTION_STATUS,
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
     EVENT_STEER_CONSUMED,
+    EVENT_SUBAGENT_ACTIVITY,
     EVENT_TEXT_CHUNK,
     EVENT_THINKING_CHUNK,
     EVENT_TOOL_CALL,
+    EVENT_TOOL_RESULT,
 )
 from kiro_crew.messaging.renderer import (
     COMPACTION,
@@ -42,6 +47,8 @@ from kiro_crew.messaging.renderer import (
 )
 from kiro_crew.security import StreamRedactor, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
 
 # Approval modes (mirrors slack/handler APPROVAL_* + the dashboard ladder).
 APPROVAL_AUTO = "auto"
@@ -59,6 +66,13 @@ ApprovalDecider = Callable[[Any], Awaitable[bool]]
 #: (keeping the driver channel-neutral) to preserve hook-driven auto-approval
 #: such as ``auto_approve_subagent_spawn`` for the ``spawn_run`` tool.
 AutoApprovePredicate = Callable[[str], bool]
+
+#: A session-directive consumer: ``(kind, args) -> awaitable``. The driver
+#: invokes it when a genuine directive-tool result (see ``session_directive``)
+#: carries a decoded marker; the caller injects a consumer bound to ITS OWN
+#: session key (keeping the driver channel-neutral), typically
+#: ``messaging.dispatch.build_directive_consumer``.
+DirectiveConsumer = Callable[[str, dict[str, Any]], Awaitable[None]]
 
 # kiro-cli embeds this protocol frame in ordinary agent_message_chunk text when
 # it folds a mid-turn steer. It is transport metadata, not assistant speech.
@@ -273,6 +287,15 @@ class TurnDriver:
         permission request in this turn is auto-approved immediately (no
         buttons, no wait). Injected by the caller to honor per-session Trust /
         global YOLO without the driver depending on any channel module.
+    directive_consumer:
+        Optional async callback ``(kind, args) -> None``. When set, the driver
+        decodes session-directive markers from genuine directive-tool results
+        (``EVENT_TOOL_RESULT``) and invokes the callback with the validated
+        payload, so a stateless session-bound tool (``monitor_start`` /
+        ``autonudge_stop`` / ...) takes effect on standalone channel
+        transports. Injected by the caller with its own session key bound, so
+        the driver stays channel-neutral. When omitted, directive markers are
+        ignored exactly as before.
     """
 
     def __init__(
@@ -285,6 +308,7 @@ class TurnDriver:
         auto_approve_tool: AutoApprovePredicate | None = None,
         auto_approve_session: Callable[[], bool] | None = None,
         tool_gate: Callable[[Any], str] | None = None,
+        directive_consumer: DirectiveConsumer | None = None,
     ) -> None:
         self.provider = provider
         self.renderer = renderer
@@ -300,6 +324,10 @@ class TurnDriver:
         # handle_message enforces via hooks.on_tool_call. Runs BEFORE the
         # auto/trust/YOLO ladder so a DENY can never be overridden.
         self.tool_gate = tool_gate
+        # Session-directive consumer (see the class docstring). Applied on
+        # EVENT_TOOL_RESULT for a tool call whose trusted ``_meta.kiro``
+        # identity was recorded at EVENT_TOOL_CALL — the forgery gate.
+        self.directive_consumer = directive_consumer
 
     async def run(self, message: str) -> str:
         """Drive one turn; return the accumulated channel-safe assistant text."""
@@ -313,6 +341,19 @@ class TurnDriver:
         stream_redactor = StreamRedactor(_redact)
         pending_steer_events = 0
         unmatched_marker_events = 0
+        # tool_call_id -> canonical directive-tool name, recorded at
+        # EVENT_TOOL_CALL from the trusted ``_meta.kiro`` identity and consumed
+        # at the matching EVENT_TOOL_RESULT. Only populated when a directive
+        # consumer is injected, so a consumer-less turn does no extra work.
+        pending_directives: dict[str, str] = {}
+        # tool_call_ids owned by a NATIVE (in-session) sub-agent, announced via
+        # EVENT_SUBAGENT_ACTIVITY before the child's flat tool_call/tool_result
+        # frames arrive on this same stream. A native child's directive call
+        # carries a genuine core-MCP identity but has no independently bindable
+        # session, so it must be REFUSED rather than applied to the parent —
+        # sub-agent isolation, mirroring the dashboard consumer's
+        # ``_native_tc_card`` refusal.
+        native_tool_call_ids: set[str] = set()
 
         async def emit_text(text: str) -> None:
             nonlocal accumulated
@@ -383,6 +424,47 @@ class TurnDriver:
                         tool_purpose=_redact(getattr(event, "tool_purpose", "")),
                     )
                 )
+                # Forgery gate: record the directive-tool name ONLY from the
+                # trusted ``_meta.kiro`` identity and ONLY for a genuine call
+                # served by Kiro Crew's OWN core MCP server — never the
+                # LLM-authored title, and never another (possibly third-party)
+                # MCP server that merely exposes a tool named e.g.
+                # "monitor_start". A shell tool has no mcp_server_name and a
+                # canonical tool_name like "execute_bash", so it can never
+                # register here. (Mirrors the dashboard consumer in
+                # chat_runner.)
+                if (
+                    self.directive_consumer is not None
+                    and event.tool_call_id
+                    and getattr(event, "mcp_server_name", "")
+                    == session_directive.CORE_MCP_SERVER
+                ):
+                    canonical = session_directive.match_tool(
+                        getattr(event, "tool_name", "") or ""
+                    )
+                    if canonical:
+                        pending_directives[event.tool_call_id] = canonical
+            elif kind == EVENT_SUBAGENT_ACTIVITY:
+                # Native sub-agent lifecycle marker. Its only role in this
+                # driver is the isolation gate above: remember which
+                # tool_call_ids belong to a child session so their directives
+                # are refused. Tracked regardless of the consumer being set at
+                # THIS point in the stream, because the set is only read when a
+                # consumer exists and the bookkeeping is O(1) per event.
+                if event.tool_call_id and getattr(event, "sub_session_id", ""):
+                    native_tool_call_ids.add(event.tool_call_id)
+            elif kind == EVENT_TOOL_RESULT:
+                # Session directive: a stateless session-bound tool returns a
+                # marker instead of resolving its own session identity; the
+                # caller-injected consumer applies it against the caller's own
+                # session. Gated on the identity recorded above — a forged
+                # marker under any other tool resolves no entry and is
+                # ignored. Without a consumer this event stays inert,
+                # preserving the pre-consumer behavior exactly.
+                if self.directive_consumer is not None:
+                    await self._consume_directive(
+                        event, pending_directives, native_tool_call_ids
+                    )
             elif kind == EVENT_PERMISSION_REQUEST:
                 # PreToolUse security gate — sensitive-path keystone +
                 # governance ceiling + deny-list. Runs FIRST, before the
@@ -485,6 +567,85 @@ class TurnDriver:
                     OutputEvent(kind=DONE, stop_reason=event.stop_reason)
                 )
         return accumulated
+
+    async def _consume_directive(
+        self, event: Any, pending: dict[str, str], native_tool_call_ids: set[str]
+    ) -> None:
+        """Decode one directive-tool result and apply it via the consumer.
+
+        SINGLE-CONSUME: one tool call can surface more than one result frame
+        (a mid-stream content frame and the final ``status=completed``
+        rawOutput frame), so the mapping is popped BEFORE the consumer runs —
+        a second frame must never re-apply the effect (two armed loops, a
+        repeated mutation). A mid-stream frame with no decodable marker leaves
+        the mapping in place for the final frame. Mirrors the dashboard
+        consumer in ``chat_runner``.
+        """
+        consumer = self.directive_consumer
+        tool = pending.get(event.tool_call_id or "", "")
+        if consumer is None or not tool:
+            return
+        if event.tool_call_id in native_tool_call_ids:
+            # Sub-agent ISOLATION: a native child's tool calls surface as flat
+            # events on the parent stream with a genuine core-MCP identity, but
+            # the child has no independently bindable session — applying its
+            # directive here would let a sub-agent arm/mutate its PARENT. Pop
+            # (terminal for this call) and audit the refusal so the denial is
+            # never a silent drop, mirroring the dashboard consumer.
+            pending.pop(event.tool_call_id, None)
+            sel().log_api_access(
+                caller="turn_driver",
+                operation="session_directive",
+                outcome="denied",
+                source="messaging",
+                resources=(
+                    f"tool={tool} tool_call_id={event.tool_call_id} "
+                    "reason=native_subagent_isolation"
+                ),
+            )
+            logger.info(
+                "session-directive %r from a native sub-agent refused "
+                "(tool_call_id=%s): no session of its own to act on",
+                tool,
+                event.tool_call_id,
+            )
+            return
+        output = event.tool_output or ""
+        args = session_directive.decode(output, tool)
+        if args is None:
+            if getattr(event, "tool_final", False):
+                if session_directive.is_refusal(output):
+                    # encode() refused to emit a marker (payload over the
+                    # delivery limit): nothing was applied and the result text
+                    # already told the model so. Terminal for this call.
+                    pending.pop(event.tool_call_id, None)
+                    logger.info(
+                        "session-directive REFUSED for %r (tool_call_id=%s): "
+                        "payload over the %d-char delivery limit; nothing applied",
+                        tool,
+                        event.tool_call_id,
+                        session_directive.MAX_DIRECTIVE_CHARS,
+                    )
+                else:
+                    # Authenticated directive tool, final frame, no marker:
+                    # the effect is being dropped outright. Never let that be
+                    # silent — this exact silence can hide a marker-escaping
+                    # transport regression.
+                    logger.warning(
+                        "session-directive decode FAILED for %r (tool_call_id=%s, "
+                        "out_len=%d) — effect dropped",
+                        tool,
+                        event.tool_call_id,
+                        len(output),
+                    )
+            return
+        pending.pop(event.tool_call_id, None)
+        try:
+            await consumer(tool, args)
+        except Exception:
+            # The consumer is injected code applying a side effect; a failure
+            # there must never abort the rest of the turn's stream.
+            logger.warning("session-directive consumer failed for %r", tool, exc_info=True)
 
     async def _approve(self, event: Any) -> bool:
         """Apply the approval ladder to a permission-request event."""

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -872,6 +872,13 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # no output of its own -- the registered sinks are the modules that call
         # it (slack/format.py, messaging/renderer.py).
         "messaging/display_safety.py",
+        # Gate-side log hygiene: the session-directive consumer redacts the
+        # applier's confirmation string (which interpolates LLM-derived text —
+        # a stop reason, a rejected path, exception args) before writing it to
+        # the gateway log. The channel surface never renders tool results, so
+        # this line is an operational record, not an output boundary bound for
+        # a human; the applier itself SEL-audits every outcome.
+        "messaging/dispatch.py",
         "autonudge_authz.py",
         # Gate-side log hygiene for a channel whose user identity IS a phone
         # number or an Apple Account email. ``redact_handle`` shortens a handle

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -9,11 +9,17 @@ refused because a session-sharing subagent would misattribute to its parent).
 Rather than invent a per-process identity source, these tools stay STATELESS:
 the tool VALIDATES its arguments and returns a *directive* — a human-readable
 confirmation line plus a machine-readable marker carrying the validated payload
-(and NO session key). The session-aware consumer that processes the tool result
-(:func:`dashboard.chat_runner._run_chat`'s ``EVENT_TOOL_RESULT`` handler, which
-runs for every interactive surface and owns ``slot.key``) decodes the marker and
-applies the effect against ITS OWN session, then strips the marker from the
-stored transcript.
+(and NO session key). A session-aware consumer that processes the tool result
+decodes the marker and applies the effect against ITS OWN session, then keeps
+the marker out of what it stores or renders. There are TWO consumers, one per
+turn loop: :func:`dashboard.chat_runner._run_chat`'s ``EVENT_TOOL_RESULT``
+handler (the dashboard-driven surfaces, which own ``slot.key``), and
+:class:`messaging.driver.TurnDriver` (the standalone channel transports —
+Telegram, Discord, standalone Slack, iMessage, Teams, Webex, WeCom, Weixin —
+whose dispatchers inject a consumer bound to the turn's session key via
+``messaging.dispatch.build_directive_consumer``). Both funnel into
+``dashboard.session_directive_apply.apply_session_directive``, so the security
+boundaries live in one place.
 
 Subagent isolation is therefore STRUCTURAL, not cryptographic: a subagent's
 tool result flows through the subagent's own runner, so it can only ever bind to

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -1642,6 +1642,10 @@ async def _dispatch_queued(
                 show_thinking=KiroCrewConfig.load().slack.show_thinking,
                 consolidator=orch.consolidator,
                 user_display_name=kwargs.get("user_display_name"),
+                # Live gateway state for the session-directive consumer (a
+                # monitor directive on a dashboard-owned thread resolves its
+                # slot through orch.dashboard_state).
+                gateway=orch,
             )
             return
         await handle_message(
@@ -2524,6 +2528,10 @@ async def _route_message(
                 # handle_message (parity: don't drop these on the transport path).
                 consolidator=orch.consolidator,
                 user_display_name=_sender_display,
+                # Live gateway state for the session-directive consumer (a
+                # monitor directive on a dashboard-owned thread resolves its
+                # slot through orch.dashboard_state).
+                gateway=orch,
             )
         )
         orch._session_tasks[session_key] = t

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -30,6 +30,7 @@ from kiro_crew.dashboard.chat_utils import (
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import HOOK_REPLY, TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.llm_helpers import save_conversation_turn_off_loop
+from kiro_crew.messaging.dispatch import build_directive_consumer
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import canonical_key
@@ -128,11 +129,18 @@ async def handle_message_transport(
     show_thinking: bool = True,
     consolidator: HistoryConsolidator | None = None,
     user_display_name: str | None = None,
+    gateway: Any | None = None,
 ) -> None:
     """Drive a Slack message through the new transport path end-to-end.
 
     This replaces handle_message when the feature flag is on. It uses
     TurnDriver + SlackRenderer instead of the inline stream loop.
+
+    ``gateway`` is the orchestrator that owns this dispatch (when the caller
+    has one): its ``dashboard_state`` attribute supplies the live gateway
+    state to the session-directive consumer, so a monitor directive on a
+    dashboard-owned thread can resolve the slot instead of failing closed on
+    the sessions-backed stand-in.
     """
     Stats().inc_message_received()
     _t0 = time.monotonic()
@@ -564,6 +572,15 @@ async def handle_message_transport(
             # PreToolUse deny/auto gate (runs before the ladder in TurnDriver;
             # a DENY is un-overridable by auto/trust/YOLO).
             tool_gate=_tool_gate,
+            # Session-directive consumer: monitor_start / autonudge_stop / ...
+            # return a marker the driver decodes; apply it against THIS turn's
+            # session key. ``gateway`` (when the caller passed one) carries the
+            # live ``dashboard_state``; without it the consumer falls back to
+            # its sessions-backed authorizer stand-in (dashboard-only
+            # directives stay refused either way).
+            directive_consumer=build_directive_consumer(
+                session_key=session_key, sessions=sessions, dispatcher=gateway
+            ),
         )
         # The thread's owner as of the moment the turn starts producing output.
         # A dashboard link landing during the run moves the conversation to a

--- a/src/kiro_crew/teams/transport_dispatch.py
+++ b/src/kiro_crew/teams/transport_dispatch.py
@@ -27,7 +27,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.dispatch import (
+    ChannelTurn,
+    build_directive_consumer,
+    drive_turn,
+    inbound_permitted,
+)
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.teams.commands import HELP_TEXT, ConversationState, parse_command
@@ -157,6 +162,13 @@ class TeamsDispatcher:
             ChannelTurn(
                 channel_type="teams",
                 session_key=session_key,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker TurnDriver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
                 conversation_id=f"teams:{email}",
                 agent=agent,
                 user_text=text,

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -35,7 +35,7 @@ from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.attachments import IngestLimits, append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
-from kiro_crew.messaging.dispatch import delivery_is_muted
+from kiro_crew.messaging.dispatch import build_directive_consumer, delivery_is_muted
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import (
@@ -497,6 +497,13 @@ class TelegramDispatcher:
                 # PreToolUse gate BEFORE this, so a hard deny still wins.
                 auto_approve_session=lambda: safety_override().is_active(),
                 tool_gate=_tool_gate,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker the driver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
             )
             accumulated = await driver.run(full_message)
 

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -27,7 +27,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.dispatch import (
+    ChannelTurn,
+    build_directive_consumer,
+    drive_turn,
+    inbound_permitted,
+)
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.webex.commands import HELP_TEXT, ConversationState, parse_command
@@ -150,6 +155,13 @@ class WebexDispatcher:
             ChannelTurn(
                 channel_type="webex",
                 session_key=session_key,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker TurnDriver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
                 conversation_id=conversation_id,
                 agent=agent,
                 user_text=text,

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -27,7 +27,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.dispatch import (
+    ChannelTurn,
+    build_directive_consumer,
+    drive_turn,
+    inbound_permitted,
+)
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.wecom.client import new_stream_id
@@ -164,6 +169,13 @@ class WeComDispatcher:
             ChannelTurn(
                 channel_type="wecom",
                 session_key=session_key,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker TurnDriver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
                 conversation_id=conversation_id,
                 agent=agent,
                 user_text=text,

--- a/src/kiro_crew/weixin/transport_dispatch.py
+++ b/src/kiro_crew/weixin/transport_dispatch.py
@@ -34,7 +34,12 @@ from typing import TYPE_CHECKING, Any
 
 from kiro_crew.messaging.attachments import append_attachment_context
 from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
-from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn, inbound_permitted
+from kiro_crew.messaging.dispatch import (
+    ChannelTurn,
+    build_directive_consumer,
+    drive_turn,
+    inbound_permitted,
+)
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
 from kiro_crew.messaging.transport import InboundMessage
@@ -241,6 +246,13 @@ class WeixinDispatcher:
             ChannelTurn(
                 channel_type="weixin",
                 session_key=session_key,
+                # Session-directive consumer: monitor_start / autonudge_stop /
+                # ... return a marker TurnDriver decodes; apply it against THIS
+                # turn's session key (dashboard-only directives stay refused
+                # for channel sessions).
+                directive_consumer=build_directive_consumer(
+                    session_key=session_key, sessions=self.sessions, dispatcher=self
+                ),
                 conversation_id=conversation_id,
                 agent=agent,
                 user_text=text,

--- a/test/test_driver_session_directives.py
+++ b/test/test_driver_session_directives.py
@@ -1,0 +1,596 @@
+"""TurnDriver session-directive consumption (#4540).
+
+``TurnDriver`` never consumed ``EVENT_TOOL_RESULT``, so on every standalone
+messaging transport (Telegram, Discord, standalone Slack, iMessage, Teams,
+Webex, WeCom, Weixin) the session-directive marker returned by the stateless
+session-bound tools (``monitor_start`` / ``monitor_update`` / ``autonudge_stop``
+/ ``set_project`` …) was silently discarded: the model was told the effect was
+requested and nothing ever happened.
+
+These tests lock the three halves of the fix:
+
+* **Driver consumption + forgery gate** — the directive-tool identity is
+  recorded at ``EVENT_TOOL_CALL`` ONLY from the trusted ``_meta.kiro`` fields
+  (core MCP server + canonical tool name), the marker is decoded from the
+  matching ``EVENT_TOOL_RESULT``, applied exactly once (single-consume across
+  result frames), and a forged marker under a shell tool, a third-party MCP
+  server, or a non-directive tool is ignored. Without an injected consumer the
+  driver's behavior is unchanged.
+* **Channel applier boundary** — ``apply_session_directive`` with ``slot=None``
+  (the channel-caller shape) applies the monitor trio on a nudge-able channel
+  session and keeps refusing the ``_DASHBOARD_ONLY_DIRECTIVES``, including when
+  the session key would pass ``has_dashboard_surface``.
+* **Consumer wiring** — ``build_directive_consumer`` funnels into the shared
+  applier with the dispatcher's live ``dashboard_state`` when present, and a
+  fail-closed ``sessions``-backed stand-in when not (the Slack shape).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kiro_crew import session_directive
+from kiro_crew.acp.types import (
+    EVENT_COMPLETE,
+    EVENT_TEXT_CHUNK,
+    EVENT_TOOL_CALL,
+    EVENT_TOOL_RESULT,
+    AcpEvent,
+)
+from kiro_crew.dashboard.session_directive_apply import apply_session_directive
+from kiro_crew.messaging import TransportCapabilities, TurnDriver
+from kiro_crew.messaging.dispatch import _ChannelDirectiveState, build_directive_consumer
+from kiro_crew.messaging.renderer import Renderer
+
+MONITOR_ARGS = {"message": "watch PR #1", "idle_secs": 300, "max_cycles": 5, "max_runtime_secs": 0}
+
+
+def _directive(kind: str = "monitor_start", args: dict | None = None) -> str:
+    return session_directive.encode(kind, dict(args or MONITOR_ARGS), "Monitor loop requested.")
+
+
+class _RecordingRenderer(Renderer):
+    def __init__(self):
+        super().__init__(TransportCapabilities())
+        self.events: list[tuple] = []
+
+    async def on_text_chunk(self, text):
+        self.events.append(("text_chunk", text))
+
+    async def on_thinking(self, text):
+        self.events.append(("thinking", text))
+
+    async def on_tool_call(self, tool_call_id, title, tool_kind="", tool_purpose=""):
+        self.events.append(("tool_call", tool_call_id, title))
+
+    async def on_prompt_choice(self, options, request_id):
+        self.events.append(("prompt_choice", options, request_id))
+
+    async def on_compaction(self, pct):
+        self.events.append(("compaction", pct))
+
+    async def on_done(self, stop_reason=""):
+        self.events.append(("done", stop_reason))
+
+    async def on_steer_consumed(self, summary=""):
+        self.events.append(("steer_consumed", summary))
+
+
+class _ScriptedProvider:
+    def __init__(self, events):
+        self._events = events
+
+    async def stream(self, message):
+        for ev in self._events:
+            yield ev
+
+    async def approve_tool(self, request_id, *, always=False):
+        pass
+
+    async def reject_tool(self, request_id):
+        pass
+
+
+class _SpyConsumer:
+    """Records every (kind, args) the driver hands to the directive consumer."""
+
+    def __init__(self):
+        self.applied: list[tuple[str, dict]] = []
+
+    async def __call__(self, kind: str, args: dict) -> None:
+        self.applied.append((kind, args))
+
+
+def _core_call(tool: str = "monitor_start", tcid: str = "tc-1") -> AcpEvent:
+    """A genuine core-served directive tool call (trusted ``_meta.kiro``)."""
+    return AcpEvent(
+        kind=EVENT_TOOL_CALL,
+        tool_call_id=tcid,
+        title=tool,
+        tool_name=tool,
+        mcp_server_name=session_directive.CORE_MCP_SERVER,
+    )
+
+
+def _result(text: str, tcid: str = "tc-1", *, final: bool = True) -> AcpEvent:
+    return AcpEvent(kind=EVENT_TOOL_RESULT, tool_call_id=tcid, tool_output=text, tool_final=final)
+
+
+def _run(events, consumer) -> str:
+    driver = TurnDriver(
+        _ScriptedProvider(events),
+        _RecordingRenderer(),
+        directive_consumer=consumer,
+    )
+    return asyncio.run(driver.run("hello"))
+
+
+class TestDriverConsumesDirectives:
+    def test_core_directive_tool_result_is_applied(self):
+        """The monitor trio takes effect on a channel transport: a genuine
+        core-served directive call's marker reaches the consumer decoded."""
+        spy = _SpyConsumer()
+        _run(
+            [
+                _core_call("monitor_start"),
+                _result(_directive("monitor_start")),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == [("monitor_start", MONITOR_ARGS)]
+
+    def test_single_consume_across_result_frames(self):
+        """One tool call can surface a mid-stream content frame AND the final
+        rawOutput frame, both carrying the marker — the effect applies once."""
+        spy = _SpyConsumer()
+        _run(
+            [
+                _core_call("monitor_start"),
+                _result(_directive("monitor_start"), final=False),
+                _result(_directive("monitor_start"), final=True),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert len(spy.applied) == 1
+
+    def test_mid_stream_frame_without_marker_leaves_final_frame_consumable(self):
+        spy = _SpyConsumer()
+        _run(
+            [
+                _core_call("autonudge_stop"),
+                _result("working…", final=False),
+                _result(_directive("autonudge_stop", {"reason": "done"}), final=True),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == [("autonudge_stop", {"reason": "done"})]
+
+    def test_consumer_failure_does_not_abort_the_turn(self):
+        async def _boom(kind, args):
+            raise RuntimeError("consumer exploded")
+
+        renderer = _RecordingRenderer()
+        driver = TurnDriver(
+            _ScriptedProvider(
+                [
+                    _core_call("monitor_start"),
+                    _result(_directive("monitor_start")),
+                    AcpEvent(kind=EVENT_TEXT_CHUNK, text="still streaming"),
+                    AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+                ]
+            ),
+            renderer,
+            directive_consumer=_boom,
+        )
+        out = asyncio.run(driver.run("hello"))
+        assert out == "still streaming"
+        assert ("done", "end_turn") in renderer.events
+
+
+class TestForgedMarkersIgnored:
+    """A model can emit the literal marker bytes anywhere; only the trusted
+    ``_meta.kiro`` identity recorded at EVENT_TOOL_CALL may consume one."""
+
+    def test_shell_tool_output_forging_marker_is_ignored(self):
+        """A shell command titled "monitor_start" has no mcp_server_name and a
+        canonical tool_name of execute_bash — its stdout must never apply."""
+        spy = _SpyConsumer()
+        _run(
+            [
+                AcpEvent(
+                    kind=EVENT_TOOL_CALL,
+                    tool_call_id="tc-sh",
+                    title="monitor_start",
+                    tool_name="execute_bash",
+                    mcp_server_name="",
+                    is_shell=True,
+                ),
+                _result(_directive("monitor_start"), tcid="tc-sh"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+    def test_third_party_mcp_server_same_tool_name_is_ignored(self):
+        spy = _SpyConsumer()
+        _run(
+            [
+                AcpEvent(
+                    kind=EVENT_TOOL_CALL,
+                    tool_call_id="tc-evil",
+                    title="monitor_start",
+                    tool_name="monitor_start",
+                    mcp_server_name="third-party-mcp",
+                ),
+                _result(_directive("monitor_start"), tcid="tc-evil"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+    def test_core_non_directive_tool_forging_marker_is_ignored(self):
+        spy = _SpyConsumer()
+        _run(
+            [
+                _core_call("artifact_save", tcid="tc-art"),
+                _result(_directive("monitor_start"), tcid="tc-art"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+    def test_kind_mismatch_marker_is_not_applied(self):
+        """The recorded identity and the marker's ``kind`` must agree — a
+        monitor_start call whose result carries an autonudge_stop marker
+        resolves to no directive (decode's forgery gate)."""
+        spy = _SpyConsumer()
+        _run(
+            [
+                _core_call("monitor_start"),
+                _result(_directive("autonudge_stop", {"reason": "x"})),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+    def test_encode_refusal_is_not_applied(self):
+        """An oversized payload makes encode() return a refusal (no marker) —
+        nothing must reach the consumer."""
+        refusal = session_directive.encode("monitor_start", {"message": "x" * 5000}, "too big")
+        assert session_directive.is_refusal(refusal)
+        spy = _SpyConsumer()
+        _run(
+            [
+                _core_call("monitor_start"),
+                _result(refusal),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+
+class TestNoConsumerIsInert:
+    def test_tool_result_stays_inert_without_consumer(self):
+        """No injected consumer => byte-identical behavior to before: the
+        directive marker is neither decoded nor rendered, and the turn's
+        renderer output is unchanged."""
+        renderer = _RecordingRenderer()
+        driver = TurnDriver(
+            _ScriptedProvider(
+                [
+                    _core_call("monitor_start"),
+                    _result(_directive("monitor_start")),
+                    AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
+                    AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+                ]
+            ),
+            renderer,
+        )
+        out = asyncio.run(driver.run("hello"))
+        assert out == "hi"
+        assert [e[0] for e in renderer.events] == ["tool_call", "text_chunk", "done"]
+
+
+class TestNativeSubAgentIsolation:
+    """A NATIVE (in-session) sub-agent's tool calls surface as flat events on
+    the parent stream with a genuine core-MCP identity; EVENT_SUBAGENT_ACTIVITY
+    announces their tool_call_ids first. The driver must refuse those
+    directives — a child session can never arm/mutate its parent."""
+
+    def test_native_subagent_directive_is_refused(self):
+        spy = _SpyConsumer()
+        _run(
+            [
+                AcpEvent(
+                    kind="subagent_activity",
+                    sub_session_id="sub-1",
+                    tool_call_id="tc-native",
+                ),
+                _core_call("monitor_start", tcid="tc-native"),
+                _result(_directive("monitor_start"), tcid="tc-native"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+    def test_native_refusal_is_terminal_across_frames(self):
+        """The refusal pops the mapping, so a second result frame for the same
+        native call cannot sneak the effect through."""
+        spy = _SpyConsumer()
+        _run(
+            [
+                AcpEvent(
+                    kind="subagent_activity",
+                    sub_session_id="sub-1",
+                    tool_call_id="tc-native",
+                ),
+                _core_call("monitor_start", tcid="tc-native"),
+                _result(_directive("monitor_start"), tcid="tc-native", final=False),
+                _result(_directive("monitor_start"), tcid="tc-native", final=True),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == []
+
+    def test_parent_directive_still_applies_alongside_native_activity(self):
+        """Isolation is per tool_call_id: a native child's marker is refused
+        while the parent's own directive call in the same turn still applies."""
+        spy = _SpyConsumer()
+        _run(
+            [
+                AcpEvent(
+                    kind="subagent_activity",
+                    sub_session_id="sub-1",
+                    tool_call_id="tc-native",
+                ),
+                _core_call("monitor_start", tcid="tc-native"),
+                _result(_directive("monitor_start"), tcid="tc-native"),
+                _core_call("autonudge_stop", tcid="tc-parent"),
+                _result(_directive("autonudge_stop", {"reason": "done"}), tcid="tc-parent"),
+                AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+            ],
+            spy,
+        )
+        assert spy.applied == [("autonudge_stop", {"reason": "done"})]
+
+
+# ── Channel applier boundary (apply_session_directive with slot=None) ─────────
+
+
+class _FakeLoop:
+    def __init__(self, loop_id="loop-1"):
+        self.id = loop_id
+        self.idle_secs = 300
+        self.max_cycles = 5
+        self.cycle_count = 0
+        self.active = True
+        self.stopped_reason = ""
+
+
+class _ArmSvc:
+    """AutoNudge service double recording arms/removals for channel sessions."""
+
+    def __init__(self, loop=None):
+        self._loop = loop
+        self.added: list[dict] = []
+        self.removed: list[str] = []
+
+    def get_by_slot(self, key):
+        return self._loop
+
+    async def add(self, **kw):
+        self.added.append(kw)
+        return _FakeLoop("loop-armed")
+
+    async def remove(self, loop_id):
+        self.removed.append(loop_id)
+
+
+class _ChannelSessions:
+    """SessionManager double: knows one routable Slack session."""
+
+    def __init__(self, known_key: str):
+        self._known = known_key
+
+    def get_channel(self, key):
+        return "C123" if key == self._known else ""
+
+
+@pytest.fixture()
+def no_dashboard_tabs():
+    """Pin the dashboard-surface registry empty for the test, then restore."""
+    from kiro_crew import session_surface
+
+    before = session_surface.dashboard_surfaced_keys()
+    session_surface.set_dashboard_surfaced(())
+    yield
+    session_surface.set_dashboard_surfaced(before)
+
+
+class TestChannelApplierBoundary:
+    @pytest.mark.asyncio
+    async def test_monitor_start_applies_on_slack_channel_session(
+        self, monkeypatch, no_dashboard_tabs
+    ):
+        """The monitor trio WORKS from a channel turn: slot=None, a nudge-able
+        slack: session key, and the REAL authorize_and_add_nudge chokepoint
+        (Slack routability via state.sessions) arm the loop."""
+        session_key = "slack:1755000000.123456"
+        svc = _ArmSvc()
+        monkeypatch.setattr("kiro_crew.autonudge.get_instance", lambda: svc)
+        state = _ChannelDirectiveState(sessions=_ChannelSessions(session_key))
+        result = await apply_session_directive(
+            state, None, session_key, "monitor_start", dict(MONITOR_ARGS)
+        )
+        assert "started on this session" in result
+        assert len(svc.added) == 1
+        assert svc.added[0]["slot_key"] == session_key
+        assert svc.added[0]["idle_secs"] == 300
+
+    @pytest.mark.asyncio
+    async def test_autonudge_stop_applies_on_slack_channel_session(
+        self, monkeypatch, no_dashboard_tabs
+    ):
+        session_key = "slack:1755000000.123456"
+        svc = _ArmSvc(loop=_FakeLoop("loop-9"))
+        monkeypatch.setattr("kiro_crew.autonudge.get_instance", lambda: svc)
+        state = _ChannelDirectiveState(sessions=_ChannelSessions(session_key))
+        result = await apply_session_directive(
+            state, None, session_key, "autonudge_stop", {"reason": "done"}
+        )
+        assert "stopped on this session" in result
+        assert svc.removed == ["loop-9"]
+
+    @pytest.mark.asyncio
+    async def test_monitor_start_not_supported_on_non_nudgeable_channel(
+        self, monkeypatch, no_dashboard_tabs
+    ):
+        """A telegram: session has no AutoNudge binding — the applier answers
+        honestly instead of arming anything (and instead of silence)."""
+        svc = _ArmSvc()
+        monkeypatch.setattr("kiro_crew.autonudge.get_instance", lambda: svc)
+        state = _ChannelDirectiveState(sessions=_ChannelSessions("other"))
+        result = await apply_session_directive(
+            state, None, "telegram:kirocrew:direct:42", "monitor_start", dict(MONITOR_ARGS)
+        )
+        assert "not supported from this session type" in result
+        assert svc.added == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", ["monitor_start", "monitor_update", "autonudge_stop"])
+    async def test_not_supported_paths_audit_denied_never_success(
+        self, kind, monkeypatch, no_dashboard_tabs
+    ):
+        """SEL truthfulness: an effect that was NOT applied must never audit
+        ``success``. The not-supported refusal on a non-nudge-able channel
+        session lands as ``denied`` for the whole monitor trio."""
+        calls: list[dict] = []
+
+        class _SelSpy:
+            def log_tool_invocation(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr("kiro_crew.sel.sel", lambda: _SelSpy())
+        monkeypatch.setattr("kiro_crew.autonudge.get_instance", lambda: _ArmSvc())
+        result = await apply_session_directive(
+            _ChannelDirectiveState(sessions=_ChannelSessions("x")),
+            None,
+            "telegram:kirocrew:direct:42",
+            kind,
+            dict(MONITOR_ARGS) if kind != "autonudge_stop" else {},
+        )
+        assert "not supported from this session type" in result
+        directive_calls = [c for c in calls if c.get("source") == "mcp-directive"]
+        assert [c["outcome"] for c in directive_calls] == ["denied"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", ["set_project", "suggest_followup", "ask_question"])
+    async def test_dashboard_only_directives_refused_on_channel_transport(
+        self, kind, no_dashboard_tabs
+    ):
+        """SECURITY INVARIANT (#4540): _DASHBOARD_ONLY_DIRECTIVES stay DENIED
+        for non-dashboard sessions — the channel consumer must not widen the
+        gate."""
+        state = _ChannelDirectiveState(sessions=_ChannelSessions("x"))
+        result = await apply_session_directive(
+            state, None, "slack:1755000000.123456", kind, {"project": "/tmp"}
+        )
+        assert result.startswith("Error:")
+        assert "only works from a dashboard chat session" in result
+
+    @pytest.mark.asyncio
+    async def test_dashboard_only_refused_for_slotless_caller_even_with_open_tab(self):
+        """A channel-born session CAN have an open dashboard tab
+        (has_dashboard_surface True), but a slot-less channel turn still must
+        not drive a slot-targeted effect — the effect targets the SLOT and this
+        turn holds none. Guards the slot=None tightening."""
+        from kiro_crew import session_surface
+
+        session_key = "slack:1755000000.777"
+        before = session_surface.dashboard_surfaced_keys()
+        session_surface.set_dashboard_surfaced({session_key})
+        try:
+            result = await apply_session_directive(
+                _ChannelDirectiveState(sessions=_ChannelSessions("x")),
+                None,
+                session_key,
+                "set_project",
+                {"project": "/tmp"},
+            )
+        finally:
+            session_surface.set_dashboard_surfaced(before)
+        assert result.startswith("Error:")
+        assert "only works from a dashboard chat session" in result
+
+
+# ── build_directive_consumer wiring ──────────────────────────────────────────
+
+
+class TestBuildDirectiveConsumer:
+    @pytest.mark.asyncio
+    async def test_prefers_dispatcher_dashboard_state(self, monkeypatch):
+        """A dispatcher with gateway state attached (register_channel_transport)
+        hands the REAL state to the applier — re-read per directive, so a
+        consumer built before the attachment still sees it."""
+        seen: list[tuple] = []
+
+        async def _spy(state, slot, session_key, kind, args):
+            seen.append((state, slot, session_key, kind, args))
+            return "ok"
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.session_directive_apply.apply_session_directive", _spy
+        )
+
+        class _Dispatcher:
+            pass
+
+        dispatcher = _Dispatcher()
+        consume = build_directive_consumer(
+            session_key="discord:kirocrew:direct:42",
+            sessions=object(),
+            dispatcher=dispatcher,
+        )
+        dashboard_state = object()  # attached AFTER the consumer was built
+        dispatcher.dashboard_state = dashboard_state
+        await consume("monitor_start", dict(MONITOR_ARGS))
+        assert len(seen) == 1
+        state, slot, session_key, kind, args = seen[0]
+        assert state is dashboard_state
+        assert slot is None
+        assert session_key == "discord:kirocrew:direct:42"
+        assert (kind, args) == ("monitor_start", MONITOR_ARGS)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sessions_stand_in(self, monkeypatch):
+        """No dispatcher object (the Slack shape): the applier gets the
+        fail-closed sessions-backed stand-in, never None."""
+        seen: list = []
+
+        async def _spy(state, slot, session_key, kind, args):
+            seen.append(state)
+            return "ok"
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.session_directive_apply.apply_session_directive", _spy
+        )
+        sessions = object()
+        consume = build_directive_consumer(session_key="slack:1755000000.1", sessions=sessions)
+        await consume("autonudge_stop", {})
+        assert len(seen) == 1
+        state = seen[0]
+        assert isinstance(state, _ChannelDirectiveState)
+        assert state.sessions is sessions
+        assert state._slots == {} and state.channel_transports == {}


### PR DESCRIPTION
## Summary

`TurnDriver.run()` never consumed `EVENT_TOOL_RESULT` — the only event carrying `tool_output` together with the `_meta.kiro` identity the session-directive forgery gate needs. The dashboard's `chat_runner` applies directives, but every standalone messaging transport (Telegram, Discord, standalone Slack, iMessage, Teams, Webex, WeCom, Weixin) drives turns through `TurnDriver` alone — so `monitor_start` / `monitor_update` / `autonudge_stop` / `set_project` returned their optimistic confirmation while the marker was silently discarded and the effect never happened.

**The fix** (injection pattern the class already uses for `tool_gate` / `auto_approve_tool`):

- `TurnDriver` gains an optional `directive_consumer` callback. The trusted `_meta.kiro` identity (`mcp_server_name == "kirocrew-core"` + `match_tool(tool_name)`) is recorded at `EVENT_TOOL_CALL`; the matching `EVENT_TOOL_RESULT`'s marker is decoded with the existing `session_directive` codec and applied exactly once (single-consume across result frames). Without an injected consumer the driver's behavior is unchanged.
- All 8 `*/transport_dispatch.py` modules inject the shared `messaging.dispatch.build_directive_consumer` bound to the turn's session key. It funnels into the same `apply_session_directive` core the dashboard consumer uses, with `slot=None`.
- **Native sub-agent isolation**: a tool call announced by `EVENT_SUBAGENT_ACTIVITY` (a native child's flat events on the parent stream) is refused with a SEL `denied` audit — a child session can never arm/mutate its parent, mirroring `chat_runner`'s `_native_tc_card` refusal.

## Security invariants (not widened — tightened)

- `_DASHBOARD_ONLY_DIRECTIVES` (`set_project` / `suggest_followup` / `ask_question`) stay DENIED for non-dashboard sessions, and the gate is now **stricter**: a slot-less caller is refused outright even when the session has an open dashboard tab (the effect targets a chat slot this turn does not hold).
- Marker forgery keys on `_meta.kiro` only: a shell tool forging the marker in stdout, a third-party MCP server exposing a same-named tool, and a core-served non-directive tool are all ignored (tests for each).
- **SEL outcome truthfulness (applies to the dashboard path too)**: every not-applied monitor-trio result (unsupported session type, auto-nudge disabled, authorizer refusal, no loop to update) now audits `denied` instead of the previous `success` — including when the caller is the dashboard consumer. The old derivation recognized only the `"Error:"` prefix, so e.g. a dashboard `monitor_start` whose authorizer refused was recorded as `success`. `autonudge_stop` with nothing to stop stays `success` as an idempotent no-op. SEL is an append-only audit trail (security panel + integrity verification); nothing branches on these outcome values programmatically.
- The monitor trio takes effect where the session is nudge-able (`slack:` / `discord:`, through the real `authorize_and_add_nudge` chokepoint); the other six transports get an honest, logged + SEL-audited "not supported from this session type" instead of the old silent drop (no loop is armed there until `autonudge.binding_key_for` admits those keys — see Known limits).

## Testing

- New `test/test_driver_session_directives.py` (22 tests): consumption + single-consume, all three forgery variants, kind-mismatch, `encode()` refusal, consumer-exception containment, no-consumer inertness, **native sub-agent isolation ×3**, the three security-invariant applier tests the issue demands (monitor trio applied on a channel transport / dashboard-only still refused there / forged marker ignored), and `build_directive_consumer` state-resolution wiring.
- Full local gates: isort / flake8 / black (range gate) / mypy (0 new errors) / `python -m pytest`: **61188 passed**.
- 6 failures in `test_imessage_rpc.py` (30s RPC timeouts) and 1 flake in `test_telegram.py::test_concurrent_queue_adds_share_one_receipt` reproduce identically on clean `main` on this host — pre-existing, not introduced here. The telegram flake's root cause is a governance profile-store concurrent-first-load race (`profile store not yet loaded … denying`) dropping one of four concurrent messages; follow-up issue to be filed.

## Pre-push review (two model-pinned read-only subagents)

- GPT 5.6: PASS, no findings.
- Opus 5: 1 BLOCKING + 3 advisories, all verified against the code and addressed: native sub-agent isolation (fixed + audited + 3 tests), applier-result log line now redacted, Slack's function-style dispatch now threads the live gateway state (`gateway=orch`) so a dashboard-owned thread's monitor directive can resolve its slot instead of failing closed, and the spec now states the six non-nudge-able transports explicitly.

## Known limits

- On Telegram / iMessage / Teams / Webex / WeCom / Weixin the monitor trio still cannot arm a loop — `autonudge.binding_key_for` admits only `dashboard:` / `slack:` / `discord:`, and the AutoNudge fire path has no delivery route for those channels. This PR converts the silent drop into a refusal that is logged and SEL-audited; extending nudge delivery to more channels is a separate feature.

Closes #4540
