### PR TITLE
feat: add durable monitor decisions

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -875,6 +875,50 @@ as `research-notes`, and user-created canonical lookalikes such as
 `research-deadbeef`, are ordinary dashboard slots and retain remove-on-stop
 behavior.
 
+**Structured monitor substrate** (`monitoring/models.py`,
+`monitoring/decision.py`): `NudgeLoop.monitor` is an optional, versioned
+controller record for probe-first monitors. Absence is the durable compatibility
+marker for a legacy prompt loop, and serialization omits the absent field so an
+unrelated save does not eagerly migrate old records. The record owns target and
+objective identity, canonical observation and wake fingerprints, in-flight
+state, provider-error streak, completed agent-turn and token totals, probe
+deadline, and terminal outcome. Load reconstructs the typed record; a terminal
+current-version record with a contradictory active loop is deactivated. An
+AutoNudge dashboard response recursively passes every string in the structured
+monitor mapping through `redact_via_context`, including provider-controlled
+observation keys and values, before it leaves the backend. Legacy loop fields
+retain their existing response shape. An
+unsupported monitor version is marked blocked in its compatibility view and
+retained for inspection rather than executed under an older policy; its raw
+future payload and outer active intent survive an unrelated store rewrite
+unchanged. A generic legacy Save with `active=true` likewise leaves that future
+outer intent untouched. Its inert compatibility view uses validated current
+identity values when
+present and placeholders otherwise, so a future schema may rename those fields
+without making an older reader delete the raw record. Its compatibility view is
+inert under the older runtime without rewriting the outer active intent, allowing
+a later compatible gateway to resume it. A malformed current-version
+monitor mapping is quarantined inactive with `invalid_monitor_record`; its exact
+strict-JSON monitor payload remains durable across unrelated store rewrites for
+inspection. A non-mapping payload is skipped because it has no preservable monitor
+identity. Structured cadence is typed state with a 300-second default;
+the legacy loop default remains 60 seconds. This substrate has no delivery
+controller: loading, generic updating, arming, or a pre-existing timer all fail
+closed without a model turn until a later slice wires typed decisions. The pure
+`decide_monitor` policy performs no I/O. It
+checks the non-zero runtime/turn/token budgets first, classifies provider errors
+without a model turn, suppresses an unchanged observation, and permits
+`wake_actionable` only when the actionable fingerprint differs from the last
+acknowledged wake fingerprint. The defaults are 14,400 seconds, eight completed
+agent turns, 250,000 aggregate input/output tokens, and three consecutive
+provider errors. This substrate does not yet schedule a provider probe or expose
+a new MCP tool; those are later RFC implementation slices.
+
+Every persisted monitor mapping must encode as strict JSON; nested non-finite numbers
+and other values accepted only by Python's permissive encoder invalidate the record.
+Timestamp-like integers too large for finite float arithmetic are likewise quarantined
+with a zeroed compatibility timestamp while their exact raw monitor payload is retained.
+
 A reasonless inactive update is idempotent for a Research Lab stop tombstone:
 it preserves the source-owned `autonudge_stop` reason until the watchdog
 consumes it. An API retry or unrelated patch therefore cannot downgrade a

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -36,7 +36,7 @@ import tempfile
 import time
 import uuid
 from contextlib import asynccontextmanager, contextmanager
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Iterator
 
@@ -44,6 +44,14 @@ from kiro_crew import platform_compat, shutdown_event
 from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.loader import config_dir, data_home
 from kiro_crew.config.paths import legacy_home
+from kiro_crew.monitoring.models import (
+    MONITOR_STATE_VERSION,
+    MonitorOutcome,
+    MonitorState,
+    monitor_state_from_dict,
+    monitor_state_to_dict,
+    quarantine_monitor_state,
+)
 from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
@@ -425,6 +433,10 @@ class NudgeLoop:
     # so a restart resumes the countdown. A lost background write degrades to
     # a fresh full countdown after restart, never a lost or premature fire.
     next_due_ts: float = 0.0
+    # Optional typed controller state. Its absence is the compatibility marker
+    # for a legacy prompt-driven loop; legacy records are never inferred into a
+    # monitor merely because they use a babysit-shaped message.
+    monitor: MonitorState | None = None
 
 
 def _repair_number(
@@ -519,9 +531,8 @@ class AutoNudgeService:
         # the durable row until the dependent worker has been archived.
         self._maintenance_quiescing: set[str] = set()
         self._maintenance_quiesce_events: dict[str, asyncio.Event] = {}
-        # Set by _load() when a persisted loop was repaired in memory (currently
-        # a re-homed/dropped stop_sentinel_path) so start() can flush the
-        # correction back to disk ONCE instead of re-deriving it every boot.
+        # Set by _load() when persisted state is repaired in memory so start()
+        # flushes the correction before any loop can re-arm.
         self._store_dirty = False
         # Consecutive non-delivery count per loop (drives escalating re-arm
         # backoff + once-per-streak failure logging). Not persisted; resets on
@@ -547,7 +558,40 @@ class AutoNudgeService:
             data = json.load(fh)
         for raw in data.get("loops", []):
             try:
-                loop = NudgeLoop(**{k: raw[k] for k in raw if k in NudgeLoop.__dataclass_fields__})
+                loop_values = {
+                    key: raw[key]
+                    for key in raw
+                    if key in NudgeLoop.__dataclass_fields__ and key != "monitor"
+                }
+                loop = NudgeLoop(**loop_values)
+                if "monitor" in raw:
+                    monitor_raw = raw["monitor"]
+                    try:
+                        loop.monitor = monitor_state_from_dict(monitor_raw)
+                    except (TypeError, ValueError):
+                        loop.monitor = quarantine_monitor_state(monitor_raw)
+                        loop.active = False
+                        loop.next_due_ts = 0.0
+                        self._store_dirty = True
+                        logger.warning(
+                            "AutoNudge: quarantined malformed monitor record for loop %s",
+                            loop.id,
+                            exc_info=True,
+                        )
+                    if loop.monitor.version != MONITOR_STATE_VERSION:
+                        # An older controller cannot safely interpret a newer
+                        # policy. Runtime guards keep it inert without
+                        # rewriting the active intent a newer gateway needs.
+                        loop.monitor.outcome = MonitorOutcome.BLOCKED
+                        loop.monitor.stopped_reason = "unsupported_monitor_version"
+                    elif loop.active:
+                        # Structured monitor delivery belongs to the controller,
+                        # which is intentionally not wired in this substrate.
+                        # Deactivate rather than allowing the legacy timer to
+                        # inject the prompt before a typed decision is made.
+                        loop.active = False
+                        loop.next_due_ts = 0.0
+                        self._store_dirty = True
                 # Re-home / re-validate the persisted kill-switch path. A loop
                 # armed before the data-home move would otherwise be re-armed
                 # with a sentinel path nothing can ever create (see
@@ -644,8 +688,19 @@ class AutoNudgeService:
         """
         return {
             "version": _STORE_VERSION,
-            "loops": [asdict(lp) for lp in self._loops.values()],
+            "loops": [self._serialize_loop(lp) for lp in self._loops.values()],
         }
+
+    @staticmethod
+    def _serialize_loop(loop: NudgeLoop) -> dict[str, Any]:
+        payload = asdict(loop)
+        if loop.monitor is None:
+            # Preserve the legacy wire shape instead of eagerly migrating every
+            # record the next time an unrelated loop is saved.
+            payload.pop("monitor", None)
+        else:
+            payload["monitor"] = monitor_state_to_dict(loop.monitor)
+        return payload
 
     def _write_state(self, payload: dict) -> None:
         # Atomic write: serialize to a temp file in the same dir, fsync, then
@@ -703,7 +758,9 @@ class AutoNudgeService:
                     await self._persist_locked()
                     self._store_dirty = False
                 except Exception:  # noqa: BLE001 - in-memory repair still applies
-                    logger.warning("AutoNudge: could not persist sentinel repair", exc_info=True)
+                    logger.warning(
+                        "AutoNudge: could not persist loaded-state repair", exc_info=True
+                    )
             for loop in self._loops.values():
                 if loop.active:
                     self._arm_from_deadline(loop)
@@ -1043,7 +1100,9 @@ class AutoNudgeService:
             loop = self._loops.get(loop_id)
             if not loop:
                 return None
-            previous = asdict(loop)
+            # Keep typed nested values intact. ``asdict`` recursively converts
+            # MonitorState to a plain dict, which is not a valid rollback value.
+            previous = {item.name: getattr(loop, item.name) for item in fields(loop)}
             was_active = loop.active
             if message is not None:
                 loop.message = message
@@ -1057,6 +1116,16 @@ class AutoNudgeService:
             if max_runtime_secs is not None:
                 loop.max_runtime_secs = max(0, int(max_runtime_secs))
             if active is not None:
+                if active and loop.monitor is not None:
+                    if loop.monitor.version == MONITOR_STATE_VERSION:
+                        # The generic loop update path owns legacy prompt cycles,
+                        # not structured monitor policy. Task4 supplies the
+                        # controller that can deliberately re-arm these records.
+                        loop.active = False
+                        loop.next_due_ts = 0.0
+                    # An older gateway cannot interpret future structured state.
+                    # Ignore its generic Save flag instead of changing the outer
+                    # active intent that a compatible version may resume.
                 # TERMINAL-TRANSITION ATOMICITY: a bound-tagged deactivation
                 # (stopped_reason supplied — the _timer's cycle_cap /
                 # runtime_budget paths) must never OVERWRITE a deactivation
@@ -1070,7 +1139,7 @@ class AutoNudgeService:
                 # already inactive. The reverse order is already safe — a
                 # manual pause overwriting a bound tag only ever NARROWS
                 # revivability ("manual" never auto-revives).
-                if (
+                elif (
                     not active
                     and stopped_reason is None
                     and loop.stopped_reason == AUTONUDGE_STOP_REASON
@@ -1453,6 +1522,12 @@ class AutoNudgeService:
         sending another message. The delay is capped at ``idle_secs`` so a
         clock jump can never park the timer beyond one full interval.
         """
+        if loop.monitor is not None:
+            # A typed monitor needs a pre-delivery decision controller. PR1
+            # persists its substrate only, so any legacy timer is cancelled and
+            # cannot reach _run_fire_cycle before Task4 wires that controller.
+            self._cancel_timer(loop.id)
+            return
         now = time.time()
         if loop.next_due_ts <= 0:
             loop.next_due_ts = now + loop.idle_secs
@@ -1490,6 +1565,13 @@ class AutoNudgeService:
         except asyncio.CancelledError:
             return
         if shutdown_event.is_set():
+            return
+        if loop.monitor is not None:
+            # A timer can predate monitor attachment or a process upgrade. It
+            # must never dispatch a structured record through legacy prompt
+            # delivery, even if it was already sleeping when state changed.
+            if loop.active:
+                await self.update(loop.id, active=False)
             return
         # Kill switch: sentinel file present?
         if loop.stop_sentinel_path and Path(loop.stop_sentinel_path).exists():
@@ -1558,7 +1640,7 @@ class AutoNudgeService:
         # Fire. Update state only if the callback reports actual delivery —
         # otherwise skipped nudges (e.g. slot mid-turn) inflate cycle_count and
         # prematurely trip max_cycles. Missing callback → nothing to deliver.
-        if self._on_fire is None:
+        if self._on_fire is None or loop.monitor is not None:
             return
         self._firing.add(loop.id)
         try:
@@ -1582,7 +1664,7 @@ class AutoNudgeService:
         Runs entirely inside the caller's ``_firing`` window so a concurrent
         ``update()`` never cancels this task between delivery and persistence.
         """
-        if self._on_fire is None:
+        if self._on_fire is None or loop.monitor is not None:
             return
         # Mark the fire window so a concurrent update() defers its re-arm
         # instead of cancelling this task mid-turn (see update()). The window

--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -20,6 +20,7 @@ from kiro_crew.autonudge_authz import (  # noqa: F401 - re-exported
     resolve_stop_sentinel,
 )
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.platform import redact_via_context
 from kiro_crew.sel import sel
 from kiro_crew.session_ledger import ledger_key, render_snapshot
 
@@ -58,8 +59,24 @@ async def compose_nudge_body(
     return body
 
 
-def _serialize(loop: Any) -> dict:
-    return asdict(loop)
+def _redact_monitor_value(value: Any) -> Any:
+    """Redact every string in provider-controlled monitor evidence."""
+    if isinstance(value, str):
+        return redact_via_context(value)
+    if isinstance(value, dict):
+        return {
+            _redact_monitor_value(key): _redact_monitor_value(item) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_monitor_value(item) for item in value]
+    return value
+
+
+def _serialize(loop: Any) -> dict[str, Any]:
+    payload = asdict(loop)
+    if payload.get("monitor") is not None:
+        payload["monitor"] = _redact_monitor_value(payload["monitor"])
+    return payload
 
 
 async def api_autonudge_list(request: web.Request) -> web.Response:

--- a/src/kiro_crew/monitoring/__init__.py
+++ b/src/kiro_crew/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Typed state and deterministic policy for probe-first session monitors."""

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -1,0 +1,84 @@
+"""Pure decision policy for structured monitors."""
+
+from __future__ import annotations
+
+from kiro_crew.monitoring.models import (
+    MONITOR_STATE_VERSION,
+    MonitorBudgets,
+    MonitorDecision,
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorOutcome,
+    MonitorState,
+    ProviderErrorKind,
+)
+
+_RETRYABLE_PROVIDER_ERRORS = frozenset(
+    {ProviderErrorKind.TRANSIENT, ProviderErrorKind.RATE_LIMITED}
+)
+
+
+def decide_monitor(
+    state: MonitorState,
+    observation: MonitorObservation,
+    *,
+    now: float,
+) -> MonitorDecision:
+    """Return the only controller effect permitted for an observation.
+
+    Budget checks lead because a spent bound must never buy one additional
+    unattended turn. Provider failures are classified without a model. For a
+    normal observation, only a new actionable fingerprint may wake the owning
+    session.
+    """
+    if state.version != MONITOR_STATE_VERSION:
+        return MonitorDecision.STOP_BLOCKED
+    terminal = _terminal_decision(state.outcome)
+    if terminal is not None:
+        return terminal
+    if _budget_exhausted(state, state.budgets, now=now):
+        return MonitorDecision.STOP_BUDGET
+    if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
+        return _provider_error_decision(state, observation, state.budgets)
+    if observation.status is MonitorObservationStatus.ACTIONABLE:
+        if observation.fingerprint == state.last_wake_fingerprint:
+            return MonitorDecision.NO_CHANGE
+        return MonitorDecision.WAKE_ACTIONABLE
+    if observation.fingerprint == state.last_fingerprint:
+        return MonitorDecision.NO_CHANGE
+    if observation.status is MonitorObservationStatus.PENDING:
+        return MonitorDecision.RECORD_ONLY
+    if observation.status is MonitorObservationStatus.SUCCESS:
+        return MonitorDecision.STOP_SUCCESS
+    return MonitorDecision.STOP_BLOCKED
+
+
+def _terminal_decision(outcome: MonitorOutcome | None) -> MonitorDecision | None:
+    if outcome is MonitorOutcome.SUCCESS:
+        return MonitorDecision.STOP_SUCCESS
+    if outcome is MonitorOutcome.BUDGET:
+        return MonitorDecision.STOP_BUDGET
+    if outcome is not None:
+        return MonitorDecision.STOP_BLOCKED
+    return None
+
+
+def _budget_exhausted(state: MonitorState, budgets: MonitorBudgets, *, now: float) -> bool:
+    return (
+        now - state.created_ts >= budgets.max_runtime_secs
+        or state.agent_turns >= budgets.max_agent_turns
+        or state.total_tokens >= budgets.max_tokens
+    )
+
+
+def _provider_error_decision(
+    state: MonitorState,
+    observation: MonitorObservation,
+    budgets: MonitorBudgets,
+) -> MonitorDecision:
+    error = observation.provider_error
+    if error not in _RETRYABLE_PROVIDER_ERRORS:
+        return MonitorDecision.STOP_BLOCKED
+    if state.consecutive_provider_errors + 1 >= budgets.max_provider_errors:
+        return MonitorDecision.STOP_BLOCKED
+    return MonitorDecision.RETRY_PROVIDER

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -1,0 +1,296 @@
+"""Transport-independent monitor state.
+
+The scheduler, provider adapters, and session delivery code exchange these
+small records. They deliberately contain no provider clients or callbacks, so
+they can be persisted and evaluated without starting an agent turn.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field, fields
+from enum import Enum
+from typing import Any
+
+MONITOR_STATE_VERSION = 1
+DEFAULT_MONITOR_RUNTIME_SECS = 14_400
+DEFAULT_MONITOR_AGENT_TURNS = 8
+DEFAULT_MONITOR_TOKENS = 250_000
+DEFAULT_MONITOR_PROVIDER_ERRORS = 3
+DEFAULT_MONITOR_CADENCE_SECS = 300
+MONITOR_STOP_INVALID_RECORD = "invalid_monitor_record"
+
+
+def _is_finite_non_negative_number(value: object) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+class MonitorDecision(str, Enum):
+    """Effect the monitor controller applies after a probe."""
+
+    NO_CHANGE = "no_change"
+    RECORD_ONLY = "record_only"
+    WAKE_ACTIONABLE = "wake_actionable"
+    STOP_SUCCESS = "stop_success"
+    STOP_BLOCKED = "stop_blocked"
+    RETRY_PROVIDER = "retry_provider"
+    STOP_BUDGET = "stop_budget"
+
+
+class MonitorObservationStatus(str, Enum):
+    """Domain-owned classification of one canonical observation."""
+
+    PENDING = "pending"
+    ACTIONABLE = "actionable"
+    SUCCESS = "success"
+    BLOCKED = "blocked"
+    PROVIDER_ERROR = "provider_error"
+
+
+class ProviderErrorKind(str, Enum):
+    """Provider failures that have different retry safety."""
+
+    TRANSIENT = "transient"
+    RATE_LIMITED = "rate_limited"
+    AUTHENTICATION = "authentication"
+    AUTHORIZATION = "authorization"
+    NOT_FOUND = "not_found"
+
+
+class MonitorOutcome(str, Enum):
+    """Durable terminal result retained after the monitor stops."""
+
+    SUCCESS = "success"
+    BLOCKED = "blocked"
+    BUDGET = "budget"
+    USER_STOP = "user_stop"
+    SESSION_CLOSE = "session_close"
+    TARGET_UNAVAILABLE = "target_unavailable"
+
+
+@dataclass(frozen=True)
+class MonitorBudgets:
+    """Hard bounds for a structured monitor.
+
+    Unlike legacy AutoNudge values, zero never means unlimited here.
+    """
+
+    max_runtime_secs: int = DEFAULT_MONITOR_RUNTIME_SECS
+    max_agent_turns: int = DEFAULT_MONITOR_AGENT_TURNS
+    max_tokens: int = DEFAULT_MONITOR_TOKENS
+    max_provider_errors: int = DEFAULT_MONITOR_PROVIDER_ERRORS
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_runtime_secs",
+            "max_agent_turns",
+            "max_tokens",
+            "max_provider_errors",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class MonitorObservation:
+    """Small canonical result produced by a typed provider probe."""
+
+    fingerprint: str
+    status: MonitorObservationStatus
+    provider_error: ProviderErrorKind | None = None
+    reason_code: str = ""
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, MonitorObservationStatus):
+            raise ValueError("status must be a MonitorObservationStatus")
+        if not isinstance(self.fingerprint, str):
+            raise ValueError("fingerprint must be a string")
+        if not isinstance(self.reason_code, str):
+            raise ValueError("reason_code must be a string")
+        if not isinstance(self.summary, str):
+            raise ValueError("summary must be a string")
+        if self.status is MonitorObservationStatus.PROVIDER_ERROR:
+            if not isinstance(self.provider_error, ProviderErrorKind):
+                raise ValueError("provider_error must be a ProviderErrorKind for a provider error")
+            return
+        if not self.fingerprint:
+            raise ValueError("fingerprint is required for a comparable observation")
+        if self.provider_error is not None:
+            raise ValueError("provider_error is only valid for a provider error observation")
+
+
+@dataclass
+class MonitorState:
+    """Restart-durable state for one structured monitor."""
+
+    kind: str
+    target: str
+    objective: str
+    created_ts: float
+    version: int = MONITOR_STATE_VERSION
+    budgets: MonitorBudgets = field(default_factory=MonitorBudgets)
+    cadence_secs: int = DEFAULT_MONITOR_CADENCE_SECS
+    last_observation: dict[str, object] = field(default_factory=dict)
+    last_fingerprint: str = ""
+    last_observed_at: float = 0.0
+    last_wake_fingerprint: str = ""
+    wake_in_flight: bool = False
+    agent_turns: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    consecutive_provider_errors: int = 0
+    next_probe_at: float = 0.0
+    outcome: MonitorOutcome | None = None
+    stopped_reason: str = ""
+    stopped_at: float = 0.0
+    extra_fields: dict[str, object] = field(default_factory=dict, repr=False)
+    _raw_payload: dict[str, object] | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        for name in ("kind", "target", "objective"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if isinstance(self.version, bool) or not isinstance(self.version, int) or self.version <= 0:
+            raise ValueError("version must be a positive integer")
+        for name in ("created_ts", "last_observed_at", "next_probe_at", "stopped_at"):
+            value = getattr(self, name)
+            if not _is_finite_non_negative_number(value):
+                raise ValueError(f"{name} must be a finite non-negative number")
+        for name in (
+            "agent_turns",
+            "input_tokens",
+            "output_tokens",
+            "consecutive_provider_errors",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if not isinstance(self.budgets, MonitorBudgets):
+            raise ValueError("budgets must be MonitorBudgets")
+        if (
+            isinstance(self.cadence_secs, bool)
+            or not isinstance(self.cadence_secs, int)
+            or self.cadence_secs <= 0
+        ):
+            raise ValueError("cadence_secs must be a positive integer")
+        if not isinstance(self.last_observation, dict):
+            raise ValueError("last_observation must be an object")
+        _validate_strict_json_object("last_observation", self.last_observation)
+        if not isinstance(self.last_fingerprint, str) or not isinstance(
+            self.last_wake_fingerprint, str
+        ):
+            raise ValueError("monitor fingerprints must be strings")
+        if not isinstance(self.wake_in_flight, bool):
+            raise ValueError("wake_in_flight must be a boolean")
+        if self.outcome is not None and not isinstance(self.outcome, MonitorOutcome):
+            raise ValueError("outcome must be a MonitorOutcome")
+        if not isinstance(self.stopped_reason, str):
+            raise ValueError("stopped_reason must be a string")
+        if not isinstance(self.extra_fields, dict):
+            raise ValueError("extra_fields must be an object")
+        _validate_strict_json_object("extra_fields", self.extra_fields)
+        if self._raw_payload is not None and not isinstance(self._raw_payload, dict):
+            raise ValueError("_raw_payload must be an object")
+        if self._raw_payload is not None:
+            _validate_strict_json_object("_raw_payload", self._raw_payload)
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+def _validate_strict_json_object(name: str, value: dict[str, object]) -> None:
+    """Reject state that Python can encode only with non-standard JSON literals."""
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain strict JSON values") from exc
+
+
+def monitor_state_from_dict(raw: object) -> MonitorState:
+    """Decode a persisted monitor while ignoring fields owned by newer versions.
+
+    The caller is responsible for deactivating versions it does not implement.
+    Keeping the recognized identity fields makes such records inspectable.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError("monitor state must be an object")
+    if raw.get("version", MONITOR_STATE_VERSION) != MONITOR_STATE_VERSION:
+        # A newer version may give familiar fields different semantics. Keep an
+        # inert local view for the loader while retaining the exact raw payload
+        # for a later compatible controller to inspect and rewrite unchanged.
+        values: dict[str, Any] = {"version": raw.get("version")}
+        for key in ("kind", "target", "objective"):
+            value = raw.get(key)
+            values[key] = value if isinstance(value, str) and value else f"unsupported_{key}"
+        created_ts = raw.get("created_ts")
+        values["created_ts"] = created_ts if _is_finite_non_negative_number(created_ts) else 0.0
+        values["budgets"] = MonitorBudgets()
+        values["_raw_payload"] = deepcopy(raw)
+        return MonitorState(**values)
+    allowed = {
+        item.name
+        for item in fields(MonitorState)
+        if item.name not in {"extra_fields", "_raw_payload"}
+    }
+    values = {key: value for key, value in raw.items() if key in allowed}
+    values["extra_fields"] = {key: value for key, value in raw.items() if key not in allowed}
+    budgets = values.get("budgets")
+    if isinstance(budgets, dict):
+        values["budgets"] = MonitorBudgets(**budgets)
+    elif budgets is not None and not isinstance(budgets, MonitorBudgets):
+        raise ValueError("monitor budgets must be an object")
+    outcome = values.get("outcome")
+    if outcome is not None:
+        values["outcome"] = MonitorOutcome(outcome)
+    else:
+        values["outcome"] = None
+    return MonitorState(**values)
+
+
+def quarantine_monitor_state(raw: object) -> MonitorState:
+    """Build an inert inspection view while preserving strict raw JSON exactly."""
+    if not isinstance(raw, dict):
+        raise ValueError("monitor state must be an object")
+
+    def _identity(name: str) -> str:
+        value = raw.get(name)
+        return value if isinstance(value, str) and value else f"invalid_{name}"
+
+    raw_created_ts = raw.get("created_ts")
+    created_ts: int | float = 0.0
+    if _is_finite_non_negative_number(raw_created_ts):
+        assert isinstance(raw_created_ts, (int, float)) and not isinstance(raw_created_ts, bool)
+        created_ts = raw_created_ts
+    return MonitorState(
+        kind=_identity("kind"),
+        target=_identity("target"),
+        objective=_identity("objective"),
+        created_ts=created_ts,
+        outcome=MonitorOutcome.BLOCKED,
+        stopped_reason=MONITOR_STOP_INVALID_RECORD,
+        _raw_payload=deepcopy(raw),
+    )
+
+
+def monitor_state_to_dict(state: MonitorState) -> dict[str, object]:
+    """Encode known state while preserving fields written by a newer version."""
+    if state._raw_payload is not None:
+        return deepcopy(state._raw_payload)
+    payload = asdict(state)
+    extra = payload.pop("extra_fields")
+    payload.pop("_raw_payload")
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            payload.setdefault(key, value)
+    return payload

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -130,6 +130,15 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "source URL and its bare hostname.",
     ),
     (
+        "AutoNudge monitor responses",
+        "dashboard/handlers/autonudge.py",
+        "Structured monitor state served by the AutoNudge dashboard endpoints. "
+        "Provider observations are arbitrary nested JSON and can quote credentials "
+        "or exfiltration URLs, so every string key and value in the monitor mapping "
+        "passes through the platform-aware redaction chain before the response leaves "
+        "the backend.",
+    ),
+    (
         "AWS identity-probe failures",
         "aws_consent.py",
         "The stderr of a failed `aws sts get-caller-identity`, run to show the "

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -13,6 +13,7 @@ from kiro_crew import autonudge as _an
 from kiro_crew import autonudge_authz as _autonudge_mod
 from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
 from kiro_crew.dashboard.handlers.autonudge import render_nudge_message
+from kiro_crew.monitoring.models import MonitorOutcome, MonitorState
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +42,17 @@ def _freeze_clock(monkeypatch) -> None:
     the wall-clock dependency.
     """
     monkeypatch.setattr(_an.time, "time", lambda: _FROZEN_NOW)
+
+
+def _structured_monitor(**changes: object) -> MonitorState:
+    values: dict[str, object] = {
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+    }
+    values.update(changes)
+    return MonitorState(**values)
 
 
 @pytest.mark.asyncio
@@ -113,6 +125,119 @@ async def test_persistence_across_restart(tmp_path):
     assert restored.max_cycles == 5
     assert loop.id in svc2._timers  # timer re-armed
     svc2.stop()
+
+
+@pytest.mark.asyncio
+async def test_unwired_structured_monitor_is_not_armed_or_fired_on_start(tmp_path):
+    """PR1 persists structured monitors but cannot deliver them before Task4."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "monitor01",
+                "slot_key": "chat-1-123",
+                "message": "must not dispatch",
+                "idle_secs": 15,
+                "active": True,
+                "monitor": {
+                    "kind": "github_pull_request",
+                    "target": "owner/repo#123",
+                    "objective": "review_ready",
+                    "created_ts": 1_000.0,
+                },
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    service = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
+    await service.start()
+    try:
+        loop = service._loops["monitor01"]
+        assert not loop.active
+        assert loop.id not in service._timers
+        assert fired == []
+    finally:
+        service.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "monitor",
+    (
+        _structured_monitor(),
+        _structured_monitor(version=99),
+        _structured_monitor(outcome=MonitorOutcome.BLOCKED),
+    ),
+)
+async def test_generic_update_cannot_reactivate_a_structured_monitor(tmp_path, monitor):
+    """The legacy PATCH path cannot revive current, future, or terminal monitors."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = NudgeLoop(
+        id="monitor02",
+        slot_key="chat-1-123",
+        message="must not dispatch",
+        active=False,
+        monitor=monitor,
+    )
+    service._loops[loop.id] = loop
+
+    updated = await service.update(loop.id, active=True)
+
+    assert updated is loop
+    assert not loop.active
+    assert loop.id not in service._timers
+
+
+@pytest.mark.asyncio
+async def test_unwired_structured_monitor_timer_dispatches_zero_turns(tmp_path):
+    """A pre-existing timer cannot reach legacy delivery after monitor attachment."""
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    service = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
+    loop = NudgeLoop(
+        id="monitor03",
+        slot_key="chat-1-123",
+        message="must not dispatch",
+        monitor=_structured_monitor(),
+    )
+    service._loops[loop.id] = loop
+
+    await service._timer(loop, delay=0)
+
+    assert fired == []
+    assert not loop.active
+
+
+@pytest.mark.asyncio
+async def test_unwired_structured_monitor_fire_cycle_dispatches_zero_turns(tmp_path):
+    """Legacy delivery stays closed if monitor state changes after timer checks."""
+    fired: list[NudgeLoop] = []
+
+    async def on_fire(loop):
+        fired.append(loop)
+        return True
+
+    service = AutoNudgeService(base_dir=tmp_path, on_fire=on_fire)
+    loop = NudgeLoop(
+        id="monitor04",
+        slot_key="chat-1-123",
+        message="must not dispatch",
+        monitor=_structured_monitor(),
+    )
+
+    await service._run_fire_cycle(loop)
+
+    assert fired == []
 
 
 @pytest.mark.asyncio

--- a/test/test_autonudge_handlers_cov80.py
+++ b/test/test_autonudge_handlers_cov80.py
@@ -23,6 +23,7 @@ from aiohttp.test_utils import make_mocked_request
 
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.dashboard.handlers import autonudge as h
+from kiro_crew.monitoring.models import MonitorState
 
 
 class _FakeSvc:
@@ -104,6 +105,29 @@ async def test_list_serializes_every_loop(monkeypatch: pytest.MonkeyPatch) -> No
     # asdict() round-trip, not a repr: the full dataclass shape reaches the client.
     assert payload["loops"][0]["idle_secs"] == 300
     assert payload["loops"][0]["slot_key"] == "chat-1-111"
+
+
+@pytest.mark.asyncio
+async def test_list_redacts_nested_monitor_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    loop = _loop()
+    loop.monitor = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/example/repo/pull/1",
+        objective="review_ready",
+        created_ts=1.0,
+        last_observation={
+            "summary": f"provider returned {secret}",
+            "history": [secret],
+            secret: "credential-shaped keys are provider-controlled too",
+        },
+    )
+    _svc(monkeypatch, _FakeSvc([loop]))
+
+    payload = _body(await h.api_autonudge_list(_mk("GET", "/api/autonudge")))
+
+    assert secret not in json.dumps(payload)
+    assert "provider returned" in payload["loops"][0]["monitor"]["last_observation"]["summary"]
 
 
 # --- GET /api/autonudge/{slot_key} -------------------------------------------

--- a/test/test_monitor_decision.py
+++ b/test/test_monitor_decision.py
@@ -1,0 +1,229 @@
+"""Behavioral contract for probe-first monitor decisions."""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.models import (
+    MonitorBudgets,
+    MonitorDecision,
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorState,
+    ProviderErrorKind,
+)
+
+
+def _state(**changes: object) -> MonitorState:
+    values: dict[str, object] = {
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+    }
+    values.update(changes)
+    return MonitorState(**values)
+
+
+@pytest.mark.parametrize(
+    ("observation", "state", "expected"),
+    [
+        (
+            MonitorObservation("pending-a", MonitorObservationStatus.PENDING),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.NO_CHANGE,
+        ),
+        (
+            MonitorObservation("pending-b", MonitorObservationStatus.PENDING),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.RECORD_ONLY,
+        ),
+        (
+            MonitorObservation("failure-b", MonitorObservationStatus.ACTIONABLE),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.WAKE_ACTIONABLE,
+        ),
+        (
+            MonitorObservation("failure-b", MonitorObservationStatus.ACTIONABLE),
+            _state(
+                last_fingerprint="failure-b",
+                last_wake_fingerprint="failure-b",
+            ),
+            MonitorDecision.NO_CHANGE,
+        ),
+        (
+            MonitorObservation("ready-c", MonitorObservationStatus.SUCCESS),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.STOP_SUCCESS,
+        ),
+        (
+            MonitorObservation(
+                "closed-c",
+                MonitorObservationStatus.BLOCKED,
+                reason_code="pull_request_closed",
+            ),
+            _state(last_fingerprint="pending-a"),
+            MonitorDecision.STOP_BLOCKED,
+        ),
+    ],
+)
+def test_observation_changes_control_when_a_model_turn_is_allowed(
+    observation: MonitorObservation,
+    state: MonitorState,
+    expected: MonitorDecision,
+) -> None:
+    """A model turn is reserved for a new actionable fingerprint."""
+    assert decide_monitor(state, observation, now=1_100.0) is expected
+
+
+@pytest.mark.parametrize(
+    ("error", "consecutive_errors", "expected"),
+    [
+        (ProviderErrorKind.TRANSIENT, 0, MonitorDecision.RETRY_PROVIDER),
+        (ProviderErrorKind.RATE_LIMITED, 1, MonitorDecision.RETRY_PROVIDER),
+        (ProviderErrorKind.TRANSIENT, 2, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.AUTHENTICATION, 0, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.AUTHORIZATION, 0, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.NOT_FOUND, 0, MonitorDecision.STOP_BLOCKED),
+    ],
+)
+def test_provider_failures_never_buy_a_model_turn(
+    error: ProviderErrorKind,
+    consecutive_errors: int,
+    expected: MonitorDecision,
+) -> None:
+    """Transient failures back off; deterministic or repeated failures stop."""
+    observation = MonitorObservation(
+        "",
+        MonitorObservationStatus.PROVIDER_ERROR,
+        provider_error=error,
+    )
+
+    assert (
+        decide_monitor(
+            _state(
+                consecutive_provider_errors=consecutive_errors,
+                budgets=MonitorBudgets(max_provider_errors=3),
+            ),
+            observation,
+            now=1_100.0,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "now"),
+    [
+        (_state(budgets=MonitorBudgets(max_runtime_secs=100)), 1_100.0),
+        (
+            _state(agent_turns=8, budgets=MonitorBudgets(max_agent_turns=8)),
+            1_100.0,
+        ),
+        (
+            _state(
+                input_tokens=150_000,
+                output_tokens=100_000,
+                budgets=MonitorBudgets(max_tokens=250_000),
+            ),
+            1_100.0,
+        ),
+    ],
+)
+def test_exhausted_budget_prevents_even_an_actionable_wake(
+    state: MonitorState,
+    now: float,
+) -> None:
+    """A spent budget cannot dispatch one extra unattended model turn."""
+    observation = MonitorObservation(
+        "new-failure",
+        MonitorObservationStatus.ACTIONABLE,
+    )
+
+    assert decide_monitor(state, observation, now=now) is MonitorDecision.STOP_BUDGET
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_runtime_secs", 0),
+        ("max_agent_turns", 0),
+        ("max_tokens", 0),
+        ("max_provider_errors", 0),
+    ],
+)
+def test_structured_monitor_budgets_cannot_be_unlimited(field: str, value: int) -> None:
+    """First-class monitors reject legacy goal-loop unlimited values."""
+    with pytest.raises(ValueError, match=field):
+        MonitorBudgets(**{field: value})
+
+
+def test_provider_error_observation_requires_an_error_category() -> None:
+    """A provider failure without a category cannot choose retry versus stop."""
+    with pytest.raises(ValueError, match="provider_error"):
+        MonitorObservation("", MonitorObservationStatus.PROVIDER_ERROR)
+
+
+def test_non_error_observation_requires_a_fingerprint() -> None:
+    """A comparable observation cannot bypass wake deduplication."""
+    with pytest.raises(ValueError, match="fingerprint"):
+        MonitorObservation("", MonitorObservationStatus.ACTIONABLE)
+
+
+@pytest.mark.parametrize("fingerprint", (None, 1, True, ""))
+def test_non_error_observation_requires_a_nonempty_string_fingerprint(fingerprint: object) -> None:
+    """Only a real canonical fingerprint can participate in wake deduplication."""
+    with pytest.raises(ValueError, match="fingerprint"):
+        MonitorObservation(fingerprint, MonitorObservationStatus.ACTIONABLE)
+
+
+def test_observation_rejects_untyped_status_and_provider_error() -> None:
+    """Raw strings cannot bypass enum checks into a wake-capable decision."""
+    with pytest.raises(ValueError, match="status"):
+        MonitorObservation("actionable", "actionable")
+    with pytest.raises(ValueError, match="provider_error"):
+        MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error="transient",
+        )
+
+
+def test_provider_error_observation_requires_a_string_fingerprint() -> None:
+    """Provider errors may omit a fingerprint but cannot carry an untyped one."""
+    with pytest.raises(ValueError, match="fingerprint"):
+        MonitorObservation(
+            [],
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+        )
+
+
+@pytest.mark.parametrize(("field", "value"), (("reason_code", 42), ("summary", {})))
+def test_observation_requires_string_metadata_fields(field: str, value: object) -> None:
+    """Persisted/displayed observation metadata has one unambiguous text shape."""
+    with pytest.raises(ValueError, match=field):
+        MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+            **{field: value},
+        )
+
+
+def test_unknown_monitor_state_version_fails_closed() -> None:
+    """A newer persisted policy cannot inherit today's permissive branches."""
+    observation = MonitorObservation(
+        "new-failure",
+        MonitorObservationStatus.ACTIONABLE,
+    )
+
+    assert (
+        decide_monitor(
+            _state(version=99),
+            observation,
+            now=1_100.0,
+        )
+        is MonitorDecision.STOP_BLOCKED
+    )

--- a/test/test_monitor_persistence.py
+++ b/test/test_monitor_persistence.py
@@ -1,0 +1,443 @@
+"""Persistence compatibility for structured AutoNudge monitor state."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+from kiro_crew.monitoring.models import (
+    DEFAULT_MONITOR_CADENCE_SECS,
+    MonitorBudgets,
+    MonitorOutcome,
+    MonitorState,
+    monitor_state_from_dict,
+    monitor_state_to_dict,
+)
+
+
+def test_legacy_loop_round_trip_does_not_acquire_monitor_state(tmp_path) -> None:
+    """Reading and rewriting a legacy registry must not migrate its record."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "legacy01",
+                "slot_key": "chat-1-123",
+                "message": "keep going",
+                "idle_secs": 300,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["legacy01"]
+    assert restored.monitor is None
+    serialized = service._serialize_state()["loops"][0]
+    assert "monitor" not in serialized
+
+
+def test_explicit_null_monitor_is_malformed_and_cannot_rearm(tmp_path) -> None:
+    """Only an absent monitor field denotes a legacy loop."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "null01",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": None,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    assert "null01" not in service._loops
+
+
+def test_structured_monitor_cadence_defaults_without_changing_legacy_loop() -> None:
+    """Structured cadence lives in typed monitor state, not the legacy timer default."""
+    monitor = MonitorState(
+        kind="github_pull_request",
+        target="owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    assert monitor.cadence_secs == DEFAULT_MONITOR_CADENCE_SECS == 300
+    assert monitor_state_from_dict(monitor_state_to_dict(monitor)).cadence_secs == 300
+    assert NudgeLoop(id="legacy02", slot_key="chat-1-123", message="keep going").idle_secs == 60
+
+
+def test_structured_monitor_cadence_must_be_a_positive_integer() -> None:
+    """Structured monitors cannot inherit legacy unlimited or malformed cadence values."""
+    for cadence_secs in (0, -1, True, "300"):
+        try:
+            MonitorState(
+                kind="github_pull_request",
+                target="owner/repo#123",
+                objective="review_ready",
+                created_ts=1_000.0,
+                cadence_secs=cadence_secs,
+            )
+        except ValueError:
+            continue
+        raise AssertionError(f"cadence_secs={cadence_secs!r} was accepted")
+
+
+@pytest.mark.parametrize(
+    ("payload", "field_name"),
+    [
+        ({"last_observation": {"ratio": float("inf")}}, "last_observation"),
+        ({"future_field": {"ratio": float("nan")}}, "extra_fields"),
+        ({"version": 2, "future_field": {"ratio": float("-inf")}}, "_raw_payload"),
+    ],
+)
+def test_monitor_nested_state_rejects_non_strict_json(
+    payload: dict[str, object], field_name: str
+) -> None:
+    """Nested non-finite values cannot poison the registry or public JSON."""
+    base = {
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+    }
+
+    with pytest.raises(ValueError, match=field_name):
+        monitor_state_from_dict({**base, **payload})
+
+
+def test_monitor_state_survives_store_round_trip(tmp_path) -> None:
+    """Restart recovery retains the fingerprint, usage, budgets, and outcome."""
+    monitor = MonitorState(
+        kind="github_pull_request",
+        target="owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        budgets=MonitorBudgets(
+            max_runtime_secs=7_200,
+            max_agent_turns=4,
+            max_tokens=80_000,
+            max_provider_errors=2,
+        ),
+        cadence_secs=120,
+        last_observation={"head_revision": "abc123", "checks": "failing"},
+        last_fingerprint="failure-a",
+        last_observed_at=1_200.0,
+        last_wake_fingerprint="failure-a",
+        agent_turns=2,
+        input_tokens=12_000,
+        output_tokens=3_000,
+        consecutive_provider_errors=1,
+        next_probe_at=1_500.0,
+        outcome=MonitorOutcome.BUDGET,
+        stopped_reason="token_budget",
+        stopped_at=1_250.0,
+    )
+    service = AutoNudgeService(base_dir=tmp_path)
+    service._loops["monitor1"] = NudgeLoop(
+        id="monitor1",
+        slot_key="chat-1-123",
+        message="inspect the changed pull request",
+        monitor=monitor,
+    )
+    service._save()
+
+    restored_service = AutoNudgeService(base_dir=tmp_path)
+    restored_service._load()
+    restored_loop = restored_service._loops["monitor1"]
+    restored = restored_loop.monitor
+
+    assert restored is not None
+    assert not restored_loop.active
+    assert restored.kind == "github_pull_request"
+    assert restored.last_observation == {"head_revision": "abc123", "checks": "failing"}
+    assert restored.last_fingerprint == "failure-a"
+    assert restored.last_wake_fingerprint == "failure-a"
+    assert restored.budgets == MonitorBudgets(
+        max_runtime_secs=7_200,
+        max_agent_turns=4,
+        max_tokens=80_000,
+        max_provider_errors=2,
+    )
+    assert restored.cadence_secs == 120
+    assert restored.agent_turns == 2
+    assert restored.total_tokens == 15_000
+    assert restored.outcome is MonitorOutcome.BUDGET
+    assert restored.stopped_reason == "token_budget"
+
+
+@pytest.mark.asyncio
+async def test_failed_loop_update_restores_typed_monitor_state(tmp_path, monkeypatch) -> None:
+    """A failed registry write must leave the live typed record unchanged."""
+    monitor = MonitorState(
+        kind="github_pull_request",
+        target="owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+    loop = NudgeLoop(
+        id="monitor-update-failure",
+        slot_key="chat-1-123",
+        message="inspect the pull request",
+        next_due_ts=1_500.0,
+        monitor=monitor,
+    )
+    service = AutoNudgeService(base_dir=tmp_path)
+    service._loops[loop.id] = loop
+
+    def fail_write(_payload) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_write_state", fail_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        await service.update(loop.id, active=False)
+
+    assert loop.active
+    assert loop.next_due_ts == 1_500.0
+    assert loop.monitor is monitor
+
+
+def test_unknown_monitor_version_is_inspectable_and_inert_without_losing_active_intent(
+    tmp_path,
+) -> None:
+    """A downgrade must not durably disable work a newer gateway can resume."""
+    future_monitor = {
+        "version": 99,
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+        "cadence_secs": 123,
+        "last_fingerprint": "future-fingerprint",
+        "budgets": {
+            "max_runtime_secs": 7_777,
+            "max_agent_turns": 9,
+            "max_tokens": 88_888,
+            "max_provider_errors": 4,
+            "future_budget": "keep",
+        },
+        "outcome": "future_paused",
+        "future_policy": {"wake_every_time": True},
+    }
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "future01",
+                "slot_key": "chat-1-123",
+                "message": "future instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": future_monitor,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["future01"]
+    assert restored.active
+    assert restored.monitor is not None
+    assert restored.monitor.version == 99
+    assert restored.monitor.target == "owner/repo#123"
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "unsupported_monitor_version"
+    serialized_loop = service._serialize_state()["loops"][0]
+    assert serialized_loop["active"] is True
+    serialized_monitor = serialized_loop["monitor"]
+    assert serialized_monitor == future_monitor
+
+
+def test_future_monitor_without_current_identity_survives_store_rewrite(tmp_path) -> None:
+    """A future schema may rename every v1 identity field without being erased."""
+    future_monitor = {
+        "version": 99,
+        "identity_v2": {"resource": "opaque", "intent": "future"},
+        "future_policy": {"wake_every_time": True},
+    }
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "future02",
+                "slot_key": "chat-1-123",
+                "message": "future instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": future_monitor,
+            }
+        ],
+    }
+    path = tmp_path / "autonudge.json"
+    path.write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["future02"]
+    assert restored.active
+    assert restored.monitor is not None
+    assert restored.monitor.version == 99
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    service._save()
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["loops"][0]["active"] is True
+    assert persisted["loops"][0]["monitor"] == future_monitor
+
+
+@pytest.mark.asyncio
+async def test_generic_save_preserves_future_monitor_active_intent(tmp_path) -> None:
+    future_monitor = {
+        "version": 99,
+        "identity_v2": {"resource": "opaque", "intent": "future"},
+    }
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "future03",
+                "slot_key": "chat-1-123",
+                "message": "future instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": future_monitor,
+            }
+        ],
+    }
+    path = tmp_path / "autonudge.json"
+    path.write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+    service._load()
+
+    updated = await service.update("future03", active=True)
+
+    assert updated is not None
+    assert updated.active is True
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["loops"][0]["active"] is True
+    assert persisted["loops"][0]["monitor"] == future_monitor
+
+
+def test_malformed_monitor_cannot_rearm_after_restart(tmp_path) -> None:
+    """Invalid current state stays inspectable and cannot reach decision arithmetic."""
+    malformed_monitor = {
+        "version": 1,
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 1_000.0,
+        "agent_turns": "many",
+    }
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "broken01",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": malformed_monitor,
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["broken01"]
+    assert not restored.active
+    assert restored.monitor is not None
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "invalid_monitor_record"
+    assert service._serialize_state()["loops"][0]["monitor"] == malformed_monitor
+
+    service._save()
+    persisted = json.loads((tmp_path / "autonudge.json").read_text(encoding="utf-8"))
+    assert persisted["loops"][0]["monitor"] == malformed_monitor
+
+
+def test_oversized_monitor_timestamp_is_quarantined_without_data_loss(tmp_path) -> None:
+    """An integer too large for float conversion remains inspectable and inert."""
+    malformed_monitor = {
+        "version": 1,
+        "kind": "github_pull_request",
+        "target": "owner/repo#123",
+        "objective": "review_ready",
+        "created_ts": 10**400,
+    }
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "broken-large-timestamp",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": malformed_monitor,
+            }
+        ],
+    }
+    path = tmp_path / "autonudge.json"
+    path.write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["broken-large-timestamp"]
+    assert not restored.active
+    assert restored.monitor is not None
+    assert restored.monitor.created_ts == 0.0
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "invalid_monitor_record"
+    assert service._serialize_state()["loops"][0]["monitor"] == malformed_monitor
+
+
+def test_malformed_current_outcome_cannot_rearm_after_restart(tmp_path) -> None:
+    """A non-enum terminal value is malformed, not evidence the loop is active."""
+    store = {
+        "version": 1,
+        "loops": [
+            {
+                "id": "broken02",
+                "slot_key": "chat-1-123",
+                "message": "unsafe instructions",
+                "idle_secs": 300,
+                "active": True,
+                "monitor": {
+                    "version": 1,
+                    "kind": "github_pull_request",
+                    "target": "owner/repo#123",
+                    "objective": "review_ready",
+                    "created_ts": 1_000.0,
+                    "outcome": "",
+                },
+            }
+        ],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(store), encoding="utf-8")
+    service = AutoNudgeService(base_dir=tmp_path)
+
+    service._load()
+
+    restored = service._loops["broken02"]
+    assert not restored.active
+    assert restored.monitor is not None
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "invalid_monitor_record"


### PR DESCRIPTION
> Stacked change: **PR 2 of 8**
>
> Stack: #5180 → #5181 → #5182 → #5183 → #5184 → #5185 → #5186 → #5305
> Base: #5180
> Next: #5182

## Problem / Motivation

AutoNudge persists scheduling data but has no typed representation of monitored state, decisions, evidence, budgets, or terminal outcomes.

## Why it matters

Without a durable decision core, unchanged probes cannot be separated from costly action turns, restarts cannot recover safely, and malformed or future state can accidentally re-arm work.

## What changed (motivation → approach → change)

- Add versioned monitor state, observations, budgets, outcomes, and a pure bounded decision policy.
- Persist optional structured monitor state alongside legacy AutoNudge records without changing legacy serialization or delivery behavior, and preserve typed live values when a registry write fails.
- Preserve unsupported future payloads and their outer active intent for inspection while keeping them inert on older gateways, including when a generic legacy Save submits active=true.
- Prevent malformed or terminal structured records from entering the legacy firing path.
- Quarantine malformed current-version mappings as inactive while preserving their exact strict-JSON payload across unrelated store rewrites, including timestamp integers too large for finite arithmetic.

## Tests

- Monitor decision tables and budget precedence
- Persistence round-trips, malformed/future-version handling, and restart behavior
- AutoNudge scheduling, deadline, approval-stall, and legacy-compatibility coverage

## Manual verification

N/A — deterministic decision and persistence coverage exercises the complete surface introduced by this PR.

## Related Issues

N/A — implements the durable-state layer specified in #5180.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests cover the new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not yet supply final CLA wording.



