### PR TITLE
feat: add durable monitor decisions

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -804,6 +804,33 @@ as `research-notes`, and user-created canonical lookalikes such as
 `research-deadbeef`, are ordinary dashboard slots and retain remove-on-stop
 behavior.
 
+**Structured monitor substrate** (`monitoring/models.py`,
+`monitoring/decision.py`): `NudgeLoop.monitor` is an optional, versioned
+controller record for probe-first monitors. Absence is the durable compatibility
+marker for a legacy prompt loop, and serialization omits the absent field so an
+unrelated save does not eagerly migrate old records. The record owns target and
+objective identity, canonical observation and wake fingerprints, in-flight
+state, provider-error streak, completed agent-turn and token totals, probe
+deadline, and terminal outcome. Load reconstructs the typed record; a terminal
+record with a contradictory active loop is deactivated. An unsupported monitor
+version is also deactivated, marked blocked with
+`unsupported_monitor_version`, and retained for inspection rather than executed
+under an older policy; its raw future payload survives an unrelated store rewrite
+unchanged. A malformed current-version monitor, including an explicit `null`
+payload, causes its containing loop to be skipped, so it cannot re-arm under an
+uncertain policy. Structured cadence is typed state with a 300-second default;
+the legacy loop default remains 60 seconds. This substrate has no delivery
+controller: loading, generic updating, arming, or a pre-existing timer all fail
+closed without a model turn until a later slice wires typed decisions. The pure
+`decide_monitor` policy performs no I/O. It
+checks the non-zero runtime/turn/token budgets first, classifies provider errors
+without a model turn, suppresses an unchanged observation, and permits
+`wake_actionable` only when the actionable fingerprint differs from the last
+acknowledged wake fingerprint. The defaults are 14,400 seconds, eight completed
+agent turns, 250,000 aggregate input/output tokens, and three consecutive
+provider errors. This substrate does not yet schedule a provider probe or expose
+a new MCP tool; those are later RFC implementation slices.
+
 A reasonless inactive update is idempotent for a Research Lab stop tombstone:
 it preserves the source-owned `autonudge_stop` reason until the watchdog
 consumes it. An API retry or unrelated patch therefore cannot downgrade a

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -44,6 +44,13 @@ from kiro_crew import platform_compat, shutdown_event
 from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.loader import config_dir
 from kiro_crew.config.paths import legacy_home
+from kiro_crew.monitoring.models import (
+    MONITOR_STATE_VERSION,
+    MonitorOutcome,
+    MonitorState,
+    monitor_state_from_dict,
+    monitor_state_to_dict,
+)
 from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
@@ -315,6 +322,10 @@ class NudgeLoop:
     # so a restart resumes the countdown. A lost background write degrades to
     # a fresh full countdown after restart, never a lost or premature fire.
     next_due_ts: float = 0.0
+    # Optional typed controller state. Its absence is the compatibility marker
+    # for a legacy prompt-driven loop; legacy records are never inferred into a
+    # monitor merely because they use a babysit-shaped message.
+    monitor: MonitorState | None = None
 
 
 def _repair_number(
@@ -402,9 +413,8 @@ class AutoNudgeService:
         # fire callback runs the unattended turn INLINE, so cancelling it kills
         # the in-flight turn and loses its transcript and cycle bookkeeping.
         self._firing: set[str] = set()
-        # Set by _load() when a persisted loop was repaired in memory (currently
-        # a re-homed/dropped stop_sentinel_path) so start() can flush the
-        # correction back to disk ONCE instead of re-deriving it every boot.
+        # Set by _load() when persisted state is repaired in memory so start()
+        # flushes the correction before any loop can re-arm.
         self._store_dirty = False
         # Consecutive non-delivery count per loop (drives escalating re-arm
         # backoff + once-per-streak failure logging). Not persisted; resets on
@@ -430,7 +440,31 @@ class AutoNudgeService:
             data = json.load(fh)
         for raw in data.get("loops", []):
             try:
-                loop = NudgeLoop(**{k: raw[k] for k in raw if k in NudgeLoop.__dataclass_fields__})
+                loop_values = {
+                    key: raw[key]
+                    for key in raw
+                    if key in NudgeLoop.__dataclass_fields__ and key != "monitor"
+                }
+                loop = NudgeLoop(**loop_values)
+                if "monitor" in raw:
+                    monitor_raw = raw["monitor"]
+                    loop.monitor = monitor_state_from_dict(monitor_raw)
+                    if loop.monitor.version != MONITOR_STATE_VERSION:
+                        # An older controller cannot safely interpret a newer
+                        # policy. Keep its identity visible, but make executing
+                        # it impossible until a compatible version is running.
+                        loop.active = False
+                        loop.monitor.outcome = MonitorOutcome.BLOCKED
+                        loop.monitor.stopped_reason = "unsupported_monitor_version"
+                        self._store_dirty = True
+                    elif loop.active:
+                        # Structured monitor delivery belongs to the controller,
+                        # which is intentionally not wired in this substrate.
+                        # Deactivate rather than allowing the legacy timer to
+                        # inject the prompt before a typed decision is made.
+                        loop.active = False
+                        loop.next_due_ts = 0.0
+                        self._store_dirty = True
                 # Re-home / re-validate the persisted kill-switch path. A loop
                 # armed before the data-home move would otherwise be re-armed
                 # with a sentinel path nothing can ever create (see
@@ -490,8 +524,19 @@ class AutoNudgeService:
         """
         return {
             "version": _STORE_VERSION,
-            "loops": [asdict(lp) for lp in self._loops.values()],
+            "loops": [self._serialize_loop(lp) for lp in self._loops.values()],
         }
+
+    @staticmethod
+    def _serialize_loop(loop: NudgeLoop) -> dict[str, Any]:
+        payload = asdict(loop)
+        if loop.monitor is None:
+            # Preserve the legacy wire shape instead of eagerly migrating every
+            # record the next time an unrelated loop is saved.
+            payload.pop("monitor", None)
+        else:
+            payload["monitor"] = monitor_state_to_dict(loop.monitor)
+        return payload
 
     def _write_state(self, payload: dict) -> None:
         # Atomic write: serialize to a temp file in the same dir, fsync, then
@@ -552,7 +597,7 @@ class AutoNudgeService:
                 await self._persist_locked()
                 self._store_dirty = False
             except Exception:  # noqa: BLE001 - the in-memory repair still applies
-                logger.warning("AutoNudge: could not persist sentinel repair", exc_info=True)
+                logger.warning("AutoNudge: could not persist loaded-state repair", exc_info=True)
         # Re-arm timers for active loops on startup — toward each loop's
         # persisted deadline, so a restart never resets the countdown: a loop
         # that was 25 minutes into a 30-minute interval resumes with ~5 left,
@@ -657,9 +702,7 @@ class AutoNudgeService:
             # worker thread, and await it so a persistence failure still
             # propagates to the caller before the loop is reported armed.
             payload = self._serialize_state()
-            await asyncio.get_running_loop().run_in_executor(
-                None, self._write_state, payload
-            )
+            await asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
             self._arm_from_deadline(loop)
         self._emit("added", loop)
         logger.info("AutoNudge: added loop %s on slot %s (idle=%ds)", loop.id, slot_key, idle_secs)
@@ -749,6 +792,12 @@ class AutoNudgeService:
             if max_runtime_secs is not None:
                 loop.max_runtime_secs = max(0, int(max_runtime_secs))
             if active is not None:
+                if active and loop.monitor is not None:
+                    # The generic loop update path owns legacy prompt cycles,
+                    # not structured monitor policy. Task4 supplies the
+                    # controller that can deliberately re-arm these records.
+                    loop.active = False
+                    loop.next_due_ts = 0.0
                 # TERMINAL-TRANSITION ATOMICITY: a bound-tagged deactivation
                 # (stopped_reason supplied — the _timer's cycle_cap /
                 # runtime_budget paths) must never OVERWRITE a deactivation
@@ -762,7 +811,7 @@ class AutoNudgeService:
                 # already inactive. The reverse order is already safe — a
                 # manual pause overwriting a bound tag only ever NARROWS
                 # revivability ("manual" never auto-revives).
-                if (
+                elif (
                     not active
                     and stopped_reason is None
                     and loop.stopped_reason == AUTONUDGE_STOP_REASON
@@ -777,11 +826,7 @@ class AutoNudgeService:
                         "reasonless inactive update",
                         loop.id,
                     )
-                elif (
-                    stopped_reason in _TERMINAL_BOUND_REASONS
-                    and not active
-                    and not loop.active
-                ):
+                elif stopped_reason in _TERMINAL_BOUND_REASONS and not active and not loop.active:
                     logger.info(
                         "AutoNudge: loop %s already deactivated (%s) — %s bound "
                         "not overwriting it",
@@ -1060,6 +1105,12 @@ class AutoNudgeService:
         sending another message. The delay is capped at ``idle_secs`` so a
         clock jump can never park the timer beyond one full interval.
         """
+        if loop.monitor is not None:
+            # A typed monitor needs a pre-delivery decision controller. PR1
+            # persists its substrate only, so any legacy timer is cancelled and
+            # cannot reach _run_fire_cycle before Task4 wires that controller.
+            self._cancel_timer(loop.id)
+            return
         now = time.time()
         if loop.next_due_ts <= 0:
             loop.next_due_ts = now + loop.idle_secs
@@ -1097,6 +1148,13 @@ class AutoNudgeService:
         except asyncio.CancelledError:
             return
         if shutdown_event.is_set():
+            return
+        if loop.monitor is not None:
+            # A timer can predate monitor attachment or a process upgrade. It
+            # must never dispatch a structured record through legacy prompt
+            # delivery, even if it was already sleeping when state changed.
+            if loop.active:
+                await self.update(loop.id, active=False)
             return
         # Kill switch: sentinel file present?
         if loop.stop_sentinel_path and Path(loop.stop_sentinel_path).exists():
@@ -1165,7 +1223,7 @@ class AutoNudgeService:
         # Fire. Update state only if the callback reports actual delivery —
         # otherwise skipped nudges (e.g. slot mid-turn) inflate cycle_count and
         # prematurely trip max_cycles. Missing callback → nothing to deliver.
-        if self._on_fire is None:
+        if self._on_fire is None or loop.monitor is not None:
             return
         self._firing.add(loop.id)
         try:
@@ -1189,7 +1247,7 @@ class AutoNudgeService:
         Runs entirely inside the caller's ``_firing`` window so a concurrent
         ``update()`` never cancels this task between delivery and persistence.
         """
-        if self._on_fire is None:
+        if self._on_fire is None or loop.monitor is not None:
             return
         # Mark the fire window so a concurrent update() defers its re-arm
         # instead of cancelling this task mid-turn (see update()). The window

--- a/src/kiro_crew/monitoring/__init__.py
+++ b/src/kiro_crew/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Typed state and deterministic policy for probe-first session monitors."""

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -1,0 +1,84 @@
+"""Pure decision policy for structured monitors."""
+
+from __future__ import annotations
+
+from kiro_crew.monitoring.models import (
+    MONITOR_STATE_VERSION,
+    MonitorBudgets,
+    MonitorDecision,
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorOutcome,
+    MonitorState,
+    ProviderErrorKind,
+)
+
+_RETRYABLE_PROVIDER_ERRORS = frozenset(
+    {ProviderErrorKind.TRANSIENT, ProviderErrorKind.RATE_LIMITED}
+)
+
+
+def decide_monitor(
+    state: MonitorState,
+    observation: MonitorObservation,
+    *,
+    now: float,
+) -> MonitorDecision:
+    """Return the only controller effect permitted for an observation.
+
+    Budget checks lead because a spent bound must never buy one additional
+    unattended turn. Provider failures are classified without a model. For a
+    normal observation, only a new actionable fingerprint may wake the owning
+    session.
+    """
+    if state.version != MONITOR_STATE_VERSION:
+        return MonitorDecision.STOP_BLOCKED
+    terminal = _terminal_decision(state.outcome)
+    if terminal is not None:
+        return terminal
+    if _budget_exhausted(state, state.budgets, now=now):
+        return MonitorDecision.STOP_BUDGET
+    if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
+        return _provider_error_decision(state, observation, state.budgets)
+    if observation.status is MonitorObservationStatus.ACTIONABLE:
+        if observation.fingerprint == state.last_wake_fingerprint:
+            return MonitorDecision.NO_CHANGE
+        return MonitorDecision.WAKE_ACTIONABLE
+    if observation.fingerprint == state.last_fingerprint:
+        return MonitorDecision.NO_CHANGE
+    if observation.status is MonitorObservationStatus.PENDING:
+        return MonitorDecision.RECORD_ONLY
+    if observation.status is MonitorObservationStatus.SUCCESS:
+        return MonitorDecision.STOP_SUCCESS
+    return MonitorDecision.STOP_BLOCKED
+
+
+def _terminal_decision(outcome: MonitorOutcome | None) -> MonitorDecision | None:
+    if outcome is MonitorOutcome.SUCCESS:
+        return MonitorDecision.STOP_SUCCESS
+    if outcome is MonitorOutcome.BUDGET:
+        return MonitorDecision.STOP_BUDGET
+    if outcome is not None:
+        return MonitorDecision.STOP_BLOCKED
+    return None
+
+
+def _budget_exhausted(state: MonitorState, budgets: MonitorBudgets, *, now: float) -> bool:
+    return (
+        now - state.created_ts >= budgets.max_runtime_secs
+        or state.agent_turns >= budgets.max_agent_turns
+        or state.total_tokens >= budgets.max_tokens
+    )
+
+
+def _provider_error_decision(
+    state: MonitorState,
+    observation: MonitorObservation,
+    budgets: MonitorBudgets,
+) -> MonitorDecision:
+    error = observation.provider_error
+    if error not in _RETRYABLE_PROVIDER_ERRORS:
+        return MonitorDecision.STOP_BLOCKED
+    if state.consecutive_provider_errors + 1 >= budgets.max_provider_errors:
+        return MonitorDecision.STOP_BLOCKED
+    return MonitorDecision.RETRY_PROVIDER

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -1,0 +1,252 @@
+"""Transport-independent monitor state.
+
+The scheduler, provider adapters, and session delivery code exchange these
+small records. They deliberately contain no provider clients or callbacks, so
+they can be persisted and evaluated without starting an agent turn.
+"""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field, fields
+from enum import Enum
+from typing import Any
+
+MONITOR_STATE_VERSION = 1
+DEFAULT_MONITOR_RUNTIME_SECS = 14_400
+DEFAULT_MONITOR_AGENT_TURNS = 8
+DEFAULT_MONITOR_TOKENS = 250_000
+DEFAULT_MONITOR_PROVIDER_ERRORS = 3
+DEFAULT_MONITOR_CADENCE_SECS = 300
+
+
+class MonitorDecision(str, Enum):
+    """Effect the monitor controller applies after a probe."""
+
+    NO_CHANGE = "no_change"
+    RECORD_ONLY = "record_only"
+    WAKE_ACTIONABLE = "wake_actionable"
+    STOP_SUCCESS = "stop_success"
+    STOP_BLOCKED = "stop_blocked"
+    RETRY_PROVIDER = "retry_provider"
+    STOP_BUDGET = "stop_budget"
+
+
+class MonitorObservationStatus(str, Enum):
+    """Domain-owned classification of one canonical observation."""
+
+    PENDING = "pending"
+    ACTIONABLE = "actionable"
+    SUCCESS = "success"
+    BLOCKED = "blocked"
+    PROVIDER_ERROR = "provider_error"
+
+
+class ProviderErrorKind(str, Enum):
+    """Provider failures that have different retry safety."""
+
+    TRANSIENT = "transient"
+    RATE_LIMITED = "rate_limited"
+    AUTHENTICATION = "authentication"
+    AUTHORIZATION = "authorization"
+    NOT_FOUND = "not_found"
+
+
+class MonitorOutcome(str, Enum):
+    """Durable terminal result retained after the monitor stops."""
+
+    SUCCESS = "success"
+    BLOCKED = "blocked"
+    BUDGET = "budget"
+    USER_STOP = "user_stop"
+    SESSION_CLOSE = "session_close"
+    TARGET_UNAVAILABLE = "target_unavailable"
+
+
+@dataclass(frozen=True)
+class MonitorBudgets:
+    """Hard bounds for a structured monitor.
+
+    Unlike legacy AutoNudge values, zero never means unlimited here.
+    """
+
+    max_runtime_secs: int = DEFAULT_MONITOR_RUNTIME_SECS
+    max_agent_turns: int = DEFAULT_MONITOR_AGENT_TURNS
+    max_tokens: int = DEFAULT_MONITOR_TOKENS
+    max_provider_errors: int = DEFAULT_MONITOR_PROVIDER_ERRORS
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_runtime_secs",
+            "max_agent_turns",
+            "max_tokens",
+            "max_provider_errors",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class MonitorObservation:
+    """Small canonical result produced by a typed provider probe."""
+
+    fingerprint: str
+    status: MonitorObservationStatus
+    provider_error: ProviderErrorKind | None = None
+    reason_code: str = ""
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, MonitorObservationStatus):
+            raise ValueError("status must be a MonitorObservationStatus")
+        if not isinstance(self.fingerprint, str):
+            raise ValueError("fingerprint must be a string")
+        if not isinstance(self.reason_code, str):
+            raise ValueError("reason_code must be a string")
+        if not isinstance(self.summary, str):
+            raise ValueError("summary must be a string")
+        if self.status is MonitorObservationStatus.PROVIDER_ERROR:
+            if not isinstance(self.provider_error, ProviderErrorKind):
+                raise ValueError("provider_error must be a ProviderErrorKind for a provider error")
+            return
+        if not self.fingerprint:
+            raise ValueError("fingerprint is required for a comparable observation")
+        if self.provider_error is not None:
+            raise ValueError("provider_error is only valid for a provider error observation")
+
+
+@dataclass
+class MonitorState:
+    """Restart-durable state for one structured monitor."""
+
+    kind: str
+    target: str
+    objective: str
+    created_ts: float
+    version: int = MONITOR_STATE_VERSION
+    budgets: MonitorBudgets = field(default_factory=MonitorBudgets)
+    cadence_secs: int = DEFAULT_MONITOR_CADENCE_SECS
+    last_observation: dict[str, object] = field(default_factory=dict)
+    last_fingerprint: str = ""
+    last_observed_at: float = 0.0
+    last_wake_fingerprint: str = ""
+    wake_in_flight: bool = False
+    agent_turns: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    consecutive_provider_errors: int = 0
+    next_probe_at: float = 0.0
+    outcome: MonitorOutcome | None = None
+    stopped_reason: str = ""
+    stopped_at: float = 0.0
+    extra_fields: dict[str, object] = field(default_factory=dict, repr=False)
+    _raw_payload: dict[str, object] | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        for name in ("kind", "target", "objective"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if isinstance(self.version, bool) or not isinstance(self.version, int) or self.version <= 0:
+            raise ValueError("version must be a positive integer")
+        for name in ("created_ts", "last_observed_at", "next_probe_at", "stopped_at"):
+            value = getattr(self, name)
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value < 0
+            ):
+                raise ValueError(f"{name} must be a finite non-negative number")
+        for name in (
+            "agent_turns",
+            "input_tokens",
+            "output_tokens",
+            "consecutive_provider_errors",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if not isinstance(self.budgets, MonitorBudgets):
+            raise ValueError("budgets must be MonitorBudgets")
+        if (
+            isinstance(self.cadence_secs, bool)
+            or not isinstance(self.cadence_secs, int)
+            or self.cadence_secs <= 0
+        ):
+            raise ValueError("cadence_secs must be a positive integer")
+        if not isinstance(self.last_observation, dict):
+            raise ValueError("last_observation must be an object")
+        if not isinstance(self.last_fingerprint, str) or not isinstance(
+            self.last_wake_fingerprint, str
+        ):
+            raise ValueError("monitor fingerprints must be strings")
+        if not isinstance(self.wake_in_flight, bool):
+            raise ValueError("wake_in_flight must be a boolean")
+        if self.outcome is not None and not isinstance(self.outcome, MonitorOutcome):
+            raise ValueError("outcome must be a MonitorOutcome")
+        if not isinstance(self.stopped_reason, str):
+            raise ValueError("stopped_reason must be a string")
+        if not isinstance(self.extra_fields, dict):
+            raise ValueError("extra_fields must be an object")
+        if self._raw_payload is not None and not isinstance(self._raw_payload, dict):
+            raise ValueError("_raw_payload must be an object")
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+def monitor_state_from_dict(raw: object) -> MonitorState:
+    """Decode a persisted monitor while ignoring fields owned by newer versions.
+
+    The caller is responsible for deactivating versions it does not implement.
+    Keeping the recognized identity fields makes such records inspectable.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError("monitor state must be an object")
+    if raw.get("version", MONITOR_STATE_VERSION) != MONITOR_STATE_VERSION:
+        # A newer version may give familiar fields different semantics. Keep an
+        # inert local view for the loader while retaining the exact raw payload
+        # for a later compatible controller to inspect and rewrite unchanged.
+        values: dict[str, Any] = {
+            key: raw[key]
+            for key in ("kind", "target", "objective", "created_ts", "version")
+            if key in raw
+        }
+        values["budgets"] = MonitorBudgets()
+        values["_raw_payload"] = deepcopy(raw)
+        return MonitorState(**values)
+    allowed = {
+        item.name
+        for item in fields(MonitorState)
+        if item.name not in {"extra_fields", "_raw_payload"}
+    }
+    values = {key: value for key, value in raw.items() if key in allowed}
+    values["extra_fields"] = {key: value for key, value in raw.items() if key not in allowed}
+    budgets = values.get("budgets")
+    if isinstance(budgets, dict):
+        values["budgets"] = MonitorBudgets(**budgets)
+    elif budgets is not None and not isinstance(budgets, MonitorBudgets):
+        raise ValueError("monitor budgets must be an object")
+    outcome = values.get("outcome")
+    if outcome is not None:
+        values["outcome"] = MonitorOutcome(outcome)
+    else:
+        values["outcome"] = None
+    return MonitorState(**values)
+
+
+def monitor_state_to_dict(state: MonitorState) -> dict[str, object]:
+    """Encode known state while preserving fields written by a newer version."""
+    if state._raw_payload is not None:
+        return deepcopy(state._raw_payload)
+    payload = asdict(state)
+    extra = payload.pop("extra_fields")
+    payload.pop("_raw_payload")
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            payload.setdefault(key, value)
+    return payload

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -13,6 +13,7 @@ from kiro_crew import autonudge as _an
 from kiro_crew import autonudge_authz as _autonudge_mod
 from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
 from kiro_crew.dashboard.handlers.autonudge import render_nudge_message
+from kiro_crew.monitoring.models import MonitorOutcome, MonitorState
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +24,17 @@ def _enable(monkeypatch):
 @pytest.fixture
 def svc(tmp_path):
     return AutoNudgeService(base_dir=tmp_path)
+
+
+def _structured_monitor(**changes: object) -> MonitorState:
+    values: dict[str, object] = {
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+    }
+    values.update(changes)
+    return MonitorState(**values)
 
 
 @pytest.mark.asyncio
@@ -95,6 +107,119 @@ async def test_persistence_across_restart(tmp_path):
     assert restored.max_cycles == 5
     assert loop.id in svc2._timers  # timer re-armed
     svc2.stop()
+
+
+@pytest.mark.asyncio
+async def test_unwired_structured_monitor_is_not_armed_or_fired_on_start(tmp_path):
+    """PR1 persists structured monitors but cannot deliver them before Task4."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "monitor01",
+                "slot_key": "chat-1-123",
+                "message": "must not dispatch",
+                "idle_secs": 15,
+                "active": True,
+                "monitor": {
+                    "kind": "github_pull_request",
+                    "target": "owner/repo#123",
+                    "objective": "review_ready",
+                    "created_ts": 1_000.0,
+                },
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    service = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
+    await service.start()
+    try:
+        loop = service._loops["monitor01"]
+        assert not loop.active
+        assert loop.id not in service._timers
+        assert fired == []
+    finally:
+        service.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "monitor",
+    (
+        _structured_monitor(),
+        _structured_monitor(version=99),
+        _structured_monitor(outcome=MonitorOutcome.BLOCKED),
+    ),
+)
+async def test_generic_update_cannot_reactivate_a_structured_monitor(tmp_path, monitor):
+    """The legacy PATCH path cannot revive current, future, or terminal monitors."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = NudgeLoop(
+        id="monitor02",
+        slot_key="chat-1-123",
+        message="must not dispatch",
+        active=False,
+        monitor=monitor,
+    )
+    service._loops[loop.id] = loop
+
+    updated = await service.update(loop.id, active=True)
+
+    assert updated is loop
+    assert not loop.active
+    assert loop.id not in service._timers
+
+
+@pytest.mark.asyncio
+async def test_unwired_structured_monitor_timer_dispatches_zero_turns(tmp_path):
+    """A pre-existing timer cannot reach legacy delivery after monitor attachment."""
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    service = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
+    loop = NudgeLoop(
+        id="monitor03",
+        slot_key="chat-1-123",
+        message="must not dispatch",
+        monitor=_structured_monitor(),
+    )
+    service._loops[loop.id] = loop
+
+    await service._timer(loop, delay=0)
+
+    assert fired == []
+    assert not loop.active
+
+
+@pytest.mark.asyncio
+async def test_unwired_structured_monitor_fire_cycle_dispatches_zero_turns(tmp_path):
+    """Legacy delivery stays closed if monitor state changes after timer checks."""
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    service = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
+    loop = NudgeLoop(
+        id="monitor04",
+        slot_key="chat-1-123",
+        message="must not dispatch",
+        monitor=_structured_monitor(),
+    )
+
+    await service._run_fire_cycle(loop)
+
+    assert fired == []
 
 
 @pytest.mark.asyncio

--- a/test/test_monitor_decision.py
+++ b/test/test_monitor_decision.py
@@ -1,0 +1,229 @@
+"""Behavioral contract for probe-first monitor decisions."""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.models import (
+    MonitorBudgets,
+    MonitorDecision,
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorState,
+    ProviderErrorKind,
+)
+
+
+def _state(**changes: object) -> MonitorState:
+    values: dict[str, object] = {
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+    }
+    values.update(changes)
+    return MonitorState(**values)
+
+
+@pytest.mark.parametrize(
+    ("observation", "state", "expected"),
+    [
+        (
+            MonitorObservation("pending-a", MonitorObservationStatus.PENDING),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.NO_CHANGE,
+        ),
+        (
+            MonitorObservation("pending-b", MonitorObservationStatus.PENDING),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.RECORD_ONLY,
+        ),
+        (
+            MonitorObservation("failure-b", MonitorObservationStatus.ACTIONABLE),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.WAKE_ACTIONABLE,
+        ),
+        (
+            MonitorObservation("failure-b", MonitorObservationStatus.ACTIONABLE),
+            _state(
+                last_fingerprint="failure-b",
+                last_wake_fingerprint="failure-b",
+            ),
+            MonitorDecision.NO_CHANGE,
+        ),
+        (
+            MonitorObservation("ready-c", MonitorObservationStatus.SUCCESS),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.STOP_SUCCESS,
+        ),
+        (
+            MonitorObservation(
+                "closed-c",
+                MonitorObservationStatus.BLOCKED,
+                reason_code="pull_request_closed",
+            ),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.STOP_BLOCKED,
+        ),
+    ],
+)
+def test_observation_changes_control_when_a_model_turn_is_allowed(
+    observation: MonitorObservation,
+    state: MonitorState,
+    expected: MonitorDecision,
+) -> None:
+    """A model turn is reserved for a new actionable fingerprint."""
+    assert decide_monitor(state, observation, now=1_100.0) is expected
+
+
+@pytest.mark.parametrize(
+    ("error", "consecutive_errors", "expected"),
+    [
+        (ProviderErrorKind.TRANSIENT, 0, MonitorDecision.RETRY_PROVIDER),
+        (ProviderErrorKind.RATE_LIMITED, 1, MonitorDecision.RETRY_PROVIDER),
+        (ProviderErrorKind.TRANSIENT, 2, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.AUTHENTICATION, 0, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.AUTHORIZATION, 0, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.NOT_FOUND, 0, MonitorDecision.STOP_BLOCKED),
+    ],
+)
+def test_provider_failures_never_buy_a_model_turn(
+    error: ProviderErrorKind,
+    consecutive_errors: int,
+    expected: MonitorDecision,
+) -> None:
+    """Transient failures back off; deterministic or repeated failures stop."""
+    observation = MonitorObservation(
+        "",
+        MonitorObservationStatus.PROVIDER_ERROR,
+        provider_error=error,
+    )
+
+    assert (
+        decide_monitor(
+            _state(
+                consecutive_provider_errors=consecutive_errors,
+                budgets=MonitorBudgets(max_provider_errors=3),
+            ),
+            observation,
+            now=1_100.0,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "now"),
+    [
+        (_state(budgets=MonitorBudgets(max_runtime_secs=100)), 1_100.0),
+        (
+            _state(agent_turns=8, budgets=MonitorBudgets(max_agent_turns=8)),
+            1_100.0,
+        ),
+        (
+            _state(
+                input_tokens=150_000,
+                output_tokens=100_000,
+                budgets=MonitorBudgets(max_tokens=250_000),
+            ),
+            1_100.0,
+        ),
+    ],
+)
+def test_exhausted_budget_prevents_even_an_actionable_wake(
+    state: MonitorState,
+    now: float,
+) -> None:
+    """A spent budget cannot dispatch one extra unattended model turn."""
+    observation = MonitorObservation(
+        "new-failure",
+        MonitorObservationStatus.ACTIONABLE,
+    )
+
+    assert decide_monitor(state, observation, now=now) is MonitorDecision.STOP_BUDGET
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_runtime_secs", 0),
+        ("max_agent_turns", 0),
+        ("max_tokens", 0),
+        ("max_provider_errors", 0),
+    ],
+)
+def test_structured_monitor_budgets_cannot_be_unlimited(field: str, value: int) -> None:
+    """First-class monitors reject legacy goal-loop unlimited values."""
+    with pytest.raises(ValueError, match=field):
+        MonitorBudgets(**{field: value})
+
+
+def test_provider_error_observation_requires_an_error_category() -> None:
+    """A provider failure without a category cannot choose retry versus stop."""
+    with pytest.raises(ValueError, match="provider_error"):
+        MonitorObservation("", MonitorObservationStatus.PROVIDER_ERROR)
+
+
+def test_non_error_observation_requires_a_fingerprint() -> None:
+    """A comparable observation cannot bypass wake deduplication."""
+    with pytest.raises(ValueError, match="fingerprint"):
+        MonitorObservation("", MonitorObservationStatus.ACTIONABLE)
+
+
+@pytest.mark.parametrize("fingerprint", (None, 1, True, ""))
+def test_non_error_observation_requires_a_nonempty_string_fingerprint(fingerprint: object) -> None:
+    """Only a real canonical fingerprint can participate in wake deduplication."""
+    with pytest.raises(ValueError, match="fingerprint"):
+        MonitorObservation(fingerprint, MonitorObservationStatus.ACTIONABLE)
+
+
+def test_observation_rejects_untyped_status_and_provider_error() -> None:
+    """Raw strings cannot bypass enum checks into a wake-capable decision."""
+    with pytest.raises(ValueError, match="status"):
+        MonitorObservation("actionable", "actionable")
+    with pytest.raises(ValueError, match="provider_error"):
+        MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error="transient",
+        )
+
+
+def test_provider_error_observation_requires_a_string_fingerprint() -> None:
+    """Provider errors may omit a fingerprint but cannot carry an untyped one."""
+    with pytest.raises(ValueError, match="fingerprint"):
+        MonitorObservation(
+            [],
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+        )
+
+
+@pytest.mark.parametrize(("field", "value"), (("reason_code", 42), ("summary", {})))
+def test_observation_requires_string_metadata_fields(field: str, value: object) -> None:
+    """Persisted/displayed observation metadata has one unambiguous text shape."""
+    with pytest.raises(ValueError, match=field):
+        MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+            **{field: value},
+        )
+
+
+def test_unknown_monitor_state_version_fails_closed() -> None:
+    """A newer persisted policy cannot inherit today's permissive branches."""
+    observation = MonitorObservation(
+        "new-failure",
+        MonitorObservationStatus.ACTIONABLE,
+    )
+
+    assert (
+        decide_monitor(
+            _state(version=99),
+            observation,
+            now=1_100.0,
+        )
+        is MonitorDecision.STOP_BLOCKED
+    )

--- a/test/test_monitor_persistence.py
+++ b/test/test_monitor_persistence.py
@@ -1,0 +1,261 @@
+"""Persistence compatibility for structured AutoNudge monitor state."""
+
+from __future__ import annotations
+
+import json
+
+from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+from kiro_crew.monitoring.models import (
+    DEFAULT_MONITOR_CADENCE_SECS,
+    MonitorBudgets,
+    MonitorOutcome,
+    MonitorState,
+    monitor_state_from_dict,
+    monitor_state_to_dict,
+)
+
+
+def test_legacy_loop_round_trip_does_not_acquire_monitor_state(tmp_path) -> None:
+    """Reading and rewriting a legacy registry must not migrate its record."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "legacy01",
+                "slot_key": "chat-1-123",
+                "message": "keep going",
+                "idle_secs": 300,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["legacy01"]
+    assert restored.monitor is None
+    serialized = service._serialize_state()["loops"][0]
+    assert "monitor" not in serialized
+
+
+def test_explicit_null_monitor_is_malformed_and_cannot_rearm(tmp_path) -> None:
+    """Only an absent monitor field denotes a legacy loop."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "null01",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": None,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    assert "null01" not in service._loops
+
+
+def test_structured_monitor_cadence_defaults_without_changing_legacy_loop() -> None:
+    """Structured cadence lives in typed monitor state, not the legacy timer default."""
+    monitor = MonitorState(
+        kind="github_pull_request",
+        target="owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    assert monitor.cadence_secs == DEFAULT_MONITOR_CADENCE_SECS == 300
+    assert monitor_state_from_dict(monitor_state_to_dict(monitor)).cadence_secs == 300
+    assert NudgeLoop(id="legacy02", slot_key="chat-1-123", message="keep going").idle_secs == 60
+
+
+def test_structured_monitor_cadence_must_be_a_positive_integer() -> None:
+    """Structured monitors cannot inherit legacy unlimited or malformed cadence values."""
+    for cadence_secs in (0, -1, True, "300"):
+        try:
+            MonitorState(
+                kind="github_pull_request",
+                target="owner/repo#123",
+                objective="review_ready",
+                created_ts=1_000.0,
+                cadence_secs=cadence_secs,
+            )
+        except ValueError:
+            continue
+        raise AssertionError(f"cadence_secs={cadence_secs!r} was accepted")
+
+
+def test_monitor_state_survives_store_round_trip(tmp_path) -> None:
+    """Restart recovery retains the fingerprint, usage, budgets, and outcome."""
+    monitor = MonitorState(
+        kind="github_pull_request",
+        target="owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        budgets=MonitorBudgets(
+            max_runtime_secs=7_200,
+            max_agent_turns=4,
+            max_tokens=80_000,
+            max_provider_errors=2,
+        ),
+        cadence_secs=120,
+        last_observation={"head_revision": "abc123", "checks": "failing"},
+        last_fingerprint="failure-a",
+        last_observed_at=1_200.0,
+        last_wake_fingerprint="failure-a",
+        agent_turns=2,
+        input_tokens=12_000,
+        output_tokens=3_000,
+        consecutive_provider_errors=1,
+        next_probe_at=1_500.0,
+        outcome=MonitorOutcome.BUDGET,
+        stopped_reason="token_budget",
+        stopped_at=1_250.0,
+    )
+    service = AutoNudgeService(base_dir=tmp_path)
+    service._loops["monitor1"] = NudgeLoop(
+        id="monitor1",
+        slot_key="chat-1-123",
+        message="inspect the changed pull request",
+        monitor=monitor,
+    )
+    service._save()
+
+    restored_service = AutoNudgeService(base_dir=tmp_path)
+    restored_service._load()
+    restored_loop = restored_service._loops["monitor1"]
+    restored = restored_loop.monitor
+
+    assert restored is not None
+    assert not restored_loop.active
+    assert restored.kind == "github_pull_request"
+    assert restored.last_observation == {"head_revision": "abc123", "checks": "failing"}
+    assert restored.last_fingerprint == "failure-a"
+    assert restored.last_wake_fingerprint == "failure-a"
+    assert restored.budgets == MonitorBudgets(
+        max_runtime_secs=7_200,
+        max_agent_turns=4,
+        max_tokens=80_000,
+        max_provider_errors=2,
+    )
+    assert restored.cadence_secs == 120
+    assert restored.agent_turns == 2
+    assert restored.total_tokens == 15_000
+    assert restored.outcome is MonitorOutcome.BUDGET
+    assert restored.stopped_reason == "token_budget"
+
+
+def test_unknown_monitor_version_is_inspectable_but_inactive(tmp_path) -> None:
+    """A future monitor schema must not execute under an older policy."""
+    future_monitor = {
+        "version": 99,
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+        "cadence_secs": 123,
+        "last_fingerprint": "future-fingerprint",
+        "budgets": {
+            "max_runtime_secs": 7_777,
+            "max_agent_turns": 9,
+            "max_tokens": 88_888,
+            "max_provider_errors": 4,
+            "future_budget": "keep",
+        },
+        "outcome": "future_paused",
+        "future_policy": {"wake_every_time": True},
+    }
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "future01",
+                "slot_key": "chat-1-123",
+                "message": "future instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": future_monitor,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["future01"]
+    assert not restored.active
+    assert restored.monitor is not None
+    assert restored.monitor.version == 99
+    assert restored.monitor.target == "owner/repo#123"
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "unsupported_monitor_version"
+    serialized_monitor = service._serialize_state()["loops"][0]["monitor"]
+    assert serialized_monitor == future_monitor
+
+
+def test_malformed_monitor_cannot_rearm_after_restart(tmp_path) -> None:
+    """Invalid budget counters fail closed instead of reaching decision arithmetic."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "broken01",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": {
+                    "version": 1,
+                    "kind": "github_pull_request",
+                    "target": "owner/repo#123",
+                    "objective": "review_ready",
+                    "created_ts": 1_000.0,
+                    "agent_turns": "many",
+                },
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    assert "broken01" not in service._loops
+
+
+def test_malformed_current_outcome_cannot_rearm_after_restart(tmp_path) -> None:
+    """A non-enum terminal value is malformed, not evidence the loop is active."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "broken02",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": {
+                    "version": 1,
+                    "kind": "github_pull_request",
+                    "target": "owner/repo#123",
+                    "objective": "review_ready",
+                    "created_ts": 1_000.0,
+                    "outcome": "",
+                },
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    assert "broken02" not in service._loops


### PR DESCRIPTION
Stack: #5171 → #5172 → #5173 → #5174 → #5175 → #5176 → #5177

Position: 2 of 7. Base: #5171. Next: #5173.

Adds typed durable monitor state, bounded decisions, outcomes, and fail-closed persistence while preserving legacy AutoNudge behavior.

Verification: monitor decision, persistence, deadline, and AutoNudge suites.
