### PR TITLE
fix(pins): carry mid in Copy Link URLs so same-timestamp messages resolve correctly

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -151,7 +151,7 @@ import { setSessionPreviewPending, normalizeUrl, PREVIEW_EXPAND_EVENT, PREVIEW_S
 import { detectPreviewUrl, previewFeedDecision } from '../utils/detectPreviewUrl'
 import { fileLandingSlot } from '../utils/uploadRouting'
 import ChatSidebar, { SIDEBAR_MIN, SIDEBAR_MAX } from './ChatSidebar'
-import { toSlug } from '../utils/shareUrl'
+import { toSlug, resolveMsgIndex } from '../utils/shareUrl'
 import { DRAFT_SAVE_DEBOUNCE_MS, loadDrafts, mergeIntoDraft, saveDrafts as persistDrafts, setDraft } from '../utils/chatDrafts'
 import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } from '../utils/chatFileDrafts'
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
@@ -3510,6 +3510,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // over owns the first switch of this mount — see the mount re-fetch effect.
   const deepLinkPendingRef = useRef(!!initialSidRef.current && initialSidRef.current !== activeSlot)
   const initialMsgRef = useRef(searchParams.get('msg'))
+  const initialMidRef = useRef(searchParams.get('mid'))
   const initialNewRef = useRef(searchParams.get('new') === '1')
   // Deep-link mount activation in progress — stops the sync effect from stripping
   // ?sid before activation lands. Cleared once activeSlot is truthy.
@@ -5934,21 +5935,25 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [focusToolCallId, messages, messageToDisplayIdx, navToDisplayIndex])
 
   // Deep-link: scroll to ?msg= timestamp on cold load.
+  // When ?mid= is also present (copied from a pinned-message link), resolve by
+  // mid first (stable per-message identity) and fall back to ts for legacy links.
   // The scroll-to-bottom effect above is suppressed while initialMsgRef is set.
-  // Safety net: clear initialMsgRef after 5s to restore scroll-to-bottom if deep-link fails.
+  // Safety net: clear both refs after 5s to restore scroll-to-bottom if deep-link fails.
   useEffect(() => {
     if (!initialMsgRef.current) return
-    const timer = setTimeout(() => { initialMsgRef.current = null }, 5000)
+    const timer = setTimeout(() => { initialMsgRef.current = null; initialMidRef.current = null }, 5000)
     return () => clearTimeout(timer)
   }, [])
   useEffect(() => {
     const targetTs = initialMsgRef.current
+    const targetMid = initialMidRef.current
     if (!targetTs || messages.length === 0) return
-    const msgIdx = messages.findIndex(m => m.ts === targetTs)
+    const msgIdx = resolveMsgIndex(messages, targetTs, targetMid)
     if (msgIdx < 0) return
     const di = messageToDisplayIdx.get(msgIdx)
     if (di === undefined) return
     initialMsgRef.current = null
+    initialMidRef.current = null
     setTimeout(() => {
       navToDisplayIndex(di, { behavior: 'auto', align: 'center' })
       setHighlightTs(targetTs)

--- a/website/src/pages/chat/PinnedMessagesPanel.tsx
+++ b/website/src/pages/chat/PinnedMessagesPanel.tsx
@@ -98,7 +98,7 @@ const PinnedMessagesPanel = memo(function PinnedMessagesPanel({
                 <Copy size={12} />
               </button>
               <button
-                onClick={(e) => { e.stopPropagation(); copySessionLink(slotKey, slotTitle, pin.message_ts, mode) }}
+                onClick={(e) => { e.stopPropagation(); copySessionLink(slotKey, slotTitle, pin.message_ts, mode, pin.mid) }}
                 className="text-muted hover:text-text p-0.5 rounded transition-colors"
                 title={i18nT('pages.chat.pins.copy_link')}
                 aria-label={i18nT('pages.chat.pins.copy_link')}

--- a/website/src/test/shareUrl.test.ts
+++ b/website/src/test/shareUrl.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn().mockResolvedValue(undefined) }))
 import { copyToClipboard } from '../utils/clipboard'
-import { buildShareableUrl, copySessionLink } from '../utils/shareUrl'
+import { buildShareableUrl, copySessionLink, resolveMsgIndex } from '../utils/shareUrl'
 
 describe('buildShareableUrl', () => {
   it('builds URL with sid param', () => {
@@ -58,6 +58,18 @@ describe('buildShareableUrl', () => {
     const url = buildShareableUrl('chat-1', 'Title', undefined, undefined)
     expect(url).toContain('/chat/title?sid=chat-1')
   })
+
+  it('includes mid param when mid provided', () => {
+    const url = buildShareableUrl('chat-1', 'Title', '2025-05-13T14:00:00.000Z', undefined, 'msg-abc-123')
+    expect(url).toContain('mid=msg-abc-123')
+    expect(url).toContain('msg=2025-05-13T14')
+    expect(url).toContain('sid=chat-1')
+  })
+
+  it('omits mid param when mid not provided', () => {
+    const url = buildShareableUrl('chat-1', 'Title', '2025-05-13T14:00:00.000Z')
+    expect(url).not.toContain('mid=')
+  })
 })
 
 describe('copySessionLink', () => {
@@ -75,5 +87,58 @@ describe('copySessionLink', () => {
     expect(copyToClipboard).toHaveBeenCalledWith(
       expect.stringContaining('msg=2025-05-13T14')
     )
+  })
+
+  it('includes mid in URL when provided', async () => {
+    await copySessionLink('chat-1-abc', 'Title', '2025-05-13T14:00:00.000Z', undefined, 'mid-xyz')
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining('mid=mid-xyz')
+    )
+  })
+
+  it('omits mid from URL when not provided', async () => {
+    await copySessionLink('chat-1-abc', 'Title', '2025-05-13T14:00:00.000Z')
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      expect.not.stringContaining('mid=')
+    )
+  })
+})
+
+describe('resolveMsgIndex', () => {
+  const ts = '2025-05-13T14:00:00.000Z'
+  const msgs = [
+    { ts, meta: { mid: 'mid-A' } },
+    { ts, meta: { mid: 'mid-B' } },        // same ts, different mid
+    { ts: '2025-05-14T00:00:00.000Z', meta: { mid: 'mid-C' } },
+  ]
+
+  it('returns index by mid when mid matches', () => {
+    expect(resolveMsgIndex(msgs, ts, 'mid-B')).toBe(1)
+  })
+
+  it('resolves to first mid match even when ts also matches an earlier entry', () => {
+    expect(resolveMsgIndex(msgs, ts, 'mid-B')).toBe(1)
+  })
+
+  it('falls back to ts when mid not provided', () => {
+    // Without mid, returns first ts match (index 0)
+    expect(resolveMsgIndex(msgs, ts)).toBe(0)
+  })
+
+  it('falls back to ts when mid has no match', () => {
+    expect(resolveMsgIndex(msgs, ts, 'mid-unknown')).toBe(0)
+  })
+
+  it('returns -1 when neither mid nor ts matches', () => {
+    expect(resolveMsgIndex(msgs, 'nope', 'nope-mid')).toBe(-1)
+  })
+
+  it('returns -1 for empty message list', () => {
+    expect(resolveMsgIndex([], ts, 'mid-A')).toBe(-1)
+  })
+
+  it('handles messages without meta gracefully', () => {
+    const noMeta = [{ ts }, { ts, meta: { mid: 'mid-A' } }]
+    expect(resolveMsgIndex(noMeta, ts, 'mid-A')).toBe(1)
   })
 })

--- a/website/src/utils/shareUrl.ts
+++ b/website/src/utils/shareUrl.ts
@@ -1,5 +1,29 @@
 import { copyToClipboard } from './clipboard'
 
+/** Minimal message shape needed for deep-link resolution (avoids importing ChatMessage). */
+export interface ResolvableMessage {
+  ts?: string
+  meta?: Record<string, unknown>
+}
+
+/**
+ * Resolve a deep-link target to a message index.
+ * Prefers mid-based lookup (stable per-message identity) so same-timestamp
+ * messages from the same tick are disambiguated.  Falls back to ts for legacy
+ * links that carry no mid param.
+ */
+export function resolveMsgIndex(
+  messages: ResolvableMessage[],
+  targetTs: string,
+  targetMid?: string | null,
+): number {
+  if (targetMid) {
+    const byMid = messages.findIndex(m => m.meta?.mid === targetMid)
+    if (byMid >= 0) return byMid
+  }
+  return messages.findIndex(m => m.ts === targetTs)
+}
+
 export function toSlug(title: string): string {
   return title
     .toLowerCase()
@@ -14,6 +38,7 @@ export function buildShareableUrl(
   title?: string,
   messageTs?: string,
   _mode?: string,
+  mid?: string,
 ): string {
   const basePath = '/chat'
   const slug = title && title !== slotKey ? toSlug(title) : ''
@@ -21,6 +46,7 @@ export function buildShareableUrl(
   const params = new URLSearchParams()
   params.set('sid', slotKey)
   if (messageTs) params.set('msg', messageTs)
+  if (mid) params.set('mid', mid)
 
   const path = `${basePath}${slug ? '/' + slug : ''}`
   return `${window.location.origin}${path}?${params}`
@@ -31,6 +57,7 @@ export function copySessionLink(
   title?: string,
   messageTs?: string,
   mode?: string,
+  mid?: string,
 ): Promise<void> {
-  return copyToClipboard(buildShareableUrl(slotKey, title, messageTs, mode))
+  return copyToClipboard(buildShareableUrl(slotKey, title, messageTs, mode, mid))
 }


### PR DESCRIPTION
## Problem / Motivation

When a user clicks "Copy Link" on a pinned message, the copied URL contains only `?sid=<session>&msg=<timestamp>`. If two messages were appended in the same tick they share the same `ts`, so the deep-link resolver can navigate to the wrong message.

## Why it matters

The pin record already carries a stable per-message `mid` (used by the in-app jump path), but that identity was being dropped when building the shareable URL. Any session with rapid automated messages (sub-agent deliveries, tool results) is likely to hit same-tick collisions, making copied pin links unreliable.

## What changed (motivation → approach → change)

**Symptom:** Copy Link on a pinned message → open link → wrong message highlighted.  
**Root cause:** `buildShareableUrl` / `copySessionLink` accepted no `mid` argument, so the URL encoded only `?msg=<ts>`. The `ChatPage` deep-link resolver did a pure `ts` equality scan (`messages.findIndex(m => m.ts === targetTs)`), giving the wrong result when multiple messages share the same `ts`.  
**Fix:**

1. `shareUrl.ts` — added optional `mid` param to `buildShareableUrl` and `copySessionLink`; when provided, appends `?mid=<mid>` to the URL. All existing callers that omit `mid` are unchanged. Also extracted a pure `resolveMsgIndex` helper (mid-first, ts-fallback) so the resolution logic is testable without React.
2. `PinnedMessagesPanel.tsx` — passes `pin.mid` to `copySessionLink`.
3. `ChatPage.tsx` — reads `searchParams.get('mid')` into a sibling `initialMidRef` at mount; the deep-link resolver effect calls `resolveMsgIndex(messages, targetTs, targetMid)` (same mid-first/ts-fallback as `jumpToLoadedPinnedMessage`); both refs are cleared by the 5 s safety-net timer.

## Tests

Extended `website/src/test/shareUrl.test.ts` (23 tests total, all passing):

- `buildShareableUrl` — includes `mid` param when provided; omits it when absent; existing `sid`/`msg` params unchanged.
- `copySessionLink` — includes `mid` in built URL when provided; omits it when not provided.
- `resolveMsgIndex` (7 cases) — resolves by `mid` when present; prefers `mid` over earlier same-`ts` entry; falls back to `ts` when `mid` absent; falls back to `ts` when `mid` has no match; returns `-1` for no match; returns `-1` on empty list; handles messages without `meta` gracefully.

## Manual verification

N/A — the only observable change is the URL copied to clipboard gains a `?mid=` parameter. No UI layout, styling, or interaction changed.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No pixel changes anywhere — the fix only adds a `mid` query parameter to the URL that "Copy Link" places on the clipboard and teaches the deep-link resolver to prefer it; no component, style, or layout is touched.

## Related Issues

Fixes #5137

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(pins): carry mid in Copy Link URLs so same-timestamp messages resolve correctly`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

