### PR TITLE
fix(pins): reveal pin actions on keyboard focus, not just hover

### DIFF
--- a/website/src/pages/chat/PinnedMessagesPanel.tsx
+++ b/website/src/pages/chat/PinnedMessagesPanel.tsx
@@ -88,7 +88,7 @@ const PinnedMessagesPanel = memo(function PinnedMessagesPanel({
               {pin.preview}
             </div>
             {/* Hover actions — forced visible + 40px targets where the pointer cannot hover */}
-            <div className={`flex items-center gap-1 mt-0.5 opacity-0 group-hover/pin:opacity-100 transition-opacity ${HOVER_NONE_ACTIONS_ROW_CLS}`}>
+            <div data-testid="pin-actions" className={`flex items-center gap-1 mt-0.5 opacity-0 group-hover/pin:opacity-100 focus-within:opacity-100 transition-opacity ${HOVER_NONE_ACTIONS_ROW_CLS}`}>
               <button
                 onClick={(e) => { e.stopPropagation(); copyToClipboard(pin.preview) }}
                 className="text-muted hover:text-text p-0.5 rounded transition-colors"

--- a/website/src/test/chatPins.test.tsx
+++ b/website/src/test/chatPins.test.tsx
@@ -460,6 +460,17 @@ describe('PinnedMessagesPanel', () => {
     // on keydowns targeting itself (e.target === e.currentTarget check)
     expect(defaultProps.onJumpToMessage).not.toHaveBeenCalled()
   })
+
+  it('actions row reveals on keyboard focus (focus-within) — WCAG 2.4.7', () => {
+    // The actions row must be visible when any child button receives focus so that
+    // keyboard users can see and operate the controls they have tabbed onto.
+    render(<PinnedMessagesPanel {...defaultProps} />)
+    const actionRows = screen.getAllByTestId('pin-actions')
+    // Row must carry focus-within:opacity-100 so CSS reveals it on child focus
+    actionRows.forEach(row => {
+      expect(row.className).toContain('focus-within:opacity-100')
+    })
+  })
 })
 
 // === Slot-bound paging guard (regression: deferred page response must not contaminate another slot) ===


### PR DESCRIPTION
## Problem / Motivation

In `PinnedMessagesPanel`, the per-pin actions row (Copy, Copy Link, Unpin) is hidden via `opacity-0` and revealed only on `group-hover/pin:opacity-100`. No focus-based reveal exists.

When a keyboard user tabs through the panel, focus lands on the three action buttons while they remain invisible (`opacity-0`). The buttons are fully functional but completely invisible — a direct WCAG 2.4.7 (Focus Visible) violation.

## Why it matters

Screen-reader-free keyboard users navigating with Tab have no way to know focus has entered the actions row. They cannot see which button is focused, cannot confidently activate the correct action, and may not realise the row exists at all.

## What changed (motivation → approach → change)

**Motivation:** Invisible-on-focus keyboard controls fail WCAG 2.4.7 and create a confusing Tab experience.

**Approach:** The repo's established pattern for hover-only action rows is to add `focus-within:opacity-100` alongside the hover reveal — see `IconButtonGroup` in `components/ui.tsx` (`opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-within:opacity-100`) and the session list rows in `ChatSidebar.tsx`. The pin actions row already uses `group-hover/pin:opacity-100`; adding `focus-within:opacity-100` to the same `<div>` is the minimal, convention-matching fix.

**Change:**
- `PinnedMessagesPanel.tsx`: added `focus-within:opacity-100` to the actions row class string. Added `data-testid="pin-actions"` for test addressability. Hover behaviour and `HOVER_NONE_ACTIONS_ROW_CLS` unchanged.
- `chatPins.test.tsx`: new test in the `PinnedMessagesPanel — A11y coverage` block asserts every rendered actions row carries the `focus-within:opacity-100` class.

Diff: 1 line changed in the component, 11 lines added in the test.

## Tests

- `npx tsc -b` — clean, zero errors
- `npx vitest run src/test/chatPins.test.tsx` — **37/37 passed**
- New test: `actions row reveals on keyboard focus (focus-within) — WCAG 2.4.7`

## Manual verification

1. Open a chat session with at least one pinned message.
2. Open the Pins side panel.
3. Tab from the panel's top to reach the pin entry. Tab again — focus enters the actions row.
4. **Before fix:** the Copy / Copy Link / Unpin buttons remain invisible as focus lands on them.
5. **After fix:** the entire actions row becomes visible (`opacity-100`) as soon as any button inside receives focus. Tabbing out hides the row again.
6. Mouse hover still reveals the row as before; touch (`HOVER_NONE_ACTIONS_ROW_CLS`) still forces visibility on non-pointer devices.

## Screenshots / video

Real captures from the **running dashboard** (real gateway serving the built bundle from this branch, real session, three messages pinned through `POST /api/chat/pins`, real Pinned Messages side-panel tab). The runner measures `getComputedStyle(...).opacity` on the actions row in each state and asserts `0` at rest and `1` once keyboard focus lands on a pin action button — a run photographing the wrong state exits nonzero. Both themes pass.

| Before focus (unchanged idle state) | Focus on an action button (the fix) |
| --- | --- |
| ![Actions row hidden while nothing is focused](https://github.com/RohanK6/KiroCrew/raw/2a152c17a30d1479358de628e6131b2954a193ef/pins-panel-focus-real/pins-dark-A-hidden.png) | ![Actions row revealed with a visible focus ring on the Copy button](https://github.com/RohanK6/KiroCrew/raw/2a152c17a30d1479358de628e6131b2954a193ef/pins-panel-focus-real/pins-dark-B-focus-revealed.png) |

<details>
<summary>Light theme (both states)</summary>

| At rest | Focused |
| --- | --- |
| ![Light theme: actions row hidden at rest](https://github.com/RohanK6/KiroCrew/raw/2a152c17a30d1479358de628e6131b2954a193ef/pins-panel-focus-real/pins-light-A-hidden.png) | ![Light theme: actions row revealed on keyboard focus](https://github.com/RohanK6/KiroCrew/raw/2a152c17a30d1479358de628e6131b2954a193ef/pins-panel-focus-real/pins-light-B-focus-revealed.png) |

</details>

## Related Issues

Fixes #5136

## Checklist

- [x] TypeScript compiles cleanly (`tsc -b`)
- [x] Touched test file passes (`vitest run`)
- [x] New test covers the fix
- [x] PR title in Conventional Commits format
- [x] No issue numbers in commit message body
- [x] No `.github/` files touched
- [x] No host paths, usernames, or internal identifiers in this PR

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License, and I agree that it may be redistributed under those terms.


