### PR TITLE
fix(acp): log expected runtime teardown at INFO, not WARNING (#4052)

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -608,3 +608,26 @@ start and `kill()`ed when the batch drains, with each per-PR session
 `destroy()`ed on completion for context isolation. Because the runtime layer has
 no `audit_source`, the pool re-emits the equivalent per-tool SEL audit itself
 (see the `audit_source` note above). See `providers.md` and `subagent.md`.
+
+**Death-log severity is a contract: expected teardowns are INFO, genuine deaths
+are WARNING.** `_mark_dead(reason, *, expected=False)` logs the single
+`AcpRuntime dead (PID …) [returncode=…] stderr_tail: …` line at INFO when the
+death is a deliberate teardown and at WARNING otherwise; the flag changes
+severity only — futures still fail with `AcpRuntimeDead`, queues are still
+poisoned. `kill(*, expected=False)` plumbs it through, and both defaults are
+fail-safe (WARNING), so a cleanup kill on a failure path — `initialize()`'s
+failed-spawn cleanup, `AcpProvider`'s failed-session-setup kill — and any
+future call site warns without opting in; only the deliberate teardowns of a
+healthy runtime (session shutdown via `AcpSessionProvider`, `_bg`/subagent
+runtime recycling and shutdown, `ReviewPool` batch drain) pass
+`expected=True`. `_mark_dead` refuses the downgrade when the process already
+exited on its own (`returncode` set), so a replacement path reaping a death
+the reader loop has not yet marked keeps the WARNING whenever the exit has
+already been observed — best-effort: an exit the child watcher has not yet
+recorded can still take the INFO path in that narrow window. The warm-pool
+health sweep and the claim path (`_drain_and_claim`) follow the same rule: a
+TTL recycle of a healthy provider logs at INFO, while a provider found dead —
+in a TTL branch or a dead-provider branch — stays WARNING. Note the default
+`agent.log_level` is WARNING, so expected teardowns are absent from
+`gateway.log` unless the operator raises verbosity; that silence is the point
+of the split (issue #4052).

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -1213,6 +1213,8 @@ class AcpRuntime:
             logger.info("AcpRuntime initialized (PID %d)", self._pid)
         except BaseException:
             try:
+                # This death IS abnormal (failed spawn/handshake): kill()'s
+                # expected=False default keeps its log at WARNING.
                 await self.kill()
             except Exception:
                 logger.debug(
@@ -1225,13 +1227,23 @@ class AcpRuntime:
     _KILL_TERM_TIMEOUT = 5.0
     _KILL_REAP_TIMEOUT = 2.0
 
-    async def kill(self) -> None:
-        """Kill the subprocess and clean up all state."""
+    async def kill(self, *, expected: bool = False) -> None:
+        """Kill the subprocess and clean up all state.
+
+        ``expected`` changes log severity only: a deliberate teardown of a
+        healthy runtime (pool TTL recycle, session shutdown, logout) passes
+        ``expected=True`` to log the death at INFO. The default is False —
+        matching ``_mark_dead`` — so every cleanup kill on a failure path
+        (``initialize()``'s failed-spawn cleanup, a failed session setup) and
+        any future call site stays a WARNING without having to opt in.
+        ``_mark_dead`` additionally refuses to downgrade when the process
+        already exited on its own, so a reap-after-death can never log INFO.
+        """
         # Fail pending futures + poison session queues FIRST. _mark_dead sets
         # self._dead internally; doing it up front (before teardown) ensures any
         # waiters learn the runtime died. Calling it after setting _dead=True
         # would hit its early-return guard and skip all cleanup.
-        self._mark_dead("killed")
+        self._mark_dead("killed", expected=expected)
 
         if self._reader_task and not self._reader_task.done():
             self._reader_task.cancel()
@@ -2081,11 +2093,27 @@ class AcpRuntime:
         """
         return any(_NOT_LOGGED_IN_RE.search(line) for line in self._stderr_lines)
 
-    def _mark_dead(self, reason: str) -> None:
-        """Mark runtime dead, fail all pending requests, poison all session queues."""
+    def _mark_dead(self, reason: str, *, expected: bool = False) -> None:
+        """Mark runtime dead, fail all pending requests, poison all session queues.
+
+        ``expected`` selects only the log severity: a deliberate teardown (a
+        warm-pool TTL recycle, a session shutdown) logs at INFO, while every
+        genuine death path (process exit, reader crash, broken pipe, ...) keeps
+        today's WARNING. The default is False so any death path added later is
+        a WARNING without having to opt in. Everything else — the ``_dead``
+        early return, PID unshielding, failing pending futures, poisoning
+        session queues — is identical on both paths.
+        """
         if self._dead:
             return
         self._dead = True
+        # A process that already exited on its own is a genuine death being
+        # reaped, not a teardown this caller initiated — refuse the downgrade
+        # regardless of call site. This closes the race where a replacement
+        # path observes is_alive() == False (returncode set by the child
+        # watcher) and kill()s before the reader loop has marked the death.
+        if expected and self._process is not None and self._process.returncode is not None:
+            expected = False
         # Release the sweep-protection shield on ANY death path (EOF, rc!=0,
         # stdout overrun, reader crash, broken pipe) — not just kill(). Otherwise
         # the dead PID lingers in _PROTECTED_PIDS forever and, after PID reuse,
@@ -2101,7 +2129,8 @@ class AcpRuntime:
         # operators can tell an OOM/crash from a clean exit without DEBUG logs.
         rc = self._process.returncode if self._process else None
         tail = " | ".join(self._stderr_lines[-5:]) if self._stderr_lines else "<none>"
-        logger.warning(
+        log = logger.info if expected else logger.warning
+        log(
             "AcpRuntime dead (PID %s): %s [returncode=%s] stderr_tail: %s",
             self._pid,
             reason,

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -175,7 +175,7 @@ class AcpSessionProvider(LLMProvider):
         """
         if self._owns_runtime:
             try:
-                await self._runtime.kill()
+                await self._runtime.kill(expected=True)  # deliberate session teardown
             except Exception:
                 logger.debug("AcpSessionProvider.shutdown: runtime kill failed", exc_info=True)
         else:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
@@ -366,7 +366,10 @@ class _BatchRuntimeHolder:
 
     async def _kill(self, rt: "AcpRuntime") -> None:
         try:
-            await rt.kill()
+            # Deliberate pool teardown (batch drain / force_shutdown). The
+            # reap-a-dead-one caller is covered too: _mark_dead refuses the
+            # INFO downgrade when the process already exited on its own.
+            await rt.kill(expected=True)
         except Exception:
             logger.debug("code-review-sage runtime kill error", exc_info=True)
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
@@ -89,7 +89,7 @@ class FakeRuntime:
     async def spawn(self):
         self.spawned = True
 
-    async def kill(self):
+    async def kill(self, *, expected: bool = False):
         self.killed = True
 
     async def create_session(self, cwd=None, agent=None):

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -1274,7 +1274,7 @@ class SessionManager:
                                 runtime.pid,
                                 reason,
                             )
-                            await runtime.kill()
+                            await runtime.kill(expected=True)  # deliberate staleness recycle
                             self._bg_runtime = None
                     elif runtime._stale_by_age():
                         # Stale but co-tenant sessions are active, so recycling
@@ -1432,7 +1432,7 @@ class SessionManager:
             runtime = self._subagent_runtimes.pop(parent_session_key, None)
         if runtime is not None:
             try:
-                await runtime.kill()
+                await runtime.kill(expected=True)  # deliberate teardown with parent
             except Exception:
                 logger.warning(
                     "Failed to kill subagent runtime for %s", parent_session_key, exc_info=True
@@ -1942,7 +1942,17 @@ class SessionManager:
             # Check TTL (0 = disabled)
             age = time.monotonic() - spawn_time
             if self._pool_ttl_secs and age > self._pool_ttl_secs:
-                logger.warning(
+                # Same severity rule as the health sweep: a TTL recycle of a
+                # healthy provider is routine (INFO); one that also died before
+                # aging out is a genuine anomaly and keeps WARNING.
+                try:
+                    ttl_alive = (
+                        hasattr(provider, "is_process_alive") and provider.is_process_alive()
+                    )
+                except Exception:
+                    ttl_alive = False
+                ttl_log = logger.info if ttl_alive else logger.warning
+                ttl_log(
                     "Warm pool: %.0fs old provider exceeds TTL %ds, discarding",
                     age,
                     self._pool_ttl_secs,
@@ -2081,7 +2091,19 @@ class SessionManager:
                 if isinstance(pid, int):
                     self._pool_sweep_pids.add(pid)
                 if self._pool_ttl_secs and age > self._pool_ttl_secs:
-                    logger.warning(
+                    # A scheduled TTL recycle of a HEALTHY provider is the pool
+                    # working as designed, not operator-actionable — INFO. A
+                    # provider that also died before aging out is a genuine
+                    # anomaly: keep the pre-existing WARNING for it (same
+                    # message, same discard path — severity only).
+                    try:
+                        ttl_alive = (
+                            hasattr(provider, "is_process_alive") and provider.is_process_alive()
+                        )
+                    except Exception:
+                        ttl_alive = False
+                    ttl_log = logger.info if ttl_alive else logger.warning
+                    ttl_log(
                         "Pool health: %.0fs old provider (pid=%s) exceeds TTL %ds, discarding",
                         age,
                         pid,
@@ -4053,7 +4075,7 @@ class SessionManager:
             if runtime.has_active_or_initializing_sessions():
                 return False
             try:
-                await runtime.kill()
+                await runtime.kill(expected=True)  # deliberate logout teardown
             except Exception:
                 logger.warning(
                     "Failed to retire the background runtime after an identity change",
@@ -4299,7 +4321,7 @@ class SessionManager:
         # next-startup orphan reaper.
         if self._bg_runtime is not None:
             try:
-                await self._bg_runtime.kill()
+                await self._bg_runtime.kill(expected=True)  # graceful shutdown
             except Exception:
                 logger.debug("close_all: _bg_runtime kill failed", exc_info=True)
             self._bg_runtime = None

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -823,6 +823,122 @@ async def test_mark_dead_is_idempotent():
     assert q["sA"].empty()
 
 
+# ── Death-log severity: deliberate teardown vs genuine death (#4052) ──
+#
+# A warm-pool TTL recycle tears runtimes down via kill() on a schedule; logging
+# that at the same severity and shape as a crash made `kirocrew logs` misreport
+# routine recycling as process death. These tests pin the split: kill() → INFO,
+# every genuine death path → WARNING, and the state transitions identical.
+
+
+def _death_records(caplog):
+    """The 'AcpRuntime dead' records, selected by the raw log template so the
+    assertions can check levelname (severity) separately from message shape."""
+    return [r for r in caplog.records if str(r.msg).startswith("AcpRuntime dead")]
+
+
+def _neuter_kill_side_effects(monkeypatch, proc):
+    """Keep kill() away from the host: never signal the fake PID (4242 could be
+    a real process), never touch the PID-tracking files."""
+    import kiro_crew.acp.runtime as rt_mod
+
+    proc.wait = AsyncMock(return_value=0)
+    monkeypatch.setattr(rt_mod.platform_compat, "kill_process_tree", lambda *a, **k: None)
+    monkeypatch.setattr(rt_mod.platform_compat, "pid_exists", lambda pid: False)
+    monkeypatch.setattr(rt_mod, "_untrack_pid", lambda p: None)
+    monkeypatch.setattr(rt_mod, "_untrack_session_pid", lambda p: None)
+
+
+@pytest.mark.asyncio
+async def test_deliberate_kill_logs_info_and_still_fails_pending_futures(caplog, monkeypatch):
+    """A deliberate kill(expected=True) of a LIVE runtime (pool recycle /
+    session shutdown) must log the death at INFO — no WARNING — while
+    everything non-log stays identical: pending futures still fail with
+    AcpRuntimeDead and session queues are poisoned."""
+    import logging
+
+    rt, _, proc = _make_runtime()
+    _neuter_kill_side_effects(monkeypatch, proc)
+    q = _register(rt, "sA")
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    rt._pending_requests[7] = fut
+
+    with caplog.at_level(logging.INFO, logger="kiro_crew.acp.runtime"):
+        await rt.kill(expected=True)
+
+    records = _death_records(caplog)
+    assert [r.levelname for r in records] == ["INFO"]
+    assert "killed" in records[0].getMessage()
+    # Severity-only change: waiters still learn the runtime died.
+    with pytest.raises(AcpRuntimeDead):
+        await asyncio.wait_for(fut, timeout=1.0)
+    assert await asyncio.wait_for(q["sA"].get(), timeout=1.0) is None
+
+
+@pytest.mark.asyncio
+async def test_kill_default_is_unexpected_and_warns(caplog, monkeypatch):
+    """A bare kill() keeps the WARNING: the default is fail-safe so every
+    cleanup kill on a failure path — initialize()'s failed-spawn cleanup, a
+    failed session setup — and any future call site stays a WARNING without
+    opting in."""
+    import logging
+
+    rt, _, proc = _make_runtime()
+    _neuter_kill_side_effects(monkeypatch, proc)
+
+    with caplog.at_level(logging.INFO, logger="kiro_crew.acp.runtime"):
+        await rt.kill()
+
+    assert [r.levelname for r in _death_records(caplog)] == ["WARNING"]
+
+
+@pytest.mark.asyncio
+async def test_kill_refuses_info_downgrade_when_process_already_exited(caplog, monkeypatch):
+    """A replacement path can observe is_alive() == False (returncode set by
+    the child watcher) and kill() before the reader loop marks the death.
+    That is a genuine death being reaped, not a teardown this caller started:
+    expected=True must be refused and the WARNING kept."""
+    import logging
+
+    rt, _, proc = _make_runtime()
+    _neuter_kill_side_effects(monkeypatch, proc)
+    proc.returncode = 1  # process already exited on its own; _dead still False
+
+    with caplog.at_level(logging.INFO, logger="kiro_crew.acp.runtime"):
+        await rt.kill(expected=True)
+
+    records = _death_records(caplog)
+    assert [r.levelname for r in records] == ["WARNING"]
+    assert "returncode=1" in records[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_process_exit_still_warns_with_diagnostic_shape(caplog):
+    """A genuine death (process exited) keeps today's WARNING and its full
+    diagnostic shape — reason with rc, returncode=, stderr_tail: — unchanged."""
+    import logging
+
+    rt, reader, proc = _make_runtime()
+    proc.returncode = 1
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    rt._pending_requests[3] = fut
+    task = await _start_reader(rt)
+    try:
+        with caplog.at_level(logging.INFO, logger="kiro_crew.acp.runtime"):
+            reader.feed_eof()  # empty readline → process exited
+            with pytest.raises(AcpRuntimeDead):
+                await asyncio.wait_for(fut, timeout=1.0)
+    finally:
+        await _stop_reader(task)
+
+    records = _death_records(caplog)
+    assert [r.levelname for r in records] == ["WARNING"]
+    msg = records[0].getMessage()
+    assert "process exited (rc=1)" in msg
+    assert "returncode=1" in msg
+    assert "stderr_tail: <none>" in msg
+
+
 # ── Send paths ──
 
 

--- a/test/test_external_logout_detection.py
+++ b/test/test_external_logout_detection.py
@@ -573,7 +573,7 @@ class _FakeRuntime:
     def has_active_or_initializing_sessions(self) -> bool:
         return self._active or self._initializing
 
-    async def kill(self) -> None:
+    async def kill(self, *, expected: bool = False) -> None:
         self.killed += 1
 
 

--- a/test/test_session_pool.py
+++ b/test/test_session_pool.py
@@ -501,6 +501,34 @@ class TestTTLExpiration:
 
         mgr._schedule_replenish.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_claim_ttl_discard_logs_info_dead_keeps_warning(self, caplog):
+        """#4052: the claim path follows the same severity rule as the health
+        sweep — a TTL recycle of a healthy provider is INFO, one that also died
+        before aging out keeps WARNING. Both are still discarded."""
+        import logging
+
+        mgr, _ = _make_manager(pool_agent="kirocrew", pool_ttl_secs=60)
+        stale = _make_provider()
+        stale.is_process_alive = MagicMock(return_value=True)
+        stale_dead = _make_provider()
+        stale_dead.is_process_alive = MagicMock(return_value=False)
+        mgr._warm_pool.put_nowait((stale, time.monotonic() - 120))
+        mgr._warm_pool.put_nowait((stale_dead, time.monotonic() - 120))
+
+        with patch("kiro_crew.session._sync_kill_provider"):
+            with caplog.at_level(logging.INFO, logger="kiro_crew.session"):
+                result = await mgr._drain_and_claim("kirocrew")
+
+        assert result is None
+        ttl_records = [
+            r for r in caplog.records if str(r.msg).startswith("Warm pool: %.0fs old provider")
+        ]
+        # FIFO claim order: healthy-stale first (INFO), dead-stale second (WARNING).
+        assert [r.levelname for r in ttl_records] == ["INFO", "WARNING"]
+        stale.shutdown.assert_awaited_once()
+        stale_dead.shutdown.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # Model-matches-pool-default bypass (effective_model normalization)
@@ -1366,6 +1394,45 @@ class TestDiscardReaping:
 
         survivor.shutdown.assert_awaited_once()
         mock_kill.assert_called_once_with(survivor)
+        assert mgr._warm_pool.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_sweep_ttl_discard_logs_info_dead_provider_stays_warning(self, caplog):
+        """#4052: a scheduled TTL recycle of a healthy provider is the pool
+        working as designed, so its discard line is INFO. Both anomalies keep
+        WARNING: a provider that died before aging out (TTL line, dead process)
+        and the dead-provider branch below. All three are still reaped."""
+        import logging
+
+        mgr, _ = _make_manager(pool_agent="kirocrew", pool_ttl_secs=60)
+        stale = _make_provider()
+        stale.is_process_alive = MagicMock(return_value=True)
+        stale_dead = _make_provider()
+        stale_dead.is_process_alive = MagicMock(return_value=False)
+        dead = _make_provider()
+        dead.is_process_alive = MagicMock(return_value=False)
+        dead.exit_code = 9
+        mgr._warm_pool.put_nowait((stale, time.monotonic() - 120))
+        mgr._warm_pool.put_nowait((stale_dead, time.monotonic() - 120))
+        mgr._warm_pool.put_nowait((dead, time.monotonic()))
+
+        with patch("kiro_crew.session._sync_kill_provider"):
+            with caplog.at_level(logging.INFO, logger="kiro_crew.session"):
+                await mgr._sweep_warm_pool_once()
+
+        ttl_records = [
+            r for r in caplog.records if str(r.msg).startswith("Pool health: %.0fs old provider")
+        ]
+        dead_records = [
+            r for r in caplog.records if str(r.msg).startswith("Pool health: dead provider")
+        ]
+        # FIFO drain order: healthy-stale first (INFO), dead-stale second (WARNING).
+        assert [r.levelname for r in ttl_records] == ["INFO", "WARNING"]
+        assert [r.levelname for r in dead_records] == ["WARNING"]
+        # Severity-only: all three entries were still discarded and shut down.
+        stale.shutdown.assert_awaited_once()
+        stale_dead.shutdown.assert_awaited_once()
+        dead.shutdown.assert_awaited_once()
         assert mgr._warm_pool.qsize() == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What broke

A stable-channel operator running the gateway for a few hours sees a steady stream of WARNINGs in `kirocrew logs`:

```
Pool health: 1805s old provider (pid=13166) exceeds TTL 1800s, discarding
AcpRuntime dead (PID 13166): killed [returncode=None] stderr_tail: <none>
```

Nothing is broken — these are the warm pool's own scheduled TTL recycles. `AcpRuntime._mark_dead` logged unconditionally at WARNING, in the same severity and message shape as a genuine process death, so routine recycling was indistinguishable from a crash.

## Why

`AcpRuntime.kill()` (the deliberate-teardown path) calls `_mark_dead("killed")` before reaping, and `_mark_dead` had a single hardcoded `logger.warning`. The pool-health sweep's TTL-discard line had the same problem one layer up.

## What changed (severity-only; behaviour otherwise identical)

- `_mark_dead(reason, *, expected: bool = False)` — expected → `logger.info`, otherwise today's exact WARNING message and arguments. It **refuses the downgrade when the process already exited on its own** (`returncode` set): a replacement path that observes `is_alive() == False` and `kill()`s before the reader loop marks the death is reaping a genuine death, and keeps the WARNING.
- **Plumbing shape** (the spec asked this be stated): `kill(*, expected: bool = False)` — the default is **fail-safe**, matching `_mark_dead`, so every cleanup kill on a failure path (`initialize()`'s failed-spawn cleanup, `AcpProvider`'s failed-session-setup kill at `providers/acp.py:900`) and any future call site stays a WARNING without opting in. Exactly six deliberate teardowns of a healthy runtime opt in with `expected=True`: session shutdown (`AcpSessionProvider.shutdown`), `_bg`-runtime staleness recycle / logout retirement / graceful shutdown, subagent-runtime teardown with its parent, and Code Review Sage's `ReviewPool` drain. (An earlier draft defaulted `kill()` to `expected=True`; pre-push dual-model review caught that it silently downgraded the failed-session-setup cleanup — the mirror of the bug being fixed — so the default was flipped.)
- Pool-health sweep: the TTL-discard line is INFO for a **healthy** provider being recycled; a provider that also died before aging out keeps WARNING on the same line, and the abnormal `dead provider (...)` branch below stays WARNING. No control flow changed — same discard decisions, same shutdown path.
- Everything non-log in `_mark_dead` is untouched: the `_dead` early return, `unregister_protected_pid`, failing pending futures with `AcpRuntimeDead`, clearing `_pending_requests`/`_pending_init_notifications`, poisoning session queues.
- The severity contract is documented in `docs/system-specs/modules/acp-client.md` (same commit), next to the runtime's consumer enumeration.

## What was verified

- Full local gates: isort, flake8, mypy (1030 files), black baseline gate, docs-lint, full backend pytest **61190 passed / 338 skipped / 6 xfailed**.
- New tests pin the split with `caplog` asserting on record `levelname` (not formatted substrings): deliberate `kill(expected=True)` on a live runtime → INFO and no WARNING, pending futures still fail `AcpRuntimeDead`; bare `kill()` → WARNING (the contract the failure-path cleanups rely on); `kill(expected=True)` on an already-exited process → refused back to WARNING; genuine death (`process exited (rc=1)`) → WARNING with `returncode=`/`stderr_tail:` shape; sweep: healthy TTL discard INFO, dead-before-TTL WARNING, dead-provider branch WARNING, all three still reaped.
- Pre-push dual model-pinned review (GPT 5.6 + Opus): 3 blocking findings total, all verified against the code and fixed (fail-safe default flip, returncode guard, TTL-branch liveness split); two test fakes' `kill()` signatures updated to mirror the new contract.

## Known limits / trade-offs

- The default `agent.log_level` is WARNING, so expected-teardown INFO lines are absent from `gateway.log` unless the operator raises verbosity. That silence is the point of this fix (recycles are not operator-actionable), but it does mean "why was my warm provider recycled?" now needs `log_level: INFO`. Documented in acp-client.md.
- `kill()` on a live runtime logs `returncode=None` (unchanged): reaping before logging so the returncode is populated is explicitly out of scope per the issue triage; if reviewers want it, it gets a follow-up issue.
- A residual race narrower than the one closed remains: a process that exited but whose `returncode` the child watcher has not yet set can still take the INFO path if killed in that exact window. Closing it fully requires reaping before logging (out of scope, above).

Closes #4052
