### PR TITLE
feat: add github pull request monitor probe

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -845,8 +845,46 @@ without a model turn, suppresses an unchanged observation, and permits
 `wake_actionable` only when the actionable fingerprint differs from the last
 acknowledged wake fingerprint. The defaults are 14,400 seconds, eight completed
 agent turns, 250,000 aggregate input/output tokens, and three consecutive
-provider errors. This substrate does not yet schedule a provider probe or expose
-a new MCP tool; those are later RFC implementation slices.
+provider errors. This substrate does not itself schedule live provider probes or
+expose a new MCP tool; those are later RFC implementation slices.
+
+**GitHub pull-request shadow probe** (`monitoring/github_pull_request.py`,
+`monitoring/shadow.py`): the first typed provider adapter accepts only exact HTTPS
+pull-request URLs on public `github.com` (normalizing `www.github.com`); arbitrary
+hosts, enterprise instances, repository URLs, path suffixes, query/fragment identity,
+and non-positive pull-request numbers are refused before provider execution. The
+adapter resolves and invokes the shared hardened `github_runner` boundary with
+`GH_HOST` pinned to `github.com`. It reads the fixed `gh pr view` readiness fields and,
+for an open pull request, walks GraphQL review threads in pages of 100, stopping after
+at most ten pages. Merged and closed primary lifecycle states are terminal without a
+secondary GraphQL dependency. An incomplete, malformed-node, missing-cursor, or capped
+thread traversal is a pending fact and can never produce review-ready success.
+
+The durable observation is stable canonical JSON containing only normalized target
+identity, head revision, lifecycle/draft state, sorted check identities by outcome,
+normalized review/blocking state, unresolved-thread count/completeness, and
+mergeability. Provider ordering, timestamps, URLs, request/cursor ids, titles,
+bodies, comments, and logs do not enter it. Provider-controlled check labels pass
+through credential redaction and unconditional URL removal before persistence. The
+SHA-256 fingerprint covers the compact sorted serialization; a collection reorder or
+volatile provider value keeps it stable, while a new head changes it. Only a non-empty
+current head may set the changed-head fact. A changed head is also a typed decision
+fact with precedence over an otherwise-green success, so it records `wake_actionable`
+instead of stopping as ready.
+
+Classification is conservative: merged is terminal success
+(`pull_request_merged`), closed-unmerged is terminal blocked, draft/pending or
+unknown checks, incomplete review-thread evidence, and unknown mergeability remain
+pending. Mergeability succeeds only for the explicit settled `CLEAN`, `HAS_HOOKS`,
+and `UNSTABLE` states, so empty or future provider values fail closed as pending;
+failed checks, requested changes, unresolved threads, conflicts, a behind head, and
+branch-protection blocks are actionable. Rate limits and transport/provider
+failures are retryable, while authentication, authorization, not-found, and local
+`gh` setup/trust failures are terminal categories. The shadow runner persists only
+the canonical observation, decision, next-probe time, and aggregate probe/error
+metrics. It has no action dispatcher, never sets a wake fingerprint or in-flight
+claim, and raises before probing or persisting when `wake_delivery` is requested.
+This slice exposes no MCP control tool and spends no model turns.
 
 A reasonless inactive update is idempotent for a Research Lab stop tombstone:
 it preserves the source-owned `autonudge_stop` reason until the watchdog

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -937,6 +937,33 @@ the destination's ordinary security checks and to the effective
 
 `_run_json()` emits credential-free SEL tool-invocation lifecycle events around every provider CLI attempt. Unsupported providers, invalid bounds, Windows sandbox absence, untrusted executables, and sandbox rejection record `denied`. An allowlisted command awaits its synchronous critical `invoked` append on a worker thread immediately before spawn, so an audit filesystem failure denies execution rather than launching a credential-bearing process unaudited, without blocking the gateway event loop. Cancellation while that worker is active remains fail-closed and waits for it to settle; if `invoked` landed, cleanup records `failed/request_cancelled` before re-raising and never spawns the provider. Provider launchers run in a dedicated process group, and timeout, output-overflow, and cancellation cleanup kills and reaps the complete launcher/provider tree so a sandbox wrapper cannot leave `gh` or `glab` orphaned on an unread pipe. Successful JSON decoding records `completed`; spawn, output, timeout, nonzero exit, decode, cancellation, and internal errors record `failed` with only a coarse reason. Audit records contain the logical provider (`gh`/`glab`), not argv, URL, repo path, output, environment, token, thread id, or exception text. Terminal audit failures are best effort and never alter an already-completed provider result.
 
+**Structured GitHub monitor provider boundary**
+(`monitoring/github_pull_request.py`): background pull-request shadow probes are a
+separate monitor-owned consumer of the shared synchronous `github_runner`, not of the
+dashboard handler. The target gate accepts only exact public `github.com` HTTPS
+pull-request identities and normalizes `www.github.com`; it refuses arbitrary and
+enterprise hosts, credentials/ports, repository-only paths, suffixes, queries,
+fragments, and invalid owner/repository/number segments before resolving `gh`. Every
+provider call uses the runner's validated absolute executable, minimal GitHub-only
+environment, audit-or-deny invocation record, strict UTF-8 decoding, and
+`pin_host="github.com"`; no monitor-specific token source or credential storage
+exists.
+
+Raw stdout, stderr, response envelopes, URLs, timestamps, cursor/request ids, bodies,
+comments, and logs never cross the adapter boundary into monitor state, exceptions,
+or logging. Canonical state is an explicit small allowlist; check labels are stripped
+of URLs and passed through `security.redact()` before persistence. Provider failures
+are reduced in memory to fixed error kinds and reason codes, including a non-retryable
+setup kind for missing, untrusted, or unexecutable `gh`; raw diagnostic text is then
+discarded. Open-PR review-thread pagination is bounded to ten 100-node pages, and
+incomplete or capped evidence fails closed as pending; a terminal merged/closed
+primary state does not issue that secondary request. Shadow execution has no dispatcher
+dependency and refuses an enabled wake request before either provider or persistence
+work, so it cannot turn ambient GitHub authority into a model wake in this slice.
+
+The provider adapter's redaction is classified as inbound canonicalization rather
+than an egress surface.
+
 Sidebar status follows the same read-only boundary. `GET /api/chat/slots` and the WebSocket handshake schedule provider refreshes and opt into cached `ci`/`state` fields only for an exact configured-owner request, or for signed `local-app`/`local-startup` dashboard subjects when no owner is configured. Generic slot serialization omits those fields. `DashboardState` tracks owner-authorized WebSockets separately, sends generic slot updates to all authenticated clients, then overlays credential-backed status only to the owner subset. This prevents a cache populated by an owner request from being replayed to a non-owner or app-token caller. Review-thread cache removal, generation advancement, and stale in-flight detachment still complete after thread ownership validation and before mutation dispatch, so cancellation cannot preserve or repopulate pre-mutation data.
 
 **App-token least-privilege scope (CWE-269)** (`token_auth.py`): an app token is confined to its own app namespace + the API path prefixes the app declares in its manifest `permissions.api` allowlist; everything else is denied. `_enforce_app_scope()` is **deny-by-default** — `_app_api_allowlist()` returns an empty tuple on any failure (app not installed, manifest unreadable), confining the app to its own namespace only. Enforced at all grant points (the normal cookie/query-param flow and the cross-app `/apps/<other>/api` reverse-proxy path re-check); dashboard-user tokens (empty `app` claim) bypass the gate entirely. Denials emit a `log_api_access` SEL event (`operation="app_scope_check"`, `outcome="denied"`).

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -44,7 +44,7 @@ def decide_monitor(
         return MonitorDecision.STOP_BUDGET
     if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
         return _provider_error_decision(state, observation, state.budgets)
-    if observation.status is MonitorObservationStatus.ACTIONABLE:
+    if observation.head_changed or observation.status is MonitorObservationStatus.ACTIONABLE:
         if observation.fingerprint == state.last_wake_fingerprint:
             return MonitorDecision.NO_CHANGE
         return MonitorDecision.WAKE_ACTIONABLE

--- a/src/kiro_crew/monitoring/github_pull_request.py
+++ b/src/kiro_crew/monitoring/github_pull_request.py
@@ -1,0 +1,611 @@
+"""Typed public-GitHub pull-request observations for structured monitors."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from typing import Any
+from urllib.parse import urlparse
+
+from kiro_crew.github_runner import SetupError, resolve_gh, run_gh
+from kiro_crew.monitoring.models import (
+    MonitorObservation,
+    MonitorObservationStatus,
+    ProviderErrorKind,
+)
+from kiro_crew.security import redact
+
+_GITHUB_HOST = "github.com"
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_URL_IN_CHECK_IDENTITY_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_PROBE_TIMEOUT_SECS = 30.0
+_REVIEW_THREAD_PAGE_SIZE = 100
+_REVIEW_THREAD_MAX_PAGES = 10
+_MERGEABLE_SETTLED_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE"})
+_PR_FIELDS = (
+    "number,state,isDraft,headRefOid,mergeable,mergeStateStatus," "reviewDecision,statusCheckRollup"
+)
+_REVIEW_THREADS_QUERY = """
+query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:PAGE_SIZE,after:$cursor){
+        pageInfo{hasNextPage endCursor}
+        nodes{isResolved}
+      }
+    }
+  }
+}
+""".replace("PAGE_SIZE", str(_REVIEW_THREAD_PAGE_SIZE)).strip()
+
+GitHubResolver = Callable[[], str]
+GitHubRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestTarget:
+    """Validated identity of one public GitHub pull request."""
+
+    host: str
+    owner: str
+    repo: str
+    number: int
+
+    def __post_init__(self) -> None:
+        if self.host != _GITHUB_HOST:
+            raise ValueError("target must be a public GitHub pull request")
+        if any(
+            segment in {".", ".."} or _SEGMENT_RE.fullmatch(segment) is None
+            for segment in (self.owner, self.repo)
+        ):
+            raise ValueError("target must be a public GitHub pull request")
+        if isinstance(self.number, bool) or not isinstance(self.number, int) or self.number <= 0:
+            raise ValueError("target must be a public GitHub pull request")
+
+    @property
+    def identity(self) -> str:
+        return f"{self.host}/{self.owner}/{self.repo}#{self.number}"
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.host}/{self.owner}/{self.repo}/pull/{self.number}"
+
+
+@dataclass(frozen=True)
+class GitHubCheck:
+    """One normalized logical status check."""
+
+    identity: str
+    state: str
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestResponse:
+    """Allowlisted provider facts with no raw response attached."""
+
+    target: GitHubPullRequestTarget
+    state: str
+    draft: bool
+    head_revision: str
+    mergeability: str
+    review_decision: str
+    checks: tuple[GitHubCheck, ...]
+    unresolved_review_threads: int
+    review_threads_complete: bool
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestProbeResult:
+    """Canonical durable facts and their generic monitor classification."""
+
+    response: GitHubPullRequestResponse | None
+    canonical: dict[str, object]
+    observation: MonitorObservation
+
+
+class GitHubPullRequestProvider:
+    """Read public pull-request state through the authenticated hardened gh runner."""
+
+    def __init__(
+        self,
+        *,
+        resolver: GitHubResolver = resolve_gh,
+        runner: GitHubRunner = run_gh,
+    ) -> None:
+        self._resolver = resolver
+        self._runner = runner
+
+    def probe(
+        self,
+        raw_target: str,
+        *,
+        previous_observation: Mapping[str, object] | None = None,
+    ) -> GitHubPullRequestProbeResult:
+        """Return one canonical review-ready observation."""
+        target = parse_github_pull_request_target(raw_target)
+        try:
+            gh = self._resolver()
+            primary = self._runner(
+                [gh, "pr", "view", target.url, "--json", _PR_FIELDS],
+                timeout=_PROBE_TIMEOUT_SECS,
+                audit_caller="core:monitor",
+                pin_host=_GITHUB_HOST,
+            )
+            failure = _process_failure(primary)
+            if failure is not None:
+                return failure
+            raw_primary = _json_object(primary.stdout)
+            response = _normalize_response(target, raw_primary, 0, False)
+            if response.state not in {"merged", "closed"}:
+                unresolved, complete = self._review_threads(gh, target)
+                if isinstance(unresolved, GitHubPullRequestProbeResult):
+                    return unresolved
+                response = replace(
+                    response,
+                    unresolved_review_threads=unresolved,
+                    review_threads_complete=complete,
+                )
+        except SetupError:
+            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except FileNotFoundError:
+            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except subprocess.TimeoutExpired:
+            return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
+        except OSError:
+            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except (TypeError, ValueError, KeyError):
+            return _provider_error(
+                ProviderErrorKind.TRANSIENT,
+                "provider_malformed_response",
+            )
+        canonical = _canonical_response(response)
+        previous_head = (
+            previous_observation.get("head_revision")
+            if isinstance(previous_observation, Mapping)
+            else None
+        )
+        head_changed = (
+            response.state == "open"
+            and isinstance(previous_head, str)
+            and bool(previous_head)
+            and bool(response.head_revision)
+            and previous_head != response.head_revision
+        )
+        status, reason_code = _classify_response(response)
+        fingerprint_facts = (
+            _actionable_fingerprint_facts(canonical)
+            if status is MonitorObservationStatus.ACTIONABLE
+            else canonical
+        )
+        fingerprint = _fingerprint(fingerprint_facts)
+        return GitHubPullRequestProbeResult(
+            response=response,
+            canonical=canonical,
+            observation=MonitorObservation(
+                fingerprint,
+                status,
+                reason_code=reason_code,
+                head_changed=head_changed,
+            ),
+        )
+
+    def _review_threads(
+        self,
+        gh: str,
+        target: GitHubPullRequestTarget,
+    ) -> tuple[int | GitHubPullRequestProbeResult, bool]:
+        unresolved = 0
+        cursor: str | None = None
+        for page in range(_REVIEW_THREAD_MAX_PAGES):
+            argv = [
+                gh,
+                "api",
+                "graphql",
+                "-f",
+                f"query={_REVIEW_THREADS_QUERY}",
+                "-F",
+                f"owner={target.owner}",
+                "-F",
+                f"repo={target.repo}",
+                "-F",
+                f"number={target.number}",
+            ]
+            if cursor is not None:
+                argv.extend(("-F", f"cursor={cursor}"))
+            proc = self._runner(
+                argv,
+                timeout=_PROBE_TIMEOUT_SECS,
+                audit_caller="core:monitor",
+                pin_host=_GITHUB_HOST,
+            )
+            failure = _process_failure(proc)
+            if failure is not None:
+                return failure, False
+            raw = _json_object(proc.stdout)
+            if raw.get("errors"):
+                return unresolved, False
+            try:
+                threads = raw["data"]["repository"]["pullRequest"]["reviewThreads"]
+                nodes = threads["nodes"]
+                page_info = threads["pageInfo"]
+            except (KeyError, TypeError) as exc:
+                raise ValueError("GitHub review-thread response is malformed") from exc
+            if not isinstance(nodes, list) or not isinstance(page_info, Mapping):
+                raise ValueError("GitHub review-thread response is malformed")
+            for node in nodes:
+                if not isinstance(node, Mapping) or not isinstance(node.get("isResolved"), bool):
+                    return unresolved, False
+                unresolved += int(not node["isResolved"])
+            has_next = page_info.get("hasNextPage")
+            if has_next is False:
+                return unresolved, True
+            if has_next is not True:
+                return unresolved, False
+            next_cursor = page_info.get("endCursor")
+            if not isinstance(next_cursor, str) or not next_cursor:
+                return unresolved, False
+            cursor = next_cursor
+            if page + 1 == _REVIEW_THREAD_MAX_PAGES:
+                return unresolved, False
+        return unresolved, False
+
+
+def parse_github_pull_request_target(raw: str) -> GitHubPullRequestTarget:
+    """Parse one exact public GitHub pull-request URL into a typed identity."""
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("target must be a GitHub pull request URL")
+    parsed = urlparse(raw)
+    try:
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("target must be a public GitHub pull request URL") from exc
+    if (
+        parsed.scheme != "https"
+        or host not in {_GITHUB_HOST, f"www.{_GITHUB_HOST}"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("target must be a public GitHub pull request URL")
+    parts = parsed.path.split("/")
+    if len(parts) != 5 or parts[0] or parts[3] != "pull":
+        raise ValueError("target must be a GitHub pull request URL")
+    owner, repo, raw_number = parts[1], parts[2], parts[4]
+    if not raw_number.isascii() or not raw_number.isdecimal():
+        raise ValueError("target must be a GitHub pull request with a positive number")
+    try:
+        return GitHubPullRequestTarget(_GITHUB_HOST, owner, repo, int(raw_number, 10))
+    except ValueError as exc:
+        raise ValueError("target must be a valid GitHub pull request") from exc
+
+
+def _json_object(raw: str | None) -> dict[str, Any]:
+    if not isinstance(raw, str):
+        raise ValueError("GitHub response is malformed")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError("GitHub response is malformed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub response is malformed")
+    return payload
+
+
+def _normalize_response(
+    target: GitHubPullRequestTarget,
+    raw: Mapping[str, Any],
+    unresolved_review_threads: int,
+    review_threads_complete: bool,
+) -> GitHubPullRequestResponse:
+    required = {
+        "number",
+        "state",
+        "isDraft",
+        "headRefOid",
+        "mergeable",
+        "mergeStateStatus",
+        "reviewDecision",
+        "statusCheckRollup",
+    }
+    if not required.issubset(raw):
+        raise ValueError("GitHub pull request response is malformed")
+    number = raw["number"]
+    if (
+        isinstance(number, bool)
+        or not isinstance(number, int)
+        or number != target.number
+        or not isinstance(raw["isDraft"], bool)
+    ):
+        raise ValueError("GitHub pull request response is malformed")
+    for name in ("state", "headRefOid", "mergeable", "mergeStateStatus"):
+        if not isinstance(raw[name], str):
+            raise ValueError("GitHub pull request response is malformed")
+    review_decision = raw["reviewDecision"]
+    if review_decision is not None and not isinstance(review_decision, str):
+        raise ValueError("GitHub pull request response is malformed")
+    checks = _normalize_checks(raw["statusCheckRollup"])
+    return GitHubPullRequestResponse(
+        target=target,
+        state=_normalize_pr_state(raw["state"]),
+        draft=raw["isDraft"],
+        head_revision=raw["headRefOid"],
+        mergeability=_normalize_mergeability(raw["mergeable"], raw["mergeStateStatus"]),
+        review_decision=_normalize_review_decision(review_decision),
+        checks=checks,
+        unresolved_review_threads=unresolved_review_threads,
+        review_threads_complete=review_threads_complete,
+    )
+
+
+def _normalize_checks(raw: object) -> tuple[GitHubCheck, ...]:
+    if not isinstance(raw, list):
+        raise ValueError("GitHub check rollup is malformed")
+    grouped: dict[str, list[tuple[str, str]]] = {}
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise ValueError("GitHub check rollup is malformed")
+        identity, state, recency = _normalize_check(item)
+        grouped.setdefault(identity, []).append((recency, state))
+    normalized: list[GitHubCheck] = []
+    for identity, candidates in grouped.items():
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        latest_recency = candidates[0][0]
+        latest_states = {state for recency, state in candidates if recency == latest_recency}
+        state = next(iter(latest_states)) if len(latest_states) == 1 else "unknown"
+        normalized.append(GitHubCheck(identity, state))
+    return tuple(sorted(normalized, key=lambda item: item.identity))
+
+
+def _normalize_check(raw: Mapping[str, object]) -> tuple[str, str, str]:
+    typename = raw.get("__typename")
+    if typename == "CheckRun":
+        name = raw.get("name")
+        workflow = raw.get("workflowName")
+        if not isinstance(name, str) or not name:
+            raise ValueError("GitHub check rollup is malformed")
+        identity = f"{workflow} / {name}" if isinstance(workflow, str) and workflow else name
+        identity = _sanitize_check_identity(identity)
+        status = raw.get("status")
+        conclusion = raw.get("conclusion")
+        if status != "COMPLETED":
+            state = "pending" if isinstance(status, str) else "unknown"
+        elif conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+            state = "passed"
+        elif conclusion in {
+            "FAILURE",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "STARTUP_FAILURE",
+        }:
+            state = "failed"
+        else:
+            state = "unknown"
+        recency = raw.get("startedAt")
+        if not workflow:
+            normalized_recency = ""
+        elif isinstance(recency, str) and recency:
+            normalized_recency = recency
+        else:
+            normalized_recency = "\uffff" if state == "pending" else ""
+        return identity, state, normalized_recency
+    if typename == "StatusContext":
+        context = raw.get("context")
+        if not isinstance(context, str) or not context:
+            raise ValueError("GitHub check rollup is malformed")
+        raw_state = raw.get("state")
+        if isinstance(raw_state, str):
+            state = {
+                "SUCCESS": "passed",
+                "PENDING": "pending",
+                "EXPECTED": "pending",
+                "FAILURE": "failed",
+                "ERROR": "failed",
+            }.get(raw_state, "unknown")
+        else:
+            state = "unknown"
+        return _sanitize_check_identity(context), state, ""
+    raise ValueError("GitHub check rollup is malformed")
+
+
+def _normalize_pr_state(raw: str) -> str:
+    return {"OPEN": "open", "CLOSED": "closed", "MERGED": "merged"}.get(raw.upper(), "unknown")
+
+
+def _sanitize_check_identity(identity: str) -> str:
+    without_urls = _URL_IN_CHECK_IDENTITY_RE.sub("[provider-url]", identity)
+    return redact(without_urls)
+
+
+def _normalize_review_decision(raw: str | None) -> str:
+    if raw is None or raw == "":
+        return "none"
+    return {
+        "APPROVED": "approved",
+        "CHANGES_REQUESTED": "changes_requested",
+        "REVIEW_REQUIRED": "review_required",
+    }.get(raw.upper(), "unknown")
+
+
+def _normalize_mergeability(mergeable: str, merge_state: str) -> str:
+    normalized_mergeable = mergeable.upper()
+    normalized_state = merge_state.upper()
+    if normalized_mergeable == "CONFLICTING" or normalized_state == "DIRTY":
+        return "conflicting"
+    if normalized_state == "BEHIND":
+        return "behind"
+    if normalized_state == "BLOCKED":
+        return "blocked"
+    if normalized_mergeable != "MERGEABLE" or normalized_state not in _MERGEABLE_SETTLED_STATES:
+        return "pending"
+    return "mergeable"
+
+
+def _canonical_response(response: GitHubPullRequestResponse) -> dict[str, object]:
+    checks = {
+        state: sorted({check.identity for check in response.checks if check.state == state})
+        for state in ("failed", "passed", "pending", "unknown")
+    }
+    if not response.review_threads_complete:
+        blocking_review = "unknown"
+    elif response.review_decision == "changes_requested":
+        blocking_review = "changes_requested"
+    elif response.unresolved_review_threads:
+        blocking_review = "unresolved_threads"
+    else:
+        blocking_review = "none"
+    return {
+        "blocking_review": blocking_review,
+        "checks": checks,
+        "draft": response.draft,
+        "head_revision": response.head_revision,
+        "kind": "github_pull_request",
+        "mergeability": response.mergeability,
+        "review_decision": response.review_decision,
+        "review_threads_complete": response.review_threads_complete,
+        "state": response.state,
+        "target": response.target.identity,
+        "unresolved_review_threads": response.unresolved_review_threads,
+    }
+
+
+def _fingerprint(canonical: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _actionable_fingerprint_facts(canonical: Mapping[str, object]) -> dict[str, object]:
+    """Keep known blockers stable while unrelated unsettled facts continue changing."""
+    checks = canonical["checks"]
+    if not isinstance(checks, Mapping):
+        raise ValueError("canonical GitHub checks are malformed")
+    blocking_review = canonical["blocking_review"]
+    mergeability = canonical["mergeability"]
+    return {
+        "blocking_review": (
+            blocking_review
+            if blocking_review in {"changes_requested", "unresolved_threads"}
+            else "none"
+        ),
+        "failed_checks": checks["failed"],
+        "head_revision": canonical["head_revision"],
+        "kind": canonical["kind"],
+        "mergeability": (
+            mergeability if mergeability in {"conflicting", "behind", "blocked"} else "none"
+        ),
+        "state": canonical["state"],
+        "target": canonical["target"],
+    }
+
+
+def _classify_response(
+    response: GitHubPullRequestResponse,
+) -> tuple[MonitorObservationStatus, str]:
+    if response.state == "merged":
+        return MonitorObservationStatus.SUCCESS, "pull_request_merged"
+    if response.state == "closed":
+        return MonitorObservationStatus.BLOCKED, "pull_request_closed"
+    if response.state != "open" or not response.head_revision:
+        return MonitorObservationStatus.PENDING, "pull_request_state_unknown"
+    check_states = {check.state for check in response.checks}
+    if "failed" in check_states:
+        return MonitorObservationStatus.ACTIONABLE, "checks_failed"
+    if response.review_decision == "changes_requested":
+        return MonitorObservationStatus.ACTIONABLE, "changes_requested"
+    if response.unresolved_review_threads:
+        return MonitorObservationStatus.ACTIONABLE, "unresolved_review_threads"
+    if response.mergeability == "conflicting":
+        return MonitorObservationStatus.ACTIONABLE, "merge_conflict"
+    if response.mergeability == "behind":
+        return MonitorObservationStatus.ACTIONABLE, "branch_behind"
+    if response.mergeability == "blocked":
+        return MonitorObservationStatus.ACTIONABLE, "merge_blocked"
+    if response.draft:
+        return MonitorObservationStatus.PENDING, "pull_request_draft"
+    if "pending" in check_states:
+        return MonitorObservationStatus.PENDING, "checks_pending"
+    if "unknown" in check_states:
+        return MonitorObservationStatus.PENDING, "checks_unknown"
+    if not response.review_threads_complete:
+        return MonitorObservationStatus.PENDING, "review_threads_incomplete"
+    if response.review_decision == "unknown":
+        return MonitorObservationStatus.PENDING, "review_state_unknown"
+    if response.review_decision == "review_required":
+        return MonitorObservationStatus.PENDING, "review_required"
+    if response.mergeability == "pending":
+        return MonitorObservationStatus.PENDING, "mergeability_pending"
+    return MonitorObservationStatus.SUCCESS, "review_ready"
+
+
+def _process_failure(
+    proc: subprocess.CompletedProcess[str],
+) -> GitHubPullRequestProbeResult | None:
+    if proc.returncode == 0:
+        return None
+    kind = _classify_cli_error(proc.stderr if isinstance(proc.stderr, str) else "")
+    reasons = {
+        ProviderErrorKind.RATE_LIMITED: "provider_rate_limited",
+        ProviderErrorKind.AUTHENTICATION: "provider_authentication",
+        ProviderErrorKind.AUTHORIZATION: "provider_authorization",
+        ProviderErrorKind.NOT_FOUND: "provider_not_found",
+        ProviderErrorKind.TRANSIENT: "provider_transient",
+    }
+    return _provider_error(kind, reasons[kind])
+
+
+def _classify_cli_error(raw: str) -> ProviderErrorKind:
+    lowered = raw.lower()
+    if "could not resolve host" in lowered:
+        return ProviderErrorKind.TRANSIENT
+    if any(
+        marker in lowered
+        for marker in ("http 429", "rate limit", "abuse detection", "too many requests")
+    ):
+        return ProviderErrorKind.RATE_LIMITED
+    if any(
+        marker in lowered
+        for marker in (
+            "http 401",
+            "bad credentials",
+            "authentication",
+            "not logged into",
+            "gh auth login",
+        )
+    ):
+        return ProviderErrorKind.AUTHENTICATION
+    if any(
+        marker in lowered
+        for marker in ("http 404", "not found", "could not resolve to a repository")
+    ):
+        return ProviderErrorKind.NOT_FOUND
+    if any(
+        marker in lowered
+        for marker in ("http 403", "forbidden", "permission", "resource not accessible")
+    ):
+        return ProviderErrorKind.AUTHORIZATION
+    return ProviderErrorKind.TRANSIENT
+
+
+def _provider_error(kind: ProviderErrorKind, reason_code: str) -> GitHubPullRequestProbeResult:
+    return GitHubPullRequestProbeResult(
+        response=None,
+        canonical={},
+        observation=MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=kind,
+            reason_code=reason_code,
+        ),
+    )

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -57,6 +57,7 @@ class ProviderErrorKind(str, Enum):
     AUTHENTICATION = "authentication"
     AUTHORIZATION = "authorization"
     NOT_FOUND = "not_found"
+    SETUP = "setup"
 
 
 class MonitorOutcome(str, Enum):
@@ -145,6 +146,7 @@ class MonitorObservation:
     provider_error: ProviderErrorKind | None = None
     reason_code: str = ""
     summary: str = ""
+    head_changed: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.status, MonitorObservationStatus):
@@ -155,9 +157,13 @@ class MonitorObservation:
             raise ValueError("reason_code must be a string")
         if not isinstance(self.summary, str):
             raise ValueError("summary must be a string")
+        if not isinstance(self.head_changed, bool):
+            raise ValueError("head_changed must be a boolean")
         if self.status is MonitorObservationStatus.PROVIDER_ERROR:
             if not isinstance(self.provider_error, ProviderErrorKind):
                 raise ValueError("provider_error must be a ProviderErrorKind for a provider error")
+            if self.head_changed:
+                raise ValueError("head_changed is not valid for a provider error observation")
             return
         if not self.fingerprint:
             raise ValueError("fingerprint is required for a comparable observation")
@@ -189,6 +195,11 @@ class MonitorState:
     input_tokens: int = 0
     output_tokens: int = 0
     consecutive_provider_errors: int = 0
+    probe_count: int = 0
+    provider_error_count: int = 0
+    last_probe_at: float = 0.0
+    last_decision: MonitorDecision | None = None
+    last_provider_error: ProviderErrorKind | None = None
     next_probe_at: float = 0.0
     outcome: MonitorOutcome | None = None
     stopped_reason: str = ""
@@ -207,6 +218,7 @@ class MonitorState:
             "created_ts",
             "last_observed_at",
             "last_completed_at",
+            "last_probe_at",
             "next_probe_at",
             "stopped_at",
         ):
@@ -223,6 +235,8 @@ class MonitorState:
             "input_tokens",
             "output_tokens",
             "consecutive_provider_errors",
+            "probe_count",
+            "provider_error_count",
         ):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
@@ -254,6 +268,12 @@ class MonitorState:
             raise ValueError("last_completion_disposition must be a MonitorActionDisposition")
         if not isinstance(self.token_usage_known, bool):
             raise ValueError("token_usage_known must be a boolean")
+        if self.last_decision is not None and not isinstance(self.last_decision, MonitorDecision):
+            raise ValueError("last_decision must be a MonitorDecision")
+        if self.last_provider_error is not None and not isinstance(
+            self.last_provider_error, ProviderErrorKind
+        ):
+            raise ValueError("last_provider_error must be a ProviderErrorKind")
         if self.outcome is not None and not isinstance(self.outcome, MonitorOutcome):
             raise ValueError("outcome must be a MonitorOutcome")
         if not isinstance(self.stopped_reason, str):
@@ -308,6 +328,12 @@ def monitor_state_from_dict(raw: object) -> MonitorState:
     disposition = values.get("last_completion_disposition")
     if disposition is not None:
         values["last_completion_disposition"] = MonitorActionDisposition(disposition)
+    decision = values.get("last_decision")
+    if decision is not None:
+        values["last_decision"] = MonitorDecision(decision)
+    provider_error = values.get("last_provider_error")
+    if provider_error is not None:
+        values["last_provider_error"] = ProviderErrorKind(provider_error)
     return MonitorState(**values)
 
 

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -1,0 +1,81 @@
+"""Persistence-only monitor probing with no action-delivery dependency."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Awaitable, Callable, Mapping
+from copy import deepcopy
+from typing import Protocol
+
+from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
+from kiro_crew.monitoring.models import (
+    MonitorDecision,
+    MonitorObservationStatus,
+    MonitorState,
+)
+
+ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
+
+
+class ShadowWakeDeliveryRefused(RuntimeError):
+    """Raised when a caller asks the persistence-only path to wake a session."""
+
+
+class GitHubShadowProvider(Protocol):
+    """External probe boundary required by the shadow controller."""
+
+    def probe(
+        self,
+        raw_target: str,
+        *,
+        previous_observation: Mapping[str, object] | None = None,
+    ) -> GitHubPullRequestProbeResult: ...
+
+
+async def run_shadow_probe(
+    state: MonitorState,
+    provider: GitHubShadowProvider,
+    persist: ShadowStatePersistence,
+    *,
+    now: float,
+    wake_delivery: bool = False,
+) -> MonitorDecision:
+    """Probe and persist one decision without acquiring a delivery capability."""
+    if wake_delivery:
+        raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
+    if state.kind != "github_pull_request" or state.objective != "review_ready":
+        raise ValueError("shadow mode supports only github_pull_request review_ready")
+    if (
+        isinstance(now, bool)
+        or not isinstance(now, (int, float))
+        or not math.isfinite(now)
+        or now < 0
+    ):
+        raise ValueError("now must be a finite non-negative number")
+    if not callable(persist):
+        raise ValueError("persist must be callable")
+
+    result = await asyncio.to_thread(
+        provider.probe,
+        state.target,
+        previous_observation=deepcopy(state.last_observation),
+    )
+    decision = decide_monitor(state, result.observation, now=now)
+    state.probe_count += 1
+    state.last_probe_at = now
+    state.last_decision = decision
+    state.next_probe_at = now + state.cadence_secs
+    if result.observation.status is MonitorObservationStatus.PROVIDER_ERROR:
+        state.provider_error_count += 1
+        state.consecutive_provider_errors += 1
+        state.last_provider_error = result.observation.provider_error
+    else:
+        state.last_observation = deepcopy(result.canonical)
+        state.last_fingerprint = result.observation.fingerprint
+        state.last_observed_at = now
+        state.consecutive_provider_errors = 0
+        state.last_provider_error = None
+    await persist(state)
+    return decision

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1092,6 +1092,10 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # Redacts INBOUND attacker-controllable provider metadata before it is
         # stored/displayed — a sanitizer on the way in, not an output boundary.
         "dashboard/handlers/mcp_discover.py",
+        # Inbound provider sanitization: check identities are stripped of URLs and
+        # credentials before they enter canonical monitor state. The controller's
+        # later agent-session injection is the registered output boundary.
+        "monitoring/github_pull_request.py",
         # Computer use: the redaction pass runs on third-party desktop content
         # (window titles, accessibility values) on its way INTO the model's
         # context, exactly like the MCP tool-result paths above. `policy.py` owns

--- a/test/test_github_pull_request_monitor.py
+++ b/test/test_github_pull_request_monitor.py
@@ -1,0 +1,1094 @@
+"""GitHub pull-request monitor provider and canonicalization contracts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from copy import deepcopy
+
+import pytest
+
+from kiro_crew.github_runner import SetupError
+from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.github_pull_request import (
+    GitHubPullRequestProvider,
+    GitHubPullRequestTarget,
+    parse_github_pull_request_target,
+)
+from kiro_crew.monitoring.models import (
+    MonitorDecision,
+    MonitorObservationStatus,
+    MonitorState,
+    ProviderErrorKind,
+    monitor_state_to_dict,
+)
+from kiro_crew.monitoring.shadow import ShadowWakeDeliveryRefused, run_shadow_probe
+
+_HEAD = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _primary(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "number": 123,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": _HEAD,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-22T00:00:00Z",
+                "completedAt": "2026-08-22T00:01:00Z",
+            },
+            {
+                "__typename": "StatusContext",
+                "context": "lint",
+                "state": "SUCCESS",
+                "targetUrl": "https://github.com/owner/repo/statuses/sha",
+            },
+        ],
+    }
+    payload.update(changes)
+    return payload
+
+
+def _threads(
+    nodes: list[dict[str, object]] | None = None,
+    *,
+    has_next: bool = False,
+    cursor: str | None = None,
+) -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {
+                            "hasNextPage": has_next,
+                            "endCursor": cursor,
+                        },
+                        "nodes": (
+                            nodes
+                            if nodes is not None
+                            else [{"isResolved": True}, {"isResolved": True}]
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+
+class _FakeRunner:
+    def __init__(self, payloads: Sequence[dict[str, object]]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def __call__(self, argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        self.calls.append((list(argv), kwargs))
+        payload = self._payloads.pop(0)
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+
+def _provider(*payloads: dict[str, object]) -> tuple[GitHubPullRequestProvider, _FakeRunner]:
+    runner = _FakeRunner(payloads)
+    return (
+        GitHubPullRequestProvider(
+            resolver=lambda: "/trusted/bin/gh",
+            runner=runner,
+        ),
+        runner,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "https://github.com/owner/repo/pull/123",
+            GitHubPullRequestTarget("github.com", "owner", "repo", 123),
+        ),
+        (
+            "https://www.github.com/Owner-1/repo_name/pull/7",
+            GitHubPullRequestTarget("github.com", "Owner-1", "repo_name", 7),
+        ),
+    ],
+)
+def test_pull_request_target_normalizes_only_public_github_urls(
+    raw: str,
+    expected: GitHubPullRequestTarget,
+) -> None:
+    """Changing public-host normalization or typed identity breaks this contract."""
+    assert parse_github_pull_request_target(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "owner/repo#123",
+        "git@github.com:owner/repo.git",
+        "http://github.com/owner/repo/pull/123",
+        "https://github.example.com/owner/repo/pull/123",
+        "https://enterprise.github.com/owner/repo/pull/123",
+        "https://github.com/owner/repo",
+        "https://github.com/owner/repo/issues/123",
+        "https://github.com/owner/repo/pull/0",
+        "https://github.com/owner/repo/pull/-1",
+        "https://github.com/owner/repo/pull/not-a-number",
+        "https://github.com/owner/repo/pull/123/files",
+        "https://github.com/owner/repo/pull/123/",
+        "https://github.com/owner/repo/pull/123?diff=split",
+        "https://github.com/owner/repo/pull/123#discussion",
+        "https://user@github.com/owner/repo/pull/123",
+        "https://github.com:443/owner/repo/pull/123",
+        "https://github.com:notaport/owner/repo/pull/123",
+        "https://github.com/../repo/pull/123",
+        "https://github.com/owner/repo;touch/pull/123",
+    ],
+)
+def test_pull_request_target_rejects_noncanonical_or_untrusted_input(raw: str) -> None:
+    """Weakening target validation would let input select a host or command shape."""
+    with pytest.raises(ValueError, match="GitHub pull request"):
+        parse_github_pull_request_target(raw)
+
+
+def test_clean_pull_request_has_allowlisted_canonical_observation_and_fingerprint() -> None:
+    """Adding provider payload fields or omitting a readiness fact breaks persistence."""
+    provider, runner = _provider(_primary(), _threads())
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical == {
+        "blocking_review": "none",
+        "checks": {
+            "failed": [],
+            "passed": ["CI / test", "lint"],
+            "pending": [],
+            "unknown": [],
+        },
+        "draft": False,
+        "head_revision": _HEAD,
+        "kind": "github_pull_request",
+        "mergeability": "mergeable",
+        "review_decision": "approved",
+        "review_threads_complete": True,
+        "state": "open",
+        "target": "github.com/owner/repo#123",
+        "unresolved_review_threads": 0,
+    }
+    assert result.observation.status is MonitorObservationStatus.SUCCESS
+    assert result.observation.reason_code == "review_ready"
+    assert result.observation.fingerprint == (
+        "8d7a3844c6c0c44350e62e7823a62c941b9484a140a517326c630e780a8be30f"
+    )
+    primary_argv, primary_kwargs = runner.calls[0]
+    assert primary_argv == [
+        "/trusted/bin/gh",
+        "pr",
+        "view",
+        "https://github.com/owner/repo/pull/123",
+        "--json",
+        (
+            "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,"
+            "reviewDecision,statusCheckRollup"
+        ),
+    ]
+    assert primary_kwargs["audit_caller"] == "core:monitor"
+    assert primary_kwargs["pin_host"] == "github.com"
+
+
+def test_reordered_and_volatile_provider_values_keep_the_fingerprint_stable() -> None:
+    """Ordering, URLs, request ids, bodies, logs, and timestamps are never durable facts."""
+    first_provider, _ = _provider(_primary(), _threads())
+    noisy_checks = list(reversed(_primary()["statusCheckRollup"]))
+    noisy_checks[0] = {
+        **noisy_checks[0],
+        "targetUrl": "https://github.com/owner/repo/statuses/different",
+        "requestId": "request-2",
+    }
+    noisy_checks[1] = {
+        **noisy_checks[1],
+        "startedAt": "2030-01-01T00:00:00Z",
+        "completedAt": "2030-01-01T00:01:00Z",
+        "detailsUrl": "https://github.com/owner/repo/actions/runs/999",
+        "logText": "credential-like provider output",
+    }
+    noisy_primary = _primary(
+        statusCheckRollup=noisy_checks,
+        title="volatile title",
+        body="volatile body",
+        url="https://github.com/owner/repo/pull/123",
+        requestId="request-1",
+        updatedAt="2030-01-01T00:00:00Z",
+    )
+    second_provider, _ = _provider(
+        noisy_primary,
+        _threads(nodes=[{"isResolved": True}, {"isResolved": True}]),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert second.canonical == first.canonical
+    assert second.observation.fingerprint == first.observation.fingerprint
+    serialized = json.dumps(second.canonical, sort_keys=True)
+    for forbidden in (
+        "request-1",
+        "request-2",
+        "volatile title",
+        "volatile body",
+        "credential-like",
+        "2030-01-01",
+        "https://",
+    ):
+        assert forbidden not in serialized
+
+
+def test_check_identity_is_redacted_before_it_enters_canonical_state() -> None:
+    """A provider-controlled check label cannot turn monitor state into a secret sink."""
+    token = "ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(),
+                    "workflowName": f"CI {token}",
+                    "name": "https://internal.example.test/run?id=secret",
+                }
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    serialized = json.dumps(result.canonical, sort_keys=True)
+    assert token not in serialized
+    assert "internal.example.test" not in serialized
+    assert "request?id" not in serialized
+
+
+def test_latest_check_rerun_wins_without_collection_order_affecting_fingerprint() -> None:
+    """Choosing list order instead of the latest run can hide or invent a failure."""
+    older_failure = {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": "COMPLETED",
+        "conclusion": "FAILURE",
+        "startedAt": "2026-08-21T00:00:00Z",
+        "completedAt": "2026-08-21T00:01:00Z",
+    }
+    newer_success = {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "startedAt": "2026-08-22T00:00:00Z",
+        "completedAt": "2026-08-22T00:01:00Z",
+    }
+    first_provider, _ = _provider(
+        _primary(statusCheckRollup=[older_failure, newer_success]),
+        _threads(),
+    )
+    second_provider, _ = _provider(
+        _primary(statusCheckRollup=[newer_success, older_failure]),
+        _threads(),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical["checks"] == {
+        "failed": [],
+        "passed": ["CI / test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert first.observation.fingerprint == second.observation.fingerprint
+
+
+def test_ambiguous_same_identity_check_runs_fail_closed_as_unknown() -> None:
+    """A same-position pass cannot hide a distinct same-identity failure."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                _check_run(conclusion="SUCCESS"),
+                _check_run(conclusion="FAILURE"),
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": [],
+        "passed": [],
+        "pending": [],
+        "unknown": ["CI / test"],
+    }
+    assert result.observation.status is MonitorObservationStatus.PENDING
+
+
+def test_same_named_workflowless_check_runs_do_not_hide_an_older_failure() -> None:
+    """Rows without workflow identity cannot safely be treated as one rerun chain."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "workflowName": "",
+                    "startedAt": "2026-08-21T00:00:00Z",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "workflowName": "",
+                    "startedAt": "2026-08-22T00:00:00Z",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": [],
+        "passed": [],
+        "pending": [],
+        "unknown": ["test"],
+    }
+    assert result.observation.status is MonitorObservationStatus.PENDING
+
+
+def test_startedless_queued_rerun_supersedes_an_older_completed_run() -> None:
+    """A newly queued run has no timestamp but must not expose a stale green state."""
+    queued = _check_run(status="QUEUED", conclusion="")
+    queued["startedAt"] = None
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                _check_run(conclusion="SUCCESS"),
+                queued,
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": [],
+        "passed": [],
+        "pending": ["CI / test"],
+        "unknown": [],
+    }
+    assert result.observation.reason_code == "checks_pending"
+
+
+def _check_run(*, status: str = "COMPLETED", conclusion: str = "SUCCESS") -> dict[str, object]:
+    return {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": status,
+        "conclusion": conclusion,
+        "startedAt": "2026-08-22T00:00:00Z",
+        "completedAt": "2026-08-22T00:01:00Z",
+    }
+
+
+@pytest.mark.parametrize(
+    ("primary_changes", "thread_nodes", "status", "reason"),
+    [
+        (
+            {"statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")]},
+            None,
+            MonitorObservationStatus.PENDING,
+            "checks_pending",
+        ),
+        (
+            {"statusCheckRollup": [_check_run(conclusion="FROBNICATED")]},
+            None,
+            MonitorObservationStatus.PENDING,
+            "checks_unknown",
+        ),
+        (
+            {"statusCheckRollup": [_check_run(conclusion="FAILURE")]},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "checks_failed",
+        ),
+        (
+            {"reviewDecision": "CHANGES_REQUESTED"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "changes_requested",
+        ),
+        (
+            {},
+            [{"isResolved": True}, {"isResolved": False}],
+            MonitorObservationStatus.ACTIONABLE,
+            "unresolved_review_threads",
+        ),
+        (
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "merge_conflict",
+        ),
+        (
+            {"mergeStateStatus": "BEHIND"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "branch_behind",
+        ),
+        (
+            {"mergeStateStatus": "BLOCKED"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "merge_blocked",
+        ),
+        (
+            {"isDraft": True},
+            None,
+            MonitorObservationStatus.PENDING,
+            "pull_request_draft",
+        ),
+        (
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+            None,
+            MonitorObservationStatus.PENDING,
+            "mergeability_pending",
+        ),
+        (
+            {"reviewDecision": "UNKNOWN"},
+            None,
+            MonitorObservationStatus.PENDING,
+            "review_state_unknown",
+        ),
+        (
+            {"reviewDecision": "REVIEW_REQUIRED"},
+            None,
+            MonitorObservationStatus.PENDING,
+            "review_required",
+        ),
+        (
+            {"state": "CLOSED"},
+            None,
+            MonitorObservationStatus.BLOCKED,
+            "pull_request_closed",
+        ),
+        (
+            {"state": "MERGED"},
+            None,
+            MonitorObservationStatus.SUCCESS,
+            "pull_request_merged",
+        ),
+    ],
+)
+def test_pull_request_classification_matrix(
+    primary_changes: dict[str, object],
+    thread_nodes: list[dict[str, object]] | None,
+    status: MonitorObservationStatus,
+    reason: str,
+) -> None:
+    """Changing one readiness fact must select its conservative typed outcome."""
+    provider, _ = _provider(_primary(**primary_changes), _threads(nodes=thread_nodes))
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is status
+    assert result.observation.reason_code == reason
+
+
+@pytest.mark.parametrize(
+    ("primary_changes", "thread_nodes", "reason"),
+    [
+        (
+            {
+                "statusCheckRollup": [
+                    _check_run(conclusion="FAILURE"),
+                    {
+                        "__typename": "StatusContext",
+                        "context": "deploy",
+                        "state": "PENDING",
+                    },
+                ]
+            },
+            None,
+            "checks_failed",
+        ),
+        (
+            {
+                "reviewDecision": "CHANGES_REQUESTED",
+                "statusCheckRollup": [_check_run(conclusion="FROBNICATED")],
+            },
+            None,
+            "changes_requested",
+        ),
+        (
+            {"statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")]},
+            [{"isResolved": False}],
+            "unresolved_review_threads",
+        ),
+        (
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")],
+            },
+            None,
+            "merge_conflict",
+        ),
+    ],
+)
+def test_known_actionable_fact_precedes_simultaneous_pending_or_unknown_fact(
+    primary_changes: dict[str, object],
+    thread_nodes: list[dict[str, object]] | None,
+    reason: str,
+) -> None:
+    """Known work must wake the owner even when unrelated provider facts are unsettled."""
+    provider, _ = _provider(_primary(**primary_changes), _threads(nodes=thread_nodes))
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == reason
+
+
+def test_actionable_fingerprint_ignores_unrelated_pending_check_churn() -> None:
+    """Renaming an unsettled check cannot issue a second wake for the same known failure."""
+
+    def mixed_checks(pending_name: str) -> list[dict[str, object]]:
+        return [
+            _check_run(conclusion="FAILURE"),
+            {
+                "__typename": "StatusContext",
+                "context": pending_name,
+                "state": "PENDING",
+            },
+        ]
+
+    first_provider, _ = _provider(
+        _primary(statusCheckRollup=mixed_checks("deploy")),
+        _threads(),
+    )
+    second_provider, _ = _provider(
+        _primary(statusCheckRollup=mixed_checks("publish")),
+        _threads(),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical != second.canonical
+    assert first.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert second.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert first.observation.fingerprint == second.observation.fingerprint
+
+
+@pytest.mark.parametrize(
+    ("merge_state", "mergeability", "status"),
+    [
+        ("CLEAN", "mergeable", MonitorObservationStatus.SUCCESS),
+        ("HAS_HOOKS", "mergeable", MonitorObservationStatus.SUCCESS),
+        ("UNSTABLE", "mergeable", MonitorObservationStatus.SUCCESS),
+        ("", "pending", MonitorObservationStatus.PENDING),
+        ("FUTURE_STATE", "pending", MonitorObservationStatus.PENDING),
+    ],
+)
+def test_mergeability_only_accepts_known_settled_merge_states(
+    merge_state: str,
+    mergeability: str,
+    status: MonitorObservationStatus,
+) -> None:
+    """An empty or future provider enum cannot fall through to review-ready success."""
+    provider, _ = _provider(_primary(mergeStateStatus=merge_state), _threads())
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["mergeability"] == mergeability
+    assert result.observation.status is status
+
+
+def test_review_threads_paginate_and_fold_order_independently() -> None:
+    """Stopping after one page can falsely report no blocking review threads."""
+    first_provider, first_runner = _provider(
+        _primary(),
+        _threads([{"isResolved": True}], has_next=True, cursor="cursor-1"),
+        _threads([{"isResolved": False}], has_next=False),
+    )
+    second_provider, _ = _provider(
+        _primary(),
+        _threads([{"isResolved": False}], has_next=True, cursor="cursor-2"),
+        _threads([{"isResolved": True}], has_next=False),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical["unresolved_review_threads"] == 1
+    assert first.canonical["review_threads_complete"] is True
+    assert first.observation.fingerprint == second.observation.fingerprint
+    assert len(first_runner.calls) == 3
+    assert "cursor=cursor-1" in first_runner.calls[2][0]
+
+
+def test_review_thread_page_cap_is_pending_instead_of_success() -> None:
+    """An eleventh page cannot be silently treated as an empty complete tail."""
+    pages = [
+        _threads(
+            [{"isResolved": True}],
+            has_next=True,
+            cursor=f"cursor-{page}",
+        )
+        for page in range(1, 11)
+    ]
+    provider, runner = _provider(_primary(), *pages)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert len(runner.calls) == 11
+
+
+def test_review_thread_missing_next_cursor_is_pending_instead_of_success() -> None:
+    """A partial pagination envelope is not evidence that the unseen tail is empty."""
+    provider, runner = _provider(
+        _primary(),
+        _threads([{"isResolved": True}], has_next=True, cursor=None),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert len(runner.calls) == 2
+
+
+def test_review_thread_graphql_errors_make_partial_data_pending() -> None:
+    """GraphQL can return usable-looking data alongside errors; it is still incomplete."""
+    partial = _threads([{"isResolved": True}])
+    partial["errors"] = [{"message": "provider-controlled detail"}]
+    provider, _ = _provider(_primary(), partial)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert "provider-controlled detail" not in repr(result)
+
+
+def test_changed_head_is_explicitly_actionable_even_when_new_facts_are_green() -> None:
+    """A green new revision must not terminate before the owner can inspect it."""
+    previous_provider, _ = _provider(_primary(), _threads())
+    previous = previous_provider.probe("https://github.com/owner/repo/pull/123")
+    new_head = "fedcba9876543210fedcba9876543210fedcba98"
+    current_provider, _ = _provider(_primary(headRefOid=new_head), _threads())
+
+    current = current_provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation=previous.canonical,
+    )
+    state = MonitorState(
+        kind="github_pull_request",
+        target="github.com/owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation=deepcopy(previous.canonical),
+        last_fingerprint=previous.observation.fingerprint,
+    )
+
+    assert current.observation.head_changed is True
+    assert current.observation.status is MonitorObservationStatus.SUCCESS
+    assert current.observation.fingerprint != previous.observation.fingerprint
+    assert decide_monitor(state, current.observation, now=1_001.0) is (
+        MonitorDecision.WAKE_ACTIONABLE
+    )
+
+
+def test_missing_current_head_is_pending_without_a_changed_head_wake() -> None:
+    """A missing current SHA is provider uncertainty, not evidence of a new revision."""
+    provider, _ = _provider(_primary(headRefOid=""), _threads())
+    state = MonitorState(
+        kind="github_pull_request",
+        target="github.com/owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation={"head_revision": _HEAD},
+        last_fingerprint="previous-fingerprint",
+    )
+
+    result = provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation=state.last_observation,
+    )
+
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.head_changed is False
+    assert decide_monitor(state, result.observation, now=1_001.0) is MonitorDecision.RECORD_ONLY
+
+
+@pytest.mark.parametrize(
+    ("provider_state", "expected"),
+    [
+        ("MERGED", MonitorDecision.STOP_SUCCESS),
+        ("CLOSED", MonitorDecision.STOP_BLOCKED),
+    ],
+)
+def test_terminal_pull_request_state_precedes_a_head_revision_change(
+    provider_state: str,
+    expected: MonitorDecision,
+) -> None:
+    """A terminal lifecycle cannot reopen merely because its final head is new."""
+    provider, _ = _provider(_primary(state=provider_state), _threads())
+    state = MonitorState(
+        kind="github_pull_request",
+        target="github.com/owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation={"head_revision": "previous-head"},
+    )
+
+    result = provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation=state.last_observation,
+    )
+
+    assert result.observation.head_changed is False
+    assert decide_monitor(state, result.observation, now=1_001.0) is expected
+
+
+class _FailureRunner:
+    def __init__(
+        self,
+        *,
+        returncode: int = 1,
+        stderr: str = "",
+        error: BaseException | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.error = error
+
+    def __call__(self, argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if self.error is not None:
+            raise self.error
+        return subprocess.CompletedProcess(argv, self.returncode, stdout="", stderr=self.stderr)
+
+
+@pytest.mark.parametrize(
+    ("provider_state", "status", "reason"),
+    [
+        ("MERGED", MonitorObservationStatus.SUCCESS, "pull_request_merged"),
+        ("CLOSED", MonitorObservationStatus.BLOCKED, "pull_request_closed"),
+    ],
+)
+def test_terminal_lifecycle_does_not_query_review_threads(
+    provider_state: str,
+    status: MonitorObservationStatus,
+    reason: str,
+) -> None:
+    """Secondary GraphQL failure cannot override an already-terminal primary lifecycle."""
+    calls = 0
+
+    def runner(argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=json.dumps(_primary(state=provider_state)),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            argv,
+            1,
+            stdout="",
+            stderr="HTTP 503: secondary query unavailable",
+        )
+
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is status
+    assert result.observation.reason_code == reason
+    assert calls == 1
+
+
+def test_boolean_pull_request_number_is_a_malformed_primary_response() -> None:
+    """Python boolean equality must not let a non-integer provider number pass validation."""
+    provider, runner = _provider(_primary(number=True))
+
+    result = provider.probe("https://github.com/owner/repo/pull/1")
+
+    assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+    assert result.observation.reason_code == "provider_malformed_response"
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("stderr", "kind", "reason"),
+    [
+        ("HTTP 401: Bad credentials", ProviderErrorKind.AUTHENTICATION, "provider_authentication"),
+        (
+            "HTTP 403: secondary rate limit exceeded",
+            ProviderErrorKind.RATE_LIMITED,
+            "provider_rate_limited",
+        ),
+        (
+            "HTTP 403: resource not accessible",
+            ProviderErrorKind.AUTHORIZATION,
+            "provider_authorization",
+        ),
+        ("HTTP 404: Not Found", ProviderErrorKind.NOT_FOUND, "provider_not_found"),
+        ("HTTP 429: too many requests", ProviderErrorKind.RATE_LIMITED, "provider_rate_limited"),
+        ("HTTP 503: unavailable", ProviderErrorKind.TRANSIENT, "provider_transient"),
+        ("dial tcp: connection refused", ProviderErrorKind.TRANSIENT, "provider_transient"),
+        ("Could not resolve host: github.com", ProviderErrorKind.TRANSIENT, "provider_transient"),
+        (
+            "not logged into any GitHub hosts; run gh auth login",
+            ProviderErrorKind.AUTHENTICATION,
+            "provider_authentication",
+        ),
+        (
+            "Could not resolve to a Repository with the name 'owner/repo'",
+            ProviderErrorKind.NOT_FOUND,
+            "provider_not_found",
+        ),
+    ],
+)
+def test_provider_cli_failures_map_to_fixed_nonleaking_categories(
+    stderr: str,
+    kind: ProviderErrorKind,
+    reason: str,
+) -> None:
+    """Raw stderr cannot become durable or loggable monitor state."""
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr=stderr),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is None
+    assert result.canonical == {}
+    assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+    assert result.observation.provider_error is kind
+    assert result.observation.reason_code == reason
+    assert result.observation.fingerprint == ""
+    assert stderr not in repr(result)
+
+
+@pytest.mark.parametrize(
+    ("resolver", "runner", "kind"),
+    [
+        (
+            lambda: (_ for _ in ()).throw(SetupError("untrusted /tmp/gh")),
+            _FailureRunner(),
+            ProviderErrorKind.SETUP,
+        ),
+        (
+            lambda: "/trusted/bin/gh",
+            _FailureRunner(error=subprocess.TimeoutExpired(["gh"], 30)),
+            ProviderErrorKind.TRANSIENT,
+        ),
+        (
+            lambda: "/trusted/bin/gh",
+            _FailureRunner(error=FileNotFoundError("/private/path/gh")),
+            ProviderErrorKind.SETUP,
+        ),
+        (
+            lambda: "/trusted/bin/gh",
+            _FailureRunner(error=PermissionError("/private/path/gh")),
+            ProviderErrorKind.SETUP,
+        ),
+    ],
+)
+def test_provider_setup_and_transport_exceptions_have_typed_categories(
+    resolver: object,
+    runner: _FailureRunner,
+    kind: ProviderErrorKind,
+) -> None:
+    """Local setup is terminal while network timeouts remain retryable."""
+    provider = GitHubPullRequestProvider(resolver=resolver, runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.provider_error is kind
+    assert result.observation.reason_code in {"provider_setup", "provider_transient"}
+    assert "/tmp/gh" not in repr(result)
+    assert "/private/path/gh" not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "payloads",
+    [
+        ({"number": 123},),
+        (_primary(), {"data": {"repository": None}}),
+    ],
+)
+def test_malformed_provider_payload_is_a_retryable_nonleaking_error(
+    payloads: tuple[dict[str, object], ...],
+) -> None:
+    """Partial JSON is provider uncertainty, not evidence of readiness."""
+    provider, _ = _provider(*payloads)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is None
+    assert result.canonical == {}
+    assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
+    assert result.observation.reason_code == "provider_malformed_response"
+
+
+def test_secret_bearing_stderr_never_reaches_result_or_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Credentials, paths, URLs, and provider text are discarded after classification."""
+    raw = (
+        "HTTP 403 token ghp_abcdefghijklmnopqrstuvwxyz123456 "
+        "/home/user/private https://internal.example.test/request?id=secret"
+    )
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr=raw),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    combined = repr(result) + caplog.text
+    for forbidden in ("ghp_", "/home/user", "internal.example.test", "request?id"):
+        assert forbidden not in combined
+
+
+@pytest.mark.asyncio
+async def test_shadow_probe_persists_observation_decision_and_metrics_without_a_wake() -> None:
+    """An actionable shadow result records evidence but cannot claim or charge a turn."""
+    provider, _ = _provider(
+        _primary(statusCheckRollup=[_check_run(conclusion="FAILURE")]),
+        _threads(),
+    )
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+    snapshots: list[dict[str, object]] = []
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(monitor_state_to_dict(updated)))
+
+    decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert decision is MonitorDecision.WAKE_ACTIONABLE
+    assert state.last_decision is MonitorDecision.WAKE_ACTIONABLE
+    assert state.probe_count == 1
+    assert state.provider_error_count == 0
+    assert state.last_probe_at == 1_100.0
+    assert state.last_observed_at == 1_100.0
+    assert state.next_probe_at == 1_100.0 + state.cadence_secs
+    assert state.last_observation["checks"] == {
+        "failed": ["CI / test"],
+        "passed": [],
+        "pending": [],
+        "unknown": [],
+    }
+    assert state.last_fingerprint
+    assert state.last_wake_fingerprint == ""
+    assert state.wake_in_flight is False
+    assert state.agent_turns == 0
+    assert state.input_tokens == state.output_tokens == 0
+    assert len(snapshots) == 1
+    assert snapshots[0]["last_decision"] == MonitorDecision.WAKE_ACTIONABLE
+
+
+@pytest.mark.asyncio
+async def test_shadow_provider_error_persists_only_fixed_error_metrics() -> None:
+    """A retryable failure advances probe metrics without replacing the last good facts."""
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr="HTTP 429 token ghp_abcdefghijklmnopqrstuvwxyz123456"),
+    )
+    previous = {"head_revision": _HEAD, "safe": "fact"}
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation=deepcopy(previous),
+        last_fingerprint="safe-fingerprint",
+    )
+    snapshots: list[dict[str, object]] = []
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(monitor_state_to_dict(updated)))
+
+    decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert decision is MonitorDecision.RETRY_PROVIDER
+    assert state.last_observation == previous
+    assert state.last_fingerprint == "safe-fingerprint"
+    assert state.probe_count == 1
+    assert state.provider_error_count == 1
+    assert state.consecutive_provider_errors == 1
+    assert state.last_provider_error is ProviderErrorKind.RATE_LIMITED
+    assert state.last_decision is MonitorDecision.RETRY_PROVIDER
+    assert "ghp_" not in repr(snapshots)
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_refuses_wake_delivery_before_probe_or_persistence() -> None:
+    """Turning shadow mode into a dispatcher path must require a later controller change."""
+    probes = 0
+    persists = 0
+
+    class Provider:
+        def probe(self, raw_target: str, **kwargs: object) -> object:
+            nonlocal probes
+            probes += 1
+            raise AssertionError("shadow refusal must happen before the provider boundary")
+
+    async def persist(updated: MonitorState) -> None:
+        nonlocal persists
+        persists += 1
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ShadowWakeDeliveryRefused, match="shadow mode"):
+        await run_shadow_probe(
+            state,
+            Provider(),
+            persist,
+            now=1_100.0,
+            wake_delivery=True,
+        )
+
+    assert probes == 0
+    assert persists == 0
+    assert state.probe_count == 0
+    assert state.last_wake_fingerprint == ""
+    assert state.wake_in_flight is False

--- a/test/test_monitor_decision.py
+++ b/test/test_monitor_decision.py
@@ -86,6 +86,7 @@ def test_observation_changes_control_when_a_model_turn_is_allowed(
         (ProviderErrorKind.AUTHENTICATION, 0, MonitorDecision.STOP_BLOCKED),
         (ProviderErrorKind.AUTHORIZATION, 0, MonitorDecision.STOP_BLOCKED),
         (ProviderErrorKind.NOT_FOUND, 0, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.SETUP, 0, MonitorDecision.STOP_BLOCKED),
     ],
 )
 def test_provider_failures_never_buy_a_model_turn(
@@ -197,6 +198,17 @@ def test_provider_error_observation_requires_a_string_fingerprint() -> None:
             [],
             MonitorObservationStatus.PROVIDER_ERROR,
             provider_error=ProviderErrorKind.TRANSIENT,
+        )
+
+
+def test_provider_error_observation_rejects_a_changed_head_fact() -> None:
+    """A failed provider call cannot claim to have observed a new revision."""
+    with pytest.raises(ValueError, match="head_changed"):
+        MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+            head_changed=True,
         )
 
 

--- a/test/test_monitor_persistence.py
+++ b/test/test_monitor_persistence.py
@@ -8,8 +8,10 @@ from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
 from kiro_crew.monitoring.models import (
     DEFAULT_MONITOR_CADENCE_SECS,
     MonitorBudgets,
+    MonitorDecision,
     MonitorOutcome,
     MonitorState,
+    ProviderErrorKind,
     monitor_state_from_dict,
     monitor_state_to_dict,
 )
@@ -114,6 +116,11 @@ def test_monitor_state_survives_store_round_trip(tmp_path) -> None:
         input_tokens=12_000,
         output_tokens=3_000,
         consecutive_provider_errors=1,
+        probe_count=4,
+        provider_error_count=2,
+        last_probe_at=1_240.0,
+        last_decision=MonitorDecision.RETRY_PROVIDER,
+        last_provider_error=ProviderErrorKind.RATE_LIMITED,
         next_probe_at=1_500.0,
         outcome=MonitorOutcome.BUDGET,
         stopped_reason="token_budget",
@@ -148,6 +155,11 @@ def test_monitor_state_survives_store_round_trip(tmp_path) -> None:
     assert restored.cadence_secs == 120
     assert restored.agent_turns == 2
     assert restored.total_tokens == 15_000
+    assert restored.probe_count == 4
+    assert restored.provider_error_count == 2
+    assert restored.last_probe_at == 1_240.0
+    assert restored.last_decision is MonitorDecision.RETRY_PROVIDER
+    assert restored.last_provider_error is ProviderErrorKind.RATE_LIMITED
     assert restored.outcome is MonitorOutcome.BUDGET
     assert restored.stopped_reason == "token_budget"
 


### PR DESCRIPTION
Stack: #5171 → #5172 → #5173 → #5174 → #5175 → #5176 → #5177

Position: 4 of 7. Base: #5173. Next: #5175.

Adds a bounded public GitHub pull-request probe with canonical facts, stable actionable fingerprints, and no-wake shadow execution.

Verification: provider, shadow, security posture, and validation suites.
