### PR TITLE
fix(pins): broadcast pin changes so all connected tabs stay in sync

### DIFF
--- a/src/kiro_crew/dashboard/chat_pins.py
+++ b/src/kiro_crew/dashboard/chat_pins.py
@@ -241,6 +241,10 @@ async def api_chat_pins_create(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": "failed to persist pin", "code": "persist_failed"}, status=500
             )
+    # Broadcast after the lock is released: slot_key only, no pin content.
+    # dashboard-user connections only (app tokens must not receive other slots'
+    # pin signals — see CWE-269 and App Kit §5.2).
+    state.broadcast_ws_owners("pins_changed", {"slot_key": slot_key})
     return web.json_response(pin, status=201)
 
 
@@ -284,6 +288,8 @@ async def api_chat_pins_delete(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": "failed to persist pin", "code": "persist_failed"}, status=500
             )
+    # Broadcast after the lock is released: slot_key only, no pin content.
+    state.broadcast_ws_owners("pins_changed", {"slot_key": removed["slot_key"]})
     return web.json_response({"ok": True})
 
 
@@ -351,4 +357,6 @@ async def api_chat_pins_delete_by_query(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": "failed to persist pin", "code": "persist_failed"}, status=500
             )
+    # Broadcast after the lock is released: slot_key only, no pin content.
+    state.broadcast_ws_owners("pins_changed", {"slot_key": slot_key})
     return web.json_response({"ok": True})

--- a/test/test_dashboard_chat_pins.py
+++ b/test/test_dashboard_chat_pins.py
@@ -2028,3 +2028,204 @@ async def test_load_missing_file_sets_empty(tmp_path, monkeypatch):
     ]
     state.load_chat_pins()
     assert state._chat_pins == []
+
+
+# ── Broadcast (pins_changed) ──
+
+# Helper: inject a MagicMock for broadcast_ws_owners so tests can assert calls.
+
+
+def _make_state_with_broadcast_spy(tmp_path):
+    """_make_state() variant that replaces broadcast_ws_owners with a MagicMock."""
+    state = _make_state(tmp_path)
+    state.broadcast_ws_owners = MagicMock()
+    return state
+
+
+@pytest.mark.asyncio
+async def test_broadcast_fires_after_create_pin(tmp_path):
+    """broadcast_ws_owners is called with pins_changed and the correct slot_key
+    after a successful pin creation."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-bcast-create",
+                "mid": "m-bc-create1",
+                "message_ts": "2026-01-01T00:00:00Z",
+                "role": "user",
+                "preview": "broadcast test",
+            },
+        )
+        assert resp.status == 201
+    state.broadcast_ws_owners.assert_called_once_with(
+        "pins_changed", {"slot_key": "slot-bcast-create"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_broadcast_fires_after_delete_by_id(tmp_path):
+    """broadcast_ws_owners is called with pins_changed after a successful delete-by-id."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        create_resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-bcast-del-id",
+                "mid": "m-bc-del-id1",
+                "message_ts": "ts-1",
+                "role": "user",
+                "preview": "to delete",
+            },
+        )
+        assert create_resp.status == 201
+        pin = await create_resp.json()
+        state.broadcast_ws_owners.reset_mock()
+
+        del_resp = await client.delete(f"/api/chat/pins/{pin['id']}")
+        assert del_resp.status == 200
+    state.broadcast_ws_owners.assert_called_once_with(
+        "pins_changed", {"slot_key": "slot-bcast-del-id"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_broadcast_fires_after_delete_by_query(tmp_path):
+    """broadcast_ws_owners is called with pins_changed after a successful delete-by-query."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        create_resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-bcast-del-q",
+                "mid": "m-bc-del-q1",
+                "message_ts": "ts-2",
+                "role": "assistant",
+                "preview": "to delete by query",
+            },
+        )
+        assert create_resp.status == 201
+        pin = await create_resp.json()
+        state.broadcast_ws_owners.reset_mock()
+
+        del_resp = await client.delete(
+            f"/api/chat/pins/by-query?slot=slot-bcast-del-q&mid={pin['mid']}"
+        )
+        assert del_resp.status == 200
+    state.broadcast_ws_owners.assert_called_once_with(
+        "pins_changed", {"slot_key": "slot-bcast-del-q"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_broadcast_does_not_fire_on_create_persist_failure(tmp_path, monkeypatch):
+    """broadcast_ws_owners must NOT be called when persistence fails on create
+    (rollback path — the in-memory state was reverted)."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        monkeypatch.setattr(state, "save_chat_pins", _raise_os_error)
+        resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-bcast-fail-c",
+                "mid": "m-bc-fail-c1",
+                "message_ts": "ts-3",
+                "role": "user",
+                "preview": "should fail",
+            },
+        )
+        assert resp.status == 500
+    state.broadcast_ws_owners.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_does_not_fire_on_delete_persist_failure(tmp_path, monkeypatch):
+    """broadcast_ws_owners must NOT be called when persistence fails on delete-by-id
+    (rollback path — the pin was re-inserted)."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        create_resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-bcast-fail-d",
+                "mid": "m-bc-fail-d1",
+                "message_ts": "ts-4",
+                "role": "user",
+                "preview": "persist fail delete",
+            },
+        )
+        assert create_resp.status == 201
+        pin = await create_resp.json()
+        state.broadcast_ws_owners.reset_mock()
+
+        monkeypatch.setattr(state, "save_chat_pins", _raise_os_error)
+        del_resp = await client.delete(f"/api/chat/pins/{pin['id']}")
+        assert del_resp.status == 500
+    state.broadcast_ws_owners.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_does_not_fire_on_query_delete_persist_failure(tmp_path, monkeypatch):
+    """broadcast_ws_owners must NOT be called when persistence fails on delete-by-query
+    (rollback path — the pin was re-inserted)."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        create_resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-bcast-fail-q",
+                "mid": "m-bc-fail-q1",
+                "message_ts": "ts-5",
+                "role": "assistant",
+                "preview": "persist fail query",
+            },
+        )
+        assert create_resp.status == 201
+        pin = await create_resp.json()
+        state.broadcast_ws_owners.reset_mock()
+
+        monkeypatch.setattr(state, "save_chat_pins", _raise_os_error)
+        del_resp = await client.delete(
+            f"/api/chat/pins/by-query?slot=slot-bcast-fail-q&mid={pin['mid']}"
+        )
+        assert del_resp.status == 500
+    state.broadcast_ws_owners.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_does_not_fire_on_validation_failure(tmp_path):
+    """broadcast_ws_owners must NOT be called when the request is rejected for
+    validation reasons (missing required fields, etc.)."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        # Missing both slot_key and mid
+        resp = await client.post("/api/chat/pins", json={"preview": "oops"})
+        assert resp.status == 400
+    state.broadcast_ws_owners.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_payload_contains_only_slot_key(tmp_path):
+    """The broadcast payload must contain slot_key and nothing else (no pin
+    content) so no sensitive material crosses the WebSocket to any listener."""
+    state = _make_state_with_broadcast_spy(tmp_path)
+    async with _client(tmp_path, state=state) as client:
+        resp = await client.post(
+            "/api/chat/pins",
+            json={
+                "slot_key": "slot-payload-check",
+                "mid": "m-payload-chk1",
+                "message_ts": "ts-pc",
+                "role": "user",
+                "preview": "SECRET content must not appear in broadcast",
+            },
+        )
+        assert resp.status == 201
+    call_args = state.broadcast_ws_owners.call_args
+    assert call_args is not None
+    msg_type, payload = call_args[0]
+    assert msg_type == "pins_changed"
+    assert set(payload.keys()) == {"slot_key"}
+    assert "preview" not in payload
+    assert "content" not in payload

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -861,6 +861,18 @@ export function useWebSocket() {
             }
             break
           }
+          case 'pins_changed': {
+            // A pin was created or deleted on another tab (or via the API).
+            // Invalidate only the affected slot's cache so the pin affordance
+            // and pin list stay in sync without a remount. The payload carries
+            // slot_key only — no pin content — so nothing sensitive crosses the
+            // WebSocket to any listener.
+            const slotKey = (data as { slot_key?: string }).slot_key
+            if (slotKey) {
+              queryClient.invalidateQueries({ queryKey: ['chat-pins', slotKey] })
+            }
+            break
+          }
           case 'artifact_update': {
             // Live artifact refresh: the backend broadcasts from the artifact
             // mutation funnel (create / content PATCH / revert / relocate /

--- a/website/src/test/useWebSocket.pinsChanged.test.ts
+++ b/website/src/test/useWebSocket.pinsChanged.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Verifies that a `pins_changed` WebSocket frame triggers `invalidateQueries`
+ * for the named slot's chat-pins cache entry.
+ *
+ * A second tab's pin (or an API-created pin) would otherwise be invisible in
+ * the current tab until remount because React Query's ['chat-pins', slotKey]
+ * cache has no other external invalidation path.
+ *
+ * The frame carries slot_key only — no pin content — so nothing sensitive
+ * crosses the WebSocket to any listener.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+describe('useWebSocket pins_changed frame', () => {
+  let testStore: ReturnType<typeof createTestStore>
+  let qc: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    testStore = createTestStore()
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(Provider, { store: testStore },
+      createElement(QueryClientProvider, { client: qc }, children),
+    )
+  }
+
+  it('invalidates the chat-pins query for the named slot', () => {
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    spy.mockClear()
+
+    act(() => {
+      ws.simulateMessage({ type: 'pins_changed', data: { slot_key: 'dashboard:chat-42' } })
+    })
+
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).toContain(JSON.stringify(['chat-pins', 'dashboard:chat-42']))
+  })
+
+  it('does not invalidate when slot_key is missing', () => {
+    // A malformed frame must not trigger a broad invalidation over all slots.
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    spy.mockClear()
+
+    act(() => {
+      ws.simulateMessage({ type: 'pins_changed', data: {} })
+    })
+
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys.some(k => k?.includes('chat-pins'))).toBe(false)
+  })
+
+  it('invalidates only the named slot, not other slots', () => {
+    // A pin change on slot A must not invalidate slot B's cache.
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    spy.mockClear()
+
+    act(() => {
+      ws.simulateMessage({ type: 'pins_changed', data: { slot_key: 'dashboard:chat-1' } })
+    })
+
+    const keys = spy.mock.calls.map(c => JSON.stringify(c[0]?.queryKey))
+    expect(keys).toContain(JSON.stringify(['chat-pins', 'dashboard:chat-1']))
+    expect(keys).not.toContain(JSON.stringify(['chat-pins', 'dashboard:chat-2']))
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`api_chat_pins_create`, `api_chat_pins_delete`, and `api_chat_pins_delete_by_query` in `chat_pins.py` mutate and persist pins but never broadcast the change over WebSocket. The frontend caches `['chat-pins', slotKey]` in React Query (stale-while-revalidate), and nothing external invalidates it. A pin created or deleted in a second tab, or via the API, stays invisible until the tab remounts or the user manually refreshes.

## Why it matters

The pin affordance (the pin/unpin button on each message bubble) reads from the same React Query cache — so a pin created in tab A shows up as "pinned" in tab A but "unpinned" in tab B until tab B remounts. Same bug for API-driven pins (e.g. agent-created bookmarks). The fix closes the live-sync gap that makes pins feel per-tab rather than per-session.

## What changed (motivation → approach → change)

**Root cause:** mutation handlers flush to disk but have no broadcast call.

**Approach:** follow the existing `broadcast_ws_owners` pattern used for `question_card` and `mcp_app_render`. `broadcast_ws_owners` fans out only to `_owner_ws_clients` — the set that `api_ws` populates exclusively for `_is_dashboard_user=True` connections. App-token sockets land in `_ws_clients` but not in `_owner_ws_clients`, so they never receive this frame.

**Change:**
- `chat_pins.py` — after each successful `asyncio.to_thread(state.save_chat_pins)` (i.e. after the lock is released and persistence confirmed), call `state.broadcast_ws_owners("pins_changed", {"slot_key": slot_key})`. The payload contains `slot_key` only — no pin content, no preview text — so no sensitive material crosses the wire. The call is placed after the lock is released and after the persist succeeds; the rollback paths (`save_chat_pins` raising) and validation-error paths return before reaching the broadcast.
- `useWebSocket.ts` — adds `case 'pins_changed'` to the WS frame switch: reads `data.slot_key` and calls `qc.invalidateQueries({queryKey: ['chat-pins', slotKey]})`. A missing or empty `slot_key` is a no-op (guards against malformed frames). Only the named slot's cache is invalidated — other slots are unaffected.

## Tests

**Backend** (`test/test_dashboard_chat_pins.py`, 8 new tests):
- `test_broadcast_fires_after_create_pin` — `broadcast_ws_owners` called once with `("pins_changed", {"slot_key": ...})` after successful POST.
- `test_broadcast_fires_after_delete_by_id` — same after successful DELETE `/{id}`.
- `test_broadcast_fires_after_delete_by_query` — same after successful DELETE `?slot=…&mid=…`.
- `test_broadcast_does_not_fire_on_create_persist_failure` — no call when `save_chat_pins` raises (rollback path).
- `test_broadcast_does_not_fire_on_delete_persist_failure` — same for delete-by-id rollback.
- `test_broadcast_does_not_fire_on_query_delete_persist_failure` — same for delete-by-query rollback.
- `test_broadcast_does_not_fire_on_validation_failure` — no call on 400 (missing required fields).
- `test_broadcast_payload_contains_only_slot_key` — asserts payload keys == `{"slot_key"}`; `preview` and `content` absent.

`broadcast_ws_owners` is replaced with a `MagicMock` on the `DashboardState` instance, following the existing `monkeypatch.setattr(state, "save_chat_pins", ...)` pattern in the file.

**Frontend** (`website/src/test/useWebSocket.pinsChanged.test.ts`, 3 new tests, modelled on `useWebSocket.sessionSummary.test.ts`):
- Invalidates `['chat-pins', 'dashboard:chat-42']` on a well-formed frame.
- No invalidation when `slot_key` is absent (malformed frame guard).
- Only the named slot is invalidated; a different slot's cache is untouched.

All 85 backend tests pass; isort, flake8, mypy clean; tsc and vitest green.

## Manual verification

N/A — unit coverage sufficient. The fix is a pure broadcast plumbing change: mutation → persist → `broadcast_ws_owners("pins_changed", {slot_key})` → WS frame → `invalidateQueries(['chat-pins', slotKey])` → React Query refetch. No UI component, layout, or visual surface changed.

## Screenshots / video

N/A — no user-visible UI change. This is a behavioral sync fix: the pin affordance was always rendered correctly given fresh data; this fix ensures other tabs receive that fresh data without remounting.

## Related Issues

Fixes #5134

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
