### PR TITLE
feat(cli): group the top-level help and lead with gateway/service/doctor

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -84,6 +84,48 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 
 ## Commands
 
+### Top-level help
+
+`kirocrew --help` (and a bare `kirocrew`, which prints the banner first) does NOT
+use argparse's own subcommand block. With ~40 commands that block is one flat
+list in registration order, so the three commands a new install needs — `gateway`,
+`service`, `doctor` — land in the middle of it, and the `{chat,doctor,gateway,…}`
+choice blob makes the usage line unreadable.
+
+`cli_help.py` owns the taxonomy instead:
+
+- `COMMAND_GROUPS` is an ordered list of sections, each an ordered list of
+  `(command, one-line summary)`. It is the single source of truth for what the
+  top-level help lists and in what order; `Start here` is first and holds exactly
+  `gateway`, `service`, `doctor`.
+- Its notes answer the two questions the flat list never did: how `gateway`
+  (foreground, dies with the terminal) differs from `service install` (systemd
+  unit / launchd agent, detached, restarts on crash, starts at boot, only one at
+  a time), and that the dashboard on loopback `5476` is the **only** port opened
+  — messaging channels connect outbound.
+- `cli.py` sets `help=argparse.SUPPRESS` on the subparsers action to hide
+  argparse's listing, passes `cli_help.TOP_USAGE` as the top-level `usage=`
+  (the suppressed action would otherwise drop the placeholder), and pins
+  `prog="kirocrew"` on the action so each subcommand's own usage line is
+  `usage: kirocrew <cmd> …` rather than the whole top-level usage string.
+- Every user-facing command is registered with `cli_help.add_command(sub, name)`,
+  which raises `KeyError` for a name that is in no section — a new command cannot
+  be added without appearing in the help. The section summary becomes the
+  subparser's `description`, which is what `kirocrew <cmd> --help` prints, so the
+  sentence is not duplicated. A caller may pass its own longer `description`
+  (`bench` does).
+- Internal `mcp-*` servers call `sub.add_parser(name)` with no `help`, which keeps
+  them out of both listings. They are also kept out of argparse's
+  `invalid choice: 'x' (choose from …)` message: `cli_help.hide_internal_commands`
+  swaps the subparsers action's `choices` for a live Mapping view over the same
+  parser map that ITERATES only user-facing commands, in the help's section order.
+  Membership is unfiltered and `_name_parser_map` is untouched, so `kirocrew
+  mcp-core` still dispatches — the filter changes what argparse prints, never what
+  it accepts. It must be installed after the last `add_parser` and before
+  `parse_args`.
+- `test/test_cli_help.py` pins offered-vs-listed parity by reading that same
+  message, and pins that a hidden command still resolves.
+
 | Command | Description |
 |---------|-------------|
 | `kirocrew chat -m "msg"` | Send a single message, print streaming response |
@@ -144,7 +186,7 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew computer call --calls '[…]'` | Run a JSON array of tool calls in a SINGLE process, so `element_index` values from an earlier `computer_get_state` are still resolvable |
 | `kirocrew mcp-cron` | MCP server for cron tools (spawned by kiro-cli) |
 | `kirocrew mcp-core` | MCP server for spawn, learn, task tools (spawned by kiro-cli) |
-| `kirocrew mcp-computer` | MCP server for computer-use tools (spawned by kiro-cli; `argparse.SUPPRESS`-hidden). A **thin shim** — it forwards to the gateway over loopback and does no accessibility work itself. |
+| `kirocrew mcp-computer` | MCP server for computer-use tools (spawned by kiro-cli; hidden — registered with no `help`, so it is in neither listing). A **thin shim** — it forwards to the gateway over loopback and does no accessibility work itself. |
 | `kirocrew --version` | Print version |
 
 ## Token Command Output Streams

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -38,7 +38,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import NoReturn
 
-from kiro_crew import __version__, platform_compat
+from kiro_crew import __version__, cli_help, platform_compat
 from kiro_crew.apps.builtins import BUILTIN_NAMES as _BUILTIN_NAMES
 from kiro_crew.config import KiroCrewConfig, config_dir, ensure_data_home
 from kiro_crew.config.loader import (
@@ -932,6 +932,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         prog="kirocrew",
         description="Kiro Crew — personal AI agent",
+        usage=cli_help.TOP_USAGE,
+        epilog=cli_help.render_epilog(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--version", action="version", version=f"kirocrew {__version__}")
     parser.add_argument(
@@ -964,15 +967,28 @@ def main() -> None:
         "the public edition, which has no jail backend).",
     )
 
-    sub = parser.add_subparsers(dest="command")
+    # ``help=SUPPRESS`` drops argparse's own flat subcommand block — ~40 commands
+    # in registration order, with the three anybody needs first buried in the
+    # middle — in favour of the grouped listing rendered into ``epilog`` above.
+    # It also drops the placeholder from the usage line, hence the explicit
+    # ``usage=``. ``metavar`` is what an "invalid choice" error names, and
+    # ``prog`` must be pinned because argparse otherwise derives each
+    # subcommand's prog from the parent's ``usage=`` string, which would prefix
+    # every ``kirocrew <cmd> --help`` with the whole top-level usage line.
+    sub = parser.add_subparsers(
+        dest="command",
+        metavar="<command>",
+        help=argparse.SUPPRESS,
+        prog="kirocrew",
+    )
 
     # Helper for commands with examples
     _fmt = argparse.RawDescriptionHelpFormatter
 
     # chat
-    chat_parser = sub.add_parser(
+    chat_parser = cli_help.add_command(
+        sub,
         "chat",
-        help="Chat with the agent",
         epilog="""
 Examples:
   kirocrew chat                      # Interactive mode
@@ -987,7 +1003,7 @@ Examples:
     chat_parser.add_argument("--agent", help="Agent to use (default: from config)")
 
     # doctor
-    _doctor_parser = sub.add_parser("doctor", help="Verify Kiro Crew setup")
+    _doctor_parser = cli_help.add_command(sub, "doctor")
     _doctor_parser.add_argument(
         "--bundle",
         action="store_true",
@@ -995,9 +1011,7 @@ Examples:
     )
 
     # gateway
-    gw_parser = sub.add_parser(
-        "gateway", help="Start the Kiro Crew server (dashboard + messaging channels)"
-    )
+    gw_parser = cli_help.add_command(sub, "gateway")
     gw_parser.add_argument(
         "--slack-only",
         action="store_true",
@@ -1083,7 +1097,7 @@ Examples:
     )
 
     # setup
-    setup_parser = sub.add_parser("setup", help="Install agent config and run the setup wizard")
+    setup_parser = cli_help.add_command(sub, "setup")
     setup_parser.add_argument(
         "--agent-only",
         action="store_true",
@@ -1109,7 +1123,7 @@ Examples:
     )
 
     # manifest
-    manifest_parser = sub.add_parser("manifest", help="Generate Slack manifest with your alias")
+    manifest_parser = cli_help.add_command(sub, "manifest")
     manifest_parser.add_argument("--alias", help="Override alias (default: auto-detect)")
     manifest_parser.add_argument("-o", "--output", help="Output file (default: stdout)")
     manifest_parser.add_argument(
@@ -1119,9 +1133,9 @@ Examples:
     )
 
     # cron
-    cron_parser = sub.add_parser(
+    cron_parser = cli_help.add_command(
+        sub,
         "cron",
-        help="Manage scheduled jobs",
         epilog="""
 Examples:
   kirocrew cron list
@@ -1230,9 +1244,9 @@ Examples:
     )
 
     # spawn
-    spawn_parser = sub.add_parser(
+    spawn_parser = cli_help.add_command(
+        sub,
         "spawn",
-        help="Manage background subagents",
         epilog="""
 Examples:
   kirocrew spawn run 'check my open CRs'        # Wait for result
@@ -1254,9 +1268,9 @@ Examples:
     spawn_parser.add_argument("--port", type=int, default=DASHBOARD_PORT, help="Dashboard port")
 
     # run (autonomous task runner)
-    run_parser = sub.add_parser(
+    run_parser = cli_help.add_command(
+        sub,
         "run",
-        help="Run an autonomous task from a spec file",
         epilog="""
 Examples:
   kirocrew run TASK.md                  # Run task with auto-resume
@@ -1294,7 +1308,7 @@ Examples:
     )
 
     # snapshot / restore
-    snap_parser = sub.add_parser("snapshot", help="Create a portable backup of Kiro Crew state")
+    snap_parser = cli_help.add_command(sub, "snapshot")
     snap_parser.add_argument(
         "output_dir",
         nargs="?",
@@ -1306,7 +1320,7 @@ Examples:
         "--list", action="store_true", dest="list_snapshots", help="List existing snapshots"
     )
 
-    rest_parser = sub.add_parser("restore", help="Restore Kiro Crew state from a snapshot")
+    rest_parser = cli_help.add_command(sub, "restore")
     rest_parser.add_argument("snapshot", nargs="?", help="Path to snapshot .tar.gz")
     rest_parser.add_argument(
         "--mode",
@@ -1325,12 +1339,12 @@ Examples:
     )
 
     # security
-    sec_parser = sub.add_parser("security", help="Security audit and deny list")
+    sec_parser = cli_help.add_command(sub, "security")
 
     # eval (benchmark harness)
-    eval_parser = sub.add_parser(
+    eval_parser = cli_help.add_command(
+        sub,
         "eval",
-        help="Run multi-session evaluation scenarios",
         epilog="""
 Examples:
   kirocrew eval                         # smoke test (~30s)
@@ -1370,9 +1384,7 @@ Examples:
     sec_sub.add_parser("verify", help="Verify security event log HMAC integrity")
 
     # policy — governance model inspection (read-only; MCP-safe)
-    tn_parser = sub.add_parser(
-        "tailnet", help="Publish this dashboard on your tailnet (Tailscale)"
-    )
+    tn_parser = cli_help.add_command(sub, "tailnet")
     tn_sub = tn_parser.add_subparsers(dest="tailnet_action")
     for _tn_name, _tn_help in (
         ("status", "Show whether the dashboard is published and trusted on your tailnet"),
@@ -1393,7 +1405,7 @@ Examples:
             help="Dashboard port to publish (default: discover the running gateway)",
         )
 
-    tel_parser = sub.add_parser("telemetry", help="Inspect or disable anonymous usage telemetry")
+    tel_parser = cli_help.add_command(sub, "telemetry")
     tel_sub = tel_parser.add_subparsers(dest="telemetry_action")
     tel_sub.add_parser(
         "status", help="Show exactly what the anonymous beacon sends (and whether it will)"
@@ -1401,9 +1413,7 @@ Examples:
     tel_sub.add_parser("disable", help="Turn the anonymous beacon off permanently")
     tel_sub.add_parser("enable", help="Turn the anonymous beacon back on")
 
-    policy_parser = sub.add_parser(
-        "policy", help="Inspect the governance security policy + profiles"
-    )
+    policy_parser = cli_help.add_command(sub, "policy")
     policy_sub = policy_parser.add_subparsers(dest="policy_action")
     policy_show = policy_sub.add_parser("show", help="Show the effective enterprise security policy")
     policy_show.add_argument(
@@ -1435,7 +1445,7 @@ Examples:
     register_bench_parser(sub)
     register_desktop_parser(sub)
 
-    kn_parser = sub.add_parser("knowledge", help="Knowledge Base maintenance")
+    kn_parser = cli_help.add_command(sub, "knowledge")
     kn_sub = kn_parser.add_subparsers(dest="knowledge_action")
     kn_dedup = kn_sub.add_parser(
         "dedup", help="Collapse cross-source duplicate documents (dry-run unless --apply)"
@@ -1447,10 +1457,7 @@ Examples:
     )
 
     # pod — isolated, throwaway, full-stack test instances per worktree (kubectl-style)
-    pod_parser = sub.add_parser(
-        "pod",
-        help="Isolated, throwaway, full-stack test instances per worktree (kubectl-style)",
-    )
+    pod_parser = cli_help.add_command(sub, "pod")
     pod_sub = pod_parser.add_subparsers(
         dest="pod_action",
         metavar="{up,down,ls,prune,status,token,url,logs,exec,provision,install}",
@@ -1560,10 +1567,10 @@ Examples:
     pod_cleanup = pod_sub.add_parser("_cleanup")
     pod_cleanup.add_argument("name")
 
-    sub.add_parser("update", help="Update Kiro Crew to the latest version")
+    cli_help.add_command(sub, "update")
 
     # stop
-    stop_parser = sub.add_parser("stop", help="Stop a running Kiro Crew gateway")
+    stop_parser = cli_help.add_command(sub, "stop")
     stop_parser.add_argument(
         "--port",
         type=int,
@@ -1580,9 +1587,7 @@ Examples:
     # restart — service-aware: restarts the systemd/launchd service if active,
     # otherwise SIGTERMs the foreground gateway and respawns it detached so the
     # shell returns immediately. Mirrors `stop`.
-    restart_parser = sub.add_parser(
-        "restart", help="Restart a running Kiro Crew gateway (service-aware)"
-    )
+    restart_parser = cli_help.add_command(sub, "restart")
     restart_parser.add_argument(
         "--port",
         type=int,
@@ -1600,10 +1605,7 @@ Examples:
     # /etc/systemd/system/, requires sudo) or launchd LaunchAgent (macOS,
     # ~/Library/LaunchAgents/, no sudo) so the gateway survives SSH disconnect,
     # auto-restarts on crash, and auto-starts on boot.
-    svc_parser = sub.add_parser(
-        "service",
-        help="Manage the Kiro Crew gateway as a system service (requires sudo on Linux)",
-    )
+    svc_parser = cli_help.add_command(sub, "service")
     svc_sub = svc_parser.add_subparsers(dest="service_action")
     svc_sub.add_parser("install", help="Install and start the gateway service (sudo on Linux)")
     svc_sub.add_parser("uninstall", help="Stop and remove the gateway service (sudo on Linux)")
@@ -1615,9 +1617,9 @@ Examples:
     # so the agent sandbox fails closed on every spawn. These subcommands attach
     # the same single `userns` grant to the app's own executable path, which the
     # kernel applies at exec time without any privileged transition.
-    sbx_parser = sub.add_parser(
+    sbx_parser = cli_help.add_command(
+        sub,
         "sandbox",
-        help="Manage the AppArmor profile the agent sandbox needs (Linux/Ubuntu)",
         epilog="""
 Examples:
   kirocrew sandbox status                      # is THIS launch covered?
@@ -1656,9 +1658,9 @@ Only needed on hosts with kernel.apparmor_restrict_unprivileged_userns=1
 
     # cloud — provision + run KiroCrew on the user's own AWS EC2 (bring-your-own
     # AWS; credentials resolved by the aws CLI, never stored by KiroCrew).
-    cloud_parser = sub.add_parser(
+    cloud_parser = cli_help.add_command(
+        sub,
         "cloud",
-        help="Run Kiro Crew on your own AWS EC2 instance",
         epilog="""
 Examples:
   kirocrew cloud launch                  # interactive: provision + configure + open dashboard
@@ -1786,7 +1788,7 @@ Examples:
     # logs — tail the gateway log. Reads from the systemd journal when running
     # as a service on Linux, the launchd stdout file on macOS, or the
     # foreground gateway log file otherwise.
-    logs_parser = sub.add_parser("logs", help="Show gateway logs")
+    logs_parser = cli_help.add_command(sub, "logs")
     logs_parser.add_argument(
         "-f", "--follow", action="store_true", help="Follow log output (live tail)"
     )
@@ -1795,10 +1797,10 @@ Examples:
     )
 
     # token
-    token_parser = sub.add_parser("token", help="Print a dashboard access URL with auth token")
+    token_parser = cli_help.add_command(sub, "token")
 
     # logout
-    logout_parser = sub.add_parser("logout", help="Revoke all active dashboard sessions")
+    logout_parser = cli_help.add_command(sub, "logout")
     logout_parser.add_argument(
         "--port",
         type=int,
@@ -1825,7 +1827,7 @@ Examples:
     )
 
     # status
-    status_parser = sub.add_parser("status", help="Show runtime stats")
+    status_parser = cli_help.add_command(sub, "status")
     status_parser.add_argument(
         "--port",
         type=int,
@@ -1834,14 +1836,10 @@ Examples:
     )
 
     # mcp-cron (MCP server — spawned by the agent backend, not user-facing)
-    sub.add_parser("mcp-cron", help=argparse.SUPPRESS)
+    sub.add_parser("mcp-cron")
 
     # consolidate
-    consolidate_parser = sub.add_parser(
-        "consolidate",
-        help="Force history consolidation (triggers auto-skill extraction)",
-        parents=[_jail_opts],
-    )
+    consolidate_parser = cli_help.add_command(sub, "consolidate", parents=[_jail_opts])
     consolidate_parser.add_argument(
         "session_key",
         nargs="?",
@@ -1856,26 +1854,26 @@ Examples:
     )
 
     # mcp-core (MCP server — spawned by the agent backend, not user-facing)
-    sub.add_parser("mcp-core", help=argparse.SUPPRESS)
+    sub.add_parser("mcp-core")
 
     # mcp-computer (MCP server — spawned by the agent backend, not user-facing).
     # A THIN SHIM: it forwards to the gateway over loopback, where the
     # fail-closed governance gate and all accessibility work live.
-    sub.add_parser("mcp-computer", help=argparse.SUPPRESS)
+    sub.add_parser("mcp-computer")
 
     # mcp-dashboard (MCP server — spawned by the agent backend, not user-facing).
     # Mounted only for an agent whose spec grants it, so an unassigned set costs
     # a session nothing: kiro-cli loads a server only when `tools` names it.
-    sub.add_parser("mcp-dashboard", help=argparse.SUPPRESS)
+    sub.add_parser("mcp-dashboard")
 
     # Builtin app MCP servers (spawned by the agent backend, not user-facing)
     for _bname in _BUILTIN_NAMES:
-        sub.add_parser(f"mcp-{_bname}", help=argparse.SUPPRESS)
+        sub.add_parser(f"mcp-{_bname}")
 
     # them in the ``kirocrew-computer`` MCP server instead.
-    computer_parser = sub.add_parser(
+    computer_parser = cli_help.add_command(
+        sub,
         "computer",
-        help="Computer-use (desktop automation) diagnostics",
         epilog="""
 Examples:
   kirocrew computer doctor                     # Support + permission report
@@ -1894,9 +1892,9 @@ Computer use is OFF by default and is enabled only from the dashboard
     )
 
     # learn
-    learn_parser = sub.add_parser(
+    learn_parser = cli_help.add_command(
+        sub,
         "learn",
-        help="Save or manage learned corrections",
         epilog="""
 Examples:
   kirocrew learn list
@@ -1920,9 +1918,9 @@ Examples:
     learn_rm.add_argument("query", help="Substring to match against lesson rules")
 
     # artifact
-    art_parser = sub.add_parser(
+    art_parser = cli_help.add_command(
+        sub,
         "artifact",
-        help="Manage saved artifacts (LLM-generated UI)",
         epilog="""
 Examples:
   kirocrew artifact list
@@ -1986,7 +1984,7 @@ Examples:
     art_ver.add_argument("slug", help="Artifact slug")
 
     # Memory
-    mem_parser = sub.add_parser("memory", help="Manage memory (vector store + markdown layer)")
+    mem_parser = cli_help.add_command(sub, "memory")
     mem_sub = mem_parser.add_subparsers(dest="mem_action")
     mem_sub.add_parser("list", help="Show semantic memory entries")
     mem_search = mem_sub.add_parser("search", help="Search episodic memories")
@@ -2024,7 +2022,7 @@ Examples:
     mem_import.add_argument("file", help="Path to JSON file (export format)")
 
     # agent
-    agent_parser = sub.add_parser("agent", help="Manage Kiro Crew agent definitions")
+    agent_parser = cli_help.add_command(sub, "agent")
     agent_sub = agent_parser.add_subparsers(dest="agent_action")
     agent_sub.add_parser("list", help="List Kiro Crew agents")
     agent_create = agent_sub.add_parser("create", help="Create a Kiro Crew agent")
@@ -2054,7 +2052,7 @@ Examples:
     )
 
     # workspace
-    ws_parser = sub.add_parser("workspace", help="Manage workspace definitions")
+    ws_parser = cli_help.add_command(sub, "workspace")
     ws_sub = ws_parser.add_subparsers(dest="workspace_action")
     ws_sub.add_parser("list", help="List workspaces")
     ws_create = ws_sub.add_parser("create", help="Create a workspace")
@@ -2082,9 +2080,9 @@ Examples:
     ws_delete.add_argument("name", help="Workspace name to delete")
 
     # app
-    app_parser = sub.add_parser(
+    app_parser = cli_help.add_command(
+        sub,
         "app",
-        help="Manage Kiro Crew apps",
         epilog="""
 Examples:
   kirocrew app install /path/to/oncall-watchtower
@@ -2133,9 +2131,9 @@ Examples:
     app_init.add_argument("--cron", action="store_true", help="Include sample cron job")
 
     # config
-    cfg_parser = sub.add_parser(
+    cfg_parser = cli_help.add_command(
+        sub,
         "config",
-        help="Get or set configuration values",
         epilog="""
 Examples:
   kirocrew config get                   # Show all config
@@ -2160,6 +2158,11 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         help="Save to config.local.json (persists across upgrades)",
     )
     cfg_sub.add_parser("edit", help="Open config in $EDITOR")
+
+    # Last registration done: stop argparse from answering an unknown command
+    # with the internal mcp-* server names. Must come after every add_parser,
+    # and before parse_args.
+    cli_help.hide_internal_commands(sub)
 
     args = parser.parse_args()
 

--- a/src/kiro_crew/cli_bench.py
+++ b/src/kiro_crew/cli_bench.py
@@ -19,6 +19,8 @@ import argparse
 import json
 from pathlib import Path
 
+from kiro_crew import cli_help
+
 DEFAULT_OUT_DIR = "bench_results"
 
 
@@ -58,9 +60,9 @@ def _positive_int(raw: str) -> int:
 
 def register_bench_parser(sub: argparse._SubParsersAction) -> None:
     """Wire ``kirocrew bench`` into the top-level parser."""
-    parser = sub.add_parser(
+    parser = cli_help.add_command(
+        sub,
         "bench",
-        help="Run external memory benchmarks (LongMemEval, LoCoMo)",
         description=(
             "Measures the Kiro Crew memory layer against published benchmarks. The "
             "retrieval ruler is deterministic, so a delta between two commits is "

--- a/src/kiro_crew/cli_desktop.py
+++ b/src/kiro_crew/cli_desktop.py
@@ -22,7 +22,7 @@ import os
 import sys
 from pathlib import Path
 
-from kiro_crew import platform_compat
+from kiro_crew import cli_help, platform_compat
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.perf_sampler import gate_refusal_message, profiling_enabled
 
@@ -311,10 +311,7 @@ def desktop_cmd(args: argparse.Namespace) -> int:
 
 def register_desktop_parser(sub: argparse._SubParsersAction) -> None:
     """Register ``kirocrew desktop`` and its subcommands."""
-    parser = sub.add_parser(
-        "desktop",
-        help="Debug-only desktop app diagnostics (requires KIROCREW_DEBUG)",
-    )
+    parser = cli_help.add_command(sub, "desktop")
     # dest must NOT be "command": that collides with the top-level subparsers'
     # dest and silently overwrites the "desktop" value, so dispatch falls through
     # to the argparse help instead of running the subcommand.

--- a/src/kiro_crew/cli_help.py
+++ b/src/kiro_crew/cli_help.py
@@ -1,0 +1,249 @@
+"""Grouped top-level help for the ``kirocrew`` CLI.
+
+argparse lists subcommands as one flat block in registration order, which for
+~40 commands reads as a wall the first three commands anybody needs are buried
+in. This module owns the taxonomy instead: the ordered sections below are the
+single source of truth for what the top-level help shows and in what order, so
+``cli.py`` can keep registering a command wherever its arguments live.
+
+``cli.py`` hides argparse's own listing (``help=SUPPRESS`` on the subparsers
+action) and renders :func:`render_epilog` instead. Every user-facing command
+MUST be registered through :func:`add_command`, which refuses a name that is
+not in a section — that is what keeps the listing from silently omitting a new
+command. Internal commands (the ``mcp-*`` servers the agent backend spawns)
+call ``sub.add_parser`` directly with no ``help``, which keeps them out of both
+listings.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Iterable, Iterator, Mapping
+
+# The dashboard port a default install binds. Duplicated as a STRING for help
+# text only; the runtime value is config/loader.py's ``_DEFAULT_PORT``.
+_DEFAULT_PORT_TEXT = "5476"
+
+# Ordered sections -> ordered (command, one-line summary) pairs. Order here is
+# display order; the first section is what a new user should read first.
+COMMAND_GROUPS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
+    (
+        "Start here",
+        (
+            ("gateway", "Start Kiro Crew in this terminal (dashboard + messaging channels)"),
+            ("service", "Run the gateway as a background service that starts on boot"),
+            ("doctor", "Verify this install and diagnose problems"),
+        ),
+    ),
+    (
+        "Run the gateway",
+        (
+            ("status", "Show runtime stats"),
+            ("restart", "Restart a running gateway (service-aware)"),
+            ("stop", "Stop a running gateway"),
+            ("logs", "Show gateway logs"),
+            ("token", "Print a dashboard access URL with auth token"),
+            ("logout", "Revoke all active dashboard sessions"),
+            ("update", "Update Kiro Crew to the latest version"),
+        ),
+    ),
+    (
+        "Set it up",
+        (
+            ("setup", "Install agent config and run the setup wizard"),
+            ("config", "Get or set configuration values"),
+            ("sandbox", "Manage the AppArmor profile the agent sandbox needs (Linux)"),
+            ("manifest", "Generate a Slack app manifest with your alias"),
+        ),
+    ),
+    (
+        "Work with the agent",
+        (
+            ("chat", "Chat with the agent"),
+            ("run", "Run an autonomous task from a spec file"),
+            ("cron", "Manage scheduled jobs"),
+            ("spawn", "Manage background subagents"),
+            ("computer", "Computer-use (desktop automation) diagnostics"),
+        ),
+    ),
+    (
+        "Memory and knowledge",
+        (
+            ("memory", "Manage memory (vector store + markdown layer)"),
+            ("knowledge", "Knowledge Base maintenance"),
+            ("learn", "Save or manage learned corrections"),
+            ("consolidate", "Force history consolidation (triggers skill extraction)"),
+            ("artifact", "Manage saved artifacts (LLM-generated UI)"),
+        ),
+    ),
+    (
+        "Extend it",
+        (
+            ("app", "Manage Kiro Crew apps"),
+            ("agent", "Manage Kiro Crew agent definitions"),
+            ("workspace", "Manage workspace definitions"),
+        ),
+    ),
+    (
+        "Security and privacy",
+        (
+            ("security", "Security audit and deny list"),
+            ("policy", "Inspect the governance security policy + profiles"),
+            ("telemetry", "Inspect or disable anonymous usage telemetry"),
+        ),
+    ),
+    (
+        "Move it and back it up",
+        (
+            ("cloud", "Run Kiro Crew on your own AWS EC2 instance"),
+            ("tailnet", "Publish this dashboard on your tailnet (Tailscale)"),
+            ("snapshot", "Create a portable backup of Kiro Crew state"),
+            ("restore", "Restore Kiro Crew state from a snapshot"),
+        ),
+    ),
+    (
+        "Develop Kiro Crew itself",
+        (
+            ("pod", "Isolated, throwaway, full-stack test instances per worktree"),
+            ("eval", "Run multi-session evaluation scenarios"),
+            ("bench", "Run external memory benchmarks (LongMemEval, LoCoMo)"),
+            ("perf", "Debug-only performance sampling (off by default)"),
+            ("desktop", "Debug-only desktop app diagnostics (requires KIROCREW_DEBUG)"),
+        ),
+    ),
+)
+
+SUMMARIES: dict[str, str] = {
+    name: summary for _section, commands in COMMAND_GROUPS for name, summary in commands
+}
+
+# Position of each command in the help's listing, for ordering an error message
+# the same way. ``sorted`` is stable, so anything absent sorts to the end while
+# keeping its registration order.
+_LISTING_RANK: dict[str, int] = {name: index for index, name in enumerate(SUMMARIES)}
+
+
+def _listing_rank(name: str) -> int:
+    return _LISTING_RANK.get(name, len(_LISTING_RANK))
+
+
+# argparse builds the usage line from the actions it is allowed to show, and the
+# subparsers action is hidden, so the placeholder is spelled out here instead.
+TOP_USAGE = "kirocrew [-h] [--version] [-v] [--no-jail] <command> [<args>]"
+
+# Why both commands exist, and what a default install actually listens on --
+# the two questions the flat command list never answered.
+_ORIENTATION = f"""\
+gateway vs. service -- the same server, two lifetimes:
+  kirocrew gateway          runs in the foreground and stops on Ctrl-C or when
+                            the terminal closes. Best for a first look and for
+                            development.
+  kirocrew service install  registers a systemd unit (Linux, needs sudo) or a
+                            launchd agent (macOS) that runs the SAME gateway
+                            detached: it survives logout, restarts on crash and
+                            starts at boot. Then use `kirocrew service status`,
+                            `kirocrew restart`, `kirocrew logs`.
+  Run only one of them at a time -- both bind the same port.
+
+Ports: the dashboard is the only port Kiro Crew opens, and it binds loopback
+  only -- http://localhost:{_DEFAULT_PORT_TEXT}. Messaging channels (Slack, Discord, ...)
+  connect outbound, so nothing else needs to be reachable. Override the port
+  with `kirocrew gateway --port N`, KIROCREW_PORT=N, or the `dashboard.url`
+  config value; for the service, set KIROCREW_PORT when you run
+  `service install` (later, edit /etc/kirocrew/kirocrew.env and restart)."""
+
+
+def add_command(
+    sub: argparse._SubParsersAction,  # type: ignore[type-arg]
+    name: str,
+    **kwargs: Any,
+) -> argparse.ArgumentParser:
+    """Register a user-facing top-level command.
+
+    Passing ``help`` is pointless (``cli.py`` hides argparse's own listing), so
+    the section summary is used as the subparser's ``description`` instead --
+    which is what ``kirocrew <command> --help`` prints. A caller that wants a
+    longer description just passes its own.
+
+    Raises ``KeyError`` when ``name`` has no section, so a command cannot be
+    added to the CLI without also appearing in the top-level help.
+    """
+    kwargs.setdefault("description", SUMMARIES[name])
+    return sub.add_parser(name, **kwargs)
+
+
+def render_epilog(width: int = 13) -> str:
+    """Render the grouped command listing with the orientation notes inline.
+
+    The notes sit directly under the first section rather than at the end: they
+    answer "which of these two do I run, and what does it listen on" about the
+    commands immediately above them, and a reader who stops after the first
+    screen is exactly the reader who needs them.
+    """
+    lines: list[str] = []
+    for index, (section, commands) in enumerate(COMMAND_GROUPS):
+        lines.append(f"{section}:")
+        for name, summary in commands:
+            lines.append(f"  {name:<{width}}{summary}")
+        lines.append("")
+        if index == 0:
+            lines.extend([_ORIENTATION, ""])
+    lines.append("Run `kirocrew <command> -h` for a command's own options.")
+    return "\n".join(lines)
+
+
+def visible_commands(choices: Iterable[str]) -> list[str]:
+    """The registered command names that belong in the top-level listing.
+
+    ``mcp-*`` entries are MCP servers the agent backend spawns; they are not
+    commands a person runs, so they are excluded here and carry no ``help``.
+    """
+    return [name for name in choices if not name.startswith("mcp-")]
+
+
+class _VisibleCommandChoices(Mapping[str, Any]):
+    """A live view of the subparser map that ITERATES only user-facing commands.
+
+    argparse builds ``invalid choice: 'x' (choose from ...)`` by joining
+    ``action.choices``, so an unknown command otherwise gets answered with all
+    ~17 internal ``mcp-*`` server names — the same noise the listing itself was
+    just cleaned of. Validation and dispatch do not read ``choices``: the parser
+    tests membership (``__contains__``) and ``_SubParsersAction.__call__``
+    resolves through its own ``_name_parser_map``. So membership stays complete
+    while iteration is filtered, and ``kirocrew mcp-core`` keeps working.
+
+    ``__len__`` follows ``__iter__`` (the visible count) to keep this a coherent
+    view of what it claims to contain; nothing in argparse reads it.
+
+    Iteration follows the help's own section order, so a typo is answered with
+    ``gateway, service, doctor, ...`` rather than registration order. A command
+    that somehow escaped the section table is still listed, at the end, because
+    an error message must never omit a name the parser accepts.
+
+    Backed by a REFERENCE to the real map rather than a copy, so a command
+    registered after this view is installed is still recognised.
+    """
+
+    def __init__(self, commands: Mapping[str, Any]) -> None:
+        self._commands = commands
+
+    def __getitem__(self, key: str) -> Any:
+        return self._commands[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._commands
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(sorted(visible_commands(self._commands), key=_listing_rank))
+
+    def __len__(self) -> int:
+        return len(visible_commands(self._commands))
+
+
+def hide_internal_commands(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Keep ``mcp-*`` out of argparse's invalid-choice error message."""
+    # typeshed annotates ``choices`` as a concrete dict, but argparse only ever
+    # iterates it (to build that message) and tests membership (to validate the
+    # command), both of which a Mapping serves; dispatch reads the action's own
+    # ``_name_parser_map``, which is left untouched.
+    sub.choices = _VisibleCommandChoices(sub.choices)  # type: ignore[assignment]

--- a/src/kiro_crew/cli_perf.py
+++ b/src/kiro_crew/cli_perf.py
@@ -25,7 +25,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from kiro_crew import platform_compat
+from kiro_crew import cli_help, platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.gateway_lock import LOCK_FILENAME
@@ -342,7 +342,7 @@ def register_perf_parser(sub: argparse._SubParsersAction) -> None:
     exists, and "profile" is overloaded three ways in this codebase (governance
     profiles, AWS profiles, deploy profiles).
     """
-    perf_parser = sub.add_parser("perf", help="Debug-only performance sampling (off by default)")
+    perf_parser = cli_help.add_command(sub, "perf")
     perf_sub = perf_parser.add_subparsers(dest="perf_action")
     sample = perf_sub.add_parser(
         "sample",

--- a/test/test_cli_help.py
+++ b/test/test_cli_help.py
@@ -1,0 +1,138 @@
+"""Tests for the grouped top-level ``kirocrew`` help.
+
+The listing a user reads is rendered from ``cli_help.COMMAND_GROUPS``, not from
+argparse's own subcommand block, so the risk this file exists to catch is a
+command that is registered but never listed (or listed but not registered).
+"""
+
+import re
+import sys
+
+import pytest
+
+from kiro_crew import cli_help
+
+
+def _capture_cli(monkeypatch, tmp_path, capsys, argv):
+    """Run ``kirocrew <argv>`` far enough to render help, and return (out, err).
+
+    ``KIROCREW_PROJECT_DIR`` is pinned so ``main()``'s project auto-detection
+    does not walk (and then export) the checkout it happens to run in.
+    """
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["kirocrew", *argv])
+    from kiro_crew.cli import main
+
+    with pytest.raises(SystemExit):
+        main()
+    captured = capsys.readouterr()
+    return captured.out, captured.err
+
+
+def _offered_commands(monkeypatch, tmp_path, capsys) -> list[str]:
+    """The command names argparse offers after an unknown one, in order.
+
+    This is deliberately the error message rather than an attribute of the
+    subparsers action: the message is what a user reads, and argparse's
+    ``_choices_actions`` is not a public API.
+    """
+    _out, err = _capture_cli(monkeypatch, tmp_path, capsys, ["definitely-not-a-command"])
+    match = re.search(r"choose from ([^)]+)\)", err)
+    assert match, f"no invalid-choice list in stderr: {err!r}"
+    return [name.strip().strip("'\"") for name in match.group(1).split(",")]
+
+
+class TestGroupingCoversEveryCommand:
+    def test_offered_and_grouped_sets_match(self, monkeypatch, tmp_path, capsys):
+        offered = set(_offered_commands(monkeypatch, tmp_path, capsys))
+        assert offered == set(cli_help.SUMMARIES), (
+            "top-level help and the registered commands have drifted: "
+            f"registered-but-unlisted={sorted(offered - set(cli_help.SUMMARIES))}, "
+            f"listed-but-unregistered={sorted(set(cli_help.SUMMARIES) - offered)}"
+        )
+
+    def test_each_command_appears_in_exactly_one_group(self):
+        seen: list[str] = [
+            name for _section, commands in cli_help.COMMAND_GROUPS for name, _summary in commands
+        ]
+        duplicates = {name for name in seen if seen.count(name) > 1}
+        assert not duplicates, f"listed in more than one group: {sorted(duplicates)}"
+
+    def test_add_command_refuses_an_ungrouped_name(self):
+        """The guard that makes the drift above impossible for new commands."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        with pytest.raises(KeyError):
+            cli_help.add_command(sub, "not-a-real-command")
+
+
+class TestInternalCommandsStayHidden:
+    """``mcp-*`` are MCP servers the agent backend spawns, not commands."""
+
+    def test_absent_from_the_listing_and_the_invalid_choice_error(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        assert not [name for name in cli_help.SUMMARIES if name.startswith("mcp-")]
+        out, _err = _capture_cli(monkeypatch, tmp_path, capsys, ["--help"])
+        assert "mcp-" not in out
+        offered = _offered_commands(monkeypatch, tmp_path, capsys)
+        assert not [name for name in offered if name.startswith("mcp-")]
+
+    def test_still_dispatchable_despite_being_hidden(self, monkeypatch, tmp_path, capsys):
+        """Hiding filters what argparse PRINTS, never what it accepts."""
+        out, _err = _capture_cli(monkeypatch, tmp_path, capsys, ["mcp-core", "--help"])
+        assert out.startswith("usage: kirocrew mcp-core")
+
+    def test_error_lists_the_starting_commands_first(self, monkeypatch, tmp_path, capsys):
+        """The offer is ordered like the help, not like the registration order."""
+        offered = _offered_commands(monkeypatch, tmp_path, capsys)
+        assert offered[:3] == ["gateway", "service", "doctor"]
+
+    def test_choices_view_keeps_membership_complete(self):
+        commands = {"gateway": object(), "mcp-core": object()}
+        view = cli_help._VisibleCommandChoices(commands)
+        assert "mcp-core" in view and view["mcp-core"] is commands["mcp-core"]
+        assert list(view) == ["gateway"]
+        # A command registered after the view is installed is still recognised.
+        commands["doctor"] = object()
+        assert "doctor" in view and list(view) == ["gateway", "doctor"]
+
+
+class TestTopLevelHelpLayout:
+    def test_start_here_leads_with_gateway_service_doctor(self, monkeypatch, tmp_path, capsys):
+        out, _err = _capture_cli(monkeypatch, tmp_path, capsys, ["--help"])
+        lines = out.splitlines()
+        start = lines.index("Start here:")
+        listed = [line.split()[0] for line in lines[start + 1 : start + 4]]
+        assert listed == ["gateway", "service", "doctor"]
+        # Nothing may be listed above it: the sections after it are the long tail.
+        assert not any(line.endswith(":") and line[0].isupper() for line in lines[:start] if line)
+
+    def test_help_drops_the_argparse_choice_blob_and_suppress_markers(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        out, _err = _capture_cli(monkeypatch, tmp_path, capsys, ["--help"])
+        assert "==SUPPRESS==" not in out
+        assert "{chat," not in out
+        assert out.startswith("usage: kirocrew [-h] [--version] [-v] [--no-jail] <command>")
+
+    def test_subcommand_usage_is_not_prefixed_with_the_top_level_usage(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """argparse derives a subcommand's prog from the parent's ``usage=``."""
+        out, _err = _capture_cli(monkeypatch, tmp_path, capsys, ["service", "--help"])
+        assert out.startswith("usage: kirocrew service")
+
+    def test_orientation_explains_both_lifetimes_and_the_default_port(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        from kiro_crew.config.loader import _DEFAULT_PORT
+
+        out, _err = _capture_cli(monkeypatch, tmp_path, capsys, ["--help"])
+        assert "kirocrew service install" in out
+        assert "foreground" in out
+        # The help text spells the port out; keep it honest against the binder.
+        assert str(_DEFAULT_PORT) in out
+        assert cli_help._DEFAULT_PORT_TEXT == str(_DEFAULT_PORT)


### PR DESCRIPTION
## What

`kirocrew --help` was a wall. It listed ~40 subcommands as one flat argparse
block in **registration order**, so the three commands a new install actually
needs — `gateway`, `service`, `doctor` — sat in the middle of it. The usage line
was a ~400-character `{chat,doctor,gateway,…}` choice blob, 17 internal `mcp-*`
servers rendered as literal `==SUPPRESS==` rows (passing `help=argparse.SUPPRESS`
to `add_parser` prints the sentinel — argparse only honours it on the parent's
own actions), and nothing anywhere said how `gateway` differs from
`service install`, or what port either one opens.

## After

```
usage: kirocrew [-h] [--version] [-v] [--no-jail] <command> [<args>]

Start here:
  gateway      Start Kiro Crew in this terminal (dashboard + messaging channels)
  service      Run the gateway as a background service that starts on boot
  doctor       Verify this install and diagnose problems

gateway vs. service -- the same server, two lifetimes:
  kirocrew gateway          runs in the foreground and stops on Ctrl-C or when
                            the terminal closes. Best for a first look and for
                            development.
  kirocrew service install  registers a systemd unit (Linux, needs sudo) or a
                            launchd agent (macOS) that runs the SAME gateway
                            detached: it survives logout, restarts on crash and
                            starts at boot. Then use `kirocrew service status`,
                            `kirocrew restart`, `kirocrew logs`.
  Run only one of them at a time -- both bind the same port.

Ports: the dashboard is the only port Kiro Crew opens, and it binds loopback
  only -- http://localhost:5476. Messaging channels (Slack, Discord, ...)
  connect outbound, so nothing else needs to be reachable. Override the port
  with `kirocrew gateway --port N`, KIROCREW_PORT=N, or the `dashboard.url`
  config value; for the service, set KIROCREW_PORT when you run
  `service install` (later, edit /etc/kirocrew/kirocrew.env and restart).

Run the gateway:
  status       Show runtime stats
  ...
```

Nine sections follow: `Run the gateway`, `Set it up`, `Work with the agent`,
`Memory and knowledge`, `Extend it`, `Security and privacy`,
`Move it and back it up`, `Develop Kiro Crew itself`.

## How

`cli_help.py` owns the taxonomy. `COMMAND_GROUPS` — ordered sections of ordered
`(command, summary)` pairs — is the single source of truth for the listing, so
**registration order in `cli.py` no longer matters and no command block was
moved** (deliberately: `cli.py` is a hot file).

- `cli.py` sets `help=argparse.SUPPRESS` on the subparsers action to hide
  argparse's flat block, passes `cli_help.TOP_USAGE` as `usage=` (the suppressed
  action would otherwise drop the placeholder from the usage line), and pins
  `prog="kirocrew"` on the action — without it argparse derives each
  subcommand's prog from the parent's `usage=`, prefixing every
  `kirocrew <cmd> --help` with the whole top-level usage string.
- Every user-facing command registers through `cli_help.add_command`, which
  **raises `KeyError` for a name that is in no section**: a new command cannot be
  added without appearing in the help. The section summary becomes the
  subparser's `description` (what `kirocrew <cmd> --help` prints), so the
  sentence exists once. A caller may still pass a longer `description` — `bench`
  does.
- `mcp-*` register with no `help` at all, and `hide_internal_commands` swaps the
  action's `choices` for a live Mapping view over the same parser map that
  iterates only user-facing commands, in section order. So a typo now gets
  `choose from gateway, service, doctor, …` instead of a list including 17 MCP
  servers. **Membership is unfiltered and `_name_parser_map` is untouched**, so
  `kirocrew mcp-core` still dispatches — the filter changes what argparse prints,
  never what it accepts.

## Behaviour change worth calling out

Each command's one-line summary moved from `help=` to `description=`, so
`kirocrew <cmd> --help` now prints that sentence at the top. Previously it
appeared only in the parent listing.

## Tests

`test/test_cli_help.py` (11 tests): offered-vs-grouped parity read off argparse's
own invalid-choice message; no command in two sections; `add_command` refuses an
ungrouped name; `mcp-*` absent from both the help and the error but still
dispatchable; `Start here` leads with the three; no `==SUPPRESS==` / choice blob;
subcommand usage not prefixed with the top-level usage; and the help's spelled-out
port stays equal to `config.loader._DEFAULT_PORT`.

Local gates: `check_black_formatting.py`, `isort`, `flake8`, `mypy` (1031 files),
`docs-lint.sh`, brand and harness-parity gates, and 1140 existing CLI-adjacent
tests.

`docs/system-specs/modules/cli.md` documents the contract under a new
`### Top-level help`.