### PR TITLE
fix: owner-gate remaining MCP/config mutations

### DIFF
--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -44,6 +44,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_LOCAL_DASHBOARD_OWNER_SUBJECTS = frozenset({"local-app", "local-startup"})
+
+
+def is_owner_dashboard_request(request: web.Request) -> bool:
+    """Return whether *request* carries the configured dashboard-owner identity.
+
+    Dashboard mutations use the authenticated token claims populated by the
+    token-auth middleware. An empty app claim distinguishes the dashboard from
+    app-scoped tokens; when no channel owner is configured, only the signed
+    standalone-local bootstrap subjects are accepted.
+    """
+    state = request.app["state"]
+    owner_id = str(getattr(state, "owner_id", "") or "")
+    caller = str(request.get("user") or "")
+    if "app" not in request or request["app"] != "" or not caller:
+        return False
+    if owner_id:
+        return caller == owner_id
+    return caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS
+
+
 def _redact_memory_field(val: object) -> object:
     """Redact credentials and exfiltration URLs from a memory field.
 
@@ -1905,7 +1926,12 @@ def _read_memory_mode(path: "Path") -> str | None:
 
 
 async def require_owner_dashboard_request(
-    request: web.Request, operation: str
+    request: web.Request,
+    operation: str,
+    *,
+    allow_internal_auth: bool = False,
+    error: str = "owner authorization required",
+    resources: str = "non_owner_block",
 ) -> web.Response | None:
     """Owner gate shared across dashboard handler modules.
 
@@ -1919,6 +1945,9 @@ async def require_owner_dashboard_request(
     inside the function body to avoid a circular import: ``source_providers``
     imports chat-state helpers that reach back into sibling handler modules.
     """
+    if allow_internal_auth and request.get("internal_auth"):
+        return None
+
     from kiro_crew.dashboard.handlers.source_providers import (
         is_owner_dashboard_request,
     )
@@ -1939,14 +1968,15 @@ async def require_owner_dashboard_request(
             operation=operation,
             outcome="denied",
             source="dashboard",
-            resources="non_owner_block",
+            resources=resources,
+            error=error,
         )
     except Exception:  # pragma: no cover - audit must never change the outcome
         logger.debug("SEL audit for non-owner %s failed", operation, exc_info=True)
 
     # Deny decision made above; only the response label changes for a signed
     # pre-owner bootstrap subject (see stale_owner_session_response).
-    return _owner_denial_response(request)
+    return _owner_denial_response(request, error_message=error)
 
 
 def _owner_denial_response(

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -59,6 +59,7 @@ from kiro_crew.context_management import RESULT_FILE_MAX_BYTES
 from kiro_crew.dashboard.handlers._shared import (
     _pip_install_channel_available,
     pip_extra_install_command,
+    require_owner_dashboard_request,
 )
 from kiro_crew.dashboard.origin import check_host, is_direct_local_request
 from kiro_crew.dashboard.state import DashboardState
@@ -603,6 +604,9 @@ async def api_theme_config(request: web.Request) -> web.Response:
         return web.json_response(_theme_payload(cfg))
 
     # PUT
+    denied = await require_owner_dashboard_request(request, "config.theme.write")
+    if denied is not None:
+        return denied
     body = await request.json()
     if not isinstance(body, dict):
         raise web.HTTPBadRequest(text="request body must be an object")
@@ -1510,6 +1514,10 @@ async def api_kirocrew_config(request: web.Request) -> web.Response:
     from kiro_crew.config.loader import config_path  # noqa: F811
 
     if request.method == "PUT":
+        denied = await require_owner_dashboard_request(request, "config.update")
+        if denied is not None:
+            return denied
+
         caller = request.get("user", "dashboard")
 
         def _deny(error: str, status: int = 400) -> web.Response:
@@ -2101,6 +2109,10 @@ def _tailnet_governance_pinned_off() -> bool:
 
 async def api_kirocrew_config_patch(request: web.Request) -> web.Response:
     """PATCH /api/config/kirocrew — update a single config field."""
+    denied = await require_owner_dashboard_request(request, "config.patch")
+    if denied is not None:
+        return denied
+
     from kiro_crew.config.loader import ConfigReadError, config_path, update_config_locked
 
     caller = request.get("user")

--- a/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_prerequisite.py
@@ -9,6 +9,10 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.dashboard.handlers._shared import (
+    is_owner_dashboard_request,
+    require_owner_dashboard_request,
+)
 from kiro_crew.kiro_prerequisite import (
     KIRO_CLI_LOGIN_COMMAND,
     KIRO_CLI_SSO_LOGIN_COMMAND,
@@ -18,10 +22,18 @@ from kiro_crew.kiro_prerequisite import (
     PrerequisiteStatus,
     legacy_idle_operation,
 )
-from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
-_LOCAL_DASHBOARD_OWNER_SUBJECTS = frozenset({"local-app", "local-startup"})
+
+
+def _is_dashboard_owner(request: "web.Request") -> bool:
+    """Whether *request* carries the dashboard-owner identity.
+
+    Thin alias over the shared ``is_owner_dashboard_request`` so the sibling
+    modules that import this predicate by name keep working after the gate
+    moved to ``_shared``.
+    """
+    return is_owner_dashboard_request(request)
 
 
 def _not_ready_snapshot(initial_setup_complete: bool = False) -> dict[str, Any]:
@@ -64,44 +76,6 @@ def _caller(request: web.Request) -> str:
     return str(user) if user else "dashboard-user"
 
 
-def _is_dashboard_owner(request: web.Request) -> bool:
-    """Return whether a signed dashboard identity may operate host setup."""
-
-    state = request.app["state"]
-    owner_id = str(getattr(state, "owner_id", "") or "")
-    caller = str(request.get("user") or "")
-    return request.get("app") == "" and (
-        (owner_id and caller == owner_id)
-        or (not owner_id and caller in _LOCAL_DASHBOARD_OWNER_SUBJECTS)
-    )
-
-
-async def _dashboard_owner_only(request: web.Request) -> web.Response | None:
-    """Require the configured owner or a signed standalone-local identity."""
-
-    if _is_dashboard_owner(request):
-        return None
-
-    caller = str(request.get("user") or "")
-    audit_caller = str(request.get("app") or caller or "unknown")
-
-    def _audit() -> None:
-        sel().log_api_access(
-            caller=audit_caller,
-            operation="kiro_prerequisite_access",
-            outcome="denied",
-            source="dashboard",
-            resources=request.path,
-            error="dashboard owner required",
-        )
-
-    try:
-        await asyncio.to_thread(_audit)
-    except Exception:
-        logger.debug("Could not audit denied Kiro prerequisite access", exc_info=True)
-    return web.json_response({"error": "dashboard owner required"}, status=403)
-
-
 async def api_kiro_prerequisite_status(request: web.Request) -> web.Response:
     """GET /api/kiro-prerequisite — current install/login readiness.
 
@@ -115,14 +89,19 @@ async def api_kiro_prerequisite_status(request: web.Request) -> web.Response:
     """
 
     if request.get("app") != "":
-        denied = await _dashboard_owner_only(request)
+        denied = await require_owner_dashboard_request(
+            request,
+            "kiro_prerequisite_access",
+            error="dashboard owner required",
+            resources=request.path,
+        )
         assert denied is not None
         return denied
 
     # Only an owner may force a host probe; a non-owner's refresh reads latched
     # state like any other poll (they receive the redacted payload regardless).
     refresh = request.query.get("refresh")
-    is_owner = _is_dashboard_owner(request)
+    is_owner = is_owner_dashboard_request(request)
     explicit = refresh in ("1", "true", "explicit") and is_owner
     auto = refresh == "auto" and is_owner
 
@@ -145,7 +124,7 @@ async def api_kiro_prerequisite_status(request: web.Request) -> web.Response:
         # survives this path and keeps a returning user out of first-run setup.
         logger.warning("Kiro prerequisite status probe failed", exc_info=True)
         snapshot = _not_ready_snapshot(bool(service.initial_setup_complete))
-    if _is_dashboard_owner(request):
+    if is_owner_dashboard_request(request):
         return web.json_response({**snapshot, "setup_allowed": True})
 
     # Authorized non-owner dashboard users need the readiness bit so the
@@ -215,7 +194,12 @@ async def api_kiro_prerequisite_repair_specs(request: web.Request) -> web.Respon
     write, not a long-lived background operation with progress to poll.
     """
 
-    denied = await _dashboard_owner_only(request)
+    denied = await require_owner_dashboard_request(
+        request,
+        "kiro_prerequisite_access",
+        error="dashboard owner required",
+        resources=request.path,
+    )
     if denied is not None:
         return denied
     snapshot = await _service(request).repair_agent_specs(_caller(request))
@@ -236,7 +220,12 @@ async def api_kiro_prerequisite_update_cli(request: web.Request) -> web.Response
     success): it runs to completion within the request, like repair-specs.
     """
 
-    denied = await _dashboard_owner_only(request)
+    denied = await require_owner_dashboard_request(
+        request,
+        "kiro_prerequisite_access",
+        error="dashboard owner required",
+        resources=request.path,
+    )
     if denied is not None:
         return denied
     snapshot = await _service(request).update_cli(_caller(request))

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -30,7 +30,10 @@ from kiro_crew.config.loader import (
     _resolve_stub_roster,
 )
 from kiro_crew.config.paths import data_home, kiro_agents_dir
-from kiro_crew.dashboard.handlers._shared import read_bounded_json
+from kiro_crew.dashboard.handlers._shared import (
+    read_bounded_json,
+    require_owner_dashboard_request,
+)
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.env import emit_env
 from kiro_crew.loop_lock import LoopBoundLock
@@ -881,6 +884,9 @@ async def api_mcp_probe(request: web.Request) -> web.Response:
     Merges ``enabled`` and ``disabledTools`` from global mcp.json so
     probe results don't reset user's previous enable/disable choices.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.probe")
+    if denied is not None:
+        return denied
     global _mcp_probe_ts
     from kiro_crew.mcp_discovery import probe_all  # noqa: F811
 
@@ -1000,6 +1006,9 @@ async def api_mcp_measure_start(request: web.Request) -> web.Response:
     A second call while a pass is running is reported rather than queued, because
     both passes would select the same unmeasured set and simply double the spawns.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.measure")
+    if denied is not None:
+        return denied
     if _measure_progress["running"]:
         return web.json_response({"ok": False, "running": True, **_measure_progress})
     _measure_progress.update(running=True, done=0, measured=0, total=0, error="")
@@ -1058,6 +1067,10 @@ async def api_mcp_quarantine_clear(request: web.Request) -> web.Response:
     off by hand stays off. It does not mount or unmount anything either -- the
     server was never unmounted (issue #6171).
     """
+    denied = await require_owner_dashboard_request(request, "mcp.quarantine_clear")
+    if denied is not None:
+        return denied
+
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
@@ -1115,6 +1128,10 @@ async def api_mcp_sync(request: web.Request) -> web.Response:
        ``sessions_reset: 0``. Otherwise every session and the warm pool are
        reset so the next message cold-starts on the new file.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.sync")
+    if denied is not None:
+        return denied
+
     from kiro_crew.mcp_discovery import (  # noqa: F811
         kirocrew_managed_names,
         sync_discovered_servers,
@@ -1329,6 +1346,10 @@ async def api_mcp_toggle(request: web.Request) -> web.Response:
     1. Sets ``disabled`` in ``~/.kiro/settings/mcp.json`` (ACP runtime).
     2. Syncs ``tools``/``allowedTools`` in ``kirocrew.json`` (non-ACP mode).
     """
+    denied = await require_owner_dashboard_request(request, "mcp.toggle")
+    if denied is not None:
+        return denied
+
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
@@ -1395,6 +1416,10 @@ async def api_mcp_toggle_tool(request: web.Request) -> web.Response:
 
     Updates ``disabledTools`` in ``~/.kiro/settings/mcp.json``.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.toggle_tool")
+    if denied is not None:
+        return denied
+
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
@@ -1460,6 +1485,10 @@ async def api_mcp_toggle_tool(request: web.Request) -> web.Response:
 
 async def api_mcp_toggle_all(request: web.Request) -> web.Response:
     """POST /api/mcp/toggle-all — enable or disable all MCP servers."""
+    denied = await require_owner_dashboard_request(request, "mcp.toggle_all")
+    if denied is not None:
+        return denied
+
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
@@ -1507,6 +1536,10 @@ async def api_mcp_remove(request: web.Request) -> web.Response:
     on PATH it is also asked to uninstall (best-effort); on a vanilla
     machine ``aim`` is absent and that step is skipped gracefully.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.remove")
+    if denied is not None:
+        return denied
+
     body, body_err = await read_bounded_json(request)
     if body_err is not None:
         return body_err
@@ -1573,6 +1606,15 @@ async def api_mcp_server_detail(request: web.Request) -> web.Response:
 
     DELETE removes the server from the config.
     """
+    denied = await require_owner_dashboard_request(
+        request,
+        "mcp.server_detail",
+        allow_internal_auth=True,
+        resources=request.path,
+    )
+    if denied is not None:
+        return denied
+
     name = request.match_info["name"]
     if not name or not name.strip():
         return web.json_response({"error": "server name is required"}, status=400)
@@ -2191,6 +2233,10 @@ async def api_mcp_apply(request: web.Request) -> web.Response:
     closes that; the narrower file lock is retained inside ``_do_mcp_apply`` for
     cross-process coordination with bridges.py.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.apply")
+    if denied is not None:
+        return denied
+
     async with _get_apply_lock():
         return await _do_mcp_apply(request)
 
@@ -2760,6 +2806,9 @@ async def api_mcp_resolve_refresh(request: web.Request) -> web.Response:
     ``ready`` / ``unresolved`` / ``error``. A server that fails to resolve is not
     an error for the request: it simply keeps launching the way it does today.
     """
+    denied = await require_owner_dashboard_request(request, "mcp_gateway.resolve_refresh")
+    if denied is not None:
+        return denied
     state: DashboardState = request.app["state"]
     refresh = getattr(state, "_mcp_resolve_refresh", None)
     if refresh is None:
@@ -2804,6 +2853,9 @@ async def api_mcp_gateway_enable(request: web.Request) -> web.Response:
     so the dashboard session stays authenticated.  Returns the verified state
     ``{ok, enabled, running, ping_ok}``.
     """
+    denied = await require_owner_dashboard_request(request, "mcp_gateway.enable")
+    if denied is not None:
+        return denied
     from kiro_crew.config.loader import config_path  # circular import
     from kiro_crew.dashboard.handlers.agents import _get_config_lock  # circular import
 
@@ -3337,6 +3389,9 @@ async def api_mcp_gateway_set_stub(request: web.Request) -> web.Response:
     Returns ``{ok, name, stub, ...}`` for the single form and
     ``{ok, names, stub, ...}`` for the batch form.
     """
+    denied = await require_owner_dashboard_request(request, "mcp_gateway.set_stub")
+    if denied is not None:
+        return denied
     from kiro_crew.config.loader import (  # noqa: F811
         ConfigReadError,
         config_path,

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -24,6 +24,7 @@ import logging
 from aiohttp import web
 
 from kiro_crew.dashboard.handlers import mcp as _mcp
+from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
 from kiro_crew.dashboard.handlers.mcp import (
     _find_server_spec_anywhere,
     _get_kirocrew_entry,
@@ -319,6 +320,10 @@ async def api_mcp_custom_add(request: web.Request) -> web.Response:
     Validates EVERY entry before writing ANY (no partial adds), and
     refuses to clobber existing servers (409 listing the conflicts).
     """
+    denied = await require_owner_dashboard_request(request, "mcp.custom_add")
+    if denied is not None:
+        return denied
+
     try:
         body = await request.json()
     except Exception:
@@ -457,6 +462,10 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
     for management on a shared surface.  A FRESH add carries no tolerated
     keys, so a pasted block naming it is still rejected outright.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.custom_update")
+    if denied is not None:
+        return denied
+
     name = request.match_info.get("name", "")
     if not _is_valid_mcp_name(name):
         return web.json_response({"error": f"invalid server name '{name[:64]}'"}, status=400)

--- a/src/kiro_crew/dashboard/handlers/mcp_discover.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_discover.py
@@ -17,6 +17,7 @@ import re
 
 from aiohttp import web
 
+from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
 from kiro_crew.dashboard.handlers.discover import _redact_external
 from kiro_crew.dashboard.handlers.mcp import (
     _find_server_spec_anywhere,
@@ -263,6 +264,10 @@ async def api_mcp_discover_install(request: web.Request) -> web.Response:
     write it into the KiroCrew scope enabled=true (reusing the mcp.py write
     helpers). provider=capability: delegate to the edition manager.
     """
+    denied = await require_owner_dashboard_request(request, "mcp.discover_install")
+    if denied is not None:
+        return denied
+
     try:
         body = await request.json()
     except Exception:

--- a/test/test_api_server.py
+++ b/test/test_api_server.py
@@ -40,9 +40,19 @@ def _make_state(tmp_path, **kwargs):
     return state
 
 
+@web.middleware
+async def _owner_identity(request, handler):
+    request["user"] = "local-app"
+    request["app"] = ""
+    state = request.app.get("state")
+    if state is not None:
+        state.owner_id = ""
+    return await handler(request)
+
+
 def _make_api_app(state: DashboardState) -> web.Application:
     """Minimal app using only _register_mcp_routes (same as start_api_server)."""
-    app = web.Application()
+    app = web.Application(middlewares=[_owner_identity])
     app["state"] = state
     app["port"] = 5476
     _register_mcp_routes(app)
@@ -203,7 +213,7 @@ class TestApiServerSpawn:
         mock_mgr.get.return_value = old
         mock_mgr.spawn.return_value = MagicMock(id="retry-1", done=False, error="")
         state = _make_state(tmp_path, subagents=mock_mgr)
-        app = web.Application()
+        app = web.Application(middlewares=[_owner_identity])
         app["state"] = state
         app.router.add_post("/api/spawn/{agent_id}/retry", api_spawn_retry)
         async with TestClient(TestServer(app)) as client:
@@ -671,7 +681,10 @@ class TestApiKirocrewConfig:
     def _make_app(tmp_path):
         from kiro_crew.dashboard import handlers
 
-        app = web.Application()
+        app = web.Application(middlewares=[_owner_identity])
+        state = MagicMock()
+        state.owner_id = ""
+        app["state"] = state
         app.router.add_get("/api/config/kirocrew", handlers.api_kirocrew_config)
         app.router.add_put("/api/config/kirocrew", handlers.api_kirocrew_config)
         return app

--- a/test/test_api_theme_config.py
+++ b/test/test_api_theme_config.py
@@ -37,6 +37,18 @@ def _make_cfg(
     return cfg
 
 
+def _owner_request() -> MagicMock:
+    request = MagicMock(spec=web.Request)
+    state = MagicMock()
+    state.owner_id = ""
+    request.app = {"state": state}
+    claims = {"user": "local-app", "app": ""}
+    request.get = lambda key, default=None: claims.get(key, default)
+    request.__contains__.side_effect = lambda key: key in claims
+    request.__getitem__.side_effect = lambda key: claims[key]
+    return request
+
+
 @pytest.mark.asyncio
 async def test_theme_boot_returns_defaults() -> None:
     """GET /api/theme/boot returns empty defaults when unconfigured."""
@@ -112,7 +124,7 @@ async def test_theme_config_put_updates_and_saves() -> None:
     cfg = _make_cfg(theme_mode="", theme_color="", onboarded=False, import_onboarded=False)
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(
             return_value={
@@ -142,7 +154,7 @@ async def test_theme_config_put_validates_mode() -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"mode": "invalid"})
         with pytest.raises(web.HTTPBadRequest):
@@ -155,7 +167,7 @@ async def test_theme_config_put_validates_import_onboarded_boolean() -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"import_onboarded": "false"})
         with pytest.raises(web.HTTPBadRequest):
@@ -173,7 +185,7 @@ async def test_theme_config_put_persists_privacy_acked() -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"privacy_acked": True})
         resp = await core_mod.api_theme_config(req)
@@ -188,7 +200,7 @@ async def test_theme_config_put_validates_privacy_acked_boolean() -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"privacy_acked": "true"})
         with pytest.raises(web.HTTPBadRequest):
@@ -206,7 +218,7 @@ async def test_theme_config_put_no_change_no_save() -> None:
     )
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(
             return_value={
@@ -224,7 +236,7 @@ async def test_theme_config_put_no_change_no_save() -> None:
 @pytest.mark.asyncio
 async def test_theme_config_put_rejects_non_object_body() -> None:
     """PUT /api/config/theme rejects arrays instead of raising during key access."""
-    req = MagicMock(spec=web.Request)
+    req = _owner_request()
     req.method = "PUT"
     req.json = AsyncMock(return_value=["import_onboarded"])
 
@@ -276,10 +288,10 @@ async def test_theme_config_put_serializes_full_load_modify_save_transaction() -
         await both_parsed.wait()
         return value
 
-    first = MagicMock(spec=web.Request)
+    first = _owner_request()
     first.method = "PUT"
     first.json = lambda: body({"mode": "dark"})
-    second = MagicMock(spec=web.Request)
+    second = _owner_request()
     second.method = "PUT"
     second.json = lambda: body({"import_onboarded": True})
 
@@ -327,7 +339,7 @@ async def test_theme_config_put_accepts_valid_language_tags(tag: str) -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"language": tag})
         resp = await core_mod.api_theme_config(req)
@@ -342,7 +354,7 @@ async def test_theme_config_put_clears_language_to_auto() -> None:
     cfg = _make_cfg(language="zh-CN")
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"language": ""})
         resp = await core_mod.api_theme_config(req)
@@ -370,7 +382,7 @@ async def test_theme_config_put_rejects_malformed_language(bad: str) -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"language": bad})
         with pytest.raises(web.HTTPBadRequest):
@@ -384,7 +396,7 @@ async def test_theme_config_put_rejects_non_string_language() -> None:
     cfg = _make_cfg()
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"language": ["zh-CN"]})
         with pytest.raises(web.HTTPBadRequest):
@@ -402,7 +414,7 @@ async def test_theme_config_put_omitting_language_leaves_it_untouched() -> None:
     cfg = _make_cfg(language="zh-CN")
     with patch.object(core_mod, "KiroCrewConfig") as mock_cls:
         mock_cls.load.return_value = cfg
-        req = MagicMock(spec=web.Request)
+        req = _owner_request()
         req.method = "PUT"
         req.json = AsyncMock(return_value={"color": "monokai"})
         resp = await core_mod.api_theme_config(req)

--- a/test/test_config_agent_fields_redaction.py
+++ b/test/test_config_agent_fields_redaction.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config import loader as L
 from kiro_crew.config.loader import KiroCrewConfig
@@ -263,6 +264,7 @@ class TestConfigEndpointWire:
         app = web.Application()
         app.router.add_patch("/api/config/kirocrew", api_kirocrew_config_patch)
         app["state"] = SimpleNamespace(subagents=MagicMock(spec=["update_completion_keep"]))
+        as_owner(app)
         with patch("kiro_crew.config.loader.config_path", return_value=cfg_path):
             async with TestClient(TestServer(app)) as client:
                 resp = await client.patch(

--- a/test/test_config_patch.py
+++ b/test/test_config_patch.py
@@ -11,10 +11,21 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 
+@web.middleware
+async def _owner_identity(request, handler):
+    request["user"] = "local-app"
+    request["app"] = ""
+    state = request.app.get("state")
+    if state is not None:
+        state.owner_id = ""
+    return await handler(request)
+
+
 def _make_app() -> web.Application:
     from kiro_crew.dashboard.handlers import api_kirocrew_config_patch
 
-    app = web.Application()
+    app = web.Application(middlewares=[_owner_identity])
+    app["state"] = MagicMock()
     app.router.add_patch("/api/config/kirocrew", api_kirocrew_config_patch)
     return app
 

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -1628,8 +1628,21 @@ class TestSecurityStats:
 # ── Agent settings PUT (/api/config/kirocrew) ───────────────────────────
 
 
+@web.middleware
+async def _owner_identity(request, handler):
+    request["user"] = "local-app"
+    request["app"] = ""
+    state = request.app.get("state")
+    if state is not None:
+        state.owner_id = ""
+    return await handler(request)
+
+
 def _agent_cfg_app() -> web.Application:
-    app = web.Application()
+    app = web.Application(middlewares=[_owner_identity])
+    state = MagicMock()
+    state.owner_id = ""
+    app["state"] = state
     app.router.add_route("*", "/api/config/kirocrew", core_mod.api_kirocrew_config)
     return app
 
@@ -1873,7 +1886,8 @@ class TestPatchGuards:
     ) -> None:
         """A dead end ("not editable") becomes a next step for fields whose
         side effects the generic write cannot reproduce."""
-        app = web.Application()
+        app = web.Application(middlewares=[_owner_identity])
+        app["state"] = SimpleNamespace(owner_id="")
         app.router.add_patch("/api/config/kirocrew", core_mod.api_kirocrew_config_patch)
         async with TestClient(TestServer(app)) as client:
             resp = await client.patch(
@@ -1885,7 +1899,8 @@ class TestPatchGuards:
 
     @pytest.mark.asyncio
     async def test_unknown_field_is_refused(self, seeded_config, fake_sel) -> None:
-        app = web.Application()
+        app = web.Application(middlewares=[_owner_identity])
+        app["state"] = SimpleNamespace(owner_id="")
         app.router.add_patch("/api/config/kirocrew", core_mod.api_kirocrew_config_patch)
         async with TestClient(TestServer(app)) as client:
             resp = await client.patch(
@@ -1899,7 +1914,10 @@ class TestFallbackModelPatch:
     """agent.fallback_model — single-value str spec with role-model validation."""
 
     def _app(self) -> web.Application:
-        app = web.Application()
+        # PATCH /api/config/kirocrew is owner-gated: supply the same signed
+        # local-owner identity the sibling patch tests use.
+        app = web.Application(middlewares=[_owner_identity])
+        app["state"] = SimpleNamespace(owner_id="")
         app.router.add_patch("/api/config/kirocrew", core_mod.api_kirocrew_config_patch)
         return app
 

--- a/test/test_gateway_appkit_endpoints.py
+++ b/test/test_gateway_appkit_endpoints.py
@@ -139,7 +139,12 @@ class TestMcpServerRegistration:
 
     @asynccontextmanager
     async def _make_client(self):
-        app = web.Application()
+        @web.middleware
+        async def _grant_internal_auth(request, handler):
+            request["internal_auth"] = True
+            return await handler(request)
+
+        app = web.Application(middlewares=[_grant_internal_auth])
         app.router.add_put("/api/mcp/servers/{name}", api_mcp_server_detail)
         app.router.add_delete("/api/mcp/servers/{name}", api_mcp_server_detail)
         async with TestClient(TestServer(app)) as c:

--- a/test/test_handlers_mcp_coverage.py
+++ b/test/test_handlers_mcp_coverage.py
@@ -61,7 +61,10 @@ def _request(
     req.query = query or {}
     req.match_info = match_info or {}
     req.method = method
-    req.get = lambda key, default=None: default
+    claims = {"user": "local-app", "app": ""}
+    req.get = lambda key, default=None: claims.get(key, default)
+    req.__contains__.side_effect = lambda key: key in claims
+    req.__getitem__.side_effect = lambda key: claims[key]
     return req
 
 

--- a/test/test_kirocrew_config_validator.py
+++ b/test/test_kirocrew_config_validator.py
@@ -18,7 +18,13 @@ from kiro_crew.dashboard.handlers.core import api_kirocrew_config
 async def _put(agent_settings: dict, cfg_path) -> web.Response:
     request = MagicMock(spec=web.Request)
     request.method = "PUT"
-    request.get = lambda *a, **k: "test-user"
+    state = MagicMock()
+    state.owner_id = ""
+    request.app = {"state": state}
+    claims = {"user": "local-app", "app": ""}
+    request.get = lambda key, default=None: claims.get(key, default)
+    request.__contains__.side_effect = lambda key: key in claims
+    request.__getitem__.side_effect = lambda key: claims[key]
 
     async def _json():
         return {"agent": agent_settings}

--- a/test/test_mcp_apply.py
+++ b/test/test_mcp_apply.py
@@ -30,9 +30,14 @@ def _make_request(body: dict) -> MagicMock:
     ``request.content`` instead of calling ``request.json()``.
     """
     state = MagicMock()
+    state.owner_id = ""
     state._background_tasks = set()
     request = MagicMock(spec=web.Request)
     request.app = {"state": state}
+    claims = {"user": "local-app", "app": ""}
+    request.get = lambda key, default=None: claims.get(key, default)
+    request.__contains__.side_effect = lambda key: key in claims
+    request.__getitem__.side_effect = lambda key: claims[key]
     attach_body(request, body)
     return request
 
@@ -526,10 +531,13 @@ def _make_stub_request(body: dict) -> MagicMock:
     ``state`` carries no ``_mcp_gateway_apply_stub`` so the handler persists the
     allowlist without attempting an in-process pool re-apply.
     """
-    state = SimpleNamespace(_mcp_gateway_apply_stub=None)
+    state = SimpleNamespace(_mcp_gateway_apply_stub=None, owner_id="")
     request = MagicMock(spec=web.Request)
     request.app = {"state": state}
-    request.get = MagicMock(return_value="dashboard")
+    claims = {"user": "local-app", "app": ""}
+    request.get = lambda key, default=None: claims.get(key, default)
+    request.__contains__.side_effect = lambda key: key in claims
+    request.__getitem__.side_effect = lambda key: claims[key]
     attach_body(request, body)
     return request
 

--- a/test/test_mcp_config_endpoints_owner_auth.py
+++ b/test/test_mcp_config_endpoints_owner_auth.py
@@ -1,0 +1,150 @@
+"""Enumerate-the-invariant coverage for the remaining MCP/config mutations.
+
+The real ``agent_config`` registrar is walked so a newly registered targeted
+mutation cannot silently omit the owner gate. Requests deliberately omit JSON
+bodies: a handler that parses before authorizing returns 400 instead of the
+required 403.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.routes import agent_config as agent_config_routes
+
+pytestmark = pytest.mark.asyncio
+
+_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_TARGET_HANDLER_MODULES = frozenset(
+    {
+        "kiro_crew.dashboard.handlers.core",
+        "kiro_crew.dashboard.handlers.mcp",
+        "kiro_crew.dashboard.handlers.mcp_custom",
+        "kiro_crew.dashboard.handlers.mcp_discover",
+    }
+)
+_EXPECTED_MUTATING_ROUTES = {
+    ("PUT", "/api/config/kirocrew"),
+    ("PATCH", "/api/config/kirocrew"),
+    ("POST", "/api/mcp/discover/install"),
+    ("POST", "/api/mcp/custom"),
+    ("PUT", "/api/mcp/custom/{name}"),
+    ("POST", "/api/mcp/sync"),
+    ("POST", "/api/mcp/apply"),
+    ("POST", "/api/mcp/toggle"),
+    ("POST", "/api/mcp/toggle-tool"),
+    ("POST", "/api/mcp/toggle-all"),
+    ("POST", "/api/mcp/remove"),
+    ("PUT", "/api/mcp/servers/{name}"),
+    ("DELETE", "/api/mcp/servers/{name}"),
+    ("POST", "/api/mcp/probe"),
+    ("POST", "/api/mcp/quarantine/clear"),
+    ("POST", "/api/mcp/measure"),
+    ("POST", "/api/mcp-gateway/enable"),
+    ("POST", "/api/mcp-gateway/servers/stub"),
+    ("POST", "/api/mcp-gateway/resolve-refresh"),
+    ("PUT", "/api/config/theme"),
+}
+
+
+class _FakeState:
+    owner_id = ""
+
+
+def _build_app() -> web.Application:
+    @web.middleware
+    async def _identity(request, handler):
+        # Stand-in for token_auth_middleware. The test-only internal flag models
+        # the positive marker written after a validated X-Internal-Secret.
+        request["user"] = request.headers.get("X-Test-User", "local-app")
+        request["app"] = request.headers.get("X-Test-App", "")
+        if request.headers.get("X-Test-Internal") == "1":
+            request["internal_auth"] = True
+        return await handler(request)
+
+    app = web.Application(middlewares=[_identity])
+    app["state"] = _FakeState()
+    agent_config_routes.register(app)
+    return app
+
+
+def _target_mutating_routes(app: web.Application) -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    for route in app.router.routes():
+        if route.method not in _MUTATING_METHODS:
+            continue
+        if getattr(route.handler, "__module__", "") not in _TARGET_HANDLER_MODULES:
+            continue
+        resource = route.resource
+        assert resource is not None
+        found.add((route.method, resource.canonical))
+    return found
+
+
+def _route_path(canonical: str) -> str:
+    return canonical.replace("{name}", "example")
+
+
+async def test_route_walk_covers_every_targeted_mutation() -> None:
+    app = _build_app()
+    found = _target_mutating_routes(app)
+    assert found == _EXPECTED_MUTATING_ROUTES, (
+        "targeted MCP/config mutation route set drifted: "
+        f"missing={sorted(_EXPECTED_MUTATING_ROUTES - found)} "
+        f"unexpected={sorted(found - _EXPECTED_MUTATING_ROUTES)}"
+    )
+
+
+async def test_every_targeted_mutation_rejects_non_owner_before_body_parse() -> None:
+    app = _build_app()
+    async with TestClient(TestServer(app)) as client:
+        for method, canonical in sorted(_target_mutating_routes(app)):
+            response = await client.request(
+                method,
+                _route_path(canonical),
+                headers={"X-Test-User": "someone-else"},
+            )
+            assert response.status == 403, (
+                f"{method} {canonical} answered {response.status}; "
+                "owner authorization must run before body parsing"
+            )
+            body = await response.json()
+            assert body["code"] == "owner_only", (method, canonical)
+
+
+async def test_every_targeted_mutation_rejects_app_tokens() -> None:
+    app = _build_app()
+    async with TestClient(TestServer(app)) as client:
+        for method, canonical in sorted(_target_mutating_routes(app)):
+            response = await client.request(
+                method,
+                _route_path(canonical),
+                headers={"X-Test-App": "some-app"},
+            )
+            assert (
+                response.status == 403
+            ), f"{method} {canonical} answered {response.status} for an app token"
+            body = await response.json()
+            assert body["code"] == "owner_only", (method, canonical)
+
+
+async def test_internal_auth_exception_is_limited_to_server_registration() -> None:
+    app = _build_app()
+    async with TestClient(TestServer(app)) as client:
+        # The internal caller is admitted by the server-registration handler and
+        # reaches body parsing; no mutation occurs because the body is absent.
+        response = await client.put(
+            "/api/mcp/servers/example",
+            headers={"X-Test-Internal": "1"},
+        )
+        assert response.status == 400
+
+        # The same internal marker must not bypass any other targeted mutation.
+        response = await client.post(
+            "/api/mcp/sync",
+            headers={"X-Test-Internal": "1", "X-Test-User": "someone-else"},
+        )
+        assert response.status == 403
+        assert (await response.json())["code"] == "owner_only"

--- a/test/test_mcp_custom_api.py
+++ b/test/test_mcp_custom_api.py
@@ -65,11 +65,20 @@ def fake_sel(monkeypatch):
     return instance
 
 
+@web.middleware
+async def _owner_identity(request, handler):
+    request["user"] = "local-app"
+    request["app"] = ""
+    return await handler(request)
+
+
 def _make_app() -> web.Application:
     from kiro_crew.dashboard.handlers import mcp_custom as mod
 
-    app = web.Application()
-    app["state"] = MagicMock()
+    app = web.Application(middlewares=[_owner_identity])
+    state = MagicMock()
+    state.owner_id = ""
+    app["state"] = state
     app.router.add_post("/api/mcp/custom", mod.api_mcp_custom_add)
     app.router.add_get("/api/mcp/custom/{name}", mod.api_mcp_custom_get)
     app.router.add_put("/api/mcp/custom/{name}", mod.api_mcp_custom_update)
@@ -1113,8 +1122,9 @@ class TestServersListSurfacesCustomAdds:
         )
         monkeypatch.setattr("kiro_crew.mcp_discovery._extra_scope_sources", lambda: [])
 
-        app = web.Application()
+        app = web.Application(middlewares=[_owner_identity])
         state = MagicMock()
+        state.owner_id = ""
         state._background_tasks = set()
         app["state"] = state
         from kiro_crew.dashboard.handlers import mcp_custom as custom_mod

--- a/test/test_mcp_discover_api.py
+++ b/test/test_mcp_discover_api.py
@@ -154,6 +154,16 @@ def fake_sel(monkeypatch):
     return instance
 
 
+@web.middleware
+async def _owner_identity(request, handler):
+    request["user"] = "local-app"
+    request["app"] = ""
+    state = request.app.get("state")
+    if state is not None:
+        state.owner_id = ""
+    return await handler(request)
+
+
 def _make_app(provider) -> web.Application:
     from kiro_crew.dashboard.handlers import mcp_discover as mod
 
@@ -162,7 +172,7 @@ def _make_app(provider) -> web.Application:
     mod._registry = registry  # inject the fake registry
 
     state = MagicMock()
-    app = web.Application()
+    app = web.Application(middlewares=[_owner_identity])
     app["state"] = state
     app.router.add_get("/api/mcp/discover", mod.api_mcp_discover)
     app.router.add_get("/api/mcp/discover/detail", mod.api_mcp_discover_detail)
@@ -642,7 +652,7 @@ class TestDiscoverInstall:
         registry.register(capability_provider)
         mod._registry = registry
 
-        app = web.Application()
+        app = web.Application(middlewares=[_owner_identity])
         app["state"] = MagicMock()
         app.router.add_post("/api/mcp/discover/install", mod.api_mcp_discover_install)
         client = TestClient(TestServer(app))

--- a/test/test_mcp_gateway_control_plane.py
+++ b/test/test_mcp_gateway_control_plane.py
@@ -26,7 +26,10 @@ def _make_request(state: object, body: dict) -> web.Request:
     req = MagicMock(spec=web.Request)
     attach_body(req, body)
     req.app = {"state": state}
-    req.get = lambda key, default=None: default
+    claims = {"user": "local-app", "app": ""}
+    req.get = lambda key, default=None: claims.get(key, default)
+    req.__contains__.side_effect = lambda key: key in claims
+    req.__getitem__.side_effect = lambda key: claims[key]
     return req
 
 

--- a/test/test_mcp_mutation_identifiers.py
+++ b/test/test_mcp_mutation_identifiers.py
@@ -26,6 +26,12 @@ from kiro_crew.dashboard.handlers import mcp as h
 
 def _req(body: object) -> web.Request:
     app = web.Application()
+    # The MCP mutation endpoints are owner-gated: model the token-auth
+    # middleware's signed local-owner claims so the type-contract under test
+    # is what answers, not the guard.
+    state = MagicMock()
+    state.owner_id = ""
+    app["state"] = state
     raw = json.dumps(body).encode()
     req = make_mocked_request(
         "POST",
@@ -34,6 +40,8 @@ def _req(body: object) -> web.Request:
         headers={"Content-Length": str(len(raw))},
         payload=BodyStreamPayload(raw),
     )
+    req["user"] = "local-app"
+    req["app"] = ""
     return req
 
 

--- a/test/test_mcp_probe_treadmill.py
+++ b/test/test_mcp_probe_treadmill.py
@@ -38,6 +38,16 @@ def _request(state) -> object:
     class _Req:
         def __init__(self, app):
             self.app = app
+            self._claims = {"user": "local-app", "app": ""}
+
+        def get(self, key, default=None):
+            return self._claims.get(key, default)
+
+        def __contains__(self, key):
+            return key in self._claims
+
+        def __getitem__(self, key):
+            return self._claims[key]
 
     app = _App()
     app["state"] = state

--- a/test/test_mcp_quarantine.py
+++ b/test/test_mcp_quarantine.py
@@ -631,8 +631,19 @@ def endpoint(tmp_path, monkeypatch):
 
 
 async def _client(mod) -> TestClient:
-    app = web.Application()
-    app["state"] = MagicMock()
+    # The quarantine-clear route is owner-gated: model the token-auth
+    # middleware's signed local-owner claims so the endpoint behavior under
+    # test is what answers, not the guard.
+    @web.middleware
+    async def _owner_identity(request, handler):
+        request["user"] = "local-app"
+        request["app"] = ""
+        return await handler(request)
+
+    app = web.Application(middlewares=[_owner_identity])
+    state = MagicMock()
+    state.owner_id = ""
+    app["state"] = state
     app.router.add_post("/api/mcp/quarantine/clear", mod.api_mcp_quarantine_clear)
     client = TestClient(TestServer(app))
     await client.start_server()

--- a/test/test_stale_owner_session_signal.py
+++ b/test/test_stale_owner_session_signal.py
@@ -269,11 +269,13 @@ async def test_mcp_apps_gate_labels_stale_bootstrap_denial() -> None:
 
 @pytest.mark.asyncio
 async def test_agents_gate_labels_stale_bootstrap_denial() -> None:
-    from kiro_crew.dashboard.handlers import agents
+    # agents' former module-local ``_require_owner`` delegates to the shared
+    # ``require_owner_dashboard_request`` guard; pin the relabel contract on
+    # the guard itself.
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
 
     request = _mocked_request()
-    with patch.object(agents, "_sel", return_value=MagicMock()):
-        resp = await agents._require_owner(request, "agents.update")
+    resp = await require_owner_dashboard_request(request, "agents.update")
     assert resp is not None and resp.status == 401
     assert resp.text is not None and STALE in resp.text
 

--- a/test/test_stt_config_field_types.py
+++ b/test/test_stt_config_field_types.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
+from dashboard_owner_helpers import NoConfiguredOwner
 
 import kiro_crew.dashboard.handlers.core as core
 from kiro_crew.config.loader import config_path
@@ -17,6 +18,13 @@ def _put(body: dict) -> MagicMock:
     request = MagicMock(spec=web.Request)
     request.method = "PUT"
     request.json = AsyncMock(return_value=body)
+    # api_theme_config is owner-gated: model the token-auth middleware's signed
+    # local-owner claims so the field contract under test is what answers.
+    request.app = {"state": NoConfiguredOwner()}
+    claims = {"user": "local-app", "app": ""}
+    request.get = lambda key, default=None: claims.get(key, default)
+    request.__contains__.side_effect = lambda key: key in claims
+    request.__getitem__.side_effect = lambda key: claims[key]
     return request
 
 

--- a/test/test_tailnet_governance.py
+++ b/test/test_tailnet_governance.py
@@ -351,10 +351,18 @@ class TestStatusState:
 # ── Chokepoint (b): the dashboard PATCH allowlist ─────────────────────────
 
 
+@web.middleware
+async def _owner_identity(request, handler):
+    request["user"] = "local-app"
+    request["app"] = ""
+    return await handler(request)
+
+
 def _patch_app() -> web.Application:
     from kiro_crew.dashboard.handlers import api_kirocrew_config_patch
 
-    app = web.Application()
+    app = web.Application(middlewares=[_owner_identity])
+    app["state"] = SimpleNamespace(owner_id="")
     app.router.add_patch("/api/config/kirocrew", api_kirocrew_config_patch)
     return app
 


### PR DESCRIPTION
## Problem / Motivation

The dashboard still exposes MCP and configuration mutation routes that can write machine-global state, restart sessions, install or remove capabilities, or change gateway behavior. The routes this PR targets did not share one owner authorization boundary, so the protection could drift between handlers. Several owner-denial helpers also duplicated the same identity rule in different modules.

## Why it matters

MCP and dashboard configuration writes affect the host and future sessions, not only the requesting tab. An app-scoped token or an authenticated non-owner must not be able to trigger those side effects. Authorization must happen before JSON parsing, locks, resolver work, process spawning, or any other mutation side effect.

## What changed

- **One shared owner boundary.** Centralize the owner predicate and denial response in the shared dashboard handler module; the response is `403` with machine-readable code `owner_only`.
- **Enumerate the invariant.** Gate all 20 targeted mutation routes across MCP sync/apply/toggle/custom/discovery/server/probe/measure/quarantine, MCP gateway control, config, and theme operations. Six further mutating routes in the same registrar (dashboard config write, onboarding import, OAuth relay, connections mint/cancel) remain outside this boundary and are tracked in #6224.
- **Preserve the internal-auth contract.** `X-Internal-Secret` remains an explicit opt-in exception only for MCP server registration (`PUT`/`DELETE /api/mcp/servers/{name}`); it does not bypass the other mutation routes.
- **Remove drift.** Replace duplicated owner-denial helpers with the shared boundary while preserving compatibility exports used by existing callers and tests.
- **Test the ordering guarantee.** Walk the real route registrar and send requests without JSON bodies, proving non-owner and app-token requests receive `403 owner_only` before a handler can return a body-parse error or perform a side effect.

## Tests

- Targeted authorization/config suite: **702 passed, 6 deselected**.
- Route invariant test: **4 passed**.
- Fixture regression group: **146 passed**.
- Additional probe/theme/gateway route tests: **65 passed**.
- Compatibility regression for MCP sync handlers: **66 passed**.
- `py_compile` passed for all changed Python files.
- `git diff --check` passed.

The final targeted run deselected 6 environment-only test nodes. The broader relevant run had 3 environment-only failures: two pip-channel checks because the uv-created environment has no `pip` module, and one optional STT capability check because voice/Transcribe dependencies were not installed. Formatting/lint executables (`black`, `isort`, `flake8`, and `ruff`) were unavailable in the isolated worktree environment.

## Review and CI status

The local diff was reviewed and the available targeted validation passed. No separate model-pinned review is claimed here. Upstream automated checks for this fork PR are currently held by GitHub `action_required` approval for the fork workflows; this is an execution-permission blocker, not a source-test failure. After an upstream maintainer approves and runs the workflows, CI and review results should be evaluated for the current head revision.

## Scope

Backend-only authorization and regression coverage. No frontend behavior changes and no screenshot evidence is applicable.

Closes #5014
