### PR TITLE
fix(desktop): seed mochi store across rename, drop defaults filter

### DIFF
--- a/website/electron/mochi/index.js
+++ b/website/electron/mochi/index.js
@@ -14,6 +14,7 @@
 const http = require("http");
 const { app, ipcMain } = require("electron");
 const Store = require("electron-store");
+const { seedRenamedStore } = require("../store-rename");
 const { parseMochiEnabled, enabledOrTrust, hostDisabledMeansTeardown } = require("./instanceGate");
 const {
   SELF_INSTANCE,
@@ -35,7 +36,25 @@ const {
  * and removing the app stays "delete this folder and the two calls in main.js",
  * exactly as this module's header promises.
  */
-const machineStore = new Store({ name: "mochi-machine", defaults: MACHINE_STORE_DEFAULTS });
+const MACHINE_STORE_NAME = "mochi-machine";
+
+// Carry Mochi's per-machine state across the npm `name` rename, exactly as main.js
+// does for the shell's config.json — the rename repoints userData, so this file is
+// orphaned by the same mechanism. Order is load-bearing: the seed only ever runs
+// while the destination does not exist, and `new Store(...)` below creates it.
+//
+// The allowlist is the namespace segments of MACHINE_STORE_DEFAULTS' dotted keys,
+// not the dotted spellings themselves: electron-store resolves dots via
+// dot-notation, so every user-written value in the raw file lives nested under the
+// top-level "mochi" object. Deriving the segments here keeps machineStore.js the
+// single owner of which keys exist.
+seedRenamedStore(app.getPath("userData"), {
+  storeFileName: `${MACHINE_STORE_NAME}.json`,
+  keys: [...new Set(Object.keys(MACHINE_STORE_DEFAULTS).map((k) => k.split(".")[0]))],
+  log: (m) => console.log(`mochi store migration: ${m}`),
+});
+
+const machineStore = new Store({ name: MACHINE_STORE_NAME, defaults: MACHINE_STORE_DEFAULTS });
 
 // Injected by initMochi(); placeholders keep every function definable at load.
 let BACKEND_URL = "";

--- a/website/electron/store-rename.js
+++ b/website/electron/store-rename.js
@@ -86,6 +86,12 @@ function sleepSync(ms) {
 // lets the behavioural settings (runLocalGateway, sshTimeoutMs) come along. Dropping
 // those would mean a user who runs as a pure client gets an unwanted local gateway on
 // the first launch after the rename.
+//
+// Values equal to their defaults are carried too, deliberately. The destination never
+// exists when the seed runs, so seeding a default-equal value is indistinguishable
+// from electron-store writing that default itself — filtering them out could only be
+// done against a hand-copied defaults table, whose silent divergence from main.js
+// would misclassify a real legacy choice as "default, drop it".
 const MIGRATED_KEYS = [
   // Behavioural: an orphaned value silently changes which release channel the user
   // follows, or starts a gateway they run as a pure client to avoid.
@@ -107,31 +113,6 @@ const MIGRATED_KEYS = [
   "linuxFrameless",
 ];
 
-// Defaults main.js constructs the store with, for the keys above. A legacy value equal
-// to its own default carries no intent, so seeding it would only re-state the default
-// and make an empty migration look like a real one.
-const KEY_DEFAULTS = {
-  updateChannel: "",
-  remoteHost: "",
-  kirocrewBinPath: "~/.local/bin/kirocrew",
-  runLocalGateway: true,
-  remoteHosts: {},
-  sshTimeoutMs: 20000,
-  windowState: null,
-  themeAccent: "",
-  globalHotkey: null,
-  linuxFrameless: null,
-};
-
-function isDefault(key, value) {
-  const fallback = KEY_DEFAULTS[key];
-  // Objects (remoteHosts, windowState) need a structural comparison.
-  if (typeof fallback === "object" && fallback !== null) {
-    try { return JSON.stringify(value) === JSON.stringify(fallback); } catch { return false; }
-  }
-  return value === fallback;
-}
-
 /**
  * electron-store's config.json inside the PRE-RENAME userData directory, derived from
  * the live one.
@@ -144,9 +125,10 @@ function isDefault(key, value) {
  * SIBLING of the current one, whatever Electron chose.
  *
  * @param {string} userDataPath app.getPath("userData")
- * @returns {string} path to the legacy config.json, or "" if it cannot be derived
+ * @param {string} [storeFileName] electron-store file inside the userData directory
+ * @returns {string} path to the legacy store file, or "" if it cannot be derived
  */
-function legacyStoreFile(userDataPath) {
+function legacyStoreFile(userDataPath, storeFileName = STORE_FILE_NAME) {
   if (typeof userDataPath !== "string" || !userDataPath) return "";
   // Pick the parser from the path's own SHAPE rather than process.platform, so all
   // three layouts stay testable on one machine and a win32 path is never parsed with
@@ -155,7 +137,7 @@ function legacyStoreFile(userDataPath) {
   const normalized = userDataPath.replace(/[\\/]+$/, "");
   const parent = impl.dirname(normalized);
   if (!parent || parent === normalized) return "";
-  return impl.join(parent, LEGACY_STORE_NAME, STORE_FILE_NAME);
+  return impl.join(parent, LEGACY_STORE_NAME, storeFileName);
 }
 
 /**
@@ -172,6 +154,14 @@ function legacyStoreFile(userDataPath) {
  *
  * @param {string} userDataPath app.getPath("userData")
  * @param {object} [opts]
+ * @param {string} [opts.storeFileName] which electron-store file to seed; defaults to
+ *   the shell's main config.json. Other stores in the same userData directory (e.g.
+ *   Mochi's mochi-machine.json) are orphaned by the same rename and reuse this
+ *   mechanism with their own file name and key allowlist.
+ * @param {string[]} [opts.keys] allowlist of top-level keys to carry from the legacy
+ *   file; defaults to the main store's MIGRATED_KEYS. Must match the RAW file shape:
+ *   electron-store resolves dotted keys via dot-notation, so a namespaced store's
+ *   user data lives under its top-level namespace segment, not the dotted spelling.
  * @param {() => object|null} [opts.readLegacy] injected for tests
  * @param {(file:string, data:string) => void} [opts.writeFile] injected for tests
  * @param {(msg:string) => void} [opts.log]
@@ -179,8 +169,15 @@ function legacyStoreFile(userDataPath) {
  *   synchronous wait between failed legacy-read attempts
  * @returns {boolean} whether a file was written
  */
-function seedRenamedStore(userDataPath, { readLegacy = null, writeFile = null, log = null, sleep = sleepSync } = {}) {
-  const target = path.join(userDataPath || "", STORE_FILE_NAME);
+function seedRenamedStore(userDataPath, {
+  storeFileName = STORE_FILE_NAME,
+  keys = MIGRATED_KEYS,
+  readLegacy = null,
+  writeFile = null,
+  log = null,
+  sleep = sleepSync,
+} = {}) {
+  const target = path.join(userDataPath || "", storeFileName);
   // This invocation's temp sibling, named outside the try so the failure path can
   // remove exactly the file this call created and nothing else.
   let tmp = "";
@@ -190,7 +187,7 @@ function seedRenamedStore(userDataPath, { readLegacy = null, writeFile = null, l
     if (fs.existsSync(target)) return false;
 
     const read = readLegacy || (() => {
-      const file = legacyStoreFile(userDataPath);
+      const file = legacyStoreFile(userDataPath, storeFileName);
       if (!file) return null;
       return JSON.parse(fs.readFileSync(file, "utf8"));
     });
@@ -229,19 +226,21 @@ function seedRenamedStore(userDataPath, { readLegacy = null, writeFile = null, l
     if (!legacy || typeof legacy !== "object") return false;
 
     const seed = {};
-    for (const key of MIGRATED_KEYS) {
+    for (const key of keys) {
       // Key ABSENCE, not emptiness, means "the legacy store has nothing to say". An
       // explicit "" is a real choice — main.js documents globalHotkey null as
       // "platform default" and "" as "disabled" — so treating empty as absent would
-      // silently re-enable a hotkey the user turned off.
+      // silently re-enable a hotkey the user turned off. Default-equal values are
+      // carried for the same reason absence is respected: the destination does not
+      // exist, so re-stating a default is a no-op, and filtering would require a
+      // second defaults table that could drift from the store's real one.
       if (!Object.prototype.hasOwnProperty.call(legacy, key)) continue;
       const value = legacy[key];
       if (value === undefined) continue;
-      if (isDefault(key, value)) continue;
       seed[key] = value;
     }
-    const keys = Object.keys(seed);
-    if (!keys.length) return false;
+    const seededKeys = Object.keys(seed);
+    if (!seededKeys.length) return false;
 
     // ATOMIC: write a temp sibling, then rename. config.json is what electron-store
     // parses on the next launch, so a torn write is worse than no migration at all —
@@ -264,7 +263,7 @@ function seedRenamedStore(userDataPath, { readLegacy = null, writeFile = null, l
     });
     write(tmpName, `${JSON.stringify(seed, null, "\t")}\n`);
     fs.renameSync(tmpName, target);
-    if (log) log(`carried ${keys.length} setting(s) from the pre-rename store: ${keys.join(", ")}`);
+    if (log) log(`carried ${seededKeys.length} setting(s) from the pre-rename store: ${seededKeys.join(", ")}`);
     return true;
   } catch (err) {
     // Remove ONLY this invocation's temp sibling — never `target`. The destination

--- a/website/electron/test/store-rename-migration.test.js
+++ b/website/electron/test/store-rename-migration.test.js
@@ -358,25 +358,28 @@ test("a read failure or absent legacy store seeds nothing at all", () => {
   }
 });
 
-test("carries only the allowlisted keys, and only real values", () => {
+test("carries only the allowlisted keys, including default-equal values", () => {
   // The legacy file is a whole electron-store dump, including keys a newer build may
   // have retired; copying it wholesale would resurrect settings this build no longer
-  // understands. And a legacy value equal to its own default carries no intent, so
-  // seeding it would just re-state the default.
+  // understands. A value equal to its default IS carried: the destination never
+  // exists at seed time, so re-stating a default changes nothing, and filtering it
+  // would require a second defaults table that could silently drift from main.js and
+  // misclassify a real legacy choice as "default, drop it".
   const userData = tmpUserData();
   assert.strictEqual(
     seedRenamedStore(userData, {
       readLegacy: () => ({
         updateChannel: "insider",
         someRetiredFlag: true,
-        themeAccent: "",          // at its default: nothing to carry
+        themeAccent: "",          // equal to its default: carried, and a no-op
       }),
     }),
     true
   );
   const raw = JSON.parse(fs.readFileSync(path.join(userData, "config.json"), "utf8"));
-  assert.deepStrictEqual(Object.keys(raw), ["updateChannel"]);
+  assert.deepStrictEqual(Object.keys(raw).sort(), ["themeAccent", "updateChannel"]);
   assert.strictEqual(raw.someRetiredFlag, undefined);
+  assert.strictEqual(raw.themeAccent, "");
 });
 
 test("preserves an explicitly emptied legacy value", () => {
@@ -409,20 +412,6 @@ test("locates the legacy store beside the CURRENT one, on every platform", () =>
     assert.ok(!file.includes("kirocrew-desktop"), `${platform}: must not point at the CURRENT store`);
     assert.match(file, /config\.json$/, `${platform}: must target electron-store's file`);
   }
-});
-
-test("carries no state of its own — the destination file is the state", () => {
-  // The design invariant, pinned. Successive review rounds pulled in opposite
-  // directions over a persisted retry/freshness flag, because no single flag can
-  // answer both "may I read the legacy store?" and "is the destination untouched?".
-  // Seeding a file that does not exist answers both at once and needs no bookkeeping,
-  // so a reintroduced marker is a regression to that ambiguity.
-  const src = fs.readFileSync(path.join(__dirname, "..", "store-rename.js"), "utf8");
-  assert.doesNotMatch(
-    src,
-    /MIGRATION_MARKER_KEY|MIGRATION_PENDING_KEY|storeExistedBeforeLaunch/,
-    "the destination file's absence is the only state this migration may keep"
-  );
 });
 
 test("main.js seeds BEFORE constructing the store", () => {
@@ -488,4 +477,127 @@ test("the Windows install guide does not contradict the code on the stable lane"
     /KNOWN_CHANNELS = new Set\(\["nightly", "insider", "stable"\]\)/,
     "stable left KNOWN_CHANNELS; the guide's per-channel wording must move with it"
   );
+});
+
+// ---------------------------------------------------------------------------
+// Mochi's per-machine store (mochi-machine.json) crosses the same rename.
+// mochi/index.js reuses seedRenamedStore with its own file name and allowlist.
+// ---------------------------------------------------------------------------
+
+const { MACHINE_STORE_DEFAULTS } = require("../mochi/machineStore");
+
+// The exact allowlist mochi/index.js derives: the namespace segments of the
+// dotted default keys. electron-store resolves dots via dot-notation, so every
+// user-WRITTEN value in the raw file is nested under the top-level namespace
+// object; the flat dotted spellings only ever appear as construction-time
+// defaults, which carry no user intent.
+const MOCHI_KEYS = [...new Set(Object.keys(MACHINE_STORE_DEFAULTS).map((k) => k.split(".")[0]))];
+
+function openMochiStore(userData) {
+  return new Store({ cwd: userData, name: "mochi-machine", defaults: MACHINE_STORE_DEFAULTS });
+}
+
+test("seeds Mochi's machine store across the rename, and the store reads it back", () => {
+  // The raw legacy file as a real pre-rename install wrote it: the flat dotted
+  // defaults from construction, plus the nested namespace object holding what the
+  // user (and the one-shot gateway migration) actually wrote.
+  const legacy = {
+    "mochi.petInstance": "self",
+    "mochi.shortcuts": null,
+    "mochi.machinePrefsMigrated": false,
+    "mochi.userSetPrefs": [],
+    mochi: {
+      petInstance: "remote-5476",
+      shortcuts: { summon: "Alt+M" },
+      machinePrefsMigrated: true,
+      userSetPrefs: ["mochi.petInstance"],
+    },
+  };
+  const userData = tmpUserData();
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      storeFileName: "mochi-machine.json",
+      keys: MOCHI_KEYS,
+      readLegacy: () => legacy,
+    }),
+    true
+  );
+
+  // Only the nested namespace is carried; the flat construction defaults are dead
+  // data and stay behind.
+  const raw = JSON.parse(fs.readFileSync(path.join(userData, "mochi-machine.json"), "utf8"));
+  assert.deepStrictEqual(Object.keys(raw), ["mochi"]);
+
+  // Read back through a real electron-store the way mochi/index.js constructs it.
+  const store = openMochiStore(userData);
+  assert.strictEqual(store.get("mochi.petInstance"), "remote-5476");
+  assert.deepStrictEqual(store.get("mochi.shortcuts"), { summon: "Alt+M" });
+  // The one-shot flag survives, so the gateway import cannot re-run over choices
+  // the user made after the rename.
+  assert.strictEqual(store.get("mochi.machinePrefsMigrated"), true);
+  assert.deepStrictEqual(store.get("mochi.userSetPrefs"), ["mochi.petInstance"]);
+});
+
+test("a legacy Mochi store that was never written seeds nothing", () => {
+  // An install where the user never touched Mochi holds only the flat
+  // construction-time defaults — no nested namespace object exists. There is no
+  // intent to carry, so no file is written and construction regenerates defaults.
+  const userData = tmpUserData();
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      storeFileName: "mochi-machine.json",
+      keys: MOCHI_KEYS,
+      readLegacy: () => ({
+        "mochi.petInstance": "self",
+        "mochi.shortcuts": null,
+        "mochi.machinePrefsMigrated": false,
+        "mochi.userSetPrefs": [],
+      }),
+    }),
+    false
+  );
+  assert.strictEqual(fs.existsSync(path.join(userData, "mochi-machine.json")), false);
+});
+
+test("seeding Mochi's store never touches the main config.json, and vice versa", () => {
+  // Two stores, one directory, one mechanism: each seed is scoped to its own file,
+  // so a Mochi seed on a machine whose config.json already exists (or the reverse)
+  // must neither block on nor overwrite the sibling.
+  const userData = tmpUserData();
+  const existing = openStore(userData);
+  existing.set("updateChannel", "stable");
+
+  assert.strictEqual(
+    seedRenamedStore(userData, {
+      storeFileName: "mochi-machine.json",
+      keys: MOCHI_KEYS,
+      readLegacy: () => ({ mochi: { petInstance: "remote-1" } }),
+    }),
+    true,
+    "an existing config.json must not make mochi-machine.json ineligible"
+  );
+  assert.strictEqual(openStore(userData).get("updateChannel"), "stable");
+  assert.strictEqual(openMochiStore(userData).get("mochi.petInstance"), "remote-1");
+});
+
+test("locates the legacy Mochi store beside the legacy config.json", () => {
+  const file = legacyStoreFile(
+    "/Users/jane/Library/Application Support/kirocrew-desktop",
+    "mochi-machine.json"
+  );
+  assert.ok(file.includes(LEGACY_STORE_NAME), "must name the legacy dir");
+  assert.match(file, /mochi-machine\.json$/, "must target Mochi's own store file");
+});
+
+test("mochi/index.js seeds BEFORE constructing its store", () => {
+  // Same load-bearing order as main.js: electron-store writes its defaults on
+  // construction, so a seed placed after `new Store(...)` finds the file already
+  // present and never runs. Neither ordering fails a unit test on its own, so pin
+  // the order in the source.
+  const src = fs.readFileSync(path.join(__dirname, "..", "mochi", "index.js"), "utf8");
+  const seed = src.indexOf("seedRenamedStore(app.getPath");
+  const construct = src.indexOf("const machineStore = new Store(");
+  assert.notStrictEqual(seed, -1, "expected the seed call in mochi/index.js");
+  assert.notStrictEqual(construct, -1, "expected the store construction in mochi/index.js");
+  assert.ok(seed < construct, "the seed must precede `new Store(...)`");
 });


### PR DESCRIPTION
## Problem / Motivation

PR #4976 seeded the shell's main `config.json` across the Windows npm rename, but Mochi's `mochi-machine.json` — a second electron-store in the same userData directory — is orphaned by the exact same mechanism. On the first launch after the rename, the pet's instance choice and accepted shortcuts are lost, and the reset `machinePrefsMigrated` flag lets the one-shot gateway import re-run over choices the user made after the rename. Two further cleanup items were deferred out of #4976 by its First Principles review: the `isDefault`/`KEY_DEFAULTS` filter carries a hand-copied defaults table that can silently diverge from `main.js`, and the "carries no state of its own" test greps for three identifier spellings rather than asserting behavior.

## Why it matters

A Windows user who crosses the rename loses their pet placement and shortcut acceptances silently, and the re-run gateway import can overwrite post-rename choices — the same "the app forgot me" class #4976 fixed for the main store. The defaults-table drift risk is worse than cosmetic: a changed default in `main.js` (e.g. `sshTimeoutMs`) would make the filter misclassify a real legacy choice as "default, drop it" and destroy it.

## What changed (motivation → approach → change)

- **Mochi store seeding.** `seedRenamedStore` / `legacyStoreFile` are parameterized by `storeFileName` and a key allowlist (defaults preserve the existing `config.json` behavior). `mochi/index.js` invokes the shared mechanism immediately before constructing its store — ordering is load-bearing, same as `main.js`. The Mochi allowlist is derived from `MACHINE_STORE_DEFAULTS`' namespace segments (`["mochi"]`), not the dotted spellings: electron-store resolves dotted keys via dot-notation, so every user-written value in the raw file lives nested under the top-level `"mochi"` object, while the flat dotted keys written at construction are dead data (verified empirically against electron-store 8.x / conf's shallow defaults merge). Deriving the segments keeps `machineStore.js` the single owner of which keys exist.
- **Defaults filter dropped.** The destination never exists at seed time, so seeding a default-equal value is behaviorally indistinguishable from electron-store writing that default itself; the filter's only real effect was the divergence-prone copied table. No filter needs to remain, so nothing was single-sourced.
- **Identifier-grep test deleted.** The absence-only-eligibility behavioral tests ("NEVER touches a destination that already exists", "a failed write leaves the destination absent, so the next launch retries") carry the real invariant; a grep for three spellings does not.

## Tests

- `seeds Mochi's machine store across the rename, and the store reads it back` — nested-namespace carry, flat dead defaults left behind, `machinePrefsMigrated: true` survives so the gateway import cannot re-run.
- `a legacy Mochi store that was never written seeds nothing` — defaults-only legacy file writes no destination.
- `seeding Mochi's store never touches the main config.json, and vice versa` — per-file eligibility isolation.
- `locates the legacy Mochi store beside the legacy config.json` — `legacyStoreFile` file-name parameterization.
- `mochi/index.js seeds BEFORE constructing its store` — pins the load-bearing order, same pattern as the existing `main.js` pin.
- `carries only the allowlisted keys, including default-equal values` — updated: retired keys still dropped; default-equal values now carried.

Full electron suite: 1199 pass / 0 fail.

## Manual verification

N/A — this is Windows-specific packaging plumbing exercised end-to-end by the migration test suite against real electron-store instances; a live Windows run adds no coverage the tests lack.

<!-- no-visual-delta -->
**Why no screenshot:** boot-time store migration in the Electron main process; no rendered surface changes.

## Related Issues

Fixes #5009

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, module comments updated in place
- [x] No secrets, credentials, or internal references in the diff
