### PR TITLE
fix: refuse update hard reset on a diverged checkout (#5143)

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -148,7 +148,7 @@ choice blob makes the usage line unreadable.
 | `kirocrew token` | Print a dashboard access URL with auth token |
 | `kirocrew logout` | Revoke all active dashboard sessions, refresh chains included |
 | `kirocrew manifest` | Generate Slack manifest with user alias auto-populated |
-| `kirocrew update` | Update to latest version (git pull + rebuild) |
+| `kirocrew update` | Update to latest version (git fetch + hard reset to upstream + rebuild; a diverged checkout is refused — `--force` discards its local commits) |
 | `kirocrew status` | Show runtime stats from running gateway |
 | `kirocrew stop` | Stop a running gateway (service-aware: stops the systemd/launchd service if active, otherwise terminates the gateway found by a cross-platform port lookup — lsof on POSIX, netstat on Windows). Pass `--port N` to bypass the service short-circuit and target a specific gateway. |
 | `kirocrew restart` | Restart a running gateway (service-aware: restarts the systemd/launchd service if active, otherwise terminates the foreground gateway and respawns it detached). Pass `--port N` to bypass the service short-circuit and target a specific gateway. |
@@ -579,7 +579,25 @@ Each step checks if the tool is already installed and skips if present.
 
 `kirocrew update` pulls the latest source and rebuilds:
 
-1. `git pull` from `KIROCREW_PROJECT_DIR`
+1. `git fetch` + `git reset --hard origin/<branch>` from `KIROCREW_PROJECT_DIR`.
+   The reset only runs for a FAST-FORWARDABLE checkout — behind its upstream
+   and not ahead of it (`git rev-list --count --left-right
+   HEAD...origin/<branch>` shows behind > 0, ahead = 0) — mirroring the
+   dashboard check's verdict, because the hard reset discards committed local
+   work and the uncommitted-changes prompt does not cover it. A DIVERGED
+   checkout (both sides non-zero) is refused with a non-zero exit and a
+   rebase-or-merge instruction; `--force` is the explicit opt-in that lets the
+   reset discard the local commits. An ahead-only checkout has nothing to pull
+   and is reported as up to date without resetting (even under `--force` — the
+   flag lets a real update discard diverged work, it does not delete commits
+   when there is nothing to update to). An unreadable comparison refuses
+   (fail closed). Uncommitted tracked changes still prompt before being
+   discarded — and because that prompt makes the gap to the reset unbounded,
+   the divergence count is re-taken immediately before the reset and refuses
+   commits that appeared while the update was waiting (committing the listed
+   edits in another terminal to rescue them is the natural response to the
+   prompt, and is exactly what would otherwise be reset away). Only `HEAD` can
+   move in that window, so the re-check needs no second fetch.
 2. Rebuilds the dashboard via `build_frontend_sync()` (npm; non-fatal on failure)
 3. Reinstalls backend via `pip install -e .`
 

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1567,7 +1567,15 @@ Examples:
     pod_cleanup = pod_sub.add_parser("_cleanup")
     pod_cleanup.add_argument("name")
 
-    cli_help.add_command(sub, "update")
+    update_parser = cli_help.add_command(sub, "update")
+    update_parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Discard local commits when a git checkout has diverged from its "
+            "upstream (git installs only)"
+        ),
+    )
 
     # stop
     stop_parser = cli_help.add_command(sub, "stop")
@@ -2427,7 +2435,7 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
     elif args.command == "update":
         from kiro_crew.cli_server import _update
 
-        _update()
+        _update(force=args.force)
     elif args.command == "stop":
         from kiro_crew.cli_server import _stop
 

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -950,12 +950,20 @@ def _restart(cli_port: int | None = None) -> None:
     _print_token_url(port)
 
 
-def _update() -> None:
+def _update(force: bool = False) -> None:
     """Update Kiro Crew — dispatches based on install layout.
 
     Three install layouts, three update paths:
 
     * **git checkout** — fetch + reset --hard + rebuild (existing path).
+      The reset only runs for a FAST-FORWARDABLE checkout (behind its
+      upstream, not ahead). A checkout that has DIVERGED (committed local
+      work both ahead of and behind ``origin/<branch>``) is refused: the
+      hard reset would discard the local commits, and the tracked-change
+      prompt only covers uncommitted edits. ``force=True`` (the ``--force``
+      CLI flag) is the explicit opt-in that lets the reset discard them.
+      An ahead-only checkout has nothing to pull and is reported as up to
+      date without resetting.
     * **wheel / cli.sh** — fetch the release feed, compare versions, and
       re-run the installer if newer. This is the path that was missing and
       caused the ``KIROCREW_PROJECT_DIR not set`` error for cli.sh installs.
@@ -1062,6 +1070,84 @@ def _update() -> None:
         print("\n✅ Already up to date!")
         return
 
+    # Divergence guard. The hard reset below discards local COMMITTED work,
+    # and the tracked-change prompt after this only sees uncommitted edits —
+    # a checkout carrying its own commits passes that prompt silently.
+    # Mirror the dashboard check's verdict: only a fast-forwardable checkout
+    # (behind and not ahead) proceeds to the reset; ahead-only has nothing to
+    # pull and returns without resetting; true divergence refuses unless the
+    # operator explicitly opted in with --force. Counted against
+    # origin/<branch> — the exact ref the reset targets, freshly updated by
+    # the fetch above.
+    #
+    # This runs TWICE — once here, once immediately before the reset — because
+    # the prompt below makes the gap to the destructive step unbounded. Both
+    # calls go through one classifier so the two sites differ only in what they
+    # PRINT, never in which states they recognise: a state handled in one and
+    # forgotten in the other is how a guard grows a hole.
+    def _divergence_verdict() -> tuple[str, int, int]:
+        """Classify HEAD against ``origin/<branch>`` for the reset decision.
+
+        Returns ``(verdict, ahead, behind)`` where verdict is one of:
+
+        * ``"unreadable"`` — the comparison could not be read; the caller must
+          refuse, since a guard that cannot count must not wave a destructive
+          reset through.
+        * ``"up_to_date"`` — nothing to pull (``behind == 0``), so
+          origin/<branch> is an ancestor of HEAD and the reset could only
+          REMOVE commits. Never resettable, ``--force`` included: that flag
+          exists to let a real update discard diverged work, not to delete
+          commits when there is nothing to update to.
+        * ``"diverged"`` — ahead AND behind; resettable only under ``--force``.
+        * ``"fast_forward"`` — behind and not ahead; nothing of its own to lose.
+        """
+        result = subprocess.run(
+            ["git", "rev-list", "--count", "--left-right", f"HEAD...origin/{branch}"],
+            cwd=proj,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            print(f"  ❌ Could not compare HEAD against origin/{branch}:")
+            print(f"     {result.stderr.strip() or result.stdout.strip()}")
+            return "unreadable", -1, -1
+        # ``--left-right`` with the three-dot range prints "<ahead>\t<behind>":
+        # left is reachable from HEAD only, right from origin/<branch> only.
+        try:
+            ahead_text, behind_text = result.stdout.split()
+            ahead, behind = int(ahead_text), int(behind_text)
+        except ValueError:
+            print(f"  ❌ Could not parse the commit counts against origin/{branch}:")
+            print(f"     {result.stdout.strip()!r}")
+            return "unreadable", -1, -1
+        if behind == 0:
+            return "up_to_date", ahead, behind
+        if ahead > 0:
+            return "diverged", ahead, behind
+        return "fast_forward", ahead, behind
+
+    def _report_up_to_date(ahead: int) -> None:
+        suffix = f" ({ahead} local commit(s) ahead of origin/{branch})" if ahead else ""
+        print(f"\n✅ Already up to date!{suffix}")
+
+    verdict, ahead, behind = _divergence_verdict()
+    if verdict == "unreadable":
+        sys.exit(1)
+    if verdict == "up_to_date":
+        _report_up_to_date(ahead)
+        return
+    if verdict == "diverged":
+        if not force:
+            print(f"  ⚠️  This checkout has diverged from origin/{branch}:")
+            print(f"      {ahead} local commit(s) not on origin/{branch}, {behind} behind.")
+            print("  A hard reset would discard the local commits. Reconcile instead:")
+            print(f"      git rebase origin/{branch}    (or: git merge origin/{branch})")
+            print("  Or discard the local commits explicitly:")
+            print("      kirocrew update --force")
+            sys.exit(1)
+        print(f"  ⚠️  --force: discarding {ahead} local commit(s) not on origin/{branch}.")
+
     # Warn about local tracked-file changes before discarding
     status = subprocess.run(
         ["git", "status", "--porcelain"],
@@ -1081,6 +1167,29 @@ def _update() -> None:
         if resp != "y":
             print("  Aborted.")
             sys.exit(0)
+
+    # Re-classify immediately before the reset. The verdict above is a
+    # snapshot, and the prompt makes the gap to the reset unbounded:
+    # committing the listed changes in another terminal is the natural way to
+    # rescue them, and rebasing them onto the upstream afterwards is the
+    # natural next step — the first leaves the snapshot stale, the second
+    # turns the checkout ahead-only, and both end in the reset deleting the
+    # commits the operator just made to save that work. Only HEAD can move
+    # here (origin/<branch> is a local ref that only a fetch rewrites), so
+    # this needs no second network round trip.
+    verdict, ahead, behind = _divergence_verdict()
+    if verdict == "unreadable":
+        sys.exit(1)
+    if verdict == "up_to_date":
+        # Not an error: the operator's own commits made the update unnecessary.
+        # Unresettable even under --force, exactly as in the first pass.
+        _report_up_to_date(ahead)
+        return
+    if verdict == "diverged" and not force:
+        print(f"  ⚠️  Refusing to reset: {ahead} local commit(s) appeared on HEAD while")
+        print("      this update was waiting, which a hard reset would discard.")
+        print(f"      Reconcile with: git rebase origin/{branch}")
+        sys.exit(1)
 
     print(f"  🔄 git reset --hard origin/{branch}…")
     result = subprocess.run(

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -937,6 +937,9 @@ class _GitStub:
         self.rc = rc
         self.calls: list[list[str]] = []
         self.status_out = ""
+        # Behind-only by default: these tests model a fast-forwardable
+        # checkout, which the divergence guard waves through.
+        self.rev_list_out = "0\t5\n"
 
     def __call__(self, argv, **kw):
         self.calls.append(list(argv))
@@ -946,6 +949,10 @@ class _GitStub:
             return subprocess.CompletedProcess(argv, self.rc.get("fetch", 0), "", "no remote")
         if argv[:2] == ["git", "diff"]:
             return subprocess.CompletedProcess(argv, self.rc.get("diff", 1), "", "")
+        if argv[:2] == ["git", "rev-list"]:
+            return subprocess.CompletedProcess(
+                argv, self.rc.get("rev_list", 0), self.rev_list_out, ""
+            )
         if argv[:2] == ["git", "status"]:
             return subprocess.CompletedProcess(argv, 0, self.status_out, "")
         if argv[:2] == ["git", "reset"]:

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -796,6 +796,15 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_server.py::_logs_cmd",
         "cli_server.py::_spawn_detached_gateway",
         "cli_server.py::_update",
+        # Nested helper inside ``_update``, keyed separately because the audit
+        # keys by function name. Same class as its enclosing function, already
+        # allowlisted above: a read-only ``git rev-list --count --left-right
+        # HEAD...origin/<branch>`` on the install's own checkout, run on the
+        # one-shot ``kirocrew update`` path. Fixed argv with no shell; the only
+        # interpolated value is the branch name ``git rev-parse --abbrev-ref
+        # HEAD`` just reported, and it sits after the ``origin/`` prefix so it
+        # cannot become an option. Nothing agent-supplied, nothing written.
+        "cli_server.py::_divergence_verdict",
         "cli_server.py::_update_wheel",
         "cli_setup.py::_setup_electron",
         # Cursor Motion overlay renderer: `<this interpreter> -m

--- a/test/test_update_wheel_dispatch.py
+++ b/test/test_update_wheel_dispatch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import subprocess  # noqa: F401 -- used via monkeypatch.setattr
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -445,3 +445,340 @@ class TestUpdateDispatch:
         # Verify git commands were issued
         git_calls = [c for c in calls if c[0] == "git"]
         assert any("rev-parse" in c for c in git_calls)
+
+
+class TestUpdateDivergenceGuard:
+    """The git update path refuses a hard reset on a DIVERGED checkout.
+
+    ``git reset --hard origin/<branch>`` discards committed local work, and the
+    uncommitted-changes prompt only covers dirty files — a checkout both ahead
+    of and behind its upstream passed it silently. The dashboard's update check
+    only offers fast-forwardable updates for the same reason; the CLI mirrors
+    that verdict, with ``--force`` as the operator's explicit opt-in.
+    """
+
+    def _run_update(
+        self,
+        monkeypatch,
+        tmp_path,
+        *,
+        counts: str,
+        revlist_rc: int = 0,
+        force: bool = False,
+        porcelain: str = "",
+        answer: str = "y",
+        calls: list[list[str]] | None = None,
+        later_counts: str | None = None,
+    ) -> list[list[str]]:
+        """Drive ``cs._update`` through a faked git checkout; return the call log.
+
+        ``calls`` may be supplied by the caller so the log stays readable when
+        the update exits via ``SystemExit`` (the return value never lands then).
+        """
+        proj = tmp_path / "project"
+        proj.mkdir()
+        _init_repo(proj)
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.resolve_remote_url", lambda *a, **k: ""
+        )
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.update_blocked_reason", lambda *a: ""
+        )
+
+        import kiro_crew.cli_server as cs
+
+        if calls is None:
+            calls = []
+        seen_revlist = [0]
+
+        def fake_run(args, **kwargs):
+            calls.append(list(args))
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            if args[0] == "git":
+                if "--show-toplevel" in args:
+                    result.stdout = f"{proj}\n"
+                elif "--abbrev-ref" in args:
+                    result.stdout = "main\n"
+                elif "diff" in args:
+                    # Non-zero: the upstream has new commits, so the update
+                    # proceeds past the up-to-date early return.
+                    result.returncode = 1
+                elif "rev-list" in args:
+                    result.returncode = revlist_rc
+                    # ``later_counts`` models HEAD moving between the guard's
+                    # count and the pre-reset re-check (the operator committing
+                    # while the prompt waits): every call after the first
+                    # answers with the new distance.
+                    seen_revlist[0] += 1
+                    if later_counts is not None and seen_revlist[0] > 1:
+                        result.stdout = later_counts
+                    else:
+                        result.stdout = counts
+                elif "status" in args:
+                    result.stdout = porcelain
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        # Short-circuit everything after the reset: the guard under test sits
+        # before these steps, and they are not what these tests assert on.
+        monkeypatch.setattr("kiro_crew.cli_server.shutil.which", lambda *_: None)
+        monkeypatch.setattr("kiro_crew.cli._ensure_node", lambda *_: None)
+        monkeypatch.setattr("kiro_crew.cli_server.build_frontend_sync", lambda *_: None)
+        monkeypatch.setattr("kiro_crew.cli_server.dep_sync.sync_or_reinstall", lambda *a, **k: 0)
+        monkeypatch.setattr("builtins.input", lambda *_: answer)
+
+        cs._update(force=force)
+        return calls
+
+    @staticmethod
+    def _reset_calls(calls: list[list[str]]) -> list[list[str]]:
+        return [c for c in calls if c[0] == "git" and "reset" in c]
+
+    def test_diverged_refuses_without_reset(self, monkeypatch, tmp_path, capsys) -> None:
+        """Ahead AND behind → refuse with counts + guidance, exit 1, NO reset."""
+        calls: list[list[str]] = []
+        with pytest.raises(SystemExit) as exc:
+            self._run_update(monkeypatch, tmp_path, counts="2\t5\n", calls=calls)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "diverged" in out
+        assert "2 local commit(s)" in out
+        assert "5 behind" in out
+        assert "git rebase origin/main" in out
+        assert "--force" in out
+        assert not self._reset_calls(calls)
+
+    def test_diverged_with_force_resets(self, monkeypatch, tmp_path, capsys) -> None:
+        """``--force`` is the explicit opt-in: the reset runs, with a warning."""
+        calls = self._run_update(monkeypatch, tmp_path, counts="2\t5\n", force=True)
+        assert self._reset_calls(calls)
+        out = capsys.readouterr().out
+        assert "discarding 2 local commit(s)" in out
+
+    def test_behind_only_still_updates(self, monkeypatch, tmp_path, capsys) -> None:
+        """A fast-forwardable checkout (behind, not ahead) resets as before."""
+        calls = self._run_update(monkeypatch, tmp_path, counts="0\t5\n")
+        assert self._reset_calls(calls)
+        assert "diverged" not in capsys.readouterr().out
+
+    def test_ahead_only_reports_up_to_date_without_reset(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        """Ahead-only has nothing to pull: no reset, reported as up to date.
+
+        With behind = 0 the upstream is an ancestor of HEAD, so a hard reset
+        could only REMOVE the local commits and never bring anything in.
+        """
+        calls = self._run_update(monkeypatch, tmp_path, counts="3\t0\n")
+        assert not self._reset_calls(calls)
+        out = capsys.readouterr().out
+        assert "Already up to date" in out
+        assert "3 local commit(s) ahead" in out
+
+    def test_ahead_only_force_still_never_resets(self, monkeypatch, tmp_path, capsys) -> None:
+        """--force lets a real update discard diverged work; with nothing to
+        pull it must not become a commit-deletion command."""
+        calls = self._run_update(monkeypatch, tmp_path, counts="3\t0\n", force=True)
+        assert not self._reset_calls(calls)
+        assert "Already up to date" in capsys.readouterr().out
+
+    def test_unreadable_counts_fail_closed(self, monkeypatch, tmp_path, capsys) -> None:
+        """A failed rev-list must not wave the destructive reset through."""
+        calls: list[list[str]] = []
+        with pytest.raises(SystemExit) as exc:
+            self._run_update(monkeypatch, tmp_path, counts="", revlist_rc=128, calls=calls)
+        assert exc.value.code == 1
+        assert "Could not compare" in capsys.readouterr().out
+        assert not self._reset_calls(calls)
+
+    def test_unparseable_counts_fail_closed(self, monkeypatch, tmp_path, capsys) -> None:
+        """rev-list succeeding with garbage output is still a refusal."""
+        with pytest.raises(SystemExit) as exc:
+            self._run_update(monkeypatch, tmp_path, counts="not-a-count\n")
+        assert exc.value.code == 1
+        assert "Could not parse the commit counts" in capsys.readouterr().out
+
+    def test_uncommitted_prompt_abort_unchanged(self, monkeypatch, tmp_path, capsys) -> None:
+        """The dirty-tree prompt still runs and still aborts on anything but y."""
+        calls: list[list[str]] = []
+        with pytest.raises(SystemExit) as exc:
+            self._run_update(
+                monkeypatch,
+                tmp_path,
+                counts="0\t5\n",
+                porcelain=" M file.py\n",
+                answer="n",
+                calls=calls,
+            )
+        assert exc.value.code == 0
+        assert "Aborted" in capsys.readouterr().out
+        assert not self._reset_calls(calls)
+
+    def test_uncommitted_prompt_continue_unchanged(self, monkeypatch, tmp_path) -> None:
+        """Answering y at the dirty-tree prompt still proceeds to the reset."""
+        calls = self._run_update(
+            monkeypatch, tmp_path, counts="0\t5\n", porcelain=" M file.py\n", answer="y"
+        )
+        assert self._reset_calls(calls)
+
+    def test_commits_made_while_the_prompt_waits_are_not_reset(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        """Committing the listed changes during the prompt must not lose them.
+
+        The first count is a snapshot and the prompt makes the gap to the reset
+        unbounded. Rescuing the listed edits with a commit in another terminal
+        is the natural response to that prompt, and it is exactly what makes
+        the snapshot's ``ahead`` stale.
+        """
+        calls: list[list[str]] = []
+        with pytest.raises(SystemExit) as exc:
+            self._run_update(
+                monkeypatch,
+                tmp_path,
+                counts="0\t5\n",  # fast-forwardable when the guard looked
+                later_counts="2\t5\n",  # two commits appeared during the prompt
+                porcelain=" M file.py\n",
+                answer="y",
+                calls=calls,
+            )
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "appeared on HEAD while" in out
+        assert "2 local commit(s)" in out
+        assert not self._reset_calls(calls)
+
+    def test_force_still_resets_commits_made_during_the_prompt(self, monkeypatch, tmp_path) -> None:
+        """``--force`` keeps its meaning across the re-check: discard and reset."""
+        calls = self._run_update(
+            monkeypatch,
+            tmp_path,
+            counts="0\t5\n",
+            later_counts="2\t5\n",
+            porcelain=" M file.py\n",
+            answer="y",
+            force=True,
+            calls=[],
+        )
+        assert self._reset_calls(calls)
+
+    def test_recheck_fails_closed_when_it_cannot_count(self, monkeypatch, tmp_path, capsys) -> None:
+        """An unreadable re-check refuses too — the reset is the destructive step."""
+        calls: list[list[str]] = []
+        with pytest.raises(SystemExit) as exc:
+            self._run_update(
+                monkeypatch,
+                tmp_path,
+                counts="0\t5\n",
+                later_counts="garbage\n",
+                porcelain=" M file.py\n",
+                answer="y",
+                calls=calls,
+            )
+        assert exc.value.code == 1
+        assert "Could not parse the commit counts" in capsys.readouterr().out
+        assert not self._reset_calls(calls)
+
+    def test_rebased_during_the_prompt_is_never_reset_even_with_force(
+        self, monkeypatch, tmp_path, capsys
+    ) -> None:
+        """Ahead-only after the prompt must not reset, ``--force`` included.
+
+        Committing the listed edits and then rebasing them onto the upstream is
+        the natural two-step rescue. It leaves the checkout ahead-only, where a
+        reset can only delete those commits — so the re-check has to recognise
+        `up_to_date` exactly as the first pass does, rather than only asking
+        whether the checkout is diverged.
+        """
+        calls: list[list[str]] = []
+        self._run_update(
+            monkeypatch,
+            tmp_path,
+            counts="0\t5\n",  # fast-forwardable when the guard looked
+            later_counts="3\t0\n",  # committed + rebased during the prompt
+            porcelain=" M file.py\n",
+            answer="y",
+            force=True,
+            calls=calls,
+        )
+        assert not self._reset_calls(calls)
+        out = capsys.readouterr().out
+        assert "Already up to date" in out
+        assert "3 local commit(s) ahead" in out
+
+    @pytest.mark.parametrize(
+        "later, resets, force",
+        [
+            ("0\t5\n", True, False),  # still fast-forwardable -> reset
+            ("2\t5\n", False, False),  # became diverged -> refuse
+            ("2\t5\n", True, True),  # became diverged, opted in -> reset
+            ("3\t0\n", False, False),  # became ahead-only -> nothing to pull
+            ("3\t0\n", False, True),  # ...and --force does not change that
+            ("garbage\n", False, False),  # unreadable -> fail closed
+            ("garbage\n", False, True),  # ...and --force does not change that
+        ],
+    )
+    def test_recheck_recognises_the_same_states_as_the_first_pass(
+        self, monkeypatch, tmp_path, later, resets, force
+    ) -> None:
+        """The two passes may differ in wording, never in which states they see.
+
+        Both route through one classifier; this pins every verdict at the
+        second call site so a state handled before the prompt cannot be
+        forgotten after it.
+        """
+        calls: list[list[str]] = []
+        try:
+            self._run_update(
+                monkeypatch,
+                tmp_path,
+                counts="0\t5\n",
+                later_counts=later,
+                porcelain=" M file.py\n",
+                answer="y",
+                force=force,
+                calls=calls,
+            )
+        except SystemExit as exc:
+            assert exc.code == 1, "a refusal after the prompt is an error exit"
+        assert bool(self._reset_calls(calls)) is resets
+
+    def test_cli_wires_force_flag(self, monkeypatch) -> None:
+        """``kirocrew update --force`` reaches ``_update(force=True)``."""
+        import sys
+
+        with (
+            patch.object(sys, "argv", ["kirocrew", "update", "--force"]),
+            # These tests exercise argparse wiring only. Real logging setup
+            # attaches a RotatingFileHandler on gateway.log that outlives the
+            # test, and an open fd there blocks the isolated home's cleanup on
+            # Windows.
+            patch("kiro_crew.cli._setup_cli_logging"),
+            patch("kiro_crew.cli_server._update") as mock_update,
+        ):
+            from kiro_crew.cli import main
+
+            main()
+            mock_update.assert_called_once_with(force=True)
+
+    def test_cli_defaults_force_off(self, monkeypatch) -> None:
+        """A bare ``kirocrew update`` keeps the guard armed (force=False)."""
+        import sys
+
+        with (
+            patch.object(sys, "argv", ["kirocrew", "update"]),
+            patch("kiro_crew.cli._setup_cli_logging"),
+            patch("kiro_crew.cli_server._update") as mock_update,
+        ):
+            from kiro_crew.cli import main
+
+            main()
+            mock_update.assert_called_once_with(force=False)


### PR DESCRIPTION
## Problem / Motivation

`kirocrew update` on a git-checkout install runs `git reset --hard origin/<branch>` after warning only about **uncommitted** tracked changes (`git status --porcelain`). A DIVERGED checkout — committed local work that is both ahead of and behind its upstream — passes that porcelain check silently, so the hard reset discards the committed local commits with **no warning at all**.

The dashboard surfaces already received the equivalent guard (#4498): the update check computes `ahead`/`behind` in both directions and only offers a fast-forwardable update. The CLI path was out of that work's scope and still had the gap — this is the follow-up flagged as the unfixed sibling of the same root cause.

## Why it matters

Anyone developing against a source checkout (the exact audience of `kirocrew update`'s git path) can lose committed work to a single routine update command. The loss is silent — recovery is reflog-only, which is invisible to the user whose branch just lost commits.

## What changed (motivation → approach → change)

Symptom: committed local work vanishes on `kirocrew update`. Root cause: the only pre-reset guard reads `git status --porcelain`, which by definition cannot see committed divergence. The dashboard's check path already established the codebase's verdict for this reset: only a **fast-forwardable** checkout (behind, not ahead) may take it.

The CLI now mirrors that verdict. After the existing `git fetch`, `_update()` counts divergence in both directions with `git rev-list --count --left-right HEAD...origin/<branch>` — the exact ref the reset targets. There is no importable shared helper for this: #5119 (the dashboard half of #4498) has since merged and kept the computation inline, so `dashboard/handlers/updates.py` now carries two copies itself; factoring the four in-tree call sites into one helper is a separate change, filed as #5205 rather than widening this fix. The four quadrants:

- **Behind-only** (fast-forwardable): resets as before, including the unchanged uncommitted-changes prompt.
- **Diverged** (ahead > 0 and behind > 0): refuses with the counts and a rebase-or-merge instruction, exits non-zero, never resets. A new `--force` flag on `kirocrew update` is the explicit opt-in that lets the reset discard the local commits — reasonable on the CLI (the operator is present and explicit) where it is not on the server endpoint.
- **Ahead-only** (behind = 0): `origin/<branch>` is an ancestor of `HEAD`, so a reset could only *remove* commits and can never bring anything in — reported as "Already up to date (N local commit(s) ahead)" and returns without resetting, `--force` included. The flag lets a real update discard diverged work; it does not delete commits when there is nothing to update to. This is deliberately stricter than the merged `POST /api/update` precondition, which refuses only true divergence: that endpoint's action primitive is `git pull --ff-only`, which is already a no-op on an ahead-only tree, whereas `git reset --hard` there is purely destructive. Different action, different precondition.
- **Unreadable comparison** (rev-list fails or output unparseable): refuses, fail closed — a guard that cannot count must not wave a destructive reset through.

**The count is taken twice, and the second time is the load-bearing one.** The quadrant decision above is a snapshot, and the uncommitted-changes prompt makes the gap between it and the reset unbounded. Worse, the natural response to `Local tracked-file changes will be discarded` is to rescue that work by committing it in another terminal — which is precisely what leaves the snapshot's `ahead` stale, so answering `y` would then delete the commits just made to save it. So the count is re-taken immediately before the reset and refuses commits that appeared in the meantime (`--force` still discards, keeping the flag's meaning identical across both checks; an unreadable re-check fails closed like the first). Both checks share one local `_count_divergence()` helper rather than a second copy of the parse, and the re-check needs no second `git fetch`: only `HEAD` can move in that window, since `origin/<branch>` is a local ref that only a fetch rewrites.

Docs: `docs/system-specs/modules/cli.md`'s Update Command section and command-table row updated in the same commit (the table row previously claimed `git pull`, the exact merge-semantics misconception behind the issue).

## Tests

All in `test/test_update_wheel_dispatch.py` (new `TestUpdateDivergenceGuard`, faked-git harness recording every subprocess call):

- diverged → refuses with counts + guidance, exit 1, **no reset call issued**
- diverged + `--force` → reset runs, with an explicit discarding warning
- behind-only → still resets (fast-forwardable path unchanged)
- ahead-only → no reset, reported up to date with the ahead count
- ahead-only + `--force` → still no reset (the flag never becomes a commit-deletion command)
- rev-list failure and unparseable output → exit 1, no reset (fail closed)
- uncommitted-changes prompt: abort ("n" → exit 0, no reset) and continue ("y" → reset) both unchanged
- commits appearing **during** the prompt (0→2 ahead across the `input()`): refuses, exit 1, no reset call issued
- the same case under `--force`: still resets, so the flag keeps one meaning across both checks
- an unreadable **re**-check: refuses too, since the reset is the destructive step either way
- CLI wiring: `kirocrew update --force` reaches `_update(force=True)`; bare `kirocrew update` passes `force=False`

`test/test_cli_server_more_coverage.py`'s `_GitStub` answers the new `rev-list` call with a behind-only count so the existing early-exit-branch tests keep their intent.

Verified with the prepare-pr `prove.py` harness: with the production hunks reverted and the tests kept, the new tests fail at assertion (PROVEN).

## Manual verification

N/A — unit coverage sufficient: the guard's quadrants, exit codes, and the reset call's presence/absence are all pinned by the faked-git tests, and the surrounding update pipeline is untouched.

## Related Issues

Fixes #5143

Two follow-ups found while making this fix, both deliberately out of scope here:

- **#5163** — the remaining unguarded `git reset --hard origin/<branch>` site. `_auto_apply_update` (`slack/gateway.py`) is reached from the **mandatory policy version-floor** branch on `can_apply` alone, bypassing the `can_fast_forward` gate that makes the ordinary `auto_update` trigger safe, and its own preflight is a content diff that a diverged checkout passes. So a diverged checkout under a policy `min_version` still loses committed work unattended. It needs a different mechanism from this PR's — there is no operator present to prompt, and `--force` semantics do not map onto a policy mandate.
- **#5205** — the ahead/behind `rev-list --left-right` computation now has three in-tree inline copies (`updates.py` ×2 after #5119 merged keeping it inline, plus `cli_server.py` here). No shared helper exists today; factoring them is its own change.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend/CLI-only change; no frontend file touched and no rendered UI delta.



