### PR TITLE
fix(pins): never send optimistic temp ids to the unpin endpoint

### DIFF
--- a/website/src/hooks/useChatPins.ts
+++ b/website/src/hooks/useChatPins.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { PIN_PREVIEW_INPUT_MAX_CHARS, pinsApi, type ChatPin, type PinMessageBody } from '../api/pins'
 import { secureRandomId } from '../utils/secureId'
@@ -15,12 +15,35 @@ type UnpinMutation = { id: string; slotKey: string }
  *
  * Pin identity uses `mid` (server-minted message ID from meta.mid) so that
  * messages sharing a timestamp can each be pinned independently.
+ *
+ * In-flight create tracking: when the Unpin button is clicked while the
+ * create request is still in flight (optimistic id starts with "temp-"),
+ * we await the in-flight promise before deciding whether to DELETE the server
+ * pin or just clear local state.  This prevents a DELETE /api/chat/pins/temp-…
+ * → 404 → "unpin failed" toast in that race window.
  */
 export function useChatPins(slotKey: string | undefined) {
   const qc = useQueryClient()
   const queryKey = useMemo(() => pinQueryKey(slotKey), [slotKey])
   const [error, setError] = useState<'pin' | 'unpin' | null>(null)
   const clearError = useCallback(() => setError(null), [])
+
+  /**
+   * Tracks in-flight create promises keyed by mid.
+   * When an unpin is requested for a pin whose id is still "temp-…" we await
+   * this promise to learn the real server id (or know the create failed).
+   */
+  const inFlightCreates = useRef<Map<string, Promise<ChatPin>>>(new Map())
+
+  /**
+   * Monotonic pin-intent generation per `${slot_key}::${mid}`. Bumped by every
+   * pinMessage; a temp-id unpin snapshots the generation it is cancelling and,
+   * after awaiting the create, only deletes the server pin if no NEWER pin
+   * intent arrived meanwhile. Without this, Pin -> pending Unpin -> Pin again
+   * loses the second pin: the idempotent create returns the first record's id,
+   * and the deferred DELETE would remove the pin the user just re-created.
+   */
+  const pinGenerations = useRef<Map<string, number>>(new Map())
 
   const { data: pins = [], isLoading: loading } = useQuery<ChatPin[]>({
     queryKey,
@@ -95,6 +118,72 @@ export function useChatPins(slotKey: string | undefined) {
     },
   })
 
+  /**
+   * Core unpin logic shared by both unpinMessage and unpinById.
+   *
+   * If the pin's id is a temporary optimistic id (starts with "temp-"):
+   *  1. Optimistically remove it from the cache right away so the UI reacts immediately.
+   *  2. Await the in-flight create promise for that mid.
+   *     - If the create succeeded, DELETE the real server id via the normal mutation.
+   *     - If the create failed/rejected, there is nothing on the server — just swallow.
+   * If the id is already a real server id, delegate straight to the unpin mutation.
+   */
+  const _doUnpin = useCallback(
+    async (pin: ChatPin) => {
+      const resolvedSlotKey = pin.slot_key ?? slotKey ?? ''
+
+      if (pin.id.startsWith('temp-')) {
+        // Optimistically remove from cache immediately (no network call yet)
+        const mutationQueryKey = pinQueryKey(resolvedSlotKey)
+        qc.setQueryData<ChatPin[]>(mutationQueryKey, old =>
+          (old ?? []).filter(p => p.id !== pin.id),
+        )
+        qc.invalidateQueries({ queryKey: mutationQueryKey })
+
+        const inFlight = inFlightCreates.current.get(`${resolvedSlotKey}::${pin.mid}`)
+        if (!inFlight) {
+          // No tracked promise. This is NOT always "nothing on the server":
+          // the create may have already succeeded and been cleaned from the
+          // map while the caller held a stale temp-id reference (onSuccess
+          // swaps temp -> real in the cache, but a snapshot taken before the
+          // swap still carries the temp id). Check the cache for the settled
+          // pin with this mid and delete that if present.
+          const settled = qc
+            .getQueryData<ChatPin[]>(mutationQueryKey)
+            ?.find(p => p.mid === pin.mid && !p.id.startsWith('temp-'))
+          if (settled) {
+            await unpinMessageAsync({ id: settled.id, slotKey: settled.slot_key })
+          }
+          return
+        }
+
+        let realPin: ChatPin
+        const inFlightKey = `${resolvedSlotKey}::${pin.mid}`
+        const generationAtUnpin = pinGenerations.current.get(inFlightKey) ?? 0
+        try {
+          realPin = await inFlight
+        } catch {
+          // Create failed — no server pin exists, nothing to DELETE.
+          return
+        }
+
+        // If the user pinned this message AGAIN while we awaited the create,
+        // that newer intent wins: the idempotent create returns the same
+        // record, so deleting it now would destroy the re-created pin.
+        if ((pinGenerations.current.get(inFlightKey) ?? 0) !== generationAtUnpin) {
+          return
+        }
+
+        // Create succeeded and no newer pin intent — delete the server pin.
+        await unpinMessageAsync({ id: realPin.id, slotKey: realPin.slot_key })
+        return
+      }
+
+      await unpinMessageAsync({ id: pin.id, slotKey: resolvedSlotKey })
+    },
+    [slotKey, qc, unpinMessageAsync],
+  )
+
   const isPinned = useCallback(
     (mid: string) => pins.some(p => p.mid === mid),
     [pins],
@@ -103,11 +192,29 @@ export function useChatPins(slotKey: string | undefined) {
   const pinMessage = useCallback(
     async (body: Omit<PinMessageBody, 'slot_key'>) => {
       if (!slotKey) return
-      await pinMessageAsync({
+      const fullBody: PinMessageBody = {
         ...body,
         slot_key: slotKey,
         preview: body.preview.slice(0, PIN_PREVIEW_INPUT_MAX_CHARS),
+      }
+      // Register the in-flight promise so concurrent unpins can await it.
+      // Keyed by (slot_key, mid): forked sessions can carry the same mid in
+      // different slots, and a mid-only key would let one slot's create
+      // overwrite the other's entry (unpinning one slot could then delete the
+      // other slot's pin). The .finally cleanup only removes the entry when it
+      // still holds THIS promise, so a concurrent create for the same key can
+      // never have its registration deleted by an older settling promise.
+      const inFlightKey = `${fullBody.slot_key}::${fullBody.mid}`
+      // A new pin intent supersedes any unpin still awaiting the previous
+      // create for this message (see pinGenerations).
+      pinGenerations.current.set(inFlightKey, (pinGenerations.current.get(inFlightKey) ?? 0) + 1)
+      const promise = pinMessageAsync(fullBody).finally(() => {
+        if (inFlightCreates.current.get(inFlightKey) === promise) {
+          inFlightCreates.current.delete(inFlightKey)
+        }
       })
+      inFlightCreates.current.set(inFlightKey, promise)
+      await promise
     },
     [slotKey, pinMessageAsync],
   )
@@ -117,18 +224,29 @@ export function useChatPins(slotKey: string | undefined) {
       if (!slotKey) return
       const pin = pins.find(p => p.mid === mid)
       if (!pin) return
-      await unpinMessageAsync({ id: pin.id, slotKey: pin.slot_key })
+      await _doUnpin(pin)
     },
-    [slotKey, pins, unpinMessageAsync],
+    [slotKey, pins, _doUnpin],
   )
 
   const unpinById = useCallback(
     async (id: string) => {
       if (!slotKey) return
       const pin = pins.find(candidate => candidate.id === id)
-      await unpinMessageAsync({ id, slotKey: pin?.slot_key ?? slotKey })
+      if (pin) {
+        // Pin is in local cache: use the full _doUnpin path (handles temp- ids).
+        await _doUnpin(pin)
+        return
+      }
+      // Pin not in local cache (e.g. not yet loaded): fall back to direct
+      // unpin by id — but never with a temp id. A second click on the same
+      // still-saving pin lands here after the first click already removed the
+      // temp entry from the cache; the first click's flow owns the server
+      // deletion, so this one is a no-op rather than a guaranteed-404 DELETE.
+      if (id.startsWith('temp-')) return
+      await unpinMessageAsync({ id, slotKey })
     },
-    [slotKey, pins, unpinMessageAsync],
+    [slotKey, pins, _doUnpin, unpinMessageAsync],
   )
 
   const refresh = useCallback(() => {

--- a/website/src/test/chatPins.test.tsx
+++ b/website/src/test/chatPins.test.tsx
@@ -312,6 +312,259 @@ describe('useChatPins', () => {
     expect(hookSrc).not.toContain('crypto.randomUUID()')
   })
 
+  // === In-flight create + unpin race (issue #5135) ===
+
+  it('unpin during in-flight create issues NO network DELETE with a temp- id', async () => {
+    // The create is pending; unpinById is called before it resolves.
+    // No DELETE should ever reach the network with a temp-… id.
+    let resolveCreate!: (pin: ChatPin) => void
+    ;(pinsApi.create as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<ChatPin>(resolve => { resolveCreate = resolve }),
+    )
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useChatPins('slot-abc'), { wrapper: createWrapper(qc) })
+    await waitFor(() => expect(result.current.pins).toHaveLength(1))
+
+    // Start the pin mutation (do not await — it's pending)
+    let pinPromise!: Promise<void>
+    act(() => {
+      pinPromise = result.current.pinMessage({
+        mid: 'm-inflight-mid',
+        message_ts: 'ts-inflight',
+        role: 'user',
+        preview: 'in-flight pin',
+      })
+    })
+
+    // Wait for the optimistic entry to appear in the cache
+    let tempPin!: ChatPin
+    await waitFor(() => {
+      const found = result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempPin = found!
+    })
+
+    // Unpin immediately — create still pending
+    let unpinPromise!: Promise<void>
+    act(() => {
+      unpinPromise = result.current.unpinById(tempPin.id)
+    })
+
+    // No DELETE should have been issued yet with a temp- id
+    await waitFor(() => {
+      const deleteCallsWithTempId = (pinsApi.remove as ReturnType<typeof vi.fn>)
+        .mock.calls.filter(([id]: [string]) => id.startsWith('temp-'))
+      expect(deleteCallsWithTempId).toHaveLength(0)
+    })
+
+    // Clean up: resolve the in-flight create so both promises settle
+    const serverPin: ChatPin = { ...mockPin, id: 'pin-server-inflight', mid: 'm-inflight-mid' }
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [] })
+    await act(async () => {
+      resolveCreate(serverPin)
+      await Promise.allSettled([pinPromise, unpinPromise])
+    })
+  })
+
+  it('after create resolves the real id is deleted on the server', async () => {
+    // After the in-flight create resolves, unpin should DELETE the real server id.
+    let resolveCreate!: (pin: ChatPin) => void
+    ;(pinsApi.create as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<ChatPin>(resolve => { resolveCreate = resolve }),
+    )
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useChatPins('slot-abc'), { wrapper: createWrapper(qc) })
+    await waitFor(() => expect(result.current.pins).toHaveLength(1))
+
+    // Start the pin mutation (do not await — it's pending)
+    let pinPromise!: Promise<void>
+    act(() => {
+      pinPromise = result.current.pinMessage({
+        mid: 'm-resolve-mid',
+        message_ts: 'ts-resolve',
+        role: 'user',
+        preview: 'will resolve',
+      })
+    })
+
+    // Wait for the optimistic entry to appear in the cache
+    let tempPin!: ChatPin
+    await waitFor(() => {
+      const found = result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempPin = found!
+    })
+
+    // Trigger unpin while create is still pending
+    let unpinPromise!: Promise<void>
+    act(() => {
+      unpinPromise = result.current.unpinById(tempPin.id)
+    })
+
+    // Now resolve the create with a real server id
+    const serverPin: ChatPin = { ...mockPin, id: 'pin-real-server', mid: 'm-resolve-mid' }
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [] })
+    await act(async () => {
+      resolveCreate(serverPin)
+      await Promise.allSettled([pinPromise, unpinPromise])
+    })
+
+    // pinsApi.remove should have been called with the real server id, not the temp id
+    await waitFor(() => {
+      expect(pinsApi.remove).toHaveBeenCalledWith('pin-real-server')
+    })
+    const tempDeleteCalls = (pinsApi.remove as ReturnType<typeof vi.fn>)
+      .mock.calls.filter(([id]: [string]) => id.startsWith('temp-'))
+    expect(tempDeleteCalls).toHaveLength(0)
+  })
+
+  it('same mid in two slots: unpinning one slot never touches the other slot (in-flight map keyed by slot)', async () => {
+    // Forked sessions can carry the SAME mid in DIFFERENT slots. Two hooks,
+    // one per slot, each start a create for mid 'm-shared'. Unpinning the
+    // temp pin in slot-a must await slot-a's create and delete slot-a's
+    // server pin — never slot-b's.
+    let resolveA!: (pin: ChatPin) => void
+    let resolveB!: (pin: ChatPin) => void
+    ;(pinsApi.create as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(new Promise<ChatPin>(r => { resolveA = r }))
+      .mockReturnValueOnce(new Promise<ChatPin>(r => { resolveB = r }))
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [] })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const hookA = renderHook(() => useChatPins('slot-a'), { wrapper: createWrapper(qc) })
+    const hookB = renderHook(() => useChatPins('slot-b'), { wrapper: createWrapper(qc) })
+    await waitFor(() => expect(hookA.result.current.loading).toBe(false))
+    await waitFor(() => expect(hookB.result.current.loading).toBe(false))
+
+    const body = { mid: 'm-shared', message_ts: 'ts-x', role: 'user' as const, preview: 'p' }
+    let pinA!: Promise<void>
+    let pinB!: Promise<void>
+    act(() => { pinA = hookA.result.current.pinMessage(body) })
+    act(() => { pinB = hookB.result.current.pinMessage(body) })
+
+    let tempA!: ChatPin
+    await waitFor(() => {
+      const found = hookA.result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempA = found!
+    })
+
+    // Unpin slot-a's temp pin while both creates are in flight.
+    let unpinA!: Promise<void>
+    act(() => { unpinA = hookA.result.current.unpinById(tempA.id) })
+
+    // Resolve both creates: distinct server pins per slot.
+    const serverA: ChatPin = { ...mockPin, id: 'pin-real-a', mid: 'm-shared', slot_key: 'slot-a' }
+    const serverB: ChatPin = { ...mockPin, id: 'pin-real-b', mid: 'm-shared', slot_key: 'slot-b' }
+    ;(pinsApi.remove as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    act(() => { resolveA(serverA); resolveB(serverB) })
+    await act(async () => { await Promise.allSettled([pinA, pinB, unpinA]) })
+
+    // slot-a's real pin was deleted; slot-b's was never touched.
+    const removedIds = (pinsApi.remove as ReturnType<typeof vi.fn>).mock.calls.map(([id]: [string]) => id)
+    expect(removedIds).toContain('pin-real-a')
+    expect(removedIds).not.toContain('pin-real-b')
+  })
+
+  it('pin -> pending unpin -> pin again: the deferred delete is skipped and the re-created pin survives', async () => {
+    // GPT round-2 scenario: while the unpin awaits the first create, the user
+    // pins the same message again. The server create is idempotent (returns
+    // the FIRST record), so the deferred DELETE would destroy the re-created
+    // pin. The newer pin intent must win: no DELETE at all.
+    let resolveCreate1!: (pin: ChatPin) => void
+    const serverPin: ChatPin = { ...mockPin, id: 'pin-idem-1', mid: 'm-repin' }
+    ;(pinsApi.create as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(new Promise<ChatPin>(r => { resolveCreate1 = r }))
+      .mockResolvedValueOnce(serverPin) // idempotent second create: same record
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [] })
+    ;(pinsApi.remove as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useChatPins('slot-abc'), { wrapper: createWrapper(qc) })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const body = { mid: 'm-repin', message_ts: 'ts-r', role: 'user' as const, preview: 'p' }
+    let pin1!: Promise<void>
+    act(() => { pin1 = result.current.pinMessage(body) })
+
+    let tempPin!: ChatPin
+    await waitFor(() => {
+      const found = result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempPin = found!
+    })
+
+    // Unpin while create 1 is still pending.
+    let unpin1!: Promise<void>
+    act(() => { unpin1 = result.current.unpinById(tempPin.id) })
+
+    // User pins the SAME message again before create 1 resolves.
+    let pin2!: Promise<void>
+    act(() => { pin2 = result.current.pinMessage(body) })
+
+    // Now the first create resolves.
+    act(() => { resolveCreate1(serverPin) })
+    await act(async () => { await Promise.allSettled([pin1, pin2, unpin1]) })
+
+    // The deferred delete was skipped: the re-created pin was never removed.
+    expect((pinsApi.remove as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled()
+  })
+
+  it('create-fails-then-unpin does not call remove and surfaces no unpin error', async () => {
+    // If the create failed, there is nothing on the server.
+    // Unpinning the already-gone optimistic entry must not call remove
+    // and must not set error='unpin'.
+    let rejectCreate!: (err: Error) => void
+    ;(pinsApi.create as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<ChatPin>((_resolve, reject) => { rejectCreate = reject }),
+    )
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(() => useChatPins('slot-abc'), { wrapper: createWrapper(qc) })
+    await waitFor(() => expect(result.current.pins).toHaveLength(1))
+
+    // Start the pin mutation (do not await — it's pending, will be rejected later)
+    let pinPromise!: Promise<void>
+    act(() => {
+      pinPromise = result.current.pinMessage({
+        mid: 'm-fail-then-unpin',
+        message_ts: 'ts-fail',
+        role: 'user',
+        preview: 'will fail',
+      }).catch(() => { /* expected rejection */ })
+    })
+
+    // Wait for the optimistic entry to appear in the cache
+    let tempPin!: ChatPin
+    await waitFor(() => {
+      const found = result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempPin = found!
+    })
+
+    // Trigger unpin while create is still pending (but we'll reject it next)
+    let unpinPromise!: Promise<void>
+    act(() => {
+      unpinPromise = result.current.unpinById(tempPin.id)
+    })
+
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [mockPin] })
+    // Reject the create — simulates a network failure
+    await act(async () => {
+      rejectCreate(new Error('create failed'))
+      await Promise.allSettled([pinPromise, unpinPromise])
+    })
+
+    // remove must never have been called
+    expect(pinsApi.remove).not.toHaveBeenCalled()
+    // The error state should reflect 'pin' failure, not 'unpin'
+    await waitFor(() => {
+      expect(result.current.error).not.toBe('unpin')
+    })
+  })
+
   it('removes ghost optimistic pin on error when ctx.prev is undefined', async () => {
     // Create a fresh QueryClient with NO pre-seeded data for the slot,
     // so when the mutation's onMutate runs cancelQueries + getQueryData,


### PR DESCRIPTION
## Problem / Motivation

When the user clicks **Unpin** on a pin whose create request is still in flight,
the hook sends `DELETE /api/chat/pins/temp-<random-id>`.  The server has no such
resource, returns 404, and the hook's `onError` handler restores the snapshot and
sets `error='unpin'`, surfacing a false "unpin failed" toast.  The pin disappears
briefly, snaps back, and shows an error the user did nothing wrong to cause.

## Why it matters

The race window is easy to hit: click **Pin**, then click the **Unpin** button
that appears immediately in the panel while the network round-trip completes.
The result is confusing — the pin looks like it was removed, then reappears with
an error.  The pin was never actually deleted.

## What changed (motivation → approach → change)

**Root cause**: `unpinById` / `unpinMessage` called `pinsApi.remove(id)` with
whatever id was in the cache, including temporary optimistic ids prefixed
`temp-`.

**Approach**: track in-flight create promises in a `useRef` `Map<mid, Promise<ChatPin>>`.
The `pinMessage` wrapper registers its promise keyed by `mid` and cleans up in
`.finally()`.  A new `_doUnpin` helper checks whether the resolved pin's id
starts with `'temp-'`:

1. **Yes (in-flight)**: optimistically remove from cache, then `await` the
   in-flight create.
   - Create succeeds → `DELETE` the real server id via the normal unpin mutation.
   - Create fails → nothing exists on the server; swallow silently.
2. **No (settled id)**: delegate straight to the existing unpin mutation,
   unchanged.

Pins not yet in the local cache fall back to the original direct-by-id path so
that external callers (e.g. `ChatPage` triggering unpin before the list has
loaded) continue to work.

**Files changed** (repo-relative):
- `website/src/hooks/useChatPins.ts` — added `inFlightCreates` ref, `_doUnpin`
  helper, updated `pinMessage` / `unpinMessage` / `unpinById`.
- `website/src/test/chatPins.test.tsx` — five new tests for the race window and the review-round hardening.


### Review-round hardening (same design, four gaps closed)

- **In-flight map key is `(slot_key, mid)`, not `mid` alone.** Forked sessions can carry the same `mid` in different slots; a mid-only key let one slot's create overwrite the other's entry, so unpinning one slot could delete the other slot's pin. The `.finally` cleanup also only deletes the entry when it still holds its own promise, so an older settling create can never evict a newer registration.
- **The "no tracked promise" branch no longer assumes nothing exists server-side.** That state also arises when the create already succeeded and was cleaned from the map while the caller held a stale temp-id snapshot. The branch now checks the cache for the settled pin with the same `mid` and deletes that, instead of silently dropping the unpin.
- **A second click on the same still-saving pin is a no-op.** After the first click removes the temp entry from the cache, `unpinById`'s not-in-cache fallback now refuses `temp-` ids outright (the first click's flow owns the server deletion), instead of sending a guaranteed-404 DELETE.

- **A re-pin during a pending unpin wins.** Each pin intent bumps a monotonic generation per (slot_key, mid); a temp-id unpin snapshots the generation and, after awaiting the create, skips the DELETE if a newer pin intent arrived meanwhile. Without this, Pin -> pending Unpin -> Pin again destroyed the re-created pin (the idempotent create returns the first record, so the deferred DELETE removed the pin the user just re-made).

## Tests

Five new cases added to `website/src/test/chatPins.test.tsx`:

- **"unpin during in-flight create issues NO network DELETE with a temp- id"** —
  verifies `pinsApi.remove` is never called with a `temp-` id while the create
  is still pending.
- **"after create resolves the real id is deleted on the server"** — verifies
  that once the create settles `pinsApi.remove` is called with the real server
  id, not the temp id.
- **"create-fails-then-unpin does not call remove and surfaces no unpin error"** —
  verifies that a create failure followed by an unpin calls `remove` zero times
  and does not set `error='unpin'`.
- **"same mid in two slots: unpinning one slot never touches the other slot"** —
  creates the same `mid` in two different slots and verifies unpinning slot A's
  temp pin deletes only slot A's server pin (exercises the `(slot_key, mid)`
  in-flight map key).
- **"pin -> pending unpin -> pin again: the deferred delete is skipped and the
  re-created pin survives"** — a newer pin intent bumps the generation so the
  deferred DELETE never fires and `pinsApi.remove` is not called (exercises the
  monotonic pin-generation guard).

All 161 tests across the 5 files that import `useChatPins` or `pinsApi` pass:
`chatPins.test.tsx` (41), `ChatPageCoverage.test.tsx` (43),
`ChatPageMoreCoverage.test.tsx` (28), `ChatPageW3Coverage.test.tsx` (39),
`Frontend5Api.cov80.test.ts` (10).

`tsc -b` passes with zero errors.

## Manual verification

N/A — no visual change; this removes an erroneous error toast in a race window.

## Screenshots / video

N/A — no visual change; this fix removes an erroneous "unpin failed" error toast that appeared in a race window.

## Related Issues

Fixes #5135

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] My changes do not introduce new TypeScript errors
- [ ] I have updated documentation (N/A — internal hook change, no public API or
  user-visible documentation affected)




