### PR TITLE
refactor: account for completed monitor turns

### DIFF
--- a/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+++ b/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
@@ -110,6 +110,11 @@ keys `slot._approval_futures` on `str(event.request_id)`, and
 `chat_runner.py:7487` ships `{"id": str(event.request_id)}` to the browser. A raw
 JSON-RPC id is part of the frontend contract.
 
+The first domain vocabulary now owned by `kiro_crew.agent_sdk` is the minimal
+completed-turn contract used by structured monitors: provider-neutral input and
+output token dimensions plus terminal stop reasons. Monitor accounting consumes
+that SDK surface instead of importing ACP's `TurnUsage` and constants directly.
+
 ### 2.2 The boundary is bypassed
 
 68 direct `kiro_crew.acp` import edges across 42 files. The heaviest:

--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -298,6 +298,13 @@ next turn into the same slot:
 - Loops persist to `autonudge.json` under the data home and are re-armed on gateway
   restart. A slot that is unreachable (no history, deleted, or closed) has its loop
   removed.
+- Structured monitor action accounting is a separate internal completion
+  callback, not a new injected-message envelope. Until the probe dispatcher is
+  attached, structured records remain fail-closed. The dormant adapters do not
+  change the legacy `[auto-nudge cycle N]` body, delivered-cycle count, `fired`
+  event, or rearm timing. When attached, dashboard and Discord report only a raw
+  provider completion; Slack likewise requires the raw provider completion and
+  shares its one consumed usage result with telemetry.
 
 **How to treat it:** it is a self-prompt. Continue the work; the operator asked for
 the loop, but is not waiting on this specific message.

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1006,9 +1006,18 @@ on the first exhausted runtime, turn, or token bound (in that precedence), and
 the completed-turn bound is validated against the universal eight-turn ceiling
 when constructed or loaded. Approval-stall completion is terminal and budget exhaustion takes
 precedence when both apply.
+Claim, budget-stop, completion, and pre-turn dispatch-failure mutations are
+applied to a staged copy; the replacement snapshot is persisted before the live
+record or timer changes. A failed write therefore leaves runtime state aligned
+with the restart snapshot instead of suppressing or releasing a wake only in
+memory.
 
 Dashboard structured actions receive a runtime-only completion hook and report
-only from `_run_chat`'s raw `EVENT_COMPLETE` branch. That correlated completion
+only from `_run_chat`'s `EVENT_COMPLETE` branch when its reason is safe completion
+evidence. ACP-synthesized terminal reasons are excluded from accounting. The
+stale-stream compatibility path reuses `end_turn` for a synthetic completion, so
+that reason is also excluded until ACP events carry provenance that distinguishes
+it from a provider result. That correlated completion
 is persisted before cancellable token-analytics I/O, so slot cleanup cannot lose
 provider completion evidence after the event has arrived. Legacy dashboard nudge
 scheduling still returns immediately and still rearms from the existing

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -992,9 +992,28 @@ strict-JSON monitor payload remains durable across unrelated store rewrites for
 inspection. A non-mapping payload is skipped because it has no preservable monitor
 identity. Structured cadence is typed state with a 300-second default;
 the legacy loop default remains 60 seconds. This substrate has no delivery
-controller: loading, generic updating, arming, or a pre-existing timer all fail
-closed without a model turn until a later slice wires typed decisions. The pure
-`decide_monitor` policy performs no I/O. It
+dispatcher: loading, generic updating, arming, or a pre-existing timer all fail
+closed without a model turn until the probe controller is wired. It does expose
+a dormant completed-turn controller seam. An actionable fingerprint is persisted
+in-flight before dispatch; dispatch failure clears that claim without spend; a
+correlated completion charges one agent turn exactly once, adds only reported
+non-negative token counts, and records token usage as unknown when authoritative
+counts are unavailable. Duplicate, removed, replaced, legacy, and mismatched
+callbacks are no-ops. Recovery of persisted in-flight state deactivates the
+record with `completion_evidence_unavailable` while retaining the acknowledged
+fingerprint, so restart cannot immediately duplicate the wake. Completion stops
+on the first exhausted runtime, turn, or token bound (in that precedence), and
+the completed-turn bound is validated against the universal eight-turn ceiling
+when constructed or loaded. Approval-stall completion is terminal and budget exhaustion takes
+precedence when both apply.
+
+Dashboard structured actions receive a runtime-only completion hook and report
+only from `_run_chat`'s raw `EVENT_COMPLETE` branch. That correlated completion
+is persisted before cancellable token-analytics I/O, so slot cleanup cannot lose
+provider completion evidence after the event has arrived. Legacy dashboard nudge
+scheduling still returns immediately and still rearms from the existing
+`notify_turn_complete` `finally`; the completion hook neither replaces nor moves
+that lifecycle call. The pure `decide_monitor` policy performs no I/O. It
 checks the non-zero runtime/turn/token budgets first, classifies provider errors
 without a model turn, suppresses an unchanged observation, and permits
 `wake_actionable` only when the actionable fingerprint differs from the last

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -162,6 +162,18 @@ The dashboard does **not** flow through `TurnDriver`; it remains unchanged as th
 | `EVENT_COMPACTION_STATUS` | `COMPACTION` |
 | `EVENT_COMPLETE` | `DONE` |
 
+An optional structured-monitor completion hook is orthogonal to rendering. It
+is invoked exactly from the raw `EVENT_COMPLETE` branch, before buffered output,
+steering, redaction, or `DONE` is flushed to the renderer, with the event's
+`TurnUsage` and a disposition derived from its stop reason. Completion accounting
+therefore survives failure or cancellation during renderer finalization. A normal
+handler return, command intercept, or stream exception does not manufacture
+completion evidence. Callback failure is logged and cannot change the channel
+turn's output or error behavior. The hook is absent from ordinary inbound turns
+and legacy AutoNudge turns. Slack reports a raw completion before its cancellable,
+best-effort analytics usage-row write, so cancellation after `EVENT_COMPLETE` cannot
+leave an accepted monitor wake in flight.
+
 ### Approval ladder
 
 Four modes (constants, mirroring the native Slack + dashboard ladder):

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -163,13 +163,16 @@ The dashboard does **not** flow through `TurnDriver`; it remains unchanged as th
 | `EVENT_COMPLETE` | `DONE` |
 
 An optional structured-monitor completion hook is orthogonal to rendering. It
-is invoked exactly from the raw `EVENT_COMPLETE` branch, before buffered output,
-steering, redaction, or `DONE` is flushed to the renderer, with the event's
-`TurnUsage` and a disposition derived from its stop reason. Completion accounting
-therefore survives failure or cancellation during renderer finalization. A normal
-handler return, command intercept, or stream exception does not manufacture
-completion evidence. Callback failure is logged and cannot change the channel
-turn's output or error behavior. The hook is absent from ordinary inbound turns
+is invoked exactly from the `EVENT_COMPLETE` branch when its reason is safe
+completion evidence, before buffered output, steering, redaction, or `DONE` is
+flushed to the renderer, with the event's `TurnUsage` and a disposition derived
+from its stop reason. ACP's stale-stream compatibility completion reuses
+`end_turn`, so that reason remains uncharged until the event carries provenance
+that distinguishes it from a provider result. Completion accounting therefore
+survives failure or cancellation during renderer finalization. A normal handler
+return, command intercept, stream exception, or ACP-synthesized terminal does not
+manufacture completion evidence. Callback failure is logged and cannot
+change the channel turn's output or error behavior. The hook is absent from ordinary inbound turns
 and legacy AutoNudge turns. Slack reports a raw completion before its cancellable,
 best-effort analytics usage-row write, so cancellation after `EVENT_COMPLETE` cannot
 leave an accepted monitor wake in flight.

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -407,6 +407,30 @@ A parent session born on any other channel (Telegram, Discord, `unified:` DM buc
 
 ## Tool Approval via Slack
 
+### Structured monitor completion adapters
+
+The AutoNudge router keeps its historical `on_fire -> bool`, `cycle_count`,
+`fired`, and rearm contracts. A separate runtime-only hook is supplied only when
+a structured monitor already has an actionable fingerprint marked in-flight;
+legacy loops and ordinary channel messages receive none. The structured probe
+dispatcher that creates those live actions lands separately.
+
+Slack's inline nudge turn consumes `provider_last_turn_usage(client)` exactly
+once. That one `TurnUsage` object is fanned out to the existing usage-row writer
+and, when the stream observed a raw `EVENT_COMPLETE`, the monitor completion
+hook, because the provider accessor destructively consumes retry-accumulated
+usage. The raw event's stop reason determines success, cancellation, or failure.
+Stream exhaustion and timeout before that event still write the existing usage
+row but do not report monitor completion or charge the monitor budget. Callback
+or usage-row persistence failure does not change the Slack delivery result.
+
+Discord synthetic nudge injection passes the same hook through
+`DiscordDispatcher` to `TurnDriver`. Only the driver's raw `EVENT_COMPLETE`
+branch reports completion; a command return, dispatch exception, or renderer
+`close()` is not completion evidence. Thus dashboard, Slack, and Discord all
+reach the same typed controller callback even though their transport lifecycles
+remain different.
+
 Background task approvals (subagent, cron, task runner, and AutoNudge) post approval buttons to Slack DM via `_interactive_approval()`, racing with dashboard approval:
 
 1. Posts ✅ Approve / 🚫 Reject buttons to owner DM

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -417,16 +417,18 @@ dispatcher that creates those live actions lands separately.
 
 Slack's inline nudge turn consumes `provider_last_turn_usage(client)` exactly
 once. That one `TurnUsage` object is fanned out to the existing usage-row writer
-and, when the stream observed a raw `EVENT_COMPLETE`, the monitor completion
+and, when the stream observed safe completion evidence, the monitor completion
 hook, because the provider accessor destructively consumes retry-accumulated
-usage. The raw event's stop reason determines success, cancellation, or failure.
+usage. ACP-synthesized terminals are excluded. Because stale-stream synthesis
+reuses `end_turn`, that reason remains uncharged until ACP events expose the
+completion's provenance; other safe reasons determine cancellation or failure.
 Stream exhaustion and timeout before that event still write the existing usage
 row but do not report monitor completion or charge the monitor budget. Callback
 or usage-row persistence failure does not change the Slack delivery result.
 
 Discord synthetic nudge injection passes the same hook through
-`DiscordDispatcher` to `TurnDriver`. Only the driver's raw `EVENT_COMPLETE`
-branch reports completion; a command return, dispatch exception, or renderer
+`DiscordDispatcher` to `TurnDriver`. Only a safe `EVENT_COMPLETE` reason reports
+completion; a command return, dispatch exception, or renderer
 `close()` is not completion evidence. Thus dashboard, Slack, and Discord all
 reach the same typed controller callback even though their transport lifecycles
 remain different.

--- a/src/kiro_crew/agent_sdk/__init__.py
+++ b/src/kiro_crew/agent_sdk/__init__.py
@@ -1,10 +1,9 @@
 """The one import surface between application code and an agent backend.
 
-This package was declared before it had contents, on purpose: the boundary it
-names is enforced from the moment it exists, by
-``scripts/check_agent_sdk_boundary.py`` and ``test/test_agent_sdk_boundary.py``,
-so the leak it is meant to drain cannot grow while the rest is still being
-designed.
+Provider-neutral turn usage and stop-reason vocabulary live here first. The
+boundary is enforced by ``scripts/check_agent_sdk_boundary.py`` and
+``test/test_agent_sdk_boundary.py``, so application code cannot introduce new
+direct dependencies on the backend packages while the rest of the SDK is built.
 
 The first capability to land is :mod:`kiro_crew.agent_sdk.backend_install` --
 whether each backend's harness is actually installed on THIS machine, as a
@@ -46,6 +45,8 @@ Design of record, including what each later phase moves in here:
 
 from __future__ import annotations
 
+from typing import Protocol
+
 from kiro_crew.agent_sdk.backend_install import (
     CACHE_TTL_SECONDS,
     COMPONENT_CLAUDE_ACP_ADAPTER,
@@ -60,7 +61,19 @@ from kiro_crew.agent_sdk.backend_install import (
     probe_backends,
 )
 
+TURN_STOP_REASON_CANCELLED = "cancelled"
+TURN_STOP_REASON_END_TURN = "end_turn"
+
+
+class AgentTurnUsage(Protocol):
+    """Provider-neutral token dimensions reported for one completed turn."""
+
+    input_tokens: int
+    output_tokens: int
+
+
 __all__ = [
+    "AgentTurnUsage",
     "CACHE_TTL_SECONDS",
     "COMPONENT_CLAUDE_ACP_ADAPTER",
     "COMPONENT_CLAUDE_CODE_CLI",
@@ -72,4 +85,6 @@ __all__ = [
     "clear_probe_cache",
     "probe_backend",
     "probe_backends",
+    "TURN_STOP_REASON_CANCELLED",
+    "TURN_STOP_REASON_END_TURN",
 ]

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -36,6 +36,7 @@ import tempfile
 import time
 import uuid
 from contextlib import asynccontextmanager, contextmanager
+from copy import deepcopy
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Iterator
@@ -44,8 +45,14 @@ from kiro_crew import platform_compat, shutdown_event
 from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.loader import config_dir, data_home
 from kiro_crew.config.paths import legacy_home
+from kiro_crew.monitoring.decision import monitor_budget_reason
 from kiro_crew.monitoring.models import (
     MONITOR_STATE_VERSION,
+    MONITOR_STOP_APPROVAL_STALL,
+    MONITOR_STOP_COMPLETION_UNAVAILABLE,
+    MONITOR_STOP_UNSUPPORTED_VERSION,
+    MonitorActionCompletion,
+    MonitorActionDisposition,
     MonitorOutcome,
     MonitorState,
     monitor_state_from_dict,
@@ -580,7 +587,20 @@ class AutoNudgeService:
                         # policy. Runtime guards keep it inert without
                         # rewriting the active intent a newer gateway needs.
                         loop.monitor.outcome = MonitorOutcome.BLOCKED
-                        loop.monitor.stopped_reason = "unsupported_monitor_version"
+                        loop.monitor.stopped_reason = MONITOR_STOP_UNSUPPORTED_VERSION
+                    elif loop.monitor.wake_in_flight:
+                        # A persisted claim proves dispatch was acknowledged but
+                        # says nothing about whether the process died before or
+                        # after the turn completed. Retire it deterministically:
+                        # charging would invent work, while clearing the wake
+                        # fingerprint would permit an immediate duplicate.
+                        loop.monitor.wake_in_flight = False
+                        if loop.monitor.outcome is None:
+                            loop.monitor.outcome = MonitorOutcome.BLOCKED
+                            loop.monitor.stopped_reason = MONITOR_STOP_COMPLETION_UNAVAILABLE
+                        loop.active = False
+                        loop.next_due_ts = 0.0
+                        self._store_dirty = True
                     elif loop.active:
                         # Structured monitor delivery belongs to the controller,
                         # which is intentionally not wired in this substrate.
@@ -1343,6 +1363,209 @@ class AutoNudgeService:
 
     def list_all(self) -> list[NudgeLoop]:
         return list(self._loops.values())
+
+    def _monitor_snapshot_with_replacement(
+        self,
+        loop: NudgeLoop,
+        replacement: NudgeLoop,
+    ) -> dict:
+        """Serialize one staged monitor replacement without changing live state."""
+        return {
+            "version": _STORE_VERSION,
+            "loops": [
+                self._serialize_loop(replacement if candidate.id == loop.id else candidate)
+                for candidate in self._loops.values()
+            ],
+        }
+
+    def _apply_staged_monitor(self, loop: NudgeLoop, staged: NudgeLoop) -> None:
+        """Publish a durable staged transition while preserving live object identity."""
+        state = loop.monitor
+        staged_state = staged.monitor
+        if state is None or staged_state is None:
+            raise ValueError("structured monitor replacement requires monitor state")
+        for loop_field in fields(NudgeLoop):
+            if loop_field.name != "monitor":
+                setattr(loop, loop_field.name, deepcopy(getattr(staged, loop_field.name)))
+        for state_field in fields(MonitorState):
+            setattr(
+                state,
+                state_field.name,
+                deepcopy(getattr(staged_state, state_field.name)),
+            )
+
+    async def _persist_staged_monitor_locked(
+        self,
+        loop: NudgeLoop,
+        staged: NudgeLoop,
+    ) -> None:
+        """Persist a complete replacement before publishing it to live readers."""
+        payload = self._monitor_snapshot_with_replacement(loop, staged)
+        try:
+            await self._write_monitor_snapshot_locked(payload)
+        except asyncio.CancelledError:
+            # The snapshot writer propagates cancellation only after draining
+            # the executor write. Publish the state that is already durable
+            # before preserving the caller's cancellation.
+            self._apply_staged_monitor(loop, staged)
+            raise
+        self._apply_staged_monitor(loop, staged)
+
+    async def mark_monitor_action_in_flight(
+        self,
+        monitor_id: str,
+        fingerprint: str,
+        *,
+        now: float | None = None,
+    ) -> bool:
+        """Persist the dispatch claim for one actionable fingerprint."""
+        if not isinstance(fingerprint, str) or not fingerprint:
+            raise ValueError("fingerprint must be a non-empty string")
+        checked_at = time.time() if now is None else now
+        if (
+            isinstance(checked_at, bool)
+            or not isinstance(checked_at, (int, float))
+            or not math.isfinite(checked_at)
+            or checked_at < 0
+        ):
+            raise ValueError("now must be a finite non-negative number")
+        dispatched = False
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or not loop.active
+                or state.outcome is not None
+                or state.wake_in_flight
+                or state.last_wake_fingerprint == fingerprint
+            ):
+                return False
+            reason = monitor_budget_reason(state, now=checked_at)
+            if reason:
+                self._stop_monitor_for_budget(loop, reason, stopped_at=checked_at)
+            else:
+                state.last_wake_fingerprint = fingerprint
+                state.wake_in_flight = True
+                dispatched = True
+            await self._write_monitor_snapshot_locked()
+        self._emit("updated", loop)
+        return dispatched
+
+    async def record_monitor_turn_completion(
+        self,
+        completion: MonitorActionCompletion,
+    ) -> None:
+        """Charge one correlated, completed action turn exactly once."""
+        async with self._lock:
+            loop = self._loops.get(completion.monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or not state.wake_in_flight
+                or state.last_wake_fingerprint != completion.fingerprint
+            ):
+                return
+            staged = deepcopy(loop)
+            staged_state = staged.monitor
+            assert staged_state is not None
+            disposition = (
+                MonitorActionDisposition.APPROVAL_STALL
+                if staged.approval_stalled
+                else completion.disposition
+            )
+            staged_state.wake_in_flight = False
+            staged_state.last_completion_fingerprint = completion.fingerprint
+            staged_state.last_completion_disposition = disposition
+            staged_state.last_completed_at = completion.completed_ts
+            staged_state.agent_turns += 1
+            if completion.input_tokens is None or completion.output_tokens is None:
+                staged_state.token_usage_known = False
+            if completion.input_tokens is not None:
+                staged_state.input_tokens += completion.input_tokens
+            if completion.output_tokens is not None:
+                staged_state.output_tokens += completion.output_tokens
+            reason = monitor_budget_reason(staged_state, now=completion.completed_ts)
+            if reason and staged_state.outcome is None:
+                staged.active = False
+                staged.next_due_ts = 0.0
+                staged_state.outcome = MonitorOutcome.BUDGET
+                staged_state.stopped_reason = reason
+                staged_state.stopped_at = completion.completed_ts
+            elif (
+                disposition is MonitorActionDisposition.APPROVAL_STALL
+                and staged_state.outcome is None
+            ):
+                staged.active = False
+                staged.next_due_ts = 0.0
+                staged_state.outcome = MonitorOutcome.BLOCKED
+                staged_state.stopped_reason = MONITOR_STOP_APPROVAL_STALL
+                staged_state.stopped_at = completion.completed_ts
+            await self._persist_staged_monitor_locked(loop, staged)
+            if not loop.active:
+                self._cancel_timer(loop.id)
+        self._emit("updated", loop)
+
+    def _stop_monitor_for_budget(
+        self,
+        loop: NudgeLoop,
+        reason: str,
+        *,
+        stopped_at: float,
+    ) -> None:
+        """Apply one structured-monitor budget stop under ``_lock``."""
+        state = loop.monitor
+        if state is None:
+            return
+        loop.active = False
+        loop.next_due_ts = 0.0
+        state.outcome = MonitorOutcome.BUDGET
+        state.stopped_reason = reason
+        state.stopped_at = stopped_at
+        self._cancel_timer(loop.id)
+
+    async def _write_monitor_snapshot_locked(self, payload: dict | None = None) -> None:
+        """Persist a monitor transition without releasing ``_lock`` mid-write."""
+        if payload is None:
+            payload = self._serialize_state()
+        future = asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
+        cancelled = False
+        while not future.done():
+            try:
+                await asyncio.shield(future)
+            except asyncio.CancelledError:
+                # Executor writes cannot be cancelled. Absorb every
+                # cancellation until the write settles so the caller's lock
+                # scope cannot release around an older snapshot.
+                cancelled = True
+        future.result()
+        if cancelled:
+            # Propagate cancellation only after the executor result has been
+            # observed while the caller still owns the lock.
+            raise asyncio.CancelledError
+
+    async def record_monitor_dispatch_failure(
+        self,
+        monitor_id: str,
+        fingerprint: str,
+    ) -> None:
+        """Release an unstarted dispatch claim without charging its budget."""
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or not state.wake_in_flight
+                or state.last_wake_fingerprint != fingerprint
+            ):
+                return
+            state.wake_in_flight = False
+            state.last_wake_fingerprint = ""
+            await self._write_monitor_snapshot_locked()
+        self._emit("updated", loop)
 
     def _find_by_slot(self, slot_key: str) -> NudgeLoop | None:
         """The loop bound to *slot_key*, which may be a binding key OR a tab name.

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -1442,14 +1442,19 @@ class AutoNudgeService:
                 or state.last_wake_fingerprint == fingerprint
             ):
                 return False
-            reason = monitor_budget_reason(state, now=checked_at)
+            staged = deepcopy(loop)
+            staged_state = staged.monitor
+            assert staged_state is not None
+            reason = monitor_budget_reason(staged_state, now=checked_at)
             if reason:
-                self._stop_monitor_for_budget(loop, reason, stopped_at=checked_at)
+                self._apply_monitor_budget_stop(staged, reason, stopped_at=checked_at)
             else:
-                state.last_wake_fingerprint = fingerprint
-                state.wake_in_flight = True
+                staged_state.last_wake_fingerprint = fingerprint
+                staged_state.wake_in_flight = True
                 dispatched = True
-            await self._write_monitor_snapshot_locked()
+            await self._persist_staged_monitor_locked(loop, staged)
+            if not loop.active:
+                self._cancel_timer(loop.id)
         self._emit("updated", loop)
         return dispatched
 
@@ -1508,14 +1513,14 @@ class AutoNudgeService:
                 self._cancel_timer(loop.id)
         self._emit("updated", loop)
 
-    def _stop_monitor_for_budget(
+    def _apply_monitor_budget_stop(
         self,
         loop: NudgeLoop,
         reason: str,
         *,
         stopped_at: float,
     ) -> None:
-        """Apply one structured-monitor budget stop under ``_lock``."""
+        """Apply budget-stop fields without changing the live timer registry."""
         state = loop.monitor
         if state is None:
             return
@@ -1524,7 +1529,6 @@ class AutoNudgeService:
         state.outcome = MonitorOutcome.BUDGET
         state.stopped_reason = reason
         state.stopped_at = stopped_at
-        self._cancel_timer(loop.id)
 
     async def _write_monitor_snapshot_locked(self, payload: dict | None = None) -> None:
         """Persist a monitor transition without releasing ``_lock`` mid-write."""
@@ -1562,9 +1566,12 @@ class AutoNudgeService:
                 or state.last_wake_fingerprint != fingerprint
             ):
                 return
-            state.wake_in_flight = False
-            state.last_wake_fingerprint = ""
-            await self._write_monitor_snapshot_locked()
+            staged = deepcopy(loop)
+            staged_state = staged.monitor
+            assert staged_state is not None
+            staged_state.wake_in_flight = False
+            staged_state.last_wake_fingerprint = ""
+            await self._persist_staged_monitor_locked(loop, staged)
         self._emit("updated", loop)
 
     def _find_by_slot(self, slot_key: str) -> NudgeLoop | None:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -201,6 +201,10 @@ from kiro_crew.messaging.renderer import chunk_for_transport
 from kiro_crew.metrics.events import TURN_TIMEOUT_CAUSE, emit_counter
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.metrics.turns import emit_turn_duration, turn_outcome
+from kiro_crew.monitoring.completion import (
+    MonitorCompletionHook,
+    disposition_for_stop_reason,
+)
 from kiro_crew.name_grant import (
     Refusal,
     log_decline,
@@ -4591,6 +4595,7 @@ async def _run_chat(
     regenerate_hint: str = "",
     _on_consumed: "Callable[[bool], None] | None" = None,
     _on_irreversibly_consumed: "Callable[[], Awaitable[None] | None] | None" = None,
+    monitor_completion: MonitorCompletionHook | None = None,
 ) -> None:
     """Stream LLM response into *slot*.  Survives browser disconnect."""
 
@@ -7963,6 +7968,17 @@ async def _run_chat(
                 # so cards don't stay stuck "running".
                 _native_subagent_close_all(state, slot, _native_tracker, _native_card_output)
                 _u = event.usage
+                if monitor_completion is not None:
+                    try:
+                        await monitor_completion.complete(
+                            disposition_for_stop_reason(event.stop_reason),
+                            event.usage,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "dashboard monitor turn completion callback failed",
+                            exc_info=True,
+                        )
                 # Capture per-turn stats for the assistant-message footer.
                 # Prefer the provider-reported duration (claude_code) over the
                 # local wall clock (kiro/acp reports duration_ms=0).

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -204,6 +204,7 @@ from kiro_crew.metrics.turns import emit_turn_duration, turn_outcome
 from kiro_crew.monitoring.completion import (
     MonitorCompletionHook,
     disposition_for_stop_reason,
+    is_monitor_completion_evidence,
 )
 from kiro_crew.name_grant import (
     Refusal,
@@ -7968,7 +7969,9 @@ async def _run_chat(
                 # so cards don't stay stuck "running".
                 _native_subagent_close_all(state, slot, _native_tracker, _native_card_output)
                 _u = event.usage
-                if monitor_completion is not None:
+                if monitor_completion is not None and is_monitor_completion_evidence(
+                    event.stop_reason
+                ):
                     try:
                         await monitor_completion.complete(
                             disposition_for_stop_reason(event.stop_reason),

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -78,6 +78,7 @@ from kiro_crew.messaging.link import (
 from kiro_crew.messaging.renderer import Renderer, SilentRenderer
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.messaging.upload_gate import live_dashboard_slot, uploads_restricted
+from kiro_crew.monitoring.completion import MonitorCompletionHook
 from kiro_crew.safety_override import describe_grant_lifetime, safety_override
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -262,6 +263,7 @@ class DiscordDispatcher:
         drain: bool = True,
         interpret_commands: bool = True,
         origin_tag: str = "",
+        monitor_completion: MonitorCompletionHook | None = None,
     ) -> None:
         """Drive one authorized inbound message through TurnDriver end-to-end.
 
@@ -720,6 +722,7 @@ class DiscordDispatcher:
                 audit_session_key=session_key,
                 audit_agent=agent or "kirocrew",
                 closing_gate=lambda: self.sessions.begin_turn(session_key),
+                monitor_completion=monitor_completion,
             )
             accumulated = await driver.run(full_message)
 

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -1431,6 +1431,7 @@ async def stream_and_collect(
     on_chunk: Callable[[str], None] | None = None,
     on_tool_approval: Callable[[LLMEvent], Awaitable[bool]] | None = None,
     on_steer_consumed: Callable[[str], None] | None = None,
+    on_complete: Callable[[LLMEvent], None] | None = None,
     on_tool_gate: Callable[[str, bool, bool], None] | None = None,
     retry_transient: bool = True,
     max_turns: int | None = None,
@@ -1457,6 +1458,10 @@ async def stream_and_collect(
             fire-and-forget write, so this echo is the ONLY authoritative signal
             that the backend injected it; a caller that steers must observe this
             to know which of its steers to requeue when the turn ends.
+        on_complete: Optional callback invoked with the provider's raw
+            ``EVENT_COMPLETE``. It is not invoked when the stream exhausts or
+            the caller cancels before that event. Raising from the callback is
+            swallowed so observation cannot fail the completed turn.
         on_tool_gate: Optional callback invoked once per tool permission
             decision with ``(tool_title, approved, security_blocked)``. Lets a
             caller tell "the model did work" apart from "every tool the model
@@ -1627,6 +1632,11 @@ async def stream_and_collect(
                 elif event.kind == EVENT_STEER_CONSUMED:
                     consumed_this_attempt.append(event.text or "")
                 elif event.kind == EVENT_COMPLETE:
+                    if on_complete:
+                        try:
+                            on_complete(event)
+                        except Exception:
+                            logger.debug("on_complete callback failed", exc_info=True)
                     break
             return result_text
         except AcpError as exc:

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -45,6 +45,10 @@ from kiro_crew.messaging.renderer import (
     OutputEvent,
     Renderer,
 )
+from kiro_crew.monitoring.completion import (
+    MonitorCompletionHook,
+    disposition_for_stop_reason,
+)
 from kiro_crew.security import StreamRedactor, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -325,6 +329,7 @@ class TurnDriver:
         audit_session_key: str = "",
         audit_agent: str = "kirocrew",
         closing_gate: Callable[[], None] | None = None,
+        monitor_completion: MonitorCompletionHook | None = None,
     ) -> None:
         self.provider = provider
         self.renderer = renderer
@@ -351,6 +356,7 @@ class TurnDriver:
         # EVENT_TOOL_RESULT for a tool call whose trusted ``_meta.kiro``
         # identity was recorded at EVENT_TOOL_CALL — the forgery gate.
         self.directive_consumer = directive_consumer
+        self.monitor_completion = monitor_completion
         # Terminal stop reason of the last run() — read by the dispatcher's
         # post-turn bookkeeping (e.g. COMPACTION_FAILED -> session reset).
         self.last_stop_reason: str = ""
@@ -718,6 +724,17 @@ class TurnDriver:
                 # sent end_turn) and needs a session reset the driver cannot
                 # perform itself (it holds no session key).
                 self.last_stop_reason = event.stop_reason or ""
+                if self.monitor_completion is not None:
+                    try:
+                        await self.monitor_completion.complete(
+                            disposition_for_stop_reason(event.stop_reason),
+                            event.usage,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "monitor turn completion callback failed",
+                            exc_info=True,
+                        )
                 pending = compaction_filter.flush()
                 if pending:
                     await dispatch_frames(steering_filter.feed(pending))

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -48,6 +48,7 @@ from kiro_crew.messaging.renderer import (
 from kiro_crew.monitoring.completion import (
     MonitorCompletionHook,
     disposition_for_stop_reason,
+    is_monitor_completion_evidence,
 )
 from kiro_crew.security import StreamRedactor, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -724,7 +725,9 @@ class TurnDriver:
                 # sent end_turn) and needs a session reset the driver cannot
                 # perform itself (it holds no session key).
                 self.last_stop_reason = event.stop_reason or ""
-                if self.monitor_completion is not None:
+                if self.monitor_completion is not None and is_monitor_completion_evidence(
+                    event.stop_reason
+                ):
                     try:
                         await self.monitor_completion.complete(
                             disposition_for_stop_reason(event.stop_reason),

--- a/src/kiro_crew/monitoring/completion.py
+++ b/src/kiro_crew/monitoring/completion.py
@@ -17,6 +17,22 @@ from kiro_crew.monitoring.models import (
 )
 
 MonitorCompletionCallback = Callable[[MonitorActionCompletion], Awaitable[None]]
+_SYNTHETIC_STOP_REASONS = frozenset(
+    {
+        "",
+        TURN_STOP_REASON_END_TURN,
+        "timeout",
+        "stale_recover",
+        "error: cancel unacked",
+        "error: tool stall",
+        "error: compaction failed",
+    }
+)
+
+
+def is_monitor_completion_evidence(stop_reason: str) -> bool:
+    """Return whether a terminal event proves that an agent turn completed."""
+    return stop_reason not in _SYNTHETIC_STOP_REASONS
 
 
 def disposition_for_stop_reason(stop_reason: str) -> MonitorActionDisposition:

--- a/src/kiro_crew/monitoring/completion.py
+++ b/src/kiro_crew/monitoring/completion.py
@@ -1,0 +1,86 @@
+"""Runtime-only completion adapter shared by monitor delivery surfaces."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from kiro_crew.agent_sdk import (
+    TURN_STOP_REASON_CANCELLED,
+    TURN_STOP_REASON_END_TURN,
+    AgentTurnUsage,
+)
+from kiro_crew.monitoring.models import (
+    MonitorActionCompletion,
+    MonitorActionDisposition,
+)
+
+MonitorCompletionCallback = Callable[[MonitorActionCompletion], Awaitable[None]]
+
+
+def disposition_for_stop_reason(stop_reason: str) -> MonitorActionDisposition:
+    """Map an authoritative provider stop reason onto monitor accounting."""
+    if stop_reason == TURN_STOP_REASON_END_TURN:
+        return MonitorActionDisposition.SUCCESS
+    if stop_reason == TURN_STOP_REASON_CANCELLED:
+        return MonitorActionDisposition.CANCELLATION
+    return MonitorActionDisposition.FAILURE
+
+
+@dataclass(frozen=True)
+class MonitorCompletionHook:
+    """Bind a surface's raw turn result to one monitor action identity."""
+
+    monitor_id: str
+    fingerprint: str
+    callback: MonitorCompletionCallback
+
+    def __post_init__(self) -> None:
+        for name in ("monitor_id", "fingerprint"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if not callable(self.callback):
+            raise ValueError("callback must be callable")
+
+    async def complete(
+        self,
+        disposition: MonitorActionDisposition,
+        usage: AgentTurnUsage | None = None,
+        *,
+        completed_ts: float | None = None,
+    ) -> None:
+        """Deliver one normalized record to the controller callback."""
+        input_tokens, output_tokens = _authoritative_token_counts(usage)
+        await self.callback(
+            MonitorActionCompletion(
+                monitor_id=self.monitor_id,
+                fingerprint=self.fingerprint,
+                disposition=disposition,
+                completed_ts=time.time() if completed_ts is None else completed_ts,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        )
+
+
+def _authoritative_token_counts(
+    usage: AgentTurnUsage | None,
+) -> tuple[int | None, int | None]:
+    """Return token dimensions only when the provider reported real counts."""
+    if usage is None:
+        return None, None
+    try:
+        input_tokens = int(usage.input_tokens)
+        output_tokens = int(usage.output_tokens)
+    except (TypeError, ValueError, OverflowError):
+        return None, None
+    if input_tokens < 0 or output_tokens < 0:
+        return None, None
+    if input_tokens == 0 and output_tokens == 0:
+        # Kiro ACP bills in credits and leaves both token fields at their
+        # dataclass defaults. Zero therefore means unavailable on that seam,
+        # not authoritative proof that a completed agent turn used no tokens.
+        return None, None
+    return input_tokens, output_tokens

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from kiro_crew.monitoring.models import (
     MONITOR_STATE_VERSION,
+    MONITOR_STOP_AGENT_TURN_BUDGET,
+    MONITOR_STOP_RUNTIME_BUDGET,
+    MONITOR_STOP_TOKEN_BUDGET,
     MonitorBudgets,
     MonitorDecision,
     MonitorObservation,
@@ -36,7 +39,7 @@ def decide_monitor(
     terminal = _terminal_decision(state.outcome)
     if terminal is not None:
         return terminal
-    if _budget_exhausted(state, state.budgets, now=now):
+    if monitor_budget_reason(state, now=now):
         return MonitorDecision.STOP_BUDGET
     if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
         return _provider_error_decision(state, observation, state.budgets)
@@ -63,12 +66,16 @@ def _terminal_decision(outcome: MonitorOutcome | None) -> MonitorDecision | None
     return None
 
 
-def _budget_exhausted(state: MonitorState, budgets: MonitorBudgets, *, now: float) -> bool:
-    return (
-        now - state.created_ts >= budgets.max_runtime_secs
-        or state.agent_turns >= budgets.max_agent_turns
-        or state.total_tokens >= budgets.max_tokens
-    )
+def monitor_budget_reason(state: MonitorState, *, now: float) -> str:
+    """Return the first exhausted hard bound in stable policy order."""
+    budgets = state.budgets
+    if now - state.created_ts >= budgets.max_runtime_secs:
+        return MONITOR_STOP_RUNTIME_BUDGET
+    if state.agent_turns >= budgets.max_agent_turns:
+        return MONITOR_STOP_AGENT_TURN_BUDGET
+    if state.total_tokens >= budgets.max_tokens:
+        return MONITOR_STOP_TOKEN_BUDGET
+    return ""
 
 
 def _provider_error_decision(

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -21,6 +21,12 @@ DEFAULT_MONITOR_TOKENS = 250_000
 DEFAULT_MONITOR_PROVIDER_ERRORS = 3
 DEFAULT_MONITOR_CADENCE_SECS = 300
 MONITOR_STOP_INVALID_RECORD = "invalid_monitor_record"
+MONITOR_STOP_RUNTIME_BUDGET = "runtime_budget"
+MONITOR_STOP_AGENT_TURN_BUDGET = "agent_turn_budget"
+MONITOR_STOP_TOKEN_BUDGET = "token_budget"
+MONITOR_STOP_APPROVAL_STALL = "approval_stall"
+MONITOR_STOP_COMPLETION_UNAVAILABLE = "completion_evidence_unavailable"
+MONITOR_STOP_UNSUPPORTED_VERSION = "unsupported_monitor_version"
 
 
 def _is_finite_non_negative_number(value: object) -> bool:
@@ -75,6 +81,48 @@ class MonitorOutcome(str, Enum):
     TARGET_UNAVAILABLE = "target_unavailable"
 
 
+class MonitorActionDisposition(str, Enum):
+    """Terminal disposition reported by a started monitor action turn."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    CANCELLATION = "cancellation"
+    APPROVAL_STALL = "approval_stall"
+
+
+@dataclass(frozen=True)
+class MonitorActionCompletion:
+    """Authoritative evidence that one monitor action turn stopped running."""
+
+    monitor_id: str
+    fingerprint: str
+    disposition: MonitorActionDisposition
+    completed_ts: float
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("monitor_id", "fingerprint"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if not isinstance(self.disposition, MonitorActionDisposition):
+            raise ValueError("disposition must be a MonitorActionDisposition")
+        if (
+            isinstance(self.completed_ts, bool)
+            or not isinstance(self.completed_ts, (int, float))
+            or not math.isfinite(self.completed_ts)
+            or self.completed_ts < 0
+        ):
+            raise ValueError("completed_ts must be a finite non-negative number")
+        for name in ("input_tokens", "output_tokens"):
+            value = getattr(self, name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(f"{name} must be a non-negative integer or None")
+
+
 @dataclass(frozen=True)
 class MonitorBudgets:
     """Hard bounds for a structured monitor.
@@ -97,6 +145,8 @@ class MonitorBudgets:
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{name} must be a positive integer")
+        if self.max_agent_turns > DEFAULT_MONITOR_AGENT_TURNS:
+            raise ValueError(f"max_agent_turns must be at most {DEFAULT_MONITOR_AGENT_TURNS}")
 
 
 @dataclass(frozen=True)
@@ -144,6 +194,10 @@ class MonitorState:
     last_observed_at: float = 0.0
     last_wake_fingerprint: str = ""
     wake_in_flight: bool = False
+    last_completion_fingerprint: str = ""
+    last_completion_disposition: MonitorActionDisposition | None = None
+    last_completed_at: float = 0.0
+    token_usage_known: bool = True
     agent_turns: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
@@ -162,7 +216,13 @@ class MonitorState:
                 raise ValueError(f"{name} must be a non-empty string")
         if isinstance(self.version, bool) or not isinstance(self.version, int) or self.version <= 0:
             raise ValueError("version must be a positive integer")
-        for name in ("created_ts", "last_observed_at", "next_probe_at", "stopped_at"):
+        for name in (
+            "created_ts",
+            "last_observed_at",
+            "last_completed_at",
+            "next_probe_at",
+            "stopped_at",
+        ):
             value = getattr(self, name)
             if not _is_finite_non_negative_number(value):
                 raise ValueError(f"{name} must be a finite non-negative number")
@@ -186,12 +246,23 @@ class MonitorState:
         if not isinstance(self.last_observation, dict):
             raise ValueError("last_observation must be an object")
         _validate_strict_json_object("last_observation", self.last_observation)
-        if not isinstance(self.last_fingerprint, str) or not isinstance(
-            self.last_wake_fingerprint, str
+        if any(
+            not isinstance(value, str)
+            for value in (
+                self.last_fingerprint,
+                self.last_wake_fingerprint,
+                self.last_completion_fingerprint,
+            )
         ):
             raise ValueError("monitor fingerprints must be strings")
         if not isinstance(self.wake_in_flight, bool):
             raise ValueError("wake_in_flight must be a boolean")
+        if self.last_completion_disposition is not None and not isinstance(
+            self.last_completion_disposition, MonitorActionDisposition
+        ):
+            raise ValueError("last_completion_disposition must be a MonitorActionDisposition")
+        if not isinstance(self.token_usage_known, bool):
+            raise ValueError("token_usage_known must be a boolean")
         if self.outcome is not None and not isinstance(self.outcome, MonitorOutcome):
             raise ValueError("outcome must be a MonitorOutcome")
         if not isinstance(self.stopped_reason, str):
@@ -255,6 +326,9 @@ def monitor_state_from_dict(raw: object) -> MonitorState:
         values["outcome"] = MonitorOutcome(outcome)
     else:
         values["outcome"] = None
+    disposition = values.get("last_completion_disposition")
+    if disposition is not None:
+        values["last_completion_disposition"] = MonitorActionDisposition(disposition)
     return MonitorState(**values)
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -44,6 +44,7 @@ import kiro_crew
 import kiro_crew.crash_guard as crash_guard
 from kiro_crew import agent_scratch, beacon, dep_sync, name_grant, platform_compat, shutdown_event
 from kiro_crew.acp.client import AcpError, AcpProcessDied
+from kiro_crew.agent_sdk import AgentTurnUsage
 from kiro_crew.agents_janitor import sweep_agents_dir
 from kiro_crew.autonudge import (
     APPROVAL_STALL_REASON,
@@ -206,6 +207,12 @@ from kiro_crew.messaging.link import (
 )
 from kiro_crew.messaging.renderer import chunk_for_transport
 from kiro_crew.messaging.transport import InboundMessage, delivery_confirmed
+from kiro_crew.monitoring.completion import (
+    MonitorCompletionHook,
+    disposition_for_stop_reason,
+    is_monitor_completion_evidence,
+)
+from kiro_crew.monitoring.models import MonitorActionDisposition
 from kiro_crew.platform import boot_platform
 from kiro_crew.platform.context import (
     PlatformCompositionError,
@@ -306,6 +313,7 @@ async def _persist_turn_row(
     surface: str,
     agent_fallback: Callable[[], str],
     t0: float,
+    usage: AgentTurnUsage | None = None,
 ) -> None:
     """Persist one per-turn usage row for a background dispatch surface.
 
@@ -333,7 +341,7 @@ async def _persist_turn_row(
         await persist_token_record_async(
             session_key,
             "",
-            provider_last_turn_usage(client),
+            provider_last_turn_usage(client) if usage is None else usage,
             provider=provider,
             surface=surface,
             agent=read_effective_agent(client) or agent_fallback(),
@@ -5364,6 +5372,11 @@ class GatewayOrchestrator:
             full_msg, _ = await run_in_embed_pool(
                 self.ctx_builder.build_message, tagged, is_new, key, provider_type=_provider
             )
+            _raw_completions: list[LLMEvent] = []
+            _completion_hook = self._monitor_completion_hook(loop)
+            _completion_kwargs: dict[str, Any] = {}
+            if _completion_hook is not None:
+                _completion_kwargs["on_complete"] = _raw_completions.append
             # Clock started outside wait_for so BOTH the success path and the
             # TimeoutError branch below can report the real elapsed time. acp
             # never assigns TurnUsage.duration_ms, so the row needs this.
@@ -5380,10 +5393,21 @@ class GatewayOrchestrator:
                     approval_policy=ToolApprovalPolicy.HOOK_BASED,
                     hooks=self.ctx_builder.hooks,
                     on_tool_approval=self._interactive_approval("autonudge", nudge_key=key),
+                    **_completion_kwargs,
                 ),
                 timeout=_NUDGE_TURN_TIMEOUT,
             )
+            _turn_usage = provider_last_turn_usage(client)
 
+            if _raw_completions and is_monitor_completion_evidence(
+                _raw_completions[-1].stop_reason
+            ):
+                await self._report_monitor_completion(
+                    loop,
+                    disposition_for_stop_reason(_raw_completions[-1].stop_reason),
+                    _turn_usage,
+                    hook=_completion_hook,
+                )
             # ── Per-turn usage row: attribute monitor spend. ──
             await _persist_turn_row(
                 client,
@@ -5392,6 +5416,7 @@ class GatewayOrchestrator:
                 surface="monitor",
                 agent_fallback=lambda: _get_agent_for_session(key),
                 t0=_turn_t0,
+                usage=_turn_usage,
             )
         except asyncio.TimeoutError:
             # ── Timeout spend is REAL spend (issue #874 follow-up). ──
@@ -5409,6 +5434,14 @@ class GatewayOrchestrator:
                 key,
                 loop.id,
             )
+            _turn_usage = provider_last_turn_usage(client)
+            if _raw_completions:
+                await self._report_monitor_completion(
+                    loop,
+                    disposition_for_stop_reason(_raw_completions[-1].stop_reason),
+                    _turn_usage,
+                    hook=_completion_hook,
+                )
             await _persist_turn_row(
                 client,
                 key,
@@ -5416,6 +5449,7 @@ class GatewayOrchestrator:
                 surface="monitor",
                 agent_fallback=lambda: _get_agent_for_session(key),
                 t0=_turn_t0,
+                usage=_turn_usage,
             )
             return False
         except Exception:
@@ -5533,8 +5567,12 @@ class GatewayOrchestrator:
                 conversation_id=conversation_id,
                 text=tagged,
             )
+            dispatch_kwargs: dict[str, Any] = {"interpret_commands": False}
+            completion_hook = self._monitor_completion_hook(loop)
+            if completion_hook is not None:
+                dispatch_kwargs["monitor_completion"] = completion_hook
             await asyncio.wait_for(
-                dispatcher.handle_message(synthetic, interpret_commands=False),
+                dispatcher.handle_message(synthetic, **dispatch_kwargs),
                 timeout=_NUDGE_TURN_TIMEOUT,
             )
             return True
@@ -5754,6 +5792,10 @@ class GatewayOrchestrator:
         # independently and would otherwise put N turns on the runtime at once.
         # An attended slot (any user session with a monitor loop) is passed
         # straight through, so babysit loops on human sessions are unaffected.
+        run_kwargs: dict[str, Any] = {}
+        completion_hook = self._monitor_completion_hook(loop)
+        if completion_hook is not None:
+            run_kwargs["monitor_completion"] = completion_hook
         task = spawn_guarded_turn(
             self.dashboard_state,
             slot,
@@ -5764,6 +5806,7 @@ class GatewayOrchestrator:
                     slot,
                     tagged,
                     _directive_user_origin=False,
+                    **run_kwargs,
                 ),
             ),
         )
@@ -5773,6 +5816,42 @@ class GatewayOrchestrator:
         self._session_tasks[slot.key] = task
         self.dashboard_state.push_slots_update()
         return True
+
+    def _monitor_completion_hook(self, loop: NudgeLoop) -> MonitorCompletionHook | None:
+        """Bind a structured loop's in-flight identity to controller accounting."""
+        state = getattr(loop, "monitor", None)
+        if state is None:
+            return None
+        service = self.autonudge_svc
+        if service is None or not state.wake_in_flight or not state.last_wake_fingerprint:
+            return None
+        return MonitorCompletionHook(
+            loop.id,
+            state.last_wake_fingerprint,
+            service.record_monitor_turn_completion,
+        )
+
+    async def _report_monitor_completion(
+        self,
+        loop: NudgeLoop,
+        disposition: MonitorActionDisposition,
+        usage: AgentTurnUsage | None,
+        *,
+        hook: MonitorCompletionHook | None = None,
+    ) -> None:
+        """Best-effort monitor accounting that cannot change delivery outcome."""
+        if hook is None:
+            hook = self._monitor_completion_hook(loop)
+        if hook is None:
+            return
+        try:
+            await hook.complete(disposition, usage)
+        except Exception:
+            logger.warning(
+                "monitor turn completion callback failed for loop %s",
+                loop.id,
+                exc_info=True,
+            )
 
     async def _init_autonudge(self) -> None:
         """Initialize and start the auto-nudge service (feature-flagged)."""

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -1810,6 +1810,66 @@ class TestAutonudgeUpdateConcurrency:
             svc.stop()
 
     @pytest.mark.asyncio
+    async def test_repeated_cancellation_cannot_release_lock_during_snapshot(self, tmp_path):
+        """Every cancellation waits for the executor write before releasing the lock."""
+        entered = threading.Event()
+        gate = threading.Event()
+
+        svc = AutoNudgeService(base_dir=tmp_path)
+        await svc.start()
+        first: asyncio.Task | None = None
+        second: asyncio.Task | None = None
+        try:
+            loop_obj = await svc.add(slot_key="chat-9-4b", message="original", idle_secs=15)
+            svc._cancel_timer(loop_obj.id)
+            loop_obj.message = "first"
+            first_payload = svc._serialize_state()
+            loop_obj.message = "second"
+            second_payload = svc._serialize_state()
+            real_write = svc._write_state
+            calls = {"n": 0}
+
+            def _gated(payload):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    entered.set()
+                    gate.wait(5)
+                return real_write(payload)
+
+            svc._write_state = _gated  # type: ignore[method-assign]
+
+            async def _persist(payload):
+                async with svc._lock:
+                    await svc._write_monitor_snapshot_locked(payload)
+
+            first = asyncio.create_task(_persist(first_payload))
+            await asyncio.to_thread(entered.wait, 2)
+            first.cancel()
+            await asyncio.sleep(0)
+            assert not first.done(), "the first cancellation stopped draining the write"
+            first.cancel()
+            await asyncio.sleep(0)
+
+            second = asyncio.create_task(_persist(second_payload))
+            await asyncio.sleep(0.1)
+            assert not second.done(), "a repeated cancellation released the persistence lock"
+
+            gate.set()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+            await asyncio.wait_for(second, timeout=5)
+            on_disk = json.loads((tmp_path / "autonudge.json").read_text(encoding="utf-8"))
+            stored = {lp["id"]: lp for lp in on_disk["loops"]}[loop_obj.id]
+            assert stored["message"] == "second", "a stale snapshot replaced the newer state"
+        finally:
+            gate.set()
+            await asyncio.gather(
+                *(task for task in (first, second) if task is not None),
+                return_exceptions=True,
+            )
+            svc.stop()
+
+    @pytest.mark.asyncio
     async def test_delivered_cycle_persistence_is_not_cancellable_by_update(self, tmp_path):
         """The fire window must cover bookkeeping, not just the callback.
 

--- a/test/test_autonudge_dashboard_fire.py
+++ b/test/test_autonudge_dashboard_fire.py
@@ -24,6 +24,8 @@ import pytest
 
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.monitoring.completion import MonitorCompletionHook
+from kiro_crew.monitoring.models import MonitorState
 from kiro_crew.slack import gateway as gw
 
 
@@ -179,6 +181,34 @@ class TestDashboardNudgeSlotResolution:
             assert await orch._fire_dashboard_nudge(_loop()) is True
         rehydrate.assert_not_awaited()
         assert spawn.calls == [live]
+
+    @pytest.mark.asyncio
+    async def test_structured_monitor_passes_completion_hook_only_to_its_turn(self) -> None:
+        """A dashboard action reports raw completion without changing legacy turns."""
+        orch = _orchestrator()
+        live = _slot()
+        orch.dashboard_state.get_slot = MagicMock(return_value=live)
+        structured = _loop()
+        structured.monitor = MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        )
+        spawn = _fake_spawn()
+        run_chat = AsyncMock()
+        with (
+            patch.object(gw, "spawn_guarded_turn", spawn),
+            patch("kiro_crew.dashboard.chat._run_chat", new=run_chat),
+        ):
+            assert await orch._fire_dashboard_nudge(structured) is True
+            assert await orch._fire_dashboard_nudge(_loop()) is True
+
+        first, second = run_chat.call_args_list
+        assert isinstance(first.kwargs["monitor_completion"], MonitorCompletionHook)
+        assert "monitor_completion" not in second.kwargs
 
     @pytest.mark.asyncio
     async def test_unreachable_session_retires_the_loop_once_with_a_reason(

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6063,8 +6063,8 @@ class TestTokenPersistenceBackfill:
         return state
 
     @pytest.mark.asyncio
-    async def test_raw_complete_reports_structured_monitor_usage(self, tmp_path, monkeypatch):
-        """Normal runner return is not the accounting boundary; EVENT_COMPLETE is."""
+    async def test_safe_complete_reports_structured_monitor_usage(self, tmp_path, monkeypatch):
+        """Normal runner return is not the accounting boundary; safe evidence is."""
         from kiro_crew.dashboard.chat import _run_chat
         from kiro_crew.monitoring.completion import MonitorCompletionHook
         from kiro_crew.monitoring.models import (
@@ -6077,7 +6077,7 @@ class TestTokenPersistenceBackfill:
             LLMEvent(kind=EVENT_TEXT_CHUNK, text="done"),
             LLMEvent(
                 kind=EVENT_COMPLETE,
-                stop_reason="end_turn",
+                stop_reason="max_tokens",
                 usage=TurnUsage(input_tokens=12, output_tokens=4),
             ),
         ]
@@ -6104,9 +6104,47 @@ class TestTokenPersistenceBackfill:
         )
 
         assert len(completions) == 1
-        assert completions[0].disposition is MonitorActionDisposition.SUCCESS
+        assert completions[0].disposition is MonitorActionDisposition.FAILURE
         assert completions[0].input_tokens == 12
         assert completions[0].output_tokens == 4
+
+    @pytest.mark.asyncio
+    async def test_synthetic_timeout_complete_does_not_report_monitor_usage(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.monitoring.completion import MonitorCompletionHook
+        from kiro_crew.monitoring.models import MonitorActionCompletion
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        event = LLMEvent(
+            kind=EVENT_COMPLETE,
+            stop_reason="timeout",
+            usage=TurnUsage(input_tokens=12, output_tokens=4),
+        )
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = self._make_mock_client([LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial"), event])
+        client.context_used_tokens = MagicMock(return_value=0)
+        client.context_window_tokens = MagicMock(return_value=0)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.generate_session_summary",
+            AsyncMock(return_value=None),
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        await _run_chat(
+            state,
+            slot,
+            "hello",
+            monitor_completion=MonitorCompletionHook("monitor1", "failure-a", _capture),
+        )
+
+        assert completions == []
 
     @pytest.mark.asyncio
     async def test_raw_complete_survives_cancellation_during_token_persistence(
@@ -6120,7 +6158,7 @@ class TestTokenPersistenceBackfill:
 
         event = LLMEvent(
             kind=EVENT_COMPLETE,
-            stop_reason="end_turn",
+            stop_reason="cancelled",
             usage=TurnUsage(input_tokens=12, output_tokens=4),
         )
         state = self._make_state_for_run_chat(tmp_path, monkeypatch)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6063,6 +6063,101 @@ class TestTokenPersistenceBackfill:
         return state
 
     @pytest.mark.asyncio
+    async def test_raw_complete_reports_structured_monitor_usage(self, tmp_path, monkeypatch):
+        """Normal runner return is not the accounting boundary; EVENT_COMPLETE is."""
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.monitoring.completion import MonitorCompletionHook
+        from kiro_crew.monitoring.models import (
+            MonitorActionCompletion,
+            MonitorActionDisposition,
+        )
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        events = [
+            LLMEvent(kind=EVENT_TEXT_CHUNK, text="done"),
+            LLMEvent(
+                kind=EVENT_COMPLETE,
+                stop_reason="end_turn",
+                usage=TurnUsage(input_tokens=12, output_tokens=4),
+            ),
+        ]
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = self._make_mock_client(events)
+        client.context_used_tokens = MagicMock(return_value=0)
+        client.context_window_tokens = MagicMock(return_value=0)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.generate_session_summary",
+            AsyncMock(return_value=None),
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        await _run_chat(
+            state,
+            slot,
+            "hello",
+            monitor_completion=MonitorCompletionHook("monitor1", "failure-a", _capture),
+        )
+
+        assert len(completions) == 1
+        assert completions[0].disposition is MonitorActionDisposition.SUCCESS
+        assert completions[0].input_tokens == 12
+        assert completions[0].output_tokens == 4
+
+    @pytest.mark.asyncio
+    async def test_raw_complete_survives_cancellation_during_token_persistence(
+        self, tmp_path, monkeypatch
+    ):
+        """Provider completion evidence is durable before cancellable analytics I/O."""
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.monitoring.completion import MonitorCompletionHook
+        from kiro_crew.monitoring.models import MonitorActionCompletion
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        event = LLMEvent(
+            kind=EVENT_COMPLETE,
+            stop_reason="end_turn",
+            usage=TurnUsage(input_tokens=12, output_tokens=4),
+        )
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = self._make_mock_client([event])
+        client.context_used_tokens = MagicMock(return_value=0)
+        client.context_window_tokens = MagicMock(return_value=0)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.generate_session_summary",
+            AsyncMock(return_value=None),
+        )
+
+        async def _cancel_persistence(*_args, **_kwargs) -> None:
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.persist_token_record_async",
+            _cancel_persistence,
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        await _run_chat(
+            state,
+            slot,
+            "hello",
+            monitor_completion=MonitorCompletionHook("monitor1", "failure-a", _capture),
+        )
+
+        assert len(completions) == 1
+        assert completions[0].input_tokens == 12
+        assert completions[0].output_tokens == 4
+
+    @pytest.mark.asyncio
     async def test_late_backfill_populates_model_for_cc_session(self, tmp_path, monkeypatch):
         """When slot.model is empty at EVENT_COMPLETE but the provider has
         learned its model (CC init event), persist_token_record receives the

--- a/test/test_llm_helpers.py
+++ b/test/test_llm_helpers.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kiro_crew.acp.client import AcpError, AcpPromptBusy
+from kiro_crew.acp.types import STOP_REASON_CANCELLED, TurnUsage
 from kiro_crew.llm_helpers import (
     FALLBACK_CANDIDATE_ATTEMPTS,
     TURN_FALLBACK_ATTR,
@@ -335,6 +336,37 @@ class TestStreamAndCollectPromptBusy:
 
         assert result == "hello"
         provider.cancel.assert_not_awaited()
+
+
+class TestStreamAndCollectRawCompletion:
+    @pytest.mark.asyncio
+    async def test_callback_receives_the_raw_complete_event(self) -> None:
+        """Callers needing terminal evidence must see the provider event itself."""
+        complete = LLMEvent(
+            kind=EVENT_COMPLETE,
+            stop_reason=STOP_REASON_CANCELLED,
+            usage=TurnUsage(input_tokens=12, output_tokens=3),
+        )
+        provider = _make_provider(
+            events=[LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial"), complete]
+        )
+        observed: list[LLMEvent] = []
+
+        result = await stream_and_collect(provider, "test", on_complete=observed.append)
+
+        assert result == "partial"
+        assert observed == [complete]
+
+    @pytest.mark.asyncio
+    async def test_stream_exhaustion_does_not_invent_completion(self) -> None:
+        """A provider iterator ending without EVENT_COMPLETE is not a completed turn."""
+        provider = _make_provider(events=[LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial")])
+        observed: list[LLMEvent] = []
+
+        result = await stream_and_collect(provider, "test", on_complete=observed.append)
+
+        assert result == "partial"
+        assert observed == []
 
 
 # ── Transient backend (5xx / throttle / stream-reset) retry tests ──

--- a/test/test_messaging_driver.py
+++ b/test/test_messaging_driver.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from kiro_crew.acp.types import (
     EVENT_COMPACTION_STATUS,
     EVENT_COMPLETE,
@@ -18,6 +20,7 @@ from kiro_crew.acp.types import (
     EVENT_TEXT_CHUNK,
     EVENT_TOOL_CALL,
     AcpEvent,
+    TurnUsage,
 )
 from kiro_crew.messaging import (
     APPROVAL_AUTO,
@@ -26,6 +29,8 @@ from kiro_crew.messaging import (
     TurnDriver,
 )
 from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.monitoring.completion import MonitorCompletionHook
+from kiro_crew.monitoring.models import MonitorActionCompletion, MonitorActionDisposition
 
 
 class _RecordingRenderer(Renderer):
@@ -92,6 +97,88 @@ class TestTurnDriverTranslation:
         out = _run(p, r)
         assert out == "Hello world"
         assert [e[0] for e in r.events] == ["text_chunk", "text_chunk", "done"]
+
+    def test_raw_complete_reports_monitor_action_once(self):
+        r = _RecordingRenderer()
+        p = _ScriptedProvider(
+            [
+                AcpEvent(
+                    kind=EVENT_COMPLETE,
+                    stop_reason="end_turn",
+                    usage=TurnUsage(input_tokens=20, output_tokens=5),
+                )
+            ]
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+        _run(p, r, monitor_completion=hook)
+
+        assert len(completions) == 1
+        assert completions[0].disposition is MonitorActionDisposition.SUCCESS
+        assert completions[0].input_tokens == 20
+        assert completions[0].output_tokens == 5
+
+    def test_raw_complete_reports_monitor_action_before_renderer_finalization(self):
+        class _CancellingDoneRenderer(_RecordingRenderer):
+            async def on_done(self, stop_reason=""):
+                await super().on_done(stop_reason)
+                raise asyncio.CancelledError
+
+        r = _CancellingDoneRenderer()
+        p = _ScriptedProvider(
+            [
+                AcpEvent(
+                    kind=EVENT_COMPLETE,
+                    stop_reason="end_turn",
+                    usage=TurnUsage(input_tokens=20, output_tokens=5),
+                )
+            ]
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+        with pytest.raises(asyncio.CancelledError):
+            _run(p, r, monitor_completion=hook)
+
+        assert len(completions) == 1
+        assert completions[0].input_tokens == 20
+        assert completions[0].output_tokens == 5
+
+    def test_raw_complete_reports_monitor_action_before_buffered_rendering(self):
+        class _FailingTextRenderer(_RecordingRenderer):
+            async def on_text_chunk(self, text):
+                raise RuntimeError("transport unavailable")
+
+        r = _FailingTextRenderer()
+        p = _ScriptedProvider(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="✅ Conversation comp"),
+                AcpEvent(
+                    kind=EVENT_COMPLETE,
+                    stop_reason="end_turn",
+                    usage=TurnUsage(input_tokens=20, output_tokens=5),
+                ),
+            ]
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+        with pytest.raises(RuntimeError, match="transport unavailable"):
+            _run(p, r, monitor_completion=hook)
+
+        assert len(completions) == 1
+        assert completions[0].input_tokens == 20
+        assert completions[0].output_tokens == 5
 
     def test_tool_calls_emit_uniform_tool_call(self):
         r = _RecordingRenderer()

--- a/test/test_messaging_driver.py
+++ b/test/test_messaging_driver.py
@@ -98,13 +98,13 @@ class TestTurnDriverTranslation:
         assert out == "Hello world"
         assert [e[0] for e in r.events] == ["text_chunk", "text_chunk", "done"]
 
-    def test_raw_complete_reports_monitor_action_once(self):
+    def test_safe_complete_reports_monitor_action_once(self):
         r = _RecordingRenderer()
         p = _ScriptedProvider(
             [
                 AcpEvent(
                     kind=EVENT_COMPLETE,
-                    stop_reason="end_turn",
+                    stop_reason="max_tokens",
                     usage=TurnUsage(input_tokens=20, output_tokens=5),
                 )
             ]
@@ -118,11 +118,44 @@ class TestTurnDriverTranslation:
         _run(p, r, monitor_completion=hook)
 
         assert len(completions) == 1
-        assert completions[0].disposition is MonitorActionDisposition.SUCCESS
+        assert completions[0].disposition is MonitorActionDisposition.FAILURE
         assert completions[0].input_tokens == 20
         assert completions[0].output_tokens == 5
 
-    def test_raw_complete_reports_monitor_action_before_renderer_finalization(self):
+    @pytest.mark.parametrize(
+        "stop_reason",
+        [
+            "",
+            "end_turn",
+            "timeout",
+            "stale_recover",
+            "error: cancel unacked",
+            "error: tool stall",
+            "error: compaction failed",
+        ],
+    )
+    def test_synthetic_complete_does_not_report_monitor_action(self, stop_reason):
+        r = _RecordingRenderer()
+        p = _ScriptedProvider(
+            [
+                AcpEvent(
+                    kind=EVENT_COMPLETE,
+                    stop_reason=stop_reason,
+                    usage=TurnUsage(input_tokens=20, output_tokens=5),
+                )
+            ]
+        )
+        completions: list[MonitorActionCompletion] = []
+
+        async def _capture(completion: MonitorActionCompletion) -> None:
+            completions.append(completion)
+
+        hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+        _run(p, r, monitor_completion=hook)
+
+        assert completions == []
+
+    def test_safe_complete_reports_monitor_action_before_renderer_finalization(self):
         class _CancellingDoneRenderer(_RecordingRenderer):
             async def on_done(self, stop_reason=""):
                 await super().on_done(stop_reason)
@@ -133,7 +166,7 @@ class TestTurnDriverTranslation:
             [
                 AcpEvent(
                     kind=EVENT_COMPLETE,
-                    stop_reason="end_turn",
+                    stop_reason="max_tokens",
                     usage=TurnUsage(input_tokens=20, output_tokens=5),
                 )
             ]
@@ -151,7 +184,7 @@ class TestTurnDriverTranslation:
         assert completions[0].input_tokens == 20
         assert completions[0].output_tokens == 5
 
-    def test_raw_complete_reports_monitor_action_before_buffered_rendering(self):
+    def test_safe_complete_reports_monitor_action_before_buffered_rendering(self):
         class _FailingTextRenderer(_RecordingRenderer):
             async def on_text_chunk(self, text):
                 raise RuntimeError("transport unavailable")
@@ -162,7 +195,7 @@ class TestTurnDriverTranslation:
                 AcpEvent(kind=EVENT_TEXT_CHUNK, text="✅ Conversation comp"),
                 AcpEvent(
                     kind=EVENT_COMPLETE,
-                    stop_reason="end_turn",
+                    stop_reason="max_tokens",
                     usage=TurnUsage(input_tokens=20, output_tokens=5),
                 ),
             ]

--- a/test/test_monitor_turn_completion.py
+++ b/test/test_monitor_turn_completion.py
@@ -1,0 +1,351 @@
+"""Completed-turn accounting for structured monitors."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from copy import deepcopy
+
+import pytest
+
+from kiro_crew.acp.types import TurnUsage
+from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+from kiro_crew.monitoring import models
+from kiro_crew.monitoring.models import MonitorBudgets, MonitorOutcome, MonitorState
+
+
+def _structured_loop() -> NudgeLoop:
+    return NudgeLoop(
+        id="monitor1",
+        slot_key="chat-1-123",
+        message="inspect the changed pull request",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+        ),
+    )
+
+
+def test_monitor_completion_contract_is_typed() -> None:
+    """An untyped completion payload could bypass correlation and validation."""
+    assert hasattr(models, "MonitorActionCompletion")
+    assert hasattr(models, "MonitorActionDisposition")
+    completion = models.MonitorActionCompletion(
+        monitor_id="monitor1",
+        fingerprint="failure-a",
+        disposition=models.MonitorActionDisposition.SUCCESS,
+        completed_ts=1_120.0,
+        input_tokens=1_200,
+        output_tokens=None,
+    )
+
+    assert completion.monitor_id == "monitor1"
+    assert completion.disposition is models.MonitorActionDisposition.SUCCESS
+    assert completion.input_tokens == 1_200
+    assert completion.output_tokens is None
+
+    with pytest.raises(ValueError, match="input_tokens"):
+        models.MonitorActionCompletion(
+            monitor_id="monitor1",
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.FAILURE,
+            completed_ts=1_120.0,
+            input_tokens=-1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_charges_nothing_until_the_action_turn_completes(tmp_path) -> None:
+    """Moving completed-turn accounting into dispatch would spend budget early."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 0
+    assert loop.monitor.total_tokens == 0
+    assert loop.monitor.wake_in_flight
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_120.0,
+            input_tokens=1_200,
+            output_tokens=300,
+        )
+    )
+
+    assert loop.monitor.agent_turns == 1
+    assert loop.monitor.input_tokens == 1_200
+    assert loop.monitor.output_tokens == 300
+    assert not loop.monitor.wake_in_flight
+
+
+@pytest.mark.asyncio
+async def test_completion_persistence_failure_leaves_live_accounting_unchanged(
+    tmp_path, monkeypatch
+) -> None:
+    """A failed completion write cannot charge counters that restart will forget."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.budgets = MonitorBudgets(max_agent_turns=1)
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+    before = deepcopy(loop)
+    persisted_before = service._path.read_bytes()
+
+    async def fail_snapshot(_payload=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_write_monitor_snapshot_locked", fail_snapshot)
+
+    with pytest.raises(OSError, match="disk full"):
+        await service.record_monitor_turn_completion(
+            models.MonitorActionCompletion(
+                monitor_id=loop.id,
+                fingerprint="failure-a",
+                disposition=models.MonitorActionDisposition.SUCCESS,
+                completed_ts=1_120.0,
+                input_tokens=1_200,
+                output_tokens=300,
+            )
+        )
+
+    assert loop == before
+    assert service._path.read_bytes() == persisted_before
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_before_turn_start_does_not_charge(tmp_path) -> None:
+    """A failed handoff is not an agent turn and must remain retryable."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+
+    await service.record_monitor_dispatch_failure(loop.id, "failure-a")
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 0
+    assert loop.monitor.total_tokens == 0
+    assert not loop.monitor.wake_in_flight
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_101.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("budgets", "completed_ts", "input_tokens", "output_tokens", "reason"),
+    [
+        (MonitorBudgets(max_runtime_secs=100), 1_100.0, 1, 1, "runtime_budget"),
+        (MonitorBudgets(max_agent_turns=1), 1_050.0, 1, 1, "agent_turn_budget"),
+        (MonitorBudgets(max_tokens=100), 1_050.0, 75, 25, "token_budget"),
+    ],
+)
+async def test_completion_stops_on_the_first_exhausted_budget(
+    tmp_path,
+    budgets: MonitorBudgets,
+    completed_ts: float,
+    input_tokens: int,
+    output_tokens: int,
+    reason: str,
+) -> None:
+    """Runtime, then turn, then token precedence gives one stable stop reason."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.budgets = budgets
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.FAILURE,
+            completed_ts=completed_ts,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    )
+
+    assert not loop.active
+    assert loop.monitor.outcome is MonitorOutcome.BUDGET
+    assert loop.monitor.stopped_reason == reason
+    assert loop.monitor.stopped_at == completed_ts
+
+
+def test_agent_turn_budget_above_universal_bound_is_rejected() -> None:
+    """Persisted configuration and enforcement must expose the same ceiling."""
+    with pytest.raises(ValueError, match="max_agent_turns"):
+        MonitorBudgets(max_agent_turns=9)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_and_mismatched_completions_are_idempotent(tmp_path) -> None:
+    """A retry or stale surface callback cannot charge a second turn."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+    stale = models.MonitorActionCompletion(
+        monitor_id=loop.id,
+        fingerprint="failure-b",
+        disposition=models.MonitorActionDisposition.FAILURE,
+        completed_ts=1_055.0,
+        input_tokens=500,
+        output_tokens=100,
+    )
+    completion = models.MonitorActionCompletion(
+        monitor_id=loop.id,
+        fingerprint="failure-a",
+        disposition=models.MonitorActionDisposition.SUCCESS,
+        completed_ts=1_060.0,
+        input_tokens=10,
+        output_tokens=5,
+    )
+
+    await service.record_monitor_turn_completion(stale)
+    await service.record_monitor_turn_completion(completion)
+    await service.record_monitor_turn_completion(completion)
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 1
+    assert loop.monitor.total_tokens == 15
+    assert loop.monitor.last_completion_fingerprint == "failure-a"
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_charges_turn_without_inventing_tokens(tmp_path) -> None:
+    """Unavailable authoritative counts remain unknown rather than becoming zero."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.CANCELLATION,
+            completed_ts=1_060.0,
+        )
+    )
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 1
+    assert loop.monitor.total_tokens == 0
+    assert not loop.monitor.token_usage_known
+    assert loop.monitor.last_completion_disposition is models.MonitorActionDisposition.CANCELLATION
+
+
+@pytest.mark.asyncio
+async def test_approval_stall_is_a_completed_turn_and_terminal_blocker(tmp_path) -> None:
+    """An unattended approval stall must not wake the same monitor again."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.APPROVAL_STALL,
+            completed_ts=1_060.0,
+            input_tokens=10,
+            output_tokens=5,
+        )
+    )
+
+    assert loop.monitor is not None
+    assert loop.monitor.agent_turns == 1
+    assert not loop.active
+    assert loop.monitor.outcome is MonitorOutcome.BLOCKED
+    assert loop.monitor.stopped_reason == "approval_stall"
+
+
+@pytest.mark.asyncio
+async def test_surface_approval_evidence_overrides_a_nominal_success_frame(tmp_path) -> None:
+    """A provider end-turn after approval timeout remains an approval stall."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_050.0)
+    loop.approval_stalled = True
+
+    await service.record_monitor_turn_completion(
+        models.MonitorActionCompletion(
+            monitor_id=loop.id,
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_060.0,
+            input_tokens=10,
+            output_tokens=5,
+        )
+    )
+
+    assert loop.monitor is not None
+    assert loop.monitor.last_completion_disposition is (
+        models.MonitorActionDisposition.APPROVAL_STALL
+    )
+    assert loop.monitor.outcome is MonitorOutcome.BLOCKED
+
+
+def test_restart_fails_closed_when_completion_evidence_is_unavailable(tmp_path) -> None:
+    """An acknowledged in-flight fingerprint cannot redispatch after restart."""
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.last_wake_fingerprint = "failure-a"
+    loop.monitor.wake_in_flight = True
+    payload = {
+        "version": 1,
+        "loops": [AutoNudgeService._serialize_loop(loop)],
+    }
+    (tmp_path / "autonudge.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    restored_service = AutoNudgeService(base_dir=tmp_path)
+    restored_service._load()
+    restored = restored_service._loops[loop.id]
+
+    assert restored.monitor is not None
+    assert not restored.active
+    assert not restored.monitor.wake_in_flight
+    assert restored.monitor.last_wake_fingerprint == "failure-a"
+    assert restored.monitor.outcome is MonitorOutcome.BLOCKED
+    assert restored.monitor.stopped_reason == "completion_evidence_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_completion_hook_delivers_one_typed_record_with_explicit_unknown_usage() -> None:
+    """A credits-only usage result must not fabricate authoritative token counts."""
+    assert importlib.util.find_spec("kiro_crew.monitoring.completion") is not None
+    from kiro_crew.monitoring.completion import MonitorCompletionHook
+
+    completions: list[models.MonitorActionCompletion] = []
+
+    async def _capture(completion: models.MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    hook = MonitorCompletionHook("monitor1", "failure-a", _capture)
+    await hook.complete(
+        models.MonitorActionDisposition.SUCCESS,
+        TurnUsage(credits=1.0),
+        completed_ts=1_100.0,
+    )
+
+    assert completions == [
+        models.MonitorActionCompletion(
+            monitor_id="monitor1",
+            fingerprint="failure-a",
+            disposition=models.MonitorActionDisposition.SUCCESS,
+            completed_ts=1_100.0,
+            input_tokens=None,
+            output_tokens=None,
+        )
+    ]

--- a/test/test_monitor_turn_completion.py
+++ b/test/test_monitor_turn_completion.py
@@ -122,6 +122,50 @@ async def test_completion_persistence_failure_leaves_live_accounting_unchanged(
 
 
 @pytest.mark.asyncio
+async def test_claim_persistence_failure_leaves_live_monitor_unchanged(
+    tmp_path, monkeypatch
+) -> None:
+    """A claim is not live until the snapshot that suppresses duplicates is durable."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    before = deepcopy(loop)
+
+    async def fail_snapshot(_payload=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_write_monitor_snapshot_locked", fail_snapshot)
+
+    with pytest.raises(OSError, match="disk full"):
+        await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+
+    assert loop == before
+
+
+@pytest.mark.asyncio
+async def test_budget_stop_persistence_failure_leaves_live_monitor_armed(
+    tmp_path, monkeypatch
+) -> None:
+    """A failed terminal write cannot stop only the in-memory monitor."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    assert loop.monitor is not None
+    loop.monitor.budgets = MonitorBudgets(max_runtime_secs=50)
+    service._loops[loop.id] = loop
+    before = deepcopy(loop)
+
+    async def fail_snapshot(_payload=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_write_monitor_snapshot_locked", fail_snapshot)
+
+    with pytest.raises(OSError, match="disk full"):
+        await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+
+    assert loop == before
+
+
+@pytest.mark.asyncio
 async def test_dispatch_failure_before_turn_start_does_not_charge(tmp_path) -> None:
     """A failed handoff is not an agent turn and must remain retryable."""
     service = AutoNudgeService(base_dir=tmp_path)
@@ -136,6 +180,28 @@ async def test_dispatch_failure_before_turn_start_does_not_charge(tmp_path) -> N
     assert loop.monitor.total_tokens == 0
     assert not loop.monitor.wake_in_flight
     assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_101.0)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_persistence_failure_keeps_live_claim(tmp_path, monkeypatch) -> None:
+    """A failed release write cannot expose a claim that restart still considers held."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = _structured_loop()
+    service._loops[loop.id] = loop
+    assert await service.mark_monitor_action_in_flight(loop.id, "failure-a", now=1_100.0)
+    before = deepcopy(loop)
+    persisted_before = service._path.read_bytes()
+
+    async def fail_snapshot(_payload=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_write_monitor_snapshot_locked", fail_snapshot)
+
+    with pytest.raises(OSError, match="disk full"):
+        await service.record_monitor_dispatch_failure(loop.id, "failure-a")
+
+    assert loop == before
+    assert service._path.read_bytes() == persisted_before
 
 
 @pytest.mark.asyncio

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -32,6 +32,8 @@ import pytest
 from kiro_crew import subagent as _sa
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.monitoring.completion import MonitorCompletionHook
+from kiro_crew.monitoring.models import MonitorState
 from kiro_crew.slack import gateway as gw
 
 # ─── Helpers ─────────────────────────────────────────────────────────────
@@ -237,6 +239,30 @@ class TestFireDiscordNudge:
         assert kwargs["interpret_commands"] is False
 
     @pytest.mark.asyncio
+    async def test_structured_monitor_supplies_completion_hook(self):
+        """Only a structured synthetic turn carries monitor accounting state."""
+        transport = _discord_transport()
+        orch = _discord_orchestrator(transport)
+        structured = _loop(_DKEY)
+        structured.monitor = MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        )
+
+        assert await orch._fire_discord_nudge(structured) is True
+        _, structured_kwargs = _awaited(transport.dispatcher.handle_message)
+        assert isinstance(structured_kwargs["monitor_completion"], MonitorCompletionHook)
+
+        transport.dispatcher.handle_message.reset_mock()
+        assert await orch._fire_discord_nudge(_loop(_DKEY)) is True
+        _, legacy_kwargs = _awaited(transport.dispatcher.handle_message)
+        assert "monitor_completion" not in legacy_kwargs
+
+    @pytest.mark.asyncio
     async def test_dispatch_failure_returns_false(self):
         transport = _discord_transport()
         transport.dispatcher.handle_message.side_effect = RuntimeError("dispatch blew up")
@@ -341,6 +367,49 @@ class TestFireSlackNudgeGuards:
         orch.sessions.cancel_current.assert_awaited_once()
         orch.sessions.release.assert_called_once()
         orch.slack.post_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("times_out", [False, True])
+    async def test_raw_completion_is_recorded_before_cancellable_usage_persistence(
+        self, monkeypatch, times_out
+    ):
+        """A completed turn cannot remain in flight if analytics persistence is cancelled."""
+        orch = _slack_nudge_orchestrator()
+        orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=AsyncMock())
+        loop = _loop()
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        )
+        order: list[str] = []
+
+        async def _stream(*_args, **kwargs):
+            kwargs["on_complete"](SimpleNamespace(stop_reason="end_turn"))
+            if times_out:
+                await asyncio.Event().wait()
+            return "reply body"
+
+        async def _report(*_args, **_kwargs):
+            order.append("completion")
+
+        async def _persist(*_args, **_kwargs):
+            order.append("persist")
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(gw, "stream_and_collect", _stream)
+        monkeypatch.setattr(gw, "_persist_turn_row", _persist)
+        monkeypatch.setattr(orch, "_report_monitor_completion", _report)
+        if times_out:
+            monkeypatch.setattr(gw, "_NUDGE_TURN_TIMEOUT", 0.01)
+
+        with pytest.raises(asyncio.CancelledError):
+            await orch._fire_slack_nudge(loop)
+
+        assert order == ["completion", "persist"]
 
     @pytest.mark.asyncio
     async def test_cleanup_failures_do_not_mask_the_turn_result(self, monkeypatch):

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -370,7 +370,7 @@ class TestFireSlackNudgeGuards:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("times_out", [False, True])
-    async def test_raw_completion_is_recorded_before_cancellable_usage_persistence(
+    async def test_safe_completion_is_recorded_before_cancellable_usage_persistence(
         self, monkeypatch, times_out
     ):
         """A completed turn cannot remain in flight if analytics persistence is cancelled."""
@@ -388,7 +388,7 @@ class TestFireSlackNudgeGuards:
         order: list[str] = []
 
         async def _stream(*_args, **kwargs):
-            kwargs["on_complete"](SimpleNamespace(stop_reason="end_turn"))
+            kwargs["on_complete"](SimpleNamespace(stop_reason="max_tokens"))
             if times_out:
                 await asyncio.Event().wait()
             return "reply body"

--- a/test/test_turn_duration_slack.py
+++ b/test/test_turn_duration_slack.py
@@ -37,10 +37,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew.acp.types import TurnUsage
+from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN, TurnUsage
 from kiro_crew.autonudge import NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.dashboard.handlers.usage import _token_usage_dir
+from kiro_crew.monitoring.models import (
+    MonitorActionCompletion,
+    MonitorActionDisposition,
+    MonitorState,
+)
+from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
 from kiro_crew.slack import gateway as gw
 
 
@@ -227,3 +233,225 @@ def test_provider_duration_wins_over_local_clock(monkeypatch):
     assert len(rows) == 1
     assert rows[0]["duration_ms"] == 5000  # provider wins
     assert rows[0]["duration_ms"] != 1234  # not the local-clock fallback
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected_disposition"),
+    [
+        (STOP_REASON_END_TURN, MonitorActionDisposition.SUCCESS),
+        (STOP_REASON_CANCELLED, MonitorActionDisposition.CANCELLATION),
+        ("max_tokens", MonitorActionDisposition.FAILURE),
+    ],
+)
+def test_structured_monitor_fans_out_usage_only_from_raw_completion(
+    monkeypatch,
+    stop_reason: str,
+    expected_disposition: MonitorActionDisposition,
+):
+    """One destructive usage read serves telemetry and the evidenced disposition."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    usage = TurnUsage(input_tokens=40, output_tokens=10, credits=0.25)
+    reads = 0
+
+    def _usage_once(_client):
+        nonlocal reads
+        reads += 1
+        return usage
+
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(gw, "provider_last_turn_usage", _usage_once)
+
+    async def _stream_ok(*_a, on_complete=None, **_k):
+        assert on_complete is not None
+        on_complete(LLMEvent(kind=EVENT_COMPLETE, stop_reason=stop_reason))
+        return "done"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_ok)
+    loop = NudgeLoop(
+        id="loop-structured",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is True
+
+    assert reads == 1
+    assert len(completions) == 1
+    assert completions[0].disposition is expected_disposition
+    assert completions[0].input_tokens == 40
+    assert completions[0].output_tokens == 10
+    rows = _monitor_rows()
+    assert len(rows) == 1
+    assert rows[0]["input"] == 40
+    assert rows[0]["output"] == 10
+
+
+def test_structured_monitor_stream_exhaustion_charges_no_completion(monkeypatch):
+    """A bare string return without EVENT_COMPLETE is not completion evidence."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(
+        gw,
+        "provider_last_turn_usage",
+        lambda _client: TurnUsage(input_tokens=40, output_tokens=10),
+    )
+
+    async def _stream_exhausted(*_a, **_k):
+        return "partial"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_exhausted)
+    loop = NudgeLoop(
+        id="loop-exhausted",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is True
+    assert completions == []
+    assert len(_monitor_rows()) == 1
+
+
+def test_structured_monitor_synthetic_timeout_charges_no_completion(monkeypatch):
+    """A synthetic timeout event is not provider completion evidence."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(
+        gw,
+        "provider_last_turn_usage",
+        lambda _client: TurnUsage(input_tokens=40, output_tokens=10),
+    )
+
+    async def _stream_timeout(*_a, on_complete=None, **_k):
+        assert on_complete is not None
+        on_complete(LLMEvent(kind=EVENT_COMPLETE, stop_reason="timeout"))
+        return "partial"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_timeout)
+    loop = NudgeLoop(
+        id="loop-synthetic-timeout",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is True
+    assert completions == []
+    assert len(_monitor_rows()) == 1
+
+
+def test_structured_monitor_timeout_before_complete_charges_no_completion(monkeypatch):
+    """Transport cancellation cannot stand in for a raw cancelled completion."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(gw, "provider_last_turn_usage", lambda _client: TurnUsage(credits=0.2))
+    monkeypatch.setattr(gw, "_NUDGE_TURN_TIMEOUT", 0.01)
+
+    async def _stream_hang(*_a, **_k):
+        await asyncio.sleep(1.0)
+        return "unreachable"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_hang)
+    loop = NudgeLoop(
+        id="loop-timeout-structured",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is False
+    assert completions == []
+    assert len(_monitor_rows()) == 1
+
+
+def test_structured_monitor_timeout_after_raw_completion_preserves_event(monkeypatch):
+    """A timeout does not replace raw cancellation evidence with inference."""
+    client = _fake_client()
+    orch = _build_orchestrator(client)
+    completions: list[MonitorActionCompletion] = []
+
+    async def _capture(completion: MonitorActionCompletion) -> None:
+        completions.append(completion)
+
+    orch.autonudge_svc = SimpleNamespace(record_monitor_turn_completion=_capture)
+    monkeypatch.setattr(gw, "provider_last_turn_usage", lambda _client: TurnUsage(credits=0.2))
+    monkeypatch.setattr(gw, "_NUDGE_TURN_TIMEOUT", 0.01)
+
+    async def _stream_complete_then_hang(*_a, on_complete=None, **_k):
+        assert on_complete is not None
+        on_complete(LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_CANCELLED))
+        await asyncio.sleep(1.0)
+        return "unreachable"
+
+    monkeypatch.setattr(gw, "stream_and_collect", _stream_complete_then_hang)
+    loop = NudgeLoop(
+        id="loop-timeout-after-complete",
+        slot_key="slack:111.222",
+        message="check it",
+        monitor=MonitorState(
+            kind="github_pull_request",
+            target="owner/repo#123",
+            objective="review_ready",
+            created_ts=1_000.0,
+            last_wake_fingerprint="failure-a",
+            wake_in_flight=True,
+        ),
+    )
+
+    assert asyncio.run(orch._fire_slack_nudge(loop)) is False
+    assert len(completions) == 1
+    assert completions[0].disposition is MonitorActionDisposition.CANCELLATION
+    assert len(_monitor_rows()) == 1

--- a/test/test_turn_duration_slack.py
+++ b/test/test_turn_duration_slack.py
@@ -238,7 +238,7 @@ def test_provider_duration_wins_over_local_clock(monkeypatch):
 @pytest.mark.parametrize(
     ("stop_reason", "expected_disposition"),
     [
-        (STOP_REASON_END_TURN, MonitorActionDisposition.SUCCESS),
+        (STOP_REASON_END_TURN, None),
         (STOP_REASON_CANCELLED, MonitorActionDisposition.CANCELLATION),
         ("max_tokens", MonitorActionDisposition.FAILURE),
     ],
@@ -246,7 +246,7 @@ def test_provider_duration_wins_over_local_clock(monkeypatch):
 def test_structured_monitor_fans_out_usage_only_from_raw_completion(
     monkeypatch,
     stop_reason: str,
-    expected_disposition: MonitorActionDisposition,
+    expected_disposition: MonitorActionDisposition | None,
 ):
     """One destructive usage read serves telemetry and the evidenced disposition."""
     client = _fake_client()
@@ -290,10 +290,13 @@ def test_structured_monitor_fans_out_usage_only_from_raw_completion(
     assert asyncio.run(orch._fire_slack_nudge(loop)) is True
 
     assert reads == 1
-    assert len(completions) == 1
-    assert completions[0].disposition is expected_disposition
-    assert completions[0].input_tokens == 40
-    assert completions[0].output_tokens == 10
+    if expected_disposition is None:
+        assert completions == []
+    else:
+        assert len(completions) == 1
+        assert completions[0].disposition is expected_disposition
+        assert completions[0].input_tokens == 40
+        assert completions[0].output_tokens == 10
     rows = _monitor_rows()
     assert len(rows) == 1
     assert rows[0]["input"] == 40


### PR DESCRIPTION
> Stacked change: **PR 3 of 8**
>
> Stack: #5180 → #5181 → #5182 → #5183 → #5184 → #5185 → #5186 → #5305
> Base: #5181
> Next: #5183

## Problem / Motivation

Legacy delivery counts dispatch attempts, while structured monitors need to charge only work that actually reaches a provider completion boundary.

## Why it matters

Charging probes, busy handoffs, or failed delivery overstates cost; inferring completion from helper returns can undercount failures or double-count retries.

## What changed (motivation → approach → change)

- Add a shared completion adapter correlated to the persisted monitor claim and fingerprint.
- Account from raw provider EVENT_COMPLETE evidence before any buffered renderer flush or finalization, including authoritative token usage when available.
- Persist Slack raw completion before cancellable analytics usage-row writes so cancellation cannot strand a completed wake.
- Share the completion boundary across dashboard, Slack, Discord, and the messaging driver.
- Keep missing-token usage explicit and preserve all legacy loop accounting.
- Validate the configured completed-turn budget against the universal eight-turn ceiling before persistence or enforcement.

## Tests

- Raw-completion correlation, duplicate suppression, and missing-token behavior
- Dashboard, Slack, Discord, and messaging completion paths
- Restart-safe in-flight state and approval/runtime/turn/token precedence

## Manual verification

N/A — transport and completion behavior is covered with deterministic provider-event fixtures.

## Related Issues

N/A — implements the accounting layer specified in #5180 and depends on #5181.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests cover the new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not yet supply final CLA wording.
