### PR TITLE
fix(i18n): boot the thinking-block capture through the all-languages entry

### DIFF
--- a/website/capture/thinking-block-align.tsx
+++ b/website/capture/thinking-block-align.tsx
@@ -15,7 +15,7 @@
  */
 import { createRoot } from 'react-dom/client'
 import { CircleDot } from 'lucide-react'
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
 import '../src/index.css'
 import { ToolDetails } from '../src/pages/chat/ToolDetails'
 import ThinkingBlock from '../src/pages/chat/ThinkingBlock'


### PR DESCRIPTION
## 1. What is the problem?

`main` is red on `Frontend Tests`, and so is every open PR rebased past it.

`website/src/test/i18nAllLanguagesEntry.test.ts` scans every page entry point for
one that boots i18n through `src/i18n/index.ts` -- the English-only entry -- instead
of `src/i18n/all.ts`. It reports one:

```
capture/thinking-block-align.tsx -- '../src/i18n' registers no catalog for
bn, de, en-XA, es, fr, hi, it, ja, ko, pt, ru, zh-CN
```

Neither side did anything wrong on its way in. The capture harness landed in #5001
importing `../src/i18n`, which was correct at the time. #5125 then made
`src/i18n/index.ts` register the English catalog only and taught this scan to
report entry points that boot through it. Each passed in isolation; they only
conflict with both on main.

## 2. Why this issue matters to the user

The scan is repo-wide, not diff-scoped, so it fails on work that touches neither
file. Any PR that rebases onto current main inherits a red `Frontend Tests` shard,
which cascades into `Frontend Coverage Merge` and then `PR Readiness`. A re-run
cannot clear it -- the failure is deterministic -- so every author has to either
diagnose a red they did not cause or fold an unrelated fix into their diff.

The scan itself is worth keeping exactly as it is. Its own message makes the case:
booting through the English-only entry throws nothing and renders no raw keys, so a
user who picked Japanese silently gets English and this scan is the only thing that
would ever report it.

## 3. How our fix solves it

One line, in the file the scan names:

```diff
-import { initI18n } from '../src/i18n'
+import { initI18n } from '../src/i18n/all'
```

`src/i18n/all.ts` registers every catalog at module scope and re-exports the same
runtime API, so this is the same call with every language present. Eleven sibling
capture harnesses -- `palette-narrow.tsx`, `copy-link-feedback.tsx`,
`error-handoff.tsx` and the rest -- already import it that way, so this brings the
twelfth in line rather than introducing a pattern.

Deliberately NOT done: relaxing the scan, or exempting `capture/`. The invariant is
the point, and a capture harness that renders a localised surface is exactly where
you want every catalog registered.

## 4. What tests we did

`vitest run src/test/i18nAllLanguagesEntry.test.ts` on the branch: 5 passed, up from
1 failed / 4 passed, with the flagged entry gone from the reported list. Reproduced
the failure first on an unmodified tree to confirm the diagnosis before changing
anything, and confirmed both implicated files were byte-identical to main.

## 5. Any other suggestions on the work

The general shape here is worth noting: a repo-wide invariant test plus a
non-diff-scoped scan means two independently-green PRs can turn main red on merge,
and the cost lands on unrelated authors. The same asymmetry already exists in the
black-baseline gate's graduated half. Neither is wrong, but both are cases where
main can only be repaired by whoever happens to notice, so a periodic
main-is-green sweep would surface them sooner than the next author's rebase does.
