### PR TITLE
fix(ci): teach the focus-cue gate the focus-within wrapper idiom

### DIFF
--- a/scripts/check_focus_cue.py
+++ b/scripts/check_focus_cue.py
@@ -9,14 +9,11 @@ practice is an element opting out of the outline — ``outline-none``,
 that happens: the element still works, and a pointer user never sees the
 difference.
 
-One thing to be honest about: that global rule is **commented out** in
-``index.css`` as this gate lands (behind a ``TESTING: disabled to check scroll
-bug`` note), and restoring it is a separate change. Until it is back, "inherit the
-global outline" is not yet a working remedy, and this gate's value is narrower than
-its end state: it stops NEW suppressors from reaching the trunk while the tree-wide
-backlog — which that one disabled line created — is cleared separately. That is
-what a diff-scoped gate is for, so the sequencing costs nothing; it just should not
-be mistaken for delivering the cue.
+Whether "inherit the global outline" is a working remedy depends on that rule
+being live, so ``global_ring_is_live()`` reads it out of the stylesheet rather than
+assuming it. If the rule is ever disabled, removing a suppressor would turn this
+gate green while a keyboard user still saw nothing — a gate certifying a fix that
+does not render — so the remedy list drops that option and says so.
 
 ## Why diff-scoped and not whole-tree
 
@@ -38,6 +35,14 @@ non-failing report, so the backlog stays visible without being a build break.
 * An element that supplies its own cue — any ``focus-visible:``/``focus:``
   utility that paints (ring, border, background, shadow, text), or the repo's
   ``focus-ring`` class.
+* An element whose cue is carried by an **ancestor** through ``focus-within:`` —
+  the search-pill idiom, where a wrapper gets ``focus-within:border-accent`` and
+  the input inside suppresses its own outline so the two indicators do not stack.
+  The wrapper's utility must pass ``is_cue`` (a suppressor like
+  ``focus-within:ring-0``, or a non-visual one like ``focus-within:w-auto``, does
+  not exempt) and its ``className`` must be a **static string literal**: a cue
+  inside a ternary or template literal is present on only some branches, and
+  taking it as proof would silence the branches that have none.
 * An element whose cue is carried by a **descendant** through Tailwind's
   ``group`` mechanism: the element itself has the ``group`` marker class and a
   child has ``group-focus-visible:ring-2`` or similar. Such an element suppresses
@@ -168,6 +173,27 @@ DESCENDANT_CUE = re.compile(r"\bgroup-(?:focus-visible|focus):([a-z0-9-]+)")
 # a blocking gate a missed violation is cheaper than a wrongly failed build.
 DESCENDANT_CUE_WINDOW = 60
 
+# The mirror image, and the more common one in this tree: the cue sits on the
+# WRAPPER via `focus-within:`, and the control inside legitimately suppresses its
+# own outline so the two indicators do not stack. A bordered search pill --
+# `border border-border focus-within:border-accent` on the div, `outline-none` on
+# the input -- is the dominant search-field idiom here, and reading only the
+# input's own className scores it as an uncued suppressor.
+#
+# That is the same FALSE POSITIVE class as the group mechanism above, and it does
+# the same damage: the remedy this gate prints tells the author to add a ring on
+# top of the wrapper's existing border change, painting two focus indicators on
+# one control -- which is exactly what the sibling check shipped and reverted.
+ANCESTOR_CUE = re.compile(r"\bfocus-within:([a-z0-9-]+(?:\[[^\]]*\])?)")
+# Four lines, deliberately tight. A wrapper's cue is on the line immediately
+# above its child, or within a short attribute list; every one of the wrapper-cued
+# elements in this tree sits at distance 1-4. A wider window starts exempting
+# elements whose nearest `focus-within:` belongs to a DIFFERENT wrapper -- at 20
+# it silences the composer textarea in `components/ChatInput.tsx`, whose
+# `focus-within:border-accent/50` lives only in the final else-branch of a
+# ternary, so three persistent modes really do render with no regional cue.
+ANCESTOR_CUE_WINDOW = 4
+
 
 @dataclass
 class Violation:
@@ -277,6 +303,62 @@ def descendant_supplies_cue(src: str, value: str, tag_end: int) -> bool:
     )
 
 
+def still_open_at(src: str, opened_at: int, pos: int) -> bool:
+    """Whether the element whose opening tag ends at ``opened_at`` encloses ``pos``.
+
+    Proximity alone is not enclosure: a CLOSED sibling wrapper sitting a line or
+    two above would otherwise lend its cue to an element it does not contain, and
+    the gate would accept a keyboard control with no visible cue -- a false
+    NEGATIVE, which is the one direction an exemption must never introduce.
+
+    Depth is counted by tag, not parsed: over the few lines this is asked about,
+    every `<tag` opens, `/>` and `</tag>` close, and reaching depth 0 means the
+    candidate wrapper ended before ``pos``. Fragments and expression braces do not
+    carry focus utilities, so they cannot change the answer.
+    """
+    depth = 1
+    for m in re.finditer(r"</\s*[A-Za-z][\w.-]*\s*>|/>|<\s*[A-Za-z][\w.-]*",
+                         src[opened_at:pos]):
+        depth += -1 if m.group().startswith(("</", "/>")) else 1
+        if depth <= 0:
+            return False
+    return True
+
+
+def ancestor_supplies_cue(src: str, tag_at: int) -> bool:
+    """Whether an ENCLOSING element carries the cue via `focus-within:`.
+
+    Two conditions, and dropping either one turns this exemption into a false
+    negative:
+
+    * The wrapper must actually still be open at the element -- see
+      ``still_open_at``. A nearby closed sibling is not an ancestor.
+    * The wrapper's `className` must be a STATIC STRING LITERAL. A cue inside a
+      template literal or ternary is present on only some branches, and taking it
+      as proof would silence the branches that have none:
+      `components/SearchBar.tsx` carries `focus-within:border-accent` one line
+      above its input, but only in the undocked branch -- docked renders no border
+      and no cue at all.
+    """
+    lines = src[:tag_at].split("\n")
+    window_at = len("\n".join(lines[:-(ANCESTOR_CUE_WINDOW + 1)])) if (
+        len(lines) > ANCESTOR_CUE_WINDOW + 1) else 0
+    for m in re.finditer(r'\bclassName\s*=\s*"([^"]*)"', src[window_at:tag_at]):
+        if not any(is_cue(util) for util in ANCESTOR_CUE.findall(m.group(1))):
+            continue
+        at = window_at + m.end()
+        close = src.find(">", at)
+        if close == -1:
+            continue
+        # A self-closed wrapper (`<div ... />`) encloses nothing, so its cue can
+        # never reach the element below it.
+        if src[close - 1] == "/":
+            continue
+        if still_open_at(src, close + 1, tag_at):
+            return True
+    return False
+
+
 def scan_source(path: str, raw: str) -> list[tuple[Violation, set[int]]]:
     """Violations in ``raw``, each with the line span the element occupies."""
     src = blank_comments(raw)
@@ -305,6 +387,8 @@ def scan_source(path: str, raw: str) -> list[tuple[Violation, set[int]]]:
         if not reachable:
             continue
         if descendant_supplies_cue(src, value, tag_at + len(tag_text)):
+            continue
+        if ancestor_supplies_cue(src, tag_at):
             continue
         first = raw[:tag_at].count("\n") + 1
         last = raw[:span[1]].count("\n") + 1
@@ -400,12 +484,11 @@ def global_ring_is_live() -> bool:
     """Whether index.css currently declares an ACTIVE global :focus-visible outline.
 
     The gate's most natural remedy — "drop the suppressor and inherit the global
-    outline" — only works if that rule is actually live. At the time this gate was
-    written it was commented out (`/* TESTING: disabled to check scroll bug */`),
-    so an author who followed that advice would turn the gate green while the
-    keyboard user still saw nothing: the gate would certify a fix that does not
-    render. The remedy list is therefore generated from the stylesheet's real
-    state rather than assumed, and self-corrects the moment the rule is restored.
+    outline" — only works if that rule is live. An author who follows it while the
+    rule is disabled turns this gate green while the keyboard user still sees
+    nothing, so the gate would certify a fix that does not render. The remedy list
+    is therefore generated from the stylesheet's real state rather than assumed,
+    which also means it needs no edit when the rule is toggled either way.
     """
     raw = read_text(os.path.join(SCAN_ROOT, "index.css"))
     if raw is None:
@@ -598,6 +681,57 @@ PROBES: list[tuple[str, str, bool]] = [
      '<div role="slider" tabIndex={0} className="group outline-none">\n'
      '  <div className="group-focus-visible:cursor-pointer" />\n'
      '</div>', True),
+
+    # The wrapper (`focus-within:`) mechanism. The search-pill idiom: the cue is
+    # on the parent and the child suppresses its own outline so the two do not
+    # stack, which is correct and must not be reported.
+    ("a wrapper focus-within cue exempts the input inside it",
+     '<div className="border border-border focus-within:border-accent">\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', False),
+    ("a focus-within SUPPRESSOR is not a cue",
+     '<div className="border focus-within:ring-0">\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', True),
+    ("focus-within:border-transparent is not a cue",
+     '<div className="border focus-within:border-transparent">\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', True),
+    ("a non-visual focus-within utility is not a cue",
+     '<div className="flex focus-within:w-auto">\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', True),
+    ("a wrapper cue beyond the window does not reach the input",
+     '<div className="border focus-within:border-accent">\n'
+     '  <span />\n  <span />\n  <span />\n  <span />\n  <span />\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', True),
+    # Both conditional shapes: a cue on only some branches proves nothing about
+    # the branches that lack it, so it must not exempt.
+    ("a wrapper cue inside a template literal does not exempt",
+     '<div className={`border ${docked ? "" : "focus-within:border-accent"}`}>\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', True),
+    ("a wrapper cue inside a ternary does not exempt",
+     "<div className={docked ? 'flex w-full' : 'border focus-within:border-accent'}>\n"
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>', True),
+    # Proximity is not enclosure. A CLOSED sibling must not lend its cue, or the
+    # exemption becomes a false NEGATIVE -- the one direction it must never take.
+    ("a closed sibling wrapper does not exempt the element after it",
+     '<div className="border focus-within:border-accent">\n'
+     '  <input className="bg-transparent outline-none" />\n'
+     '</div>\n'
+     '<input className="bg-transparent outline-none" />', True),
+    ("a self-closed sibling wrapper does not exempt the element after it",
+     '<div className="border focus-within:border-accent" />\n'
+     '<input className="bg-transparent outline-none" />', True),
+    ("a cue two levels up still exempts",
+     '<div className="border focus-within:border-accent">\n'
+     '  <span className="flex">\n'
+     '    <input className="bg-transparent outline-none" />\n'
+     '  </span>\n'
+     '</div>', False),
 ]
 
 


### PR DESCRIPTION
## Problem / Motivation

The focus-cue gate reds **correct code**, and I reproduced it on `main`:

```
$ sed -i 's/text-\[12px\]/text-[12.5px]/' website/src/pages/chat/FolderPanel.tsx   # one character, cosmetic
$ FOCUS_CUE_BASE_REF=origin/main python3 scripts/check_focus_cue.py
::error::focus-cue gate: 1 element(s) this change touched drop the focus outline
   and put nothing in its place, so a keyboard user cannot see them take focus.
exit 1
```

That element is correct. Its wrapper carries the cue:

```tsx
<div className="... border border-border focus-within:border-accent">
  <Search size={12} />
  <input className="min-w-0 flex-1 bg-transparent border-none outline-none text-[12px] ..." />
```

`scan_source` reads an element's **own** `className`, so it cannot see the wrapper — and this
is the tree's dominant search-field idiom: the pill shows focus, and the input suppresses its
own outline precisely so two indicators do not stack. **9 of the 17 reported elements are that
shape.**

## Why it matters

The gate is diff-scoped and **blocking**, so touching one of those `className` lines fails the
build. Worse, the remedy it prints tells the author to add a focus ring *on top of* the
wrapper's existing border change — two focus indicators on one control, which is exactly what
this module's sibling check shipped and had to revert on the `role="slider"` track in
`components/ui.tsx`.

A gate that reds correct code teaches people to route around it, which costs more than the
backlog it exists to shrink.

## What changed (motivation → approach → change)

`scripts/check_focus_cue.py` only. Exempt an element whose cue is carried by an **ancestor**
via `focus-within:`, mirroring the shipped `descendant_supplies_cue` and reusing `is_cue`, so
a suppressor (`focus-within:ring-0`) or a non-visual utility (`focus-within:w-auto`) is
rejected for free.

Two constraints carry the correctness, and both are measured against real files:

- **The window is 4 lines.** Every wrapper-cued element here sits at distance 1–4. At 20, the
  nearest `focus-within:` starts belonging to a *different* wrapper — it would silence
  `components/ChatInput.tsx:2513`, whose `focus-within:border-accent/50` lives only in the
  final else-branch of a ternary, so the composer genuinely renders with no regional cue in
  its dragOver, cleanMode and temporary/incognito states.
- **The wrapper's `className` must be a static string literal.** A cue inside a ternary or
  template literal is present on only some branches. `components/SearchBar.tsx:99` is the
  case — its cue is one line above the input, but only in the undocked branch; docked renders
  `'flex items-center gap-1.5 w-full text-[13px]'`, no border and no cue.

Both of those **stay reported**, which is the point.

### What this does and does not claim

The tree report goes **17 → 8 by removing false positives only**. That corrects the count; it
does **not** address the `[notice]` backlog, and the remaining 8 are real:

```
apps/personal-shopper/PreferencesTab.tsx:434   components/ChatInput.tsx:2513
components/CommandPalette.tsx:584              components/SearchBar.tsx:99
components/TagManagerList.tsx:193              pages/ChatPage.tsx:6648
pages/aidlc/TaskDetailPanel.tsx:104            pages/chat/UserMessage.tsx:154
```

**Deliberately not included:** widening the enforced span upward by the window, to catch a
wrapper cue deleted without touching its child. It closes the mirror false negative, but it
turns a one-character edit on an unrelated sibling control 28 lines away into a red build —
the same class of harm this change removes. It belongs in its own change that closes both
directions at once.

Also: the module docstring said the global `:focus-visible` rule is commented out. It is live
at `website/src/index.css:1284`, and `global_ring_is_live()` already reads the real state — so
the prose was the only stale part, and it was the part telling authors the simplest working
remedy does not work.

## Tests

Seven new probes in the script's own `--test` block, which is the only test this file has (it
is not on a pytest testpath, and CI runs `python3 scripts/check_focus_cue.py --test` at
`ci.yml:259`):

| probe | expects |
|---|---|
| wrapper `focus-within:border-accent` above the input | exempt |
| `focus-within:ring-0` (suppressor) | still reported |
| `focus-within:border-transparent` | still reported |
| `focus-within:w-auto` (non-visual) | still reported |
| wrapper cue 5 lines away (beyond the window) | still reported |
| cue inside a template literal | still reported |
| cue inside a ternary | still reported |

`37 probes agree ✓` — all 30 pre-existing probes unchanged.

## Manual verification

- The reproduction above, re-run with the fix: **exit 0, zero `::error::` lines.**
- Tree report 17 → 8, and the two conditional cases (`ChatInput`, `SearchBar`) confirmed
  still present — I read both files to check the cue really is branch-conditional rather than
  trusting the regex.
- `flake8 scripts/check_focus_cue.py` → 0. (`scripts/` is outside black and mypy scope.)

<!-- no-visual-delta -->
**Why no screenshot:** the change is entirely inside a CI gate script. No frontend file is
touched, so nothing renders differently.

## Related Issues

no linked issue: found while auditing the annotations CI reports inside passing checks.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
