### PR TITLE
refactor: route babysit through structured monitors

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1422,6 +1422,15 @@ review threads, and merge blockers) take precedence over simultaneous pending or
 unknown facts. For an actionable classification its deduplication fingerprint
 contains the known blockers but excludes unrelated pending/unknown check churn;
 the full allowlisted canonical observation remains available for inspection.
+Before any fresh provider probe or persisted `BUSY` redispatch, the controller
+persists a terminal budget outcome when a positive runtime, completed-turn, or
+reported-token limit is already spent; an exhausted monitor therefore performs
+neither another provider request nor another action attempt. A previously
+accepted `DISPATCHED` wake still waits for its completion evidence or its bounded
+evidence deadline instead of being cancelled by this check. Token enforcement
+uses the usage values the provider reports; the public `token_usage_known` field
+states whether every completed turn supplied them, while runtime and completed-
+turn limits remain hard fallbacks.
 
 A new actionable fingerprint atomically records `last_wake_fingerprint` and
 `wake_in_flight=True` before delivery. Concurrent or restarted ticks cannot
@@ -1433,7 +1442,8 @@ not completion evidence. A pre-turn delivery failure retires the record as
 target unavailable without charging a turn or immediately retrying the same
 fingerprint. Every adapter returns `DISPATCHED`, `BUSY`, or `UNAVAILABLE`.
 `BUSY` persists a short retry for the existing claim without probing or entering
-the model; `DISPATCHED` persists a bounded completion-evidence deadline; only
+the model, but a spent budget terminates it before redispatch; `DISPATCHED`
+persists a bounded completion-evidence deadline; only
 `UNAVAILABLE` is terminal. Expiry without a raw completion event retains the
 terminal `completion_evidence_unavailable` outcome and clears the claim without
 charging or redispatching it. Cadence changes update the policy used for the next
@@ -1448,7 +1458,10 @@ The stateless MCP surface is `monitor_watch`, the extended `monitor_update`,
 `monitor_inspect`, and `monitor_stop`. Create/update/stop directives carry no
 session or loop identifier and are applied to the consumer's authoritative
 binding after the same dashboard/Slack/Discord authorization and critical SEL
-audit as legacy loops. `monitor_inspect` alone is a direct read: it requires a
+audit as legacy loops. A create acknowledgement is therefore only pending until
+the current turn ends; the operator may confirm application in the dashboard,
+while the agent can inspect only from a later user/wake turn. `monitor_inspect`
+alone is a direct read: it requires a
 strict authenticated session key and reports unavailable rather than using
 ancestor fallback. Changing target/objective clears comparison and wake
 baselines and increments the durable configuration generation; a probe result is
@@ -1481,7 +1494,8 @@ fields. Legacy `PATCH
 a structured id through the monitor stop authorizer and its audit-before-mutation
 ordering; the generic service update also fails closed for structured records.
 The public monitor projection used by list, slot, WebSocket, and authenticated
-`monitor_inspect` reads includes the canonical `last_observation` plus the dedicated
+`monitor_inspect` reads includes `token_usage_known`, the canonical
+`last_observation`, plus the dedicated
 `last_observation_status`, `last_observation_reason_code`, and
 `last_observation_summary`; persistence-only and raw provider fields remain excluded.
 The projection reconstructs GitHub facts from fixed root and check-bucket allowlists

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -636,6 +636,17 @@ help a user enable and interpret it. It does not enable the feature or trigger
 generation, and holds no runtime-written frontmatter, since a builtin skill is
 re-synced by `rmtree` + `copytree` on upgrade.
 
+The bundled `kirocrew-dev/babysit` skill is an on-demand, pointer-on-trigger recipe.
+For a public GitHub pull request with the `review_ready` objective it gives the
+agent one exact bounded `monitor_watch` call and makes retained inspection state
+authoritative; its acknowledgement remains pending until the current turn ends,
+so agent inspection happens only at the start of a later user/wake turn. It also
+explains that reported-token enforcement may be incomplete while runtime and
+completed-turn limits remain hard fallbacks. It does not reproduce provider
+polling policy in the prompt. Its legacy `monitor_start` recipe is limited to
+unsupported targets and requires a positive cadence, cycle cap, and runtime
+bound while naming the full-turn/token cost and ordinary approval policy.
+
 **Loading:**
 1. **Always-on**: skills with `always: true` have full content injected every new session
 2. **On-demand**: skill summaries (name + description + dir path) in session context; LLM can `cat` the file when relevant

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -1193,6 +1193,32 @@ class AutoNudgeService:
         self._emit("updated", loop)
         return decision
 
+    async def stop_monitor_if_budget_exhausted(
+        self,
+        monitor_id: str,
+        *,
+        now: float,
+    ) -> bool:
+        """Stop a spent structured monitor before starting another provider probe."""
+        stopped_loop: NudgeLoop | None = None
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is not None
+                and state is not None
+                and loop.active
+                and state.outcome is None
+            ):
+                reason = monitor_budget_reason(state, now=now)
+                if reason:
+                    self._stop_monitor_for_budget(loop, reason, stopped_at=now)
+                    await self._write_monitor_snapshot_locked()
+                    stopped_loop = loop
+        if stopped_loop is not None:
+            self._emit("updated", stopped_loop)
+        return stopped_loop is not None
+
     def _set_monitor_deadline(self, loop: NudgeLoop, deadline: float) -> None:
         """Write the scheduler authority and inspection mirror together."""
         loop.next_due_ts = deadline

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
@@ -1,547 +1,78 @@
 ---
 name: babysit
-description: Same-session monitoring loop for PRs, CI runs, tickets, and deployments using the monitor_start / monitor_update / autonudge_stop MCP tools. The loop re-injects your check instructions into THIS session on an idle interval — same context, same tools — and works from dashboard chat, Slack threads, and Discord DMs. Use when the user says "babysit", "monitor", "keep checking", "keep an eye on", "loop on this PR", "let me know when", or wants polling that outlives a wait+poll window. NOT for fresh-session work (use cron_add) or external-system callbacks (use register_hook).
-tags: [skill, kirocrew, monitor, babysit, autonudge, loop]
+description: Use when a user asks to babysit, monitor, keep checking, keep an eye on, or report when a pull request, CI run, ticket, deployment, or other changing target reaches an outcome.
+inject_on_trigger: false
+tags: [skill, kirocrew, monitor, babysit]
 ---
 
-# Babysit (same-session monitoring loop)
+# Babysit
 
 ## Overview
 
-`monitor_start(message, interval_secs?, max_cycles?)` binds a monitoring loop
-to **your current session**. Every `interval_secs` the message is re-injected
-as your next turn. User messages defer a due fire until their turn ends but do
-NOT restart the countdown, so the loop stays on schedule even in a session the
-user is actively chatting in. You keep the full conversation context, memory,
-and tools on every cycle. Loops persist to `~/.kiro/crew/autonudge.json` and
-survive gateway restarts (the countdown resumes where it left off).
+Use a structured monitor whenever the target is a public GitHub pull request and
+the objective is review readiness. Kiro Crew probes before invoking the model, so
+unchanged polling does not consume agent turns.
 
-Works from:
+## GitHub pull request: one bounded watch
 
-| Surface | Binding | Cadence |
-|---|---|---|
-| Dashboard chat | bare slot key | deadline timer (user turns defer, never reset) |
-| Slack thread | `slack:<thread_ts>` | fixed interval after each unattended turn |
-| Discord DM | `discord:{agent}:direct:{user}` | fixed interval after each unattended turn |
+Call this once with the canonical pull-request URL:
 
-`autonudge_stop(reason?)` stops the loop bound to the current session from
-any of those surfaces. `monitor_update(message?, interval_secs?, max_cycles?)`
-revises the loop already bound to this session in place, keeping its cycle
-count — use it when the instruction you armed has gone stale, or to raise the
-cap on a loop that is still doing useful work.
-
-### `interval_secs` counts between the loop's own cycles
-
-Each delivered cycle's countdown starts when that cycle's turn **ends**, so
-the real cadence is `interval_secs` + however long each cycle's work takes. A
-300s interval with 5-minute checks wakes you roughly every 10 minutes. Size it
-for the gap you want *between* cycles. User messages in the session never
-stretch this: a due fire waits for the user's turn to end, then delivers.
-
-### You must stop the loop yourself
-
-`max_cycles` (default 24) is a **runaway backstop, not a finish line**. A loop
-that coasts into its cap did not complete — it ran out of rope, and whatever
-it was watching is still unresolved. Evaluate the exit condition every single
-cycle and stop deliberately.
-
-**This is the dominant failure, not a rare one.** Measured on a real loop store
-(4 loops, 84 delivered cycles, 14.9h wall clock, 7.5h of model turn time):
-**4 of 4 ended at exactly their cap** — 24/24, 20/20, 28/28, 12/12 — with
-`stopped_reason` either empty or `cycle_cap`, and **0 of 4 carried an
-agent-supplied stop reason**. None set `max_runtime_secs`, so cycle count was
-the only bound on spend.
-
-The reason this is expensive rather than merely untidy: the cap is reached the
-same way whether the loop **converged early** and then re-polled for nothing, or
-**never converged** and stopped with the work still unresolved. The two are
-indistinguishable from outside — the loop simply goes inactive — so a loop that
-stops only at its cap tells you nothing about which happened, and bills you for
-the difference.
-
-### Stall tripwire — stop on no-progress, not just on success
-
-An exit condition keyed only on *success* cannot end a loop that is stuck, and
-stuck is the common case: a blocker needing a human decision, an upstream
-outage, a flake nobody owns. So carry a second exit condition.
-
-Each cycle, record the **progress key** — `pr_status.py --json` emits every
-field of it:
-
-| field | why it is in the key |
-|---|---|
-| `head_sha` | a new head means you pushed; work happened |
-| `failing_checks` (sorted, workflow-qualified) | *which* checks are red, not how many — qualified by workflow because two workflows can publish the same check name, and a name-only list stays identical when one starts failing as the other stops |
-| `checks_failing` | the count, as a cheap scalar |
-| `readiness_kind` | distinguishes running from failing from unpublished |
-| `exit_code` | collapses the whole verdict |
-| `status` | the verdict *reason* — a conflict and a failing check are both exit `20` and can carry an identical check set, so without this a changed blocker extends a stall streak instead of resetting it |
-
-If the key is byte-identical for **3 consecutive counting cycles** and you pushed
-nothing in that span, the loop is not making progress. **Stop it**: report what is
-blocking, why you could not move it, and what decision you need, then call
-`autonudge_stop` with that as the reason.
-
-**Only a settled cycle counts.** A cycle whose poll exits `10` is reporting work
-still in flight, and waiting is exactly what the loop is for — so an exit-`10`
-cycle neither counts toward the tripwire nor resets it; skip it and move on.
-**Both exit `0` and exit `20` are settled, and both count.** A PR can sit at exit
-`0` indefinitely — green checks, but not review-ready because a human-owned thread
-or an unanswered advisory concern is outstanding — and a tripwire that counted only
-`20` would never notice that kind of stall. Exit `2` is an environment fault:
-escalate it rather than counting it.
-
-This matters because a running PR yields a byte-identical key every cycle by
-construction (`failing_checks` empty, `readiness_kind` `running`, `exit_code` 10),
-so counting those would fire the tripwire after ~15 minutes of ordinary CI on a
-repo where a single gate can legitimately run an hour. Skipping rather than
-resetting is deliberate too: a PR that flickers between running and blocked would
-otherwise reset forever and never be recognised as stuck. What bounds a genuinely
-endless wait is not this tripwire but `max_runtime_secs`.
-
-**Persist the key AND the streak count — session memory is not durable enough.**
-A stalled loop is precisely the long-running case that walks into compaction (see
-above), which can summarise away the counter at the moment it matters; the loop
-then coasts to its cap exactly as before, which is the failure this tripwire
-exists to prevent. Storing only the last key is not enough: that tells the next
-cycle what the previous key was but not whether this is match one, two or three,
-so the streak itself would still live in memory and still be lost. Write BOTH to
-one file — the key plus an integer count — and read it first on every settled
-cycle, then:
-
-- key matches the stored key → increment the count, write it back, trip at 3;
-- key differs → overwrite with the new key and a count of 1.
-
-**Put that file where the loop's own state lives, not in temp.** A babysit runs
-for hours and `TMPDIR` is periodically reaped by the OS, which would silently
-reset the streak — the same erasure as compaction, just a different eraser. Use
-the data home beside the loop's stop sentinel, i.e.
-`${KIROCREW_HOME:-$HOME/.kiro/crew}/workspace/.babysit-key-<loop-id>`, which is the
-convention `stop_sentinel_path` already follows and is not machine-cleaned. Write
-`$HOME`, not `~`: a tilde inside a parameter-expansion default is not expanded, so
-the literal `~` would survive and the state would land in a `~/` directory
-relative to the current working directory — lost the moment that directory
-changes.
-
-Nothing in the monitor engine observes the key today, so that file is the only
-durable record; moving the counter into the loop store, so the engine itself could
-stop on it, is the follow-up that would make this enforceable rather than
-advisory.
-
-**The key is GitHub-only today.** `pr_status.py --json` is its only emitter, so on
-GitLab or Bitbucket you must first derive an equivalent key from that host's own
-verdict fields (the table above). The 3-cycle rule means nothing until something
-emits a comparable value.
-
-Two things deliberately stay OUT of the key:
-
-- **Finding counts.** A finding you rebutted or deferred keeps being re-raised,
-  so a key including it never stabilises and the tripwire never fires. Worse,
-  the count moves when a bot merely re-words a comment. Read findings to decide
-  *what to do*; do not let them decide *whether you are stuck*.
-- **Unresolved-thread counts.** `?` means "could not establish", and a transient
-  API blip would read as progress.
-
-Escalating early is correct — a stalled loop does not become unstuck by being
-re-run 18 more times; it becomes unstuck when a human answers the question. This
-is **not** licence to park on a *fixable* blocker: the tripwire fires only when
-nothing changed **because there was nothing you could change unilaterally**. A
-diagnosed, verified fix gets applied and pushed, which moves `head_sha` and
-resets the count by construction.
-
-Deliberate stops are the goal. `autonudge_stop` should carry a real sentence
-naming the exit condition, the tripwire, or a terminal PR state. A loop whose
-store row later reads `cycle_cap` is a defect in that loop's instructions, not
-a completed job.
-
-### Context grows every cycle
-
-Each cycle appends a full turn — tool calls, CI output, diffs — to the **same**
-session. That shared context is the point of a same-session loop, but nothing
-bounds it: long babysits walk into compaction, which can summarise away the
-very instructions the loop keeps re-injecting. Keep per-cycle output minimal.
-
-### Verify the loop armed — the return string is not evidence
-
-`monitor_start` returns an acknowledgement whether or not the loop was
-actually armed. The applier runs after the tool returns, and its failure
-message is not visible to you, so a confident-looking success string is
-consistent with nothing being scheduled at all.
-
-Confirm against state, not the reply: read `~/.kiro/crew/autonudge.json` (or
-`GET /api/autonudge`) and check the loop is present, then that `cycle_count`
-advances on the next cycle. If it never appears, no monitoring is running —
-fall back to an in-turn `wait`+poll loop and tell the user monitoring is not
-active.
-
-If `monitor_start` explicitly reports it could not arm, believe it. That
-message is distinct from the transient MCP reconnects you retry through — do
-not write it off as flakiness.
-
-## Decision table
-
-- User is waiting and total time < 30 min → `wait` + poll, no loop.
-- "Babysit / monitor / keep checking" in THIS conversation → `monitor_start`.
-- Reacting to review feedback or CI on a PR → `monitor_start` or in-turn
-  `wait`+poll. **Never `cron_add`, never HEARTBEAT.md** (see below).
-- Work belongs in a fresh isolated session each cycle, and needs no tools that
-  require approval → `cron_add`.
-- Cleaning up after a merge you have already verified → `cron_add`, as a
-  `script` cron at roughly a 5-minute interval.
-- External system will call back → `register_hook`.
-
-### Never use cron or heartbeat to react to reviewer feedback
-
-Both are structurally incapable of it, and both fail in ways that look like
-success:
-
-- **Cron.** A cron job has no owning chat slot, so it can never earn per-slot
-  trust: its tool calls land on a deny-by-default approval path and time out
-  after 180 seconds unless a global auto-approve grant happens to be active.
-  Worse, a denied *tool* inside a *completed* turn still records
-  `last_status: ok`, so the job registry reports health while the job does
-  nothing. Measured on a real PR watcher: 101 runs over 25 hours, 23 blocked at
-  approval, hours of model time, zero commits pushed, and a green-looking
-  registry throughout.
-- **Heartbeat.** Its approval path is a strict name allowlist
-  (`HEARTBEAT_SAFE_TOOLS`), deny-by-default, with no shell and no `git push`.
-  It cannot amend a commit or push a revision, so it can never close the loop
-  it was asked to watch.
-
-Cron *is* the right tool for post-merge cleanup — but as a `script` cron, which
-bypasses the LLM approval layer entirely, at roughly a 5-minute interval. An
-hourly job loses the race: one observed merge-to-teardown window was 17
-minutes.
-
-## Reading PR/MR state — ask the host for its verdict, don't hand-roll a filter
-
-Whatever you are babysitting, the read step is **not** yours to invent. These
-five rules hold on GitHub, GitLab and Bitbucket alike; only the command changes.
-
-1. **Ask the host for its own aggregate verdict.** Do not reduce a list of
-   individual checks into a pass/fail yourself. Every host computes a merge
-   verdict and exposes it; a filter you write over the raw list is a second,
-   worse implementation of it that silently disagrees.
-2. **Classify every state you see, and fail closed on the ones you don't.** An
-   unrecognized or unmapped status must count as *not passing*, never as
-   passing. Collapse superseded runs to the newest attempt per check identity
-   before counting failures, or a stale cancelled run reads as a live failure.
-3. **"Checks are green" is not "nothing is outstanding."** Unresolved review
-   threads and *advisory* (non-blocking) results are separate axes that the
-   aggregate verdict does not cover, by design. Read them separately, every
-   cycle, or the loop will declare readiness over an open thread.
-4. **Lifecycle state is terminal — read it every cycle.** Merged, closed, or
-   declined means stop, report the real outcome, and call `autonudge_stop`.
-   Do not infer this from the checks; ask for the state field.
-5. **Mergeability is computed asynchronously.** "Unknown", "checking" or
-   "unchecked" means **wait**, not pass — and on a non-open object it may never
-   resolve at all (see the GitHub limits below).
-6. **A conflicted PR's checks are stale, not signal — so a conflict means rebase
-   NOW, not wait.** This is the mechanism behind rule 1, worth knowing because it
-   is invisible in the status list: a conflicted PR cannot produce a merge ref, so
-   the host dispatches **no** `pull_request` workflows at all, and every check you
-   can see belongs to the old head. A status-only loop therefore reports "nothing
-   new" indefinitely while the clock runs. On GitHub you do not read these fields
-   yourself — `pr_status.py` already reads `mergeable`, `mergeStateStatus` and
-   `reviewDecision`, and it ranks a conflict **above** in-flight checks precisely
-   so this cannot happen: a conflicted PR exits **20** on the first poll rather
-   than reporting "running" forever while nothing can complete. The same holds
-   for `BEHIND`, a draft, and `CHANGES_REQUESTED` — each survives any amount of
-   waiting, so each is surfaced immediately. What this rule adds is the
-   response: on a conflict or `BEHIND`, re-sync and re-push instead of polling,
-   and never report the previous head's green.
-7. **A fully green PR can still be terminally blocked by a human decision.**
-   `reviewDecision == CHANGES_REQUESTED` survives every push and is invisible to
-   the checks rollup; `pr_status.py` reports it as 20 ahead of any in-flight
-   check, so it surfaces on the first poll. The judgment the exit code cannot
-   make is *what kind* of block it is: when the content is a product hold rather
-   than a defect, there is nothing to converge on, so report it **once**, quoting
-   the blocking reviewer, and stop rather than cycling.
-
-### Where each host keeps those answers
-
-| host | one-shot verdict | unresolved-thread axis | the local trap |
-|---|---|---|---|
-| **GitHub** | `pr_status.py` (below); optionally an aggregate status context | review threads via GraphQL (`pr_status.py` prints the count) | `statusCheckRollup` is a `CheckRun \| StatusContext` union — `.conclusion` vs `.state` |
-| **GitLab** | `detailed_merge_status` on the MR (`glab mr view <iid>`, or `glab api projects/:id/merge_requests/:iid`) | `glab mr view <iid> --unresolved`, or the Discussions API | a pipeline reports `success` while its `allow_failure: true` jobs failed |
-| **Bitbucket Cloud** | none — combine PR `state` with the commit's build statuses (`/2.0/repositories/{ws}/{repo}/commit/{sha}/statuses`) | PR comments/tasks on the PR resource | below Premium, unresolved merge checks only **warn**; the host still allows the merge |
-
-GitLab specifics worth knowing: use `detailed_merge_status`, not `merge_status`
-(deprecated since 15.6 and it does not account for every state). Its values are
-themselves the loop's decision — `ci_still_running` / `checking` / `preparing` /
-`unchecked` are *wait*; `mergeable` is clean; `conflict`, `need_rebase`,
-`not_approved`, `draft_status`, `discussions_not_resolved`,
-`status_checks_must_pass` and `requested_changes` are each a distinct blocked
-reason worth reporting as itself. Note that `blocking_discussions_resolved` is
-**not** an unresolved-thread count: it only tells you whether resolution is
-required *and* satisfied, so on a project that does not require resolution it can
-be `true` with threads still open. Count threads from the discussions, and treat
-external status checks as their own axis, separate from the pipeline.
-
-Bitbucket specifics: there is no single "can this merge" field to poll, so rule 1
-becomes "combine the two sources the host does give you" — the PR's `state`
-(non-`OPEN` is terminal) and the head commit's build statuses. And because merge
-checks are advisory below Premium, a Bitbucket "green" is weaker evidence than
-elsewhere: rule 3 is not optional there.
-
-Provenance: the GitHub path below is exercised (including against an unrelated
-public repo); the GitLab and Bitbucket rows come from those vendors' API docs and
-are **not** something this skill has run. Verify the exact flag or field against
-your host before trusting a value you have not seen come back.
-
-### On GitHub: use `pr_status.py`
-
-The `prepare-pr` skill owns the tool, and it is project-agnostic — stdlib Python
-over `gh`, no repo-specific assumptions baked in. Call it by path from the target
-repo (do **not** `cd` into the skill folder; the scripts read which repo they are
-talking about from your cwd):
-
-```bash
-SKILL_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr"
-python3 "$SKILL_DIR/scripts/pr_status.py" <pr#>     # exit 0 clean / 10 running / 20 blocked / 2 env
-python3 "$SKILL_DIR/scripts/pr_status.py" <pr#> --json   # same exit code, plus the progress key on stdout
-python3 "$SKILL_DIR/scripts/pr_findings.py" <pr#>   # only after 20: failed steps, log tails, threads
+```text
+monitor_watch({
+  "kind": "github_pull_request",
+  "target": "https://github.com/OWNER/REPO/pull/NUMBER",
+  "objective": "review_ready",
+  "interval_secs": 300,
+  "max_runtime_secs": 14400,
+  "max_agent_turns": 8,
+  "max_tokens": 250000,
+  "max_provider_errors": 3,
+  "wake_instructions": "Inspect the named blocker, fetch only the needed details, act safely, and verify the result."
+})
 ```
 
-`--json` adds one machine-readable object to stdout and changes nothing else —
-same exit codes, same prose above it. Use it for the stall tripwire: the object
-carries the full 40-char `head_sha` (the prose only ever prints 12), the sorted
-`failing_checks` list, and `readiness_kind`, so two cycles can be compared
-byte-for-byte instead of by eyeballing a diff of human text.
+The reply is a pending application request, not proof that the monitor armed.
+End the turn so the session-aware consumer can apply it. The operator can then
+confirm it in the dashboard. The agent cannot inspect after ending that same
+turn; at the start of a later user/wake turn, call `monitor_inspect({})` before
+acting or reporting. Its retained session-bound state is authoritative and it
+takes no monitor id, target, or session key.
 
-Its `advisory` half is what you read when checking the exit conditions below:
-`unresolved_threads` (`null` there is the same "could not establish" as a `?`),
-`findings` per reviewer, and `stale_reviewers` / `blocking_reviewers`. Nothing
-else is emitted — ambient PR state (mergeable, merge state, review decision,
-check totals) stays in the prose above, which is where those conditions already
-read it, so there is no second copy to keep in sync.
+The server performs ordinary probes. Unchanged state, provider retry, success,
+and terminal blockers use zero model turns. A new actionable fingerprint wakes
+the session at most once with a compact, bounded summary. Only then fetch logs,
+comments, or diffs needed to act. The token cap applies only when the provider
+reports usage; `token_usage_known` exposes whether it did. Positive runtime and
+completed-turn caps remain hard fallbacks. Provider errors are also bounded.
 
-Drive the cycle off the **exit code**, not off prose: `10` → report nothing and
-wait for the next cycle; `20` → drill in with `pr_findings.py` and act; `2` →
-environment problem, escalate rather than loop on it.
+Use `monitor_update({...})` without an id to change `interval_secs`, positive
+budgets, or `wake_instructions`. Those edits preserve the comparison baseline;
+changing `target` or `objective` starts a new baseline. Terminal records are
+read-only, so start an explicit new watch to restart. Use
+`monitor_stop({"reason": "User ended the watch."})` for a deliberate stop; the
+retained outcome is `user_stop`. `autonudge_stop` remains a compatibility alias.
 
-**Exit `0` is necessary but not sufficient — do not stop on it alone** (rule 3).
-The script's decision is fail-closed about *checks*, but the unresolved-thread
-count it prints is **advisory: it is not part of the exit code**, so a PR with
-open review threads still exits `0`. Before you declare review-ready and call
-`autonudge_stop`, confirm all five:
+## Legacy — unsupported target only
 
-1. `pr_status.py` exits `0`;
-2. its `unresolved threads (advisory)` line reads `0` — a `?` means the count
-   could not be retrieved, which is not a zero, so treat it as unresolved and
-   check the threads yourself with `pr_findings.py`;
-3. every reviewer that raised something has an answer from you on the PR. An
-   **advisory** reviewer posts its concerns *and* passes its own check, so its
-   verdict appears in neither the exit code nor the aggregate. In this repo that
-   is `Design Review` / `UX Review` reporting `🟡 CONCERNS` while green; in
-   another repo it is whatever non-blocking bots and human reviewers comment
-   there. See `prepare-pr`'s "Answer every concern".
-4. its `mergeable=` / `mergeState=` / `reviewDecision=` line (the script prints
-   all three) shows no conflict, no `BEHIND`, and no `CHANGES_REQUESTED` — exit 0
-   already implies this, so read the line to know *which* to report, not to
-   re-decide it (rules 6-7);
-5. **no finding on the current head lacks a disposition.** Not "zero findings" —
-   that can never be reached. A **fixed** finding disappears from the bot's
-   in-place-updated body on the next review, but one you **rebutted** or
-   **accepted-and-deferred** (or **needs-a-decision**) keeps being re-raised, so a zero-findings test
-   deadlocks the loop against your own correct answer. The test is *unanswered*,
-   which is also what the `autonudge_stop` prohibition below is keyed on. The
-   mechanical half of this condition is the script's, not yours: `pr_status.py`
-   reads the bot comments itself, holds every `[<NAME>-REVIEWED]` stamp to the
-   current head SHA, and folds a stale stamp or a `[BLOCK-MERGE]` marker for
-   the current head into exit `20` — so exit `0` already proves reviewer
-   freshness and the absence of a blocking finding. On a repo with a known
-   reviewer fleet, PIN it (`--reviewers NAME1,NAME2` /
-   `PREPARE_PR_REVIEWERS`): a pinned reviewer must have a fresh stamp, so a
-   bot that fails to post — or an emitter drift that stops stamps appearing at
-   all — blocks instead of silently un-gating; unpinned discovery mode holds
-   whatever stamps it finds to freshness but does not require presence. One reading note: a stale stamp maps onto exit `20`, and
-   on a repo whose reviewer bots are comment- or cron-triggered (not in the
-   check rollup) that `20` can mean "the bot has not posted for this head yet"
-   rather than "author action needed" -- the reason string names the stale
-   reviewer, so read it before treating the exit code as a fix signal. What stays yours is the judgment half: the script prints
-   each fresh reviewer's advisory `FINDING` count but deliberately never gates
-   on it, so read those from `pr_findings.py` (which lists each one with a
-   stable `span=` identity), subtract the ones your own `ai-review-disposition`
-   comments already answer, and disposition what remains.
+Use a prompt loop only when `monitor_watch` does not support the target or
+objective:
 
-**Never call `autonudge_stop` while an un-dispositioned finding exists for the
-current head SHA.** If you must stop for another reason, post the open-finding
-list so the handoff is visible to a human — otherwise findings sit unread for
-hours while the loop looks healthy.
-
-### Verify what your reviewer's conclusion actually means — once per repo
-
-Rule 1 says ask the host for its verdict. That holds for CI, but a **review bot is
-not a build**: its check conclusion is whatever its workflow chose to exit with, and
-that is a per-repo implementation detail. So before you build an exit condition on
-it, establish once what it means in the repo you are in, and re-check if the review
-fleet is renamed or replaced. The failure modes to look for, any of which makes a
-status-only loop unsound:
-
-- **Red that only means "found something."** The workflow exits nonzero when the
-  review succeeded and produced a finding. Red becomes its normal state.
-- **A verdict that never posted.** An empty comment while the job log holds the
-  finding — the loop sees no findings and concludes clean.
-- **Green with findings in the body.** Worse than red, because red at least wakes a
-  watch loop.
-- **A verdict that is not reproducible.** Re-dispatch on an identical tree flips it,
-  so bot-green is not terminal and one red is not a stable fact about the diff.
-- **Inflated failure counts.** Per-SHA double dispatch, or runs reporting `failure`
-  with zero failed jobs. Collapse to the newest run per (workflow, SHA) — rule 2 —
-  before counting anything.
-
-> **Establish this per repo before trusting a conclusion, and write down what you
-> found.** If any of the five holds, resolve reviewer state from the **comment
-> body for the current head SHA** instead — which is exactly what `pr_status.py`
-> does mechanically: it never reads the review workflow's conclusion, only the
-> per-SHA stamps and blocking markers in the bodies, so "stamp matches head AND
-> no blocking marker" is already folded into its exit code. Which repos are
-> affected, and the evidence for each, belongs in that repo's issue tracker — not
-> in this skill, which ships to every install and cannot be corrected in copies
-> already distributed. For kirodotdev/KiroCrew that record is #2548; #2550 moved
-> the check itself into the script so the conditional is data, not prose.
-
-Where a reviewer's conclusion *is* trustworthy, none of the above applies and reading
-job logs every cycle is wasted work: check first, then decide.
-
-If any of the five is unmet, the loop has not reached its exit condition —
-keep cycling (or escalate), and do not report the PR as review-ready.
-
-Two GitHub-shaped traps this closes, both of which produce a confidently wrong
-reading:
-
-- **`.conclusion` is not universal — this is a GitHub API shape, not a
-  per-repo quirk.** `statusCheckRollup` is a union: **CheckRun** entries carry
-  `.conclusion`, while **StatusContext** entries (the legacy commit-status API,
-  still how many third-party integrations and any home-grown aggregate report)
-  carry `.state` instead. So
-  `gh pr view --jq '.statusCheckRollup[] | select(.conclusion==...)'` silently
-  drops every status context in any repo that has one, and the PR reads cleaner
-  than it is. `pr_status.py` classifies both shapes, and treats an aggregate
-  status as authoritative over the individual rollup when one is published —
-  naming it with `--readiness-context NAME` (or `PREPARE_PR_READINESS_CONTEXT`;
-  the default is this repo's `PR Readiness`, and `resolve_profile.py` reports
-  the right name for another project, which you then pass in). With no aggregate
-  published it falls back to the full rollup, so it still works on a repo that
-  publishes none.
-- **The failing count is fail-closed, not a bug count** (rule 2). Any
-  unrecognized COMPLETED conclusion counts as a failure, and superseded re-run
-  attempts are collapsed to the newest run per check identity before counting —
-  so every remaining `[fail]` line is live. Read the per-check lines before
-  naming causes to the user.
-
-Two limits worth knowing before you trust it on an arbitrary PR:
-
-- **Run it from a checkout of the target repo.** A bare PR number resolves
-  against your cwd's repo. A full PR URL works for any repo, but the
-  unresolved-thread count re-resolves the repo from cwd (`gh repo view`), so a
-  URL from a foreign checkout mixes two repos: usually that prints `?` (the
-  number does not exist there), but if the cwd repo happens to have a PR with
-  the same number you get a thread count for the *wrong* PR with nothing marking
-  it as such.
-- **A merged, closed or declined PR exits `20`** with `PR state is ... (not
-  OPEN; terminal)` — that satisfies rule 4, so on that message report the real
-  outcome and stop the loop rather than triaging it as a failure.
-- **`?` is not `0`.** It means the count could not be established (auth, page
-  cap, wrong repo). Treat it as unresolved.
-
-## Workflow
-
-1. **Write the message as instructions to your future self.** Include:
-   - what to check (PR URL, job id, ticket),
-   - what to do with findings (fix + push, summarize, escalate),
-   - the exit condition, ending with: "when met, tell the user and call
-     `autonudge_stop`".
-2. **Call `monitor_start`, and always pass a wall-clock budget.**
-   `interval_secs` default 300 suits CI/review polling. `max_cycles` defaults to
-   24 (≈2h of idle gaps at 300s); raise it for longer work, and pass `0` for
-   unlimited only when the user explicitly asks for an unbounded loop.
-   **Set `max_runtime_secs` too.** It is the only bound that holds when
-   per-cycle work grows: measured cycles ran 124s–823s of model time *on top of*
-   the idle gap, so a 12-cycle cap took 4.1 hours. Cycle count does not bound
-   spend. Budget the wall clock you would actually accept (e.g. `14400` for four
-   hours) so a stalled loop dies on time rather than on arithmetic.
-3. **Confirm it armed.** Read `~/.kiro/crew/autonudge.json` and check your
-   loop is there. The tool's reply is not evidence — see above.
-4. **Tell the user monitoring is active and END YOUR TURN.** The loop wakes
-   you — do not wait+poll on top of it.
-5. **Each cycle:** do the check, act, and report only real signals. Don't
-   post "nothing new" every cycle. If the instruction no longer matches
-   reality, `monitor_update` it rather than working around it.
-   **Keep a no-signal cycle cheap.** On exit `10` the correct cycle is: read the
-   exit code, write nothing, end the turn. Do not re-read review-bot bodies, job
-   logs, or diffs on a cycle whose own status call already said nothing changed —
-   that is where a watch loop turns into a spend loop. One `pr_status.py` run is
-   6–8 `gh` invocations; the expensive reads belong to exit `20`.
-6. **Persist the progress key and its streak count to a file** (not session
-   memory — compaction eats both) and apply the stall tripwire above: 3
-   byte-identical keys on *settled* cycles (exit `0` or `20`) with no push means
-   stop and escalate. Exit-`10` cycles are skipped, not counted and not reset;
-   exit `2` escalates.
-7. **On the exit condition** (or the user saying stop): report, then call
-   `autonudge_stop` with a reason. Do not let the cap do this for you.
-
-## Example
-
-User: "babysit PR #247 until it's review-ready"
-
-```
-monitor_start(
-  message="Check PR #247. FIRST read
-           gh pr view 247 --json mergeable,mergeStateStatus,reviewDecision —
-           rules 6 and 7 of the babysit skill govern what each value means.
-           Then run
-           python3 \"${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr/scripts/pr_status.py\" 247
-           and act on its exit code, passing --json so the progress key is
-           machine-comparable (10 = still running, report nothing and do not
-           read bot bodies or job logs;
-           20 = drill in with pr_findings.py, or stop if the reason is a
-           terminal PR state). Keep the progress_key AND a consecutive-match
-           count in the data home beside the loop's stop sentinel, reading that
-           file rather than trusting memory: 3 byte-identical keys on settled
-           cycles (exit 0 or 20) with no push in that span means stop and
-           escalate. If this repo's reviewer conclusions are on the
-           unreliable list you established for it, resolve the AI review lane
-           from the job log plus the comment body for the current head SHA
-           rather than the conclusion; where the conclusion is trustworthy, use
-           it. Fix legitimate
-           High/Medium findings and push, following this repo's history
-           convention; before rebutting a finding that has returned a 3rd time,
-           re-run the reviewer once on the unchanged SHA and re-derive the claim.
-           Stop ONLY when all five exit conditions in the babysit skill hold, and
-           never while an UN-DISPOSITIONED finding exists for the current head
-           SHA — a finding you rebutted or deferred stays visible in the bot's
-           body, so "any finding at all" would never let the loop finish. Then
-           tell the
-           user the PR is review-ready and call autonudge_stop.",
-  interval_secs=300,
-  max_cycles=20,
-  max_runtime_secs=14400,
-)
+```text
+monitor_start({
+  "message": "Watch <unsupported target>. On each injected cycle, perform the smallest safe status check. Act only on a real change. If the objective is met, the target is terminal, or a human decision is needed, report the outcome and call autonudge_stop with a reason.",
+  "interval_secs": 300,
+  "max_cycles": 24,
+  "max_runtime_secs": 14400
+})
 ```
 
-The example deliberately **points at** the five conditions rather than restating
-them; a re-serialized copy inside the prompt drifts from the list above.
+All three limits must be nonzero; use a larger finite value, never `0`, for a
+longer request. Every delivered legacy cycle is a full agent turn that extends
+session context and spends model/tool tokens even when nothing changed. The reply
+is only an arm request; verify the loop through the dashboard monitor/goal-loop
+surface or `GET /api/autonudge`.
 
-On GitLab or Bitbucket the shape is identical — only the first line changes (the
-host's own verdict call from the table above), plus its own thread axis and its
-own "green is weaker than it looks" caveat.
-
-## Rules & gotchas
-
-- **One loop per session** — a new `monitor_start` replaces the existing loop.
-- **Busy sessions skip a cycle** (never queue) — a long-running turn delays
-  the next check to the following interval; skipped cycles don't count
-  toward `max_cycles`.
-- **Unattended turns are bounded to 30 min** on Slack/Discord; keep each
-  cycle's work small and incremental.
-- **Slack/Discord loops auto-approve tools** on the unattended turn
-  (Slack always; Discord follows the gateway approval mode — under
-  interactive approval a Discord cycle cannot use tools, so prefer
-  dashboard/Slack for tool-heavy babysitting or run the gateway with
-  `--approval yolo`/`auto`).
-- **Kill switches:** `autonudge_stop` (preferred), the dashboard 🎯 popover
-  (dashboard loops), `max_cycles`, or the per-loop STOP sentinel file.
-- Loops fire `[auto-nudge cycle N]`-tagged messages — treat them as your own
-  scheduled wake-ups, not user input.
+Legacy tool calls remain under normal PreToolUse governance and approval policy.
+An unattended Slack or Discord turn has no blanket grant: approval may be
+requested, rejected, or time out, and the loop records an approval stall instead
+of silently succeeding.

--- a/src/kiro_crew/docs/README.md
+++ b/src/kiro_crew/docs/README.md
@@ -22,6 +22,7 @@ organized for someone browsing the repository.
 |---|---|
 | [agents.md](agents.md) | Switching between specialized agents per conversation, thread, or cron job. |
 | [skills.md](skills.md) | Drop-in markdown knowledge packs for domain-specific workflows. |
+| [monitoring.md](monitoring.md) | Token-efficient pull-request monitoring and finite legacy fallbacks. |
 | [cron-and-scheduling.md](cron-and-scheduling.md) | Scheduling recurring tasks. |
 | [subagents.md](subagents.md) | Spawning parallel background workers for fan-out work. |
 | [dynamic-subagent-sizing.md](dynamic-subagent-sizing.md) | How the concurrent sub-agent cap is sized from host memory and CPU. |

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -28,6 +28,7 @@ index, first-time setup, and connecting messaging channels.
 | Capability | Description |
 |------------|-------------|
 | [Cron Jobs](cron-and-scheduling.md) | Schedule recurring tasks, e.g. "every weekday at 9am give me a pipeline briefing" |
+| [Monitoring](monitoring.md) | Watch a public GitHub pull request with zero-turn unchanged probes and bounded action wakes |
 | [Subagents](subagents.md) | Spawn parallel background workers for fan-out research and multi-package work |
 | [Dynamic Sub-Agent Sizing](dynamic-subagent-sizing.md) | Auto-size the concurrent sub-agent cap from host memory/CPU and a learned per-agent cost |
 | [Memory](memory-and-learning.md) | Persistent preferences, project context, and learned corrections across sessions, plus per-session persistent / incognito / temporary memory modes |

--- a/src/kiro_crew/docs/monitoring.md
+++ b/src/kiro_crew/docs/monitoring.md
@@ -1,0 +1,80 @@
+# Monitoring pull requests and changing work
+
+Kiro Crew can watch a public GitHub pull request until it is review-ready while
+keeping model use proportional to real changes. Cheap status probes run on a
+schedule; the owning conversation wakes only when new evidence needs action.
+
+## Start a pull-request monitor
+
+In a dashboard, Slack, or Discord conversation, ask Kiro Crew to babysit or
+monitor the full pull-request URL. The supported first release watches public
+`github.com` pull requests for the `review_ready` objective.
+
+The default monitor is finite:
+
+| Limit | Default |
+|---|---:|
+| Probe interval | 5 minutes |
+| Runtime | 4 hours |
+| Completed agent turns | 8 |
+| Reported aggregate input and output tokens | 250,000 |
+| Consecutive provider errors | 3 |
+
+The tool reply means application is pending in the owning session. It does not
+prove the monitor is active. End that turn so the session can apply the request;
+the operator can then confirm it in the dashboard. The agent cannot inspect
+after ending the same turn. At the start of a later user turn or monitor wake,
+it calls `monitor_inspect` before acting or reporting. The retained state shows
+its target, objective, next probe, bounds, latest classification, usage, and
+final outcome.
+
+The token cap applies only to usage the model provider reports. Inspection's
+`token_usage_known` field says whether all completed-turn usage was available.
+The runtime and completed-agent-turn caps remain hard fallbacks when it was not.
+
+## What spends a model turn
+
+The status probe and comparison happen before the conversation is invoked:
+
+| Observation | Agent turn |
+|---|---:|
+| No material change | 0 |
+| Checks still pending | 0 |
+| Provider retry | 0 |
+| Review-ready success or terminal blocker | 0 |
+| New actionable fingerprint | At most 1 |
+
+An actionable wake contains a compact summary. The agent can then fetch the
+specific logs, comments, or diff needed for the change instead of replaying the
+whole polling history. A restart cannot wake twice for the same accepted
+fingerprint.
+
+## Inspect, update, stop, and restart
+
+Inspect on a later turn after creating or editing a monitor, and before reporting
+its result. Cadence, positive budgets, and compact wake instructions can change
+without discarding the comparison baseline. Changing the target or objective
+starts a new baseline and is refused while an action is in flight.
+
+Stopping is durable: the dashboard and agent inspection keep a `user_stop`
+outcome rather than deleting the evidence. Success, provider/authentication
+blocks, exhausted budgets, unavailable sessions, and missing completion evidence
+also retain a specific terminal reason. Terminal records are read-only. Use the
+dashboard Restart action or ask the agent to start a new explicit watch.
+
+Monitoring does not grant extra tool authority. An action turn uses the normal
+governance and approval policy for its conversation.
+
+## Unsupported targets use the costly legacy loop
+
+Tickets, deployments, other forges, and custom objectives are not yet structured
+monitor kinds. Kiro Crew can use a legacy same-session goal loop for them, but
+every delivered check is a full agent turn. It extends the conversation context
+and spends model and tool tokens even when the target did not change.
+
+Keep a legacy loop finite with a positive interval, cycle cap, and runtime
+budget. Its acknowledgement is also only an arm request; verify the active goal
+loop in the dashboard. Stop deliberately when the objective is met, the target
+is terminal, or a person must decide. Approval can be requested, rejected, or
+time out on an unattended channel turn; monitoring is never a blanket approval
+grant.

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -169,9 +169,9 @@ def schemas() -> list[dict[str, Any]]:
                 "Stop the auto-nudge loop driving your current session. Call this "
                 "when you determine the loop should halt (e.g. goal complete, "
                 "blocked on user input, or a STOP sentinel file indicates shutdown). "
-                "Removes the loop from the AutoNudgeService so no further nudges "
-                "fire into this session. Safe to call even if no loop is active — "
-                "returns a no-op message."
+                "Legacy loops are removed. For a structured monitor, this compatibility "
+                "alias records a durable user-stop outcome and retains the record for "
+                "inspection. Safe to call even if no loop is active."
             ),
             "inputSchema": {
                 "type": "object",
@@ -330,17 +330,17 @@ def schemas() -> list[dict[str, Any]]:
         {
             "name": "monitor_start",
             "description": (
-                "Start a monitoring loop on YOUR CURRENT session: every "
+                "Legacy fallback for targets or objectives unsupported by monitor_watch. "
+                "A public GitHub pull-request review-readiness watch must use monitor_watch. "
+                "Start a prompt loop on YOUR CURRENT session: every "
                 "interval_secs the given message is re-injected into this same "
                 "session as your next turn — same context, same tools, same "
                 "conversation. The countdown is deadline-preserving: user "
                 "messages defer a due fire until their turn ends but do NOT "
                 "restart the interval, so checks stay on schedule even in an "
                 "actively-used session. Works from dashboard chat, Slack "
-                "threads, and Discord DMs. Use when the user asks to babysit / "
-                "monitor / keep checking something (a PR, CI run, ticket, "
-                "deployment): put the check instructions and the exit condition "
-                "in the message, then END YOUR TURN — the loop wakes you on the "
+                "threads, and Discord DMs. Put the check instructions and the exit "
+                "condition in the message, then END YOUR TURN — the loop wakes you on the "
                 "interval. When the exit condition is met (or the user says "
                 "stop), call autonudge_stop — reaching max_cycles is a runaway "
                 "backstop, NOT a successful finish. Use monitor_update to "
@@ -966,8 +966,10 @@ def monitor_watch(name: str, args: dict[str, Any]) -> str:
     return session_directive.encode(
         "monitor_watch",
         payload,
-        "Structured monitor requested for this session. End your turn; inspect the monitor "
-        "to confirm the authoritative consumer armed it.",
+        "Structured monitor requested for this session; application is still pending. "
+        "End your turn so the owning session can apply it. The operator can confirm it in "
+        "the dashboard; the agent can call monitor_inspect only at the start of a later "
+        "turn or in response to a later wake.",
     )
 
 
@@ -1015,6 +1017,7 @@ def _compact_monitor_inspection(result: dict[str, Any]) -> dict[str, Any]:
         "last_wake_fingerprint",
         "wake_in_flight",
         "wake_count",
+        "token_usage_known",
         "agent_turns",
         "input_tokens",
         "output_tokens",

--- a/src/kiro_crew/monitoring/controller.py
+++ b/src/kiro_crew/monitoring/controller.py
@@ -35,6 +35,13 @@ class _Loop(Protocol):
 
 
 class _Service(Protocol):
+    async def stop_monitor_if_budget_exhausted(
+        self,
+        monitor_id: str,
+        *,
+        now: float,
+    ) -> bool: ...
+
     async def apply_monitor_probe(
         self,
         monitor_id: str,
@@ -116,6 +123,8 @@ class MonitorController:
         if state.wake_in_flight:
             deadline = state.completion_evidence_deadline
             if state.wake_delivery is MonitorDispatchResult.BUSY:
+                if await self._service.stop_monitor_if_budget_exhausted(loop.id, now=now):
+                    return MonitorDecision.STOP_BUDGET
                 if now < state.next_probe_at:
                     return MonitorDecision.NO_CHANGE
                 return await self._dispatch_claimed(loop, state, now=now)
@@ -130,6 +139,8 @@ class MonitorController:
                     now=now,
                 )
             return MonitorDecision.NO_CHANGE
+        if await self._service.stop_monitor_if_budget_exhausted(loop.id, now=now):
+            return MonitorDecision.STOP_BUDGET
         config_generation = state.config_generation
         target = state.target
         previous_observation = deepcopy(state.last_observation)

--- a/test/test_babysit_monitor_scenarios.py
+++ b/test/test_babysit_monitor_scenarios.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import mcp_core, session_directive
+from kiro_crew.autonudge import AutoNudgeService
+from kiro_crew.dashboard.session_directive_apply import apply_session_directive
+from kiro_crew.monitoring.controller import MonitorController
+from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
+from kiro_crew.monitoring.models import (
+    MonitorDecision,
+    MonitorDispatchResult,
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorOutcome,
+    ProviderErrorKind,
+    monitor_state_public_dict,
+)
+
+_SESSION_KEY = "dashboard:chat-1"
+_BINDING = "chat-1"
+_TARGET = "https://github.com/acme/widgets/pull/7"
+
+
+@pytest.fixture
+def monitor_service(tmp_path):
+    service = AutoNudgeService(base_dir=tmp_path)
+    yield service
+    service.stop()
+
+
+def _canonical(*, head_revision: str = "abc123") -> dict[str, object]:
+    return {
+        "kind": "github_pull_request",
+        "target": "github.com/acme/widgets#7",
+        "state": "open",
+        "draft": False,
+        "head_revision": head_revision,
+        "mergeability": "mergeable",
+        "review_decision": "approved",
+        "blocking_review": "none",
+        "unresolved_review_threads": 0,
+        "review_threads_complete": True,
+        "checks": {"failed": [], "passed": ["ci"], "pending": [], "unknown": []},
+    }
+
+
+def _probe_result(
+    status: MonitorObservationStatus,
+    *,
+    fingerprint: str = "fp-1",
+    reason_code: str = "checks_pending",
+    provider_error: ProviderErrorKind | None = None,
+) -> GitHubPullRequestProbeResult:
+    return GitHubPullRequestProbeResult(
+        response=None,
+        canonical={} if provider_error is not None else _canonical(),
+        observation=MonitorObservation(
+            "" if provider_error is not None else fingerprint,
+            status,
+            provider_error=provider_error,
+            reason_code=reason_code,
+            summary="Safe monitor summary.",
+        ),
+    )
+
+
+@dataclass
+class _Provider:
+    results: list[GitHubPullRequestProbeResult]
+    probe_count: int = 0
+
+    def probe(self, target: str, *, previous_observation=None):
+        del target, previous_observation
+        result = self.results[min(self.probe_count, len(self.results) - 1)]
+        self.probe_count += 1
+        return result
+
+
+def _state_and_slot():
+    state = SimpleNamespace(
+        _slots={_BINDING: SimpleNamespace(workspace="default")},
+        sessions=None,
+        channel_transports={},
+    )
+    return state, SimpleNamespace(key=_BINDING, _app="")
+
+
+def _call_directive(tool_name: str, args: dict[str, object]) -> tuple[str, dict[str, object]]:
+    with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=_SESSION_KEY):
+        result = mcp_core._call_tool_inner(tool_name, args)
+    directive = session_directive.decode(result, tool_name)
+    assert directive is not None
+    return result, directive
+
+
+async def _apply(
+    service: AutoNudgeService,
+    tool_name: str,
+    directive: dict[str, object],
+) -> str:
+    state, slot = _state_and_slot()
+    with (
+        patch("kiro_crew.autonudge.get_instance", return_value=service),
+        patch("kiro_crew.autonudge_authz.sel", return_value=MagicMock()),
+    ):
+        return await apply_session_directive(state, slot, _SESSION_KEY, tool_name, directive)
+
+
+async def _arm_via_session_consumer(
+    service: AutoNudgeService,
+    *,
+    max_runtime_secs: int = 14_400,
+) -> tuple[str, dict[str, object]]:
+    acknowledgement, directive = _call_directive(
+        "monitor_watch",
+        {
+            "kind": "github_pull_request",
+            "target": _TARGET,
+            "objective": "review_ready",
+            "interval_secs": 300,
+            "max_runtime_secs": max_runtime_secs,
+            "max_agent_turns": 8,
+            "max_tokens": 250_000,
+            "max_provider_errors": 3,
+            "wake_instructions": "Inspect the named blocker and act only if needed.",
+        },
+    )
+    assert service.get_by_slot(_BINDING) is None
+    applied = await _apply(service, "monitor_watch", directive)
+    assert "started" in applied
+    return acknowledgement, directive
+
+
+def _inspection(service: AutoNudgeService) -> dict[str, object]:
+    loop = service.get_by_slot(_BINDING)
+    response: dict[str, object] = {"enabled": True, "monitor": None}
+    if loop is not None and loop.monitor is not None:
+        response.update(
+            {
+                "active": loop.active,
+                "monitor_id": loop.id,
+                "monitor": monitor_state_public_dict(loop.monitor),
+            }
+        )
+    with (
+        patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=_SESSION_KEY),
+        patch("kiro_crew.mcp_core._get", return_value=response),
+    ):
+        return json.loads(mcp_core._call_tool_inner("monitor_inspect", {}))
+
+
+@pytest.mark.asyncio
+async def test_babysit_create_requires_application_before_state_is_authoritative(
+    monitor_service,
+):
+    acknowledgement, directive = _call_directive(
+        "monitor_watch",
+        {
+            "kind": "github_pull_request",
+            "target": _TARGET,
+            "objective": "review_ready",
+        },
+    )
+
+    assert "requested" in acknowledgement.lower()
+    assert "later turn" in acknowledgement.lower()
+    assert "session_key" not in directive
+    assert _inspection(monitor_service)["monitor"] is None
+
+    applied = await _apply(monitor_service, "monitor_watch", directive)
+    assert "started" in applied
+    inspection = _inspection(monitor_service)
+    monitor = inspection["monitor"]
+    assert inspection["active"] is True
+    assert isinstance(monitor, dict)
+    assert monitor["target"] == _TARGET
+    assert monitor["objective"] == "review_ready"
+    assert monitor["cadence_secs"] == 300
+    assert monitor["token_usage_known"] is True
+    assert monitor["budgets"] == {
+        "max_runtime_secs": 14_400,
+        "max_agent_turns": 8,
+        "max_tokens": 250_000,
+        "max_provider_errors": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_babysit_unchanged_observations_probe_without_agent_turns(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    created = loop.monitor.created_ts
+    provider = _Provider([_probe_result(MonitorObservationStatus.PENDING)])
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    first = await controller.tick(loop, now=created + 10)
+    second = await controller.tick(loop, now=created + 310)
+
+    assert first is MonitorDecision.RECORD_ONLY
+    assert second is MonitorDecision.NO_CHANGE
+    assert provider.probe_count == 2
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["probe_count"] == 2
+    assert inspection["wake_count"] == inspection["agent_turns"] == 0
+    assert inspection["next_probe_at"] == created + 610
+
+
+@pytest.mark.asyncio
+async def test_babysit_actionable_fingerprint_wakes_once_across_restart(monitor_service, tmp_path):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider(
+        [
+            _probe_result(
+                MonitorObservationStatus.ACTIONABLE,
+                fingerprint="head-2",
+                reason_code="new_head_revision",
+            )
+        ]
+    )
+    dispatch = AsyncMock(return_value=MonitorDispatchResult.DISPATCHED)
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+    now = loop.monitor.created_ts + 10
+
+    first = await controller.tick(loop, now=now)
+    second = await controller.tick(loop, now=now + 1)
+
+    assert first is MonitorDecision.WAKE_ACTIONABLE
+    assert second is MonitorDecision.NO_CHANGE
+    assert provider.probe_count == 1
+    dispatch.assert_awaited_once()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["last_wake_fingerprint"] == "head-2"
+    assert inspection["wake_count"] == 1
+    assert inspection["agent_turns"] == 0
+
+    monitor_service.stop()
+    restarted = AutoNudgeService(base_dir=tmp_path, on_monitor_tick=AsyncMock())
+    await restarted.start()
+    try:
+        restored = restarted.get_by_slot(_BINDING)
+        assert restored is not None and restored.monitor is not None
+        restarted_provider = _Provider(
+            [_probe_result(MonitorObservationStatus.ACTIONABLE, fingerprint="head-2")]
+        )
+        restarted_dispatch = AsyncMock(return_value=MonitorDispatchResult.DISPATCHED)
+        restarted_controller = MonitorController(
+            restarted,
+            restarted_dispatch,
+            provider=restarted_provider,
+        )
+
+        decision = await restarted_controller.tick(restored, now=now + 2)
+
+        assert decision is MonitorDecision.NO_CHANGE
+        assert restarted_provider.probe_count == 0
+        restarted_dispatch.assert_not_awaited()
+        assert restored.monitor.wake_count == 1
+    finally:
+        restarted.stop()
+
+
+@pytest.mark.asyncio
+async def test_babysit_success_stops_without_an_agent_turn(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider(
+        [
+            _probe_result(
+                MonitorObservationStatus.SUCCESS,
+                reason_code="review_ready",
+            )
+        ]
+    )
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.created_ts + 10)
+
+    assert decision is MonitorDecision.STOP_SUCCESS
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)
+    monitor = inspection["monitor"]
+    assert inspection["active"] is False
+    assert isinstance(monitor, dict)
+    assert monitor["outcome"] == MonitorOutcome.SUCCESS.value
+    assert monitor["stopped_reason"] == "review_ready"
+    assert monitor["agent_turns"] == 0
+
+
+@pytest.mark.asyncio
+async def test_babysit_provider_block_is_safe_and_turn_free(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider(
+        [
+            _probe_result(
+                MonitorObservationStatus.PROVIDER_ERROR,
+                reason_code="github_authentication_failed",
+                provider_error=ProviderErrorKind.AUTHENTICATION,
+            )
+        ]
+    )
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.created_ts + 10)
+
+    assert decision is MonitorDecision.STOP_BLOCKED
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["outcome"] == MonitorOutcome.BLOCKED.value
+    assert inspection["stopped_reason"] == "github_authentication_failed"
+    assert "stderr" not in json.dumps(inspection).lower()
+
+
+@pytest.mark.asyncio
+async def test_babysit_runtime_budget_stops_before_another_probe_or_turn(monitor_service):
+    await _arm_via_session_consumer(monitor_service, max_runtime_secs=60)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider([_probe_result(MonitorObservationStatus.ACTIONABLE)])
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.created_ts + 60)
+
+    assert decision is MonitorDecision.STOP_BUDGET
+    assert provider.probe_count == 0
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["outcome"] == MonitorOutcome.BUDGET.value
+    assert inspection["stopped_reason"] == "runtime_budget"
+    assert inspection["wake_count"] == inspection["agent_turns"] == 0
+
+
+@pytest.mark.asyncio
+async def test_babysit_busy_retry_stops_at_runtime_without_another_action_attempt(
+    monitor_service,
+):
+    await _arm_via_session_consumer(monitor_service, max_runtime_secs=20)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider([_probe_result(MonitorObservationStatus.ACTIONABLE)])
+    dispatch = AsyncMock(return_value=MonitorDispatchResult.BUSY)
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    first = await controller.tick(loop, now=loop.monitor.created_ts + 10)
+    expired = await controller.tick(loop, now=loop.monitor.created_ts + 25)
+
+    assert first is MonitorDecision.WAKE_ACTIONABLE
+    assert expired is MonitorDecision.STOP_BUDGET
+    assert provider.probe_count == 1
+    dispatch.assert_awaited_once()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["outcome"] == MonitorOutcome.BUDGET.value
+    assert inspection["stopped_reason"] == "runtime_budget"
+    assert inspection["wake_count"] == inspection["agent_turns"] == 0
+
+
+@pytest.mark.asyncio
+async def test_babysit_user_stop_uses_real_tool_and_retains_terminal_state(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    _acknowledgement, directive = _call_directive(
+        "monitor_stop", {"reason": "User ended the watch."}
+    )
+
+    applied = await _apply(monitor_service, "monitor_stop", directive)
+
+    assert "retained" in applied
+    inspection = _inspection(monitor_service)
+    monitor = inspection["monitor"]
+    assert inspection["active"] is False
+    assert isinstance(monitor, dict)
+    assert monitor["outcome"] == MonitorOutcome.USER_STOP.value
+    assert monitor["stopped_reason"] == "user_stop"
+
+    provider = _Provider([_probe_result(MonitorObservationStatus.ACTIONABLE)])
+    dispatch = AsyncMock(return_value=MonitorDispatchResult.DISPATCHED)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.stopped_at + 1)
+
+    assert decision is MonitorDecision.STOP_BLOCKED
+    dispatch.assert_not_awaited()

--- a/test/test_mcp_tool_registry.py
+++ b/test/test_mcp_tool_registry.py
@@ -63,6 +63,21 @@ def test_tool_names_are_unique_across_domains() -> None:
     assert sorted(names) == sorted(set(names))
 
 
+def test_legacy_monitor_descriptors_route_structured_watches_correctly() -> None:
+    """Model-facing compatibility tools must not steal supported PR watches."""
+    descriptors = {tool["name"]: tool["description"] for tool in _domain("control").schemas()}
+
+    start = descriptors["monitor_start"].lower()
+    assert "unsupported" in start
+    assert "monitor_watch" in start
+    assert "github" in start
+
+    stop = descriptors["autonudge_stop"].lower()
+    assert "structured" in stop
+    assert "durable" in stop
+    assert "retain" in stop
+
+
 @pytest.mark.parametrize("domain", DOMAIN_MODULES)
 def test_descriptor_shape(domain: str) -> None:
     """kiro-cli drops a tool whose descriptor is missing any of the three keys."""

--- a/test/test_monitor_controller.py
+++ b/test/test_monitor_controller.py
@@ -425,11 +425,13 @@ async def test_busy_delivery_retry_is_bounded_by_monitor_runtime(tmp_path):
     )
     controller = MonitorController(service, dispatched, provider=provider)
 
-    await controller.tick(loop, now=110.0)
-    await controller.tick(loop, now=125.0)
+    first = await controller.tick(loop, now=110.0)
+    expired = await controller.tick(loop, now=125.0)
 
+    assert first is MonitorDecision.WAKE_ACTIONABLE
+    assert expired is MonitorDecision.STOP_BUDGET
     assert len(provider.previous) == 1
-    assert dispatched.await_count == 2
+    assert dispatched.await_count == 1
     assert loop.monitor is not None
     assert not loop.active
     assert not loop.monitor.wake_in_flight
@@ -467,10 +469,11 @@ async def test_cadence_edits_during_busy_preserve_retry_and_runtime_bound(tmp_pa
     assert loop.monitor.completion_evidence_deadline == 0.0
     assert service._timers.get(loop.id) is retry_timer
 
-    await controller.tick(loop, now=retry_at)
+    expired = await controller.tick(loop, now=retry_at)
 
+    assert expired is MonitorDecision.STOP_BUDGET
     assert len(provider.previous) == 1
-    assert dispatched.await_count == 2
+    assert dispatched.await_count == 1
     assert not loop.active
     assert loop.monitor.outcome is MonitorOutcome.BUDGET
     assert loop.next_due_ts == loop.monitor.next_probe_at == 0.0

--- a/test/test_monitor_mcp.py
+++ b/test/test_monitor_mcp.py
@@ -64,6 +64,7 @@ def test_monitor_inspect_passes_strict_identity_without_fallback():
                 "monitor": {
                     "kind": "github_pull_request",
                     "wake_count": 3,
+                    "token_usage_known": False,
                     "wake_instructions": "large prompt omitted from inspect",
                     "last_observation_status": "pending",
                     "last_observation_reason_code": "checks_pending",
@@ -82,6 +83,7 @@ def test_monitor_inspect_passes_strict_identity_without_fallback():
     payload = json.loads(result)
     assert payload["monitor"]["kind"] == "github_pull_request"
     assert payload["monitor"]["wake_count"] == 3
+    assert payload["monitor"]["token_usage_known"] is False
     assert payload["monitor"]["last_observation_status"] == "pending"
     assert payload["monitor"]["last_observation_reason_code"] == "checks_pending"
     assert payload["monitor"]["last_observation_summary"] == "Two checks are pending."


### PR DESCRIPTION
Stack: #5171 → #5172 → #5173 → #5174 → #5175 → #5176 → #5177

Position: 7 of 7. Base: #5176.

Routes GitHub babysitting through bounded structured monitors, keeps a finite unsupported-target fallback, and adds executable lifecycle scenarios.

Verification: lifecycle scenarios, monitor regression suites, docs, brand, scrub, and stack-wide gates.
