### PR TITLE
refactor: account for completed monitor turns

### DIFF
--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -265,6 +265,13 @@ next turn into the same slot:
 - Loops persist to `autonudge.json` under the data home and are re-armed on gateway
   restart. A slot that is unreachable (no history, deleted, or closed) has its loop
   removed.
+- Structured monitor action accounting is a separate internal completion
+  callback, not a new injected-message envelope. Until the probe dispatcher is
+  attached, structured records remain fail-closed. The dormant adapters do not
+  change the legacy `[auto-nudge cycle N]` body, delivered-cycle count, `fired`
+  event, or rearm timing. When attached, dashboard and Discord report only a raw
+  provider completion; Slack likewise requires the raw provider completion and
+  shares its one consumed usage result with telemetry.
 
 **How to treat it:** it is a self-prompt. Continue the work; the operator asked for
 the loop, but is not waiting on this specific message.

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -820,9 +820,26 @@ unchanged. A malformed current-version monitor, including an explicit `null`
 payload, causes its containing loop to be skipped, so it cannot re-arm under an
 uncertain policy. Structured cadence is typed state with a 300-second default;
 the legacy loop default remains 60 seconds. This substrate has no delivery
-controller: loading, generic updating, arming, or a pre-existing timer all fail
-closed without a model turn until a later slice wires typed decisions. The pure
-`decide_monitor` policy performs no I/O. It
+dispatcher: loading, generic updating, arming, or a pre-existing timer all fail
+closed without a model turn until the probe controller is wired. It does expose
+a dormant completed-turn controller seam. An actionable fingerprint is persisted
+in-flight before dispatch; dispatch failure clears that claim without spend; a
+correlated completion charges one agent turn exactly once, adds only reported
+non-negative token counts, and records token usage as unknown when authoritative
+counts are unavailable. Duplicate, removed, replaced, legacy, and mismatched
+callbacks are no-ops. Recovery of persisted in-flight state deactivates the
+record with `completion_evidence_unavailable` while retaining the acknowledged
+fingerprint, so restart cannot immediately duplicate the wake. Completion stops
+on the first exhausted runtime, turn, or token bound (in that precedence), and
+eight completed turns remains the universal ceiling even if a persisted bound is
+larger. Approval-stall completion is terminal and budget exhaustion takes
+precedence when both apply.
+
+Dashboard structured actions receive a runtime-only completion hook and report
+only from `_run_chat`'s raw `EVENT_COMPLETE` branch. Legacy dashboard nudge
+scheduling still returns immediately and still rearms from the existing
+`notify_turn_complete` `finally`; the completion hook neither replaces nor moves
+that lifecycle call. The pure `decide_monitor` policy performs no I/O. It
 checks the non-zero runtime/turn/token budgets first, classifies provider errors
 without a model turn, suppresses an unchanged observation, and permits
 `wake_actionable` only when the actionable fingerprint differs from the last

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -99,6 +99,14 @@ The dashboard does **not** flow through `TurnDriver`; it remains unchanged as th
 | `EVENT_COMPACTION_STATUS` | `COMPACTION` |
 | `EVENT_COMPLETE` | `DONE` |
 
+An optional structured-monitor completion hook is orthogonal to rendering. It
+is invoked exactly from the raw `EVENT_COMPLETE` branch, after `DONE`, with the
+event's `TurnUsage` and a disposition derived from its stop reason. A normal
+handler return, command intercept, renderer finalization, or stream exception
+does not manufacture completion evidence. Callback failure is logged and cannot
+change the channel turn's output or error behavior. The hook is absent from
+ordinary inbound turns and legacy AutoNudge turns.
+
 ### Approval ladder
 
 Four modes (constants, mirroring the native Slack + dashboard ladder):

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -412,6 +412,30 @@ A parent session born on any other channel (Telegram, Discord, `unified:` DM buc
 
 ## Tool Approval via Slack
 
+### Structured monitor completion adapters
+
+The AutoNudge router keeps its historical `on_fire -> bool`, `cycle_count`,
+`fired`, and rearm contracts. A separate runtime-only hook is supplied only when
+a structured monitor already has an actionable fingerprint marked in-flight;
+legacy loops and ordinary channel messages receive none. The structured probe
+dispatcher that creates those live actions lands separately.
+
+Slack's inline nudge turn consumes `provider_last_turn_usage(client)` exactly
+once. That one `TurnUsage` object is fanned out to the existing usage-row writer
+and, when the stream observed a raw `EVENT_COMPLETE`, the monitor completion
+hook, because the provider accessor destructively consumes retry-accumulated
+usage. The raw event's stop reason determines success, cancellation, or failure.
+Stream exhaustion and timeout before that event still write the existing usage
+row but do not report monitor completion or charge the monitor budget. Callback
+or usage-row persistence failure does not change the Slack delivery result.
+
+Discord synthetic nudge injection passes the same hook through
+`DiscordDispatcher` to `TurnDriver`. Only the driver's raw `EVENT_COMPLETE`
+branch reports completion; a command return, dispatch exception, or renderer
+`close()` is not completion evidence. Thus dashboard, Slack, and Discord all
+reach the same typed controller callback even though their transport lifecycles
+remain different.
+
 Background task approvals (subagent/cron/taskrunner) post approval buttons to Slack DM via `_interactive_approval()`, racing with dashboard approval:
 
 1. Posts ✅ Approve / 🚫 Reject buttons to owner DM

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -44,8 +44,14 @@ from kiro_crew import platform_compat, shutdown_event
 from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.loader import config_dir
 from kiro_crew.config.paths import legacy_home
+from kiro_crew.monitoring.decision import monitor_budget_reason
 from kiro_crew.monitoring.models import (
     MONITOR_STATE_VERSION,
+    MONITOR_STOP_APPROVAL_STALL,
+    MONITOR_STOP_COMPLETION_UNAVAILABLE,
+    MONITOR_STOP_UNSUPPORTED_VERSION,
+    MonitorActionCompletion,
+    MonitorActionDisposition,
     MonitorOutcome,
     MonitorState,
     monitor_state_from_dict,
@@ -455,7 +461,22 @@ class AutoNudgeService:
                         # it impossible until a compatible version is running.
                         loop.active = False
                         loop.monitor.outcome = MonitorOutcome.BLOCKED
-                        loop.monitor.stopped_reason = "unsupported_monitor_version"
+                        loop.monitor.stopped_reason = MONITOR_STOP_UNSUPPORTED_VERSION
+                        self._store_dirty = True
+                    elif loop.monitor.wake_in_flight:
+                        # A persisted claim proves dispatch was acknowledged but
+                        # says nothing about whether the process died before or
+                        # after the turn completed. Retire it deterministically:
+                        # charging would invent work, while clearing the wake
+                        # fingerprint would permit an immediate duplicate.
+                        loop.monitor.wake_in_flight = False
+                        if loop.monitor.outcome is None:
+                            loop.monitor.outcome = MonitorOutcome.BLOCKED
+                            loop.monitor.stopped_reason = (
+                                MONITOR_STOP_COMPLETION_UNAVAILABLE
+                            )
+                        loop.active = False
+                        loop.next_due_ts = 0.0
                         self._store_dirty = True
                     elif loop.active:
                         # Structured monitor delivery belongs to the controller,
@@ -962,6 +983,151 @@ class AutoNudgeService:
 
     def list_all(self) -> list[NudgeLoop]:
         return list(self._loops.values())
+
+    async def mark_monitor_action_in_flight(
+        self,
+        monitor_id: str,
+        fingerprint: str,
+        *,
+        now: float | None = None,
+    ) -> bool:
+        """Persist the dispatch claim for one actionable fingerprint."""
+        if not isinstance(fingerprint, str) or not fingerprint:
+            raise ValueError("fingerprint must be a non-empty string")
+        checked_at = time.time() if now is None else now
+        if (
+            isinstance(checked_at, bool)
+            or not isinstance(checked_at, (int, float))
+            or not math.isfinite(checked_at)
+            or checked_at < 0
+        ):
+            raise ValueError("now must be a finite non-negative number")
+        dispatched = False
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or not loop.active
+                or state.outcome is not None
+                or state.wake_in_flight
+                or state.last_wake_fingerprint == fingerprint
+            ):
+                return False
+            reason = monitor_budget_reason(state, now=checked_at)
+            if reason:
+                self._stop_monitor_for_budget(loop, reason, stopped_at=checked_at)
+            else:
+                state.last_wake_fingerprint = fingerprint
+                state.wake_in_flight = True
+                dispatched = True
+            await self._write_monitor_snapshot_locked()
+        self._emit("updated", loop)
+        return dispatched
+
+    async def record_monitor_turn_completion(
+        self,
+        completion: MonitorActionCompletion,
+    ) -> None:
+        """Charge one correlated, completed action turn exactly once."""
+        async with self._lock:
+            loop = self._loops.get(completion.monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or not state.wake_in_flight
+                or state.last_wake_fingerprint != completion.fingerprint
+            ):
+                return
+            disposition = (
+                MonitorActionDisposition.APPROVAL_STALL
+                if loop.approval_stalled
+                else completion.disposition
+            )
+            state.wake_in_flight = False
+            state.last_completion_fingerprint = completion.fingerprint
+            state.last_completion_disposition = disposition
+            state.last_completed_at = completion.completed_ts
+            state.agent_turns += 1
+            if completion.input_tokens is None or completion.output_tokens is None:
+                state.token_usage_known = False
+            if completion.input_tokens is not None:
+                state.input_tokens += completion.input_tokens
+            if completion.output_tokens is not None:
+                state.output_tokens += completion.output_tokens
+            reason = monitor_budget_reason(state, now=completion.completed_ts)
+            if reason and state.outcome is None:
+                self._stop_monitor_for_budget(
+                    loop,
+                    reason,
+                    stopped_at=completion.completed_ts,
+                )
+            elif (
+                disposition is MonitorActionDisposition.APPROVAL_STALL
+                and state.outcome is None
+            ):
+                loop.active = False
+                loop.next_due_ts = 0.0
+                state.outcome = MonitorOutcome.BLOCKED
+                state.stopped_reason = MONITOR_STOP_APPROVAL_STALL
+                state.stopped_at = completion.completed_ts
+                self._cancel_timer(loop.id)
+            await self._write_monitor_snapshot_locked()
+        self._emit("updated", loop)
+
+    def _stop_monitor_for_budget(
+        self,
+        loop: NudgeLoop,
+        reason: str,
+        *,
+        stopped_at: float,
+    ) -> None:
+        """Apply one structured-monitor budget stop under ``_lock``."""
+        state = loop.monitor
+        if state is None:
+            return
+        loop.active = False
+        loop.next_due_ts = 0.0
+        state.outcome = MonitorOutcome.BUDGET
+        state.stopped_reason = reason
+        state.stopped_at = stopped_at
+        self._cancel_timer(loop.id)
+
+    async def _write_monitor_snapshot_locked(self) -> None:
+        """Persist a monitor transition without releasing ``_lock`` mid-write."""
+        payload = self._serialize_state()
+        future = asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
+        try:
+            await asyncio.shield(future)
+        except asyncio.CancelledError:
+            # Executor writes cannot be cancelled. Drain before the caller's
+            # lock scope exits so a later transition cannot be overwritten by
+            # this older snapshot after cancellation.
+            await asyncio.shield(future)
+            raise
+
+    async def record_monitor_dispatch_failure(
+        self,
+        monitor_id: str,
+        fingerprint: str,
+    ) -> None:
+        """Release an unstarted dispatch claim without charging its budget."""
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or not state.wake_in_flight
+                or state.last_wake_fingerprint != fingerprint
+            ):
+                return
+            state.wake_in_flight = False
+            state.last_wake_fingerprint = ""
+            await self._write_monitor_snapshot_locked()
+        self._emit("updated", loop)
 
     def _find_by_slot(self, slot_key: str) -> NudgeLoop | None:
         """The loop bound to *slot_key*, which may be a binding key OR a tab name.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -184,6 +184,10 @@ from kiro_crew.messaging.link import SLACK_NAMESPACE, telemetry_channel_of
 from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.metrics.events import TURN_TIMEOUT_CAUSE, emit_counter
 from kiro_crew.metrics.provider import get_recorder
+from kiro_crew.monitoring.completion import (
+    MonitorCompletionHook,
+    disposition_for_stop_reason,
+)
 from kiro_crew.platform import redact_via_context
 from kiro_crew.providers.acp import is_claude_backend
 from kiro_crew.providers.base import (
@@ -4322,6 +4326,7 @@ async def _run_chat(
     _synthetic_payload: bool = False,
     regenerate_hint: str = "",
     _on_consumed: "Callable[[bool], None] | None" = None,
+    monitor_completion: MonitorCompletionHook | None = None,
 ) -> None:
     """Stream LLM response into *slot*.  Survives browser disconnect."""
 
@@ -7389,6 +7394,17 @@ async def _run_chat(
                         _stop_reason,
                         slot.key,
                     )
+                if monitor_completion is not None:
+                    try:
+                        await monitor_completion.complete(
+                            disposition_for_stop_reason(event.stop_reason),
+                            event.usage,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "dashboard monitor turn completion callback failed",
+                            exc_info=True,
+                        )
                 break
 
         # Turn stream ended: flush any withheld thinking tail (a thinking-final

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -64,6 +64,7 @@ from kiro_crew.messaging.link import (
 )
 from kiro_crew.messaging.renderer import Renderer, SilentRenderer
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.monitoring.completion import MonitorCompletionHook
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session_map import ConversationOwnershipConflict
@@ -224,6 +225,7 @@ class DiscordDispatcher:
         *,
         drain: bool = True,
         interpret_commands: bool = True,
+        monitor_completion: MonitorCompletionHook | None = None,
     ) -> None:
         """Drive one authorized inbound message through TurnDriver end-to-end."""
         assert self.client is not None, "DiscordDispatcher.client must be set"
@@ -548,6 +550,7 @@ class DiscordDispatcher:
                 directive_consumer=build_directive_consumer(
                     session_key=session_key, sessions=self.sessions, dispatcher=self
                 ),
+                monitor_completion=monitor_completion,
             )
             accumulated = await driver.run(full_message)
 

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -773,6 +773,7 @@ async def stream_and_collect(
     on_chunk: Callable[[str], None] | None = None,
     on_tool_approval: Callable[[LLMEvent], Awaitable[bool]] | None = None,
     on_steer_consumed: Callable[[str], None] | None = None,
+    on_complete: Callable[[LLMEvent], None] | None = None,
     on_tool_gate: Callable[[str, bool, bool], None] | None = None,
     retry_transient: bool = True,
     max_turns: int | None = None,
@@ -798,6 +799,10 @@ async def stream_and_collect(
             fire-and-forget write, so this echo is the ONLY authoritative signal
             that the backend injected it; a caller that steers must observe this
             to know which of its steers to requeue when the turn ends.
+        on_complete: Optional callback invoked with the provider's raw
+            ``EVENT_COMPLETE``. It is not invoked when the stream exhausts or
+            the caller cancels before that event. Raising from the callback is
+            swallowed so observation cannot fail the completed turn.
         on_tool_gate: Optional callback invoked once per tool permission
             decision with ``(tool_title, approved, security_blocked)``. Lets a
             caller tell "the model did work" apart from "every tool the model
@@ -937,6 +942,11 @@ async def stream_and_collect(
                 elif event.kind == EVENT_STEER_CONSUMED:
                     consumed_this_attempt.append(event.text or "")
                 elif event.kind == EVENT_COMPLETE:
+                    if on_complete:
+                        try:
+                            on_complete(event)
+                        except Exception:
+                            logger.debug("on_complete callback failed", exc_info=True)
                     break
             return result_text
         except AcpError as exc:

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -45,6 +45,10 @@ from kiro_crew.messaging.renderer import (
     OutputEvent,
     Renderer,
 )
+from kiro_crew.monitoring.completion import (
+    MonitorCompletionHook,
+    disposition_for_stop_reason,
+)
 from kiro_crew.security import StreamRedactor, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -309,6 +313,7 @@ class TurnDriver:
         auto_approve_session: Callable[[], bool] | None = None,
         tool_gate: Callable[[Any], str] | None = None,
         directive_consumer: DirectiveConsumer | None = None,
+        monitor_completion: MonitorCompletionHook | None = None,
     ) -> None:
         self.provider = provider
         self.renderer = renderer
@@ -328,6 +333,7 @@ class TurnDriver:
         # EVENT_TOOL_RESULT for a tool call whose trusted ``_meta.kiro``
         # identity was recorded at EVENT_TOOL_CALL — the forgery gate.
         self.directive_consumer = directive_consumer
+        self.monitor_completion = monitor_completion
 
     async def run(self, message: str) -> str:
         """Drive one turn; return the accumulated channel-safe assistant text."""
@@ -566,6 +572,17 @@ class TurnDriver:
                 await self.renderer.dispatch(
                     OutputEvent(kind=DONE, stop_reason=event.stop_reason)
                 )
+                if self.monitor_completion is not None:
+                    try:
+                        await self.monitor_completion.complete(
+                            disposition_for_stop_reason(event.stop_reason),
+                            event.usage,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "monitor turn completion callback failed",
+                            exc_info=True,
+                        )
         return accumulated
 
     async def _consume_directive(

--- a/src/kiro_crew/monitoring/completion.py
+++ b/src/kiro_crew/monitoring/completion.py
@@ -1,0 +1,80 @@
+"""Runtime-only completion adapter shared by monitor delivery surfaces."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN, TurnUsage
+from kiro_crew.monitoring.models import (
+    MonitorActionCompletion,
+    MonitorActionDisposition,
+)
+
+MonitorCompletionCallback = Callable[[MonitorActionCompletion], Awaitable[None]]
+
+
+def disposition_for_stop_reason(stop_reason: str) -> MonitorActionDisposition:
+    """Map an authoritative provider stop reason onto monitor accounting."""
+    if stop_reason == STOP_REASON_END_TURN:
+        return MonitorActionDisposition.SUCCESS
+    if stop_reason == STOP_REASON_CANCELLED:
+        return MonitorActionDisposition.CANCELLATION
+    return MonitorActionDisposition.FAILURE
+
+
+@dataclass(frozen=True)
+class MonitorCompletionHook:
+    """Bind a surface's raw turn result to one monitor action identity."""
+
+    monitor_id: str
+    fingerprint: str
+    callback: MonitorCompletionCallback
+
+    def __post_init__(self) -> None:
+        for name in ("monitor_id", "fingerprint"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if not callable(self.callback):
+            raise ValueError("callback must be callable")
+
+    async def complete(
+        self,
+        disposition: MonitorActionDisposition,
+        usage: TurnUsage | None = None,
+        *,
+        completed_ts: float | None = None,
+    ) -> None:
+        """Deliver one normalized record to the controller callback."""
+        input_tokens, output_tokens = _authoritative_token_counts(usage)
+        await self.callback(
+            MonitorActionCompletion(
+                monitor_id=self.monitor_id,
+                fingerprint=self.fingerprint,
+                disposition=disposition,
+                completed_ts=time.time() if completed_ts is None else completed_ts,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        )
+
+
+def _authoritative_token_counts(usage: TurnUsage | None) -> tuple[int | None, int | None]:
+    """Return token dimensions only when the provider reported real counts."""
+    if usage is None:
+        return None, None
+    try:
+        input_tokens = int(usage.input_tokens)
+        output_tokens = int(usage.output_tokens)
+    except (TypeError, ValueError, OverflowError):
+        return None, None
+    if input_tokens < 0 or output_tokens < 0:
+        return None, None
+    if input_tokens == 0 and output_tokens == 0:
+        # Kiro ACP bills in credits and leaves both token fields at their
+        # dataclass defaults. Zero therefore means unavailable on that seam,
+        # not authoritative proof that a completed agent turn used no tokens.
+        return None, None
+    return input_tokens, output_tokens

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from kiro_crew.monitoring.models import (
+    DEFAULT_MONITOR_AGENT_TURNS,
     MONITOR_STATE_VERSION,
+    MONITOR_STOP_AGENT_TURN_BUDGET,
+    MONITOR_STOP_RUNTIME_BUDGET,
+    MONITOR_STOP_TOKEN_BUDGET,
     MonitorBudgets,
     MonitorDecision,
     MonitorObservation,
@@ -36,7 +40,7 @@ def decide_monitor(
     terminal = _terminal_decision(state.outcome)
     if terminal is not None:
         return terminal
-    if _budget_exhausted(state, state.budgets, now=now):
+    if monitor_budget_reason(state, now=now):
         return MonitorDecision.STOP_BUDGET
     if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
         return _provider_error_decision(state, observation, state.budgets)
@@ -63,12 +67,17 @@ def _terminal_decision(outcome: MonitorOutcome | None) -> MonitorDecision | None
     return None
 
 
-def _budget_exhausted(state: MonitorState, budgets: MonitorBudgets, *, now: float) -> bool:
-    return (
-        now - state.created_ts >= budgets.max_runtime_secs
-        or state.agent_turns >= budgets.max_agent_turns
-        or state.total_tokens >= budgets.max_tokens
-    )
+def monitor_budget_reason(state: MonitorState, *, now: float) -> str:
+    """Return the first exhausted hard bound in stable policy order."""
+    budgets = state.budgets
+    if now - state.created_ts >= budgets.max_runtime_secs:
+        return MONITOR_STOP_RUNTIME_BUDGET
+    turn_limit = min(budgets.max_agent_turns, DEFAULT_MONITOR_AGENT_TURNS)
+    if state.agent_turns >= turn_limit:
+        return MONITOR_STOP_AGENT_TURN_BUDGET
+    if state.total_tokens >= budgets.max_tokens:
+        return MONITOR_STOP_TOKEN_BUDGET
+    return ""
 
 
 def _provider_error_decision(

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -19,6 +19,12 @@ DEFAULT_MONITOR_AGENT_TURNS = 8
 DEFAULT_MONITOR_TOKENS = 250_000
 DEFAULT_MONITOR_PROVIDER_ERRORS = 3
 DEFAULT_MONITOR_CADENCE_SECS = 300
+MONITOR_STOP_RUNTIME_BUDGET = "runtime_budget"
+MONITOR_STOP_AGENT_TURN_BUDGET = "agent_turn_budget"
+MONITOR_STOP_TOKEN_BUDGET = "token_budget"
+MONITOR_STOP_APPROVAL_STALL = "approval_stall"
+MONITOR_STOP_COMPLETION_UNAVAILABLE = "completion_evidence_unavailable"
+MONITOR_STOP_UNSUPPORTED_VERSION = "unsupported_monitor_version"
 
 
 class MonitorDecision(str, Enum):
@@ -62,6 +68,48 @@ class MonitorOutcome(str, Enum):
     USER_STOP = "user_stop"
     SESSION_CLOSE = "session_close"
     TARGET_UNAVAILABLE = "target_unavailable"
+
+
+class MonitorActionDisposition(str, Enum):
+    """Terminal disposition reported by a started monitor action turn."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    CANCELLATION = "cancellation"
+    APPROVAL_STALL = "approval_stall"
+
+
+@dataclass(frozen=True)
+class MonitorActionCompletion:
+    """Authoritative evidence that one monitor action turn stopped running."""
+
+    monitor_id: str
+    fingerprint: str
+    disposition: MonitorActionDisposition
+    completed_ts: float
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("monitor_id", "fingerprint"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if not isinstance(self.disposition, MonitorActionDisposition):
+            raise ValueError("disposition must be a MonitorActionDisposition")
+        if (
+            isinstance(self.completed_ts, bool)
+            or not isinstance(self.completed_ts, (int, float))
+            or not math.isfinite(self.completed_ts)
+            or self.completed_ts < 0
+        ):
+            raise ValueError("completed_ts must be a finite non-negative number")
+        for name in ("input_tokens", "output_tokens"):
+            value = getattr(self, name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(f"{name} must be a non-negative integer or None")
 
 
 @dataclass(frozen=True)
@@ -133,6 +181,10 @@ class MonitorState:
     last_observed_at: float = 0.0
     last_wake_fingerprint: str = ""
     wake_in_flight: bool = False
+    last_completion_fingerprint: str = ""
+    last_completion_disposition: MonitorActionDisposition | None = None
+    last_completed_at: float = 0.0
+    token_usage_known: bool = True
     agent_turns: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
@@ -151,7 +203,13 @@ class MonitorState:
                 raise ValueError(f"{name} must be a non-empty string")
         if isinstance(self.version, bool) or not isinstance(self.version, int) or self.version <= 0:
             raise ValueError("version must be a positive integer")
-        for name in ("created_ts", "last_observed_at", "next_probe_at", "stopped_at"):
+        for name in (
+            "created_ts",
+            "last_observed_at",
+            "last_completed_at",
+            "next_probe_at",
+            "stopped_at",
+        ):
             value = getattr(self, name)
             if (
                 isinstance(value, bool)
@@ -179,12 +237,23 @@ class MonitorState:
             raise ValueError("cadence_secs must be a positive integer")
         if not isinstance(self.last_observation, dict):
             raise ValueError("last_observation must be an object")
-        if not isinstance(self.last_fingerprint, str) or not isinstance(
-            self.last_wake_fingerprint, str
+        if any(
+            not isinstance(value, str)
+            for value in (
+                self.last_fingerprint,
+                self.last_wake_fingerprint,
+                self.last_completion_fingerprint,
+            )
         ):
             raise ValueError("monitor fingerprints must be strings")
         if not isinstance(self.wake_in_flight, bool):
             raise ValueError("wake_in_flight must be a boolean")
+        if self.last_completion_disposition is not None and not isinstance(
+            self.last_completion_disposition, MonitorActionDisposition
+        ):
+            raise ValueError("last_completion_disposition must be a MonitorActionDisposition")
+        if not isinstance(self.token_usage_known, bool):
+            raise ValueError("token_usage_known must be a boolean")
         if self.outcome is not None and not isinstance(self.outcome, MonitorOutcome):
             raise ValueError("outcome must be a MonitorOutcome")
         if not isinstance(self.stopped_reason, str):
@@ -236,6 +305,9 @@ def monitor_state_from_dict(raw: object) -> MonitorState:
         values["outcome"] = MonitorOutcome(outcome)
     else:
         values["outcome"] = None
+    disposition = values.get("last_completion_disposition")
+    if disposition is not None:
+        values["last_completion_disposition"] = MonitorActionDisposition(disposition)
     return MonitorState(**values)
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -193,6 +193,11 @@ from kiro_crew.messaging.link import (
 )
 from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.monitoring.completion import (
+    MonitorCompletionHook,
+    disposition_for_stop_reason,
+)
+from kiro_crew.monitoring.models import MonitorActionDisposition
 from kiro_crew.platform import boot_platform
 from kiro_crew.platform.context import (
     PlatformCompositionError,
@@ -255,6 +260,7 @@ from kiro_crew.subagent_completion_meta import (
 from kiro_crew.taskrunner import TaskRunner
 
 if TYPE_CHECKING:
+    from kiro_crew.acp.types import TurnUsage
     from kiro_crew.dashboard.state import _ChatSlot
     from kiro_crew.discord.client import DiscordClient
     from kiro_crew.imessage.client import IMessageClient
@@ -277,6 +283,7 @@ async def _persist_turn_row(
     surface: str,
     agent_fallback: Callable[[], str],
     t0: float,
+    usage: "TurnUsage | None" = None,
 ) -> None:
     """Persist one per-turn usage row for a background dispatch surface.
 
@@ -304,7 +311,7 @@ async def _persist_turn_row(
         await persist_token_record_async(
             session_key,
             "",
-            provider_last_turn_usage(client),
+            provider_last_turn_usage(client) if usage is None else usage,
             provider=provider,
             surface=surface,
             agent=read_effective_agent(client) or agent_fallback(),
@@ -4837,6 +4844,11 @@ class GatewayOrchestrator:
             full_msg, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message, tagged, is_new, key, provider_type=_provider
             )
+            _raw_completions: list[LLMEvent] = []
+            _completion_hook = self._monitor_completion_hook(loop)
+            _completion_kwargs: dict[str, Any] = {}
+            if _completion_hook is not None:
+                _completion_kwargs["on_complete"] = _raw_completions.append
             # Clock started outside wait_for so BOTH the success path and the
             # TimeoutError branch below can report the real elapsed time. acp
             # never assigns TurnUsage.duration_ms, so the row needs this.
@@ -4853,9 +4865,11 @@ class GatewayOrchestrator:
                     approval_policy=ToolApprovalPolicy.HOOK_BASED,
                     hooks=self.ctx_builder.hooks,
                     on_tool_approval=self._interactive_approval("autonudge", nudge_key=key),
+                    **_completion_kwargs,
                 ),
                 timeout=_NUDGE_TURN_TIMEOUT,
             )
+            _turn_usage = provider_last_turn_usage(client)
 
             # ── Per-turn usage row: attribute monitor spend. ──
             await _persist_turn_row(
@@ -4865,7 +4879,15 @@ class GatewayOrchestrator:
                 surface="monitor",
                 agent_fallback=lambda: _get_agent_for_session(key),
                 t0=_turn_t0,
+                usage=_turn_usage,
             )
+            if _raw_completions:
+                await self._report_monitor_completion(
+                    loop,
+                    disposition_for_stop_reason(_raw_completions[-1].stop_reason),
+                    _turn_usage,
+                    hook=_completion_hook,
+                )
         except asyncio.TimeoutError:
             # ── Timeout spend is REAL spend (issue #874 follow-up). ──
             # A timed-out nudge turn previously fell through to the generic
@@ -4882,6 +4904,7 @@ class GatewayOrchestrator:
                 key,
                 loop.id,
             )
+            _turn_usage = provider_last_turn_usage(client)
             await _persist_turn_row(
                 client,
                 key,
@@ -4889,7 +4912,15 @@ class GatewayOrchestrator:
                 surface="monitor",
                 agent_fallback=lambda: _get_agent_for_session(key),
                 t0=_turn_t0,
+                usage=_turn_usage,
             )
+            if _raw_completions:
+                await self._report_monitor_completion(
+                    loop,
+                    disposition_for_stop_reason(_raw_completions[-1].stop_reason),
+                    _turn_usage,
+                    hook=_completion_hook,
+                )
             return False
         except Exception:
             logger.exception("AutoNudge: slack nudge turn failed for %s (loop %s)", key, loop.id)
@@ -5006,8 +5037,12 @@ class GatewayOrchestrator:
                 conversation_id=conversation_id,
                 text=tagged,
             )
+            dispatch_kwargs: dict[str, Any] = {"interpret_commands": False}
+            completion_hook = self._monitor_completion_hook(loop)
+            if completion_hook is not None:
+                dispatch_kwargs["monitor_completion"] = completion_hook
             await asyncio.wait_for(
-                dispatcher.handle_message(synthetic, interpret_commands=False),
+                dispatcher.handle_message(synthetic, **dispatch_kwargs),
                 timeout=_NUDGE_TURN_TIMEOUT,
             )
             return True
@@ -5131,11 +5166,15 @@ class GatewayOrchestrator:
         # independently and would otherwise put N turns on the runtime at once.
         # An attended slot (any user session with a monitor loop) is passed
         # straight through, so babysit loops on human sessions are unaffected.
+        run_kwargs: dict[str, Any] = {}
+        completion_hook = self._monitor_completion_hook(loop)
+        if completion_hook is not None:
+            run_kwargs["monitor_completion"] = completion_hook
         task = spawn_guarded_turn(
             self.dashboard_state,
             slot,
             self.dashboard_state.run_background_turn(
-                slot, _run_chat(self.dashboard_state, slot, tagged)
+                slot, _run_chat(self.dashboard_state, slot, tagged, **run_kwargs)
             ),
         )
         # Mirror dashboard /api/chat/send path so slot.running == True and sidebar
@@ -5144,6 +5183,46 @@ class GatewayOrchestrator:
         self._session_tasks[slot.key] = task
         self.dashboard_state.push_slots_update()
         return True
+
+    def _monitor_completion_hook(self, loop: NudgeLoop) -> MonitorCompletionHook | None:
+        """Bind a structured loop's in-flight identity to controller accounting."""
+        state = getattr(loop, "monitor", None)
+        if state is None:
+            return None
+        service = self.autonudge_svc
+        if (
+            service is None
+            or not state.wake_in_flight
+            or not state.last_wake_fingerprint
+        ):
+            return None
+        return MonitorCompletionHook(
+            loop.id,
+            state.last_wake_fingerprint,
+            service.record_monitor_turn_completion,
+        )
+
+    async def _report_monitor_completion(
+        self,
+        loop: NudgeLoop,
+        disposition: MonitorActionDisposition,
+        usage: "TurnUsage | None",
+        *,
+        hook: MonitorCompletionHook | None = None,
+    ) -> None:
+        """Best-effort monitor accounting that cannot change delivery outcome."""
+        if hook is None:
+            hook = self._monitor_completion_hook(loop)
+        if hook is None:
+            return
+        try:
+            await hook.complete(disposition, usage)
+        except Exception:
+            logger.warning(
+                "monitor turn completion callback failed for loop %s",
+                loop.id,
+                exc_info=True,
+            )
 
     async def _init_autonudge(self) -> None:
         """Initialize and start the auto-nudge service (feature-flagged)."""

--- a/test/test_autonudge_dashboard_fire.py
+++ b/test/test_autonudge_dashboard_fire.py
@@ -24,6 +24,8 @@ import pytest
 
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.monitoring.completion import MonitorCompletionHook
+from kiro_crew.monitoring.models import MonitorState
 from kiro_crew.slack import gateway as gw
 
 
@@ -179,6 +181,34 @@ class TestDashboardNudgeSlotResolution:
             assert await orch._fire_dashboard_nudge(_loop()) is True
         rehydrate.assert_not_awaited()
         assert spawn.calls == [live]
+
+    @pytest.mark.asyncio
+    async def test_structured_monitor_passes_completion_hook_only_to_its_turn(self) -> None:
+        """A dashboard action reports raw completion without changing legacy turns."""
+        orch = _orchestrator()
+        live = _slot()
+        orch.dashboard_state.get_slot = MagicMock(return_value=live)
+        structured = _loop()
+        structured.monitor = MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        )
+        spawn = _fake_spawn()
+        run_chat = AsyncMock()
+        with (
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=run_chat),
+        ):
+            assert await orch._fire_dashboard_nudge(structured) is True
+            assert await orch._fire_dashboard_nudge(_loop()) is True
+
+        first, second = run_chat.call_args_list
+        assert isinstance(first.kwargs["monitor_completion"], MonitorCompletionHook)
+        assert "monitor_completion" not in second.kwargs
 
     @pytest.mark.asyncio
     async def test_unreachable_session_retires_the_loop_once_with_a_reason(

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -5396,6 +5396,52 @@ class TestTokenPersistenceBackfill:
         return state
 
     @pytest.mark.asyncio
+    async def test_raw_complete_reports_structured_monitor_usage(self, tmp_path, monkeypatch):
+        """Normal runner return is not the accounting boundary; EVENT_COMPLETE is."""
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.monitoring.completion import MonitorCompletionHook
+        from kiro_crew.monitoring.models import (
+            MonitorActionCompletion,
+            MonitorActionDisposition,
+        )
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        events = [
+            LLMEvent(kind=EVENT_TEXT_CHUNK, text="done"),
+            LLMEvent(
+                kind=EVENT_COMPLETE,
+                stop_reason="end_turn",
+                usage=TurnUsage(input_tokens=12, output_tokens=4),
+            ),
+        ]
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = self._make_mock_client(events)
+        client.context_used_tokens = MagicMock(return_value=0)
+        client.context_window_tokens = MagicMock(return_value=0)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.generate_session_summary",
+            AsyncMock(return_value=None),
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        await _run_chat(
+            state,
+            slot,
+            "hello",
+            monitor_completion=MonitorCompletionHook("monitor1", "failure-a", _capture),
+        )
+
+        assert len(completions) == 1
+        assert completions[0].disposition is MonitorActionDisposition.SUCCESS
+        assert completions[0].input_tokens == 12
+        assert completions[0].output_tokens == 4
+
+    @pytest.mark.asyncio
     async def test_late_backfill_populates_model_for_cc_session(self, tmp_path, monkeypatch):
         """When slot.model is empty at EVENT_COMPLETE but the provider has
         learned its model (CC init event), persist_token_record receives the

--- a/test/test_llm_helpers.py
+++ b/test/test_llm_helpers.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kiro_crew.acp.client import AcpError, AcpPromptBusy
+from kiro_crew.acp.types import STOP_REASON_CANCELLED, TurnUsage
 from kiro_crew.llm_helpers import (
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
@@ -330,6 +331,37 @@ class TestStreamAndCollectPromptBusy:
 
         assert result == "hello"
         provider.cancel.assert_not_awaited()
+
+
+class TestStreamAndCollectRawCompletion:
+    @pytest.mark.asyncio
+    async def test_callback_receives_the_raw_complete_event(self) -> None:
+        """Callers needing terminal evidence must see the provider event itself."""
+        complete = LLMEvent(
+            kind=EVENT_COMPLETE,
+            stop_reason=STOP_REASON_CANCELLED,
+            usage=TurnUsage(input_tokens=12, output_tokens=3),
+        )
+        provider = _make_provider(
+            events=[LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial"), complete]
+        )
+        observed: list[LLMEvent] = []
+
+        result = await stream_and_collect(provider, "test", on_complete=observed.append)
+
+        assert result == "partial"
+        assert observed == [complete]
+
+    @pytest.mark.asyncio
+    async def test_stream_exhaustion_does_not_invent_completion(self) -> None:
+        """A provider iterator ending without EVENT_COMPLETE is not a completed turn."""
+        provider = _make_provider(events=[LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial")])
+        observed: list[LLMEvent] = []
+
+        result = await stream_and_collect(provider, "test", on_complete=observed.append)
+
+        assert result == "partial"
+        assert observed == []
 
 
 # ── Transient backend (5xx / throttle / stream-reset) retry tests ──

--- a/test/test_messaging_driver.py
+++ b/test/test_messaging_driver.py
@@ -18,6 +18,7 @@ from kiro_crew.acp.types import (
     EVENT_TEXT_CHUNK,
     EVENT_TOOL_CALL,
     AcpEvent,
+    TurnUsage,
 )
 from kiro_crew.messaging import (
     APPROVAL_AUTO,
@@ -26,6 +27,8 @@ from kiro_crew.messaging import (
     TurnDriver,
 )
 from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.monitoring.completion import MonitorCompletionHook
+from kiro_crew.monitoring.models import MonitorActionCompletion, MonitorActionDisposition
 
 
 class _RecordingRenderer(Renderer):
@@ -88,6 +91,30 @@ class TestTurnDriverTranslation:
         out = _run(p, r)
         assert out == "Hello world"
         assert [e[0] for e in r.events] == ["text_chunk", "text_chunk", "done"]
+
+    def test_raw_complete_reports_monitor_action_once(self):
+        r = _RecordingRenderer()
+        p = _ScriptedProvider(
+            [
+                AcpEvent(
+                    kind=EVENT_COMPLETE,
+                    stop_reason="end_turn",
+                    usage=TurnUsage(input_tokens=20, output_tokens=5),
+                )
+            ]
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+        _run(p, r, monitor_completion=hook)
+
+        assert len(completions) == 1
+        assert completions[0].disposition is MonitorActionDisposition.SUCCESS
+        assert completions[0].input_tokens == 20
+        assert completions[0].output_tokens == 5
 
     def test_tool_calls_emit_uniform_tool_call(self):
         r = _RecordingRenderer()

--- a/test/test_monitor_turn_completion.py
+++ b/test/test_monitor_turn_completion.py
@@ -1,0 +1,334 @@
+"""Completed-turn accounting for structured monitors."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+
+import pytest
+
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+from kiro_crew.monitoring import models
+from kiro_crew.monitoring.models import MonitorBudgets, MonitorOutcome, MonitorState
+
+
+def _structured_loop() -> NudgeLoop:
+    return NudgeLoop(
+        id="monitor1",
+        slot_key="chat-1-123",
+        message="inspect the changed pull request",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+        ),
+    )
+
+
+def test_monitor_completion_contract_is_typed() -> None:
+    """An untyped completion payload could bypass correlation and validation."""
+    assert hasattr(models, "MonitorActionCompletion")
+    assert hasattr(models, "MonitorActionDisposition")
+    completion = models.MonitorActionCompletion(
+        monitor_id="monitor1",
+        fingerprint="failure-a",
+        disposition=models.MonitorActionDisposition.SUCCESS,
+        completed_ts=1_120.0,
+        input_tokens=1_200,
+        output_tokens=None,
+    )
+
+    assert completion.monitor_id == "monitor1"
+    assert completion.disposition is models.MonitorActionDisposition.SUCCESS
+    assert completion.input_tokens == 1_200
+    assert completion.output_tokens is None
+
+    with pytest.raises(ValueError, match="input_tokens"):
+        models.MonitorActionCompletion(
+            monitor_id="monitor1",
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.FAILURE,
+            completed_ts=1_120.0,
+            input_tokens=-1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_charges_nothing_until_the_action_turn_completes(tmp_path) -> None:
+    """Moving completed-turn accounting into dispatch would spend budget early."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 0
+    assert loop.monitor.total_tokens == 0
+    assert loop.monitor.wake_in_flight
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_120.0,
+            input_tokens=1_200,
+            output_tokens=300,
+        )
+    )
+
+    assert loop.monitor.agent_turns == 1
+    assert loop.monitor.input_tokens == 1_200
+    assert loop.monitor.output_tokens == 300
+    assert not loop.monitor.wake_in_flight
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_before_turn_start_does_not_charge(tmp_path) -> None:
+    """A failed handoff is not an agent turn and must remain retryable."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+
+    await service.record_monitor_dispatch_failure(loop.id, "failure-a")
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 0
+    assert loop.monitor.total_tokens == 0
+    assert not loop.monitor.wake_in_flight
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_101.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("budgets", "completed_ts", "input_tokens", "output_tokens", "reason"),
+    [
+        (MonitorBudgets(max_runtime_secs=100), 1_100.0, 1, 1, "runtime_budget"),
+        (MonitorBudgets(max_agent_turns=1), 1_050.0, 1, 1, "agent_turn_budget"),
+        (MonitorBudgets(max_tokens=100), 1_050.0, 75, 25, "token_budget"),
+    ],
+)
+async def test_completion_stops_on_the_first_exhausted_budget(
+    tmp_path,
+    budgets: MonitorBudgets,
+    completed_ts: float,
+    input_tokens: int,
+    output_tokens: int,
+    reason: str,
+) -> None:
+    """Runtime, then turn, then token precedence gives one stable stop reason."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.budgets = budgets
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.FAILURE,
+            completed_ts=completed_ts,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    )
+
+    assert not loop.active
+    assert loop.monitor.outcome is MonitorOutcome.BUDGET
+    assert loop.monitor.stopped_reason == reason
+    assert loop.monitor.stopped_at == completed_ts
+
+
+@pytest.mark.asyncio
+async def test_eight_completed_turns_is_a_universal_hard_bound(tmp_path) -> None:
+    """A configured turn ceiling above eight cannot weaken the product backstop."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.budgets = MonitorBudgets(max_agent_turns=99)
+    loop.monitor.agent_turns = 7
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_060.0,
+        )
+    )
+
+    assert loop.monitor.agent_turns == 8
+    assert not loop.active
+    assert loop.monitor.stopped_reason == "agent_turn_budget"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_and_mismatched_completions_are_idempotent(tmp_path) -> None:
+    """A retry or stale surface callback cannot charge a second turn."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+    stale = models.MonitorActionCompletion(
+        monitor_id=loop.id,
+        fingerprint="failure-b",
+        disposition=models.MonitorActionDisposition.FAILURE,
+        completed_ts=1_055.0,
+        input_tokens=500,
+        output_tokens=100,
+    )
+    completion = models.MonitorActionCompletion(
+        monitor_id=loop.id,
+        fingerprint="failure-a",
+        disposition=models.MonitorActionDisposition.SUCCESS,
+        completed_ts=1_060.0,
+        input_tokens=10,
+        output_tokens=5,
+    )
+
+    await service.record_monitor_turn_completion(stale)
+    await service.record_monitor_turn_completion(completion)
+    await service.record_monitor_turn_completion(completion)
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 1
+    assert loop.monitor.total_tokens == 15
+    assert loop.monitor.last_completion_fingerprint == "failure-a"
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_charges_turn_without_inventing_tokens(tmp_path) -> None:
+    """Unavailable authoritative counts remain unknown rather than becoming zero."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.CANCELLATION,
+            completed_ts=1_060.0,
+        )
+    )
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 1
+    assert loop.monitor.total_tokens == 0
+    assert not loop.monitor.token_usage_known
+    assert loop.monitor.last_completion_disposition is models.MonitorActionDisposition.CANCELLATION
+
+
+@pytest.mark.asyncio
+async def test_approval_stall_is_a_completed_turn_and_terminal_blocker(tmp_path) -> None:
+    """An unattended approval stall must not wake the same monitor again."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.APPROVAL_STALL,
+            completed_ts=1_060.0,
+            input_tokens=10,
+            output_tokens=5,
+        )
+    )
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 1
+    assert not loop.active
+    assert loop.monitor.outcome is MonitorOutcome.BLOCKED
+    assert loop.monitor.stopped_reason == "approval_stall"
+
+
+@pytest.mark.asyncio
+async def test_surface_approval_evidence_overrides_a_nominal_success_frame(tmp_path) -> None:
+    """A provider end-turn after approval timeout remains an approval stall."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+    loop.approval_stalled = True
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_060.0,
+            input_tokens=10,
+            output_tokens=5,
+        )
+    )
+
+    assert loop.monitor is not None
+    assert loop.monitor.last_completion_disposition is (
+        models.MonitorActionDisposition.APPROVAL_STALL
+    )
+    assert loop.monitor.outcome is MonitorOutcome.BLOCKED
+
+
+def test_restart_fails_closed_when_completion_evidence_is_unavailable(tmp_path) -> None:
+    """An acknowledged in-flight fingerprint cannot redispatch after restart."""
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.last_wake_fingerprint = "failure-a"
+    loop.monitor.wake_in_flight = True
+    payload = {
+        "version": 1,
+        "loops": [AutoNudgeService._serialize_loop(loop)],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    restored_service = AutoNudgeService(base_dir=tmp_path)
+    restored_service._load()
+    restored = restored_service._loops[loop.id]
+
+    assert restored.monitor is not None
+    assert not restored.active
+    assert not restored.monitor.wake_in_flight
+    assert restored.monitor.last_wake_fingerprint == "failure-a"
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "completion_evidence_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_completion_hook_delivers_one_typed_record_with_explicit_unknown_usage() -> None:
+    """A credits-only usage result must not fabricate authoritative token counts."""
+    assert importlib.util.find_spec("kiro_crew.monitoring.completion") is not None
+    from kiro_crew.monitoring.completion import MonitorCompletionHook
+
+    completions: list[models.MonitorActionCompletion] = []
+
+    async def _capture(completion: models.MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+    await hook.complete(
+        models.MonitorActionDisposition.SUCCESS,
+        TurnUsage(credits=1.0),
+        completed_ts=1_100.0,
+    )
+
+    assert completions == [
+        models.MonitorActionCompletion(
+            monitor_id="monitor1",
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_100.0,
+            input_tokens=None,
+            output_tokens=None,
+        )
+    ]

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -32,6 +32,8 @@ import pytest
 from kiro_crew import subagent as _sa
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.monitoring.completion import MonitorCompletionHook
+from kiro_crew.monitoring.models import MonitorState
 from kiro_crew.slack import gateway as gw
 
 # ─── Helpers ─────────────────────────────────────────────────────────────
@@ -235,6 +237,30 @@ class TestFireDiscordNudge:
         assert "keep checking" in synthetic.text
         # interpret_commands=False keeps a nudge body from parsing as `!command`.
         assert kwargs["interpret_commands"] is False
+
+    @pytest.mark.asyncio
+    async def test_structured_monitor_supplies_completion_hook(self):
+        """Only a structured synthetic turn carries monitor accounting state."""
+        transport = _discord_transport()
+        orch = _discord_orchestrator(transport)
+        structured = _loop(_DKEY)
+        structured.monitor = MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        )
+
+        assert await orch._fire_discord_nudge(structured) is True
+        _, structured_kwargs = _awaited(transport.dispatcher.handle_message)
+        assert isinstance(structured_kwargs["monitor_completion"], MonitorCompletionHook)
+
+        transport.dispatcher.handle_message.reset_mock()
+        assert await orch._fire_discord_nudge(_loop(_DKEY)) is True
+        _, legacy_kwargs = _awaited(transport.dispatcher.handle_message)
+        assert "monitor_completion" not in legacy_kwargs
 
     @pytest.mark.asyncio
     async def test_dispatch_failure_returns_false(self):

--- a/test/test_turn_duration_slack.py
+++ b/test/test_turn_duration_slack.py
@@ -37,10 +37,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew.acp.types import TurnUsage
+from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN, TurnUsage
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.handlers.usage import _token_usage_dir
+from kiro_crew.monitoring.models import (
+    MonitorActionCompletion,
+    MonitorActionDisposition,
+    MonitorState,
+)
+from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
 from kiro_crew.slack import gateway as gw
 
 
@@ -227,3 +233,184 @@ def test_provider_duration_wins_over_local_clock(monkeypatch):
     assert len(rows) == 1
     assert rows[0]["duration_ms"] == 5000  # provider wins
     assert rows[0]["duration_ms"] != 1234  # not the local-clock fallback
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected_disposition"),
+    [
+        (STOP_REASON_END_TURN, MonitorActionDisposition.SUCCESS),
+        (STOP_REASON_CANCELLED, MonitorActionDisposition.CANCELLATION),
+        ("max_tokens", MonitorActionDisposition.FAILURE),
+    ],
+)
+def test_structured_monitor_fans_out_usage_only_from_raw_completion(
+    monkeypatch,
+    stop_reason: str,
+    expected_disposition: MonitorActionDisposition,
+):
+    """One destructive usage read serves telemetry and the evidenced disposition."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    usage = TurnUsage(input_tokens=40, output_tokens=10, credits=0.25)
+    reads = 0
+
+    def _usage_once(_client):
+        nonlocal reads
+        reads += 1
+        return usage
+
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(gw, "provider_last_turn_usage", _usage_once)
+
+    async def _stream_ok(*_a, on_complete=None, **_k):
+        assert on_complete is not None
+        on_complete(LLMEvent(kind=EVENT_COMPLETE, stop_reason=stop_reason))
+        return "done"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_ok)
+    loop = NudgeLoop(
+        id="loop-structured",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is True
+
+    assert reads == 1
+    assert len(completions) == 1
+    assert completions[0].disposition is expected_disposition
+    assert completions[0].input_tokens == 40
+    assert completions[0].output_tokens == 10
+    rows = _monitor_rows()
+    assert len(rows) == 1
+    assert rows[0]["input"] == 40
+    assert rows[0]["output"] == 10
+
+
+def test_structured_monitor_stream_exhaustion_charges_no_completion(monkeypatch):
+    """A bare string return without EVENT_COMPLETE is not completion evidence."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(
+        gw,
+        "provider_last_turn_usage",
+        lambda _client: TurnUsage(input_tokens=40, output_tokens=10),
+    )
+
+    async def _stream_exhausted(*_a, **_k):
+        return "partial"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_exhausted)
+    loop = NudgeLoop(
+        id="loop-exhausted",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is True
+    assert completions == []
+    assert len(_monitor_rows()) == 1
+
+
+def test_structured_monitor_timeout_before_complete_charges_no_completion(monkeypatch):
+    """Transport cancellation cannot stand in for a raw cancelled completion."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(gw, "provider_last_turn_usage", lambda _client: TurnUsage(credits=0.2))
+    monkeypatch.setattr(gw, "_NUDGE_TURN_TIMEOUT", 0.01)
+
+    async def _stream_hang(*_a, **_k):
+        await asyncio.sleep(1.0)
+        return "unreachable"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_hang)
+    loop = NudgeLoop(
+        id="loop-timeout-structured",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is False
+    assert completions == []
+    assert len(_monitor_rows()) == 1
+
+
+def test_structured_monitor_timeout_after_raw_completion_preserves_event(monkeypatch):
+    """A timeout does not replace raw cancellation evidence with inference."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(gw, "provider_last_turn_usage", lambda _client: TurnUsage(credits=0.2))
+    monkeypatch.setattr(gw, "_NUDGE_TURN_TIMEOUT", 0.01)
+
+    async def _stream_complete_then_hang(*_a, on_complete=None, **_k):
+        assert on_complete is not None
+        on_complete(LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_CANCELLED))
+        await asyncio.sleep(1.0)
+        return "unreachable"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_complete_then_hang)
+    loop = NudgeLoop(
+        id="loop-timeout-after-complete",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is False
+    assert len(completions) == 1
+    assert completions[0].disposition is MonitorActionDisposition.CANCELLATION
+    assert len(_monitor_rows()) == 1


### PR DESCRIPTION
Stack: #5171 → #5172 → #5173 → #5174 → #5175 → #5176 → #5177

Position: 3 of 7. Base: #5172. Next: #5174.

Charges monitor budgets from correlated raw completion evidence across dashboard, Slack, and Discord.

Verification: completion, dashboard, Slack, Discord, and messaging suites.
