### PR TITLE
test: pin the host-memory reading on the subagent spawn path

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -665,6 +665,38 @@ body = os.urandom(20_000)
 body = random.Random(20260803).randbytes(20_000)
 ```
 
+**Host MEMORY is the other one, and it fails with a misleading exception.**
+`SubagentManager.spawn` refuses — returning before it registers anything in
+`_tasks` — while the machine looks short of memory, and it does so twice: an
+absolute floor (`check_memory_available` against `agent.spawn_min_memory_gb`) and
+the posture tier (`cached_admission_check`, refusing while the cgroup-clamped
+reading is CRITICAL). What makes it expensive to diagnose is that a refusal IS a
+`SubagentInfo` — a done one carrying `error` — so `assert info is not None` still
+passes and the test dies on the NEXT line, at `await mgr._tasks[info.id]`, with a
+bare `KeyError` naming an id nothing else mentions. Measured on a CI runner with
+~0.5 GB free.
+
+Fix: pin the reading with `healthy_host_memory` (`test/conftest.py`), which any
+file driving `spawn` opts into at module scope:
+
+```python
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+```
+
+It pins only the HOST reading — a caller that names its own `path` is feeding the
+`/proc/meminfo` parser a fixture file rather than asking about this machine, so
+those tests still run the real function and a parser regression still goes red. A
+test that is actually ABOUT either guard patches it in its own body, which lands on
+top of the fixture and reverts to it.
+
+Opt-in rather than autouse, because the pin is not free of consequence: the tests
+that drive the probe with no `path` and stub `safe_read_file` underneath it —
+`test_subagent_coverage.py::TestCheckMemoryAvailable` — never reach their own stub
+once the reading is pinned. `test_subagent_spawn_host_pin.py` is what keeps opt-in
+from decaying into "whoever remembered": a module that names `SubagentManager` and
+calls `.spawn(` must be pinned or excluded with a reason, so the next spawning test
+file cannot land unpinned.
+
 ### 2. Wall-clock races
 
 Asserting a *rate* or a *count* that the host controls. Windows rounds `time.sleep` /

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md
@@ -217,6 +217,15 @@ stopped pruning an entry whose owner "must be dead", and one accused a planted `
 of executing when it had not. If the code *probes* the PID, pin the probe; if the number
 must never appear in real output, pick one no OS can allocate (`99999999999`).
 
+The host's free MEMORY is an input too, and the most-used probe of it is
+`SubagentManager.spawn`, which refuses — registering nothing in `_tasks` — on a
+pressured machine. A refusal is still a `SubagentInfo`, so the test dies a line
+later on a bare `KeyError`, not on the assert that would have named the cause. Any
+file driving `spawn` takes `pytestmark = pytest.mark.usefixtures("healthy_host_memory")`,
+and `test_subagent_spawn_host_pin.py` fails when a new one does not. The two guards it
+pins, and why it stays transparent for the parser's own tests, are in
+testing-conventions § Determinism 1.
+
 ## Rule 3 — Cross-platform: macOS, Linux (x86_64 + arm64), Windows
 
 - **Route POSIX calls through `platform_compat`.** See AGENTS.md's shim table. Most

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1007,3 +1007,61 @@ def named_cron_caller(monkeypatch):
     key = "dashboard:conftest-slot"
     monkeypatch.setenv("KIROCREW_SESSION_KEY", key)
     return key
+
+
+#: Comfortably clear of both memory guards ``SubagentManager.spawn`` runs: the
+#: absolute floor (``agent.spawn_min_memory_gb``, 4 GB) and the posture tier
+#: (``agent.resource_critical_gb``, 2 GB).
+_HEALTHY_AVAILABLE_GB = 8.0
+
+
+@pytest.fixture
+def healthy_host_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the host-memory readings ``SubagentManager.spawn`` consults.
+
+    ``spawn`` refuses -- returning before it registers anything in ``_tasks`` --
+    whenever the machine looks short of memory, and it does so twice: an
+    absolute floor (``check_memory_available`` against
+    ``agent.spawn_min_memory_gb``) and the posture tier
+    (``cached_admission_check``, which refuses while the cgroup-clamped reading
+    is CRITICAL). Both read the host the suite happens to be running on, so
+    without this the verdict is the operator's machine rather than the test's
+    own input.
+
+    The failure it produces is misleading, which is why it is worth a shared
+    fixture: a refusal IS a ``SubagentInfo`` -- a done one carrying ``error`` --
+    so ``assert info is not None`` still passes and the test dies one line later
+    on ``mgr._tasks[info.id]`` with a bare ``KeyError``. Measured on a CI runner
+    with ~0.5 GB free.
+
+    Only the HOST reading is pinned: a caller that names its own ``path`` is
+    feeding the ``/proc/meminfo`` parser a fixture file rather than asking about
+    this machine, so it still runs the real function and a parser regression
+    still goes red. A test that is actually ABOUT either guard patches it in its
+    own body, which lands on top of this and reverts to it.
+    """
+    import kiro_crew.resource_status as resource_status
+    import kiro_crew.subagent as subagent
+
+    real_check = subagent.check_memory_available
+
+    def _pinned_check(
+        min_gb: float | None = None, path: str | None = None
+    ) -> tuple[bool, float]:
+        if path is None:
+            return (True, _HEALTHY_AVAILABLE_GB)
+        if min_gb is None:
+            return real_check(path=path)
+        return real_check(min_gb=min_gb, path=path)
+
+    def _admit() -> resource_status.AdmissionDecision:
+        return resource_status.AdmissionDecision(
+            admitted=True,
+            posture=resource_status.POSTURE_AMPLE,
+            available_gb=_HEALTHY_AVAILABLE_GB,
+        )
+
+    monkeypatch.setattr(subagent, "check_memory_available", _pinned_check)
+    # Also keeps the 5s-TTL refresh thread behind the cached verdict from
+    # starting, so no test leaves one probing the host after it ends.
+    monkeypatch.setattr(subagent, "cached_admission_check", _admit)

--- a/test/test_approval_threading.py
+++ b/test/test_approval_threading.py
@@ -14,6 +14,10 @@ import pytest
 from kiro_crew.llm_helpers import LLMEvent
 from kiro_crew.slack.handler import _PendingApproval
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 
 def _make_gateway():
     from kiro_crew.slack.gateway import GatewayOrchestrator

--- a/test/test_session_cleanup.py
+++ b/test/test_session_cleanup.py
@@ -35,6 +35,10 @@ from kiro_crew.subagent_persistence import (
     write_tombstone,
 )
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # ── Fixtures ──────────────────────────────────────────────────────────
 
 
@@ -43,12 +47,6 @@ def agent_root(tmp_path, monkeypatch):
     """Point subagent persistence at a temp directory."""
     monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
     return tmp_path
-
-
-@pytest.fixture(autouse=True)
-def _mock_memory_ok(monkeypatch):
-    """Prevent memory guard from refusing spawns on low-RAM build machines."""
-    monkeypatch.setattr("kiro_crew.subagent.check_memory_available", lambda **_kw: (True, 8.0))
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -18,6 +18,10 @@ from kiro_crew.acp.types import AcpEvent
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.subagent import SubagentManager
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Subagent-registry isolation is provided globally by the autouse
 # ``_isolate_subagents_dir`` fixture in ``conftest.py`` — no per-file fixture needed.
 

--- a/test/test_spawn_reasoning_effort.py
+++ b/test/test_spawn_reasoning_effort.py
@@ -22,6 +22,10 @@ import pytest
 from kiro_crew.effort import EFFORT_LEVELS
 from kiro_crew.validation import SPAWN_RUN_SCHEMA, ValidationError, validate_tool_args
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 
 def _run_tool(args: dict[str, Any]) -> tuple[list[dict], str]:
     """Run spawn_run and return (POSTed bodies, returned text)."""

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -15,6 +15,10 @@ import pytest
 
 from kiro_crew.subagent import _TURN_LIMIT, SubagentManager
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Subagent-registry isolation is provided globally by the autouse
 # ``_isolate_subagents_dir`` fixture in ``conftest.py`` — no per-file fixture needed.
 

--- a/test/test_subagent_context_group_applied.py
+++ b/test/test_subagent_context_group_applied.py
@@ -22,6 +22,10 @@ import pytest
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.subagent import SubagentManager
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 
 def _stream(*_a: object, **_k: object):
     async def _gen():

--- a/test/test_subagent_context_group_plumbing.py
+++ b/test/test_subagent_context_group_plumbing.py
@@ -28,6 +28,10 @@ from kiro_crew.subagent import (
 )
 from kiro_crew.subagent_persistence import create_agent_folder, read_state
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 
 def _mock_sessions() -> MagicMock:
     sessions = MagicMock()

--- a/test/test_subagent_continuable.py
+++ b/test/test_subagent_continuable.py
@@ -23,6 +23,10 @@ import pytest
 
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Subagent-registry isolation is provided globally by the autouse
 # ``_isolate_subagents_dir`` fixture in ``conftest.py``.
 

--- a/test/test_subagent_cwd.py
+++ b/test/test_subagent_cwd.py
@@ -20,6 +20,10 @@ import pytest
 
 from kiro_crew.subagent import SubagentManager, validate_cwd
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # ---------------------------------------------------------------------------
 # validate_cwd helper
 # ---------------------------------------------------------------------------

--- a/test/test_subagent_persistence.py
+++ b/test/test_subagent_persistence.py
@@ -20,20 +20,16 @@ from kiro_crew.subagent_persistence import (
     write_tombstone,
 )
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 
 @pytest.fixture()
 def agent_root(tmp_path, monkeypatch):
     """Point persistence at a temp directory."""
     monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
     return tmp_path
-
-
-@pytest.fixture(autouse=True)
-def _mock_memory_ok(monkeypatch):
-    """Prevent memory guard from refusing spawns on low-RAM build machines."""
-    monkeypatch.setattr(
-        "kiro_crew.subagent.check_memory_available", lambda **_kw: (True, 8.0)
-    )
 
 
 # ── create_agent_folder ──────────────────────────────────────────────

--- a/test/test_subagent_scale.py
+++ b/test/test_subagent_scale.py
@@ -25,6 +25,10 @@ import pytest
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 from kiro_crew.subagent_scale import SubagentEventCoalescer
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Subagent-registry isolation is provided globally by the autouse
 # ``_isolate_subagents_dir`` fixture in ``conftest.py``.
 

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -16,6 +16,10 @@ import pytest
 import kiro_crew.subagent as subagent
 from kiro_crew.subagent import compute_max_subagents, resolve_max_subagents
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 
 @pytest.fixture(autouse=True)
 def _no_learned_cost(monkeypatch):

--- a/test/test_subagent_spawn_host_pin.py
+++ b/test/test_subagent_spawn_host_pin.py
@@ -1,0 +1,115 @@
+"""A NEW test that spawns a subagent must not read the host's free memory.
+
+``SubagentManager.spawn`` refuses -- returning before it registers anything in
+``_tasks`` -- while the machine looks short of memory, and it does so twice: an
+absolute floor (``check_memory_available`` against ``agent.spawn_min_memory_gb``)
+and the posture tier (``cached_admission_check``, refusing while the
+cgroup-clamped reading is CRITICAL). ``test/conftest.py``'s
+``healthy_host_memory`` pins both, but only for a file that asks for it -- so
+this is what stops the pinned set falling behind ``test/``.
+
+A ratchet rather than a convention, because of how the failure reads: a refusal
+IS a ``SubagentInfo`` -- a done one carrying ``error`` -- so
+``assert info is not None`` still passes and the test dies on the NEXT line with
+a bare ``KeyError`` naming an id nothing else mentions. Nothing in the traceback
+says "memory"; the only evidence is a WARNING in the captured log. Measured on a
+CI runner with ~0.5 GB free, on a PR that touched none of this.
+
+Deliberately WIDER than the fixture acts on, the same way
+``test_host_isolation_floor.py``'s ratchet is: a module that names
+``SubagentManager`` AND calls ``.spawn(`` must be either pinned or excluded with
+a reason, so adding one forces a decision instead of an omission. Files whose
+``spawn`` is ``AcpRuntime.spawn`` never name ``SubagentManager`` and so are not
+swept up -- that method has no memory gate.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import pathlib
+
+_TEST_DIR = pathlib.Path(__file__).resolve().parent
+
+#: The fixture in ``test/conftest.py`` that pins both guards. A rename that
+#: misses this file turns every module below into an unpinned one, so the
+#: ratchet goes red rather than quietly stopping.
+_FIXTURE = "healthy_host_memory"
+
+
+@functools.lru_cache(maxsize=1)
+def _spawning_modules() -> tuple[tuple[str, bool], ...]:
+    """Every ``test/`` module that reaches ``spawn``, paired with whether it is pinned.
+
+    A module qualifies when it names ``SubagentManager`` anywhere and calls some
+    ``.spawn(``. Pinned means the fixture appears inside a ``usefixtures(...)``
+    call -- at module, class, or test scope, so a file that mixes guard tests
+    with spawning ones can opt in narrowly.
+
+    Cached and returned as a tuple: parsing ``test/``'s ~1,500 modules costs
+    ~5s, and both tests below need the same answer.
+    """
+    found: list[tuple[str, bool]] = []
+    for path in sorted(_TEST_DIR.glob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+        names |= {a.attr for a in ast.walk(tree) if isinstance(a, ast.Attribute)}
+        if "SubagentManager" not in names:
+            continue
+        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+        spawns = any(
+            isinstance(node.func, ast.Attribute) and node.func.attr == "spawn" for node in calls
+        )
+        if not spawns:
+            continue
+        pinned = any(
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "usefixtures"
+            and any(isinstance(arg, ast.Constant) and arg.value == _FIXTURE for arg in node.args)
+            for node in calls
+        )
+        found.append((path.name, pinned))
+    return tuple(found)
+
+
+class TestTheSpawnHostMemoryPinRatchet:
+    """A new ``SubagentManager.spawn`` caller must not land unpinned."""
+
+    #: Modules that reach ``spawn`` and deliberately need no pin. Each states
+    #: why, in the same spirit as ``test_host_isolation_floor.py``'s
+    #: ``_EXCLUDED``.
+    _EXCLUDED: dict[str, str] = {
+        # The tests OF the two guards. Each patches ``check_memory_available``
+        # and ``cached_admission_check`` in its own body, to refused AND to
+        # admitted, which is the behaviour under test. Pinning the file would
+        # not break them -- an inner patch lands on top -- but it would state a
+        # precondition the opposite of what they exist to vary.
+        "test_admission_gate.py": "drives both guards itself, to refused and to admitted",
+    }
+
+    def test_every_spawning_module_is_pinned_or_excluded(self) -> None:
+        modules = _spawning_modules()
+        assert modules, "the scan found no spawning modules — it has stopped matching"
+
+        unhandled = sorted(
+            name for name, pinned in modules if not pinned and name not in self._EXCLUDED
+        )
+
+        assert not unhandled, (
+            "these test modules drive SubagentManager.spawn without pinning the "
+            "host-memory reading:\n    " + "\n    ".join(unhandled) + "\n"
+            f'Add `pytestmark = pytest.mark.usefixtures("{_FIXTURE}")` at module '
+            "scope, or exclude the file in _EXCLUDED and say why. Unpinned, the "
+            "spawn is refused on a memory-pressured runner and the test fails as a "
+            "bare KeyError on the following line."
+        )
+
+    def test_the_exclusion_list_has_not_gone_stale(self) -> None:
+        """An exclusion for a module that no longer spawns hides the next one."""
+        reached = {name for name, _pinned in _spawning_modules()}
+        stale = sorted(name for name in self._EXCLUDED if name not in reached)
+
+        assert not stale, f"_EXCLUDED names modules that no longer reach spawn: {stale}"

--- a/test/test_subagent_stall_activity_scope.py
+++ b/test/test_subagent_stall_activity_scope.py
@@ -55,6 +55,10 @@ from kiro_crew.providers.base import (
 )
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Ancient wall-clock stamp: any refresh replaces it with ~time.time(), so
 # "unchanged" cannot be satisfied by an accidental re-write.
 _ANCIENT = 1.0

--- a/test/test_subagent_turn_resilience.py
+++ b/test/test_subagent_turn_resilience.py
@@ -32,6 +32,10 @@ from kiro_crew.subagent import (
     SubagentManager,
 )
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Subagent-registry isolation is provided globally by the autouse
 # ``_isolate_subagents_dir`` fixture in ``conftest.py``.
 

--- a/test/test_turn_duration_subagent.py
+++ b/test/test_turn_duration_subagent.py
@@ -33,6 +33,10 @@ from kiro_crew.acp.types import TurnUsage
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.subagent import SubagentManager
 
+# ``SubagentManager.spawn`` refuses -- registering no task -- while the host
+# looks short of memory, which is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
 # Implausibly large: no unit-test turn runs ~16 minutes, so a row carrying this
 # value can only have come from the provider, never from the local wall clock.
 _PROVIDER_DURATION_MS = 987654


### PR DESCRIPTION
## Problem / Motivation

`test/test_subagent_stall_activity_scope.py` fails intermittently in CI when the
runner is under memory pressure:

```
FAILED test/test_subagent_stall_activity_scope.py::test_routed_roster_event_is_own_activity
  - KeyError: '3e39cc91'
test/test_subagent_stall_activity_scope.py:231: KeyError
    await mgr._tasks[info.id]

WARNING kiro_crew.subagent:subagent.py:3211 Subagent spawn refused: host memory is
critical (~0.5 GB free, critical <= 2 GB) - retry when memory frees
```

`SubagentManager.spawn` runs **two** host-memory gates before it registers
anything in `_tasks`, and both read the machine the suite happens to be running
on:

| Gate | Reads | Refuses when |
|---|---|---|
| `check_memory_available` | `/proc/meminfo` `MemAvailable` | below `agent.spawn_min_memory_gb` (4 GB) |
| `cached_admission_check` | cgroup-clamped `_available_memory_gb` | posture CRITICAL, `agent.resource_critical_gb` (2 GB) |

So the verdict is the operator's machine rather than the test's own input — the
"host is an input" flake class in
[testing-conventions § Determinism 1](docs/system-specs/common/testing-conventions.md).

## Why it matters

Two costs, and the second is the larger one.

It reds PRs that never touched the subagent subsystem — this was found while
driving #4172 green, whose branch has `test_subagent_stall_activity_scope.py`,
`src/kiro_crew/subagent.py`, `conftest.py` and `test/conftest.py` all
byte-identical to `origin/main`.

And the failure actively misdirects whoever picks it up. A refusal **is** a
`SubagentInfo` — a done one carrying `error` — so `assert info is not None`
passes and the test dies on the *next* line with a bare `KeyError` naming a uuid
that appears nowhere else. Nothing in the traceback points at memory; the only
evidence is a `WARNING` in the captured log, which is easy to read past.

The exposure was also wider than the one reported file: **15** test files drive
`SubagentManager.spawn`, and only one of them pinned both gates.

## What changed (motivation → approach → change)

**Symptom → cause.** The `KeyError` is a spawn that returned early. Both guards
sit ahead of the `_tasks` registration and both are host reads.

**Approach.** Pin the reading, not the assertion — no rerun, no `sleep`, no
weakened assert. Two existing per-file fixtures already did half of this
(`_mock_memory_ok` in `test_subagent_persistence.py` and `test_session_cleanup.py`),
but each pinned only `check_memory_available` and left the admission gate — the
one that actually fired in CI — uncovered. Rather than duplicate a corrected
version of that fixture 15 times, this promotes it to one shared, opt-in fixture
alongside the suite's other named preconditions (`named_cron_caller`,
`short_sock_dir`).

Opt-in rather than autouse, deliberately: an autouse pin would break the tests
*of* the probe in `test_subagent_coverage.py`, which call it with no `path` and
stub `safe_read_file` instead. It is also not a rootdir-conftest concern — no
in-package testpath spawns subagents, so `test/conftest.py` is the right floor
and the in-package suites pay nothing.

**Change.**

- New `healthy_host_memory` fixture in `test/conftest.py`, pinning both gates.
  Only the **host** reading is pinned: a caller that names its own `path` is
  feeding the `/proc/meminfo` parser a fixture file rather than asking about this
  machine, so `TestCheckMemoryAvailable`'s six tests still run the real function
  and a parser regression still goes red. A test that is actually *about* either
  guard patches it in its own body, which lands on top of the fixture and reverts
  to it — so `test_admission_gate.py` and `test_subagent_sizing.py`'s refusal
  tests keep their teeth.
- `pytestmark = pytest.mark.usefixtures("healthy_host_memory")` in the 15 files
  that drive `SubagentManager.spawn`. Files whose `spawn` is `AcpRuntime.spawn`
  (`test_kas_spawn`, `test_acp_runtime`, `test_kas_mode_binding`,
  `test_image_primitives`, `test_acp_spawn_offload`) are untouched — that method
  has no memory gate.
- Removed the two superseded `_mock_memory_ok` fixtures.
- Patching `cached_admission_check` also stops its 5s-TTL daemon refresh thread
  from starting, so no test leaves one probing the host after it ends.
- **`test/test_subagent_spawn_host_pin.py`** — a ratchet, added in response to the
  design review below. Opt-in only lasts as long as authors remember it, and the
  failure it prevents names no cause, so a module that references `SubagentManager`
  and calls `.spawn(` must now be pinned or excluded with a reason. Same shape as
  `test_host_isolation_floor.py`'s ratchet, and deliberately wider than the fixture
  acts on, so adding a caller forces a decision instead of an omission.
  `test_admission_gate.py` is the single exclusion.

No production code changed.

## Tests

No new test cases — this removes a nondeterministic input from existing ones. What
it locks in:

- `healthy_host_memory` pins both guards for the 15 files that spawn, so the
  outcome no longer depends on host RAM.
- The pin stays transparent for a caller-supplied `path`, so the `/proc/meminfo`
  parser keeps its own coverage in `test_subagent.py::TestCheckMemoryAvailable`
  and `test_subagent_coverage.py::TestCheckMemoryAvailable`.

Two new tests, in `test_subagent_spawn_host_pin.py`:

- `test_every_spawning_module_is_pinned_or_excluded` — fails when a module reaches
  `spawn` without the pin. Mutation-checked: dropping the mark from
  `test_session_sharing.py` reds it, naming the file.
- `test_the_exclusion_list_has_not_gone_stale` — fails when `_EXCLUDED` names a
  module that no longer spawns, so a stale entry cannot mask the next one.
  Mutation-checked with a bogus entry.

Docs updated in the same commit, since this is guidance a test author needs
before they write the next spawning test: a new entry under
[testing-conventions § Determinism 1](docs/system-specs/common/testing-conventions.md)
and a pointer from the
[writing-tests skill](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md).

## Manual verification

**Mutation-tested**, since a fixture that removes a flake is indistinguishable
from one that does nothing on a healthy host. A throwaway pytest plugin made
every test see the runner that produced the failure (~0.5 GB free, posture
critical):

- **without** the `pytestmark` → the exact reported failure reproduces: `3 failed`,
  `KeyError` at `await mgr._tasks[info.id]`
- **with** it → `8 passed`

The design review's autouse suggestion was measured rather than argued: making
`healthy_host_memory` autouse reds **5** tests in
`test_subagent_coverage.py::TestCheckMemoryAvailable`, which call the probe with no
`path` and stub `safe_read_file` *underneath* it — so they never reach their own
stub once the reading is pinned. Their override story is not the same as the guard
tests', which patch the guard itself. The ratchet closes the same gap without that
cost.

Suite runs, on the changed files plus `test_admission_gate.py`,
`test_subagent_coverage.py` and `test_host_isolation_floor.py`:

- `751 passed` plainly (pre-ratchet)
- `816 passed` under `-n 4 --dist loadgroup` (the CI shape), with the ratchet

Gates: `black --target-version py310` on the four files outside
`.github/black-baseline.txt` (unchanged), `isort --check-only` and `flake8` clean
on the diff, brand gate and `docs-lint.sh` pass. `mypy` is unaffected — no `src/`
Python changed. Not run locally: the **full** suite, which this box budgets 2
xdist workers for; the fixture is non-autouse and its name is unused elsewhere,
so nothing outside the 15 files sees a behavior change.

## Screenshots / video

N/A — no user-visible surface; test and docs only.

## Related Issues

Pre-existing flake, surfaced while driving #4172 (`fix/mcp-oauth-affordance`)
green. That PR does not touch the subagent subsystem, so this lands separately.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — removes a nondeterministic input from existing tests)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
