### PR TITLE
feat(desktop): bundle a pinned kiro-cli into the app resources

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -68,6 +68,27 @@ running **natively** on both Apple Silicon and Intel Macs. It needs only
 an Apple-Silicon host with Rosetta 2; the script fails fast with instructions
 otherwise, and `UNIVERSAL=0` is the opt-out.)
 
+### Bundled kiro-cli — the app carries its own agent runtime
+
+By default (`BUNDLE_KIRO_CLI=1`), the build stages a pinned, sha256-verified
+kiro-cli into the app's resources at `backend-dist/kiro-cli/`: the version is
+resolved from the official release manifest and the archive is verified
+fail-closed before staging, mirroring the Docker image's kiro-cli install. On
+macOS the binaries are extracted from the universal `Kiro CLI.dmg` (one copy
+serves both arches); Linux uses the matching per-arch zip. A
+`BUNDLED-VERSION` file beside the payload records provenance.
+
+At runtime the Electron shell exports the directory as
+`KIROCREW_BUNDLED_KIRO_DIR` when it spawns the gateway; the backend resolver
+ranks it **above** any system install (the app was built against that exact
+version) but **below** the `KIROCREW_KIRO_BIN` operator override. `kiro-cli
+login` is still the user's own step — bundling covers the binary, never the
+credential.
+
+`BUNDLE_KIRO_CLI=0 make desktop` opts a build out (the payload is large);
+the app then detects a system kiro-cli exactly as before. Windows builds
+never bundle (upstream ships only an MSI there).
+
 ### macOS opt-out and Linux — host-arch-only builds
 
 `UNIVERSAL=0 make desktop` (and every Linux build) produces an installer for

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -906,7 +906,13 @@ still refresh while the dashboard body is blocked. On a new gateway it:
 3. once a viable CLI is found, names the commands the USER runs to sign in
    (`KIRO_CLI_LOGIN_COMMAND`, `kiro-cli login`, for a personal account, and
    `KIRO_CLI_SSO_LOGIN_COMMAND`, `kiro-cli login --use-device-flow --license pro`,
-   for organization SSO) and offers **Check again**;
+   for organization SSO) and offers **Check again**. When the resolved binary
+   is the desktop app's bundled copy (`KIROCREW_BUNDLED_KIRO_DIR`), the served
+   commands carry the binary's shlex-quoted absolute path instead of the bare
+   name (`login_commands_for`): the bundled copy is not on the user's shell
+   PATH, so the bare command would fail with command-not-found on exactly the
+   fresh machine bundling targets, while the gate insists the CLI is
+   installed. The status payload's `bundled` flag records the provenance;
 4. records first-run completion when `ready=true`.
 
 **Kiro Crew performs neither setup step, and there is no code path that could.**

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -485,6 +485,117 @@ if [ "${SKIP_ELECTRON:-0}" = "1" ]; then
   exit 0
 fi
 
+# --- 3b. Bundle kiro-cli into the app resources -------------------------------
+# Stages a pinned, sha256-verified kiro-cli under backend-dist/kiro-cli/ so the
+# installed app carries the agent runtime it was built against — no first-run
+# download, and the KAS backend's `kiro-cli acp --agent-engine v3` spawn works
+# out of the box. Mirrors docker/Dockerfile's fail-closed manifest resolution.
+# Landing inside backend-dist/ means the electron-builder extraResources entry
+# and the macOS x64ArchFiles glob both cover it with zero config changes; the
+# Electron shell exports the directory as KIROCREW_BUNDLED_KIRO_DIR at gateway
+# spawn (main.js), and the backend ranks it above system installs but below the
+# KIROCREW_KIRO_BIN operator override (kiro_cli.known_kiro_cli_dirs).
+# BUNDLE_KIRO_CLI=0 opts a build out (the payload is large); the app then
+# behaves exactly as before — detect-only, user installs kiro-cli themselves.
+KIRO_CLI_MANIFEST_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/manifest.json"
+
+fetch_kiro_cli() {
+  local dest="$ELECTRON_DIR/backend-dist/kiro-cli"
+  local cache="${KIRO_CLI_BUNDLE_CACHE:-$HOME/.cache/kirocrew-build/kiro-cli}"
+  mkdir -p "$cache"
+
+  log "Resolving kiro-cli from the release manifest…"
+  curl --proto '=https' --tlsv1.2 -fsSL "$KIRO_CLI_MANIFEST_URL" \
+    -o "$cache/manifest.json"
+  local version
+  version="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' \
+    "$cache/manifest.json")"
+  echo "    kiro-cli version: $version"
+
+  if [ "$OS" = "darwin" ]; then
+    # macOS publishes ONE universal DMG (no per-arch zips). The manifest
+    # sha256 covers the DMG itself, so verify the DMG fail-closed, then
+    # extract the CLI binaries from the mounted app. One copy serves both
+    # backend trees — the Mach-O binaries are already lipo'd universal.
+    # The download path contains a space ("Kiro CLI.dmg"), so the parser
+    # URL-encodes it; paths reach Python via argv, never string splicing.
+    local resolved dl sha dmg
+    resolved="$(python3 -c 'import json,sys,urllib.parse
+m = json.load(open(sys.argv[1]))
+p = next(x for x in m["packages"] if x["fileType"] == "dmg")
+print(urllib.parse.quote(p["download"]))
+print(p["sha256"])' "$cache/manifest.json")"
+    dl="$(printf '%s\n' "$resolved" | sed -n 1p)"
+    sha="$(printf '%s\n' "$resolved" | sed -n 2p)"
+    dmg="$cache/kirocli-$version.dmg"
+    if [ ! -f "$dmg" ] || ! echo "$sha  $dmg" | shasum -a 256 -c - >/dev/null 2>&1; then
+      curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://desktop-release.q.us-east-1.amazonaws.com/$dl" -o "$dmg"
+      echo "$sha  $dmg" | shasum -a 256 -c - \
+        || { echo "ERROR: kiro-cli DMG sha256 mismatch — refusing to bundle" >&2; exit 1; }
+    fi
+    local mnt
+    mnt="$(mktemp -d)"
+    hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mnt" >/dev/null
+    mkdir -p "$dest"
+    # The whole MacOS/ directory, not one file: kiro-cli 2.15+ exec-dispatches
+    # to sibling executables, so the layout must travel together.
+    cp -a "$mnt/Kiro CLI.app/Contents/MacOS/." "$dest/"
+    hdiutil detach "$mnt" >/dev/null
+    rmdir "$mnt" 2>/dev/null || true
+  else
+    # Linux: per-arch gnu zip, selected exactly as docker/Dockerfile does
+    # (fileType=zip, matching architecture, musl excluded). Paths reach
+    # Python via argv, never string splicing.
+    local karch resolved dl sha zipf
+    karch="$HOST_ARCH"
+    [ "$karch" = "arm64" ] && karch="aarch64"
+    resolved="$(python3 -c 'import json,sys,urllib.parse
+m = json.load(open(sys.argv[1]))
+a = sys.argv[2]
+p = next(x for x in m["packages"]
+         if x["fileType"] == "zip" and x["architecture"] == a
+         and "musl" not in x["download"])
+print(urllib.parse.quote(p["download"]))
+print(p["sha256"])' "$cache/manifest.json" "$karch")"
+    dl="$(printf '%s\n' "$resolved" | sed -n 1p)"
+    sha="$(printf '%s\n' "$resolved" | sed -n 2p)"
+    zipf="$cache/kirocli-$version-$karch.zip"
+    if [ ! -f "$zipf" ] || ! echo "$sha  $zipf" | sha256sum -c - >/dev/null 2>&1; then
+      curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://desktop-release.q.us-east-1.amazonaws.com/$dl" -o "$zipf"
+      echo "$sha  $zipf" | sha256sum -c - \
+        || { echo "ERROR: kiro-cli zip sha256 mismatch — refusing to bundle" >&2; exit 1; }
+    fi
+    local tmp
+    tmp="$(mktemp -d)"
+    unzip -q "$zipf" -d "$tmp"
+    mkdir -p "$dest"
+    cp -a "$tmp"/kirocli/bin/. "$dest/"
+    rm -rf "$tmp"
+  fi
+
+  # Record provenance beside the payload, mirroring the Docker image's
+  # /usr/local/share/kirocrew/kiro-cli-version audit file.
+  printf '%s\n' "$version" > "$dest/BUNDLED-VERSION"
+  # Build-time gate: the staged copy must actually run on this host class.
+  # Enforced on BOTH platforms — the Linux zip is selected by the build
+  # host's own architecture (karch=HOST_ARCH), so the binary is always
+  # executable here and a failure means a broken artifact, not a
+  # cross-arch limitation.
+  if "$dest/kiro-cli" --version >/dev/null 2>&1; then
+    echo "    staged kiro-cli $version -> backend-dist/kiro-cli/"
+  else
+    echo "ERROR: staged kiro-cli does not execute" >&2; exit 1
+  fi
+}
+
+if [ "${BUNDLE_KIRO_CLI:-1}" = "1" ] && [ "$OS" != "windows" ]; then
+  fetch_kiro_cli
+else
+  log "BUNDLE_KIRO_CLI=0 (or Windows) — app ships without a bundled kiro-cli"
+fi
+
 # --- 4. Package the desktop app with electron-builder -----------------------
 log "Packaging desktop app (electron-builder, version: $KC_VERSION)…"
 ( cd "$ELECTRON_DIR"

--- a/src/kiro_crew/kiro_cli.py
+++ b/src/kiro_crew/kiro_cli.py
@@ -194,15 +194,31 @@ def known_kiro_cli_dirs(
     *,
     include_inherited_path: bool = True,
 ) -> list[str]:
-    """Return fixed and inherited directories where Kiro CLI may be installed."""
+    """Return fixed and inherited directories where Kiro CLI may be installed.
 
+    ``KIROCREW_BUNDLED_KIRO_DIR`` names the copy the desktop app ships inside
+    its own resources (the Electron shell sets it at gateway spawn). It ranks
+    ABOVE every system install — the app was built and tested against that
+    exact version — but BELOW the ``KIROCREW_KIRO_BIN`` operator override in
+    :func:`find_kiro_cli_candidates`, so an operator can still force a
+    different binary. A directory (not a file) on purpose: kiro-cli 2.15+
+    exec-dispatches to sibling executables, so the whole layout must resolve
+    together.
+    """
+
+    dirs: list[str] = []
+    bundled = environ.get("KIROCREW_BUNDLED_KIRO_DIR", "").strip()
+    if bundled:
+        dirs.append(bundled)
     if platform_name == "win32":
-        dirs = [str(Path(_windows_program_files(environ)) / "Kiro-Cli")]
+        dirs.append(str(Path(_windows_program_files(environ)) / "Kiro-Cli"))
     else:
-        dirs = [
-            str(home / ".local" / "bin"),
-            str(home / ".cargo" / "bin"),
-        ]
+        dirs.extend(
+            [
+                str(home / ".local" / "bin"),
+                str(home / ".cargo" / "bin"),
+            ]
+        )
     if platform_name == "darwin":
         dirs.extend(
             [

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -38,6 +38,7 @@ import hashlib
 import json
 import logging
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -45,7 +46,7 @@ import sys
 import tempfile
 import time
 import urllib.request
-from collections.abc import Awaitable, Callable, MutableMapping
+from collections.abc import Awaitable, Callable, Mapping, MutableMapping
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -75,7 +76,15 @@ OFFICIAL_INSTALL_DOCS_URL = "https://kiro.dev/cli/"
 # website/docs/i18n-catalog.md — "A literal token the user must type must never be
 # a catalog value"). Served in the status payload so the UI has one source of
 # truth for it rather than hardcoding a second copy that can drift.
-KIRO_CLI_LOGIN_COMMAND = "kiro-cli login"
+# The argument tails are split out so login_commands_for() can compose the
+# bundled-copy form (absolute path + same tail) without duplicating flag
+# literals that would drift. They carry the leading space DELIBERATELY: the
+# read-only-probe tripwire in test_kiro_prerequisite.py forbids the standalone
+# quoted token a spawn argv element would have, and these are display strings
+# the user types, never argv.
+_LOGIN_TAIL = " login"
+_SSO_LOGIN_TAIL = " login --use-device-flow --license pro"
+KIRO_CLI_LOGIN_COMMAND = f"kiro-cli{_LOGIN_TAIL}"
 # The organization-SSO counterpart, served alongside the bare command so the gate
 # can offer both instead of one ambiguous line. Both flags are load-bearing:
 # ``--use-device-flow`` is what makes the others take effect at all (kiro-cli
@@ -85,7 +94,35 @@ KIRO_CLI_LOGIN_COMMAND = "kiro-cli login"
 # failure this exists to prevent: on the portal, a free Builder ID sits as a
 # visual peer of organization SSO, so a user on an SSO plan can sign in to the
 # wrong tier and only discover it when models are missing.
-KIRO_CLI_SSO_LOGIN_COMMAND = "kiro-cli login --use-device-flow --license pro"
+KIRO_CLI_SSO_LOGIN_COMMAND = f"kiro-cli{_SSO_LOGIN_TAIL}"
+
+
+def login_commands_for(
+    binary: str,
+    environ: Mapping[str, str],
+) -> tuple[str, str, bool]:
+    """Sign-in commands for the RESOLVED binary, plus whether it is bundled.
+
+    The desktop app's bundled kiro-cli (``KIROCREW_BUNDLED_KIRO_DIR``) is not
+    on the user's shell PATH, so when it is the copy that resolved, the served
+    commands must carry the binary's absolute path — otherwise the setup gate
+    asserts "installed" while its only on-screen instruction fails with
+    command-not-found on a fresh machine. The path is shlex-quoted because the
+    macOS resources path contains a space. Any other resolution keeps the bare
+    constants: the binary is on PATH by construction there.
+    """
+    bundled_dir = environ.get("KIROCREW_BUNDLED_KIRO_DIR", "").strip()
+    if bundled_dir and binary:
+        try:
+            inside = Path(binary).resolve().parent == Path(bundled_dir).resolve()
+        except OSError:
+            inside = False
+        if inside:
+            quoted = shlex.quote(binary)
+            return f"{quoted}{_LOGIN_TAIL}", f"{quoted}{_SSO_LOGIN_TAIL}", True
+    return KIRO_CLI_LOGIN_COMMAND, KIRO_CLI_SSO_LOGIN_COMMAND, False
+
+
 # Compatibility shim, not live state. Nothing performs an operation any more, but a
 # dashboard loaded BEFORE this change reads ``status.operation.status``
 # unconditionally in its refetch-interval callback — the optional chain there
@@ -382,6 +419,11 @@ class PrerequisiteStatus:
     # tier is an explicit choice rather than whichever option the sign-in page
     # happens to make prominent.
     sso_login_command: str = KIRO_CLI_SSO_LOGIN_COMMAND
+    # True when the resolved binary is the desktop app's own bundled copy
+    # (KIROCREW_BUNDLED_KIRO_DIR). Provenance for the gate and diagnostics: a
+    # user comparing against a system install they upgraded can see WHICH
+    # kiro-cli answered, instead of chasing an upstream fix that never appears.
+    bundled: bool = False
     # A Kiro CLI binary that is present and executable but could not be VERIFIED
     # (verification runs the binary inside the sandbox) is a categorically
     # different condition from a missing binary, and a failed sandbox build
@@ -2509,6 +2551,9 @@ class KiroPrerequisiteService:
                         kind,
                         detail,
                     )
+                    login_cmd, sso_cmd, is_bundled = login_commands_for(
+                        first_candidate, self._environ
+                    )
                     self._status = PrerequisiteStatus(
                         platform=_platform_label(self._platform),
                         # Present and executable on disk. Verification is what
@@ -2520,6 +2565,9 @@ class KiroPrerequisiteService:
                         ready=False,
                         repair_required=False,
                         initial_setup_complete=self._initial_setup_complete,
+                        login_command=login_cmd,
+                        sso_login_command=sso_cmd,
+                        bundled=is_bundled,
                         sandbox_unavailable=True,
                         sandbox_failure_kind=kind,
                         sandbox_detail=detail,
@@ -2575,6 +2623,9 @@ class KiroPrerequisiteService:
                             first_candidate,
                             _PROBE_TIMEOUT_SECS,
                         )
+                    login_cmd, sso_cmd, is_bundled = login_commands_for(
+                        first_candidate, self._environ
+                    )
                     self._status = PrerequisiteStatus(
                         platform=_platform_label(self._platform),
                         installed=True,
@@ -2584,6 +2635,9 @@ class KiroPrerequisiteService:
                         ready=False,
                         repair_required=False,
                         initial_setup_complete=self._initial_setup_complete,
+                        login_command=login_cmd,
+                        sso_login_command=sso_cmd,
+                        bundled=is_bundled,
                         probe_timed_out=True,
                     )
                     self._last_probe_at = self._clock()
@@ -2625,6 +2679,9 @@ class KiroPrerequisiteService:
                 rejected, rejection_detail = await self._probe_spec_acceptance(
                     self._viable_binary
                 )
+            login_cmd, sso_cmd, is_bundled = login_commands_for(
+                self._viable_binary, self._environ
+            )
             self._status = PrerequisiteStatus(
                 platform=_platform_label(self._platform),
                 installed=True,
@@ -2634,6 +2691,9 @@ class KiroPrerequisiteService:
                 ready=whoami.ok and not rejected,
                 repair_required=bool(rejected),
                 initial_setup_complete=self._initial_setup_complete,
+                login_command=login_cmd,
+                sso_login_command=sso_cmd,
+                bundled=is_bundled,
                 rejected_agent_specs=rejected,
                 agent_spec_rejection_detail=rejection_detail,
             )

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -49,6 +49,7 @@ from kiro_crew.kiro_prerequisite import (
     ProcessResult,
     _run_process,
     find_kiro_cli_candidates,
+    login_commands_for,
 )
 
 
@@ -492,6 +493,81 @@ class TestKiroPrerequisiteHelpers:
         )
 
         assert str(executable) in candidates
+
+    def test_bundled_dir_ranks_above_system_installs(self, tmp_path: Path) -> None:
+        """KIROCREW_BUNDLED_KIRO_DIR (the desktop app's own copy) wins over a
+        user install, because the app was built against that exact version."""
+        bundled = tmp_path / "resources" / "kiro-cli" / "kiro-cli"
+        user_install = tmp_path / "home" / ".local" / "bin" / "kiro-cli"
+        _make_executable(bundled)
+        _make_executable(user_install)
+
+        resolved = resolve_kiro_cli(
+            platform_name="linux",
+            home=tmp_path / "home",
+            environ={"KIROCREW_BUNDLED_KIRO_DIR": str(bundled.parent), "PATH": ""},
+        )
+
+        assert resolved == str(bundled)
+
+    def test_operator_override_still_beats_the_bundled_dir(self, tmp_path: Path) -> None:
+        """KIROCREW_KIRO_BIN stays the highest-priority escape hatch: an
+        operator can force a different binary even on a bundled install."""
+        bundled = tmp_path / "resources" / "kiro-cli" / "kiro-cli"
+        forced = tmp_path / "operator" / "kiro-cli"
+        _make_executable(bundled)
+        _make_executable(forced)
+
+        resolved = resolve_kiro_cli(
+            platform_name="linux",
+            home=tmp_path / "home",
+            environ={
+                "KIROCREW_KIRO_BIN": str(forced),
+                "KIROCREW_BUNDLED_KIRO_DIR": str(bundled.parent),
+                "PATH": "",
+            },
+        )
+
+        assert resolved == str(forced)
+
+    def test_bundled_login_command_carries_the_absolute_path(self, tmp_path: Path) -> None:
+        """A bundled resolution serves sign-in commands the user can actually
+        run: the bundled copy is not on their shell PATH, and the macOS
+        resources path contains a space, so the path must be quoted."""
+        bundled_dir = tmp_path / "Kiro Res" / "kiro-cli"
+        binary = bundled_dir / "kiro-cli"
+        _make_executable(binary)
+
+        login, sso, bundled = login_commands_for(
+            str(binary), {"KIROCREW_BUNDLED_KIRO_DIR": str(bundled_dir)}
+        )
+
+        assert bundled is True
+        assert login.endswith(" login")
+        assert str(bundled_dir) in login.replace("'", "")
+        assert "--license pro" in sso
+
+    def test_system_resolution_keeps_the_bare_login_command(self, tmp_path: Path) -> None:
+        bundled_dir = tmp_path / "resources" / "kiro-cli"
+        bundled_dir.mkdir(parents=True)
+
+        login, sso, bundled = login_commands_for(
+            "/usr/local/bin/kiro-cli",
+            {"KIROCREW_BUNDLED_KIRO_DIR": str(bundled_dir)},
+        )
+
+        assert bundled is False
+        assert login == KIRO_CLI_LOGIN_COMMAND
+        assert sso == KIRO_CLI_SSO_LOGIN_COMMAND
+
+    def test_no_bundled_env_keeps_the_bare_login_command(self, tmp_path: Path) -> None:
+        binary = tmp_path / "resources" / "kiro-cli" / "kiro-cli"
+        _make_executable(binary)
+
+        login, _sso, bundled = login_commands_for(str(binary), {})
+
+        assert bundled is False
+        assert login == KIRO_CLI_LOGIN_COMMAND
 
     def test_windows_candidates_include_inherited_path(
         self,

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -990,6 +990,23 @@ function spawnGateway(resolve) {
             // gateway spawns (app servers run on the same interpreter), so
             // the whole process tree stays out of the bundle.
             PYTHONPYCACHEPREFIX: path.join(kirocrewDir, "cache", "pycache"),
+            // The kiro-cli copy staged into the app's resources at build
+            // time (packaging/build-desktop.sh, BUNDLE_KIRO_CLI). Spread
+            // only when the directory actually shipped: the backend ranks
+            // it above system installs but below the KIROCREW_KIRO_BIN
+            // operator override (kiro_cli.known_kiro_cli_dirs). A build
+            // without the payload leaves the env unset, so discovery falls
+            // through to the user's own install exactly as before.
+            ...(() => {
+              const bundledKiro = path.join(process.resourcesPath || "", "backend-dist", "kiro-cli");
+              try {
+                return fs.statSync(bundledKiro).isDirectory()
+                  ? { KIROCREW_BUNDLED_KIRO_DIR: bundledKiro }
+                  : {};
+              } catch {
+                return {};
+              }
+            })(),
           },
         });
         gatewayProcess = child;


### PR DESCRIPTION
## Summary

The desktop build now stages a **pinned, sha256-verified kiro-cli** into the app's resources (`backend-dist/kiro-cli/`), so the installed app carries the exact agent runtime it was built against — no first-run download, and the KAS backend's `kiro-cli acp --agent-engine v3` spawn (#5015) works out of the box.

## Design

- **Build time** (`packaging/build-desktop.sh`, `BUNDLE_KIRO_CLI=1` default): version + digest resolved from the official release manifest, fail-closed sha256 verification — the same pattern `docker/Dockerfile` already uses for its kiro-cli install. macOS extracts from the universal DMG (one copy serves both arches; the whole `MacOS/` directory travels together because kiro-cli 2.15+ exec-dispatches to sibling executables). Linux uses the per-arch gnu zip. `BUNDLED-VERSION` records provenance. Landing inside `backend-dist/` means the existing electron-builder `extraResources` entry and macOS `x64ArchFiles` glob need **zero config changes**.
- **Runtime** (`website/electron/main.js`): the shell exports `KIROCREW_BUNDLED_KIRO_DIR` at gateway spawn, only when the directory actually shipped.
- **Discovery** (`src/kiro_crew/kiro_cli.py`): the bundled dir ranks **above** system installs but **below** the `KIROCREW_KIRO_BIN` operator override. A build without the payload behaves exactly as before.

## Deliberately unchanged

- The runtime's **detect-only posture**: Kiro Crew still never installs or executes an installer — bundling is a packaging-time act.
- Auth: `kiro-cli login` remains the user's own step; only the binary is bundled, never a credential.
- Windows: upstream ships only an MSI, so Windows builds never bundle.

## Tested

- `test/test_kiro_prerequisite.py`: 174 passed locally, including two new ordering contracts (bundled > system installs; operator override > bundled).
- `bash -n` on the build script, `node --check` on main.js.
- Full desktop build not run locally (needs macOS/CI packaging lanes); the staging path reuses the Docker lane's proven manifest+sha256 flow.

## Trade-off to review

The kiro-cli payload is large (~900 MB unpacked per platform), so installer size grows materially. `BUNDLE_KIRO_CLI=0` opts a build out, and the release lanes can choose per-channel. Flagging for maintainer judgment on the default.