### PR TITLE
fix(build): make npm run typecheck actually type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1135,9 +1135,10 @@ jobs:
 
       - name: Type check
         working-directory: website
-        # `tsc -b`, NOT `npm run typecheck`: the root tsconfig has `files: []`
-        # + project references, so `tsc --noEmit` (what `typecheck` runs) checks
-        # ZERO files and always passes. `tsc -b` actually type-checks the project.
+        # Spelled out rather than `npm run typecheck` so this gate cannot be
+        # changed from package.json. Build mode is required either way: the root
+        # tsconfig is `files: []` + project references, and references are followed
+        # only by `-b`, so a plain `tsc --noEmit` there compiles an empty program.
         run: npx tsc -b
 
       - name: Lint

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/references/gate-floor.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/references/gate-floor.md
@@ -90,11 +90,13 @@ Both obvious alternatives fail one of the three constraints:
 
 ## Prefer the workflow's command over the package's convenience script
 
-They are not always the same check. `npm run typecheck` runs `tsc --noEmit`, and
-the root tsconfig is `files: []` plus project references, so it checks **zero
-files and always passes**. CI type-checks with `tsc -b` for exactly that reason. A
-floor built from `package.json` script names would carry a gate that is enforced
-in appearance only — strictly worse than a missing gate, because nobody goes
+They are not always the same check, and the difference is usually invisible from
+the script name. The `Bundle Size Gate` is the live example: `npm run build`
+deliberately writes no `dist/bundle-report.json`, so CI runs
+`vite build --mode analyze` FIRST and only then `scripts/check-bundle-size.mjs`.
+Reproduce the gate with `npm run build` alone and the checker exits 2 on a missing
+report — a floor entry built from the convenience script would be enforced in
+appearance only, which is strictly worse than a missing gate because nobody goes
 looking for it.
 
 ## Working directory is part of the command
@@ -129,10 +131,11 @@ PR. A check written as a bare binary (`cfn-lint`, `mypy`, `flake8`) is invisible
 a `scripts/`-and-`npm run` scan, so the parity test also enumerates the **tool
 names** `ci.yml` invokes and makes each one either a gate or a named exemption.
 
-Strip comment-only lines before any such scan. `ci.yml` explains in prose why the
-Type check step uses `tsc -b` and *not* `npm run typecheck`, so a naive grep for
-`npm run <script>` "finds" a script CI deliberately avoids — the same trap as
-reading a ratchet number out of a comment.
+Strip comment-only lines before any such scan. `ci.yml` names commands in prose as
+well as running them — the Type check step's comment explains why it spells out
+`npx tsc -b` instead of going through a script — so a naive grep for
+`npm run <script>` "finds" scripts no step invokes, the same trap as reading a
+ratchet number out of a comment.
 
 ## Checks with no local entry point
 

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -320,19 +320,51 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
 
 
 def test_floor_typechecks_the_way_ci_does():
-    """`npm run typecheck` is a no-op gate; the floor must use `tsc -b`.
+    """The floor spells out `tsc -b` rather than going through an npm script.
 
-    ci.yml documents this: the root tsconfig is `files: []` plus project
-    references, so `tsc --noEmit` -- what the `typecheck` script runs -- checks
-    ZERO files and always passes. A floor carrying the convenient script would
-    look enforced and catch nothing, which is worse than having no gate.
+    Build mode is what makes the check real: the root tsconfig is `files: []`
+    plus project references, and references are followed only by `-b`, so any
+    single-project invocation there compiles an EMPTY program and passes
+    unconditionally. Naming the command directly means the floor cannot be
+    changed out from under itself by an edit to `package.json` -- the same reason
+    ci.yml's Type check step spells it out too.
     """
     gates = "\n".join(
         json.loads((PROFILES_DIR / "kirocrew.json").read_text(encoding="utf-8"))["gates"]
     )
     assert "tsc -b" in gates, "the gate floor no longer type-checks with `tsc -b`"
     assert "run typecheck" not in gates, (
-        "the floor uses the `typecheck` npm script, which checks zero files"
+        "the floor reaches type-checking through an npm script, so a package.json "
+        "edit can silently change what this gate runs"
+    )
+
+
+def test_typecheck_script_actually_type_checks():
+    """`npm run typecheck` must run in BUILD mode, or it checks nothing at all.
+
+    `website/tsconfig.json` is a solution-style config -- `{"files": [], "references":
+    [...]}`. TypeScript follows `references` only in build mode, so `tsc --noEmit`
+    there compiles an empty program: measured 0 files listed, exit 0 with a genuine
+    type error present in `src/App.tsx`. `npm run check` chains this script, so the
+    one command that looks like a pre-push gate would pass over the whole tree.
+
+    Nothing else pins the spelling, so without this a revert to `tsc --noEmit`
+    restores a gate that is enforced in appearance only.
+    """
+    scripts = json.loads(
+        (REPO_ROOT / "website" / "package.json").read_text(encoding="utf-8")
+    )["scripts"]
+    typecheck = scripts["typecheck"]
+
+    assert "tsc -b" in typecheck, (
+        f"website `typecheck` script is {typecheck!r}; it must use build mode "
+        "(`tsc -b`) because the root tsconfig has `files: []` and a "
+        "non-build invocation there type-checks zero files"
+    )
+    assert "--noEmit" not in typecheck, (
+        f"website `typecheck` script is {typecheck!r}; `--noEmit` selects "
+        "single-project mode, which compiles an empty program against the "
+        "solution-style root tsconfig"
     )
 
 

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -29,12 +29,8 @@ React 18, Redux Toolkit, React Query (`@tanstack/react-query`), React Router v7,
 Framer Motion, Tailwind CSS 3, Lucide React, DOMPurify, highlight.js, Monaco,
 TypeScript, Vite 5. Prefer the library already here over a new dependency.
 
-## Build and test: two gotchas that produce a silent false green
+## Build and test: a gotcha that produces a silent false green
 
-- **`npm run typecheck` checks ZERO files.** It runs `tsc --noEmit`, and the root
-  `tsconfig.json` has `"files": []` with project references, so nothing is
-  type-checked and it always passes. Use **`npx tsc -b`** (what `npm run build` and
-  CI run) whenever you mean to type-check.
 - **The `localStorage` test polyfill must stay on `Storage.prototype`.** Assigning
   it elsewhere makes the mock silently miss.
 

--- a/website/README.md
+++ b/website/README.md
@@ -33,8 +33,9 @@ npm run lint         # eslint
 npm run test         # website vitest suite + the Electron suite (a jscpd pretest runs first)
 ```
 
-**`npm run typecheck` checks zero files** (it is `tsc --noEmit`, and the root
-`tsconfig.json` has `"files": []`), so use `npx tsc -b` when you mean to type-check.
+`npm run typecheck` runs `tsc -b`, the same build-mode check as `npm run build` and
+CI. Build mode is what follows the root `tsconfig.json`'s project references; a plain
+`tsc --noEmit` there compiles an empty program and passes unconditionally.
 Test layers, when to use which, and how Playwright really runs:
 [docs/testing.md](docs/testing.md).
 

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -22,11 +22,8 @@ npm run test:playwright:headless
 npx tsc -b                # the real type check
 ```
 
-Two traps worth knowing before you trust a green run:
+One trap worth knowing before you trust a green run:
 
-- **`npm run typecheck` checks ZERO files.** It runs `tsc --noEmit`, and the root
-  `tsconfig.json` sets `"files": []` with project references, so nothing is checked
-  and it always passes. Use `npx tsc -b`, which is what `npm run build` and CI run.
 - **`npm test` is wider than it looks.** It runs the Electron suite as well as the
   website suite, and the `pretest` hook runs a jscpd duplication check first, so
   `npm test` can fail on copy-paste before a single test executes.

--- a/website/package.json
+++ b/website/package.json
@@ -24,7 +24,7 @@
     "test:playwright": "playwright test --headed --workers=1",
     "test:playwright:headless": "playwright test",
     "lint": "eslint src --ext .ts,.tsx",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "check": "npm run typecheck && npm run lint && npm run test",
     "jscpd": "jscpd .",
     "gen:settings": "node scripts/gen-settings-registry.mjs",


### PR DESCRIPTION
## Problem / Motivation

`npm run typecheck` type-checks **zero files** and passes unconditionally.

`website/tsconfig.json` is a solution-style config — `{"files": [], "references": [...]}`.
TypeScript follows `references` only in **build mode**, so `tsc --noEmit` there compiles an
empty program. Measured on `main`:

```
$ npx tsc --noEmit --listFiles | wc -l
0
$ printf '\nconst x: number = "not a number"\n' >> src/App.tsx
$ npm run typecheck ; echo $?      # 0   ← a real type error, silently accepted
$ npx tsc -b        ; echo $?      # 1   ← caught: not assignable to type 'number'
```

## Why it matters

`"check": "npm run typecheck && npm run lint && npm run test"` — so the one command that
looks like a pre-push gate passes over all 1,164 files it appears to cover. A contributor
runs it, sees green, and pushes type errors.

CI already knew and worked around it by spelling out `npx tsc -b`, and the trap was
documented in **five** separate places. That is the tell: a doc note is the weakest available
fix for a trap whose whole nature is that it looks like it worked. A vacuous gate is worse
than a missing one, because it buys confidence nobody re-examines.

## What changed (motivation → approach → change)

Root cause is the *mode*, not the config: the root tsconfig is correct for a project-
references setup, and `tsc -b` is the invocation that honours it. So the script moves to
`tsc -b` — the same check `npm run build` and CI already run.

Then the note is retired **everywhere**, not just where it is most visible. Leaving three of
five behind is worse than leaving five: a reader who lands on `README.md` would be told the
now-real gate is a no-op and skip it.

- `website/package.json` — `"typecheck": "tsc -b"`.
- `website/AGENTS.md`, `website/docs/testing.md` — both **counted their own list in a
  heading** ("two gotchas", "Two traps"), so the headings change with the lists.
- `website/README.md` — replaced with what the command now does, and why build mode is what
  makes it real.
- `.github/workflows/ci.yml` — **keeps spelling the command out** rather than calling the
  script. Naming it directly means this gate cannot be changed out from under itself by an
  edit to `package.json`. The comment now says that instead of explaining the bug.
- `prepare-pr/references/gate-floor.md` — keeps its *"prefer the workflow's command over the
  package's convenience script"* section, because the lesson holds. Its **worked example was
  this bug**, so it moves to one that is still true: the `Bundle Size Gate` needs
  `vite build --mode analyze` first, since `npm run build` deliberately writes no report and
  the checker exits 2 without one.

## Tests

`test_typecheck_script_actually_type_checks` (in the existing `test/test_prepare_pr_profiles.py`,
which already loads `website/package.json`) asserts the script uses build mode and does not
use `--noEmit`. Nothing pinned this before, so a revert silently restores a vacuous gate.

**Mutation-checked:** with the script put back to `tsc --noEmit`, the test fails with
`website 'typecheck' script is 'tsc --noEmit'; it must use build mode…`. Restored, 30/30 pass.

`test_floor_typechecks_the_way_ci_does` keeps its assertion — the floor should still name
`tsc -b` directly — but its docstring said `typecheck` "checks zero files", which is now
false. It would have kept passing while lying about why it exists, so the rationale is
corrected in the same commit.

## Manual verification

Ran the real gates rather than trusting the script I just changed:

| check | result |
|---|---|
| `npm run typecheck` on a clean tree | exit 0 |
| `npm run typecheck` with an injected type error | **exit 1**, error reported |
| `flake8`, `isort`, `mypy` (1,030 files) | 0 |
| `check_black_formatting.py` (7-file scope) | 0 |
| `docs-lint.sh`, `scrub-lint.sh --no-history`, `check_brand_name.py` | 0 |
| `test/test_prepare_pr_profiles.py` | 30 passed |

<!-- no-visual-delta -->
**Why no screenshot:** no runtime code changes — a package script, a CI comment, four docs,
and one test. Nothing renders.

## Related Issues

no linked issue: found by auditing which CI gates can pass while the thing they name is
broken.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
