### PR TITLE
perf(i18n): give test files an English-only catalog path

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -903,7 +903,7 @@ membership: `context.ui_language_tag()` checks the tag against
 to a language the chrome cannot render (#1130). Adding a language is therefore
 the three frontend edits — add `locales/<tag>.json`, register the picker entry
 in `SUPPORTED_LANGUAGES`, and add the static import plus `AUTHORED_CATALOGS`
-entry in `i18n/index.ts` — **plus one mechanical backend entry** in
+entry in `i18n/catalogs.ts` — **plus one mechanical backend entry** in
 `_UI_LANGUAGE_CATALOGS`, which the drift gate in
 `test/test_context_ui_language.py` names explicitly on failure.
 
@@ -926,10 +926,12 @@ load regardless of the language they read.
 
 The documented next step is therefore to keep `en` static and lazily fetch the
 active non-English catalog. That seam is already isolated to
-`website/src/i18n/index.ts` plus a `<Suspense>` boundary in `main.tsx`; no call
-site changes. **Catalog #13 belongs behind that seam**: Korean is #12 and the last
-one this chunk absorbs in front of it. Re-measure when the seam lands — the figure
-above is what says whether it worked.
+`website/src/i18n/catalogs.ts` — the module that owns every catalog import — plus
+a `<Suspense>` boundary in `main.tsx`; no call site changes, and
+`registerCatalogs()` is where a fetching backend hands its catalog over.
+**Catalog #13 belongs behind that seam**: Korean is #12 and the last one this
+chunk absorbs in front of it. Re-measure when the seam lands — the figure above
+is what says whether it worked.
 
 #### The tag reaches the agent, too
 

--- a/website/capture/builtin-row-author.tsx
+++ b/website/capture/builtin-row-author.tsx
@@ -27,7 +27,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 // Initialise i18next exactly as main.tsx does. Importing the module only DEFINES
 // initI18n — without calling it, every label in the frame is blank, which
 // silently produces screenshots that misrepresent the real UI.
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 // Without the app's own stylesheet every Tailwind class in the row is inert:
 // the frame renders unstyled, the icon tile loses its size constraint and fills
 // the shot, and the theme tokens never paint. A screenshot in that state

--- a/website/capture/copy-link-feedback.tsx
+++ b/website/capture/copy-link-feedback.tsx
@@ -30,7 +30,7 @@ import type {
 } from '../src/apps/issue-radar/api'
 import IssueDetail from '../src/apps/issue-radar/components/IssueDetail'
 import { IssueRadarProvider } from '../src/apps/issue-radar/context'
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { store } from '../src/store'
 import '../src/index.css'
 

--- a/website/capture/error-handoff.tsx
+++ b/website/capture/error-handoff.tsx
@@ -20,7 +20,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import ExecutionsView from '../src/components/ExecutionsView'
 import JobLogsView from '../src/components/JobLogsView'
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import '../src/index.css'
 
 const params = new URLSearchParams(location.search)

--- a/website/capture/ime-enter-swallow.tsx
+++ b/website/capture/ime-enter-swallow.tsx
@@ -24,7 +24,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { store } from '../src/store'
 import ChatInput from '../src/components/ChatInput'
 import '../src/index.css'

--- a/website/capture/palette-narrow.tsx
+++ b/website/capture/palette-narrow.tsx
@@ -24,7 +24,7 @@ import { MemoryRouter } from 'react-router-dom'
 // Initialise i18next exactly as main.tsx does. Importing the module only DEFINES
 // initI18n — without calling it every label in the frame is blank, which
 // silently produces screenshots that misrepresent the real UI.
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { store } from '../src/store'
 import { ThemeProvider } from '../src/hooks/useTheme'
 import CommandPalette from '../src/components/CommandPalette'

--- a/website/capture/selection-toolbar-ask.tsx
+++ b/website/capture/selection-toolbar-ask.tsx
@@ -17,7 +17,7 @@
 import { useRef } from 'react'
 import { createRoot } from 'react-dom/client'
 
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import SelectionToolbar, { useSelectionActions } from '../src/components/SelectionToolbar'
 import '../src/index.css'
 

--- a/website/capture/side-chat-oversize.tsx
+++ b/website/capture/side-chat-oversize.tsx
@@ -17,7 +17,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { store } from '../src/store'
 import SideChat from '../src/pages/chat/SideChat'
 import '../src/index.css'

--- a/website/capture/thinking-live-line.tsx
+++ b/website/capture/thinking-live-line.tsx
@@ -19,7 +19,7 @@ import { createRoot } from 'react-dom/client'
 // Initialise i18next exactly as main.tsx does. Importing the module only DEFINES
 // initI18n — without calling it, every label in the frame is blank, which
 // silently produces screenshots that misrepresent the real UI.
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { RowDisclosureProvider } from '../src/pages/chat/rowDisclosure'
 import ThinkingBlock from '../src/pages/chat/ThinkingBlock'
 import '../src/index.css'

--- a/website/capture/tool-purpose-status.tsx
+++ b/website/capture/tool-purpose-status.tsx
@@ -30,7 +30,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { Provider } from 'react-redux'
 
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { store } from '../src/store'
 import { setActiveSlot } from '../src/store/chatSlice'
 import { useWebSocket } from '../src/hooks/useWebSocket'

--- a/website/capture/topbar-search-variants.tsx
+++ b/website/capture/topbar-search-variants.tsx
@@ -33,7 +33,7 @@ import { useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Home, Search, Bell, Lightbulb, Bug, Layers, Coins, AudioWaveform, ChevronDown, Menu } from 'lucide-react'
 
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import '../src/index.css'
 
 const params = new URLSearchParams(location.search)

--- a/website/capture/webhooks-settings.tsx
+++ b/website/capture/webhooks-settings.tsx
@@ -19,7 +19,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import { store } from '../src/store'
 import { WebhooksPanel } from '../src/pages/settings/WebhooksPanel'
 import '../src/index.css'

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -10,7 +10,7 @@ Backend and whole-system docs are in [`../../docs/`](../../docs/README.md).
 | [theming-contract.md](theming-contract.md) | The CSS variable contract, the stable class hooks a theme may target, and what is deliberately not customizable. |
 | [frontend-conventions.md](frontend-conventions.md) | Shared components, accessibility, URL sanitization, data fetching, live-collection identity, animation, and styling. |
 | [i18n-catalog.md](i18n-catalog.md) | Catalog structure, key naming, plurals, and the formatting seam. |
-| [testing.md](testing.md) | The three test layers, which to use when, how Playwright really runs, how to keep a test deterministic under a loaded shard, and the manual procedures. |
+| [testing.md](testing.md) | The three test layers, which to use when, what a `setupFiles` entry costs per test file, how Playwright really runs, how to keep a test deterministic under a loaded shard, and the manual procedures. |
 | [extension-seams.md](extension-seams.md) | The registry seams a downstream edition composes against, and the fail-closed edition opt-in. |
 
 Related, outside this directory:

--- a/website/docs/i18n-catalog.md
+++ b/website/docs/i18n-catalog.md
@@ -62,10 +62,12 @@ Adding a language is a **data change**: three edits, no component or test change
 
 1. `locales/<tag>.json`, with the same key set as `en.json` plus `en.manual.json`.
 2. One entry in `SUPPORTED_LANGUAGES` (`src/i18n/languages.ts`).
-3. One line in `CATALOGS` (`src/i18n/index.ts`).
+3. One line in `AUTHORED_CATALOGS` (`src/i18n/catalogs.ts`, the module that owns
+   every catalog import; `src/i18n/all.ts` is the entry that registers them).
 
 The parity tests generate their cases from `SUPPORTED_LANGUAGES` and read catalogs
-from the runtime `CATALOGS` map, so a new language automatically gets its
+from the `CATALOGS` map in `src/i18n/catalogs.ts` (the map registration is fed
+from), so a new language automatically gets its
 key-parity, placeholder-preservation, and no-empty-value coverage. Miss one of the
 three edits and CI fails naming the gap; it cannot silently ship as English. There
 is **no allowlist**, so every language lands in the same commit. That is what makes

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -57,6 +57,65 @@ a component under test talks to a realistic API without a gateway running.
 When a test fails with an unhandled request, the fix is almost always a missing
 handler rather than a change to the component: add the endpoint to the mock server.
 
+## What a `setupFiles` entry costs
+
+`isolate: true` clears each worker's module registry between files, so vitest
+re-fetches `integration/setup.ts` and its whole module graph **once per test
+FILE** — ~1,400 of them. The total can exceed the cost of running the tests.
+Reaching all 14 locale catalogs from it cost more in setup than the whole suite
+spent running tests; owning them elsewhere is where the numbers below come from.
+
+Measured back to back on one host at `maxWorkers: 3`, same `node_modules`, both
+runs green:
+
+| | all 14 in the setup graph | English only |
+|---|---|---|
+| wall | 1166.5s | **822.2s** (1.42x, -29.5%) |
+| setup | 1363.5s | **371.6s** (3.67x less) |
+| tests | 873.5s | 817.8s |
+| setup as a share of the tests phase | 1.56x | 0.45x |
+
+Quote the ratio rather than the wall clock: the absolute number moves with
+`maxWorkers` and host load, and an earlier pair on a quieter host read 17m06s ->
+11m30s for the same change.
+
+**The cost is the per-module round trip, not the bytes.** Parsing all 14 catalogs
+measures 32 ms and compiling them 1.5 ms, against ~690 ms per file of measured
+saving — what is expensive is 14 vite-node module fetches crossing the fork IPC
+channel, repeated per file. So the lever is always *fewer modules in the graph*;
+making the same modules cheaper to parse buys nothing, which is why Vite's
+`json.stringify` (on by default above 10 KB) does not help. Count modules, not
+kilobytes, when you judge a setup import.
+
+The test path is also heavier than the production bundle: `en-XA.json` is 1.33 MiB
+and DEV-only, and `import.meta.env.DEV` is true under vitest, so it loads here and
+is dropped from a release build.
+
+That is why `src/i18n/index.ts` imports **English only** (726,947 bytes, 5.9% of the
+12,242,932 authored bytes), `src/i18n/catalogs.ts` owns every catalog import, and
+`src/i18n/all.ts` is the entry that registers them. Three rules hold that split in
+place:
+
+- **No non-English catalog import in `src/i18n/index.ts`** — that is the module
+  `integration/setup.ts` and ~600 components import.
+- **No all-catalogs import in `integration/setup.ts`**: neither `src/i18n/all` nor
+  `src/i18n/catalogs`, and not transitively through a helper it pulls in.
+- **A page entry point imports `initI18n` from `src/i18n/all`**, never from
+  `src/i18n/index`. Both export the same signature so `tsc` accepts either, but
+  through the English-only module the dashboard renders English to a user who
+  picked Japanese: i18next falls back, nothing throws, no key renders raw.
+
+`src/test/i18nAllLanguagesEntry.test.ts` gates all three by scanning the static
+import graph, because none of them changes a test result on its own.
+
+A test that needs a language other than English imports `src/i18n/all`; a test that
+audits the whole catalog set imports `CATALOGS` from `src/i18n/catalogs`. Either way
+a single file pays the load. None of this defers a load — `t()` is synchronous on
+every path — it only settles which module owns the import.
+
+Weigh anything else you put in the setup graph the same way: multiply it by the
+file count first.
+
 ## Playwright: how it actually runs
 
 The config is `playwright.config.ts`, and several of its choices surprise people:
@@ -85,9 +144,12 @@ match when you are debugging a CI-only failure: see
 - **jscpd** duplication check: copy-pasted code fails the build.
 - Coverage is emitted as cobertura XML from `test:website`.
 - `npx tsc -b` and eslint run as their own blocking steps.
-- Coverage runs use at most two fork workers with a 3072 MB old-space ceiling
-  per worker. The cap leaves room for the Vitest coordinator, coverage maps,
-  happy-dom state, and the operating system on a standard hosted runner.
+- Coverage runs cap fork workers (`maxWorkers` in `vite.config.ts`) with a
+  3072 MB old-space ceiling per worker. The cap leaves room for the Vitest
+  coordinator, coverage maps, happy-dom state, and the operating system on a
+  standard hosted runner; without it one fork per core exceeds host RAM and the
+  kernel OOM-kills a worker, which surfaces as "Worker exited unexpectedly"
+  even though every test passed.
 
 Backend-side test determinism and suite-speed rules (they apply to the same CI run)
 are in

--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -37,10 +37,19 @@ export const DEFAULT_BUDGET_BYTES = 500 * KB
  * is a bundle-size regression and needs to be justified in the PR that does it.
  */
 export const CHUNK_BUDGETS = {
-  // Eager i18n catalogs for all shipped languages (src/i18n). Grows a little
-  // with every translated string, which is expected and fine; what this ceiling
-  // catches is a NEW library or surface landing in the catalog chunk.
-  t: 9500 * KB, // measured 9029 KB
+  // Eager i18n catalogs for all shipped languages, reached through
+  // `src/i18n/all.ts` — Rolldown names the chunk after that entry. Grows a
+  // little with every translated string, which is expected and fine; what this
+  // ceiling catches is a NEW library or surface landing in the catalog chunk.
+  all: 9100 * KB, // measured 8666 KB
+
+  // The i18n RUNTIME — the i18next singleton, `initI18n`, the English catalog —
+  // named after `src/i18n/t.ts`. Held separately from `all` above because
+  // `src/i18n/index.ts` imports English alone, so the ~600 components that call
+  // `t()` no longer pull the other twelve catalogs in behind them. Sized for the
+  // English catalog plus headroom; a jump here means a non-English catalog, or a
+  // library, reached the runtime module.
+  t: 700 * KB, // measured 641 KB
 
   // Pierre editor implementation (PR #4072 replaced Monaco, whose
   // 'editor.api2' chunk this entry set used to carry) -- the code-editor

--- a/website/scripts/check-i18n-keys.mjs
+++ b/website/scripts/check-i18n-keys.mjs
@@ -713,7 +713,7 @@ if (shadowed.length > 0) {
   console.error(
     `\n${shadowed.length} key(s) exist in BOTH en.json and en.manual.json:\n`
     + `${shadowed.slice(0, 20).map((k) => `  ${k}`).join('\n')}\n\n`
-    + '`src/i18n/index.ts` deep-merges with the manual catalog winning, so the generated value is\n'
+    + '`src/i18n/enCatalog.ts` deep-merges with the manual catalog winning, so the generated value is\n'
     + 'dead while the codemod keeps regenerating it — the two drift apart with nothing to say so.\n'
     + 'Keep the key in exactly one file: en.manual.json if it has no source literal to extract,\n'
     + 'otherwise let the codemod own it and delete the manual copy.',

--- a/website/scripts/i18n-shard.mjs
+++ b/website/scripts/i18n-shard.mjs
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
 /**
- * English source = the SAME two files the runtime merges (`src/i18n/index.ts`).
+ * English source = the SAME two files the runtime merges (`src/i18n/enCatalog.ts`).
  *
  * Reading only `en.json` was a real bug: the 43 hand-authored keys in
  * `en.manual.json` (nav labels, Settings tab labels/descriptions, the language

--- a/website/scripts/settingsExtract.ts
+++ b/website/scripts/settingsExtract.ts
@@ -30,7 +30,7 @@ import type { SettingEntry, SettingPrimitiveType } from '../src/components/comma
 
 export type { SettingEntry, SettingPrimitiveType }
 
-/** English catalogs, in load order (manual wins) — mirrors `src/i18n/index.ts`. */
+/** English catalogs, in load order (manual wins) — mirrors `src/i18n/enCatalog.ts`. */
 const EN_CATALOG_PATHS = [
   path.resolve(__dirname, '../src/i18n/locales/en.json'),
   path.resolve(__dirname, '../src/i18n/locales/en.manual.json'),

--- a/website/src/apps/crew-companion/gallery.tsx
+++ b/website/src/apps/crew-companion/gallery.tsx
@@ -7,7 +7,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { adoptDashboardTheme, watchThemeChanges } from './dashboardTheme'
-import { initI18n } from '../../i18n'
+// The all-languages entry: plain `../../i18n` registers English only.
+import { initI18n } from '../../i18n/all'
 import { GalleryPanel } from './GalleryPanel'
 
 const host = document.getElementById('root')

--- a/website/src/apps/crew-companion/panel.tsx
+++ b/website/src/apps/crew-companion/panel.tsx
@@ -14,7 +14,8 @@
 import { StrictMode, useCallback, useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { adoptDashboardTheme, watchThemeChanges } from './dashboardTheme'
-import { initI18n } from '../../i18n'
+// The all-languages entry: plain `../../i18n` registers English only.
+import { initI18n } from '../../i18n/all'
 import BreathingOverlay from './BreathingOverlay'
 import { PanelCard } from './PanelCard'
 import type { PanelView } from './PanelViews'

--- a/website/src/apps/crew-companion/pet.tsx
+++ b/website/src/apps/crew-companion/pet.tsx
@@ -24,7 +24,8 @@ import { createRoot } from 'react-dom/client'
 // this side supplies the sentence — and without init they resolved to nothing, so
 // the companion stayed silent while reminders (which carry their own text) worked.
 import { adoptDashboardTheme, watchThemeChanges } from './dashboardTheme'
-import { initI18n } from '../../i18n'
+// The all-languages entry: plain `../../i18n` registers English only.
+import { initI18n } from '../../i18n/all'
 import { i18nT } from '../../i18n/t'
 import { PENDING_PATH, PRESENCE_PATH } from './constants'
 import { nudgeTextFor } from './nudgeKeys'

--- a/website/src/apps/mochi/mochiLanguage.tsx
+++ b/website/src/apps/mochi/mochiLanguage.tsx
@@ -34,7 +34,9 @@
  */
 import React, { useEffect, useState } from 'react'
 
-import { changeLanguage, i18next, initI18n } from '../../i18n'
+// The all-languages entry: plain `../../i18n` registers English only, which would
+// leave every override below falling back to it.
+import { changeLanguage, i18next, initI18n } from '../../i18n/all'
 import { readStoredLanguage } from '../../i18n/detect'
 import { api } from './src/mochiApi'
 

--- a/website/src/hooks/useSettingHighlight.test.ts
+++ b/website/src/hooks/useSettingHighlight.test.ts
@@ -112,12 +112,15 @@ describe('useSettingHighlight against the real registry and catalogs', () => {
    * catalogs under a real language switch, so those two failures are reachable.
    */
   afterAll(async () => {
-    const { i18next } = await import('../i18n')
+    const { i18next } = await import('../i18n/all')
     await i18next.changeLanguage('en')
   })
 
   it('highlights a control whose rendered label is translated', async () => {
-    const { i18next } = await import('../i18n')
+    // `/all` for the Japanese catalog: `../i18n` registers English only, so the
+    // switch below would fall back to English and the label match would be
+    // self-consistently wrong.
+    const { i18next } = await import('../i18n/all')
     const { i18nT } = await import('../i18n/t')
     const { SETTINGS_REGISTRY } = await import('../components/commandPalette/settingsRegistry.gen')
 

--- a/website/src/i18n/LanguageProvider.test.tsx
+++ b/website/src/i18n/LanguageProvider.test.tsx
@@ -4,6 +4,10 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
+// './all' for the zh-CN catalog: these cases switch language to exercise
+// resolution and persistence, and `changeLanguage` refuses in dev when the
+// target has no registered catalog.
+import './all'
 import { LanguageProvider, useLanguage } from './LanguageProvider'
 import { LANG_STORAGE_KEY } from './detect'
 import { api } from '../api/client'

--- a/website/src/i18n/all.ts
+++ b/website/src/i18n/all.ts
@@ -1,0 +1,17 @@
+/**
+ * The all-languages i18n entry.
+ *
+ * Importing it registers every catalog and re-exports the runtime API, so a
+ * caller needs exactly one import. This is what production boots through and
+ * what a test that switches language uses; `./index` is the English-only path
+ * the vitest setup file takes. Why the two exist: `./index`'s header.
+ */
+
+import { CATALOGS } from './catalogs'
+import { registerCatalogs } from './index'
+
+// At module scope, so importing this entry is the whole registration step: a
+// caller that forgot to call something would render bare keys.
+registerCatalogs(CATALOGS)
+
+export * from './index'

--- a/website/src/i18n/catalogParity.test.ts
+++ b/website/src/i18n/catalogParity.test.ts
@@ -8,15 +8,16 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from './index'
+import { CATALOGS as RUNTIME_CATALOGS } from './catalogs'
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, isSupportedLanguage } from './languages'
 import pluralKeys from './pluralKeys.json'
 
 /**
  * Catalogs exactly as the runtime composes them — including English's
- * generated + manual merge. Reading `CATALOGS` from `./index` rather than
- * re-importing the JSON means this suite can never disagree with what actually
- * ships, and adding a language needs no edit here.
+ * generated + manual merge. Reading `CATALOGS` from `./catalogs`, the module that
+ * owns every catalog import, rather than re-importing the JSON means this suite
+ * can never disagree with what actually ships, and adding a language needs no
+ * edit here.
  */
 const CATALOGS: Record<string, unknown> = Object.fromEntries(
   Object.entries(RUNTIME_CATALOGS).map(([code, bundle]) => [
@@ -132,7 +133,7 @@ describe('language registry', () => {
     expect(
       authored.length,
       'Adding a catalog puts its full weight in every user\'s first load. Land the '
-      + 'lazy-loading seam in i18n/index.ts instead, or re-measure and say why here.',
+      + 'lazy-loading seam in i18n/catalogs.ts instead, or re-measure and say why here.',
     ).toBeLessThanOrEqual(12)
   })
 })

--- a/website/src/i18n/catalogs.ts
+++ b/website/src/i18n/catalogs.ts
@@ -1,0 +1,78 @@
+/**
+ * Every catalog import lives here — a pure data module with no side effects and
+ * no i18next dependency.
+ *
+ * Importing it pulls 14 modules and ~12 MB into the graph, which is why it is
+ * separate from `./index`: only `./all` (the production entry) and the tests that
+ * audit the full catalog set pay that cost. Under vitest that cost is charged
+ * once per test FILE, and it is the module count rather than the bytes that
+ * dominates. `./index`'s header carries the ownership split, the measurements,
+ * and why `t()` stays synchronous regardless.
+ */
+
+import zhCN from './locales/zh-CN.json'
+import hi from './locales/hi.json'
+import es from './locales/es.json'
+import fr from './locales/fr.json'
+import bn from './locales/bn.json'
+import pt from './locales/pt.json'
+import ru from './locales/ru.json'
+import de from './locales/de.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import it from './locales/it.json'
+import enXA from './locales/en-XA.json'
+import { EN_TRANSLATION } from './enCatalog'
+
+/**
+ * Catalog registry — the SINGLE place a language's catalog is bound to its code.
+ *
+ * Holds the authored languages; the generated pseudolocale is appended below in
+ * DEV builds only, and `CATALOGS` (not this constant) is the runtime registry.
+ *
+ * Exported via `CATALOGS` so tests read the same map the runtime uses instead of
+ * maintaining a parallel copy. That parallel copy was a real trap: it made "add
+ * a language" a 4-edit job where forgetting the 4th produced a confusing parity
+ * failure pointing at the catalog rather than at the test's own map.
+ *
+ * A language listed in `SUPPORTED_LANGUAGES` MUST appear here; `catalogParity.test.ts`
+ * asserts the two lists agree, so a language added to one and not the other fails
+ * CI instead of silently rendering keys.
+ *
+ * Single `translation` namespace: keys are already domain-prefixed
+ * (`settings.display.view`, `chat.composer.send`), which gives the same
+ * grouping a namespace split would without making every call site name one.
+ */
+const AUTHORED_CATALOGS: Record<string, { translation: Record<string, unknown> }> = {
+  en: { translation: EN_TRANSLATION },
+  'zh-CN': { translation: zhCN },
+  hi: { translation: hi },
+  es: { translation: es },
+  fr: { translation: fr },
+  bn: { translation: bn },
+  pt: { translation: pt },
+  ru: { translation: ru },
+  de: { translation: de },
+  ja: { translation: ja },
+  ko: { translation: ko },
+  it: { translation: it },
+}
+
+/**
+ * The pseudolocale is registered in DEV builds ONLY.
+ *
+ * It is unreachable in a production build by two independent guards already —
+ * `devOnly` hides it from the picker and `isRestorableLanguage()` refuses it
+ * from persisted state — so shipping its catalog was pure weight: the accented,
+ * expansion-padded copy of every English string is the single largest catalog
+ * (~88 KB gzip on first load) and no production user can select it.
+ *
+ * `import.meta.env.DEV` is statically replaced with `false` at build time, so
+ * the ternary below is dead code in a production build and Rollup drops the
+ * `en-XA.json` module with it. The import stays static (not `await import`)
+ * because `t()` must remain SYNCHRONOUS — see `./index`'s header.
+ */
+export const CATALOGS: Record<string, { translation: Record<string, unknown> }> =
+  import.meta.env.DEV
+    ? { ...AUTHORED_CATALOGS, 'en-XA': { translation: enXA } }
+    : AUTHORED_CATALOGS

--- a/website/src/i18n/contextSidecar.test.ts
+++ b/website/src/i18n/contextSidecar.test.ts
@@ -58,7 +58,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from './index'
+import { CATALOGS as RUNTIME_CATALOGS } from './catalogs'
 import { DEFAULT_LANGUAGE } from './languages'
 import contextSidecar from './en.context.json'
 

--- a/website/src/i18n/deadKeys.test.ts
+++ b/website/src/i18n/deadKeys.test.ts
@@ -28,7 +28,7 @@ import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { CATALOGS as RUNTIME_CATALOGS } from './index'
+import { CATALOGS as RUNTIME_CATALOGS } from './catalogs'
 import { DEFAULT_LANGUAGE } from './languages'
 import pluralKeys from './pluralKeys.json'
 

--- a/website/src/i18n/destructiveConfirm.test.ts
+++ b/website/src/i18n/destructiveConfirm.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest'
 
 import { OPERAND_QUOTE_PAIRS, DEFAULT_QUOTE_PAIR } from '../../scripts/lib/qa-checks.mjs'
-import { CATALOGS } from './index'
+import { CATALOGS } from './catalogs'
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './languages'
 import { BULK_DELETE_TOKEN } from '../pages/SchedulePage'
 import { BULK_PR_CLOSE_TOKEN, SEQUENTIAL_MERGE_TOKEN } from '../apps/issue-radar/components/PrBulkBar'

--- a/website/src/i18n/enCatalog.ts
+++ b/website/src/i18n/enCatalog.ts
@@ -1,0 +1,42 @@
+/**
+ * The English catalog, merged once, and the merge itself.
+ *
+ * English arrives in two files: `en.json` is REGENERATED wholesale by
+ * `scripts/i18n-codemod.mjs` (so a fixed source string can't leave a stale key
+ * behind), and `en.manual.json` holds hand-authored strings that have no source
+ * literal to extract — like the language picker's own labels. Keeping them
+ * separate is what lets the codemod overwrite its own output safely.
+ *
+ * `EN_TRANSLATION` lives here rather than in `./index` because BOTH catalog
+ * owners need it: `./index` seeds its registry with English alone, and
+ * `./catalogs` lists it alongside the other twelve. The module cache makes one
+ * merge serve both, and the shared object identity is what lets
+ * `registerCatalogs` recognise the English bundle it already holds instead of
+ * re-merging it.
+ *
+ * `mergeCatalogs` is here too, with its only other caller one import away, so
+ * `./index`'s graph stays at four modules. That graph is re-fetched once per test
+ * file, so a module in it is not free — see `docs/testing.md` § "What a
+ * `setupFiles` entry costs".
+ */
+
+import enGenerated from './locales/en.json'
+import enManual from './locales/en.manual.json'
+
+/** Deep-merge two catalogs; the later argument wins on a leaf collision. */
+export function mergeCatalogs(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...a }
+  for (const [key, value] of Object.entries(b)) {
+    const existing = out[key]
+    out[key] = value !== null && typeof value === 'object' && !Array.isArray(value)
+      && existing !== null && typeof existing === 'object' && !Array.isArray(existing)
+      ? mergeCatalogs(existing as Record<string, unknown>, value as Record<string, unknown>)
+      : value
+  }
+  return out
+}
+
+export const EN_TRANSLATION: Record<string, unknown> = mergeCatalogs(enGenerated, enManual)

--- a/website/src/i18n/format.test.ts
+++ b/website/src/i18n/format.test.ts
@@ -31,7 +31,10 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 
-import { i18next } from './index'
+// `./all` for the non-English catalogs: `./index` registers English only, and
+// `activeLocale()` reads i18next's RESOLVED language — an unregistered language
+// resolves to `en`, so every locale case below would format in English.
+import { i18next } from './all'
 import { SUPPORTED_LANGUAGES } from './languages'
 import {
   activeLocale,

--- a/website/src/i18n/glossary.test.ts
+++ b/website/src/i18n/glossary.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from './index'
+import { CATALOGS as RUNTIME_CATALOGS } from './catalogs'
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from './languages'
 import glossary from './glossary.json'
 

--- a/website/src/i18n/index.ts
+++ b/website/src/i18n/index.ts
@@ -1,10 +1,10 @@
 /**
  * i18n runtime (react-i18next).
  *
- * ## Why the catalogs are imported statically
+ * ## Why every catalog is registered before first render
  *
- * Authored catalogs are bundled and registered up front, so `t()` is always
- * SYNCHRONOUS. That is a deliberate correctness choice, not an oversight:
+ * Catalogs are bundled and registered up front, so `t()` is always SYNCHRONOUS.
+ * That is a deliberate correctness choice, not an oversight:
  *
  *  - ~600 components call `t()` during render. With lazily-fetched catalogs
  *    every one of them becomes Suspense-sensitive, and any component rendering
@@ -14,9 +14,28 @@
  *    synchronous `t()` keeps them all valid with no per-test `await`.
  *
  * The cost is bundle size: every language ships to every user (except the
- * pseudolocale, which is DEV-only — see `CATALOGS`). At 12 catalogs that is
- * ~2.0 MB gzip, ~173 KB of it for each language the user will never read, so
- * this approach does NOT scale indefinitely.
+ * pseudolocale, which is DEV-only). At 12 catalogs that is ~2.0 MB gzip,
+ * ~173 KB of it for each language the user will never read, so this approach
+ * does NOT scale indefinitely.
+ *
+ * ## Which module owns the imports
+ *
+ * THIS module imports English only and seeds the registry with it. `./catalogs`
+ * owns every catalog import; `./all` joins the two by calling
+ * `registerCatalogs(CATALOGS)` at module scope and re-exporting this API.
+ * Production boots through `./all`, so what reaches a browser is unchanged.
+ *
+ * The split exists for the test path: `integration/setup.ts` is a vitest
+ * `setupFiles` entry, so its module graph is re-fetched once per test FILE and
+ * reaching all 14 catalogs from here cost more than running the tests. The cost is
+ * the per-module round trip rather than the JSON, which is why the fix is to keep
+ * modules OUT of this graph and why making them cheaper to parse would not have
+ * worked. Numbers, and the rules that keep the split in place, live in
+ * `website/docs/testing.md` § "What a `setupFiles` entry costs" — one owner, because
+ * four copies of a measurement disagree the first time anyone re-measures.
+ *
+ * This is ownership, not lazy loading: no load is deferred on any path, and
+ * `t()` is synchronous on all of them.
  *
  * ## Lazy-loading seam
  *
@@ -25,106 +44,72 @@
  * `i18next-http-backend` + `Suspense`:
  * catalogs move to `public/locales/<lng>/<ns>.json` and only the active
  * language is fetched. Nothing in the call sites changes — `useTranslation()`
- * and `t()` keep the same signatures — so this is an isolated swap of THIS
- * file plus a `<Suspense>` boundary in `main.tsx`. Keeping call sites free of
- * loading concerns is exactly what makes that migration cheap later.
+ * and `t()` keep the same signatures — so this is an isolated swap of
+ * `./catalogs` plus a `<Suspense>` boundary in `main.tsx`. `registerCatalogs` is
+ * where a backend hands its fetched catalog over, so the seam needs no change to
+ * this module at all.
  */
 
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
-import enGenerated from './locales/en.json'
-import enManual from './locales/en.manual.json'
-import zhCN from './locales/zh-CN.json'
-import hi from './locales/hi.json'
-import es from './locales/es.json'
-import fr from './locales/fr.json'
-import bn from './locales/bn.json'
-import pt from './locales/pt.json'
-import ru from './locales/ru.json'
-import de from './locales/de.json'
-import ja from './locales/ja.json'
-import ko from './locales/ko.json'
-import it from './locales/it.json'
-import enXA from './locales/en-XA.json'
+import { EN_TRANSLATION, mergeCatalogs } from './enCatalog'
 import { DEFAULT_LANGUAGE, SUPPORTED_CODES } from './languages'
 import { readStoredLanguage, resolveLanguage } from './detect'
 
+/** The one namespace every catalog uses — keys carry their own domain prefix. */
+const NAMESPACE = 'translation'
+
 /**
- * Deep-merge two catalogs (later wins on a leaf collision).
+ * The resources `initI18n()` hands to i18next, seeded English-only.
  *
- * English arrives in two files: `en.json` is REGENERATED wholesale by
- * `scripts/i18n-codemod.mjs` (so a fixed source string can't leave a stale key
- * behind), and `en.manual.json` holds hand-authored strings that have no source
- * literal to extract — like the language picker's own labels. Keeping them
- * separate is what lets the codemod overwrite its own output safely.
+ * `./catalogs` holds the full language-to-catalog map; everything beyond English
+ * arrives through `registerCatalogs`.
  */
-function mergeCatalogs(
-  a: Record<string, unknown>,
-  b: Record<string, unknown>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = { ...a }
-  for (const [key, value] of Object.entries(b)) {
-    const existing = out[key]
-    out[key] = value !== null && typeof value === 'object' && !Array.isArray(value)
-      && existing !== null && typeof existing === 'object' && !Array.isArray(existing)
-      ? mergeCatalogs(existing as Record<string, unknown>, value as Record<string, unknown>)
-      : value
+const REGISTERED_CATALOGS: Record<string, { translation: Record<string, unknown> }> = {
+  en: { translation: EN_TRANSLATION },
+}
+
+/**
+ * Add language catalogs to the registry.
+ *
+ * Works BOTH before and after `initI18n()`, and both cases are reachable:
+ * production registers at module scope before init, while vitest evaluates
+ * `setupFiles` — which calls `initI18n('en')` — BEFORE it imports the test file
+ * that pulls `./all` in. Before init the registry is simply what
+ * `init({ resources })` receives.
+ *
+ * After init, `addResourceBundle` is what makes the post-init case a stated
+ * contract rather than a coincidence: i18next's `ResourceStore` holds the object
+ * given to `init({ resources })` BY REFERENCE, so extending the registry in place
+ * already reaches the live instance. Registering into the registry alone would
+ * rest on that undocumented aliasing, and the day i18next copies instead, every
+ * `changeLanguage` test would fall back to English rather than fail.
+ *
+ * That insurance is not free — `addResourceBundle` deep-copies what it is handed,
+ * measured at 67-109 ms for the twelve catalogs, per file that imports `./all`. It
+ * is kept unconditional anyway: skipping it for a language the store already holds
+ * would silently drop a REPLACEMENT catalog, which is exactly what the lazy-backend
+ * seam above hands over, and ~4 s across the suite is not worth that hole.
+ */
+export function registerCatalogs(
+  extra: Record<string, { translation: Record<string, unknown> }>,
+): void {
+  for (const [lng, bundle] of Object.entries(extra)) {
+    const existing = REGISTERED_CATALOGS[lng]?.translation
+    // `./all` hands back the very English bundle this module seeded, so identity
+    // means there is nothing to merge -- and deep-merging ~11k leaves into
+    // themselves is pure cost on a path that runs before first paint.
+    if (existing === bundle.translation) continue
+
+    const translation = existing ? mergeCatalogs(existing, bundle.translation) : bundle.translation
+    REGISTERED_CATALOGS[lng] = { translation }
+
+    if (i18next.isInitialized) {
+      i18next.addResourceBundle(lng, NAMESPACE, translation, true, true)
+    }
   }
-  return out
 }
-
-/**
- * Catalog registry — the SINGLE place a language's catalog is bound to its code.
- *
- * Holds the authored languages; the generated pseudolocale is appended below in
- * DEV builds only, and `CATALOGS` (not this constant) is the runtime registry.
- *
- * Exported via `CATALOGS` so tests read the same map the runtime uses instead of
- * maintaining a parallel copy. That parallel copy was a real trap: it made "add
- * a language" a 4-edit job where forgetting the 4th produced a confusing parity
- * failure pointing at the catalog rather than at the test's own map.
- *
- * A language listed in `SUPPORTED_LANGUAGES` MUST appear here; `catalogParity.test.ts` asserts the two lists agree, so a language
- * added to one and not the other fails CI instead of silently rendering keys.
- *
- * Single `translation` namespace: keys are already domain-prefixed
- * (`settings.display.view`, `chat.composer.send`), which gives the same
- * grouping a namespace split would without making every call site name one.
- */
-const AUTHORED_CATALOGS: Record<string, { translation: Record<string, unknown> }> = {
-  en: { translation: mergeCatalogs(enGenerated, enManual) },
-  'zh-CN': { translation: zhCN },
-  hi: { translation: hi },
-  es: { translation: es },
-  fr: { translation: fr },
-  bn: { translation: bn },
-  pt: { translation: pt },
-  ru: { translation: ru },
-  de: { translation: de },
-  ja: { translation: ja },
-  ko: { translation: ko },
-  it: { translation: it },
-}
-
-/**
- * The pseudolocale is registered in DEV builds ONLY.
- *
- * It is unreachable in a production build by two independent guards already —
- * `devOnly` hides it from the picker and `isRestorableLanguage()` refuses it
- * from persisted state — so shipping its catalog was pure weight: the accented,
- * expansion-padded copy of every English string is the single largest catalog
- * (~88 KB gzip on first load) and no production user can select it.
- *
- * `import.meta.env.DEV` is statically replaced with `false` at build time, so
- * the ternary below is dead code in a production build and Rollup drops the
- * `en-XA.json` module with it. The import stays static (not `await import`)
- * because `t()` must remain SYNCHRONOUS — see the file header.
- */
-export const CATALOGS: Record<string, { translation: Record<string, unknown> }> =
-  import.meta.env.DEV
-    ? { ...AUTHORED_CATALOGS, 'en-XA': { translation: enXA } }
-    : AUTHORED_CATALOGS
 
 /**
  * The product name rendered by `{{productName}}` in catalog values.
@@ -174,7 +159,7 @@ export function initI18n(initialLanguage?: string): typeof i18next {
   const lng = resolveLanguage(initialLanguage ?? readStoredLanguage())
 
   i18next.use(initReactI18next).init({
-    resources: CATALOGS,
+    resources: REGISTERED_CATALOGS,
     lng,
     fallbackLng: DEFAULT_LANGUAGE,
     supportedLngs: [...SUPPORTED_CODES],
@@ -214,7 +199,32 @@ export function initI18n(initialLanguage?: string): typeof i18next {
  * to the server.
  */
 export async function changeLanguage(code: string): Promise<void> {
-  await i18next.changeLanguage(resolveLanguage(code))
+  const resolved = resolveLanguage(code)
+
+  // Switching to a language nobody registered is otherwise SILENT: i18next falls
+  // back to English, nothing throws, no key renders raw, and in the browser the
+  // caller still sets `<html lang>` — so the page claims Japanese and reads
+  // English. The only way to get here is a caller that reached the English-only
+  // `./index` when it needed `./all`; `resolveLanguage` returns nothing outside
+  // `SUPPORTED_CODES`, which `catalogParity.test.ts` pins against the catalog map.
+  //
+  // It REPORTS rather than throws, and that is deliberate. Both callers invoke
+  // this as `void changeLanguage(...)`, so a rejection here would surface as an
+  // unhandled rejection — which `integration/setup.ts` re-raises, killing the
+  // worker on an exception attributed to no test and no file. A guard that turns a
+  // wrong-language render into an unattributable shard failure costs more than it
+  // explains. `isInitialized` is checked first because `hasResourceBundle` is
+  // installed by `init()` and is undefined before it.
+  if (import.meta.env.DEV && i18next.isInitialized
+      && !i18next.hasResourceBundle(resolved, NAMESPACE)) {
+    console.error(
+      `i18n: no catalog is registered for '${resolved}', so this switch renders `
+        + 'English. Import from `i18n/all` rather than `i18n` — same exports, same '
+        + 'synchronous `t()`, all twelve languages.',
+    )
+  }
+
+  await i18next.changeLanguage(resolved)
 }
 
 export { i18next }

--- a/website/src/i18n/languages.ts
+++ b/website/src/i18n/languages.ts
@@ -4,10 +4,11 @@
  * Adding a language is a DATA change, not a code change — exactly three edits:
  *   1. add `src/i18n/locales/<code>.json` (same key set as `en.json`)
  *   2. add one entry here
- *   3. register the catalog in `src/i18n/index.ts` `CATALOGS`
+ *   3. register the catalog in `src/i18n/catalogs.ts` `AUTHORED_CATALOGS`
  *
  * No component changes, and no test changes: `catalogParity.test.ts` derives its
- * cases from this list and reads catalogs from the runtime `CATALOGS` map, so a
+ * cases from this list and reads catalogs from the `CATALOGS` map in
+ * `src/i18n/catalogs.ts` — the map registration is fed from — so a
  * new language automatically gains its own parity/placeholder/empty-value tests.
  * A half-added language therefore fails CI (naming the missing piece) instead of
  * silently rendering English.

--- a/website/src/i18n/memoBailout.test.tsx
+++ b/website/src/i18n/memoBailout.test.tsx
@@ -29,6 +29,11 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
+// Registers the zh-CN catalog. `./index` — what the vitest setup file inits — is
+// English only, and a switch that silently falls back to English would leave the
+// control leaf reading 'View' too, so `it.fails` below would pass for the wrong
+// reason and hide the defect it is probing.
+import './all'
 import { LanguageProvider, useLanguage } from './LanguageProvider'
 import { i18nT } from './t'
 import { api } from '../api/client'

--- a/website/src/i18n/navLabels.test.tsx
+++ b/website/src/i18n/navLabels.test.tsx
@@ -15,7 +15,8 @@
 
 import { describe, it, expect, afterEach } from 'vitest'
 
-import { i18next } from './index'
+// `./all` for the non-English catalogs: `./index` registers English only.
+import { i18next } from './all'
 import { SUPPORTED_CODES } from './languages'
 import { surfaceLabel } from '../surfaces/registry'
 import '../surfaces/builtins'

--- a/website/src/i18n/pseudolocale.test.ts
+++ b/website/src/i18n/pseudolocale.test.ts
@@ -28,7 +28,7 @@ import {
   DEFAULT_LANGUAGE,
 } from './languages'
 import { resolveLanguage } from './detect'
-import { CATALOGS } from './index'
+import { CATALOGS } from './catalogs'
 
 const PSEUDO = 'en-XA'
 const devOnly = SUPPORTED_LANGUAGES.filter((l) => l.devOnly).map((l) => l.code)

--- a/website/src/i18n/pseudolocaleBundle.test.ts
+++ b/website/src/i18n/pseudolocaleBundle.test.ts
@@ -25,7 +25,7 @@ const AUTHORED = SUPPORTED_LANGUAGES.filter(l => !l.devOnly).map(l => l.code)
 async function catalogsWithDev(dev: boolean): Promise<Record<string, unknown>> {
   vi.stubEnv('DEV', dev)
   vi.resetModules()
-  const mod = await import('./index')
+  const mod = await import('./catalogs')
   return mod.CATALOGS as Record<string, unknown>
 }
 

--- a/website/src/i18n/qa.test.ts
+++ b/website/src/i18n/qa.test.ts
@@ -63,7 +63,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from './index'
+import { CATALOGS as RUNTIME_CATALOGS } from './catalogs'
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from './languages'
 // One definition of the checks, shared with `check-source-strings.mjs`, which runs the
 // same predicates at ZERO tolerance over the values a branch changed. Two copies would

--- a/website/src/i18n/registerCatalogs.test.ts
+++ b/website/src/i18n/registerCatalogs.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `registerCatalogs` has two branches, and PRODUCTION only ever takes the first.
+ *
+ * `./all` calls it at module scope, before anything calls `initI18n`, so on every
+ * browser boot the catalogs land in the registry that `init({ resources })` later
+ * consumes. Under vitest the opposite branch runs: `integration/setup.ts` has
+ * already called `initI18n('en')` by the time any test file is imported, so a test
+ * that reaches for another language arrives AFTER init and is served by
+ * `addResourceBundle`.
+ *
+ * That asymmetry is the trap: every other test in the suite exercises the post-init
+ * branch, so deleting the pre-init one leaves the whole suite green while shipping a
+ * dashboard that renders English to everyone. These cases pin the branch production
+ * depends on, with a fresh module registry so init has not run.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+/** A catalog shaped like the real ones, small enough to assert on exactly. */
+const GERMAN = { translation: { 'settings.display.view': 'Ansicht' } }
+
+afterEach(() => {
+  vi.doUnmock('i18next')
+  vi.resetModules()
+})
+
+/**
+ * A fresh, uninitialized i18n module graph — the state a browser boot starts from.
+ *
+ * `vi.resetModules()` alone is not enough: it clears the local module graph, but
+ * `i18next` resolves from `node_modules`, so the same already-initialized singleton
+ * comes back and the pre-init branch stays unreachable. `importActual` keeps the
+ * real i18next behaviour; only the instance identity is substituted.
+ *
+ * The mock is registered per call with `doMock` rather than hoisted with `vi.mock`,
+ * because a hoisted factory is evaluated once and its instance then carries the
+ * language the previous test initialized: `initI18n` is idempotent, so the next
+ * test's call returns early and silently asserts against the wrong language.
+ */
+async function freshI18n() {
+  vi.resetModules()
+  const actual = await vi.importActual<typeof import('i18next')>('i18next')
+  vi.doMock('i18next', () => ({ ...actual, default: actual.default.createInstance() }))
+  return import('./index')
+}
+
+describe('registerCatalogs before initI18n — the production boot path', () => {
+  it('starts from an uninitialized instance, or this file tests the wrong branch', async () => {
+    const { i18next } = await freshI18n()
+
+    expect(i18next.isInitialized).toBeFalsy()
+  })
+
+  it('registers a language that initI18n then resolves', async () => {
+    const { registerCatalogs, initI18n, i18next } = await freshI18n()
+
+    registerCatalogs({ de: GERMAN })
+    initI18n('de')
+
+    expect(i18next.language).toBe('de')
+    expect(i18next.t('settings.display.view')).toBe('Ansicht')
+  })
+
+  it('keeps English, so registering does not displace the seeded catalog', async () => {
+    const { registerCatalogs, initI18n, i18next } = await freshI18n()
+
+    registerCatalogs({ de: GERMAN })
+    initI18n('en')
+
+    // Asserted on a key this test did NOT supply, and on its real English value:
+    // a key from GERMAN would still resolve if the seed had been replaced, and a
+    // not-the-raw-key check would pass on any non-empty fallback.
+    expect(i18next.t('app.changelog')).toBe('Changelog')
+  })
+
+  it('merges into a language already present instead of replacing it', async () => {
+    const { registerCatalogs, initI18n, i18next } = await freshI18n()
+
+    registerCatalogs({ de: GERMAN })
+    registerCatalogs({ de: { translation: { 'chat.composer.send': 'Senden' } } })
+    initI18n('de')
+
+    expect(i18next.t('settings.display.view')).toBe('Ansicht')
+    expect(i18next.t('chat.composer.send')).toBe('Senden')
+  })
+})
+
+describe('registerCatalogs after initI18n — the vitest path', () => {
+  it('reaches the live instance, since init has already consumed the registry', async () => {
+    const { registerCatalogs, initI18n, i18next } = await freshI18n()
+
+    initI18n('en')
+    expect(i18next.isInitialized).toBe(true)
+
+    registerCatalogs({ de: GERMAN })
+    await i18next.changeLanguage('de')
+
+    expect(i18next.t('settings.display.view')).toBe('Ansicht')
+  })
+})
+
+describe('the all-languages entry registers every declared language', () => {
+  /**
+   * The gate in `src/test/i18nAllLanguagesEntry.test.ts` asserts static
+   * REACHABILITY — that `./all` imports `./catalogs` — which is satisfied however
+   * `all.ts` uses what it imports. Narrowing its one call to
+   * `registerCatalogs({ en: CATALOGS.en })` therefore leaves that gate green, and
+   * every other test too, while production renders English to everyone. Before the
+   * split `init({ resources: CATALOGS })` made the mismatch impossible by
+   * construction; this is what replaces that guarantee.
+   */
+  it('has a resource bundle for every code the picker offers', async () => {
+    vi.resetModules()
+    const { SUPPORTED_CODES } = await import('./languages')
+    const { i18next, initI18n } = await import('./all')
+    initI18n('en')
+
+    const missing = SUPPORTED_CODES.filter((code) => !i18next.hasResourceBundle(code, 'translation'))
+
+    expect(
+      missing,
+      'importing `i18n/all` must register every language in SUPPORTED_CODES — '
+        + 'these have no catalog, so the UI renders English for them',
+    ).toEqual([])
+  })
+})

--- a/website/src/i18n/renderSwitch.test.tsx
+++ b/website/src/i18n/renderSwitch.test.tsx
@@ -18,6 +18,10 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
+// Registers the zh-CN catalog the assertions below read. The vitest setup file
+// inits i18next through `./index`, which registers English only, so without this
+// a switch to zh-CN silently falls back to English.
+import './all'
 import { LanguageProvider, useLanguage } from './LanguageProvider'
 import { i18nT } from './t'
 import { LANG_STORAGE_KEY } from './detect'

--- a/website/src/i18n/sendFailedSharedKey.test.ts
+++ b/website/src/i18n/sendFailedSharedKey.test.ts
@@ -28,7 +28,7 @@ import { join } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS } from './index'
+import { CATALOGS } from './catalogs'
 
 const SHARED_KEY = 'pages.chatPage.send_failed_with_error'
 const RETIRED_KEY = 'apps.designTweak.status.send_failed'

--- a/website/src/i18n/style/bnStyle.test.ts
+++ b/website/src/i18n/style/bnStyle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/deStyle.test.ts
+++ b/website/src/i18n/style/deStyle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/esStyle.test.ts
+++ b/website/src/i18n/style/esStyle.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/frStyle.test.ts
+++ b/website/src/i18n/style/frStyle.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/hiStyle.test.ts
+++ b/website/src/i18n/style/hiStyle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/itStyle.test.ts
+++ b/website/src/i18n/style/itStyle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/jaStyle.test.ts
+++ b/website/src/i18n/style/jaStyle.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 /** Kana and kanji. Deliberately excludes the CJK punctuation block. */
 const JP = '぀-ゟ゠-ヿ一-鿿々'

--- a/website/src/i18n/style/koStyle.test.ts
+++ b/website/src/i18n/style/koStyle.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 const HANGUL = '가-힣'
 const HANGUL_RE = new RegExp(`[${HANGUL}]`)

--- a/website/src/i18n/style/ptStyle.test.ts
+++ b/website/src/i18n/style/ptStyle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/ruStyle.test.ts
+++ b/website/src/i18n/style/ruStyle.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {}

--- a/website/src/i18n/style/zhStyle.test.ts
+++ b/website/src/i18n/style/zhStyle.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS as RUNTIME_CATALOGS } from '../index'
+import { CATALOGS as RUNTIME_CATALOGS } from '../catalogs'
 
 const CJK = /[\u4e00-\u9fff]/
 

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -17,8 +17,10 @@ import ThemeExperienceLayer from './components/ThemeExperienceLayer'
 import { initRum } from './rum'
 import { isEmbeddedPane } from './lib/embedded'
 // i18n must initialize before the first render — a component rendering ahead of
-// init would emit its bare translation key instead of text.
-import { initI18n } from './i18n'
+// init would emit its bare translation key instead of text. The `/all` entry is
+// what registers every language; plain `./i18n` is English-only, so importing it
+// here would render English for every user whatever language they picked.
+import { initI18n } from './i18n/all'
 import { LanguageProvider } from './i18n/LanguageProvider'
 import App from './App'
 import { queryClient } from './api/queryClient'

--- a/website/src/test/CapabilitiesPage.tabLanguage.test.tsx
+++ b/website/src/test/CapabilitiesPage.tabLanguage.test.tsx
@@ -30,7 +30,8 @@ vi.mock('../pages/overview', () => ({
 vi.mock('../components/RestartButton', () => ({ default: () => <div /> }))
 
 import CapabilitiesPage from '../pages/CapabilitiesPage'
-import { i18next } from '../i18n/index'
+// `/all` for the Japanese catalog: `../i18n` registers English only.
+import { i18next } from '../i18n/all'
 
 function wrap(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/website/src/test/CrewCompanionAskPills.test.ts
+++ b/website/src/test/CrewCompanionAskPills.test.ts
@@ -16,7 +16,10 @@
  */
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS } from '../i18n'
+// `EN_TRANSLATION` IS the object `catalogs.ts` binds to `en`, so this is the same
+// value with none of the parallel-copy risk — and it reaches two JSON modules
+// instead of fourteen, which the setup graph already pays for.
+import { EN_TRANSLATION } from '../i18n/enCatalog'
 import { ASK_CHOICE_KEYS } from '../apps/crew-companion/ReminderInput'
 
 function flatten(obj: unknown, prefix = ''): Record<string, string> {
@@ -30,7 +33,7 @@ function flatten(obj: unknown, prefix = ''): Record<string, string> {
   return out
 }
 
-const en = flatten((CATALOGS.en as { translation: unknown }).translation)
+const en = flatten(EN_TRANSLATION)
 
 describe('ask-row pill labels resolve', () => {
   it('every pill key is fully namespaced', () => {

--- a/website/src/test/CrewCompanionPanelCoverage.test.tsx
+++ b/website/src/test/CrewCompanionPanelCoverage.test.tsx
@@ -52,6 +52,18 @@ const petBridgeStub = {
   }),
 }
 vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: petBridgeStub }))
+// Both harnesses re-import the entry per test with `vi.resetModules()`, and the
+// entry boots through `../i18n/all` — so without this every test would re-fetch the
+// twelve non-English catalogs, 434 ms each. They pin `mc-lang` to `en` and assert
+// English only, so not one of those catalogs is ever read: measured 20.6s -> 3.1s
+// here. Delegating to `../i18n/index` keeps
+// real `initI18n`/`t()` behaviour rather than stubbing them, so the English strings
+// these tests assert on still come from the real catalog.
+//
+// `i18nAllLanguagesEntry.test.ts` independently pins that the entry imports
+// `/all`, so mocking the id here cannot hide a regression in what it boots through.
+vi.mock('../i18n/all', async () => await import('../i18n/index'))
+
 
 /** What the last add resolved to — the panel's own true/false contract. */
 let addResult: boolean | null = null

--- a/website/src/test/CrewCompanionPet.coverage.test.tsx
+++ b/website/src/test/CrewCompanionPet.coverage.test.tsx
@@ -49,6 +49,18 @@ const bridge = {
   contextMenuAction: vi.fn(),
 }
 vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: bridge }))
+// Both harnesses re-import the entry per test with `vi.resetModules()`, and the
+// entry boots through `../i18n/all` — so without this every test would re-fetch the
+// twelve non-English catalogs, 434 ms each. They pin `mc-lang` to `en` and assert
+// English only, so not one of those catalogs is ever read: measured 32.7s -> 5.4s
+// here. Delegating to `../i18n/index` keeps
+// real `initI18n`/`t()` behaviour rather than stubbing them, so the English strings
+// these tests assert on still come from the real catalog.
+//
+// `i18nAllLanguagesEntry.test.ts` independently pins that the entry imports
+// `/all`, so mocking the id here cannot hide a regression in what it boots through.
+vi.mock('../i18n/all', async () => await import('../i18n/index'))
+
 
 /** The gateway socket is replaced by a handle on the callbacks the overlay passes. */
 let watch: SessionWatchOptions | null = null

--- a/website/src/test/DesignCritiqueComposer.i18n.test.tsx
+++ b/website/src/test/DesignCritiqueComposer.i18n.test.tsx
@@ -19,7 +19,9 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 
 import Composer from '../apps/design-critique/Composer'
-import { i18next } from '../i18n/index'
+// `/all` for the 11 authored catalogs this file reads: `../i18n` registers
+// English only.
+import { i18next } from '../i18n/all'
 
 const noop = () => {}
 

--- a/website/src/test/DesignCritiqueStartLabel.i18n.test.tsx
+++ b/website/src/test/DesignCritiqueStartLabel.i18n.test.tsx
@@ -34,7 +34,9 @@ import { describe, it, expect, vi, afterEach, afterAll } from 'vitest'
 
 import Composer from '../apps/design-critique/Composer'
 import ScopingPicker from '../apps/design-critique/ScopingPicker'
-import { i18next } from '../i18n/index'
+// `/all` for the Chinese catalog `withSentinel` injects into and restores from:
+// `../i18n` registers English only, which would make the restore a no-op.
+import { i18next } from '../i18n/all'
 import type { Scope, StagedItem } from '../apps/design-critique/types'
 
 const noop = () => {}

--- a/website/src/test/DisplayPanel.language.test.tsx
+++ b/website/src/test/DisplayPanel.language.test.tsx
@@ -6,9 +6,11 @@ vi.mock('@radix-ui/react-select', async () => await import('./__mocks__/@radix-u
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import React from 'react'
-import i18next from 'i18next'
 
 import { renderWithProviders } from './helpers'
+// The app's own i18next, through `/all` so the Chinese catalog the zoom-description
+// case asserts on is registered — `../i18n` registers English only.
+import { i18next } from '../i18n/all'
 import { LANG_STORAGE_KEY } from '../i18n/detect'
 
 // DisplayPanel pulls in the zoom / theme / UI-mode / palette contexts; none of

--- a/website/src/test/Frontend5CcGallery.cov80.test.tsx
+++ b/website/src/test/Frontend5CcGallery.cov80.test.tsx
@@ -36,8 +36,10 @@ vi.mock('../apps/crew-companion/dashboardTheme', () => ({
   extractStylesheetHrefs: () => [],
 }))
 
+// The entry imports the all-languages module, so that is the id to intercept —
+// mocking `../i18n` would miss it and leave the spy silent.
 const initI18n = vi.fn()
-vi.mock('../i18n', () => ({ initI18n: () => initI18n(), i18next: {} }))
+vi.mock('../i18n/all', () => ({ initI18n: () => initI18n(), i18next: {} }))
 
 // The panel owns the whole surface (including its own ✕ and Escape); stubbing it
 // keeps every assertion here about the entry's own bootstrap.

--- a/website/src/test/ModelDropdownList.multiplier.test.tsx
+++ b/website/src/test/ModelDropdownList.multiplier.test.tsx
@@ -10,7 +10,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
-import { i18next } from '../i18n'
+// `/all` for the bn/de catalogs: `../i18n` registers English only, and an
+// unregistered language resolves to `en`, which renders Latin digits.
+import { i18next } from '../i18n/all'
 import ModelDropdownList, { formatMultiplier, costTier } from '../components/ModelDropdownList'
 import { withAutoFirst } from '../providers/modelList'
 

--- a/website/src/test/ReasoningEffortDropdown.i18n.test.tsx
+++ b/website/src/test/ReasoningEffortDropdown.i18n.test.tsx
@@ -16,7 +16,8 @@ import React from 'react'
 
 import ReasoningEffortDropdown from '../components/ReasoningEffortDropdown'
 import { api } from '../api/client'
-import { i18next } from '../i18n/index'
+// `/all` for the Chinese catalog: `../i18n` registers English only.
+import { i18next } from '../i18n/all'
 
 function wrap(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/website/src/test/TrustDropdown.test.tsx
+++ b/website/src/test/TrustDropdown.test.tsx
@@ -4,7 +4,8 @@ vi.mock("@radix-ui/react-dropdown-menu", async () => await import("./__mocks__/@
 
 import { render, screen, fireEvent } from '@testing-library/react'
 import TrustDropdown from '../components/TrustDropdown'
-import { i18next } from '../i18n/index'
+// `/all` for the ja/ko/de/zh-CN catalogs: `../i18n` registers English only.
+import { i18next } from '../i18n/all'
 
 const btnClass = 'px-2 py-1 rounded text-sm'
 

--- a/website/src/test/i18nAllLanguagesEntry.test.ts
+++ b/website/src/test/i18nAllLanguagesEntry.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Which i18n module an entry point boots through.
+ *
+ * `src/i18n/index.ts` imports the English catalog only; `src/i18n/all.ts` adds the
+ * other twelve. Both export `initI18n` with the same signature, so a page entry can
+ * boot through either one and `tsc` is happy either way — but through the
+ * English-only module the dashboard renders English for a user who picked Japanese.
+ * Nothing suspends, nothing throws, no key renders raw: i18next simply falls back.
+ * No test goes red and the diff shows one plausible import path, which is why this
+ * guard is a source-level scan rather than a behavioural one.
+ *
+ * Both directions of the split are pinned, and each is anchored on a PROPERTY of the
+ * module graph rather than on a module name: which catalogs the entry's transitive
+ * static imports reach. Renaming `all.ts`, folding `catalogs.ts` back into it, or
+ * adding a thirteenth language all keep this green; pointing an entry at the
+ * English-only module is what fails it.
+ */
+import { describe, it, expect } from 'vitest'
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import ts from 'typescript'
+
+import { SUPPORTED_CODES } from '../i18n/languages'
+import { readSource } from './readSource'
+
+const SRC = resolve(__dirname, '..')
+const WEBSITE = resolve(SRC, '..')
+const LOCALES = join(SRC, 'i18n', 'locales')
+
+/**
+ * Trees under `website/` that hold no page entry, so the scan skips them.
+ *
+ * This is a DENYLIST on purpose, because the two failure modes are not symmetric. A
+ * missing denylist entry costs a red test somebody fixes in a minute. A missing
+ * ALLOWLIST root costs nothing until a user sees the wrong language — and the roots
+ * that matter most are the least obvious: `capture/` holds ~40 page entries, eleven
+ * of them running a non-English language, one driven by a script that waits on a
+ * Chinese string and would hang for its full timeout. So a new tree of pages is
+ * governed by default, and opting one out is a visible edit here.
+ *
+ * `integration/` is listed because the vitest setup file SHOULD reach the
+ * English-only entry — that is the property the second describe block asserts.
+ */
+const NON_ENTRY_TREES = new Set([
+  'node_modules', 'dist', 'build', 'coverage', 'public', 'docs', 'scripts',
+  'integration', 'playwright', 'electron', 'eslint-rules', 'temp-screenshots',
+])
+
+/**
+ * Trees the call-site scan does not descend into.
+ *
+ * The test-support ones are deliberate, not an oversight: a helper or a setup file
+ * SHOULD reach for the English-only entry, which is the whole point of the split.
+ */
+const SKIP_DIRS = new Set(['node_modules', 'locales', 'test', 'tests', '__tests__', '__mocks__'])
+
+/** Extensions a bare specifier can resolve to, in the order Vite tries them. */
+const RESOLVE_SUFFIXES = ['', '.ts', '.tsx', '.json', '/index.ts', '/index.tsx']
+
+const rel = (file: string) => relative(WEBSITE, file).split('\\').join('/')
+
+/**
+ * The language a catalog file carries.
+ *
+ * A code may be spread over several files (`en.json` + `en.manual.json`), so the
+ * qualifier after the code is dropped: what matters for registration is the set of
+ * LANGUAGES reached, not the file count. `en-XA` keeps its hyphenated code — the
+ * pseudolocale is a separate language, not a variant of the English catalog.
+ */
+function languageCodeOf(basename: string): string {
+  return basename.split('.')[0]
+}
+
+/**
+ * The languages a production entry must reach — the DECLARED set, not the disk.
+ *
+ * `SUPPORTED_CODES` is the list the picker offers and `resolveLanguage` accepts, so
+ * it is the set a user can actually ask for. Reading `locales/` instead would make a
+ * stray unregistered `nl.json` demand that every entry reach it, which is not the
+ * rule this file states. `catalogParity.test.ts` pins the declared list against the
+ * catalog map in both directions, so the two cannot drift apart unnoticed.
+ */
+const ALL_LANGUAGES = new Set<string>(SUPPORTED_CODES)
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name) && !NON_ENTRY_TREES.has(entry.name)) walk(full, out)
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function parse(file: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+}
+
+/**
+ * Resolve a module specifier to a file, or null when it leaves the repo.
+ *
+ * Only relative and `@/`-aliased specifiers are followed; a bare specifier is a
+ * package, and a `.css` import resolves to none of the candidate suffixes. Both
+ * are dead ends for a catalog, so returning null skips them.
+ */
+function resolveModule(fromFile: string, specifier: string): string | null {
+  let base: string
+  if (specifier.startsWith('.')) base = resolve(dirname(fromFile), specifier)
+  else if (specifier.startsWith('@/')) base = join(SRC, specifier.slice(2))
+  else return null
+
+  for (const suffix of RESOLVE_SUFFIXES) {
+    const candidate = base + suffix
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate
+  }
+  return null
+}
+
+/** Every static `import`/`export … from` specifier in a parsed module. */
+function staticSpecifiers(sf: ts.SourceFile): string[] {
+  const out: string[] = []
+  for (const statement of sf.statements) {
+    if (
+      (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement))
+      && statement.moduleSpecifier
+      && ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      out.push(statement.moduleSpecifier.text)
+    }
+  }
+  return out
+}
+
+/**
+ * The languages an entry module registers, via its transitive static imports.
+ *
+ * Static reachability is the right measure precisely because `t()` is synchronous:
+ * a catalog that is not statically imported is not registered before first render,
+ * so nothing renders it. `export … from` is followed as well as `import` — the
+ * all-languages entry re-exports the runtime API that way.
+ */
+function languagesReachedFrom(entry: string): Set<string> {
+  const reached = new Set<string>()
+  const seen = new Set<string>([entry])
+  const queue = [entry]
+
+  while (queue.length) {
+    const file = queue.pop()!
+    if (file.startsWith(LOCALES) && file.endsWith('.json')) {
+      reached.add(languageCodeOf(file.slice(LOCALES.length + 1)))
+      continue
+    }
+    if (!/\.tsx?$/.test(file)) continue
+    for (const specifier of staticSpecifiers(parse(file, readSource(file)))) {
+      const next = resolveModule(file, specifier)
+      if (next && !seen.has(next)) {
+        seen.add(next)
+        queue.push(next)
+      }
+    }
+  }
+  return reached
+}
+
+/** A non-test module that calls `initI18n`, and where it imports the call from. */
+interface CallSite {
+  file: string
+  /** Specifiers supplying `initI18n`; more than one would be a genuine oddity. */
+  specifiers: string[]
+  /**
+   * Every `initI18n` call here passes the literal `'en'`, so English is all it can
+   * ever render and the English-only entry is the correct import.
+   *
+   * A bare `initI18n()` is NOT exempt: with no argument it resolves the language from
+   * `readStoredLanguage()`, so it can land on any of the twelve.
+   */
+  englishOnly: boolean
+}
+
+/**
+ * Find the call sites by AST, not by text match.
+ *
+ * Comments are not AST nodes, so a module that only mentions `initI18n()` in prose
+ * is skipped for free, and so is the declaration in `i18n/index.ts` — it exports the
+ * function without calling it. A module that both declares and calls its own
+ * `initI18n` is a redeclaration, not a boot path, so it is skipped explicitly.
+ */
+function findCallSites(): CallSite[] {
+  const sites: CallSite[] = []
+
+  for (const file of walk(WEBSITE)) {
+    const source = readSource(file)
+    if (!source.includes('initI18n')) continue
+
+    const sf = parse(rel(file), source)
+    const specifiers = new Set<string>()
+    let calls = false
+    let declares = false
+    let nonEnglishCall = false
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+        const bindings = node.importClause?.namedBindings
+        const supplies = bindings
+          && ((ts.isNamedImports(bindings)
+            && bindings.elements.some((e) => (e.propertyName ?? e.name).text === 'initI18n'))
+            // A namespace import reaches the same function as `ns.initI18n()`.
+            || ts.isNamespaceImport(bindings))
+        if (supplies) specifiers.add(node.moduleSpecifier.text)
+      }
+      if (ts.isCallExpression(node)) {
+        const callee = node.expression
+        if (
+          (ts.isIdentifier(callee) && callee.text === 'initI18n')
+          || (ts.isPropertyAccessExpression(callee) && callee.name.text === 'initI18n')
+        ) {
+          calls = true
+          const [arg] = node.arguments
+          // Anything that is not the literal 'en' — including no argument at all,
+          // which falls through to the stored language — can render another language.
+          if (!(arg && ts.isStringLiteral(arg) && arg.text === 'en')) nonEnglishCall = true
+        }
+      }
+      // Switching after init reaches another catalog just as much as booting into
+      // one, and neither `changeLanguage` nor a mounted `<LanguageProvider>` shows up
+      // in an `initI18n` argument. Without this, an entry pinned to `initI18n('en')`
+      // that renders the language picker would be exempt and broken.
+      if (
+        (ts.isIdentifier(node) || ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node))
+        && /^(changeLanguage|LanguageProvider)$/.test(
+          ts.isIdentifier(node) ? node.text : node.tagName.getText(sf),
+        )
+      ) {
+        nonEnglishCall = true
+      }
+      if (
+        (ts.isFunctionDeclaration(node) || ts.isVariableDeclaration(node))
+        && node.name
+        && ts.isIdentifier(node.name)
+        && node.name.text === 'initI18n'
+      ) {
+        declares = true
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sf)
+
+    if (calls && !declares) {
+      sites.push({ file, specifiers: [...specifiers], englishOnly: !nonEnglishCall })
+    }
+  }
+
+  return sites
+}
+
+/** `setupFiles` as vitest reads it: one string, or an array of them. */
+function setupFileSpecifiers(config: string): string[] {
+  const list = config.match(/setupFiles:\s*\[([^\]]*)\]/)
+  if (list) return [...list[1].matchAll(/'([^']+)'/g)].map((m) => m[1])
+  const single = config.match(/setupFiles:\s*'([^']+)'/)
+  return single ? [single[1]] : []
+}
+
+const CALL_SITES = findCallSites()
+
+describe('every entry point that boots i18n registers all languages', () => {
+  it('has a catalog per authored language to scan for', () => {
+    // Without this the main assertion is satisfiable by an empty language set, which
+    // is exactly the vacuous pass a guard is written to avoid.
+    expect(ALL_LANGUAGES.size).toBeGreaterThanOrEqual(12)
+  })
+
+  it('reaches every tree that holds an entry, not just src/', () => {
+    expect(CALL_SITES.length).toBeGreaterThan(0)
+
+    // Named trees must each contribute, or the walk quietly stopped descending and
+    // every assertion below is vacuous for whatever it no longer sees. `capture/` is
+    // listed because it is the tree a scan rooted at `src/` would silently omit.
+    // `src/i18n` is deliberately absent: it DECLARES `initI18n` and never calls it.
+    for (const tree of ['capture/', 'src/apps/', 'src/main.tsx']) {
+      expect(
+        CALL_SITES.some((site) => rel(site.file).startsWith(tree)),
+        `no initI18n call site found under ${tree} — the walk is not reaching it`,
+      ).toBe(true)
+    }
+  })
+
+  it('imports initI18n from a module whose graph reaches every catalog', () => {
+    const offenders: string[] = []
+
+    for (const { file, specifiers, englishOnly } of CALL_SITES) {
+      // A screenshot entry pinned to initI18n('en') renders English by construction,
+      // so the English-only import is right and pulling in twelve more catalogs would
+      // only slow it down.
+      if (englishOnly) continue
+      if (specifiers.length === 0) {
+        offenders.push(`${rel(file)} — calls initI18n() but imports it from nowhere findable`)
+        continue
+      }
+      for (const specifier of specifiers) {
+        const entry = resolveModule(file, specifier)
+        if (!entry) {
+          offenders.push(`${rel(file)} — cannot resolve '${specifier}' to a file`)
+          continue
+        }
+        const reached = languagesReachedFrom(entry)
+        const missing = [...ALL_LANGUAGES].filter((code) => !reached.has(code))
+        if (missing.length) {
+          offenders.push(
+            `${rel(file)} — '${specifier}' registers no catalog for ${missing.sort().join(', ')}`,
+          )
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      'A page entry point must import `initI18n` from the ALL-LANGUAGES i18n entry '
+        + '(`src/i18n/all.ts`), not from `src/i18n/index.ts`. `index.ts` deliberately '
+        + 'imports the English catalog only, so booting through it registers English '
+        + 'and nothing else: i18next then falls back for every other language and the '
+        + 'dashboard renders English to a user who picked Japanese. Nothing throws and '
+        + 'no key renders raw, so this scan is the only thing that reports it. Change '
+        + "the import to '<path>/i18n/all' — same exports, same synchronous `t()`.",
+    ).toEqual([])
+  }, 20_000)
+})
+
+describe('the vitest setup module graph stays English-only', () => {
+  /**
+   * The other direction, and the property the split exists for.
+   *
+   * A `setupFiles` module graph is re-evaluated once per test FILE — ~1400 times —
+   * so every catalog it reaches is re-fetched that many times. Reaching all fourteen
+   * cost more setup than the whole suite spent running tests; `docs/testing.md`
+   * § "What a `setupFiles` entry costs" owns the measurements. Moving one import back into `src/i18n/index.ts`
+   * while "tidying up" restores the whole cost with every test still passing, which
+   * is why the ceiling is asserted rather than left to a benchmark nobody reruns.
+   */
+  const specifiers = setupFileSpecifiers(readSource(join(WEBSITE, 'vite.config.ts')))
+
+  it('reads setupFiles out of vite.config.ts', () => {
+    expect(specifiers.length).toBeGreaterThan(0)
+  })
+
+  for (const specifier of specifiers) {
+    it(`'${specifier}' reaches no catalog beyond English`, () => {
+      const entry = resolveModule(join(WEBSITE, 'vite.config.ts'), specifier)
+      expect(entry, `setupFiles entry '${specifier}' does not resolve to a file`).not.toBeNull()
+
+      const extra = [...languagesReachedFrom(entry!)].filter((code) => code !== 'en').sort()
+      expect(
+        extra,
+        `The vitest setup graph statically imports the ${extra.join(', ')} catalog(s). `
+          + 'It is re-evaluated once per test file (~1400 times), so each of those '
+          + 'catalogs is re-fetched ~1400 times, which costs the suite more setup '
+          + 'than it spends running tests. Keep the non-English imports '
+          + 'in `src/i18n/catalogs.ts`, reached only through `src/i18n/all.ts`, and let '
+          + 'a test that needs another language import that entry itself.',
+      ).toEqual([])
+    })
+  }
+})

--- a/website/src/test/labelKeyTables.test.ts
+++ b/website/src/test/labelKeyTables.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { CATALOGS } from '../i18n/index'
+import { CATALOGS } from '../i18n/catalogs'
 import { EFFORT_LABEL_KEY, effortLabel } from '../lib/effort'
 import { FILTER_LABEL_KEY, FILTER_DESCRIPTION_KEY, SORT_LABEL_KEY } from '../pages/ChatSidebar'
 import { STAT_LABEL_KEY } from '../pages/OverviewPage'

--- a/website/src/test/metricValueIntegrity.test.ts
+++ b/website/src/test/metricValueIntegrity.test.ts
@@ -21,7 +21,10 @@
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { fmtBytes, fmtUnit, __resetFormatterCache } from '../i18n/format'
-import { i18next } from '../i18n'
+// `/all` for the catalogs of the locales below: `../i18n` registers English
+// only, and an unregistered language resolves to `en` — so every locale case
+// would measure the English separator.
+import { i18next } from '../i18n/all'
 
 const LOCALES = ['en', 'zh-CN', 'de', 'ru', 'fr', 'ja']
 


### PR DESCRIPTION
## Problem / Motivation

The frontend vitest suite spent **more time in setup than in running tests**. Measured on
one host at `maxWorkers: 3`: `setup 1363.5s` against `tests 873.5s` — setup was 1.56x the
tests phase, on a 19m27s run.

`website/integration/setup.ts` is a `setupFiles` entry, and `isolate: true` clears each
worker's module registry between files, so vitest re-fetches that whole module graph **once
per test file** — ~1,400 times. The graph reached `website/src/i18n/index.ts`, which
statically imported all 14 locale catalogs. English is 726,947 of those 12,242,932 bytes
(5.9%); the other 94% was fetched ~1,400 times for the ~97% of test files that only ever
assert English text.

## Why it matters

It is the single largest cost in the frontend suite, and it is paid by every contributor on
every run and by CI on every push. It also inflates peak memory, which matters on a laptop:
the suite is already capped (`maxWorkers: 3`) precisely because unbounded workers were
OOM-killed, surfacing as "Worker exited unexpectedly" while every test passed.

## What changed (motivation → approach → change)

**The cost is the per-module round trip, not the bytes.** Parsing all 14 catalogs measures
32 ms and compiling them 1.5 ms, against ~690 ms per file of measured saving — the expense
is 14 vite-node module fetches crossing the fork IPC channel, repeated per file. That rules
out the tempting fix: Vite's `json.stringify` is already on above 10 KB and buys nothing
here. The only lever is **removing modules from that graph**.

So catalog ownership is split, and nothing is deferred:

- **`catalogs.ts`** owns every catalog import and exports `CATALOGS` unchanged, so the 22
  catalog-QA tests that iterate every language keep reading the same map the runtime uses.
- **`enCatalog.ts`** merges English once and owns `mergeCatalogs`. Both catalog owners share
  that one merged object, and the shared identity is what lets `registerCatalogs` skip
  re-merging English on the boot path.
- **`index.ts`** imports English only, seeds the registry with it, and gains
  `registerCatalogs()`. It merges before init and calls `addResourceBundle` after — vitest
  runs `setupFiles` (which calls `initI18n('en')`) *before* it imports the test file that
  pulls another language in, so both branches are reachable and both are needed.
- **`all.ts`** registers every catalog and re-exports the API. The five production
  `initI18n` call sites and the 11 `capture/` page entries that run a non-English language
  boot through it.

`changeLanguage` now **reports in dev** when the target language has no registered catalog.
Otherwise the failure is silent — i18next falls back, nothing throws, no key renders raw,
and the browser caller still sets `<html lang>`, so the page claims Japanese and reads
English. It reports rather than throws deliberately: both callers invoke it as
`void changeLanguage(...)`, so a rejection would reach `integration/setup.ts`, which
re-raises it — killing a worker on an exception attributed to no test and no file.

This is ownership, not lazy loading: **no load is deferred on any path and `t()` stays
synchronous**, which the ~600 components calling it during render and the ~4000
English-text assertions both depend on. It also makes the `i18next-http-backend` seam the
module header describes cheaper to reach, since `registerCatalogs()` is where a fetching
backend would hand its catalog over.

### Results

Full suite, back to back on one host, same `node_modules`, both green:

| | base `7901dac5c` | this branch |
|---|---|---|
| wall | 1166.5s (19m27s) | **834.3s (13m54s)** — 1.40x, -28.5% |
| setup | 1363.5s | **374.0s** — 3.65x less |
| tests phase | 873.5s | 818.9s |
| files / tests | 1469 / 22,878 | 1471 / 22,889 |
| exit | 0 | 0 |

The +11 tests are the two new test files. Three files that pulled every catalog to read
English now read the shared English bundle: the two crew-companion coverage harnesses
re-import their entry per test, which alone was **53.3s -> 8.6s**.

**The production bundle is not byte-identical, and the difference is a chunk boundary
rather than added code.** Rolldown names the catalog chunk after the module that pulls it,
so the catalogs move out of `t` (9,529 KB) into a new `all` chunk (8,666 KB) while `t`
keeps the i18n runtime plus English (641 KB). Splitting one chunk into two costs **~54 KB
brotli across the whole bundle (+0.78%)**. Verified from the build: every catalog is
present exactly once and the DEV pseudolocale is still absent.

That rename is what made **the `Bundle Size Gate` red** — `CHUNK_BUDGETS` is keyed by
chunk name, so the 8.46 MB `all` chunk fell to the 500 KB default. It now carries its own
entry, **and `t` is re-measured in the same edit**: leaving `t` at its old 9,500 KB ceiling
would have left an ~8.8 MB silent admission window on a chunk that is now 14x smaller.
Reproduced CI's exact sequence (`vite build --mode analyze` then
`node scripts/check-bundle-size.mjs`) — exit 0, 661 chunks within budget.

## Tests

- **`website/src/test/i18nAllLanguagesEntry.test.ts`** gates the three properties the split
  rests on, none of which changes a test result on its own: no non-English import in
  `index.ts`, no all-catalogs import in the setup graph, and no page entry importing
  `initI18n` from the English-only module. It resolves the transitive static import graph
  and asserts the **set of languages reached**, so renaming `all.ts`, folding `catalogs.ts`
  back into it, or adding a 13th language all keep it green. It scans `website/` minus a
  **denylist** of non-entry trees, because an allowlist already failed here once: rooted at
  `src/` alone it exempted all 40 `capture/` entries. Mutation-checked — pointing one entry
  back at `./i18n` fails it by name with the 12 missing languages listed.
- **`website/src/i18n/registerCatalogs.test.ts`** pins the pre-init branch, which
  production is the only caller of and which no other test in the suite reaches — every
  other test arrives after `setupFiles` has already called `initI18n('en')`. It also pins
  that importing `all.ts` really registers every declared language: the reachability gate
  above is satisfied by `all.ts` merely importing `./catalogs`, so narrowing its one call
  to `registerCatalogs({ en: CATALOGS.en })` otherwise leaves the whole suite green while
  the dashboard renders English to everyone. Both mutation-checked.

## Manual verification

N/A — unit coverage sufficient, plus three whole-system checks that unit tests cannot make:
the full suite run on both sides (counts above), the analyze build plus bundle-size gate, and
`npx tsc -b --force` clean. Note `npm run typecheck` checks **zero** files (the root
tsconfig has `"files": []`), and `tsconfig.app.json` excludes test files — so the ~40 edited
test files are type-checked by nothing, and they were verified by execution instead.

<!-- no-visual-delta -->
**Why no screenshot:** the four watched files under `website/src/apps/**` change one import
path each (`'../../i18n'` -> `'../../i18n/all'`); no component, layout, style, or string
changes. The only bundle difference is a chunk boundary, detailed above; nothing a user
sees moves.

## Related Issues

no linked issue: found by profiling the suite rather than from a report.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
