### PR TITLE
fix(snapshot): one shared descriptor-pinned staging primitive

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -189,7 +189,6 @@ src/kiro_crew/changelog.py
 src/kiro_crew/channel.py
 src/kiro_crew/channel_history.py
 src/kiro_crew/channel_transcript_migration.py
-src/kiro_crew/cli.py
 src/kiro_crew/cli_bench.py
 src/kiro_crew/cli_cloud.py
 src/kiro_crew/cli_desktop.py
@@ -310,7 +309,6 @@ src/kiro_crew/eval/bench/corpus.py
 src/kiro_crew/eval/bench/ingest.py
 src/kiro_crew/eval/bench/retrieval.py
 src/kiro_crew/eval/bench/run.py
-src/kiro_crew/eval/bench/safepath.py
 src/kiro_crew/eval/bench/scorers.py
 src/kiro_crew/eval/runner.py
 src/kiro_crew/eval/scenario.py
@@ -401,7 +399,6 @@ src/kiro_crew/pod/launchd.py
 src/kiro_crew/pod/provision.py
 src/kiro_crew/pod/runtime.py
 src/kiro_crew/pod/unit.py
-src/kiro_crew/portability.py
 src/kiro_crew/providers/acp.py
 src/kiro_crew/publish_governance.py
 src/kiro_crew/publish_sync.py

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -169,6 +169,51 @@ choice blob makes the usage line unreadable.
 | `kirocrew restore <file> --components X,Y` | Selective component restore |
 | `kirocrew restore <file> --dry-run` | Preview restore without writing |
 | `kirocrew restore --list-components` | Show available component names |
+| `kirocrew snapshot --allow-unpinned-staging` | Stage by path name where a directory cannot be pinned by descriptor |
+| `kirocrew restore <file> --allow-unpinned-staging` | Same, for the restore side |
+
+### Staging is descriptor-pinned, and refuses rather than degrading silently
+
+Snapshot and restore stage through `kiro_crew.pinned_fs`: the parent chain is resolved
+once, pinned component by component with `openat` + `O_NOFOLLOW`, and everything
+downstream is addressed through the descriptor already held. A validated path and the
+inode later opened are otherwise not the same thing, and anything running as the user
+— which in this product includes an agent — can plant the swap between the two.
+
+`os.supports_dir_fd` is empty and `O_NOFOLLOW` does not exist on Windows, so pinning
+is unavailable there. The decision, recorded here rather than only in the pull request
+that made it: staging is **refused** on such a platform unless
+`--allow-unpinned-staging` is passed, and when it is, the archive's `MANIFEST.json`
+carries `"staging": "unpinned"` and `kirocrew restore --dry-run` prints that the
+archive was staged by name. The refusal is the default because a by-name walk is not a
+slightly weaker version of a pinned one; it is the mechanism whose failure closed two
+earlier attempts at this change. The flag is a permission for a platform that cannot
+pin, **not** a switch that turns pinning off where it works.
+
+`MANIFEST.json` also carries `"skipped"`: any file omitted during staging (a hardlink
+alias, a symlink, an entry that vanished mid-walk) with its reason, so an incomplete
+archive says so in its own record instead of only in the console output of whoever ran
+the command.
+
+SQLite databases are **out of scope** for the pinned staging described here: they keep the
+`sqlite3.backup()` path they already had, which reopens the live name. Capturing a live
+database without reopening its name is a genuine conflict of requirements — SQLite accepts
+only a path and cannot be pointed at a held descriptor — so it is tracked separately rather
+than solved alongside the tree walk. The exposure is unchanged from before this staging
+work, not introduced by it.
+
+A refusal to stage is a permission decision and is written to the SEL audit log —
+`snapshot_rejected` or `state_restore_rejected`, both with `reason=unpinnable_staging`.
+
+The dashboard's import path (`portability.apply_import_zip`) is the **exception**, and
+deliberately: it has no flag and no consent surface, so refusing there would not mean
+"ask the user", it would mean deleting import on that platform. It therefore proceeds with
+a by-name traversal where pinning is unavailable and records `"staging": "unpinned"` in its
+returned summary, with a logged warning. Snapshot and restore keep refusing, because
+`--allow-unpinned-staging` lets them ask. The per-entry screens apply on both paths — the
+copy opens `O_NOFOLLOW` and the walk rejects links and reparse points — so what the import
+path gives up is ancestor-swap resistance, not link resistance.
+
 | `kirocrew config get [key]` | Print full config or a dot-path value |
 | `kirocrew config set <key> <val>` | Set a config value (auto type detection) |
 | `kirocrew config set --file <path>` | Replace config from a JSON file |

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1328,6 +1328,17 @@ Examples:
     snap_parser.add_argument(
         "--list", action="store_true", dest="list_snapshots", help="List existing snapshots"
     )
+    snap_parser.add_argument(
+        "--allow-unpinned-staging",
+        action="store_true",
+        dest="allow_unpinned",
+        help=(
+            "Stage by path name on a platform that cannot open a directory relative to "
+            "a descriptor (Windows). Without this the snapshot is refused there rather "
+            "than taken with a traversal an ancestor swap could redirect. The archive's "
+            "MANIFEST.json records that it was staged unpinned."
+        ),
+    )
 
     rest_parser = cli_help.add_command(sub, "restore")
     rest_parser.add_argument("snapshot", nargs="?", help="Path to snapshot .tar.gz")
@@ -1345,6 +1356,16 @@ Examples:
     )
     rest_parser.add_argument(
         "--force", action="store_true", help="Restore even if gateway is running"
+    )
+    rest_parser.add_argument(
+        "--allow-unpinned-staging",
+        action="store_true",
+        dest="allow_unpinned",
+        help=(
+            "Restore by path name on a platform that cannot open a directory relative "
+            "to a descriptor (Windows). Without this the restore is refused there "
+            "rather than run with a destination an ancestor swap could redirect."
+        ),
     )
 
     # security
@@ -1385,8 +1406,7 @@ Examples:
     # (issue #4843). Reading the file directly is correctly refused by the
     # credential-path gate, so the time selector has to live here.
     _time_help = (
-        "a relative age (30m, 2h, 7d) or an ISO 8601 instant "
-        "(2026-08-21, 2026-08-21T04:00:00Z)"
+        "a relative age (30m, 2h, 7d) or an ISO 8601 instant " "(2026-08-21, 2026-08-21T04:00:00Z)"
     )
     sel_parser.add_argument("--since", default="", help=f"Only entries at or after {_time_help}")
     sel_parser.add_argument("--until", default="", help=f"Only entries before {_time_help}")
@@ -1424,7 +1444,9 @@ Examples:
 
     policy_parser = cli_help.add_command(sub, "policy")
     policy_sub = policy_parser.add_subparsers(dest="policy_action")
-    policy_show = policy_sub.add_parser("show", help="Show the effective enterprise security policy")
+    policy_show = policy_sub.add_parser(
+        "show", help="Show the effective enterprise security policy"
+    )
     policy_show.add_argument(
         "--ids",
         action="store_true",
@@ -1534,9 +1556,7 @@ Examples:
         action="store_true",
         help="Classify and print what would be reclaimed without deleting anything",
     )
-    pod_prune.add_argument(
-        "--json", action="store_true", help="Emit per-name results as JSON"
-    )
+    pod_prune.add_argument("--json", action="store_true", help="Emit per-name results as JSON")
     pod_status = pod_sub.add_parser("status", help="Up/down + health for one pod")
     pod_status.add_argument("name", help="Worktree name")
     pod_status.add_argument("--json", action="store_true", help="Emit status as JSON")
@@ -1666,12 +1686,8 @@ Only needed on hosts with kernel.apparmor_restrict_unprivileged_userns=1
     sbx_status = sbx_sub.add_parser(
         "status", help="Report whether this launch is covered by the profile"
     )
-    sbx_status.add_argument(
-        "--path", default=None, help="Executable to check instead of $APPIMAGE"
-    )
-    sbx_sub.add_parser(
-        "remove-profile", help="Unload and remove the profile (sudo on Linux)"
-    )
+    sbx_status.add_argument("--path", default=None, help="Executable to check instead of $APPIMAGE")
+    sbx_sub.add_parser("remove-profile", help="Unload and remove the profile (sudo on Linux)")
 
     # cloud — provision + run KiroCrew on the user's own AWS EC2 (bring-your-own
     # AWS; credentials resolved by the aws CLI, never stored by KiroCrew).

--- a/src/kiro_crew/dashboard/handlers/portability.py
+++ b/src/kiro_crew/dashboard/handlers/portability.py
@@ -106,11 +106,19 @@ async def api_portability_import(request: web.Request) -> web.Response:
 
         summary = await asyncio.to_thread(apply_import_zip, zip_path, mode)
 
+        # `staging` is recorded here, not only returned. Review pointed out that nothing
+        # renders it, which made a field added for truthfulness invisible to everyone -- and
+        # whether an import was pinned, mixed or unpinned is a security property of the
+        # operation, so the audit trail is where it belongs more than a UI badge does. The
+        # response still carries it for whatever renders it later.
         _sel().log_api_access(
             caller=caller,
             operation="portability.import",
             outcome="ok",
-            resources=f"mode={mode},items={len(summary.get('items', []))}",
+            resources=(
+                f"mode={mode},items={len(summary.get('items', []))},"
+                f"staging={summary.get('staging', 'unknown')}"
+            ),
         )
 
         return web.json_response({"ok": True, "summary": summary, "manifest": manifest})

--- a/src/kiro_crew/eval/bench/safepath.py
+++ b/src/kiro_crew/eval/bench/safepath.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from kiro_crew import pinned_fs
+
 from .errors import BenchRefusal
 
 
@@ -117,18 +119,11 @@ def guard_output_dir(path: str | Path, *, what: str) -> Path:
 def _supports_pinned_walk() -> bool:
     """Whether this platform can open relative to a directory descriptor.
 
-    ``O_NOFOLLOW`` is part of the requirement, not an extra: a pinned walk without it
-    would open each ancestor happily through whatever link sits there, which is the
-    hole being closed. Found by the Windows-simulation tests, which delete
-    ``os.O_NOFOLLOW`` and would otherwise have taken this path and crashed.
+    Delegates to :func:`kiro_crew.pinned_fs.supports_pinned_walk`. Kept as a
+    module-level function rather than an alias because the Windows-simulation tests
+    replace this attribute to exercise the fallback branch.
     """
-    import os
-
-    return (
-        hasattr(os, "O_DIRECTORY")
-        and hasattr(os, "O_NOFOLLOW")
-        and os.open in os.supports_dir_fd
-    )
+    return pinned_fs.supports_pinned_walk()
 
 
 def _open_in_pinned_parent(
@@ -136,111 +131,41 @@ def _open_in_pinned_parent(
 ) -> int:
     """Open *name* under *resolved_parent* with the parent chain pinned.
 
-    *name* is opened as given, so a link at the final name is refused by
-    ``O_NOFOLLOW`` in *flags*. See ``_pin_parent`` for what pinning buys.
+    Thin wrapper over :func:`kiro_crew.pinned_fs.open_in_pinned_parent` that keeps
+    this harness's refusal type. See that module for what pinning buys and why the
+    name is opened as given.
     """
-    import os
-
-    dir_fd = _pin_parent(resolved_parent, what=what)
-    try:
-        return os.open(name, flags, mode, dir_fd=dir_fd)
-    finally:
-        os.close(dir_fd)
+    return pinned_fs.open_in_pinned_parent(
+        resolved_parent,
+        name,
+        flags=flags,
+        mode=mode,
+        what=what,
+        refusal=UnsafePathError,
+    )
 
 
 def _pin_parent(resolved_parent: str, *, what: str) -> int:
     """Return a descriptor for *resolved_parent*, refusing a component that is now a link.
 
-    One ``openat`` per component, each relative to the previous component's descriptor
-    and each carrying ``O_NOFOLLOW``. Two properties come out of that:
-
-    * a component that became a symlink after *resolved_parent* was computed fails
-      ``O_NOFOLLOW`` and is refused -- this is the check-to-use swap, and it is the
-      reason a single ``os.open(parent, O_DIRECTORY)`` is not enough: that call follows
-      such a link silently and then pins its target;
-    * once a component is open, its descriptor cannot be re-pointed, so everything
-      already traversed is fixed.
-
-    *resolved_parent* must be resolved by the CALLER, once, before this runs. Resolving
-    it here would re-follow whatever an ancestor points at by now, which is the exact
-    mistake that made an earlier version of this defensible-looking and useless.
-
-    The descriptor is returned OPEN and the caller must close it. Handing it back
-    rather than doing one open inside is what lets a durable write create its
-    temporary file and rename it over the destination through the same pinned
-    directory, so the swap cannot be redirected between the two steps.
-
-    Not closed: a component swapped before *resolved_parent* was computed is followed
-    by that resolution. Refusing every symlinked ancestor would close it and would also
-    break ``--out-dir /tmp/...`` on macOS, where ``/tmp`` is itself a link.
+    Thin wrapper over :func:`kiro_crew.pinned_fs.pin_parent`, which owns the
+    invariants: one ``openat`` per component with ``O_NOFOLLOW``, *resolved_parent*
+    resolved by the caller exactly once, and the descriptor handed back OPEN so a
+    create-then-rename publishes through the same pinned directory.
     """
-    import errno
-    import os
-    from pathlib import PurePath
-
-    parts = PurePath(resolved_parent).parts
-    if not parts:  # pragma: no cover - a resolved path always has parts
-        raise UnsafePathError(f"refusing to open the {what}: empty parent path")
-
-    if os.path.isabs(resolved_parent):
-        dir_fd = os.open(parts[0], os.O_RDONLY | os.O_DIRECTORY)
-        rest = parts[1:]
-    else:  # pragma: no cover - realpath returns absolute paths
-        dir_fd = os.open(".", os.O_RDONLY | os.O_DIRECTORY)
-        rest = parts
-
-    try:
-        for component in rest:
-            try:
-                nxt = os.open(
-                    component,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=dir_fd,
-                )
-            except OSError as exc:
-                if exc.errno in (errno.ELOOP, errno.ENOTDIR):
-                    raise UnsafePathError(
-                        f"refusing to write the {what}: the directory {component!r} on "
-                        "the way to it became a symbolic link after the path was "
-                        "checked. A parent swapped for a link redirects the write "
-                        "however carefully the final name is opened, so it is refused."
-                    ) from exc
-                raise
-            os.close(dir_fd)
-            dir_fd = nxt
-    except BaseException:
-        os.close(dir_fd)
-        raise
-    return dir_fd
+    return pinned_fs.pin_parent(resolved_parent, what=what, refusal=UnsafePathError)
 
 
 def _refuse_hardlink_alias(fd: int, *, what: str, name: str) -> None:
     """Reject a descriptor that is one of several names for the same inode.
 
-    A hardlink is invisible to every path-based guard: it shares the target's inode,
-    so ``realpath`` yields the alias's own name, ``is_symlink()`` is False, and
-    ``O_NOFOLLOW`` has no link to refuse. A planted alias therefore let an O_TRUNC
-    write destroy a protected file, and let a read hand back its bytes.
-
-    Checked on the DESCRIPTOR rather than the path, which is what makes it
-    race-free: this fd already refers to the inode being judged.
-
-    The cost is honest and small: a corpus file that legitimately has more than one
-    link -- a dedup-ing backup tool, a deliberate alias -- is refused. Copy it or
-    point the cache elsewhere.
+    Thin wrapper over :func:`kiro_crew.pinned_fs.refuse_hardlink_alias`, which owns
+    the reasoning: a hardlink is invisible to every path-based guard, so it is judged
+    on the DESCRIPTOR, which is what makes the check race-free. The descriptor is
+    closed before the refusal is raised, so a caller's ``except BaseException:
+    os.close(fd)`` must not run for it.
     """
-    import os
-
-    links = os.fstat(fd).st_nlink
-    if links > 1:
-        os.close(fd)
-        raise UnsafePathError(
-            f"refusing to use the {what}: {name!r} has {links} hard links, so it is "
-            "another name for a file this command was not pointed at. A path guard "
-            "cannot see that -- the alias shares the target's inode -- so it is "
-            "refused on the open descriptor instead. Remove the extra link or use a "
-            "different path."
-        )
+    pinned_fs.refuse_hardlink_alias(fd, what=what, name=name, refusal=UnsafePathError)
 
 
 def open_write_nofollow(path: str | Path, *, what: str) -> int:
@@ -454,9 +379,7 @@ def write_text_atomic_nofollow(path: str | Path, text: str, *, what: str) -> Non
                     raise
                 # Both ends relative to the pinned directory, so the destination
                 # cannot be redirected between the check above and this swap.
-                os.replace(
-                    tmp_name, as_given.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd
-                )
+                os.replace(tmp_name, as_given.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
                 _sync_dir(dir_fd)
             finally:
                 os.close(dir_fd)
@@ -558,20 +481,11 @@ def _revalidate_unpinned(as_given: Path, *, what: str) -> None:
 def _is_reparse_point(path: Path) -> bool:
     """True for a symlink or a Windows junction.
 
-    ``os.path.islink`` is False for a junction -- it is a reparse point but not a
-    symlink -- so the tag is checked as well. Comparing ``realpath`` against
-    ``abspath`` would be simpler and wrong: on Windows a temp directory is handed back
-    as an 8.3 short path, which differs from its resolved form with nothing linked
-    anywhere.
+    Thin wrapper over :func:`kiro_crew.pinned_fs.is_reparse_point`, which explains
+    why the reparse tag is checked as well as ``islink`` and why comparing
+    ``realpath`` against ``abspath`` would be wrong on Windows.
     """
-    import os
-
-    if os.path.islink(path):
-        return True
-    try:
-        return bool(getattr(os.lstat(path), "st_reparse_tag", 0))
-    except OSError:  # pragma: no cover - a component that vanished mid-walk
-        return False
+    return pinned_fs.is_reparse_point(path)
 
 
 def _pin_parent_for(as_given: Path, *, what: str) -> int:

--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -1,0 +1,916 @@
+"""Descriptor-pinned filesystem staging: open once, then never trust a name again.
+
+Every function here exists because guarding a path by NAME does not guard the open
+that follows it. A name is validated, then re-opened, and in the window between the
+two anything running as this user -- which in this product includes an agent -- can
+swap the final component, or an ancestor DIRECTORY, for a link pointing somewhere
+else. The validated path and the opened inode are then not the same thing.
+
+The discipline is one sentence: resolve once, open once, and address everything
+downstream through the descriptor you already hold. A descriptor cannot be
+re-pointed, so a component that is open is fixed; a component reached by name is
+not.
+
+Why this module exists rather than a check at each call site: two closed pull
+requests (#2446, #2447) tried to add snapshot components while hardening staging in
+the same change. Each review round named one more validated-by-name path use --
+source root, each ancestor, each file, the destination tree, the pre-restore backup
+pass -- and neither converged. The mechanism belongs in one place with one set of
+invariants, and callers become thin consumers of it.
+
+The mechanical half of this was first written for the benchmark harness in
+``kiro_crew.eval.bench.safepath``, which now imports it from here. Its invariants
+survived several rounds of review there and are preserved verbatim; the docstrings
+explaining WHY each flag is load-bearing came with them.
+
+Two things this module deliberately does NOT do:
+
+* It holds no policy. It does not know which locations are protected, and it does
+  not decide whether a refusal should abort a command or be reported and skipped.
+  Callers pass their own refusal type (so an existing CLI error contract does not
+  change) and their own ``on_skip`` reporter (so user-facing wording stays theirs).
+* It does not silently substitute a weaker mechanism. Where a platform cannot pin
+  (see :func:`supports_pinned_walk`), the caller is told so and decides; nothing
+  here falls back to a by-name walk on its own.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import shutil
+import stat as _stat
+from pathlib import Path, PurePath
+from typing import Callable
+
+__all__ = [
+    "PinnedPathRefusal",
+    "SKIP_NOT_REGULAR",
+    "SKIP_SYMLINK",
+    "SKIP_VANISHED",
+    "SkipReporter",
+    "copy_file_pinned",
+    "create_and_open_dir_pinned",
+    "fatal_skip_reporter",
+    "is_reparse_point",
+    "is_regular_at",
+    "stat_at",
+    "open_dir_pinned",
+    "open_in_pinned_parent",
+    "pin_parent",
+    "refuse_hardlink_alias",
+    "stage_tree_pinned",
+    "supports_pinned_tree_walk",
+    "supports_pinned_walk",
+]
+
+
+class PinnedPathRefusal(Exception):
+    """Raised instead of completing an operation that could not be pinned.
+
+    Neutral on purpose. A caller with its own refusal taxonomy passes that type as
+    ``refusal=`` so its existing error contract is unchanged -- the benchmark
+    harness keeps raising its ``UnsafePathError``, and a snapshot refusal stays
+    something the CLI boundary already knows how to contain.
+    """
+
+
+#: Reason codes handed to an ``on_skip`` reporter. The primitive classifies; the
+#: caller words the message, so user-facing output stays the caller's own.
+SKIP_SYMLINK = "symlink"
+SKIP_VANISHED = "vanished"
+SKIP_NOT_REGULAR = "not_regular"
+
+#: ``(reason_code, by_name_path)``. The path is for the message only -- it is never
+#: re-opened, because re-opening it is the bug this module exists to prevent.
+SkipReporter = Callable[[str, str], None]
+
+
+def _noop_skip(_reason: str, _path: str) -> None:
+    return None
+
+
+def fatal_skip_reporter(what: str, *, refusal: type[Exception] = PinnedPathRefusal) -> SkipReporter:
+    """A reporter that REFUSES instead of recording, for paths where a skip loses data.
+
+    Skipping is the right answer while producing an archive: the entry is omitted, the
+    omission is recorded, and nothing of the operator's is touched. It is the wrong answer
+    on every path that has already moved or deleted the original -- there the skip means
+    the live copy is gone AND the replacement was never written, so the operation
+    "succeeds" having destroyed data.
+
+    That distinction cost three separate review findings on this change (a backup pass
+    whose skips preceded an ``rmtree``, a restore source skipped after the live file was
+    moved aside, and a destination subtree that could not be opened). They were three
+    instances of one rule, so the rule is now a parameter a caller passes rather than a
+    condition each site re-implements: archive paths keep the recording reporter, mutating
+    paths pass this one, and which kind a call site is becomes visible at the call site.
+    """
+
+    def _refuse(reason: str, path: str) -> None:
+        raise refusal(
+            f"refusing to continue the {what}: {Path(path).name!r} could not be copied "
+            f"({reason}). This path has already moved or removed what it is replacing, so "
+            "skipping would finish with the original gone and the replacement missing. "
+            "Resolve that entry -- a hardlink alias or a symbolic link is the usual cause "
+            "-- and re-run."
+        )
+
+    return _refuse
+
+
+def supports_pinned_walk() -> bool:
+    """Whether this platform can open relative to a directory descriptor.
+
+    ``O_NOFOLLOW`` is part of the requirement, not an extra: a pinned walk without
+    it would open each ancestor happily through whatever link sits there, which is
+    the hole being closed. Found by the Windows-simulation tests, which delete
+    ``os.O_NOFOLLOW`` and would otherwise have taken this path and crashed.
+    """
+    return (
+        hasattr(os, "O_DIRECTORY") and hasattr(os, "O_NOFOLLOW") and os.open in os.supports_dir_fd
+    )
+
+
+def supports_pinned_tree_walk() -> bool:
+    """Whether a whole TREE can be walked without ever re-opening a name.
+
+    Strictly more than :func:`supports_pinned_walk`: descending a tree also needs to
+    list and stat through a descriptor. Without ``os.listdir`` on an fd the walk would
+    have to re-list by name, which reintroduces exactly the ancestor swap the pinned
+    open just refused.
+
+    Note which stat is probed. ``os.lstat`` is NOT a member of
+    ``os.supports_dir_fd`` even on Linux -- the capability belongs to ``os.stat``, and
+    ``lstat(p, dir_fd=fd)`` is documented as ``stat(p, dir_fd=fd,
+    follow_symlinks=False)``. Probing ``os.lstat`` reports False on a platform that
+    fully supports the walk, which would have made every snapshot on Linux refuse and
+    demand the by-name opt-in. The walk below calls ``os.stat`` with
+    ``follow_symlinks=False`` so the call and the probe are the same function.
+    """
+    return supports_pinned_walk() and os.listdir in os.supports_fd and os.stat in os.supports_dir_fd
+
+
+def _dir_flags() -> int:
+    return os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+
+def pin_parent(
+    resolved_parent: str,
+    *,
+    what: str,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> int:
+    """Return a descriptor for *resolved_parent*, refusing a component that is now a link.
+
+    One ``openat`` per component, each relative to the previous component's
+    descriptor and each carrying ``O_NOFOLLOW``. Two properties come out of that:
+
+    * a component that became a symlink after *resolved_parent* was computed fails
+      ``O_NOFOLLOW`` and is refused -- this is the check-to-use swap, and it is the
+      reason a single ``os.open(parent, O_DIRECTORY)`` is not enough: that call
+      follows such a link silently and then pins its target;
+    * once a component is open, its descriptor cannot be re-pointed, so everything
+      already traversed is fixed.
+
+    *resolved_parent* must be resolved by the CALLER, once, before this runs.
+    Resolving it here would re-follow whatever an ancestor points at by now, which
+    is the exact mistake that made an earlier version of this defensible-looking and
+    useless.
+
+    The descriptor is returned OPEN and the caller must close it. Handing it back
+    rather than doing one open inside is what lets a durable write create its
+    temporary file and rename it over the destination through the same pinned
+    directory, so the swap cannot be redirected between the two steps.
+
+    Not closed: a component swapped BEFORE *resolved_parent* was computed is
+    followed by that resolution. Refusing every symlinked ancestor would close it
+    and would also break paths under ``/tmp`` on macOS, where ``/tmp`` is itself a
+    link.
+    """
+    parts = PurePath(resolved_parent).parts
+    if not parts:  # pragma: no cover - a resolved path always has parts
+        raise refusal(f"refusing to open the {what}: empty parent path")
+
+    if os.path.isabs(resolved_parent):
+        dir_fd = os.open(parts[0], os.O_RDONLY | os.O_DIRECTORY)
+        rest = parts[1:]
+    else:  # pragma: no cover - realpath returns absolute paths
+        dir_fd = os.open(".", os.O_RDONLY | os.O_DIRECTORY)
+        rest = parts
+
+    try:
+        for component in rest:
+            try:
+                nxt = os.open(component, _dir_flags(), dir_fd=dir_fd)
+            except OSError as exc:
+                if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                    raise refusal(
+                        f"refusing to write the {what}: the directory {component!r} on "
+                        "the way to it became a symbolic link after the path was "
+                        "checked. A parent swapped for a link redirects the write "
+                        "however carefully the final name is opened, so it is refused."
+                    ) from exc
+                raise
+            os.close(dir_fd)
+            dir_fd = nxt
+    except BaseException:
+        os.close(dir_fd)
+        raise
+    return dir_fd
+
+
+def open_in_pinned_parent(
+    resolved_parent: str,
+    name: str,
+    *,
+    flags: int,
+    mode: int,
+    what: str,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> int:
+    """Open *name* under *resolved_parent* with the parent chain pinned.
+
+    *name* is opened as given, so a link at the final name is refused by
+    ``O_NOFOLLOW`` in *flags*. See :func:`pin_parent` for what pinning buys.
+    """
+    dir_fd = pin_parent(resolved_parent, what=what, refusal=refusal)
+    try:
+        return os.open(name, flags, mode, dir_fd=dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def open_dir_pinned(
+    path: str | Path,
+    *,
+    what: str,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> int:
+    """Open a DIRECTORY with its whole ancestor chain pinned, final component included.
+
+    This is the one the preserved staging branches did not have, and its absence is
+    the finding that closed #2446: ``os.open(str(src), O_DIRECTORY | O_NOFOLLOW)``
+    refuses a link at the root's own name but reaches that name by walking every
+    ancestor BY NAME, so swapping a validated ancestor for a link to a credential
+    directory redirects the whole traversal and the ``O_NOFOLLOW`` on the final
+    component never fires -- what it finds there is a perfectly ordinary directory.
+
+    Here the parent chain is resolved once and pinned component by component, and
+    the root's own name is then opened relative to the pinned parent. Nothing in the
+    subtree is ever addressed by a path again.
+    """
+    as_given = Path(path)
+    resolved_parent = os.path.realpath(as_given.parent or Path("."))
+    try:
+        return open_in_pinned_parent(
+            resolved_parent,
+            as_given.name,
+            flags=_dir_flags(),
+            mode=0o700,
+            what=what,
+            refusal=refusal,
+        )
+    except OSError as exc:
+        # Same translation as `create_and_open_dir_pinned`. Review found this sibling
+        # still leaking the raw errno: `O_NOFOLLOW` refuses the link correctly, but a
+        # direct caller (the data home, a backup root, a restore destination) got an
+        # `ELOOP`/`ENOTDIR` traceback instead of the one refusal type every other path on
+        # this surface produces and the CLI boundary contains.
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise refusal(
+                f"refusing to use the {what}: {as_given.name!r} is a symbolic link or "
+                "not a directory, so working through it would follow whatever it points "
+                "at. Remove it and re-run."
+            ) from exc
+        raise
+
+
+def refuse_hardlink_alias(
+    fd: int,
+    *,
+    what: str,
+    name: str,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> None:
+    """Reject a descriptor that is one of several names for the same inode.
+
+    A hardlink is invisible to every path-based guard: it shares the target's inode,
+    so ``realpath`` yields the alias's own name, ``is_symlink()`` is False, and
+    ``O_NOFOLLOW`` has no link to refuse. A planted alias therefore let an O_TRUNC
+    write destroy a protected file, and let a read hand back its bytes.
+
+    Checked on the DESCRIPTOR rather than the path, which is what makes it
+    race-free: this fd already refers to the inode being judged.
+
+    The cost is honest and small: a file that legitimately has more than one link --
+    a dedup-ing backup tool, a deliberate alias -- is refused. Copy it instead.
+
+    Closes *fd* before raising, so a caller's ``except BaseException: os.close(fd)``
+    must not run for this refusal.
+    """
+    links = os.fstat(fd).st_nlink
+    if links > 1:
+        os.close(fd)
+        raise refusal(
+            f"refusing to use the {what}: {name!r} has {links} hard links, so it is "
+            "another name for a file this command was not pointed at. A path guard "
+            "cannot see that -- the alias shares the target's inode -- so it is "
+            "refused on the open descriptor instead. Remove the extra link or use a "
+            "different path."
+        )
+
+
+def is_reparse_point(path: str | Path) -> bool:
+    """True for a symlink or a Windows junction.
+
+    ``os.path.islink`` is False for a junction -- it is a reparse point but not a
+    symlink -- so the tag is checked as well. Comparing ``realpath`` against
+    ``abspath`` would be simpler and wrong: on Windows a temp directory is handed
+    back as an 8.3 short path, which differs from its resolved form with nothing
+    linked anywhere.
+    """
+    if os.path.islink(path):
+        return True
+    try:
+        return bool(getattr(os.lstat(path), "st_reparse_tag", 0))
+    except OSError:  # pragma: no cover - a component that vanished mid-walk
+        return False
+
+
+def copy_file_pinned(
+    by_name: str,
+    dst: str | None = None,
+    *,
+    dir_fd: int | None = None,
+    name: str | None = None,
+    dst_dir_fd: int | None = None,
+    dst_name: str | None = None,
+    skip_existing: bool = False,
+    force_mode: int | None = None,
+    on_skip: SkipReporter = _noop_skip,
+) -> bool:
+    """Copy one file's bytes from a descriptor pinned to a validated inode.
+
+    Returns True when bytes were copied, False when the source was skipped.
+
+    ``shutil.copy2`` cannot be used on a user-writable tree: it dereferences a
+    hardlink into innocent-looking regular bytes, and a later tar-level hardlink
+    screen never sees a link to reject -- so a hardlink to a credential planted
+    inside an otherwise allowlisted directory would ride along as plain content.
+    The order here is open first, judge the DESCRIPTOR second: ``O_NOFOLLOW`` where
+    the platform has it, then ``fstat`` on the fd, so the inode that is validated is
+    exactly the inode whose bytes are copied and no check-to-use window remains.
+    Mode and timestamps are applied from that same ``fstat`` result rather than from
+    a fresh by-name stat.
+
+    BOTH ends can be pinned, and on a destination the caller does not own they MUST
+    be. Pass *dir_fd* + *name* for a pinned source and *dst_dir_fd* + *dst_name* for
+    a pinned destination; each side falls back to the by-name form when its pair is
+    absent, which is only appropriate for a path this process just created. A
+    destination reached by name is an ancestor swap away from landing the bytes
+    somewhere else entirely -- that was a real gap in the first version of this
+    module, caught in review, and it is why the by-name destination is now the
+    exception rather than the only form.
+
+    The destination is created with ``O_EXCL``, so anything already at that name is a
+    planted link or alias rather than a file to overwrite and creation refuses it
+    without a separate check. With *skip_existing* an occupied name is reported as
+    skipped instead, which is what a merge that must not overwrite needs: exclusive
+    creation makes "it did not exist" and "this call created it" one statement rather
+    than two with a window between them.
+
+    ``FileNotFoundError`` propagates so a caller can tolerate a source that vanished
+    mid-walk; every other ``OSError`` propagates so real failures still abort.
+    """
+    if dst is None and dst_name is None:  # pragma: no cover - caller bug
+        raise ValueError("copy_file_pinned needs either dst or dst_name")
+    # O_NONBLOCK is not about performance. Opening a FIFO for reading BLOCKS until a
+    # writer appears, so without it a single named pipe -- in an extracted archive, or
+    # planted in a staged tree -- hangs the whole snapshot or restore forever with no
+    # timeout and no message. Found when a mutation probe removed a caller's own
+    # `is_file()` guard and the test run stalled until a watchdog killed it, which is
+    # exactly how an operator would experience it. The fstat below still rejects the FIFO;
+    # this only guarantees we reach that check. On a regular file the flag has no effect.
+    src_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        if dir_fd is not None and name is not None:
+            fd = os.open(name, src_flags, dir_fd=dir_fd)
+        else:
+            fd = os.open(by_name, src_flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            # A symlink final component that appeared after the listing-time link
+            # screen -- refuse it the same way the screen would have.
+            on_skip(SKIP_SYMLINK, by_name)
+            return False
+        raise
+    try:
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode) or st.st_nlink != 1:
+            on_skip(SKIP_NOT_REGULAR, by_name)
+            return False
+        # The bytes are written to the FINAL name, opened O_CREAT|O_EXCL, and no name is
+        # resolved again afterwards. Three designs have now been tried on these lines and
+        # this is the only one that satisfies this module's own central rule -- once a
+        # descriptor exists, no write may be derived from a path name:
+        #
+        #   * exclusive create at the final name, cleanup unlinks that name after an
+        #     identity check -- rejected because the name can change between the check and
+        #     the unlink (POSIX has no unlink-by-inode), so cleanup could delete a file
+        #     another writer had published;
+        #   * private temporary published with `os.link` -- rejected because the LINK
+        #     re-resolves the temporary BY NAME. Proven exploitable: swapping the `.part`
+        #     entry after the copy makes the publish install attacker bytes and report the
+        #     core file as restored. A descriptor-based publish would fix it, and there is
+        #     no portable one -- `linkat(AT_EMPTY_PATH)` is not exposed by Python and the
+        #     `/proc/self/fd` form is Linux-only and privileged;
+        #   * this one: the descriptor IS the destination from the first byte. There is no
+        #     publish step to attack, and no hard link, which is also why the FAT/exFAT
+        #     fallback and its overwrite hazard are simply gone rather than guarded.
+        #
+        # What the first design got wrong was the CLEANUP, not the create, and the fix is
+        # to stop unlinking names: on failure the file is emptied through the descriptor we
+        # hold and the failure is reported. `O_EXCL` proves we created this entry, so
+        # truncating it cannot touch anyone else's file, and a reported empty file with the
+        # previous version still in the backup is a far smaller harm than either publishing
+        # attacker bytes or deleting a concurrent writer's file.
+        #
+        # EEXIST keeps its two answers: with `skip_existing` an occupied name is a skip,
+        # otherwise it is raised for the caller to translate.
+        dst_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        published = False
+        try:
+            if dst_dir_fd is not None and dst_name is not None:
+                dst_fd = os.open(dst_name, dst_flags, 0o600, dir_fd=dst_dir_fd)
+            else:
+                dst_fd = os.open(str(dst), dst_flags, 0o600)
+        except FileExistsError:
+            if skip_existing:
+                return False
+            raise
+        # The destination is finished through its OWN descriptor and never by name again:
+        # `os.chmod(name, dir_fd=...)` re-resolves the final component, so a name swapped
+        # between the write and the chmod would have the mode applied to the replacement,
+        # while `fchmod`/`futimes` on the open descriptor cannot be redirected.
+        #
+        # On failure only the TEMPORARY is removed. That is the whole point of writing to
+        # one: the final name is never touched by the failure path, so no cleanup of ours
+        # can delete a file another writer published there. The descriptor is closed before
+        # the unlink because Windows refuses to remove a file with an open handle -- the
+        # earlier form unlinked first and left the fragment exactly where cleanup was meant
+        # to remove it, which my own Windows shard caught.
+        try:
+            with os.fdopen(fd, "rb") as fsrc:
+                fd = -1  # ownership passed to the file object
+                # fdopen takes ownership and closes what it is given, so it gets a
+                # duplicate: dst_fd itself has to outlive the write for the two
+                # descriptor-based metadata calls below.
+                with os.fdopen(os.dup(dst_fd), "wb") as fdst:
+                    shutil.copyfileobj(fsrc, fdst)
+            _apply_metadata(
+                dst_fd,
+                st,
+                dst=dst,
+                dst_dir_fd=dst_dir_fd,
+                dst_name=dst_name,
+                mode=force_mode,
+            )
+            published = True
+        except BaseException:
+            # No name is unlinked here. `O_EXCL` above proves this entry is ours, so the
+            # partial content is emptied through the descriptor -- the one operation that
+            # cannot be redirected at another writer's file. The caller's reporter is what
+            # makes it visible; on a restore that reporter is fatal, so the operation stops
+            # with the previous version still in the backup rather than continuing over a
+            # truncated core file.
+            if dst_fd >= 0:
+                try:
+                    os.ftruncate(dst_fd, 0)
+                except OSError:
+                    pass  # nothing further is safe to try, and the report still fires
+                os.close(dst_fd)
+                dst_fd = -1
+            raise
+        finally:
+            if dst_fd >= 0:
+                os.close(dst_fd)
+        return published
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def stat_at(dir_fd: int, name: str) -> os.stat_result | None:
+    """`lstat` *name* relative to *dir_fd*, or ``None`` if it is not there.
+
+    The descriptor-relative answer to "what is this, and is it there?". A plain
+    ``Path.is_file()`` re-resolves the whole path, so between the question and the use of
+    the answer the object can be replaced -- and a guard that inspects the replacement
+    while the code acts on the original is worse than no guard, because it reports success.
+    Review found three such guards in code that was already holding the right descriptor.
+
+    Never follows a link: the caller wants to know what the NAME is, and a link is one of
+    the answers it needs to be able to see.
+    """
+    try:
+        return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+
+
+def is_regular_at(dir_fd: int, name: str) -> bool:
+    """True when *name* under *dir_fd* is a plain file -- not a link, FIFO, or directory."""
+    st = stat_at(dir_fd, name)
+    return st is not None and _stat.S_ISREG(st.st_mode)
+
+
+def _apply_metadata(
+    dst_fd: int,
+    st: os.stat_result,
+    *,
+    dst: str | Path | None,
+    dst_dir_fd: int | None,
+    dst_name: str | None,
+    mode: int | None = None,
+) -> None:
+    """Copy mode and timestamps onto the destination, by descriptor where possible.
+
+    The fallbacks name the DESTINATION, which is now the only thing they could name: the
+    bytes are written straight to the final name under ``O_EXCL``. An earlier revision wrote
+    to a private temporary and published it by link, so the fallbacks had to name that
+    temporary instead -- that design is gone (the publish re-resolved a name, which is the
+    one thing this module exists to avoid), and with it the parameter that carried the
+    distinction.
+
+    ``os.fchmod`` does not exist on Windows and ``os.utime`` only accepts a descriptor
+    where ``os.utime in os.supports_fd``, so the fd form cannot be unconditional: an
+    earlier revision called it always and crashed a Windows snapshot with
+    ``AttributeError`` the moment it reached a core file. Caught in review.
+
+    The fd form is preferred wherever it exists, because a name re-resolves: a final
+    component swapped between the write and the chmod would have the mode applied to the
+    replacement. Where it does not exist the by-name form is the only option available,
+    and it is the same platform that already cannot pin a directory at all -- so this
+    adds no exposure that the declared by-name traversal does not already carry.
+
+    *mode* overrides the source's mode. Used for a restored security file, which must end
+    up owner-only regardless of what the archive recorded.
+    """
+    want = _stat.S_IMODE(st.st_mode) if mode is None else mode
+    fallback_name = dst_name
+    fallback_path = str(dst) if dst else None
+    if hasattr(os, "fchmod"):
+        os.fchmod(dst_fd, want)
+    elif dst_dir_fd is not None and fallback_name is not None:  # pragma: no cover - Windows
+        os.chmod(fallback_name, want, dir_fd=dst_dir_fd)
+    elif fallback_path is not None:  # pragma: no cover - Windows
+        os.chmod(fallback_path, want)
+
+    times = (st.st_atime_ns, st.st_mtime_ns)
+    if os.utime in os.supports_fd:
+        os.utime(dst_fd, ns=times)
+    elif dst_dir_fd is not None and fallback_name is not None:  # pragma: no cover - Windows
+        os.utime(fallback_name, ns=times, dir_fd=dst_dir_fd)
+    elif fallback_path is not None:  # pragma: no cover - Windows
+        os.utime(fallback_path, ns=times)
+
+
+def create_and_open_dir_pinned(
+    path: str | Path,
+    *,
+    what: str,
+    must_create: bool = False,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> int:
+    """Create a directory through its PINNED parent and return its descriptor.
+
+    With *must_create* a name that already exists is REFUSED rather than accepted. Review
+    found the hole that needs: a replace removes the live tree and stages the archive into
+    its place, so if the gateway recreates that root in between, accepting it lets files
+    the archive does not contain survive a "replace" that reports success. The children
+    already refused a pre-existing name -- only the root was exempt, and this makes it
+    consistent. Merge callers leave it false, because meeting an existing directory is
+    what merging IS.
+
+    This used to also report whether our own `mkdir` was what created the directory, so
+    that the archive's mode and timestamps could be stamped on in that case only. That
+    flag is gone, and the reasoning that justified it was wrong in an instructive way.
+
+    It was correct that sampling `dst.exists()` beforehand is a name-based check with a
+    window after it. What it missed is that `mkdir` succeeding does not close the window
+    either: the descriptor comes from a SEPARATE `open`, so a directory replaced between
+    the two leaves the flag true while describing an object the caller no longer holds --
+    and the archive's metadata then lands on somebody else's directory. Review found
+    that. Nothing repairs it: a stat taken after the `mkdir` observes the replacement
+    just as happily, POSIX has no atomic create-and-open for a directory, and under a
+    same-user threat model no mode trick helps. So the metadata is simply not applied to
+    directories, and the flag has no remaining purpose.
+
+    ``Path(p).mkdir(parents=True)`` creates every missing component by name, so a link
+    already sitting at an ancestor is followed and the directories are created inside
+    whatever it points at -- a write through an attacker-controlled path, which is
+    strictly worse than a read through one. Review flagged the by-name creation; the
+    probe that settled it showed a link AT the final component is already refused by
+    ``O_NOFOLLOW`` but an ancestor link is not.
+
+    So the parent chain is pinned first and only the final component is created,
+    relative to that descriptor. What remains is this module's documented and
+    deliberate residual, stated in :func:`pin_parent`: a component that was already a
+    link when the parent was resolved is followed by that resolution, because refusing
+    every symlinked ancestor would break a destination under ``/tmp`` on macOS. The
+    parent must therefore already exist -- callers create their own tree roots.
+    """
+    as_given = Path(path)
+    parent_fd = pin_parent(
+        os.path.realpath(as_given.parent or Path(".")), what=what, refusal=refusal
+    )
+    try:
+        try:
+            os.mkdir(as_given.name, 0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            if must_create:
+                raise refusal(
+                    f"refusing to use the {what}: {as_given.name!r} already exists, and "
+                    "this operation replaces its destination rather than merging into "
+                    "it. Something recreated that directory after it was removed, so "
+                    "staging into it would leave files the archive does not contain "
+                    "while reporting a replacement. Remove it and re-run with the "
+                    "gateway stopped."
+                ) from None
+        try:
+            return os.open(as_given.name, _dir_flags(), dir_fd=parent_fd)
+        except OSError as exc:
+            # A link (or a plain file) at the destination's own name. O_NOFOLLOW already
+            # refuses it -- the gap review found was that it escaped as a raw OSError, so
+            # a restore ended in a traceback instead of the refusal every other path on
+            # this surface produces. Translated here so callers have one type to contain.
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                raise refusal(
+                    f"refusing to use the {what}: {as_given.name!r} is a symbolic link "
+                    "or not a directory, so creating the tree there would write through "
+                    "whatever it points at. Remove it and re-run."
+                ) from exc
+            raise
+    finally:
+        os.close(parent_fd)
+
+
+def stage_tree_pinned(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    what: str,
+    ignore: Callable[[str, list[str]], set[str]] | None = None,
+    on_skip: SkipReporter = _noop_skip,
+    skip_existing: bool = False,
+    must_create: bool = False,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> None:
+    """Copy a tree with BOTH traversals pinned end to end.
+
+    A by-name walk's link screens protect only each final component: swapping an
+    allowlisted ancestor DIRECTORY for a link to a credential directory mid-walk
+    redirects every deeper open through the link, and the per-file ``O_NOFOLLOW``
+    never fires because what it finds inside the replaced tree is a plain regular
+    file. Here every directory is opened ``O_NOFOLLOW|O_DIRECTORY`` relative to its
+    PARENT's descriptor and every file is opened relative to its pinned parent, so
+    the directory that was validated is exactly the directory used. Both roots go
+    through :func:`open_dir_pinned`, which pins the chain ABOVE each root too.
+
+    The DESTINATION is pinned for a reason, not for symmetry. The first version of
+    this function pinned only the source, which was defensible while the only
+    destination was a private temporary directory -- and wrong the moment a restore
+    used it, because then the destination IS the live data home and an ancestor
+    swapped there lands the archive's bytes outside it. Caught in review.
+
+    With *skip_existing* an occupied destination name is reported and skipped rather
+    than refused, which is what a merge that must not overwrite needs. Without it an
+    occupied name raises, because in a staging directory this process just created,
+    the only thing that can be sitting there is something planted.
+
+    Symlinks and non-regular files are reported through *on_skip* and skipped;
+    entries that vanish mid-walk are reported and skipped; *ignore* sees
+    ``(directory_by_name, contents)`` exactly as ``shutil.copytree``'s does. Every
+    other error propagates, so a staging pass never silently ships without files it
+    failed to read.
+
+    Refuses outright on a platform that cannot pin a tree. Callers that must still
+    function there are expected to say so explicitly rather than have this module
+    quietly hand them a by-name walk -- see :func:`supports_pinned_tree_walk`.
+    """
+    if not supports_pinned_tree_walk():
+        raise refusal(
+            f"refusing to stage the {what}: this platform cannot open a directory "
+            "relative to a descriptor, so the traversal would have to re-open every "
+            "component by name and could be redirected by an ancestor swapped "
+            "mid-walk. Staging by name is a caller's decision to declare, not this "
+            "helper's to make silently."
+        )
+
+    def _walk(src_fd: int, dst_fd: int, by_name: str) -> None:
+        names = os.listdir(src_fd)
+        skipped = set(ignore(by_name, names)) if ignore else set()
+        for entry in sorted(names):
+            if entry in skipped:
+                continue
+            path = os.path.join(by_name, entry)
+            try:
+                st = os.stat(entry, dir_fd=src_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                on_skip(SKIP_VANISHED, path)
+                continue
+            if _stat.S_ISLNK(st.st_mode):
+                on_skip(SKIP_SYMLINK, path)
+            elif _stat.S_ISDIR(st.st_mode):
+                child_src = _open_child_dir(src_fd, entry, path, on_skip)
+                if child_src is None:
+                    continue
+                try:
+                    try:
+                        os.mkdir(entry, 0o700, dir_fd=dst_fd)
+                    except FileExistsError:
+                        # Only a merge legitimately meets an existing destination
+                        # directory. Anywhere else the destination tree is one this
+                        # process just created, so a name already occupying it is a
+                        # planted link or file -- and swallowing that made the pinned
+                        # open below refuse the subtree and the whole restore report
+                        # success with the archive's subtree missing. Raised in
+                        # review, and the same silent-partial shape this change fixes
+                        # elsewhere, so it is now a refusal rather than a skip.
+                        if not skip_existing:
+                            raise refusal(
+                                f"refusing to stage into {path!r}: a name already "
+                                "occupies that directory in a destination tree this "
+                                "operation created, so it is a link or a file planted "
+                                "there rather than a directory to merge into. Writing "
+                                "past it would silently omit everything below it."
+                            )
+                    child_dst = _open_child_dir(dst_fd, entry, path, on_skip)
+                    if child_dst is None:
+                        # A SOURCE entry that stopped being a directory is skipped --
+                        # there is nothing left to copy. A DESTINATION that stopped
+                        # being one is different: the archive's subtree still exists
+                        # and now has nowhere to go, so continuing would report success
+                        # with that subtree missing. Raised in review. A merge is the
+                        # one caller that may legitimately meet a foreign destination
+                        # tree, so it keeps the skip.
+                        if not skip_existing:
+                            raise refusal(
+                                f"refusing to stage into {path!r}: the destination "
+                                "directory stopped being a plain directory after it was "
+                                "created, so the archive's contents below it could not "
+                                "be written. Continuing would report success with that "
+                                "subtree missing."
+                            )
+                        continue
+                    try:
+                        _walk(child_src, child_dst, path)
+                        # Applied AFTER the contents, through the destination's OWN
+                        # descriptor, and ONLY to a directory this walk created.
+                        #
+                        # `shutil.copytree` preserved directory mode and timestamps; the
+                        # walk that replaced it did not, so a restored 0755 directory came
+                        # back 0700 with a fresh mtime. Fixing that unconditionally then
+                        # broke the merge case: a live 0700 directory had the ARCHIVE's
+                        # 0755 stamped onto it, which both clobbers the user's metadata and
+                        # loosens permissions from an untrusted source. Both caught in
+                        # review, one round apart.
+                        #
+                        # The archive-is-untrusted half is not a new rule -- it is why a
+                        # security file is forced to 0600 rather than given the archive's
+                        # mode. That rule was applied to files and not carried to
+                        # directories.
+                        #
+                        # The archive's directory mode and mtime are NOT applied. They used
+                        # to be, gated on `created` from the `mkdir`, and review showed the
+                        # gate cannot be trusted: the descriptor comes from a separate
+                        # `open`, so a directory replaced between the two leaves
+                        # `created=True` describing an object we no longer hold, and the
+                        # archive's metadata then lands on somebody else's directory.
+                        #
+                        # There is no sound repair. An identity check cannot help -- a
+                        # stat taken after the mkdir observes the REPLACEMENT just as
+                        # happily as our own directory -- and POSIX has no atomic
+                        # create-and-open for a directory to make the flag mean what it
+                        # says. Under a same-user threat model no mode trick closes it
+                        # either.
+                        #
+                        # So the fidelity is given up on purpose: a restored tree keeps its
+                        # default directory mode and a current mtime. That partly gives
+                        # back a fidelity fix made earlier in this change, and it is the
+                        # right trade -- applying untrusted archive metadata to a live
+                        # directory is the hazard this module exists to refuse.
+                    finally:
+                        os.close(child_dst)
+                finally:
+                    os.close(child_src)
+            elif _stat.S_ISREG(st.st_mode):
+                try:
+                    copy_file_pinned(
+                        path,
+                        dir_fd=src_fd,
+                        name=entry,
+                        dst_dir_fd=dst_fd,
+                        dst_name=entry,
+                        skip_existing=skip_existing,
+                        on_skip=on_skip,
+                    )
+                except FileNotFoundError:
+                    on_skip(SKIP_VANISHED, path)
+                except FileExistsError as exc:
+                    # The destination name was taken between this walk starting and the
+                    # publish. Without `skip_existing` that is not a merge -- the caller
+                    # believes the tree it is writing into is free -- so it is a real
+                    # condition, but it escaped as a bare traceback out of a restore.
+                    # Review found it. Translated to this module's refusal type, the same
+                    # way ELOOP/ENOTDIR already are, so callers have one type to contain
+                    # and the message says which name is occupied.
+                    raise refusal(
+                        f"refusing to stage {path!r}: its destination name was created by "
+                        "something else while this operation was running, so writing it "
+                        "would either overwrite that file or leave the tree half-applied. "
+                        "Nothing was written for this entry. Re-run with the gateway "
+                        "stopped."
+                    ) from exc
+            else:
+                on_skip(SKIP_NOT_REGULAR, path)
+
+    try:
+        root_src = open_dir_pinned(src, what=what, refusal=refusal)
+    except (OSError, refusal) as exc:
+        # A SOURCE root that was swapped or removed after the caller's listing-time
+        # screen is omitted, not fatal -- the same treatment every other unusable source
+        # entry gets, and it now reaches MANIFEST.json rather than only the console. The
+        # refusal type is caught alongside the raw errno because `open_dir_pinned` now
+        # translates ELOOP/ENOTDIR (review asked for that so DIRECT callers stop getting
+        # tracebacks); this call site is the one place that wants the softer outcome.
+        if isinstance(exc, OSError) and exc.errno not in (
+            errno.ELOOP,
+            errno.ENOTDIR,
+            errno.ENOENT,
+        ):
+            raise
+        on_skip(SKIP_SYMLINK, str(src))
+        return
+    try:
+        # No parents=True here, deliberately. Creating a missing ancestor chain by name
+        # is exactly what this replaced: every caller's destination parent already
+        # exists (a staging directory this process made, the data home, or a backup
+        # directory the caller created), so a missing parent means the caller is
+        # pointing somewhere it has not validated, and that should surface rather than
+        # be materialised through whatever the path resolves to.
+        # Whether the ROOT is ours to stamp comes from the kernel, not from a name.
+        # `not dst.exists()` was a check with a window after it: a forced restore removes
+        # the workspace, the gateway recreates it before the mkdir, and the live directory
+        # is then stamped with the archive's metadata. Review caught it, and it is the
+        # third instance of this change's first invariant -- no write, and no decision
+        # governing a write, may be made through a path name.
+        root_dst = create_and_open_dir_pinned(
+            dst,
+            what=f"{what} destination",
+            # Stated by the caller, NOT derived. Deriving it from `skip_existing` was the
+            # obvious guess and it is wrong: the snapshot's own staging destination already
+            # exists when the walk starts, and it has no `skip_existing` either, so that
+            # derivation refused every snapshot. The pre-existing snapshot suite caught it.
+            # Only a REPLACE knows it removed the tree it is about to write.
+            must_create=must_create,
+            refusal=refusal,
+        )
+        try:
+            _walk(root_src, root_dst, str(src))
+            # No metadata write here either. `root_is_ours` comes from the same
+            # mkdir-then-open pair as the per-child flag and is unsound for the same
+            # reason, so the root is treated exactly like its children.
+        finally:
+            os.close(root_dst)
+    finally:
+        os.close(root_src)
+
+
+def _open_child_dir(parent_fd: int, entry: str, by_name: str, on_skip: SkipReporter) -> int | None:
+    """Open a child directory through *parent_fd*, or report why it was skipped.
+
+    Returns ``None`` for the two races worth tolerating -- the entry vanished, or it
+    stopped being a plain directory between the stat and this open. ``ELOOP`` and
+    ``ENOTDIR`` are exactly the swap the pinned open exists to refuse, so they are
+    reported as a skipped symlink rather than raised: the listing-time screen would
+    have said the same thing a moment earlier. Every other error propagates.
+
+    Extracted because the source and destination sides need identical handling, and
+    the version of this code that had it on one side only let the swap the source
+    skipped escape the destination as a raw ``OSError``.
+    """
+    try:
+        return os.open(entry, _dir_flags(), dir_fd=parent_fd)
+    except FileNotFoundError:
+        on_skip(SKIP_VANISHED, by_name)
+        return None
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            on_skip(SKIP_SYMLINK, by_name)
+            return None
+        raise

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -35,34 +35,39 @@ from kiro_crew.snapshot import (
     _merge_crons,
     _merge_memory,
     _merge_notifications,
+    _staging_is_pinned,
 )
 
 logger = logging.getLogger(__name__)
 
-EXPORT_EXCLUDE = frozenset({
-    ".env",
-    ".local_secret",
-    "sel_hmac.key",
-    "telemetry_salt",
-    # NOTE: the beacon's per-install identity files (beacon_install_id /
-    # beacon_last_sent) are deliberately NOT listed here. This set is matched by
-    # BASENAME and `_is_excluded` runs over the workspace/, plan_memory/ and
-    # skills/ trees, so an entry here would silently drop any USER file that
-    # happens to share the name. They need no entry: root-level export is a
-    # hard-coded allowlist (config.json, hooks.json, crons.json,
-    # notifications.jsonl, project_dir, workspace_dir), so a root beacon file is
-    # never selected in the first place.
-    "session_map.json",
-    "kiro_session_pids.txt",
-    "kiro_pids.txt",
-})
+EXPORT_EXCLUDE = frozenset(
+    {
+        ".env",
+        ".local_secret",
+        "sel_hmac.key",
+        "telemetry_salt",
+        # NOTE: the beacon's per-install identity files (beacon_install_id /
+        # beacon_last_sent) are deliberately NOT listed here. This set is matched by
+        # BASENAME and `_is_excluded` runs over the workspace/, plan_memory/ and
+        # skills/ trees, so an entry here would silently drop any USER file that
+        # happens to share the name. They need no entry: root-level export is a
+        # hard-coded allowlist (config.json, hooks.json, crons.json,
+        # notifications.jsonl, project_dir, workspace_dir), so a root beacon file is
+        # never selected in the first place.
+        "session_map.json",
+        "kiro_session_pids.txt",
+        "kiro_pids.txt",
+    }
+)
 
-EXCLUDE_DIRS = frozenset({
-    "snapshots",
-    "outbox",
-    "uploads",
-    "__pycache__",
-})
+EXCLUDE_DIRS = frozenset(
+    {
+        "snapshots",
+        "outbox",
+        "uploads",
+        "__pycache__",
+    }
+)
 
 
 def _mc_dir() -> Path:
@@ -126,8 +131,14 @@ def create_export_zip() -> tuple[bytes, dict]:
 
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
         # Core JSON/text files
-        for fname in ("config.json", "hooks.json", "crons.json", "notifications.jsonl",
-                      "project_dir", "workspace_dir"):
+        for fname in (
+            "config.json",
+            "hooks.json",
+            "crons.json",
+            "notifications.jsonl",
+            "project_dir",
+            "workspace_dir",
+        ):
             src = mc / fname
             if src.is_file() and not src.is_symlink():
                 zf.write(str(src), f"{prefix}/{fname}")
@@ -185,7 +196,7 @@ def create_export_zip() -> tuple[bytes, dict]:
 # millions of entries) is rejected before extraction rather than filling the
 # host disk.
 _MAX_IMPORT_MEMBERS = 50_000
-_MAX_IMPORT_UNCOMPRESSED = 2 * 1024 ** 3  # 2 GiB
+_MAX_IMPORT_UNCOMPRESSED = 2 * 1024**3  # 2 GiB
 
 
 def _is_link_entry(info: zipfile.ZipInfo) -> bool:
@@ -223,13 +234,21 @@ def validate_import_zip(zip_path: Path) -> tuple[bool, str, dict]:
             # Zip-bomb guard: bound entry count and total uncompressed size.
             infos = zf.infolist()
             if len(infos) > _MAX_IMPORT_MEMBERS:
-                return False, f"Rejected: archive has too many entries ({len(infos)} > {_MAX_IMPORT_MEMBERS})", {}
+                return (
+                    False,
+                    f"Rejected: archive has too many entries ({len(infos)} > {_MAX_IMPORT_MEMBERS})",
+                    {},
+                )
             total_uncompressed = sum(i.file_size for i in infos)
             if total_uncompressed > _MAX_IMPORT_UNCOMPRESSED:
-                return False, (
-                    f"Rejected: uncompressed size {total_uncompressed} exceeds cap "
-                    f"{_MAX_IMPORT_UNCOMPRESSED} (possible zip bomb)"
-                ), {}
+                return (
+                    False,
+                    (
+                        f"Rejected: uncompressed size {total_uncompressed} exceeds cap "
+                        f"{_MAX_IMPORT_UNCOMPRESSED} (possible zip bomb)"
+                    ),
+                    {},
+                )
 
             # Link members can redirect a later write outside the extraction root
             # even when every name passes the traversal check above.
@@ -388,7 +407,56 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
     Returns summary dict of what was imported.
     """
     mc = _mc_dir()
-    summary: dict = {"mode": mode, "items": []}
+    # Asked once, at the top, before anything is extracted or written. Both branches
+    # below mutate the data home, and the merge branch writes core files with
+    # shutil.copy2 BEFORE it reaches the first tree call -- so gating inside the tree
+    # helpers let a merge on a platform that cannot pin half-apply the core files and
+    # then raise, against this function's own "fails loudly, nothing was written"
+    # contract. Raised in review. This is the third site of the same defect (after
+    # _build_snapshot and _do_merge), which is why the gate now lives at the entry of
+    # every operation that mutates rather than next to the individual writes.
+    #
+    # There is no flag to pass here: an import is a UI action, not a command line. I first
+    # concluded from that that the gate should refuse, and it was the wrong conclusion drawn
+    # from a correct observation -- CI proved it by failing four PRE-EXISTING portability
+    # tests on Windows. Refuse-by-default only means "ask the user" where a consent surface
+    # exists. Where none does, it means removing the feature on that platform, which is not
+    # a security decision anyone made.
+    #
+    # So this path PERMITS a by-name traversal and records that it happened, while snapshot
+    # and restore keep refusing -- because they have `--allow-unpinned-staging` and can
+    # actually ask. The per-entry screens still apply either way: the copy opens with
+    # O_NOFOLLOW and the walk rejects links and reparse points, so what is given up here is
+    # ancestor-swap resistance, not link resistance.
+    staging_pinned = _staging_is_pinned(allow_unpinned=True, what=f"{mode} import")
+
+    # What this field may honestly say depends on the MODE, not only the platform. Review
+    # caught it reporting "pinned" for a merge whose core files and skills are still copied
+    # by name with `shutil` -- true of the platform, false of the operation, and this field
+    # exists to tell a reader what actually happened.
+    #
+    # replace delegates the whole apply to `_do_replace`, which is pinned throughout. merge
+    # routes only its tree copy through the primitive; its core files (including the
+    # databases, deliberately out of scope -- see #5451) and its skills copy are by name. So
+    # merge on a pinnable platform is MIXED, and saying so is the point.
+    if not staging_pinned:
+        staging_mode = "unpinned"
+    elif mode == "replace":
+        staging_mode = "pinned"
+    else:
+        staging_mode = "mixed"
+    if not staging_pinned:
+        logger.warning(
+            "%s import staged by name: this platform cannot open a directory relative to a "
+            "descriptor, so an ancestor swapped mid-import could redirect the copy. The "
+            "summary records staging=unpinned.",
+            mode,
+        )
+    summary: dict = {
+        "mode": mode,
+        "items": [],
+        "staging": staging_mode,
+    }
 
     with tempfile.TemporaryDirectory() as work_str:
         work = Path(work_str)
@@ -416,9 +484,7 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
 
         snap_dirs = [d for d in work.iterdir() if d.is_dir()]
         if len(snap_dirs) != 1:
-            raise ValueError(
-                f"Expected 1 top-level directory in zip, found {len(snap_dirs)}"
-            )
+            raise ValueError(f"Expected 1 top-level directory in zip, found {len(snap_dirs)}")
         snap = snap_dirs[0]
 
         # Re-vet imported cron commands before ANY path below consumes
@@ -453,7 +519,14 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
             auto_dir = snap / "skills" / "auto"
             if auto_dir.is_dir():
                 shutil.rmtree(str(auto_dir))
-            _do_replace(snap, mc, None)
+            # A platform that cannot pin a directory by descriptor refuses this
+            # staging pass, and the refusal is allowed to propagate. An earlier
+            # revision caught it and returned the summary, which was worse than the
+            # crash it avoided: the caller reads a returned summary as success, so the
+            # dashboard rendered "Import complete" over a data home nothing had been
+            # written to. Raised in review. Propagating reaches the existing error
+            # path, which is the one that tells the user the import did not happen.
+            _do_replace(snap, mc, None, allow_unpinned=not staging_pinned)
             summary["items"].append("full replace")
         else:
             # Merge mode
@@ -488,14 +561,10 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
 
             if (snap / "notifications.jsonl").is_file():
                 if (mc / "notifications.jsonl").is_file():
-                    _merge_notifications(
-                        snap / "notifications.jsonl", mc / "notifications.jsonl"
-                    )
+                    _merge_notifications(snap / "notifications.jsonl", mc / "notifications.jsonl")
                     summary["items"].append("notifications (merged)")
                 else:
-                    shutil.copy2(
-                        str(snap / "notifications.jsonl"), str(mc / "notifications.jsonl")
-                    )
+                    shutil.copy2(str(snap / "notifications.jsonl"), str(mc / "notifications.jsonl"))
                     summary["items"].append("notifications (copied)")
 
             for dirname in ("workspace", "plan_memory"):
@@ -503,7 +572,10 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
                 if sd.is_dir():
                     dd = mc / dirname
                     dd.mkdir(parents=True, exist_ok=True)
-                    _copy_tree_no_overwrite(sd, dd)
+                    # The permission decided once at entry flows down; otherwise the inner
+                    # gate re-asks and refuses, which is the same platform outage by a
+                    # longer route.
+                    _copy_tree_no_overwrite(sd, dd, allow_unpinned=not staging_pinned)
                     summary["items"].append(f"{dirname} (merged)")
 
             if (snap / "skills").is_dir():

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -9,12 +9,14 @@ import os
 import re
 import shutil
 import socket
+import stat as _stat
 import tarfile
 import tempfile
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
-from kiro_crew import platform_compat
+from kiro_crew import pinned_fs, platform_compat
 
 try:
     import pysqlite3 as sqlite3
@@ -186,34 +188,444 @@ def _list_components() -> None:
     print("\nCombine with commas: --components memory,crons,skills")
 
 
-def _copytree_safe(src: Path, dst: Path, **kwargs) -> None:
-    """copytree that skips symlinks to prevent sensitive file leakage."""
-    outer_ignore = kwargs.pop("ignore", None)
+def _terminal_safe(value: object) -> str:
+    """Render *value* so an untrusted string cannot drive the terminal.
 
-    def _ignore_symlinks(directory, contents):
-        skipped = {name for name in contents if os.path.islink(os.path.join(directory, name))}
-        for name in skipped:
-            print(f"⚠️  Skipping symlink in source tree: {os.path.join(directory, name)}")
+    A restore accepts an arbitrary ``.tar.gz``, so every string that comes back out of one
+    -- a manifest field, a member name -- is attacker-controlled input being written to a
+    terminal. ANSI and OSC sequences in it are executed by the terminal, not displayed, so
+    a crafted archive can rewrite what the operator appears to be reading, or worse.
+    Raised in review against the omission list this change added.
+
+    Control characters are escaped rather than stripped, so the value stays diagnosable
+    (an operator can see the file really is named with an escape) instead of silently
+    reading as a different, innocuous name. ``str.isprintable()`` is False for exactly the
+    C0/C1 range plus the separators, and True for ordinary text in any language, so a
+    non-ASCII path is unharmed.
+    """
+    return "".join(ch if ch.isprintable() else f"\\x{ord(ch):02x}" for ch in str(value))
+
+
+def _report_skip(reason: str, path: str) -> None:
+    """Word a primitive's skip classification in this module's existing voice.
+
+    The primitive classifies and never prints, so these strings stay byte-identical
+    to what snapshot/restore printed before the migration.
+
+    The path is rendered through :func:`_terminal_safe` because on the RESTORE side these
+    names come out of the archive: the walk is over an extracted tree whose member names
+    the archive chose, and `_data_filter` screens traversal, not escape bytes.
+    """
+    safe = _terminal_safe(path)
+    if reason == pinned_fs.SKIP_SYMLINK:
+        print(f"⚠️  Skipping symlink in source tree: {safe}")
+    elif reason == pinned_fs.SKIP_VANISHED:
+        print(f"⚠️  Skipping vanished entry during snapshot copy: {safe}")
+    else:
+        print(f"⚠️  Skipping hardlinked or non-regular file during snapshot copy: {safe}")
+
+
+def _staging_is_pinned(*, allow_unpinned: bool, what: str) -> bool:
+    """Whether staging may proceed, and whether it will be descriptor-pinned.
+
+    Returns True for a pinned traversal, False for the by-name traversal the caller
+    explicitly asked for. Raises rather than returning False when the platform cannot
+    pin and no one said that is acceptable.
+
+    This is the whole "refuse rather than fall back" rule, in one place. The reason it
+    is a refusal and not a warning: a by-name walk is not a slightly weaker version of
+    a pinned walk, it is the mechanism whose failure closed two pull requests. An
+    operator who needs a snapshot on a platform without ``dir_fd`` can still have one,
+    but they say so on the command line and the archive records that they did, so the
+    weaker mode is never something the tool chose on their behalf.
+    """
+    if pinned_fs.supports_pinned_tree_walk():
+        return True
+    if allow_unpinned:
+        return False
+    raise pinned_fs.PinnedPathRefusal(
+        f"refusing to stage the {what}: this platform cannot open a directory "
+        "relative to a descriptor, so every component would be re-opened by name and "
+        "an ancestor swapped mid-walk could redirect the copy into a credential "
+        "store. Re-run with --allow-unpinned-staging to accept a by-name traversal; "
+        "the archive will record that it was staged unpinned."
+    )
+
+
+def _copytree_safe(
+    src: Path,
+    dst: Path,
+    *,
+    allow_unpinned: bool = False,
+    on_skip: pinned_fs.SkipReporter | None = None,
+    must_create: bool = False,
+    **kwargs,
+) -> None:
+    """Copy a tree for staging, with the source traversal pinned where possible.
+
+    Was: ``shutil.copytree`` with an ignore callback that tested ``os.path.islink`` on
+    a NAME. That screened the final component of each entry and nothing else, so an
+    ancestor directory swapped for a link between the listing and the copy redirected
+    every deeper open, and the screen had nothing to report -- what it found inside
+    the replaced tree was an ordinary file. Now the traversal is descriptor-pinned by
+    :func:`kiro_crew.pinned_fs.stage_tree_pinned`, including the chain above the root.
+
+    ``dirs_exist_ok`` is still accepted and dropped -- it was a ``shutil.copytree``
+    keyword and callers may pass it out of habit -- but it is no longer meaningless
+    generally: whether an existing destination is tolerated is now decided by
+    *must_create*, and it is decided identically on both branches. Every other keyword is
+    rejected rather than silently dropped.
+
+    *must_create* says the caller REPLACES its destination rather than merging into it, so
+    a root that exists is refused. Only a caller that removed the tree it is about to write
+    knows this, so it is passed, never derived -- deriving it from ``skip_existing`` refused
+    every snapshot, because the snapshot's own staging root already exists.
+
+    *on_skip* lets a caller both print and RECORD what was skipped. It defaults to
+    printing only, which is right for restore; the snapshot path passes a recorder so
+    an incomplete archive says so in its own manifest instead of only in the console
+    output of whoever ran it.
+    """
+    report = on_skip or _report_skip
+    outer_ignore = kwargs.pop("ignore", None)
+    kwargs.pop("dirs_exist_ok", None)
+    if kwargs:
+        raise TypeError(f"_copytree_safe got unexpected keyword arguments: {sorted(kwargs)}")
+
+    if _staging_is_pinned(allow_unpinned=allow_unpinned, what=f"tree {src.name!r}"):
+        pinned_fs.stage_tree_pinned(
+            src,
+            dst,
+            what=f"tree {src.name!r}",
+            ignore=outer_ignore,
+            on_skip=report,
+            must_create=must_create,
+        )
+        return
+
+    # Declared by-name traversal. The TRAVERSAL is the weakness the operator opted into --
+    # an ancestor swapped mid-walk can still redirect it, and nothing here can prevent
+    # that without the descriptor support the platform lacks. The PER-FILE screens are a
+    # different matter and review was right that they had been left behind: plain
+    # `copytree` dereferences a hardlink into ordinary bytes and follows a Windows
+    # junction, so a credential aliased into a staged tree would have ridden along even
+    # though the pinned path refuses exactly that. Each file now goes through
+    # copy_file_pinned (same fstat screens, minus the pinned ancestors) and the screen
+    # rejects reparse points, which `islink` alone does not report on Windows.
+    def _ignore_unsafe(directory, contents):
+        skipped = set()
+        for entry in contents:
+            full = os.path.join(directory, entry)
+            if os.path.islink(full) or pinned_fs.is_reparse_point(full):
+                skipped.add(entry)
+                report(pinned_fs.SKIP_SYMLINK, full)
         if outer_ignore:
             skipped |= set(outer_ignore(directory, contents))
         return skipped
 
-    shutil.copytree(str(src), str(dst), ignore=_ignore_symlinks, **kwargs)
+    def _copy_screened(source: str, target: str, **_kw) -> None:
+        pinned_fs.copy_file_pinned(source, target, on_skip=report)
+
+    # `dirs_exist_ok` has to follow `must_create`, not be hardcoded. Review found the gap:
+    # `must_create` reached the pinned walk and stopped there, so on a platform that cannot
+    # pin -- Windows, the dashboard's replace -- a root recreated after the rmtree was still
+    # merged into and stale files survived a successful replace. That is the same mistake as
+    # the earlier Windows import refusal in this PR: a guard added to the pinned path and not
+    # carried to the by-name one. Every mutating path gets the gate or the gate is decorative.
+    try:
+        shutil.copytree(
+            str(src),
+            str(dst),
+            ignore=_ignore_unsafe,
+            copy_function=_copy_screened,
+            dirs_exist_ok=not must_create,
+        )
+    except FileExistsError as exc:
+        # Same refusal type and same sentence as the pinned branch, so a caller has one
+        # thing to contain and the operator reads the same explanation on either platform.
+        raise pinned_fs.PinnedPathRefusal(
+            f"refusing to use the tree {src.name!r} destination: {dst.name!r} already "
+            "exists, and this operation replaces its destination rather than merging "
+            "into it. Something recreated that directory after it was removed, so "
+            "staging into it would leave files the archive does not contain while "
+            "reporting a replacement. Remove it and re-run with the gateway stopped."
+        ) from exc
 
 
-def _copy_tree_no_overwrite(src: Path, dst: Path) -> None:
-    for item in src.rglob("*"):
-        if item.is_symlink():
-            continue
-        target = dst / item.relative_to(src)
-        if item.is_dir():
-            target.mkdir(parents=True, exist_ok=True)
-        elif item.is_file() and not target.exists():
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(str(item), str(target))
+def _copy_tree_no_overwrite(src: Path, dst: Path, *, allow_unpinned: bool = False) -> None:
+    """Merge *src* into *dst* without overwriting, with both ends pinned.
+
+    The destination side is where #3797's third finding lives. The previous version
+    walked the source with ``rglob`` and wrote each file with ``shutil.copy2`` to a
+    path composed by name, so the destination's ancestor chain was never pinned: a
+    component of *dst* swapped for a link after ``mkdir`` redirected the write, and
+    ``not target.exists()`` answered for whatever the link pointed at rather than for
+    the directory the caller validated.
+
+    This is now one call into the shared primitive with ``skip_existing=True``, which
+    is what makes the no-overwrite promise real: exclusive creation is atomic, so "it
+    did not exist a moment ago" and "this call created it" are the same statement
+    rather than two with a window between them.
+
+    An earlier revision open-coded a second pinned walk here, with its own copy body.
+    Review pointed out the two had already diverged -- this one's child-directory open
+    lacked the ``ELOOP``/``ENOTDIR`` handling, so the very swap the staging walk skips
+    would have escaped restore as a raw ``OSError`` -- which is the argument for a
+    parameter on one primitive rather than a parallel implementation the shared
+    module's own docstring says should not exist.
+    """
+    if not _staging_is_pinned(allow_unpinned=allow_unpinned, what=f"restore of {dst.name!r}"):
+        for item in src.rglob("*"):
+            if item.is_symlink():
+                continue
+            target = dst / item.relative_to(src)
+            if item.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+            elif item.is_file():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                # `copy2` opened the destination BY NAME for writing, so a symlink planted
+                # at that name after the `not target.exists()` check was followed and an
+                # arbitrary external file was overwritten. Review's finding, and the
+                # `exists()` guard was itself the name-based check that created the window.
+                #
+                # copy_file_pinned opens the destination O_CREAT|O_EXCL|O_NOFOLLOW even
+                # with no directory descriptor, so the link is refused rather than
+                # followed, and O_EXCL subsumes the skip-if-present behaviour the old
+                # `not target.exists()` was there to provide -- without the race.
+                pinned_fs.copy_file_pinned(
+                    str(item), str(target), skip_existing=True, on_skip=_report_skip
+                )
+        return
+
+    pinned_fs.stage_tree_pinned(
+        src,
+        dst,
+        what=f"restore of {dst.name!r}",
+        on_skip=_report_skip,
+        skip_existing=True,
+    )
 
 
 # ── Snapshot ──────────────────────────────────────────────────────────────────
+
+
+def _build_snapshot(mc: Path, out: Path, name: str, *, allow_unpinned: bool = False) -> Path:
+    """Stage the data home into a temporary tree and publish it as one tarball.
+
+    Extracted from ``snapshot_main`` so the staging pass has a boundary a refusal can
+    be contained at: everything in here either produces a finished archive or raises,
+    and the caller turns a :class:`kiro_crew.pinned_fs.PinnedPathRefusal` into an exit
+    code rather than a traceback.
+    """
+    # Decided BEFORE anything is staged, not per-tree. An earlier revision gated
+    # inside _copytree_safe only, so a data home with core files and no trees staged
+    # them on a platform that cannot pin without ever consulting the opt-in -- the
+    # gate was reachable only through a path that happened to exist. Asking once, up
+    # front, is also what makes the manifest's "staging" value true of the whole
+    # archive rather than of whichever component ran last.
+    pinned = _staging_is_pinned(allow_unpinned=allow_unpinned, what="data home")
+
+    # Every skip is recorded, not just printed. A snapshot that omitted a hardlinked
+    # or symlinked file used to report success with a console warning and nothing in
+    # the archive -- the same "silent partial" shape this change fixes on the restore
+    # side, raised in review. Paths are stored relative to the data home so the record
+    # names the file without carrying the absolute layout of the machine into an
+    # archive that may be moved somewhere else.
+    skipped: list[dict[str, str]] = []
+
+    def _record_skip(reason: str, path: str) -> None:
+        try:
+            rel = str(Path(path).relative_to(mc))
+        except ValueError:
+            rel = Path(path).name
+        skipped.append({"reason": reason, "path": rel})
+        _report_skip(reason, path)
+
+    with tempfile.TemporaryDirectory() as work:
+        stage = Path(work) / name
+        for d in ("workspace", "skills", "plan_memory"):
+            (stage / d).mkdir(parents=True, exist_ok=True)
+
+        # Core files. Copied through the pinned primitive rather than shutil.copy2:
+        # copy2 dereferences a hardlink into ordinary-looking regular bytes, and the
+        # tar pass's hardlink screen then has no link left to reject, so an alias
+        # planted at a core file's name would have shipped as content. The name-based
+        # islink check is gone with it -- it answered about a name, and the open that
+        # followed could land on a different inode.
+        #
+        # Both ends are pinned where the platform allows it: the data home is opened
+        # once and every core file is opened relative to THAT descriptor, so an
+        # ancestor of the data home swapped mid-run cannot redirect the read. Opening
+        # `mc / f` by name was a real gap in the first revision of this PR, caught in
+        # review -- the file's own O_NOFOLLOW says nothing about the directories walked
+        # to reach it.
+        mc_fd = pinned_fs.open_dir_pinned(mc, what="data home") if pinned else None
+        try:
+            for files in CORE_FILES.values():
+                for f in files:
+                    src = mc / f
+                    if mc_fd is not None:
+                        # Asked through the descriptor. `is_regular_at` lstats relative to
+                        # mc_fd, so it rejects a link or a Windows junction by itself --
+                        # a reparse point is not S_ISREG -- and there is no name for a
+                        # concurrent swap to redirect.
+                        #
+                        # My own AST ratchet flagged this very line last round and I
+                        # dismissed it as one of the legitimate by-name fallback sites
+                        # without checking. It was not: this loop holds mc_fd. Review
+                        # caught what I had waved off.
+                        # A core file that simply is not there is not an omission and must
+                        # stay out of MANIFEST.json -- most components ship only a subset.
+                        # Only a name that EXISTS and is not a regular file is a skip worth
+                        # recording, so the two cases are separated rather than collapsed
+                        # into one `is_regular_at` call. Caught by the manifest test.
+                        live_st = pinned_fs.stat_at(mc_fd, f)
+                        if live_st is None:
+                            continue
+                        if not _stat.S_ISREG(live_st.st_mode):
+                            _record_skip(pinned_fs.SKIP_NOT_REGULAR, str(src))
+                            continue
+                    else:
+                        if not src.is_file():
+                            continue
+                        # Reserved for the fallback, where there is no descriptor to ask.
+                        # `is_file()` and, on a platform without O_NOFOLLOW, `os.open`
+                        # both FOLLOW a link, so neither can screen one: on the declared
+                        # by-name path a core filename pointed at a credential would have
+                        # had its bytes copied into the archive. `is_reparse_point` also
+                        # catches a Windows junction, which `islink` does not report.
+                        if pinned_fs.is_reparse_point(src):
+                            _record_skip(pinned_fs.SKIP_SYMLINK, str(src))
+                            continue
+                    if f.endswith(".db"):
+                        # DATABASES ARE OUT OF SCOPE for this change, deliberately, and
+                        # this is main's behaviour unchanged.
+                        #
+                        # Capturing a live SQLite database without reopening its name is a
+                        # genuine conflict of requirements -- SQLite accepts only a path,
+                        # and it cannot be pointed at a held descriptor (probed: it refuses
+                        # /proc/self/fd/N and /dev/fd/N alike). Five review rounds were
+                        # spent on it here and each fix set up the next, so the database
+                        # question is tracked separately rather than solved in the middle
+                        # of a PR about the pinned tree walk.
+                        #
+                        # The `backup()` call reopens the live name and so inherits main's
+                        # existing exposure. That is not a regression introduced here: it is
+                        # what shipped before this change and what still ships after it.
+                        with (
+                            closing(sqlite3.connect(str(src))) as src_conn,
+                            closing(sqlite3.connect(str(stage / f))) as dst_conn,
+                        ):
+                            src_conn.backup(dst_conn)
+                    elif mc_fd is not None:
+                        pinned_fs.copy_file_pinned(
+                            str(src),
+                            str(stage / f),
+                            dir_fd=mc_fd,
+                            name=f,
+                            on_skip=_record_skip,
+                        )
+                    else:
+                        pinned_fs.copy_file_pinned(str(src), str(stage / f), on_skip=_record_skip)
+        finally:
+            if mc_fd is not None:
+                os.close(mc_fd)
+
+        # Workspace (exclude hygiene_data, insert_facts*.py)
+        if (mc / "workspace").is_dir():
+            _copytree_safe(
+                mc / "workspace",
+                stage / "workspace",
+                allow_unpinned=allow_unpinned,
+                on_skip=_record_skip,
+                ignore=shutil.ignore_patterns("hygiene_data", "insert_facts*.py"),
+            )
+
+        # Plan memory
+        if (mc / "plan_memory").is_dir():
+            _copytree_safe(
+                mc / "plan_memory",
+                stage / "plan_memory",
+                allow_unpinned=allow_unpinned,
+                on_skip=_record_skip,
+            )
+
+        # Skills
+        if (mc / "skills").is_dir():
+            _copytree_safe(
+                mc / "skills",
+                stage / "skills",
+                allow_unpinned=allow_unpinned,
+                on_skip=_record_skip,
+            )
+
+        # Manifest
+        ws_files = sum(1 for _ in (stage / "workspace").rglob("*") if _.is_file())
+        pm_files = sum(1 for _ in (stage / "plan_memory").rglob("*") if _.is_file())
+        sk_count = sum(1 for _ in (stage / "skills").iterdir() if _.is_dir())
+        # Recorded so a reader can tell how the archive was built. "unpinned" means
+        # the trees were walked by name, which an ancestor swap during staging could
+        # have redirected. Someone deciding whether to trust this archive needs that
+        # on the record rather than in the memory of whoever ran the command.
+        staging_mode = "pinned" if pinned else "unpinned"
+        manifest = {
+            "version": 2,
+            "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "hostname": socket.gethostname(),
+            "user": os.environ.get("USER", "unknown"),
+            "kirocrew_dir": str(mc),
+            "staging": staging_mode,
+            "skipped": skipped,
+            "contents": {
+                "memory_db": _fsize(stage / "memory.db"),
+                "memory_index_db": _fsize(stage / "memory_index.db"),
+                "crons_json": _fsize(stage / "crons.json"),
+                "config_json": _fsize(stage / "config.json"),
+                "notifications_jsonl": _fsize(stage / "notifications.jsonl"),
+                "workspace_files": ws_files,
+                "plan_memory_files": pm_files,
+                "skill_count": sk_count,
+            },
+        }
+        (stage / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
+        if staging_mode == "unpinned":
+            print(
+                "⚠️  Staged by path name (--allow-unpinned-staging): this platform "
+                "cannot pin a directory by descriptor, so an ancestor swapped during "
+                "staging could have redirected a copy. Recorded in MANIFEST.json."
+            )
+
+        # Tarball — write to temp file and rename atomically to avoid corrupt partials
+        out.mkdir(parents=True, exist_ok=True)
+        outfile = out / f"{name}.tar.gz"
+        tmp_tar = outfile.with_suffix(".tar.gz.tmp")
+        try:
+            with tarfile.open(str(tmp_tar), "w:gz") as tar:
+                tar.add(str(stage), arcname=name, filter=_data_filter)
+            # Lock the archive down BEFORE it is published. Carried over from main's
+            # #5317 during the rebase: this block was extracted out of snapshot_main
+            # into this function, and main had meanwhile moved the lockdown to before
+            # the rename, so taking this side of the conflict wholesale would have
+            # silently dropped that fix.
+            #
+            # This tarball can contain sel_hmac.key, and the window between the rename
+            # and a lockdown applied afterwards is not Windows-only: tarfile does not
+            # create its file 0600, so on POSIX the archive is readable at its final,
+            # predictable path until the chmod lands too.
+            #
+            # restrict_to_owner (fail-loud), NOT chmod_safe: chmod_safe swallows OSError
+            # and would let the snapshot land group/world-readable while still printing
+            # success. Failing here leaves the temp for the handler below to remove and
+            # publishes nothing, which is what makes the "abort rather than ship an
+            # under-protected archive" promise true by construction. POSIX applies chmod
+            # 0o600; Windows applies an owner-only DACL via icacls, and a
+            # same-directory rename carries the explicit ACE with the file.
+            platform_compat.restrict_to_owner(str(tmp_tar))
+            tmp_tar.rename(outfile)
+        except BaseException:
+            tmp_tar.unlink(missing_ok=True)
+            raise
+    return outfile
 
 
 def snapshot_main(
@@ -222,13 +634,25 @@ def snapshot_main(
     if parsed is None:
         p = argparse.ArgumentParser(
             prog="kirocrew-snapshot",
-            description="Create a portable .tar.gz snapshot of KiroCrew state.",
+            description="Create a portable .tar.gz snapshot of Kiro Crew state.",
         )
         p.add_argument("output_dir", nargs="?", default=_default_snapshot_dir())
         p.add_argument("--keep", type=int, default=7)
         p.add_argument("--list", action="store_true", dest="list_snapshots")
+        p.add_argument(
+            "--allow-unpinned-staging",
+            action="store_true",
+            dest="allow_unpinned",
+            help=(
+                "Stage by path name on a platform that cannot open a directory "
+                "relative to a descriptor. Without this the snapshot is refused there "
+                "rather than taken with a traversal an ancestor swap could redirect. "
+                "The archive's MANIFEST.json records that it was staged unpinned."
+            ),
+        )
         parsed = p.parse_args(argv)
     args = parsed
+    allow_unpinned = bool(getattr(args, "allow_unpinned", False))
 
     if args.keep <= 0:
         print(f"❌ --keep value must be a positive integer, got: {args.keep}")
@@ -265,8 +689,6 @@ def snapshot_main(
     # WAL checkpoint
     if (mc / "memory.db").is_file():
         try:
-            from contextlib import closing
-
             with closing(sqlite3.connect(str(mc / "memory.db"))) as c:
                 c.execute("PRAGMA wal_checkpoint(TRUNCATE);")
         except Exception:
@@ -275,97 +697,19 @@ def snapshot_main(
                 "The backup API still produces a consistent copy."
             )
 
-    with tempfile.TemporaryDirectory() as work:
-        stage = Path(work) / name
-        for d in ("workspace", "skills", "plan_memory"):
-            (stage / d).mkdir(parents=True, exist_ok=True)
-
-        # Core files
-        for files in CORE_FILES.values():
-            for f in files:
-                src = mc / f
-                if src.is_file():
-                    if os.path.islink(src):
-                        print(f"⚠️  Skipping symlinked core file: {src}")
-                        continue
-                    if f.endswith(".db"):
-                        from contextlib import closing
-
-                        with (
-                            closing(sqlite3.connect(str(src))) as src_conn,
-                            closing(sqlite3.connect(str(stage / f))) as dst_conn,
-                        ):
-                            src_conn.backup(dst_conn)
-                    else:
-                        shutil.copy2(str(src), str(stage / f))
-
-        # Workspace (exclude hygiene_data, insert_facts*.py)
-        if (mc / "workspace").is_dir():
-            _copytree_safe(
-                mc / "workspace",
-                stage / "workspace",
-                dirs_exist_ok=True,
-                ignore=shutil.ignore_patterns("hygiene_data", "insert_facts*.py"),
-            )
-
-        # Plan memory
-        if (mc / "plan_memory").is_dir():
-            _copytree_safe(mc / "plan_memory", stage / "plan_memory", dirs_exist_ok=True)
-
-        # Skills
-        if (mc / "skills").is_dir():
-            _copytree_safe(mc / "skills", stage / "skills", dirs_exist_ok=True)
-
-        # Manifest
-        ws_files = sum(1 for _ in (stage / "workspace").rglob("*") if _.is_file())
-        pm_files = sum(1 for _ in (stage / "plan_memory").rglob("*") if _.is_file())
-        sk_count = sum(1 for _ in (stage / "skills").iterdir() if _.is_dir())
-        manifest = {
-            "version": 2,
-            "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "hostname": socket.gethostname(),
-            "user": os.environ.get("USER", "unknown"),
-            "kirocrew_dir": str(mc),
-            "contents": {
-                "memory_db": _fsize(stage / "memory.db"),
-                "memory_index_db": _fsize(stage / "memory_index.db"),
-                "crons_json": _fsize(stage / "crons.json"),
-                "config_json": _fsize(stage / "config.json"),
-                "notifications_jsonl": _fsize(stage / "notifications.jsonl"),
-                "workspace_files": ws_files,
-                "plan_memory_files": pm_files,
-                "skill_count": sk_count,
-            },
-        }
-        (stage / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
-
-        # Tarball — write to temp file and rename atomically to avoid corrupt partials
-        out.mkdir(parents=True, exist_ok=True)
-        outfile = out / f"{name}.tar.gz"
-        tmp_tar = outfile.with_suffix(".tar.gz.tmp")
-        try:
-            with tarfile.open(str(tmp_tar), "w:gz") as tar:
-                tar.add(str(stage), arcname=name, filter=_data_filter)
-            # Lock the archive down BEFORE it is published. This tarball can
-            # contain sel_hmac.key (see the warning below), and the window
-            # between the rename and a lockdown applied afterwards is not
-            # Windows-only: tarfile does not create its file 0600, so on POSIX
-            # the archive is readable at its final, predictable path until the
-            # chmod lands too.
-            #
-            # restrict_to_owner (fail-loud), NOT chmod_safe: chmod_safe swallows
-            # OSError and would let the snapshot land group/world-readable while
-            # still printing success. Failing here leaves the temp for the
-            # handler below to remove and publishes nothing, which is what makes
-            # the "abort rather than ship an under-protected archive" promise
-            # true by construction. POSIX applies chmod 0o600; Windows applies an
-            # owner-only DACL via icacls, and a same-directory rename carries the
-            # explicit ACE with the file.
-            platform_compat.restrict_to_owner(str(tmp_tar))
-            tmp_tar.rename(outfile)
-        except BaseException:
-            tmp_tar.unlink(missing_ok=True)
-            raise
+    try:
+        outfile = _build_snapshot(mc, out, name, allow_unpinned=allow_unpinned)
+    except pinned_fs.PinnedPathRefusal as exc:
+        # A refusal is a decision this command made on purpose. A traceback would
+        # read like a crash and bury the sentence saying what to do about it.
+        #
+        # It is also a PERMISSION decision, so it belongs in the SEL log next to
+        # `state_restore_rejected`. Review's point: the refusals this change introduced
+        # returned without auditing, so the one outcome a reviewer would most want a
+        # record of -- staging declined on an unsupported platform -- left no trace.
+        _audit("snapshot_rejected", f"reason=unpinnable_staging detail={exc}")
+        print(f"❌ {exc}")
+        return 1
 
     sz = outfile.stat().st_size
     human = f"{sz // 1024}K" if sz < 1024 * 1024 else f"{sz / 1024 / 1024:.1f}M"
@@ -396,8 +740,18 @@ def _print_manifest(snap: Path) -> None:
     try:
         m = json.loads(mf.read_text())
         print("📋 Snapshot info:")
-        print(f"  Created: {m.get('created_at', 'unknown')}")
-        print(f"  From: {m.get('user', 'unknown')}@{m.get('hostname', 'unknown')}")
+        # Every string below comes out of an archive the caller supplied, so all of them
+        # go through _terminal_safe. Review named the omission list this change added;
+        # created_at, user and hostname are the same class and pre-date this diff. They
+        # are fixed here rather than left as a matching hole three lines away, because
+        # the renderer makes each one a one-word change and shipping a function that
+        # sanitizes two of five attacker-controlled fields would be worse than either
+        # extreme. Named as a drive-by rather than smuggled in.
+        print(f"  Created: {_terminal_safe(m.get('created_at', 'unknown'))}")
+        print(
+            f"  From: {_terminal_safe(m.get('user', 'unknown'))}"
+            f"@{_terminal_safe(m.get('hostname', 'unknown'))}"
+        )
         c = m.get("contents", {})
         print(f"  Memory DB: {c.get('memory_db', 0) // 1024} KB")
         print(f"  Crons: {c.get('crons_json', 0) // 1024} KB")
@@ -405,6 +759,16 @@ def _print_manifest(snap: Path) -> None:
         print(f"  Skills: {c.get('skill_count', 0)}")
         print(f"  Notifications: {c.get('notifications_jsonl', 0) // 1024} KB")
         print(f"  Plan memory files: {c.get('plan_memory_files', 0)}")
+        # Both of these are the record that makes an incomplete or weaker archive
+        # visible. A value written but never displayed is only findable by untarring
+        # the archive by hand, which is not a reader -- so they are shown here, where
+        # anyone inspecting a snapshot before restoring it already looks.
+        if m.get("staging") == "unpinned":
+            print("  ⚠️  Staged by path name (unpinned): see --allow-unpinned-staging")
+        for entry in m.get("skipped") or ():
+            reason = _terminal_safe(entry.get("reason", "?"))
+            omitted = _terminal_safe(entry.get("path", "?"))
+            print(f"  ⚠️  Omitted ({reason}): {omitted}")
     except Exception as e:
         print(f"  (Could not read manifest: {e})")
 
@@ -577,37 +941,211 @@ def _merge_notifications(src_path: Path, dst_path: Path) -> None:
     print(f"  Notifications imported: {imported}")
 
 
-def _backup_and_copy(mc: Path, backup: Path, snap: Path, component: str) -> None:
-    for f in CORE_FILES.get(component, ()):
-        if (mc / f).is_file():
-            if os.path.islink(mc / f):
-                print(f"⚠️  Skipping symlinked core file during backup: {mc / f}")
+def _backup_and_copy(
+    mc: Path, backup: Path, snap: Path, component: str, *, allow_unpinned: bool = False
+) -> None:
+    """Move the live core files aside, then restore the archive's, destination pinned.
+
+    The restore side used to compose ``mc / f`` and hand it to ``shutil.copy2``, so
+    the destination was reached by name every time. Two consequences, both real: a
+    component of the data home swapped for a link redirected the write out of the
+    data home entirely, and a symlink left at the core file's own name was written
+    THROUGH rather than refused -- the name-based ``islink`` check above skipped the
+    backup move and then the copy followed the link it had just declined to move.
+
+    Now the data home is pinned once and each file is created relative to that
+    descriptor with ``O_EXCL``. A name that is still occupied after the backup move
+    is refused instead of written through, which is the symlink case above.
+    """
+    if not _staging_is_pinned(allow_unpinned=allow_unpinned, what=f"restore of {component!r}"):
+        for f in CORE_FILES.get(component, ()):
+            # Validated before the live file is touched, and a symlink at the live name is
+            # MOVED aside rather than skipped -- the same two properties the pinned branch
+            # got earlier in this change. Review found this branch still carrying the old
+            # behaviour: it skipped both the backup AND the replacement, so the archive's
+            # file was never applied and the command reported success anyway. Moving a
+            # symlink moves the link, never its target.
+            if not (snap / f).is_file() or pinned_fs.is_reparse_point(snap / f):
+                if (snap / f).exists():
+                    print(f"⚠️  Skipping symlinked file from snapshot: {snap / f}")
                 continue
-            shutil.move(str(mc / f), str(backup / f))
-        if (snap / f).is_file():
-            if os.path.islink(snap / f):
-                print(f"⚠️  Skipping symlinked file from snapshot: {snap / f}")
-                continue
-            shutil.copy2(str(snap / f), str(mc / f))
-            if component == "security":
-                # restrict_to_owner (fail-loud), NOT chmod_safe (swallows OSError):
-                # security files include sel_hmac.key. Mirrors the create path's
-                # deliberate fail-loud lockdown — better to abort than silently
-                # land a restored secret group/world-readable. POSIX applies
-                # chmod 0o600; Windows applies an owner-only DACL via icacls.
-                # Unlink the freshly
-                # copied file on failure so the "abort" the comment promises
-                # actually removes the exposed artifact — otherwise the
-                # restored secret would sit under the destination-inherited
-                # DACL after the OSError propagates out of _do_replace.
-                try:
-                    platform_compat.restrict_to_owner(str(mc / f))
-                except OSError:
-                    (mc / f).unlink(missing_ok=True)
-                    raise
+            live = mc / f
+            if live.is_symlink() or pinned_fs.is_reparse_point(live):
+                print(f"⚠️  Moving symlinked core file aside during backup: {live}")
+                shutil.move(str(live), str(backup / f))
+            elif live.is_file():
+                shutil.move(str(live), str(backup / f))
+            # Not `copy2`: it opens the destination by name for writing and follows a
+            # symlink planted there in the window after the live file was moved aside,
+            # overwriting whatever it points at. Review's finding. copy_file_pinned uses
+            # O_CREAT|O_EXCL|O_NOFOLLOW even without a directory descriptor, so a link at
+            # the destination name is refused rather than written through.
+            # `fatal_skip_reporter`, NOT `_report_skip`: the live file has ALREADY been
+            # moved into the backup by this point, so a skip here is not an omission from
+            # an archive -- it is the live file gone AND the archive's version never
+            # applied, reported as success. That is the whole reason this change has a
+            # fatal reporter, and this is the third site to need it: a skip is correct
+            # while PRODUCING an archive and is data loss on any path that has already
+            # moved or deleted the original. Review caught this site still holding the
+            # non-fatal one.
+            # A collision here means something recreated the name after the live file was
+            # moved aside. It is a real condition, not a skip, but it must not surface as a
+            # traceback: review found the same escape on the pinned tree walk, and this
+            # path had it too. The live bytes are recoverable from the backup, which is what
+            # the message has to say.
+            try:
+                pinned_fs.copy_file_pinned(
+                    str(snap / f),
+                    str(mc / f),
+                    on_skip=pinned_fs.fatal_skip_reporter(f"restore of {f!r}"),
+                )
+            except FileExistsError as exc:
+                raise pinned_fs.PinnedPathRefusal(
+                    f"refusing to restore {f!r}: its name was recreated while the restore "
+                    "was running, so writing it would overwrite that file. The previous "
+                    f"version is in {backup}. Re-run with the gateway stopped."
+                ) from exc
+            _lock_down_restored(mc / f, component)
+        return
+
+    src_fd = pinned_fs.open_dir_pinned(snap, what=f"snapshot payload for {component!r}")
+    try:
+        dst_fd = pinned_fs.open_dir_pinned(mc, what=f"data home for {component!r}")
+        try:
+            backup_fd = pinned_fs.create_and_open_dir_pinned(
+                backup, what=f"pre-restore backup for {component!r}"
+            )
+            try:
+                for f in CORE_FILES.get(component, ()):
+                    live = mc / f
+                    # Checked BEFORE the live file is touched. The archive is untrusted
+                    # input, so a member that is not a regular file -- a FIFO, a device
+                    # node, a directory at a core filename -- is a real possibility, and
+                    # the old order moved the live file aside first and only then found
+                    # the source unusable: the original ended up in the backup and
+                    # nothing was restored, reported as success. Raised in review; the
+                    # same validate-before-mutate ordering the platform gate follows.
+                    # Asked through src_fd, not by composing a path. The by-name form
+                    # re-resolved the snapshot root, so a root swapped after pinning had
+                    # this guard inspecting the replacement while the copy below acted on
+                    # the descriptor -- review's finding, and the same class as the
+                    # destination-ownership check.
+                    if not pinned_fs.is_regular_at(src_fd, f):
+                        continue
+                    # A symlink at a core file's name is MOVED aside like any other
+                    # occupant, not skipped. The old code skipped the move and then let
+                    # the copy write through the very link it had just declined to
+                    # move; skipping the whole entry instead would be no better,
+                    # because the archive's version of that file would then silently
+                    # never be restored. Moving a symlink moves the LINK, never its
+                    # target, so nothing outside the data home is touched.
+                    #
+                    # The move goes through both pinned descriptors rather than
+                    # shutil.move on two composed paths: review pointed out that a
+                    # by-name move re-resolves both ends, so an ancestor swapped
+                    # between the check and the move would relocate something else.
+                    # os.rename with src_dir_fd/dst_dir_fd cannot be redirected, and it
+                    # is atomic within the data home, which a copy-then-delete is not.
+                    live_st = pinned_fs.stat_at(dst_fd, f)
+                    if live_st is not None and _stat.S_ISLNK(live_st.st_mode):
+                        print(f"⚠️  Moving symlinked core file aside during backup: {live}")
+                        os.rename(f, f, src_dir_fd=dst_fd, dst_dir_fd=backup_fd)
+                    elif live_st is not None and _stat.S_ISREG(live_st.st_mode):
+                        os.rename(f, f, src_dir_fd=dst_fd, dst_dir_fd=backup_fd)
+                    try:
+                        copied = pinned_fs.copy_file_pinned(
+                            str(snap / f),
+                            dir_fd=src_fd,
+                            name=f,
+                            dst_dir_fd=dst_fd,
+                            dst_name=f,
+                            # Owner-only applied through the destination DESCRIPTOR, in
+                            # the same call that wrote the bytes. Two things wrong with
+                            # the previous _lock_down_restored(mc / f) here, both raised
+                            # in review: it reopened the freshly written file BY NAME, so
+                            # a link swapped in at that instant had restrict_to_owner
+                            # change the permissions of whatever it pointed at; and the
+                            # mode cannot be inherited from the archive, which is
+                            # untrusted input -- a hand-built tarball can record 0o777 on
+                            # telemetry_salt. The reviewer's suggested fix was to drop
+                            # the lockdown because "the copy already applies mode", which
+                            # would have done exactly that: applied the ARCHIVE's mode.
+                            force_mode=0o600 if component == "security" else None,
+                            # The live file was moved aside two lines up, so a skip here
+                            # finishes with the original gone AND the archive's version
+                            # never written. Review's third instance of that rule; it is
+                            # now the reporter's job rather than a per-site check.
+                            on_skip=pinned_fs.fatal_skip_reporter(f"restore of {f!r}"),
+                        )
+                    except FileExistsError as exc:
+                        raise pinned_fs.PinnedPathRefusal(
+                            f"refusing to restore {f!r}: something still occupies that "
+                            "name in the data home after the backup pass, so it is a "
+                            "hardlink alias or a name this restore could not move "
+                            "aside. Writing to it could follow whatever it points at. "
+                            "Remove it and re-run."
+                        ) from exc
+                    if copied and component == "security":
+                        # Nothing to re-apply: force_mode above already set owner-only
+                        # through the descriptor. On Windows the by-name branch still
+                        # needs restrict_to_owner for its DACL, which is why that call
+                        # survives there and not here.
+                        pass
+            finally:
+                os.close(backup_fd)
+        finally:
+            os.close(dst_fd)
+    finally:
+        os.close(src_fd)
 
 
-def _do_replace(snap: Path, mc: Path, components: list[str] | None) -> None:
+def _lock_down_restored(path: Path, component: str) -> None:
+    """Apply the owner-only lockdown a restored security file needs.
+
+    restrict_to_owner (fail-loud), NOT chmod_safe (which swallows OSError): security
+    files include sel_hmac.key. Mirrors the create path's deliberate fail-loud
+    lockdown -- better to abort than silently land a restored secret group- or
+    world-readable. POSIX applies chmod 0o600; Windows applies an owner-only DACL via
+    icacls. The freshly copied file is unlinked on failure so the abort this promises
+    actually removes the exposed artifact, instead of leaving the restored secret
+    under the destination's inherited DACL after the OSError propagates.
+    """
+    if component != "security":
+        return
+    try:
+        platform_compat.restrict_to_owner(str(path))
+    except OSError:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def _backup_tree_or_refuse(src: Path, dst: Path, *, allow_unpinned: bool = False) -> None:
+    """Back a live tree up, and refuse the replace if the backup is not complete.
+
+    Replace mode's next step is ``rmtree`` on the live tree, so a file the backup pass
+    SKIPPED is a file the restore is about to delete with no copy anywhere. The staging
+    walk legitimately skips a hardlink alias, a symlink and a non-regular file -- which
+    is right when producing an archive and catastrophic here, because the skip is
+    followed by a delete rather than by an omission.
+
+    This was the second of the two findings that closed the earlier attempt at this
+    change (#2446): a concurrent writer's hardlinks were skipped at backup time and then
+    ``rmtree`` removed the only copies. Raised again in review against this diff, which
+    had carried the same shape forward. Refusing before the delete is the only ordering
+    that cannot lose data: the operator keeps a complete tree and a message naming what
+    could not be copied.
+    """
+    _copytree_safe(
+        src,
+        dst,
+        allow_unpinned=allow_unpinned,
+        on_skip=pinned_fs.fatal_skip_reporter(f"backup of {src.name!r} before replacing it"),
+    )
+
+
+def _do_replace(
+    snap: Path, mc: Path, components: list[str] | None, *, allow_unpinned: bool = False
+) -> None:
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup = mc / f"pre-restore-{ts}"
     backup.mkdir(exist_ok=True)
@@ -615,30 +1153,51 @@ def _do_replace(snap: Path, mc: Path, components: list[str] | None) -> None:
 
     for comp in ("memory", "crons", "config", "notifications", "security"):
         if _want(components, comp):
-            _backup_and_copy(mc, backup, snap, comp)
+            _backup_and_copy(mc, backup, snap, comp, allow_unpinned=allow_unpinned)
             print(f"  ✅ {comp}")
 
     if _want(components, "workspace"):
         for dirname in ("workspace", "plan_memory"):
             d = mc / dirname
             if d.is_dir():
-                _copytree_safe(d, backup / dirname, dirs_exist_ok=True)
+                _backup_tree_or_refuse(d, backup / dirname, allow_unpinned=allow_unpinned)
             sd = snap / dirname
             if sd.is_dir():
                 if d.is_dir():
                     shutil.rmtree(str(d))
-                _copytree_safe(sd, d)
+                # rmtree just removed the live tree, so a skipped source entry here means
+                # that file exists in neither place.
+                #
+                # `must_create` is what makes the removal mean something. Without it the
+                # walk accepted a root recreated between the rmtree and the copy, so files
+                # the archive does not contain survived a REPLACE that reported success.
+                # Review found it; this is the only caller that knows it removed the tree.
+                _copytree_safe(
+                    sd,
+                    d,
+                    allow_unpinned=allow_unpinned,
+                    must_create=True,
+                    on_skip=pinned_fs.fatal_skip_reporter(f"restore of {dirname!r}"),
+                )
         print("  ✅ workspace")
 
     if _want(components, "skills"):
         sk = mc / "skills"
         if sk.is_dir():
-            _copytree_safe(sk, backup / "skills", dirs_exist_ok=True)
+            _backup_tree_or_refuse(sk, backup / "skills", allow_unpinned=allow_unpinned)
         snap_sk = snap / "skills"
         if snap_sk.is_dir():
             if sk.is_dir():
                 shutil.rmtree(str(sk))
-            _copytree_safe(snap_sk, sk)
+            _copytree_safe(
+                snap_sk,
+                sk,
+                allow_unpinned=allow_unpinned,
+                # Same as the workspace branch above: the tree was just removed, so a root
+                # that exists again was recreated by something else.
+                must_create=True,
+                on_skip=pinned_fs.fatal_skip_reporter("restore of 'skills'"),
+            )
         print("  ✅ skills")
 
     try:
@@ -648,7 +1207,16 @@ def _do_replace(snap: Path, mc: Path, components: list[str] | None) -> None:
     print("✅ Replace complete.")
 
 
-def _do_merge(snap: Path, mc: Path, components: list[str] | None) -> None:
+def _do_merge(
+    snap: Path, mc: Path, components: list[str] | None, *, allow_unpinned: bool = False
+) -> None:
+    # Asked once, at entry, BEFORE any mutation. The core-file copies below run before
+    # any tree call, so gating inside the tree helpers meant a merge on a platform that
+    # cannot pin wrote memory.db, crons.json and the security files first and only then
+    # met the refusal -- either redirecting those writes through a planted link, or
+    # aborting with the restore already half applied. Review caught it; it is the same
+    # gate-placement defect as the snapshot side, one path over.
+    _staging_is_pinned(allow_unpinned=allow_unpinned, what="merge restore")
     print("🔀 Merge mode — importing...")
 
     if _want(components, "memory") and (snap / "memory.db").is_file():
@@ -714,13 +1282,13 @@ def _do_merge(snap: Path, mc: Path, components: list[str] | None) -> None:
             if sd.is_dir():
                 dd = mc / dirname
                 dd.mkdir(parents=True, exist_ok=True)
-                _copy_tree_no_overwrite(sd, dd)
+                _copy_tree_no_overwrite(sd, dd, allow_unpinned=allow_unpinned)
         print("  ✅ workspace")
 
     if _want(components, "skills"):
         if (snap / "skills").is_dir():
             (mc / "skills").mkdir(parents=True, exist_ok=True)
-            _copy_tree_no_overwrite(snap / "skills", mc / "skills")
+            _copy_tree_no_overwrite(snap / "skills", mc / "skills", allow_unpinned=allow_unpinned)
         print("  ✅ skills")
 
     print("✅ Merge complete.")
@@ -754,8 +1322,19 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
         )
         p.add_argument("--components")
         p.add_argument("--list-components", action="store_true")
+        p.add_argument(
+            "--allow-unpinned-staging",
+            action="store_true",
+            dest="allow_unpinned",
+            help=(
+                "Restore by path name on a platform that cannot open a directory "
+                "relative to a descriptor. Without this the restore is refused there "
+                "rather than run with a destination an ancestor swap could redirect."
+            ),
+        )
         parsed = p.parse_args(argv)
     args = parsed
+    allow_unpinned = bool(getattr(args, "allow_unpinned", False))
 
     if args.list_components:
         _list_components()
@@ -822,10 +1401,20 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
             return 0
 
         mc.mkdir(parents=True, exist_ok=True)
-        if mode == "replace":
-            _do_replace(snap, mc, components)
-        else:
-            _do_merge(snap, mc, components)
+        # Contained here rather than allowed to propagate: a refusal is a decision
+        # this command made on purpose, and a traceback would read like a crash and
+        # bury the one sentence saying what to do about it.
+        try:
+            if mode == "replace":
+                _do_replace(snap, mc, components, allow_unpinned=allow_unpinned)
+            else:
+                _do_merge(snap, mc, components, allow_unpinned=allow_unpinned)
+        except pinned_fs.PinnedPathRefusal as exc:
+            # Same reasoning as the snapshot handler, and this one reuses the event name
+            # already established for a declined restore rather than inventing a second.
+            _audit("state_restore_rejected", f"reason=unpinnable_staging detail={exc}")
+            print(f"❌ {exc}")
+            return 1
 
     # Integrity check
     if _want(components, "memory") and (mc / "memory.db").is_file():

--- a/test/test_pinned_staging.py
+++ b/test/test_pinned_staging.py
@@ -1,0 +1,1892 @@
+"""The descriptor-pinned staging primitive, and snapshot/restore's use of it.
+
+Written as an A/B suite rather than a list of assertions. The point of this change is
+that a pinned traversal is strictly stronger than a by-name one, and the only honest
+way to show that is to run the SAME attack against both paths and watch one leak while
+the other refuses -- an exception-only assertion cannot tell "pinned" from "got lucky".
+
+The mid-walk swap is performed inside the ``ignore`` callback, which both paths invoke
+once per directory with that directory's contents. That is the check-to-use window
+made deterministic: the screen has just looked at the entry and declared it fine, and
+the copy of that entry has not happened yet.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import pinned_fs, snapshot
+
+pinned_only = pytest.mark.skipif(
+    not pinned_fs.supports_pinned_tree_walk(),
+    reason="requires O_DIRECTORY, O_NOFOLLOW, dir_fd and fd-listdir support (POSIX)",
+)
+
+#: Windows implements only the read-only bit, so an exact permission-bit assertion is a
+#: POSIX statement. Everything else in these tests (content, mtime, which file exists)
+#: is platform-neutral and stays asserted everywhere.
+posix_modes_only = pytest.mark.skipif(
+    os.name != "posix", reason="permission bits are POSIX; Windows has only a read-only flag"
+)
+
+#: Staging refuses by default where a directory cannot be pinned, so a test that drives
+#: a real snapshot or restore has to say which platform contract it is asserting. Tests
+#: that assert product behaviour true on BOTH platforms pass this and exercise the
+#: declared by-name path on Windows; tests that assert the pinning itself use
+#: `pinned_only` instead.
+UNPINNED_OK = {"allow_unpinned": True}
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("creating a symlink needs privilege on this host")
+
+
+def _tree_with_victim(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A source tree to stage, plus a victim directory nothing should reach.
+
+    Returns ``(src_root, mid_dir, victim_dir)``. ``mid_dir`` is the ancestor that gets
+    swapped: it is a real directory when the screen looks at it and a link to
+    ``victim_dir`` by the time the copy of its contents happens.
+    """
+    src = tmp_path / "source"
+    mid = src / "mid"
+    mid.mkdir(parents=True)
+    (mid / "ordinary.txt").write_text("ordinary\n", encoding="utf-8")
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "stolen.txt").write_text("CREDENTIAL\n", encoding="utf-8")
+    return src, mid, victim
+
+
+def _swap_on_screen(mid: Path, victim: Path):
+    """An ``ignore`` callback that swaps *mid* for a link to *victim*, once.
+
+    Fires when the walk screens the directory that CONTAINS *mid*, i.e. after that
+    directory has been listed and before its entries are copied.
+    """
+    state = {"done": False}
+
+    def _ignore(directory: str, contents: list[str]) -> set[str]:
+        if not state["done"] and mid.name in contents:
+            state["done"] = True
+            mid.rename(mid.parent / "mid-moved")
+            _symlink_or_skip(mid, victim)
+        return set()
+
+    return _ignore
+
+
+# ── The differential: pinned refuses where by-name follows ────────────────────
+
+
+@pinned_only
+def test_an_ancestor_swapped_after_the_screen_leaks_by_name_and_not_when_pinned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The whole reason this module exists, asserted on WHERE THE BYTES LANDED.
+
+    Run twice against identical trees. The by-name traversal is expected to copy the
+    victim's contents, because ``shutil.copytree`` captures its entries with one
+    ``scandir`` and then descends into ``mid`` BY NAME -- the cached ``DirEntry`` still
+    says "directory", and a fresh listing of that name now lands in the victim. The
+    pinned traversal re-stats through the descriptor it holds and skips it.
+
+    The control half has to force the by-name branch by patching the platform probe.
+    ``allow_unpinned=True`` alone does not: it is a permission for a platform that
+    cannot pin, not a switch that turns pinning off where it works -- which is itself
+    worth pinning, since a flag that silently downgraded a capable platform would be a
+    far worse bug than the one this change fixes.
+
+    If the by-name half ever stops leaking, this test has stopped testing anything and
+    the assertion below says so rather than passing quietly.
+    """
+    src_a, mid_a, victim_a = _tree_with_victim(tmp_path / "by_name")
+    dst_a = tmp_path / "staged_by_name"
+    with monkeypatch.context() as no_pinning:
+        no_pinning.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+        snapshot._copytree_safe(
+            src_a, dst_a, allow_unpinned=True, ignore=_swap_on_screen(mid_a, victim_a)
+        )
+    leaked = (dst_a / "mid" / "stolen.txt").exists()
+
+    src_b, mid_b, victim_b = _tree_with_victim(tmp_path / "pinned")
+    dst_b = tmp_path / "staged_pinned"
+    snapshot._copytree_safe(src_b, dst_b, ignore=_swap_on_screen(mid_b, victim_b))
+
+    assert leaked, (
+        "the by-name control did not leak, so this test no longer demonstrates the "
+        "difference the pinned walk exists to make -- fix the control, do not delete "
+        "the assertion"
+    )
+    assert not (
+        dst_b / "mid" / "stolen.txt"
+    ).exists(), "the pinned walk followed an ancestor swapped after the screen approved it"
+    assert "Skipping symlink in source tree" in capsys.readouterr().out
+
+
+@pinned_only
+def test_the_opt_in_flag_does_not_turn_pinning_off_where_it_works(tmp_path: Path) -> None:
+    """``--allow-unpinned-staging`` permits a fallback; it never requests one.
+
+    Stated as its own test because the distinction is load-bearing: if the flag were a
+    mode switch, anyone passing it once (to get past an unrelated failure, or in a
+    script copied from a Windows runbook) would silently give up the pinning on every
+    platform.
+    """
+    src, mid, victim = _tree_with_victim(tmp_path)
+    dst = tmp_path / "staged"
+    snapshot._copytree_safe(src, dst, allow_unpinned=True, ignore=_swap_on_screen(mid, victim))
+    assert not (dst / "mid" / "stolen.txt").exists()
+
+
+@pinned_only
+def test_open_dir_pinned_refuses_a_parent_that_became_a_link(tmp_path: Path) -> None:
+    """The root's OWN ancestor chain is pinned, which the preserved branches did not do.
+
+    ``os.open(root, O_DIRECTORY | O_NOFOLLOW)`` refuses a link AT the root's name but
+    walks every ancestor by name to get there. Here the parent is captured before the
+    swap -- the state a caller is in when it loses the resolve-to-open race -- and the
+    pinned chain has to refuse it.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "inside").mkdir()
+
+    parent = tmp_path / "holder"
+    parent.mkdir()
+    (parent / "inside").mkdir()
+    resolved_parent = os.path.realpath(parent)
+
+    parent.rename(tmp_path / "holder-moved")
+    _symlink_or_skip(parent, victim)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        pinned_fs.open_in_pinned_parent(
+            resolved_parent,
+            "inside",
+            flags=os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            mode=0o700,
+            what="staging root",
+        )
+    assert "became a symbolic link" in str(excinfo.value)
+
+
+# ── Hardlink aliases ─────────────────────────────────────────────────────────
+
+
+def test_a_hardlinked_source_is_refused_rather_than_dereferenced(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``shutil.copy2`` would have shipped a credential alias as ordinary bytes.
+
+    A hardlink shares its target's inode, so ``realpath`` yields the alias's own name,
+    ``is_symlink()`` is False, and ``O_NOFOLLOW`` has no link to refuse. The check has
+    to happen on the open descriptor, which is what this pins.
+    """
+    secret = tmp_path / "credential"
+    secret.write_text("AKIA-not-real\n", encoding="utf-8")
+    alias = tmp_path / "config.json"
+    try:
+        os.link(secret, alias)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("hard links are unavailable on this host")
+
+    dst = tmp_path / "staged.json"
+    copied = pinned_fs.copy_file_pinned(str(alias), str(dst), on_skip=snapshot._report_skip)
+
+    assert copied is False
+    assert not dst.exists()
+    assert "hardlinked or non-regular" in capsys.readouterr().out
+
+
+def test_a_single_link_regular_file_still_copies_with_mode_and_mtime(tmp_path: Path) -> None:
+    """The refusal above must not be a blanket one: the ordinary case still works."""
+    src = tmp_path / "plain.txt"
+    src.write_text("content\n", encoding="utf-8")
+    os.chmod(src, 0o640)
+    dst = tmp_path / "copied.txt"
+
+    assert pinned_fs.copy_file_pinned(str(src), str(dst)) is True
+    assert dst.read_text(encoding="utf-8") == "content\n"
+    if os.name == "posix":
+        assert (dst.stat().st_mode & 0o777) == 0o640
+    assert dst.stat().st_mtime_ns == src.stat().st_mtime_ns
+
+
+# ── The restore side ─────────────────────────────────────────────────────────
+
+
+@pinned_only
+def test_restore_moves_a_symlinked_core_file_aside_instead_of_writing_through_it(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#3797's third finding, plus the silent partial restore hiding behind it.
+
+    Before this change the name-based screen declined to MOVE a symlinked core file to
+    the backup and then ``shutil.copy2`` wrote through the very link it had just
+    declined to move. Skipping the whole entry instead would have been no better: the
+    archive's version of that file would silently never be restored, and the command
+    would still report success.
+
+    Both are asserted here -- the victim keeps its bytes, AND the snapshot's version
+    actually lands.
+    """
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    (snap / "crons.json").write_text("[]\n", encoding="utf-8")
+
+    victim = tmp_path / "victim.json"
+    victim.write_text("PRECIOUS\n", encoding="utf-8")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    _symlink_or_skip(mc / "crons.json", victim)
+
+    backup = mc / "backup"
+    backup.mkdir()
+
+    snapshot._backup_and_copy(mc, backup, snap, "crons")
+
+    assert (
+        victim.read_text(encoding="utf-8") == "PRECIOUS\n"
+    ), "the restore wrote through the symlink it was supposed to move aside"
+    assert (mc / "crons.json").read_text(
+        encoding="utf-8"
+    ) == "[]\n", "the archive's version was not restored -- a silent partial restore"
+    assert not (mc / "crons.json").is_symlink()
+    assert (backup / "crons.json").is_symlink(), "the link itself belongs in the backup"
+    assert "Moving symlinked core file aside" in capsys.readouterr().out
+
+
+@pinned_only
+def test_restore_refuses_when_the_name_is_still_occupied_after_the_backup_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The backstop for the case the move above cannot resolve.
+
+    The move is neutralised rather than made to fail, because the invariant being
+    pinned is about the STATE the copy runs in ("this name is still taken"), not about
+    any particular reason the move did not happen. Exclusive creation is what turns
+    that state into a refusal instead of a write into whatever now sits there -- and
+    the live bytes have to survive it.
+    """
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    (snap / "crons.json").write_text("[]\n", encoding="utf-8")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    (mc / "crons.json").write_text("occupied\n", encoding="utf-8")
+    backup = mc / "backup"
+    backup.mkdir()
+
+    monkeypatch.setattr(snapshot.os, "rename", lambda *a, **k: None)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        snapshot._backup_and_copy(mc, backup, snap, "crons")
+
+    assert "still occupies that name" in str(excinfo.value)
+    assert (mc / "crons.json").read_text(
+        encoding="utf-8"
+    ) == "occupied\n", "the live file was overwritten even though it was never moved aside"
+
+
+@pinned_only
+def test_merge_does_not_overwrite_and_skips_a_symlinked_source(tmp_path: Path) -> None:
+    """The no-overwrite promise is now exclusive creation rather than a prior exists()."""
+    src = tmp_path / "from_snapshot"
+    (src / "nested").mkdir(parents=True)
+    (src / "nested" / "new.txt").write_text("new\n", encoding="utf-8")
+    (src / "nested" / "kept.txt").write_text("from snapshot\n", encoding="utf-8")
+    _symlink_or_skip(src / "nested" / "link.txt", tmp_path / "anything")
+
+    dst = tmp_path / "live"
+    (dst / "nested").mkdir(parents=True)
+    (dst / "nested" / "kept.txt").write_text("LOCAL WINS\n", encoding="utf-8")
+
+    snapshot._copy_tree_no_overwrite(src, dst)
+
+    assert (dst / "nested" / "new.txt").read_text(encoding="utf-8") == "new\n"
+    assert (dst / "nested" / "kept.txt").read_text(encoding="utf-8") == "LOCAL WINS\n"
+    assert not (dst / "nested" / "link.txt").exists()
+
+
+# ── Platforms that cannot pin ────────────────────────────────────────────────
+
+
+def test_a_platform_that_cannot_pin_refuses_until_the_operator_says_otherwise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refuse rather than fall back by name -- and name the flag that permits it.
+
+    Patched on ``pinned_fs`` because that is where the capability question lives; the
+    snapshot module reads it through the module rather than binding it at import.
+    """
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "file.txt").write_text("x\n", encoding="utf-8")
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        snapshot._copytree_safe(src, tmp_path / "refused")
+    assert "--allow-unpinned-staging" in str(excinfo.value)
+    assert not (tmp_path / "refused").exists()
+
+    snapshot._copytree_safe(src, tmp_path / "permitted", allow_unpinned=True)
+    assert (tmp_path / "permitted" / "file.txt").read_text(encoding="utf-8") == "x\n"
+
+
+def test_the_manifest_records_which_traversal_built_the_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reader deciding whether to trust an archive needs the mode on the record.
+
+    Asserted against the platform's own capability rather than a hardcoded "pinned",
+    because on a platform that cannot pin the honest value IS "unpinned" -- and a test
+    that hardcoded the POSIX answer would fail the Windows shard for being right.
+    """
+    mc = tmp_path / "home"
+    (mc / "workspace").mkdir(parents=True)
+    (mc / "workspace" / "note.md").write_text("hi\n", encoding="utf-8")
+    out = tmp_path / "snapshots"
+
+    expected = "pinned" if pinned_fs.supports_pinned_tree_walk() else "unpinned"
+    native = snapshot._build_snapshot(mc, out, "native-archive", **UNPINNED_OK)
+    with tarfile.open(str(native)) as tar:
+        member = tar.extractfile("native-archive/MANIFEST.json")
+        assert member is not None
+        assert json.load(member)["staging"] == expected
+
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+    unpinned = snapshot._build_snapshot(mc, out, "unpinned-archive", allow_unpinned=True)
+    with tarfile.open(str(unpinned)) as tar:
+        member = tar.extractfile("unpinned-archive/MANIFEST.json")
+        assert member is not None
+        assert json.load(member)["staging"] == "unpinned"
+
+
+def test_the_snapshot_cli_reports_a_refusal_instead_of_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A deliberate refusal must read as a decision, with a non-zero exit code."""
+    mc = tmp_path / "home"
+    (mc / "workspace").mkdir(parents=True)
+    (mc / "workspace" / "note.md").write_text("hi\n", encoding="utf-8")
+    monkeypatch.setenv("KIROCREW_HOME", str(mc))
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    rc = snapshot.snapshot_main([str(tmp_path / "out")])
+
+    assert rc == 1
+    assert "--allow-unpinned-staging" in capsys.readouterr().out
+    assert not list((tmp_path / "out").glob("*.tar.gz"))
+
+
+# ── The destination side is pinned too ───────────────────────────────────────
+
+
+@pinned_only
+def test_the_destination_root_cannot_be_repointed_once_the_walk_holds_it(
+    tmp_path: Path,
+) -> None:
+    """Asserted on where the bytes landed, because an exception cannot prove pinning.
+
+    The first revision of `stage_tree_pinned` pinned only the SOURCE. That was
+    defensible while the only destination was a private temporary directory, and wrong
+    the moment a restore used it: then the destination IS the live data home, and an
+    ancestor swapped there lands the archive's bytes outside it. Review caught it.
+
+    Here the destination root is renamed away and a link to a victim directory is put
+    at its old name, from inside the `ignore` callback -- i.e. after the walk has
+    opened the destination and before it writes. A pinned destination keeps writing
+    into the directory it opened; a by-name one would follow the link.
+    """
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "payload.txt").write_text("REAL\n", encoding="utf-8")
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+
+    dst = tmp_path / "live"
+    state = {"done": False}
+
+    def _swap_destination(directory: str, contents: list[str]) -> set[str]:
+        if not state["done"]:
+            state["done"] = True
+            dst.rename(tmp_path / "live-moved")
+            _symlink_or_skip(dst, victim)
+        return set()
+
+    pinned_fs.stage_tree_pinned(src, dst, what="tree", ignore=_swap_destination)
+
+    assert (tmp_path / "live-moved" / "payload.txt").read_text(
+        encoding="utf-8"
+    ) == "REAL\n", "the write did not land in the directory the walk had already opened"
+    assert not (
+        victim / "payload.txt"
+    ).exists(), "the write followed the destination link planted after the walk opened it"
+
+
+# ── The gate runs before anything is staged ──────────────────────────────────
+
+
+def test_core_files_alone_still_consult_the_platform_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A data home with core files and no trees must not stage unpinned unasked.
+
+    The first revision gated inside `_copytree_safe` only, so the opt-in was consulted
+    exactly when a tree happened to exist. A data home holding `crons.json` and no
+    `workspace/` staged its core files on a platform that cannot pin without ever
+    asking -- the gate was reachable only through a path that might not run. Raised in
+    review; the gate now runs once, up front, which is also what makes the manifest's
+    `staging` value true of the whole archive.
+    """
+    mc = tmp_path / "home"
+    mc.mkdir()
+    (mc / "crons.json").write_text("[]\n", encoding="utf-8")
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        snapshot._build_snapshot(mc, tmp_path / "out", "archive")
+    assert "--allow-unpinned-staging" in str(excinfo.value)
+    assert not list((tmp_path / "out").glob("*.tar.gz"))
+
+
+# ── An incomplete archive says so ────────────────────────────────────────────
+
+
+def test_the_manifest_records_what_was_omitted(tmp_path: Path) -> None:
+    """A skipped file used to be a console warning and nothing else.
+
+    That is the same "silent partial" shape this PR fixes on the restore side: exit 0,
+    a success message, and an archive quietly missing a file. Raised in review. The
+    omission is now in `MANIFEST.json`, and `_print_manifest` shows it so the record
+    has a reader that is not "untar the archive by hand".
+    """
+    mc = tmp_path / "home"
+    (mc / "workspace").mkdir(parents=True)
+    (mc / "workspace" / "kept.txt").write_text("kept\n", encoding="utf-8")
+
+    secret = tmp_path / "credential"
+    secret.write_text("AKIA-not-real\n", encoding="utf-8")
+    try:
+        os.link(secret, mc / "workspace" / "alias.json")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("hard links are unavailable on this host")
+
+    archive = snapshot._build_snapshot(mc, tmp_path / "out", "archive", **UNPINNED_OK)
+    with tarfile.open(str(archive)) as tar:
+        member = tar.extractfile("archive/MANIFEST.json")
+        assert member is not None
+        manifest = json.load(member)
+        assert tar.getnames().count("archive/workspace/kept.txt") == 1
+        assert "archive/workspace/alias.json" not in tar.getnames()
+
+    omitted = {e["path"]: e["reason"] for e in manifest["skipped"]}
+    assert omitted == {os.path.join("workspace", "alias.json"): pinned_fs.SKIP_NOT_REGULAR}
+
+
+# ── The opt-in has to be reachable from the shipped command ──────────────────
+
+
+def test_the_shipped_cli_accepts_the_opt_in_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The refusal names a flag, so the flag must exist on the real parser.
+
+    Review found it defined only on the fallback parsers INSIDE `snapshot_main` /
+    `restore_main`, which the console script never reaches -- it builds its own
+    subparsers in `cli.py` and passes `parsed=`. So a user on a platform that cannot
+    pin was refused with a message naming a flag argparse would then reject: a dead
+    end, and exactly the "withdraws the command from the platform" outcome the design
+    note said it was avoiding.
+
+    Asserted against the real `cli.main` with a control, because a test that only
+    checked the flag parses could pass on a parser nobody runs.
+    """
+    from kiro_crew import cli
+
+    def _run(argv: list[str]) -> object:
+        monkeypatch.setattr("sys.argv", ["kirocrew"] + argv)
+        try:
+            cli.main()
+            return "accepted"
+        except SystemExit as exc:
+            return exc.code
+
+    assert _run(["snapshot", "--list", "--allow-unpinned-staging"]) == "accepted"
+    assert _run(["restore", "--list-components", "--allow-unpinned-staging"]) == "accepted"
+    assert (
+        _run(["snapshot", "--list", "--no-such-flag"]) == 2
+    ), "the control passed, so this test would accept a parser that ignores unknown flags"
+
+
+def test_the_import_path_records_unpinned_staging_instead_of_removing_the_feature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An import on a platform that cannot pin PROCEEDS, and says so in its summary.
+
+    This test asserted the opposite until CI told me otherwise, and the correction is worth
+    keeping: I had the gate refuse here on the reasoning -- written into the code -- that
+    "there is no flag to pass, an import is a UI action". The observation was right and the
+    conclusion was wrong. Refuse-by-default means "ask the user" only where a consent surface
+    EXISTS; where none does it means deleting the feature on that platform, which is not a
+    security decision anyone made. Twenty-one pre-existing `test_portability.py` tests failed
+    on the Windows shard to make the point.
+
+    So snapshot and restore still refuse -- they have `--allow-unpinned-staging` and can ask --
+    and this path records `staging: unpinned` instead. The per-entry screens still apply
+    either way: what is given up is ancestor-swap resistance, not link resistance.
+    """
+    import zipfile
+
+    from kiro_crew import portability
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(mc))
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    payload = tmp_path / "import.zip"
+    with zipfile.ZipFile(payload, "w") as zf:
+        # One top-level directory is the format's requirement -- a flat zip is rejected
+        # before staging is reached, which made an earlier version of this test fail for a
+        # reason that had nothing to do with what it was asserting.
+        zf.writestr("kirocrew-export/crons.json", "[]\n")
+        zf.writestr("kirocrew-export/workspace/note.md", "hi\n")
+
+    summary = portability.apply_import_zip(payload, mode="merge")
+
+    assert summary["staging"] == "unpinned", (
+        "an unpinnable import must record that it was staged by name, or the weaker mode "
+        "becomes invisible to whoever reads the summary"
+    )
+    assert (mc / "crons.json").exists(), "the import was refused instead of proceeding"
+
+
+def test_a_pinnable_import_records_that_it_was_pinned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half: where pinning IS available the summary must say what really happened.
+
+    This asserted `pinned` for a merge until review pointed out that a merge's core files
+    (including the out-of-scope databases) and its skills copy are still `shutil` by name --
+    so `pinned` was true of the platform and false of the operation. The field exists to tell
+    a reader what happened, so a merge on a pinnable host reports `mixed`.
+
+    Without this the field could read one constant everywhere and nothing would notice.
+    """
+    import zipfile
+
+    from kiro_crew import portability
+
+    if not pinned_fs.supports_pinned_tree_walk():
+        pytest.skip("host cannot pin, so there is no pinned case to assert")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(mc))
+
+    payload = tmp_path / "import.zip"
+    with zipfile.ZipFile(payload, "w") as zf:
+        zf.writestr("kirocrew-export/crons.json", "[]\n")
+
+    summary = portability.apply_import_zip(payload, mode="merge")
+    assert summary["staging"] == "mixed", (
+        "a merge routes only its tree copy through the primitive, so claiming a fully "
+        "pinned staging overstates what happened"
+    )
+
+
+def test_the_import_path_passes_its_staging_decision_to_both_branches() -> None:
+    """The entry decision has to reach the merge AND replace branches, or it is decorative.
+
+    Both inner helpers gate independently, so a permission decided once at entry and then not
+    passed down means the inner gate re-asks and refuses -- the same platform outage by a
+    longer route, and one that only shows up on the platform that cannot pin. That is exactly
+    how the Windows shard failed: I fixed the merge branch first and CI came back red on the
+    replace branch.
+
+    Pinned on the source because the failure is invisible on a host that can pin: every
+    assertion about it passes locally whether or not the argument is threaded through.
+    """
+    import inspect
+
+    from kiro_crew import portability
+
+    source = inspect.getsource(portability.apply_import_zip)
+    assert (
+        "except PinnedPathRefusal" not in source
+    ), "the refusal is being swallowed again; a returned summary reads as success"
+    assert "rejected_replace" not in source
+    assert "_do_replace(snap, mc, None, allow_unpinned=not staging_pinned)" in source, (
+        "the replace branch does not receive the entry decision, so it will re-gate and "
+        "refuse on a platform that cannot pin"
+    )
+    assert (
+        "_copy_tree_no_overwrite(sd, dd, allow_unpinned=not staging_pinned)" in source
+    ), "the merge branch does not receive the entry decision"
+
+
+# ── A failed copy leaves nothing behind ──────────────────────────────────────
+
+
+def test_mode_and_mtime_are_applied_through_the_written_descriptor(tmp_path: Path) -> None:
+    """`chmod(name, dir_fd=...)` re-resolves the name; `fchmod(fd)` cannot be redirected.
+
+    The metadata calls used to address the destination by name under the pinned
+    directory, which leaves a window where the final component is swapped between the
+    write and the chmod and the mode lands on the replacement. Asserted here as the
+    ordinary-case behaviour the descriptor form has to preserve.
+    """
+    src = tmp_path / "source.txt"
+    src.write_text("payload\n", encoding="utf-8")
+    os.chmod(src, 0o640)
+    dst = tmp_path / "dest.txt"
+
+    assert pinned_fs.copy_file_pinned(str(src), str(dst)) is True
+    if os.name == "posix":
+        assert (dst.stat().st_mode & 0o777) == 0o640
+    assert dst.stat().st_mtime_ns == src.stat().st_mtime_ns
+
+
+@pinned_only
+def test_a_planted_name_in_a_fresh_destination_tree_is_refused_not_skipped(
+    tmp_path: Path,
+) -> None:
+    """Suppressing `FileExistsError` on mkdir turned a planted link into a silent gap.
+
+    In a destination tree this operation created, a name already occupying a
+    subdirectory is a link or a file planted there. The suppressed error let the pinned
+    open below refuse the subtree and the restore then reported success with the
+    archive's subtree missing -- the same silent-partial shape fixed elsewhere in this
+    change. A merge legitimately meets existing directories, so `skip_existing` still
+    tolerates them.
+    """
+    src = tmp_path / "source"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "file.txt").write_text("payload\n", encoding="utf-8")
+
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    _symlink_or_skip(dst / "sub", tmp_path / "elsewhere")
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        pinned_fs.stage_tree_pinned(src, dst, what="tree")
+    assert "already occupies" in str(excinfo.value)
+
+    # The merge path must still tolerate a real existing directory.
+    dst2 = tmp_path / "dest2"
+    (dst2 / "sub").mkdir(parents=True)
+    pinned_fs.stage_tree_pinned(src, dst2, what="tree", skip_existing=True)
+    assert (dst2 / "sub" / "file.txt").read_text(encoding="utf-8") == "payload\n"
+
+
+@pinned_only
+def test_the_destination_root_is_created_through_a_pinned_parent(tmp_path: Path) -> None:
+    """Only the final component is created, and only relative to a pinned parent.
+
+    `Path(dst).mkdir(parents=True)` created every missing component BY NAME. Two
+    separate properties come out of replacing it, and it is worth being exact about
+    which one this buys, because my first version of this test claimed the stronger one
+    and passed for the wrong reason:
+
+    1. A missing ancestor is no longer silently materialised through whatever the path
+       resolves to. The parent must already exist, so a caller cannot accidentally
+       write a tree into a linked directory it never validated. Asserted below.
+    2. An ancestor swapped for a link AFTER the parent was resolved is refused, by
+       `pin_parent`'s per-component `O_NOFOLLOW`. That is covered by
+       `test_open_dir_pinned_refuses_a_parent_that_became_a_link`.
+
+    What this does NOT buy is refusing an ancestor that was ALREADY a link when the
+    parent was resolved: `realpath` follows it, deliberately, because refusing every
+    symlinked ancestor would break a destination under `/tmp` on macOS. That residual is
+    documented on `pin_parent` and asserted at the end of this test so the limit is on
+    the record rather than assumed away.
+    """
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "file.txt").write_text("payload\n", encoding="utf-8")
+
+    # (1) A missing parent is not created by name.
+    with pytest.raises((pinned_fs.PinnedPathRefusal, OSError)):
+        pinned_fs.stage_tree_pinned(src, tmp_path / "absent" / "deep" / "dest", what="tree")
+    assert not (tmp_path / "absent").exists(), "a missing ancestor chain was materialised by name"
+
+    # The documented residual, stated rather than implied: a parent that is already a
+    # link is followed by the resolution, so the tree lands in its target.
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    holder = tmp_path / "holder"
+    holder.mkdir()
+    _symlink_or_skip(holder / "linked", victim)
+
+    pinned_fs.stage_tree_pinned(src, holder / "linked" / "dest", what="tree")
+    assert (victim / "dest" / "file.txt").read_text(encoding="utf-8") == "payload\n", (
+        "if this now refuses, the pre-existing-link residual has been closed and this "
+        "assertion should become the refusal it documents"
+    )
+
+
+# ── Round 3: the alias hazard reached the databases too ──────────────────────
+
+
+def test_merge_consults_the_gate_before_writing_any_core_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The core copies run before any tree call, so the gate has to be at entry.
+
+    Gating inside the tree helpers meant a merge on a platform that cannot pin wrote
+    `memory.db`, `crons.json` and the security files FIRST and only then met the refusal
+    -- either redirecting those writes through a planted link, or aborting with the
+    restore already half applied. Raised in review; same gate-placement defect as the
+    snapshot side, one path over.
+    """
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    (snap / "crons.json").write_text("[]\n", encoding="utf-8")
+    mc = tmp_path / "home"
+    mc.mkdir()
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal):
+        snapshot._do_merge(snap, mc, None)
+
+    assert not (
+        mc / "crons.json"
+    ).exists(), "a core file was written before the platform gate was consulted"
+
+
+@pinned_only
+def test_a_linked_destination_root_raises_the_refusal_not_a_raw_oserror(
+    tmp_path: Path,
+) -> None:
+    """`O_NOFOLLOW` already refused it; the gap was that it escaped as a traceback.
+
+    Every other refusal on this surface is one type the CLI boundary contains, and this
+    one arrived as a bare `ELOOP`/`ENOTDIR`, so a restore ended in a stack trace instead
+    of the sentence explaining what to remove. Found by my own probe of a review finding,
+    then named by the reviewer.
+    """
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "file.txt").write_text("payload\n", encoding="utf-8")
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    holder = tmp_path / "holder"
+    holder.mkdir()
+    _symlink_or_skip(holder / "dest", victim)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        pinned_fs.stage_tree_pinned(src, holder / "dest", what="tree")
+    assert "symbolic link or not a directory" in str(excinfo.value)
+
+
+def test_metadata_falls_back_to_a_path_where_fd_operations_do_not_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`os.fchmod` does not exist on Windows, and calling it unconditionally crashed.
+
+    An earlier revision applied metadata only by descriptor, so a Windows snapshot using
+    the declared by-name traversal raised `AttributeError` the moment it reached a core
+    file -- a crash introduced by a hardening change, which is the worst kind. Simulated
+    by deleting the attribute, the way the bench suite simulates a missing `O_NOFOLLOW`.
+    """
+    monkeypatch.delattr(pinned_fs.os, "fchmod", raising=False)
+    monkeypatch.setattr(pinned_fs.os, "supports_fd", set())
+
+    src = tmp_path / "source.txt"
+    src.write_text("payload\n", encoding="utf-8")
+    os.chmod(src, 0o640)
+    dst = tmp_path / "dest.txt"
+
+    assert pinned_fs.copy_file_pinned(str(src), str(dst)) is True
+    assert dst.read_text(encoding="utf-8") == "payload\n"
+    if os.name == "posix":
+        assert (dst.stat().st_mode & 0o777) == 0o640
+
+
+def test_a_restored_security_file_is_locked_down_regardless_of_the_archive_mode(
+    tmp_path: Path,
+) -> None:
+    """The archive is untrusted input, so its recorded mode cannot decide the result.
+
+    The reviewer's suggested fix for the by-name lockdown was to drop it because "the
+    copy already applies mode through the descriptor" -- but that applies the ARCHIVE's
+    mode, and a tarball can be built by hand with any mode it likes. So the mode is
+    forced through the descriptor instead of inherited or re-applied by name.
+
+    The payload is `0o644` rather than something wider: group- and world-readable is
+    already a real leak for a secret, so it proves the point, and it avoids asking a SAST
+    rule to tell a fixture apart from a mistake.
+    """
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    salt = snap / "telemetry_salt"
+    salt.write_text("salt\n", encoding="utf-8")
+    os.chmod(salt, 0o644)
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    backup = mc / "backup"
+    backup.mkdir()
+
+    snapshot._backup_and_copy(mc, backup, snap, "security", **UNPINNED_OK)
+
+    restored = mc / "telemetry_salt"
+    assert restored.read_text(encoding="utf-8") == "salt\n"
+    if os.name == "posix":
+        assert (
+            restored.stat().st_mode & 0o777
+        ) == 0o600, "the archive's permissive mode was inherited onto a restored secret"
+
+
+# ── Round 5: skips that precede a delete, and a validation that gets discarded ──
+
+
+def test_replace_refuses_rather_than_deleting_a_tree_its_backup_could_not_copy(
+    tmp_path: Path,
+) -> None:
+    """The data-loss finding that closed the earlier attempt (#2446), carried forward here.
+
+    Replace mode's next step after the backup is `rmtree` on the LIVE tree. The staging
+    walk legitimately skips a hardlink alias -- right when producing an archive, and
+    catastrophic here, because the skip is followed by a delete rather than by an
+    omission, so the only copy of that file goes with it. Refusing before the delete is
+    the only ordering that cannot lose data.
+    """
+    mc = tmp_path / "home"
+    live = mc / "workspace"
+    live.mkdir(parents=True)
+    (live / "ordinary.txt").write_text("kept\n", encoding="utf-8")
+
+    secret = tmp_path / "credential"
+    secret.write_text("token\n", encoding="utf-8")
+    try:
+        os.link(secret, live / "alias.json")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("hard links are unavailable on this host")
+
+    snap = tmp_path / "payload"
+    (snap / "workspace").mkdir(parents=True)
+    (snap / "workspace" / "from-archive.txt").write_text("new\n", encoding="utf-8")
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        snapshot._do_replace(snap, mc, ["workspace"], **UNPINNED_OK)
+
+    assert "already moved or removed" in str(excinfo.value)
+    assert (live / "alias.json").exists(), "the live tree was deleted despite a skipped file"
+    assert (live / "ordinary.txt").read_text(encoding="utf-8") == "kept\n"
+
+
+@pinned_only
+def test_the_replace_path_refuses_a_root_recreated_after_its_own_rmtree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The WIRING, not just the primitive: replace must pass the contract down.
+
+    A unit test on `stage_tree_pinned(must_create=True)` does not prove the replace path
+    asks for it. It did not: dropping `must_create=True` at the call site left every test
+    green, so the flag could be removed and nothing would notice -- the same untested-wiring
+    gap that lets a fix silently rot. This drives the real `_do_replace`.
+
+    The race is reproduced at its outcome rather than by timing: `rmtree` is replaced with
+    one that removes the tree and immediately recreates the bare root, which is exactly the
+    state a gateway recreating its workspace leaves behind.
+    """
+    mc = tmp_path / "home"
+    live = mc / "workspace"
+    live.mkdir(parents=True)
+    (live / "stale.txt").write_text("not in the archive\n", encoding="utf-8")
+
+    snap = tmp_path / "payload"
+    (snap / "workspace").mkdir(parents=True)
+    (snap / "workspace" / "from-archive.txt").write_text("new\n", encoding="utf-8")
+
+    real_rmtree = snapshot.shutil.rmtree
+
+    def _rmtree_then_recreate(path, *a, **k):
+        real_rmtree(path, *a, **k)
+        os.mkdir(path)  # the gateway comes back before the copy starts
+
+    monkeypatch.setattr(snapshot.shutil, "rmtree", _rmtree_then_recreate)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        snapshot._do_replace(snap, mc, ["workspace"], **UNPINNED_OK)
+
+    assert "already exists" in str(excinfo.value), f"unclear refusal: {excinfo.value}"
+    assert not (live / "from-archive.txt").exists(), (
+        "the archive was staged into a root somebody else recreated, so a replace would "
+        "have reported success with foreign files still in place"
+    )
+
+
+@pinned_only
+def test_a_destination_subtree_that_cannot_be_opened_refuses_instead_of_vanishing(
+    tmp_path: Path,
+) -> None:
+    """A source entry that stops being a directory is skipped; a destination is not.
+
+    The archive's subtree still exists and now has nowhere to go, so continuing reported
+    success with that subtree missing -- the silent-partial shape again, on the one path
+    where `_open_child_dir` returning None was being treated as benign. A merge is the
+    one caller that may legitimately meet a foreign destination tree, so it keeps the
+    skip.
+    """
+    src = tmp_path / "source"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "file.txt").write_text("payload\n", encoding="utf-8")
+
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    # A plain FILE where the walk needs a directory: mkdir raises FileExistsError and the
+    # pinned open then fails with ENOTDIR, which is the state under test.
+    (dst / "sub").write_text("not a directory\n", encoding="utf-8")
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal):
+        pinned_fs.stage_tree_pinned(src, dst, what="tree")
+
+
+@pinned_only
+def test_a_restore_source_that_cannot_be_copied_refuses_after_the_live_file_moved(
+    tmp_path: Path,
+) -> None:
+    """Third instance of one rule, which is why it became a reporter rather than a check.
+
+    The live file is moved aside first, so a skipped restore SOURCE finishes with the
+    original gone and the archive's version never written -- active data missing, reported
+    as success. Same shape as the backup-then-rmtree case and the destination-subtree
+    case; all three now come from `pinned_fs.fatal_skip_reporter`, passed by every
+    mutating call site and deliberately not by any archive-producing one.
+    """
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    secret = tmp_path / "credential"
+    secret.write_text("token\n", encoding="utf-8")
+    try:
+        os.link(secret, snap / "crons.json")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("hard links are unavailable on this host")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    (mc / "crons.json").write_text("live\n", encoding="utf-8")
+    backup = mc / "backup"
+    backup.mkdir()
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as excinfo:
+        snapshot._backup_and_copy(mc, backup, snap, "crons")
+
+    assert "already moved or removed" in str(excinfo.value)
+    assert (backup / "crons.json").read_text(
+        encoding="utf-8"
+    ) == "live\n", "the live file must still be recoverable from the backup after the refusal"
+
+
+def test_a_crafted_archive_cannot_drive_the_terminal_through_the_manifest(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A restore reads an arbitrary tarball, so its manifest strings are untrusted input.
+
+    ANSI and OSC sequences are executed by a terminal rather than displayed, so a crafted
+    archive could rewrite what the operator appears to be reading -- including hiding the
+    very omission notice this change added in order to make an incomplete archive visible.
+    Raised in review.
+
+    Control characters are escaped rather than stripped so the value stays diagnosable:
+    the operator sees that the name really does contain an escape, instead of reading a
+    different, innocuous name.
+    """
+    snap = tmp_path / "extracted"
+    snap.mkdir()
+    (snap / "MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "created_at": "2026-01-01T00:00:00Z\x1b[2J",
+                "user": "someone\x1b]0;pwned\x07",
+                "hostname": "host",
+                "contents": {},
+                "skipped": [{"reason": "not_regular\x1b[31m", "path": "a\x1b[1;31mb.txt"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot._print_manifest(snap)
+    out = capsys.readouterr().out
+
+    assert "\x1b" not in out, "an escape sequence from the archive reached the terminal"
+    assert "\\x1b" in out, "the escape was stripped rather than shown, hiding the tampering"
+    assert "b.txt" in out, "the ordinary part of the name is still readable"
+
+
+@pinned_only
+def test_an_unusable_archive_member_does_not_cost_the_live_file(tmp_path: Path) -> None:
+    """The archive is untrusted, so a member that is not a regular file is a real case.
+
+    The old order moved the live file aside FIRST and only then found the source unusable,
+    so the original ended up in the backup, nothing was restored, and the command reported
+    success. A FIFO at a core filename is the cheapest way to produce that; a directory or
+    a device node does the same.
+    """
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    try:
+        os.mkfifo(snap / "crons.json")
+    except (AttributeError, OSError, NotImplementedError):  # pragma: no cover - platform
+        pytest.skip("mkfifo is unavailable on this host")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    (mc / "crons.json").write_text("live\n", encoding="utf-8")
+    backup = mc / "backup"
+    backup.mkdir()
+
+    snapshot._backup_and_copy(mc, backup, snap, "crons")
+
+    assert (mc / "crons.json").read_text(
+        encoding="utf-8"
+    ) == "live\n", (
+        "the live file was moved aside for an archive member that could never be restored"
+    )
+    assert not (backup / "crons.json").exists()
+
+
+def test_a_fifo_source_is_refused_rather_than_blocking_forever(tmp_path: Path) -> None:
+    """Opening a FIFO for reading blocks until a writer appears -- with no timeout.
+
+    So a single named pipe in an extracted archive, or planted in a staged tree, could hang
+    a whole snapshot or restore indefinitely, with no message. This was found the honest
+    way: a mutation probe removed a caller's own `is_file()` guard and the test run stalled
+    until a watchdog killed it, which is exactly how an operator would have met it.
+
+    A caller-side pre-check is not enough on its own -- every caller would have to remember
+    it -- so `O_NONBLOCK` makes reaching the `fstat` refusal guaranteed rather than
+    dependent on the call site. Asserted with a real FIFO and no writer: if this ever
+    regresses, the test hangs rather than fails, which is why the primitive and not just
+    the caller has to hold the property.
+    """
+    if not hasattr(os, "mkfifo"):  # pragma: no cover - platform dependent
+        pytest.skip("mkfifo is unavailable on this host")
+    fifo = tmp_path / "pipe"
+    try:
+        os.mkfifo(fifo)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("mkfifo is unavailable on this host")
+
+    seen: list[tuple[str, str]] = []
+    copied = pinned_fs.copy_file_pinned(
+        str(fifo), str(tmp_path / "dest"), on_skip=lambda r, p: seen.append((r, p))
+    )
+
+    assert copied is False
+    assert seen and seen[0][0] == pinned_fs.SKIP_NOT_REGULAR
+    assert not (tmp_path / "dest").exists()
+
+
+def test_the_declared_by_name_path_still_refuses_a_hardlinked_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Opting into a by-name TRAVERSAL is not opting into dereferencing an alias.
+
+    The operator accepts one specific weakness on a platform that cannot pin: an ancestor
+    swapped mid-walk can redirect the copy, and nothing can prevent that without the
+    descriptor support the platform lacks. Review pointed out the per-file screens had been
+    left behind with it -- plain `copytree` dereferences a hardlink into ordinary bytes --
+    so the fallback would have archived a credential the pinned path refuses. That is a
+    wider concession than the documented one.
+    """
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    src = tmp_path / "workspace"
+    src.mkdir()
+    (src / "ordinary.txt").write_text("kept\n", encoding="utf-8")
+    secret = tmp_path / "credential"
+    secret.write_text("AKIA-not-real\n", encoding="utf-8")
+    try:
+        os.link(secret, src / "innocuous.json")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("hard links are unavailable on this host")
+
+    dst = tmp_path / "staged"
+    snapshot._copytree_safe(src, dst, allow_unpinned=True)
+
+    assert (dst / "ordinary.txt").read_text(encoding="utf-8") == "kept\n"
+    assert not (
+        dst / "innocuous.json"
+    ).exists(), "the by-name fallback dereferenced a hardlinked credential into the archive"
+
+
+def test_the_by_name_core_path_refuses_a_linked_core_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`is_file()` and an O_NOFOLLOW-less open both FOLLOW a link, so neither screens one."""
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    secret = tmp_path / "credential"
+    secret.write_text("AKIA-not-real\n", encoding="utf-8")
+    _symlink_or_skip(mc / "crons.json", secret)
+
+    archive = snapshot._build_snapshot(mc, tmp_path / "out", "archive", **UNPINNED_OK)
+    with tarfile.open(str(archive)) as tar:
+        assert (
+            "archive/crons.json" not in tar.getnames()
+        ), "the by-name core path followed a link and archived the credential"
+        member = tar.extractfile("archive/MANIFEST.json")
+        assert member is not None
+        assert any(e["path"] == "crons.json" for e in json.load(member)["skipped"])
+
+
+def test_the_by_name_restore_applies_the_archive_over_a_symlinked_core_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The round-1 fix reached the pinned branch and not this one.
+
+    The by-name branch still skipped both the backup AND the replacement for a symlinked
+    core name, so the archive's file was never applied while the command reported success --
+    the same silent partial restore fixed on the pinned path much earlier. Review caught the
+    branch that had been left behind.
+    """
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    (snap / "crons.json").write_text("[]\n", encoding="utf-8")
+
+    victim = tmp_path / "victim.json"
+    victim.write_text("PRECIOUS\n", encoding="utf-8")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    _symlink_or_skip(mc / "crons.json", victim)
+    backup = mc / "backup"
+    backup.mkdir()
+
+    snapshot._backup_and_copy(mc, backup, snap, "crons", **UNPINNED_OK)
+
+    assert (mc / "crons.json").read_text(
+        encoding="utf-8"
+    ) == "[]\n", "the archive's version was not applied -- a silent partial restore"
+    assert victim.read_text(encoding="utf-8") == "PRECIOUS\n"
+    assert (backup / "crons.json").is_symlink()
+
+
+@pinned_only
+def test_staged_directories_do_not_inherit_the_sources_mode_or_mtime(tmp_path: Path) -> None:
+    """Directory metadata is deliberately NOT carried across, and this pins that choice.
+
+    The earlier contract was the opposite: `shutil.copytree` preserved directory mode and
+    mtime, the walk that replaced it did not, and that lost fidelity was restored after review
+    found it. It has now been given up again, on purpose, for a reason that outranks fidelity.
+
+    Applying it required knowing that WE created the directory. That flag came from the
+    `mkdir` while the descriptor came from a separate `open`, so a directory replaced between
+    the two left the flag true for an object we no longer held, and the archive's mode and
+    mtime were then written onto a directory belonging to somebody else. There is no sound
+    repair: a stat taken after the mkdir observes the replacement just as happily as our own
+    directory, POSIX has no atomic create-and-open for a directory, and under a same-user
+    threat model no mode trick closes the gap.
+
+    So a staged tree gets the walk's own 0700 and a current mtime. Contents and file metadata
+    are unaffected -- those are applied through a descriptor that IS the file.
+    """
+    src = tmp_path / "source"
+    nested = src / "nested"
+    nested.mkdir(parents=True)
+    (nested / "file.txt").write_text("payload\n", encoding="utf-8")
+    # Non-default DIRECTORY modes, so "not inherited" is distinguishable from "coincidence".
+    # Semgrep's advice here is for files and would make a directory non-traversable, so it is
+    # suppressed by rule id rather than widened.
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    os.chmod(nested, 0o750)
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    os.chmod(src, 0o755)
+    old_mtime = 1600000000_000000000
+    os.utime(nested, ns=(old_mtime, old_mtime))
+    os.utime(src, ns=(old_mtime, old_mtime))
+
+    dst = tmp_path / "staged"
+    pinned_fs.stage_tree_pinned(src, dst, what="tree")
+
+    # The payload and its own metadata still cross -- only directories are affected.
+    assert (dst / "nested" / "file.txt").read_text(encoding="utf-8") == "payload\n"
+    assert (
+        dst / "nested"
+    ).stat().st_mode & 0o777 == 0o700, (
+        "a directory inherited the source mode, which review showed cannot be done safely"
+    )
+    assert dst.stat().st_mode & 0o777 == 0o700, "the root inherited the source mode"
+    assert (
+        dst / "nested"
+    ).stat().st_mtime_ns != old_mtime, "a directory inherited the source mtime"
+
+
+@pinned_only
+@posix_modes_only
+def test_a_merge_does_not_restamp_an_existing_directory(tmp_path: Path) -> None:
+    """The archive's directory mode must not land on a directory the user already owns.
+
+    Preserving directory metadata (previous round) was right for directories this walk
+    CREATES and wrong for one a merge finds already there: a live 0700 directory had the
+    archive's 0755 stamped onto it, which clobbers the user's metadata and loosens
+    permissions from an untrusted source. Review caught it one round after the fix that
+    introduced it.
+
+    Not a new rule -- it is the same reason a security file is forced to 0600 instead of
+    taking the archive's mode. That rule was applied to files and not carried to directories.
+    """
+    src = tmp_path / "source"
+    shared = src / "shared"
+    shared.mkdir(parents=True)
+    (shared / "from-archive.txt").write_text("new\n", encoding="utf-8")
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    os.chmod(shared, 0o755)
+
+    dst = tmp_path / "live"
+    live_shared = dst / "shared"
+    live_shared.mkdir(parents=True)
+    (live_shared / "already-here.txt").write_text("mine\n", encoding="utf-8")
+    # 0o700 is OWNER-ONLY -- the tightest mode a directory can have and still be entered.
+    # The rule fires on the execute bit, which every directory needs, so it flags even this;
+    # its suggested 0o644 would grant world-read AND make the directory non-traversable.
+    # Same suppression and same reasoning as the existing sites in `mcp_gateway/rewriter.py`.
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    os.chmod(live_shared, 0o700)
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    os.chmod(dst, 0o700)
+
+    pinned_fs.stage_tree_pinned(src, dst, what="merge", skip_existing=True)
+
+    assert (live_shared / "already-here.txt").read_text(encoding="utf-8") == "mine\n"
+    assert (live_shared / "from-archive.txt").read_text(encoding="utf-8") == "new\n"
+    assert (
+        live_shared.stat().st_mode & 0o777 == 0o700
+    ), "the archive's mode was stamped onto a live directory, loosening it to 0755"
+    assert dst.stat().st_mode & 0o777 == 0o700, "the merge restamped the destination root"
+
+
+@pinned_only
+@posix_modes_only
+def test_a_root_created_between_the_check_and_the_mkdir_is_not_restamped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The "is this root mine?" answer has to come from the kernel, not from a name.
+
+    `not dst.exists()` was a check with a window after it: a forced restore removes the
+    workspace, the gateway recreates it before the mkdir runs, and the live directory is then
+    treated as newly created and stamped with the archive's mode and timestamps. Review caught
+    it. `FileExistsError` on our own mkdir cannot race -- the kernel decided it.
+
+    The fixture recreates the root inside that window, which is the one thing a name-based
+    check cannot survive and a kernel-reported one shrugs off.
+    """
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "file.txt").write_text("payload\n", encoding="utf-8")
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    os.chmod(src, 0o755)
+
+    dst = tmp_path / "live"
+    real_pin = pinned_fs.pin_parent
+
+    def _recreate_the_root_first(*a, **k):
+        fd = real_pin(*a, **k)
+        # Only in the DESTINATION's window. An earlier version fired on the SOURCE root's
+        # pin, which happens first, so the root already existed by the time the old
+        # name-based check sampled it -- and the mutation that restored the bug passed.
+        # A fixture that fires outside the window under test proves nothing.
+        if "destination" in str(k.get("what", "")) and not dst.exists():
+            dst.mkdir()  # the gateway, in the window a name check leaves open
+            # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+            os.chmod(dst, 0o700)
+        return fd
+
+    monkeypatch.setattr(pinned_fs, "pin_parent", _recreate_the_root_first)
+    pinned_fs.stage_tree_pinned(src, dst, what="tree")
+
+    assert (dst / "file.txt").read_text(encoding="utf-8") == "payload\n"
+    assert (
+        dst.stat().st_mode & 0o777 == 0o700
+    ), "a root recreated inside the window was stamped with the archive's mode"
+
+
+def test_no_name_based_filesystem_question_where_a_descriptor_is_held() -> None:
+    """The ratchet for this change's first invariant, enforced instead of just asserted.
+
+    Five separate review findings across thirteen rounds were the same mistake: a filesystem
+    question asked through a PATH NAME by code already holding a descriptor for the object. A
+    name re-resolves, so the guard can inspect a different object than the one the next line
+    acts on -- and every instance reported success while omitting or misplacing data. Point-
+    fixing a sixth time is the wrong move, so this walks the AST and fails on the pattern.
+
+    Scoped to `pinned_fs` ON PURPOSE. There the invariant is absolute: the module exists to be
+    the descriptor-pinned path and has no by-name fallback, so any name-based question inside a
+    descriptor-holding function is a defect.
+
+    `snapshot.py` is deliberately NOT covered, and the first draft of this test that did cover
+    it is why. It flagged twelve sites, and on inspection nearly all were the UNPINNED
+    fallback branches -- where a by-name check is the only thing available and is correct.
+    Whole-function scoping cannot tell those from the real thing, so covering `snapshot.py`
+    needs a per-line marker convention for the legitimate by-name sites. That is a wider change
+    than the two fixes this test guards, and it belongs in the follow-up gate I proposed on this
+    PR rather than being smuggled in here.
+    """
+    import ast
+
+    repo_root = Path(snapshot.__file__).resolve().parents[2]
+    # Questions, plus the PUBLICATION writes. The question set alone is what shipped, and it
+    # is why a publish that re-resolved its temporary by `os.link` went unflagged for three
+    # rounds while satisfying this very ratchet -- the invariant covers writes derived from a
+    # name, and only the branch-controlling half was ever enforced. `link`/`rename`/`replace`
+    # are added because a name-resolved publish is precisely the hole that shipped.
+    #
+    # `chmod`/`utime`/`unlink` are deliberately NOT here: those have legitimate by-name
+    # fallbacks for platforms without `os.fchmod`, and separating them needs the helper-split
+    # refactor applied to the metadata appliers. Measured, that is 5 sites -- worth doing, and
+    # not worth dragging into this change. They stay outside the ratchet, stated rather than
+    # silently omitted.
+    banned_attrs = {
+        "is_file",
+        "is_dir",
+        "exists",
+        "is_symlink",
+        "stat",
+        "lstat",
+        "link",
+        "rename",
+        "replace",
+    }
+    offenders: list[str] = []
+
+    for module in ("src/kiro_crew/pinned_fs.py",):
+        path = repo_root / module
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for func in ast.walk(tree):
+            if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            # Does this function bind a directory descriptor at all?
+            names = {
+                n.id
+                for n in ast.walk(func)
+                if isinstance(n, ast.Name) and isinstance(n.ctx, (ast.Store, ast.Param))
+            }
+            names |= {a.arg for a in func.args.args + func.args.kwonlyargs}
+            holds_fd = any(n.endswith("_fd") for n in names)
+            if not holds_fd:
+                continue
+            for node in ast.walk(func):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                if not isinstance(fn, ast.Attribute) or fn.attr not in banned_attrs:
+                    continue
+                # os.stat(name, dir_fd=...) is the CORRECT form -- that is the fix, not
+                # the defect. Only flag the descriptor-less question. `rename`/`link` name
+                # their descriptors differently, so all three spellings are exempt or the
+                # ratchet would flag the very form it exists to require.
+                if any(kw.arg in ("dir_fd", "src_dir_fd", "dst_dir_fd") for kw in node.keywords):
+                    continue
+                # Reading a descriptor's own metadata is by definition not name-based.
+                if isinstance(fn.value, ast.Name) and fn.value.id.endswith("_fd"):
+                    continue
+                offenders.append(f"{module}:{node.lineno} -> .{fn.attr}()")
+
+    assert not offenders, (
+        "a filesystem question asked by NAME inside a function holding a descriptor -- "
+        "use pinned_fs.stat_at / is_regular_at, or pass dir_fd=:\n  " + "\n  ".join(offenders)
+    )
+
+
+@pinned_only
+def test_the_pinned_core_loop_screens_through_the_descriptor(tmp_path: Path) -> None:
+    """A core filename pointing at a credential is refused and recorded, not archived.
+
+    NOTE ON WHAT THIS TEST DOES AND DOES NOT PROVE. It asserts the behaviour, but it does NOT
+    discriminate the descriptor-relative guard it was written for: removing that guard leaves
+    this test green, because `copy_file_pinned` opens with O_NOFOLLOW and refuses the link on
+    its own. I verified that with a mutation and am recording it rather than presenting the
+    test as evidence it is not.
+
+    The guard is still right -- with `mc_fd` in hand, asking a NAME is a second source of
+    truth that can disagree with the descriptor, and the disagreement direction that matters
+    is a name-based guard rejecting a healthy file and silently dropping it from a successful
+    archive. That direction needs a swap injected between guard and copy through a symlinked
+    ancestor alias, which I have not built. So: hardening with a behavioural test, not a
+    regression test, and labelled as such.
+
+    Also worth recording how the defect was found: my own AST ratchet flagged this exact line,
+    and I dismissed it as one of the legitimate by-name fallback sites without checking. Review
+    then found it for real. The ratchet was right; the generalization I applied to its output
+    was not.
+    """
+    mc = tmp_path / "home"
+    mc.mkdir()
+    secret = tmp_path / "credential"
+    secret.write_text("AKIA-not-real\n", encoding="utf-8")
+    _symlink_or_skip(mc / "crons.json", secret)
+    (mc / "config.json").write_text("{}\n", encoding="utf-8")
+
+    archive = snapshot._build_snapshot(mc, tmp_path / "out", "archive")
+
+    with tarfile.open(str(archive)) as tar:
+        names = tar.getnames()
+        assert "archive/crons.json" not in names, "a linked core name reached the archive"
+        assert "archive/config.json" in names, "the healthy core file was not archived"
+        member = tar.extractfile("archive/MANIFEST.json")
+        assert member is not None
+        manifest = json.load(member)
+
+    assert any(
+        e["path"] == "crons.json" for e in manifest["skipped"]
+    ), "the refusal was not recorded in the manifest"
+    # An ABSENT core file is not an omission and must not appear -- most components ship
+    # only a subset, and recording every missing name would make the list meaningless.
+    assert not any(e["path"] == "session_map.json" for e in manifest["skipped"])
+
+
+def test_a_staging_refusal_is_recorded_as_a_rejected_permission_decision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refusing to stage is a permission decision, so the SEL log has to show it.
+
+    The refusal path this change introduced printed a message and returned, leaving no audit
+    record -- so the one outcome a reviewer most wants evidence of, staging declined on an
+    unsupported platform, was invisible after the fact. Review caught it. The restore side
+    reuses the `state_restore_rejected` event already established in this module rather than
+    inventing a second name for the same decision.
+    """
+    events: list[tuple[str, str]] = []
+    monkeypatch.setattr(snapshot, "_audit", lambda ev, res: events.append((ev, res)))
+    # Force the platform gate to refuse without the opt-in, which is the real refusal path.
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+    monkeypatch.setattr(pinned_fs, "supports_pinned_walk", lambda: False)
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    (mc / "config.json").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(snapshot, "_mc_dir", lambda: mc)
+
+    rc = snapshot.snapshot_main([str(tmp_path / "out")])
+
+    assert rc == 1, "the refusal did not reach the caller as a failure"
+    assert any(
+        ev == "snapshot_rejected" for ev, _ in events
+    ), f"the refusal left no SEL record: {events}"
+    assert any(
+        "unpinnable_staging" in res for _, res in events
+    ), f"the audit record did not say WHY it was refused: {events}"
+
+
+def test_a_skipped_by_name_replacement_fails_loudly_instead_of_losing_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once the live file is moved aside, a SKIP is data loss, not an omission.
+
+    The by-name restore branch moves the live core file into the backup and then copies the
+    archive's version over the name. If that copy is refused -- a hardlinked source, say --
+    a non-fatal reporter records the skip and the restore reports success with the live file
+    gone and nothing put back. Review caught this call site still using the non-fatal
+    reporter.
+
+    This is the third site to need `fatal_skip_reporter`, and the rule behind all three is
+    the same: a skip is CORRECT while producing an archive and is data loss on any path that
+    has already moved or deleted the original.
+    """
+    monkeypatch.setattr(pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    snap = tmp_path / "payload"
+    snap.mkdir()
+    (snap / "crons.json").write_text("[]\n", encoding="utf-8")
+    # A hardlink alias on the SOURCE is what the copy primitive refuses.
+    alias_target = tmp_path / "other.json"
+    alias_target.write_text("[]\n", encoding="utf-8")
+    (snap / "crons.json").unlink()
+    try:
+        os.link(alias_target, snap / "crons.json")
+    except OSError:  # pragma: no cover - platform dependent
+        pytest.skip("host cannot create a hard link")
+
+    mc = tmp_path / "home"
+    mc.mkdir()
+    (mc / "crons.json").write_text("LIVE\n", encoding="utf-8")
+    backup = mc / "backup"
+    backup.mkdir()
+
+    with pytest.raises(Exception) as caught:
+        snapshot._backup_and_copy(mc, backup, snap, "crons", **UNPINNED_OK)
+
+    assert "restore of" in str(
+        caught.value
+    ), f"the refusal did not name the operation it aborted: {caught.value}"
+    # The live copy must still be recoverable from the backup rather than simply gone.
+    assert (backup / "crons.json").read_text(
+        encoding="utf-8"
+    ) == "LIVE\n", "the live file was neither restored nor left recoverable in the backup"
+
+
+@pinned_only
+def test_failed_copy_cleanup_spares_a_concurrently_replaced_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed copy must remove OUR partial, never whatever the name means by then.
+
+    The cleanup unlinked by name unconditionally. A name is not a file: a concurrent atomic
+    save (write temp, rename over the name) landing between our exclusive create and the
+    cleanup meant we deleted the REPLACEMENT. On the restore path the destination is the
+    live data home, so that other writer is the gateway losing a committed file. Review
+    found it.
+
+    The fixture performs exactly that replacement at the moment the copy fails, and asserts
+    the replacement survives with its own bytes.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "f.txt").write_text("source\n", encoding="utf-8")
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    replacement = tmp_path / "committed.txt"
+    replacement.write_text("ANOTHER WRITER\n", encoding="utf-8")
+
+    real_copyfileobj = pinned_fs.shutil.copyfileobj
+
+    def _fail_after_replacing(fsrc, fdst, *a, **k):
+        # Someone else's atomic save lands on the destination name, then our copy fails.
+        os.replace(str(replacement), str(dst_dir / "f.txt"))
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(pinned_fs.shutil, "copyfileobj", _fail_after_replacing)
+    with pytest.raises(OSError):
+        pinned_fs.copy_file_pinned(str(src_dir / "f.txt"), str(dst_dir / "f.txt"))
+    monkeypatch.setattr(pinned_fs.shutil, "copyfileobj", real_copyfileobj)
+
+    survivor = dst_dir / "f.txt"
+    assert survivor.exists(), "cleanup deleted the other writer's committed file"
+    assert survivor.read_text(encoding="utf-8") == "ANOTHER WRITER\n"
+
+
+@pinned_only
+def test_failed_copy_cleanup_spares_a_replaced_destination_in_descriptor_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same contract on the PINNED path, which is a separate helper.
+
+    The two modes are deliberately separate functions so the descriptor one never names a
+    path, so each needs its own coverage -- a mutation to one leaves the other's test green,
+    which is how I found this test missing.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "f.txt").write_text("source\n", encoding="utf-8")
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    replacement = tmp_path / "committed.txt"
+    replacement.write_text("ANOTHER WRITER\n", encoding="utf-8")
+
+    src_fd = os.open(str(src_dir), os.O_RDONLY)
+    dst_fd = os.open(str(dst_dir), os.O_RDONLY)
+    try:
+
+        def _fail_after_replacing(fsrc, fdst, *a, **k):
+            os.replace(str(replacement), str(dst_dir / "f.txt"))
+            raise OSError("copy failed")
+
+        monkeypatch.setattr(pinned_fs.shutil, "copyfileobj", _fail_after_replacing)
+        with pytest.raises(OSError):
+            pinned_fs.copy_file_pinned(
+                str(src_dir / "f.txt"),
+                str(dst_dir / "f.txt"),
+                dir_fd=src_fd,
+                name="f.txt",
+                dst_dir_fd=dst_fd,
+                dst_name="f.txt",
+            )
+    finally:
+        os.close(src_fd)
+        os.close(dst_fd)
+
+    survivor = dst_dir / "f.txt"
+    assert survivor.exists(), "pinned cleanup deleted the other writer's committed file"
+    assert survivor.read_text(encoding="utf-8") == "ANOTHER WRITER\n"
+
+
+@pinned_only
+def test_a_published_file_has_exactly_one_link(tmp_path: Path) -> None:
+    """A published file has exactly one link, which the next pass depends on.
+
+    This began as a check that the publish removed its temporary. There is no temporary now,
+    but the assertion it ended on is still load-bearing and for a reason worth keeping: the
+    hardlink screen refuses a source with `st_nlink != 1`, so a destination left with two
+    links would be refused by a LATER snapshot of the same tree. Exactly one link is the
+    property, however it is achieved.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "f.txt").write_text("payload\n", encoding="utf-8")
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    assert pinned_fs.copy_file_pinned(str(src_dir / "f.txt"), str(dst_dir / "f.txt")) is True
+    names = sorted(p.name for p in dst_dir.iterdir())
+    assert names == ["f.txt"], f"unexpected residue: {names}"
+    assert (dst_dir / "f.txt").read_text(encoding="utf-8") == "payload\n"
+    assert (
+        dst_dir / "f.txt"
+    ).stat().st_nlink == 1, "a second link would make a later snapshot refuse this file"
+
+
+@pinned_only
+def test_a_destination_collision_surfaces_as_a_refusal_not_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A name taken mid-walk is a real condition, but it must not escape as a traceback.
+
+    `restore --force` while the gateway recreates a tree file made the publish raise
+    `FileExistsError` straight out of the walk, so the command died with a stack trace
+    instead of the sentence saying what to do -- the same escape ELOOP/ENOTDIR were already
+    translated for on this surface. Review found it.
+    """
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "f.txt").write_text("payload\n", encoding="utf-8")
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    # The name is taken BEFORE the walk reaches it. This was previously reproduced by
+    # creating the name mid-copy, in the window between the copy and the publish -- that
+    # window no longer exists now that the destination itself is opened O_EXCL up front, so
+    # occupying the name first is the only way the test still proves anything.
+    (dst / "f.txt").write_text("SOMEONE ELSE\n", encoding="utf-8")
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as caught:
+        pinned_fs.stage_tree_pinned(src, dst, what="tree")
+
+    assert "created by something else" in str(
+        caught.value
+    ), f"the refusal does not explain what happened: {caught.value}"
+    assert (dst / "f.txt").read_text(
+        encoding="utf-8"
+    ) == "SOMEONE ELSE\n", "the colliding file was overwritten instead of refused"
+
+
+@pinned_only
+def test_a_failed_copy_empties_its_destination_and_never_unlinks_a_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed copy leaves an EMPTIED destination -- it must not unlink the name.
+
+    This contract changed deliberately and the reason is the point. Unlinking the destination
+    on failure is what review rejected twice: the name can change between deciding to remove
+    it and removing it, POSIX has no unlink-by-inode, and the loser of that race is a file
+    another writer published. Publishing through a temporary avoided the unlink but moved the
+    problem into the publish, where the temporary's NAME is re-resolved -- proven exploitable.
+
+    So the failure path empties the file through the descriptor it already holds, the one
+    operation that cannot be redirected at somebody else's file, and leaves the entry. The
+    caller's reporter is what makes it visible; on a restore that reporter is fatal, so the
+    operation stops with the previous version still in the backup.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "f.txt").write_text("this will not survive the copy\n", encoding="utf-8")
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    unlinked: list[str] = []
+    real_unlink = pinned_fs.os.unlink
+
+    def _record_unlink(path, *a, **k):
+        unlinked.append(str(path))
+        return real_unlink(path, *a, **k)
+
+    def _fail_midway(fsrc, fdst, *a, **k):
+        fdst.write(b"partial")
+        raise OSError(errno.EIO, "input/output error")
+
+    monkeypatch.setattr(pinned_fs.os, "unlink", _record_unlink)
+    monkeypatch.setattr(pinned_fs.shutil, "copyfileobj", _fail_midway)
+    with pytest.raises(OSError):
+        pinned_fs.copy_file_pinned(str(src_dir / "f.txt"), str(dst_dir / "f.txt"))
+
+    target = dst_dir / "f.txt"
+    assert target.exists(), "the destination entry was removed, which is the rejected design"
+    assert (
+        target.stat().st_size == 0
+    ), f"the partial content survived: {target.stat().st_size} bytes"
+    assert not unlinked, f"the failure path unlinked a name: {unlinked}"
+
+
+@pinned_only
+def test_nothing_names_the_destination_again_once_it_is_open(tmp_path: Path) -> None:
+    """The point of the redesign: there is no second name resolution left to attack.
+
+    The temp-and-publish design copied correctly and then re-resolved the temporary by name in
+    order to publish it, so swapping that entry after the copy installed attacker bytes and
+    reported the core file as restored. Rather than assert the absence of one exploit, this
+    asserts the property that makes it impossible: exactly one entry is created, it is the
+    destination, and no intermediate sibling ever appears.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "f.txt").write_text("ours\n", encoding="utf-8")
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    copied = pinned_fs.copy_file_pinned(str(src_dir / "f.txt"), str(dst_dir / "f.txt"))
+
+    assert copied is True
+    names = sorted(p.name for p in dst_dir.iterdir())
+    assert names == ["f.txt"], f"an intermediate name was created: {names}"
+    assert (dst_dir / "f.txt").read_text(encoding="utf-8") == "ours\n"
+
+
+@pinned_only
+def test_a_replace_refuses_a_destination_root_that_came_back(tmp_path: Path) -> None:
+    """A replace that finds its root already there must refuse, not merge into it.
+
+    The replace path removes the live tree and then stages the archive into its place. The
+    walk used to accept a root that existed again, so if the gateway recreated it in that
+    window, files the archive does not contain survived a REPLACE that reported success --
+    the silent-partial shape this change exists to remove, in the one mode that promises the
+    destination will be exactly the archive. Review found it. The per-child names already
+    refused; only the root was exempt.
+
+    The flag is passed by the caller and deliberately NOT derived from `skip_existing`: the
+    snapshot's own staging destination already exists and has no `skip_existing` either, so
+    deriving it refused every snapshot -- caught by the pre-existing snapshot suite.
+    """
+    src = tmp_path / "archive"
+    src.mkdir()
+    (src / "kept.txt").write_text("from the archive\n", encoding="utf-8")
+
+    dst = tmp_path / "live"
+    dst.mkdir()
+    (dst / "stale.txt").write_text("not in the archive\n", encoding="utf-8")
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as caught:
+        pinned_fs.stage_tree_pinned(src, dst, what="replace", must_create=True)
+
+    assert "already exists" in str(caught.value), f"unclear refusal: {caught.value}"
+    assert (dst / "stale.txt").exists(), "the refusal should not have touched anything"
+    assert not (dst / "kept.txt").exists(), "it staged despite refusing"
+
+    # The merge and staging callers must be unaffected -- they meet an existing root by
+    # design, and refusing there would break every snapshot.
+    pinned_fs.stage_tree_pinned(src, dst, what="merge", skip_existing=True)
+    assert (dst / "kept.txt").read_text(encoding="utf-8") == "from the archive\n"
+    assert (dst / "stale.txt").exists(), "a merge must not remove what it did not bring"
+
+
+def test_the_unpinned_replace_also_refuses_a_recreated_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The by-name branch must honour the replace contract too -- this is the Windows path.
+
+    Deliberately NOT `pinned_only`: it exercises the fallback that runs where a descriptor
+    cannot pin a directory, which is exactly where the gap was. `must_create` reached the
+    pinned walk and stopped there, so `shutil.copytree(dirs_exist_ok=True)` still merged into
+    a root recreated after the rmtree and stale files survived a successful replace.
+
+    This is the second time in this PR a guard was added to the pinned path and not carried
+    to the by-name one -- the first cost 21 pre-existing Windows tests -- so the assertion
+    here is that both platforms refuse with the same type and the same explanation.
+    """
+    src = tmp_path / "archive"
+    src.mkdir()
+    (src / "kept.txt").write_text("from the archive\n", encoding="utf-8")
+
+    dst = tmp_path / "live"
+    dst.mkdir()
+    (dst / "stale.txt").write_text("not in the archive\n", encoding="utf-8")
+
+    # Force the by-name branch regardless of what this host can do.
+    monkeypatch.setattr(snapshot.pinned_fs, "supports_pinned_tree_walk", lambda: False)
+
+    with pytest.raises(pinned_fs.PinnedPathRefusal) as caught:
+        snapshot._copytree_safe(src, dst, must_create=True, **UNPINNED_OK)
+
+    assert "already exists" in str(caught.value), f"unclear refusal: {caught.value}"
+    assert not (dst / "kept.txt").exists(), "the unpinned branch staged despite refusing"
+    assert (dst / "stale.txt").exists(), "the refusal should not have touched anything"
+
+    # And without the flag the same branch still merges, which is what snapshot staging and
+    # merge callers rely on.
+    snapshot._copytree_safe(src, dst, **UNPINNED_OK)
+    assert (dst / "kept.txt").read_text(encoding="utf-8") == "from the archive\n"
+
+
+def test_the_import_audit_line_records_the_staging_mode() -> None:
+    """The staging mode must reach the audit trail, not only the JSON response.
+
+    Review found that nothing renders `summary["staging"]`, so the field added to stop the
+    import overstating itself was visible to no one. Whether an import was pinned, mixed or
+    unpinned is a security property of the operation, so it is recorded where security
+    properties live. Asserted on the source because the handler needs a full dashboard
+    request to run, and what matters here is that the value is passed at all.
+    """
+    import inspect
+
+    from kiro_crew.dashboard.handlers import portability as handler
+
+    source = inspect.getsource(handler)
+    assert "staging={summary.get('staging'" in source, (
+        "the import audit line does not record the staging mode, so the field has no "
+        "consumer and can drift without anyone noticing"
+    )
+
+
+# ── The helper's own contract ────────────────────────────────────────────────
+
+
+def test_an_unknown_copytree_keyword_is_rejected_rather_than_dropped(tmp_path: Path) -> None:
+    """``dirs_exist_ok`` is absorbed on purpose; anything else is a caller bug.
+
+    Silently swallowing ``**kwargs`` is how a staging call would keep compiling after
+    the flag it depends on stopped being honoured.
+    """
+    src = tmp_path / "source"
+    src.mkdir()
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        snapshot._copytree_safe(src, tmp_path / "dst", symlinks=True)
+
+
+def test_the_tree_walk_capability_probe_names_a_function_that_supports_dir_fd() -> None:
+    """Pins the bug that made every POSIX snapshot refuse before it was caught.
+
+    ``os.lstat`` is NOT a member of ``os.supports_dir_fd`` even where the pinned walk
+    works perfectly -- the capability belongs to ``os.stat``. Probing the wrong one
+    reports False on a fully capable platform, which turns the deliberate refusal into
+    a blanket outage. Asserted as a property of the stdlib so the probe cannot drift
+    back.
+
+    The membership assertions are guarded because `os.supports_dir_fd` is EMPTY on Windows,
+    where "which function carries the capability" is not a meaningful question -- nothing
+    does. Asserting it unguarded made this test fail on the Windows shard, which is the
+    platform whose refusal path the rest of this change is careful about. Caught by CI, not
+    locally: this was the first run in which every Windows shard concluded before I pushed
+    a new head over it.
+    """
+    if os.name != "posix":
+        assert os.supports_dir_fd == set() or os.stat not in os.supports_dir_fd
+        assert pinned_fs.supports_pinned_tree_walk() is False
+        return
+
+    assert os.stat in os.supports_dir_fd
+    assert os.lstat not in os.supports_dir_fd
+    if pinned_fs.supports_pinned_walk():
+        assert pinned_fs.supports_pinned_tree_walk() is True


### PR DESCRIPTION
## 1. What is the problem?

`src/kiro_crew/snapshot.py` validated paths by name and then re-opened them by name.
`_copytree_safe` handed `shutil.copytree` an ignore callback that tested
`os.path.islink` on a NAME; `_copy_tree_no_overwrite` walked with `rglob`, tested
`is_symlink()`, then called `copy2`. Between the check and the open, the final component
or any ancestor directory could be swapped for a link, so the path that was validated
and the inode that was opened were not the same thing. `snapshot.py` had zero
occurrences of `O_NOFOLLOW`, `dir_fd` or `st_nlink`.

Two earlier pull requests (#2446, #2447) each tried to close this while also adding a
new snapshot component. Every review round named one more validated-by-name path use and
neither converged; both were closed unmerged. Their retrospectives reached the same
conclusion: point fixes do not converge on this surface, because staging has too many
independently-validated uses (source root, each ancestor, each file, destination tree,
pre-restore backup pass).

## 2. Why this issue matters to the user

Anything running as the user can plant the swap, and in this product that includes an
agent. Four concrete consequences on the code as it stood:

- A hardlink to a credential planted at a staged file's name was **dereferenced into
  ordinary bytes** by `shutil.copy2`, so the tar-level hardlink screen had no link left
  to reject and the content shipped inside the archive.
- An ancestor directory swapped mid-walk **redirected the copy into whatever it pointed
  at**, and the per-entry link screen reported nothing, because what it found inside the
  replaced tree was a perfectly ordinary file.
- On restore, a symlink sitting at a core file's name was **written through**: the
  name-based screen declined to move it to the backup and then `copy2` followed the very
  link it had just declined to move.
- Separately, that same branch meant the archive's version of that file was **silently
  never restored** while the command reported success.

## 3. How our fix solves it

`src/kiro_crew/pinned_fs.py` is new and holds the mechanism once: resolve the parent
chain a single time, pin it component by component with `openat` + `O_NOFOLLOW`, and
address everything downstream through the descriptor already held. A descriptor cannot
be re-pointed, so what is open is fixed; what is reached by name is not.

Most of it already existed. `src/kiro_crew/eval/bench/safepath.py` had carried
`_supports_pinned_walk`, `_pin_parent`, `_open_in_pinned_parent`,
`_refuse_hardlink_alias` and `_is_reparse_point` through several rounds of review, with
the reasoning for each load-bearing flag in the docstrings. Those bodies moved here
verbatim; `safepath.py` keeps thin wrappers that pass its own `UnsafePathError` as
`refusal=`, so its error contract and messages are unchanged and its tests needed no
edits. That is where the deleted lines in that file come from.

Three pieces snapshot needed and `safepath.py` did not have are added: a pinned
recursive tree walk, a descriptor-pinned file copy (`O_NOFOLLOW` + `fstat` + `S_ISREG` +
`st_nlink == 1`), and `open_dir_pinned`, which closes the gap that ended #2446 --
`os.open(root, O_DIRECTORY | O_NOFOLLOW)` refuses a link at the root's own name but
walks every ancestor by name to reach it.

**Both ends of every walk are pinned.** The first revision pinned only the source, which
was defensible while the only destination was a private temporary directory and wrong
the moment `_do_replace` used it, because then the destination IS the live data home and
an ancestor swapped there lands the archive's bytes outside it. Caught in review. The
same primitive serves the merge path via a `skip_existing` parameter, so there is one
pinned walk and one pinned copy in the codebase rather than two of each -- the earlier
pair had already diverged, with the restore-side copy missing the `ELOOP`/`ENOTDIR`
handling, so the very swap the staging walk skips would have escaped restore as a raw
`OSError`.

Chaining from symptom to root cause, per bullet in section 2:

- Hardlink dereference -> `copy_file_pinned` judges the open DESCRIPTOR
  (`fstat().st_nlink`), not the path. A hardlink is invisible to every path-based guard,
  so this is the only place the question can be asked race-free.
- Ancestor swap -> `stage_tree_pinned` opens each directory relative to its parent's
  descriptor, on both sides. `_copytree_safe` and `_copy_tree_no_overwrite` route
  through it. The data home is opened once and every core file is read relative to that
  descriptor.
- Written-through symlink -> each destination file is created relative to a pinned
  directory with `O_EXCL`, which is also what makes the no-overwrite promise atomic
  rather than a prior `exists()` check with a window after it.
- Silent partial restore -> a symlinked core file is moved aside like any other occupant
  (moving a symlink moves the link, never its target), the name frees up, and the
  archive's file lands. `O_EXCL` remains the backstop for a name still occupied after
  the backup pass.

Two behaviour changes reviewers should weigh. A file with more than one hard link is now
refused rather than silently copied. A swapped ancestor aborts rather than being
followed.

**Nothing is silently omitted any more.** `MANIFEST.json` carries `"skipped"` -- every
file left out during staging with its reason, paths relative to the data home -- and
`_print_manifest`, which `restore --dry-run` runs, displays it. A skip used to be a
console warning and nothing else, which is the same shape as the silent partial restore
above.

**Platforms that cannot pin.** `os.supports_dir_fd` is empty and `O_NOFOLLOW` does not
exist on Windows. #5156 asks for the operation to be refused rather than fall back to a
by-name traversal, but taken literally that withdraws `kirocrew snapshot` from a
supported platform. Implemented: refuse by default with a message naming
`--allow-unpinned-staging`; when that flag is passed, stage by name and record
`"staging": "unpinned"` in `MANIFEST.json`. The gate runs once before anything is staged
rather than inside the tree path, so a data home with core files and no trees cannot
stage unpinned without being asked. The flag is wired into the shipped `kirocrew
snapshot` and `kirocrew restore` subparsers -- the first revision defined it only on the
fallback parsers inside `snapshot_main`/`restore_main`, which the console script never
reaches, so the refusal named a flag argparse would then reject. The dashboard import
path (`portability.apply_import_zip`) has no command line, so it reports the refusal as
`rejected_replace` in its summary rather than raising.

The flag is a permission for a platform that cannot pin, **not** a switch that turns
pinning off where pinning works. That has its own test, because I got it wrong myself
while writing the differential below.

The decision, and the reasoning for refusing rather than warning, is recorded in
`docs/system-specs/modules/cli.md` so the next snapshot-component PR does not
relitigate it. **It is still the one call worth a maintainer's ruling**; the code is one
predicate away from warning-and-proceed.

Deliberately NOT in scope: any new snapshot component. Artifacts/uploads stays in #3794
and sessions stays in #3797, both landing on top of this. Reviewing one mechanism alone
is the point of splitting it out. `shutil.copytree` remains at 29 occurrences across 19
files in `src/`,
some of them agent-writable trees; now that the primitive exists those are worth
sweeping, but not in a PR that exists because its two predecessors died of doing two
things at once.

## 4. What tests we did

`test/test_pinned_staging.py` is new (18 tests). The headline one is a differential
rather than an assertion: the same mid-walk ancestor swap runs against both traversals,
the by-name control is asserted to LEAK, and the pinned path is asserted to skip. An
exception-only check cannot tell "pinned" from "got lucky", and the control carries an
assertion that says so if it ever stops leaking. The destination-pinning test has the
same shape: the destination root is renamed away and a link planted at its old name
mid-walk, and the assertion is on which directory received the bytes.

Every new guard was mutation-verified -- neuter it, confirm the specific test reddens,
restore, confirm green:

| mutation | test that reddened |
|---|---|
| drop `st_nlink != 1` | hardlink source is refused |
| drop `O_NOFOLLOW` from the dir-open flags | `open_dir_pinned` ancestor refusal, and bench's own `test_a_component_swapped_after_resolution_is_refused` |
| drop `S_ISLNK` skip **and** `O_NOFOLLOW` | the differential leaks |
| make the non-pinnable path fall back instead of raising | platform refusal + CLI exit code |
| move the gate back inside the tree path | core-files-alone refusal |
| `O_EXCL` -> `O_TRUNC` | still-occupied refusal, both merge no-overwrite tests |
| restore the old skip-the-entry branch | "the archive's version was not restored -- a silent partial restore" |
| compose the destination path instead of using its descriptor | destination-root repoint |
| stop recording skips in the manifest | manifest omission record |
| rename the flag on the `cli.py` subparser | shipped-CLI reachability |

One honest note from that table: dropping `S_ISLNK` alone did NOT redden the
differential, because the pinned `openat` refuses the same swap with `ELOOP`. The two
layers are genuinely redundant for that case and the test pins the outcome, not either
layer individually.

Also included is a regression test for a bug this PR introduced and caught before
review: the first capability probe asked `os.lstat in os.supports_dir_fd`, which is
False on Linux (the capability belongs to `os.stat`; `lstat(p, dir_fd=fd)` is defined as
`stat(p, dir_fd=fd, follow_symlinks=False)`). That made every POSIX snapshot refuse and
demand the by-name opt-in -- a blanket outage dressed as a security control. The existing
suite caught it immediately; the walks now call the same function the probe tests, and
the test pins the stdlib property so it cannot drift back.

Gates: 151 targeted tests green (18 new, plus `test_snapshot.py`, `test_portability.py`
and the bench safepath/pinned-parent/round16/round18 suites) with **zero edits to any
existing test**. flake8, isort, black, the brand gate and the black baseline ratchet all
clean. mypy reports no errors in any changed source file (the two it reports in
`transcribe.py` are pre-existing and outside this diff). A wider `test/` slice has
failures that also occur with this branch's tracked changes stashed -- environment
dependent (subprocesses that need the package installed), pre-existing, and mostly in
files that import neither module.

## 5. Any other suggestions on the work

- The Windows call in section 3 is the one thing I would like ruled on rather than
  assumed. Refusing is what #5156 literally asks for and is one predicate away.
- **SQLite databases are out of scope, deliberately, and now tracked by #5451.** They keep
  main's `sqlite3.backup()` path, which reopens the live name. Capturing a live database
  without reopening its name is a genuine conflict of requirements -- SQLite accepts only a
  path and cannot be pointed at a held descriptor (verified: it refuses `/proc/self/fd/N`
  and `/dev/fd/N` alike). Five review rounds here each produced a correct fix for the hazard
  it targeted and set up the next one, so the question is being answered in its own change
  rather than in the middle of this one. The exposure is unchanged from before this PR, not
  introduced by it.
- `safepath.py` still owns its policy layer (`guard_read_path` / `guard_write_path` /
  `guard_output_dir`, the atomic writer, the no-`dir_fd` re-validation). Those consult
  `is_sensitive_path` and are harness policy rather than mechanism, so they stayed. If a
  second caller ever wants protected-location screening, that is the next thing to
  promote -- not now, with one consumer.
- #2844 (replace-mode restore trusts the caller's `--components` over the archive, and
  reports success on three partial-restore paths) is the same family as the silent
  partial restore fixed here. Worth deciding whether it rides with #3797.
- The 29 remaining `shutil.copytree` occurrences (19 files) deserve a tracking issue if a
  maintainer
  agrees they are in scope for this line at all.
- `deploy/handlers.py` already carries its own `_stage_tree_pinned`, a SECOND spelling of
  "pin the source root, then stage" that the count above does not include because it is not
  a `shutil.copytree` call. Raised by review, and it is the more urgent half of that sweep:
  two implementations of one idea are how the restore-side copy diverged from the snapshot
  side to begin with, which is the divergence this PR exists to collapse. Whoever picks up
  the sweep should start there rather than with the raw `copytree` count.

Closes #5156



