### PR TITLE
feat: add github pull request monitor probe

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1049,50 +1049,76 @@ pull-request URLs on public `github.com` (normalizing `www.github.com`); arbitra
 hosts, enterprise instances, repository URLs, path suffixes, query/fragment identity,
 and non-positive pull-request numbers are refused before provider execution. The
 adapter resolves and invokes the shared hardened `github_runner` boundary with
-`GH_HOST` pinned to `github.com`. It reads the fixed `gh pr view` readiness fields and,
-for an open pull request, walks GraphQL review threads in pages of 100, stopping after
-at most ten pages. Merged and closed primary lifecycle states are terminal without a
-secondary GraphQL dependency. An incomplete, malformed-node, missing-cursor, or capped
-thread traversal is a pending fact and can never produce review-ready success.
+`GH_HOST` pinned to `github.com`. It reads lifecycle, review, and mergeability fields
+first. For an open pull request it reads `statusCheckRollup` in a separate request
+paired with `headRefOid`, then walks GraphQL review threads in pages of 100, stopping
+after at most ten pages. A missing Checks permission therefore cannot erase readable
+primary facts, and a rollup for a different head is incomplete instead of being
+combined with the primary response. A null rollup is a complete empty check set.
+Merged and closed primary lifecycle states are terminal without either supplemental
+request. An incomplete, malformed-node, repeated/missing-cursor, or capped thread
+traversal is a pending fact and can never produce review-ready success. Outdated
+unresolved threads are ignored because they no longer block the current diff.
 When GraphQL returns errors alongside usable thread nodes, the traversal remains
 incomplete but folds those nodes first, so an observed unresolved thread still wins
-as actionable evidence. An error response without a usable thread payload is a typed
-provider error instead of a pending observation, preserving the last valid facts and
-provider-error accounting in shadow persistence.
+as actionable evidence. If the supplemental review-thread request itself fails, the
+adapter retains primary lifecycle, check, review, and mergeability facts and unresolved
+threads observed on earlier pages while marking thread evidence incomplete. A known
+blocker therefore remains actionable. Without a known blocker, incomplete checks or
+threads remain pending. The supplemental failure is carried separately as a typed
+provider error, counted against the bounded provider-error streak, and retried without
+discarding the readable primary facts.
 
 The durable observation is stable canonical JSON containing only normalized target
 identity, head revision, lifecycle/draft state, sorted check identities by outcome,
 normalized review/blocking state, unresolved-thread count/completeness, and
-mergeability. Provider ordering, timestamps, URLs, request/cursor ids, titles,
+mergeability. Repeated check identities retain their multiplicity because display
+labels cannot prove that provider rows describe the same logical job. Provider
+ordering, timestamps, URLs, request/cursor ids, titles,
 bodies, comments, and logs do not enter it. Provider-controlled check labels pass
-through credential redaction and unconditional URL removal before persistence. The
-GitHub check-run and legacy status-context namespaces remain distinct during rerun
-collapse. Check-run attempts collapse only when their canonical GitHub Actions
-details URLs prove the same workflow-run id and check name; separate runs with the
-same display labels remain independent, as do rows without that provider-stable
-identity, so a same-label success cannot hide a failure. GraphQL owner, repository,
+through credential redaction, control-character removal, unconditional URL removal,
+and fixed identity/count bounds before persistence. Overflow marks check evidence
+incomplete rather than producing success. The
+GitHub check-run and legacy status-context namespaces remain distinct. A workflow
+name plus display name is not a stable logical job identity: independent jobs may
+share both, and the rollup does not expose a stable workflow-file identity. Check runs
+therefore remain independent so a newer success cannot hide a known failure from a
+different workflow definition. Workflowless rows remain independent. Duplicate legacy
+status contexts are folded by blocker severity, so a same-named success cannot hide a
+failure. `STALE` check-run conclusions are terminal non-blockers. GraphQL owner,
 and cursor variables use raw string fields; only the pull-request number uses typed
 conversion.
 SHA-256 fingerprint covers the compact sorted serialization; a collection reorder or
 volatile provider value keeps it stable, while a new head changes it. Only a non-empty
-current head may set the changed-head fact. A changed head is also a typed decision
-fact with precedence over an otherwise-green success, so it records `wake_actionable`
-instead of stopping as ready.
+current head may set the changed-head fact. A changed head does not wake while the
+observation is pending. An otherwise-green changed head records one
+`wake_actionable`; after that head is persisted and observed unchanged, the same green
+state reaches terminal success rather than being suppressed as a duplicate.
 
 Classification is conservative: merged is terminal success
-(`pull_request_merged`), closed-unmerged is terminal blocked, draft/pending or
+(`pull_request_merged`), closed-unmerged is terminal blocked, draft (which takes
+precedence over check failures), incomplete/pending or
 unknown checks, incomplete review-thread evidence, and unknown mergeability remain
 pending. Mergeability succeeds only for the explicit settled `CLEAN`, `HAS_HOOKS`,
 and `UNSTABLE` states, so empty or future provider values fail closed as pending;
 failed checks, requested changes, unresolved threads, conflicts, a behind head, and
-branch-protection blocks are actionable. A requested-changes decision or an unresolved
+concrete branch-protection failures are actionable. GitHub's generic `BLOCKED`
+merge-state is pending because it also represents an otherwise healthy pull request
+waiting for required checks or reviews; the specific check and review facts determine
+whether the observation is actionable. A requested-changes decision or an unresolved
 thread already observed remains actionable even when the unseen review-thread tail is
 incomplete; incomplete evidence can prevent success but cannot erase a known blocker.
 Rate limits and transport/provider
 failures are retryable, while authentication, authorization, not-found, and local
-`gh` setup/trust failures are terminal categories. The shadow runner persists only
+`gh` setup/trust failures on the load-bearing primary request are terminal categories.
+HTTP status is classified before repository text, while GitHub's 403 rate-limit forms
+remain retryable. Resource-pressure spawn errors are retryable rather than
+misclassified as setup. Supplemental errors of any category use the bounded retry
+streak because the primary target remains readable. The shadow runner persists only
 the canonical observation, decision, next-probe time, and aggregate probe/error
-metrics. Persistence is the commit point: a failed write leaves the live state
+metrics. It checks hard budgets before provider execution, and terminal decisions
+persist outcome, reason, stop time, and a cleared next-probe deadline. Persistence is
+the commit point: a failed write leaves the live state
 unchanged so the same observation remains eligible for retry. It has no action
 dispatcher, never sets a wake fingerprint or in-flight claim, and raises before
 probing or persisting when `wake_delivery` is requested.

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1040,8 +1040,63 @@ without a model turn, suppresses an unchanged observation, and permits
 `wake_actionable` only when the actionable fingerprint differs from the last
 acknowledged wake fingerprint. The defaults are 14,400 seconds, eight completed
 agent turns, 250,000 aggregate input/output tokens, and three consecutive
-provider errors. This substrate does not yet schedule a provider probe or expose
-a new MCP tool; those are later RFC implementation slices.
+provider errors. This substrate does not itself schedule live provider probes or
+expose a new MCP tool; those are later RFC implementation slices.
+
+**GitHub pull-request shadow probe** (`monitoring/github_pull_request.py`,
+`monitoring/shadow.py`): the first typed provider adapter accepts only exact HTTPS
+pull-request URLs on public `github.com` (normalizing `www.github.com`); arbitrary
+hosts, enterprise instances, repository URLs, path suffixes, query/fragment identity,
+and non-positive pull-request numbers are refused before provider execution. The
+adapter resolves and invokes the shared hardened `github_runner` boundary with
+`GH_HOST` pinned to `github.com`. It reads the fixed `gh pr view` readiness fields and,
+for an open pull request, walks GraphQL review threads in pages of 100, stopping after
+at most ten pages. Merged and closed primary lifecycle states are terminal without a
+secondary GraphQL dependency. An incomplete, malformed-node, missing-cursor, or capped
+thread traversal is a pending fact and can never produce review-ready success.
+When GraphQL returns errors alongside usable thread nodes, the traversal remains
+incomplete but folds those nodes first, so an observed unresolved thread still wins
+as actionable evidence. An error response without a usable thread payload is a typed
+provider error instead of a pending observation, preserving the last valid facts and
+provider-error accounting in shadow persistence.
+
+The durable observation is stable canonical JSON containing only normalized target
+identity, head revision, lifecycle/draft state, sorted check identities by outcome,
+normalized review/blocking state, unresolved-thread count/completeness, and
+mergeability. Provider ordering, timestamps, URLs, request/cursor ids, titles,
+bodies, comments, and logs do not enter it. Provider-controlled check labels pass
+through credential redaction and unconditional URL removal before persistence. The
+GitHub check-run and legacy status-context namespaces remain distinct during rerun
+collapse. Check-run attempts collapse only when their canonical GitHub Actions
+details URLs prove the same workflow-run id and check name; separate runs with the
+same display labels remain independent, as do rows without that provider-stable
+identity, so a same-label success cannot hide a failure. GraphQL owner, repository,
+and cursor variables use raw string fields; only the pull-request number uses typed
+conversion.
+SHA-256 fingerprint covers the compact sorted serialization; a collection reorder or
+volatile provider value keeps it stable, while a new head changes it. Only a non-empty
+current head may set the changed-head fact. A changed head is also a typed decision
+fact with precedence over an otherwise-green success, so it records `wake_actionable`
+instead of stopping as ready.
+
+Classification is conservative: merged is terminal success
+(`pull_request_merged`), closed-unmerged is terminal blocked, draft/pending or
+unknown checks, incomplete review-thread evidence, and unknown mergeability remain
+pending. Mergeability succeeds only for the explicit settled `CLEAN`, `HAS_HOOKS`,
+and `UNSTABLE` states, so empty or future provider values fail closed as pending;
+failed checks, requested changes, unresolved threads, conflicts, a behind head, and
+branch-protection blocks are actionable. A requested-changes decision or an unresolved
+thread already observed remains actionable even when the unseen review-thread tail is
+incomplete; incomplete evidence can prevent success but cannot erase a known blocker.
+Rate limits and transport/provider
+failures are retryable, while authentication, authorization, not-found, and local
+`gh` setup/trust failures are terminal categories. The shadow runner persists only
+the canonical observation, decision, next-probe time, and aggregate probe/error
+metrics. Persistence is the commit point: a failed write leaves the live state
+unchanged so the same observation remains eligible for retry. It has no action
+dispatcher, never sets a wake fingerprint or in-flight claim, and raises before
+probing or persisting when `wake_delivery` is requested.
+This slice exposes no MCP control tool and spends no model turns.
 
 Every persisted monitor mapping must encode as strict JSON; nested non-finite numbers
 and other values accepted only by Python's permissive encoder invalidate the record.

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1179,6 +1179,33 @@ the destination's ordinary security checks and to the effective
 
 `_run_json()` emits credential-free SEL tool-invocation lifecycle events around every provider CLI attempt. Unsupported providers, invalid bounds, Windows sandbox absence, untrusted executables, and sandbox rejection record `denied`. An allowlisted command awaits its synchronous critical `invoked` append on a worker thread immediately before spawn, so an audit filesystem failure denies execution rather than launching a credential-bearing process unaudited, without blocking the gateway event loop. Cancellation while that worker is active remains fail-closed and waits for it to settle; if `invoked` landed, cleanup records `failed/request_cancelled` before re-raising and never spawns the provider. Provider launchers run in a dedicated process group, and timeout, output-overflow, and cancellation cleanup kills and reaps the complete launcher/provider tree so a sandbox wrapper cannot leave `gh` or `glab` orphaned on an unread pipe. Successful JSON decoding records `completed`; spawn, output, timeout, nonzero exit, decode, cancellation, and internal errors record `failed` with only a coarse reason. Audit records contain the logical provider (`gh`/`glab`), not argv, URL, repo path, output, environment, token, thread id, or exception text. Terminal audit failures are best effort and never alter an already-completed provider result.
 
+**Structured GitHub monitor provider boundary**
+(`monitoring/github_pull_request.py`): background pull-request shadow probes are a
+separate monitor-owned consumer of the shared synchronous `github_runner`, not of the
+dashboard handler. The target gate accepts only exact public `github.com` HTTPS
+pull-request identities and normalizes `www.github.com`; it refuses arbitrary and
+enterprise hosts, credentials/ports, repository-only paths, suffixes, queries,
+fragments, and invalid owner/repository/number segments before resolving `gh`. Every
+provider call uses the runner's validated absolute executable, minimal GitHub-only
+environment, audit-or-deny invocation record, strict UTF-8 decoding, and
+`pin_host="github.com"`; no monitor-specific token source or credential storage
+exists.
+
+Raw stdout, stderr, response envelopes, URLs, timestamps, cursor/request ids, bodies,
+comments, and logs never cross the adapter boundary into monitor state, exceptions,
+or logging. Canonical state is an explicit small allowlist; check labels are stripped
+of URLs and passed through `security.redact()` before persistence. Provider failures
+are reduced in memory to fixed error kinds and reason codes, including a non-retryable
+setup kind for missing, untrusted, or unexecutable `gh`; raw diagnostic text is then
+discarded. Open-PR review-thread pagination is bounded to ten 100-node pages, and
+incomplete or capped evidence fails closed as pending; a terminal merged/closed
+primary state does not issue that secondary request. Shadow execution has no dispatcher
+dependency and refuses an enabled wake request before either provider or persistence
+work, so it cannot turn ambient GitHub authority into a model wake in this slice.
+
+The provider adapter's redaction is classified as inbound canonicalization rather
+than an egress surface.
+
 Sidebar status follows the same read-only boundary. `GET /api/chat/slots` and the WebSocket handshake schedule provider refreshes and opt into cached `ci`/`state` fields only for an exact configured-owner request, or for signed `local-app`/`local-startup` dashboard subjects when no owner is configured. Generic slot serialization omits those fields. `DashboardState` tracks owner-authorized WebSockets separately, sends generic slot updates to all authenticated clients, then overlays credential-backed status only to the owner subset. This prevents a cache populated by an owner request from being replayed to a non-owner or app-token caller. Review-thread cache removal, generation advancement, and stale in-flight detachment still complete after thread ownership validation and before mutation dispatch, so cancellation cannot preserve or repopulate pre-mutation data.
 
 **Stale pre-owner sessions must re-authenticate (`stale_session_reauth`)**: a dashboard token's subject is fixed at mint time as `owner_id or <bootstrap subject>`, and both `POST /api/auth/refresh` and the one-time-link exchange re-mint from the INCOMING subject, so a session signed in before `KIROCREW_OWNER_ID` was configured carries `local-app`/`local-startup` for its whole life. Setting or changing `KIROCREW_OWNER_ID` therefore requires every pre-existing dashboard session to re-authenticate: once an owner exists, the owner gate denies the bootstrap subjects, and that denial is the control working — re-accepting them would readmit every machine-local token to an owner-locked dashboard. The operator surprise comes from `owner_id` being overloaded: it is collected as the Slack Member ID for owner DM routing, but it is also the dashboard authorization principal and the token subject, so setting it for Slack DMs also rotates the dashboard's identity anchor. To make the remedy discoverable, every owner-gate deny site that fronts the shared owner predicate (`stale_owner_session_response` in `source_providers.py`, consulted by the chat mode/approve/worktree/followup gate, the source-provider routes, cloud provisioning, MCP-app calls, `ask_question`, the browser mutations, agent-config mutations, the AWS consent gate, and the instances federated search) labels exactly this case `401 {"code": "stale_session_reauth"}` instead of the generic `403 forbidden`, and the dashboard turns that signal into a sign-in-again banner that deliberately skips the silent-refresh path (refresh preserves the stale subject, so it can never recover this denial); direct-fetch surfaces that bypass the blessed transport (the app-sdk scoped API, the MCP-app tool relay, Mochi's approval bridge) raise the same prompt through the shared `staleOwnerSignal` detector. CHANGING an already-set owner also invalidates the previous owner's sessions, but those carry the old owner's subject — an ordinary non-owner now — so they keep the generic denial: the distinct label is only derivable for the bootstrap subjects, whose staleness is provable from the subject alone. The label is chosen strictly AFTER the deny decision — access is never granted, widened, or re-ordered — and only for an ALREADY-AUTHENTICATED dashboard-user caller whose signed subject is a bootstrap subject while an owner is configured; unsigned, invalid, app-token, and ordinary non-owner callers keep the generic denial, so the discriminator discloses nothing to an unauthenticated party.

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1185,7 +1185,8 @@ separate monitor-owned consumer of the shared synchronous `github_runner`, not o
 dashboard handler. The target gate accepts only exact public `github.com` HTTPS
 pull-request identities and normalizes `www.github.com`; it refuses arbitrary and
 enterprise hosts, credentials/ports, repository-only paths, suffixes, queries,
-fragments, and invalid owner/repository/number segments before resolving `gh`. Every
+fragments, raw control characters, URL parameters, non-canonical numeric aliases,
+oversized pull-request numbers, and invalid owner/repository segments before resolving `gh`. Every
 provider call uses the runner's validated absolute executable, minimal GitHub-only
 environment, audit-or-deny invocation record, strict UTF-8 decoding, and
 `pin_host="github.com"`; no monitor-specific token source or credential storage
@@ -1194,14 +1195,22 @@ exists.
 Raw stdout, stderr, response envelopes, URLs, timestamps, cursor/request ids, bodies,
 comments, and logs never cross the adapter boundary into monitor state, exceptions,
 or logging. Canonical state is an explicit small allowlist; check labels are stripped
-of URLs and passed through `security.redact()` before persistence. Provider failures
+of controls and URLs, passed through `security.redact()`, and bounded in length and
+count before persistence. Provider failures
 are reduced in memory to fixed error kinds and reason codes, including a non-retryable
 setup kind for missing, untrusted, or unexecutable `gh`; raw diagnostic text is then
-discarded. Open-PR review-thread pagination is bounded to ten 100-node pages, and
-incomplete or capped evidence fails closed as pending; a terminal merged/closed
-primary state does not issue that secondary request. Shadow execution has no dispatcher
+discarded. The load-bearing primary read excludes `statusCheckRollup`; checks are read
+separately with the head revision, so a missing Checks permission or a push between
+requests produces typed incomplete supplemental evidence without erasing authorized
+primary facts. Open-PR review-thread pagination is bounded to ten 100-node pages,
+ignores outdated threads, and preserves usable nodes from partial GraphQL errors;
+incomplete or capped evidence fails closed as pending. A terminal merged/closed
+primary state does not issue either supplemental request. Shadow execution has no dispatcher
 dependency and refuses an enabled wake request before either provider or persistence
 work, so it cannot turn ambient GitHub authority into a model wake in this slice.
+Locally imposed check and review-thread caps remain durable incomplete evidence and do
+not consume the provider-error budget; transport failures and malformed provider
+pagination remain typed supplemental errors.
 
 The provider adapter's redaction is classified as inbound canonicalization rather
 than an egress surface.

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -43,7 +43,7 @@ def decide_monitor(
         return MonitorDecision.STOP_BUDGET
     if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
         return _provider_error_decision(state, observation, state.budgets)
-    if observation.status is MonitorObservationStatus.ACTIONABLE:
+    if observation.head_changed or observation.status is MonitorObservationStatus.ACTIONABLE:
         if observation.fingerprint == state.last_wake_fingerprint:
             return MonitorDecision.NO_CHANGE
         return MonitorDecision.WAKE_ACTIONABLE

--- a/src/kiro_crew/monitoring/decision.py
+++ b/src/kiro_crew/monitoring/decision.py
@@ -43,16 +43,22 @@ def decide_monitor(
         return MonitorDecision.STOP_BUDGET
     if observation.status is MonitorObservationStatus.PROVIDER_ERROR:
         return _provider_error_decision(state, observation, state.budgets)
-    if observation.head_changed or observation.status is MonitorObservationStatus.ACTIONABLE:
+    if observation.status is MonitorObservationStatus.ACTIONABLE:
         if observation.fingerprint == state.last_wake_fingerprint:
+            if observation.supplemental_provider_error is not None:
+                return _supplemental_provider_error_decision(state, state.budgets)
             return MonitorDecision.NO_CHANGE
         return MonitorDecision.WAKE_ACTIONABLE
+    if observation.supplemental_provider_error is not None:
+        return _supplemental_provider_error_decision(state, state.budgets)
+    if observation.status is MonitorObservationStatus.SUCCESS:
+        if observation.head_changed:
+            return MonitorDecision.WAKE_ACTIONABLE
+        return MonitorDecision.STOP_SUCCESS
     if observation.fingerprint == state.last_fingerprint:
         return MonitorDecision.NO_CHANGE
     if observation.status is MonitorObservationStatus.PENDING:
         return MonitorDecision.RECORD_ONLY
-    if observation.status is MonitorObservationStatus.SUCCESS:
-        return MonitorDecision.STOP_SUCCESS
     return MonitorDecision.STOP_BLOCKED
 
 
@@ -86,6 +92,16 @@ def _provider_error_decision(
     error = observation.provider_error
     if error not in _RETRYABLE_PROVIDER_ERRORS:
         return MonitorDecision.STOP_BLOCKED
+    if state.consecutive_provider_errors + 1 >= budgets.max_provider_errors:
+        return MonitorDecision.STOP_BLOCKED
+    return MonitorDecision.RETRY_PROVIDER
+
+
+def _supplemental_provider_error_decision(
+    state: MonitorState,
+    budgets: MonitorBudgets,
+) -> MonitorDecision:
+    """Retry incomplete secondary evidence before retiring the readable target."""
     if state.consecutive_provider_errors + 1 >= budgets.max_provider_errors:
         return MonitorDecision.STOP_BLOCKED
     return MonitorDecision.RETRY_PROVIDER

--- a/src/kiro_crew/monitoring/github_pull_request.py
+++ b/src/kiro_crew/monitoring/github_pull_request.py
@@ -1,0 +1,662 @@
+"""Typed public-GitHub pull-request observations for structured monitors."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from kiro_crew.github_runner import SetupError, resolve_gh, run_gh
+from kiro_crew.monitoring.models import (
+    MonitorObservation,
+    MonitorObservationStatus,
+    ProviderErrorKind,
+)
+from kiro_crew.security import redact
+
+_GITHUB_HOST = "github.com"
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_URL_IN_CHECK_IDENTITY_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_ACTIONS_JOB_PATH_RE = re.compile(
+    r"^/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/actions/runs/([1-9][0-9]*)/job/[1-9][0-9]*$"
+)
+_PROBE_TIMEOUT_SECS = 30.0
+_REVIEW_THREAD_PAGE_SIZE = 100
+_REVIEW_THREAD_MAX_PAGES = 10
+_MERGEABLE_SETTLED_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE"})
+_PR_FIELDS = (
+    "number,state,isDraft,headRefOid,mergeable,mergeStateStatus," "reviewDecision,statusCheckRollup"
+)
+_REVIEW_THREADS_QUERY = """
+query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:PAGE_SIZE,after:$cursor){
+        pageInfo{hasNextPage endCursor}
+        nodes{isResolved}
+      }
+    }
+  }
+}
+""".replace("PAGE_SIZE", str(_REVIEW_THREAD_PAGE_SIZE)).strip()
+
+GitHubResolver = Callable[[], str]
+GitHubRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestTarget:
+    """Validated identity of one public GitHub pull request."""
+
+    host: str
+    owner: str
+    repo: str
+    number: int
+
+    def __post_init__(self) -> None:
+        if self.host != _GITHUB_HOST:
+            raise ValueError("target must be a public GitHub pull request")
+        if any(
+            segment in {".", ".."} or _SEGMENT_RE.fullmatch(segment) is None
+            for segment in (self.owner, self.repo)
+        ):
+            raise ValueError("target must be a public GitHub pull request")
+        if isinstance(self.number, bool) or not isinstance(self.number, int) or self.number <= 0:
+            raise ValueError("target must be a public GitHub pull request")
+
+    @property
+    def identity(self) -> str:
+        return f"{self.host}/{self.owner}/{self.repo}#{self.number}"
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.host}/{self.owner}/{self.repo}/pull/{self.number}"
+
+
+@dataclass(frozen=True)
+class GitHubCheck:
+    """One normalized logical status check."""
+
+    identity: str
+    state: str
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestResponse:
+    """Allowlisted provider facts with no raw response attached."""
+
+    target: GitHubPullRequestTarget
+    state: str
+    draft: bool
+    head_revision: str
+    mergeability: str
+    review_decision: str
+    checks: tuple[GitHubCheck, ...]
+    unresolved_review_threads: int
+    review_threads_complete: bool
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestProbeResult:
+    """Canonical durable facts and their generic monitor classification."""
+
+    response: GitHubPullRequestResponse | None
+    canonical: dict[str, object]
+    observation: MonitorObservation
+
+
+class GitHubPullRequestProvider:
+    """Read public pull-request state through the authenticated hardened gh runner."""
+
+    def __init__(
+        self,
+        *,
+        resolver: GitHubResolver = resolve_gh,
+        runner: GitHubRunner = run_gh,
+    ) -> None:
+        self._resolver = resolver
+        self._runner = runner
+
+    def probe(
+        self,
+        raw_target: str,
+        *,
+        previous_observation: Mapping[str, object] | None = None,
+    ) -> GitHubPullRequestProbeResult:
+        """Return one canonical review-ready observation."""
+        target = parse_github_pull_request_target(raw_target)
+        try:
+            gh = self._resolver()
+            primary = self._runner(
+                [gh, "pr", "view", target.url, "--json", _PR_FIELDS],
+                timeout=_PROBE_TIMEOUT_SECS,
+                audit_caller="core:monitor",
+                pin_host=_GITHUB_HOST,
+            )
+            failure = _process_failure(primary)
+            if failure is not None:
+                return failure
+            raw_primary = _json_object(primary.stdout)
+            response = _normalize_response(target, raw_primary, 0, False)
+            if response.state not in {"merged", "closed"}:
+                unresolved, complete = self._review_threads(gh, target)
+                if isinstance(unresolved, GitHubPullRequestProbeResult):
+                    return unresolved
+                response = replace(
+                    response,
+                    unresolved_review_threads=unresolved,
+                    review_threads_complete=complete,
+                )
+        except SetupError:
+            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except FileNotFoundError:
+            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except subprocess.TimeoutExpired:
+            return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
+        except OSError:
+            return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
+        except (TypeError, ValueError, KeyError):
+            return _provider_error(
+                ProviderErrorKind.TRANSIENT,
+                "provider_malformed_response",
+            )
+        canonical = _canonical_response(response)
+        previous_head = (
+            previous_observation.get("head_revision")
+            if isinstance(previous_observation, Mapping)
+            else None
+        )
+        head_changed = (
+            response.state == "open"
+            and isinstance(previous_head, str)
+            and bool(previous_head)
+            and bool(response.head_revision)
+            and previous_head != response.head_revision
+        )
+        status, reason_code = _classify_response(response)
+        fingerprint_facts = (
+            _actionable_fingerprint_facts(canonical)
+            if status is MonitorObservationStatus.ACTIONABLE
+            else canonical
+        )
+        fingerprint = _fingerprint(fingerprint_facts)
+        return GitHubPullRequestProbeResult(
+            response=response,
+            canonical=canonical,
+            observation=MonitorObservation(
+                fingerprint,
+                status,
+                reason_code=reason_code,
+                head_changed=head_changed,
+            ),
+        )
+
+    def _review_threads(
+        self,
+        gh: str,
+        target: GitHubPullRequestTarget,
+    ) -> tuple[int | GitHubPullRequestProbeResult, bool]:
+        unresolved = 0
+        cursor: str | None = None
+        for page in range(_REVIEW_THREAD_MAX_PAGES):
+            argv = [
+                gh,
+                "api",
+                "graphql",
+                "-f",
+                f"query={_REVIEW_THREADS_QUERY}",
+                "-f",
+                f"owner={target.owner}",
+                "-f",
+                f"repo={target.repo}",
+                "-F",
+                f"number={target.number}",
+            ]
+            if cursor is not None:
+                argv.extend(("-f", f"cursor={cursor}"))
+            proc = self._runner(
+                argv,
+                timeout=_PROBE_TIMEOUT_SECS,
+                audit_caller="core:monitor",
+                pin_host=_GITHUB_HOST,
+            )
+            failure = _process_failure(proc)
+            if failure is not None:
+                return failure, False
+            raw = _json_object(proc.stdout)
+            has_errors = bool(raw.get("errors"))
+            try:
+                threads = raw["data"]["repository"]["pullRequest"]["reviewThreads"]
+                nodes = threads["nodes"]
+                page_info = threads["pageInfo"]
+            except (KeyError, TypeError) as exc:
+                if has_errors:
+                    return (
+                        _provider_error(
+                            ProviderErrorKind.TRANSIENT,
+                            "provider_malformed_response",
+                        ),
+                        False,
+                    )
+                raise ValueError("GitHub review-thread response is malformed") from exc
+            if not isinstance(nodes, list) or not isinstance(page_info, Mapping):
+                raise ValueError("GitHub review-thread response is malformed")
+            for node in nodes:
+                if not isinstance(node, Mapping) or not isinstance(node.get("isResolved"), bool):
+                    return unresolved, False
+                unresolved += int(not node["isResolved"])
+            if has_errors:
+                return unresolved, False
+            has_next = page_info.get("hasNextPage")
+            if has_next is False:
+                return unresolved, True
+            if has_next is not True:
+                return unresolved, False
+            next_cursor = page_info.get("endCursor")
+            if not isinstance(next_cursor, str) or not next_cursor:
+                return unresolved, False
+            cursor = next_cursor
+            if page + 1 == _REVIEW_THREAD_MAX_PAGES:
+                return unresolved, False
+        return unresolved, False
+
+
+def parse_github_pull_request_target(raw: str) -> GitHubPullRequestTarget:
+    """Parse one exact public GitHub pull-request URL into a typed identity."""
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("target must be a GitHub pull request URL")
+    parsed = urlparse(raw)
+    try:
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("target must be a public GitHub pull request URL") from exc
+    if (
+        parsed.scheme != "https"
+        or host not in {_GITHUB_HOST, f"www.{_GITHUB_HOST}"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("target must be a public GitHub pull request URL")
+    parts = PurePosixPath(parsed.path).parts
+    if len(parts) != 5 or parts[0] != "/" or parts[3] != "pull":
+        raise ValueError("target must be a GitHub pull request URL")
+    owner, repo, raw_number = parts[1], parts[2], parts[4]
+    if parsed.path != f"/{owner}/{repo}/pull/{raw_number}":
+        raise ValueError("target must be a canonical GitHub pull request URL")
+    if not raw_number.isascii() or not raw_number.isdecimal():
+        raise ValueError("target must be a GitHub pull request with a positive number")
+    try:
+        return GitHubPullRequestTarget(_GITHUB_HOST, owner, repo, int(raw_number, 10))
+    except ValueError as exc:
+        raise ValueError("target must be a valid GitHub pull request") from exc
+
+
+def _json_object(raw: str | None) -> dict[str, Any]:
+    if not isinstance(raw, str):
+        raise ValueError("GitHub response is malformed")
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError("GitHub response is malformed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub response is malformed")
+    return payload
+
+
+def _normalize_response(
+    target: GitHubPullRequestTarget,
+    raw: Mapping[str, Any],
+    unresolved_review_threads: int,
+    review_threads_complete: bool,
+) -> GitHubPullRequestResponse:
+    required = {
+        "number",
+        "state",
+        "isDraft",
+        "headRefOid",
+        "mergeable",
+        "mergeStateStatus",
+        "reviewDecision",
+        "statusCheckRollup",
+    }
+    if not required.issubset(raw):
+        raise ValueError("GitHub pull request response is malformed")
+    number = raw["number"]
+    if (
+        isinstance(number, bool)
+        or not isinstance(number, int)
+        or number != target.number
+        or not isinstance(raw["isDraft"], bool)
+    ):
+        raise ValueError("GitHub pull request response is malformed")
+    for name in ("state", "headRefOid", "mergeable", "mergeStateStatus"):
+        if not isinstance(raw[name], str):
+            raise ValueError("GitHub pull request response is malformed")
+    review_decision = raw["reviewDecision"]
+    if review_decision is not None and not isinstance(review_decision, str):
+        raise ValueError("GitHub pull request response is malformed")
+    checks = _normalize_checks(raw["statusCheckRollup"])
+    return GitHubPullRequestResponse(
+        target=target,
+        state=_normalize_pr_state(raw["state"]),
+        draft=raw["isDraft"],
+        head_revision=raw["headRefOid"],
+        mergeability=_normalize_mergeability(raw["mergeable"], raw["mergeStateStatus"]),
+        review_decision=_normalize_review_decision(review_decision),
+        checks=checks,
+        unresolved_review_threads=unresolved_review_threads,
+        review_threads_complete=review_threads_complete,
+    )
+
+
+def _normalize_checks(raw: object) -> tuple[GitHubCheck, ...]:
+    if not isinstance(raw, list):
+        raise ValueError("GitHub check rollup is malformed")
+    grouped: dict[tuple[str, ...], tuple[str, list[tuple[str, str]]]] = {}
+    for row_index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise ValueError("GitHub check rollup is malformed")
+        identity, state, recency, group_key = _normalize_check(item)
+        if group_key is None:
+            group_key = ("workflowless_check_run", str(row_index))
+        _, candidates = grouped.setdefault(group_key, (identity, []))
+        candidates.append((recency, state))
+    normalized: list[GitHubCheck] = []
+    for identity, candidates in grouped.values():
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        latest_recency = candidates[0][0]
+        latest_states = {state for recency, state in candidates if recency == latest_recency}
+        state = next(iter(latest_states)) if len(latest_states) == 1 else "unknown"
+        normalized.append(GitHubCheck(_sanitize_check_identity(identity), state))
+    return tuple(sorted(normalized, key=lambda item: item.identity))
+
+
+def _normalize_check(
+    raw: Mapping[str, object],
+) -> tuple[str, str, str, tuple[str, ...] | None]:
+    typename = raw.get("__typename")
+    if typename == "CheckRun":
+        name = raw.get("name")
+        workflow = raw.get("workflowName")
+        if not isinstance(name, str) or not name:
+            raise ValueError("GitHub check rollup is malformed")
+        identity = f"{workflow} / {name}" if isinstance(workflow, str) and workflow else name
+        status = raw.get("status")
+        conclusion = raw.get("conclusion")
+        if status != "COMPLETED":
+            state = "pending" if isinstance(status, str) else "unknown"
+        elif conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+            state = "passed"
+        elif conclusion in {
+            "FAILURE",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "STARTUP_FAILURE",
+        }:
+            state = "failed"
+        else:
+            state = "unknown"
+        recency = raw.get("startedAt")
+        if not workflow:
+            normalized_recency = ""
+        elif isinstance(recency, str) and recency:
+            normalized_recency = recency
+        else:
+            normalized_recency = "\uffff" if state == "pending" else ""
+        group_key = _check_run_group_key(raw, name) if workflow else None
+        return identity, state, normalized_recency, group_key
+    if typename == "StatusContext":
+        context = raw.get("context")
+        if not isinstance(context, str) or not context:
+            raise ValueError("GitHub check rollup is malformed")
+        raw_state = raw.get("state")
+        if isinstance(raw_state, str):
+            state = {
+                "SUCCESS": "passed",
+                "PENDING": "pending",
+                "EXPECTED": "pending",
+                "FAILURE": "failed",
+                "ERROR": "failed",
+            }.get(raw_state, "unknown")
+        else:
+            state = "unknown"
+        return context, state, "", ("status_context", context)
+    raise ValueError("GitHub check rollup is malformed")
+
+
+def _check_run_group_key(
+    raw: Mapping[str, object],
+    name: str,
+) -> tuple[str, ...] | None:
+    """Return the GitHub Actions run identity shared by rerun attempts."""
+    details_url = raw.get("detailsUrl")
+    if not isinstance(details_url, str):
+        return None
+    parsed = urlparse(details_url)
+    try:
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme != "https"
+        or host != _GITHUB_HOST
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    match = _ACTIONS_JOB_PATH_RE.fullmatch(parsed.path)
+    if match is None:
+        return None
+    owner, repo, run_id = match.groups()
+    return ("check_run", owner.casefold(), repo.casefold(), run_id, name)
+
+
+def _normalize_pr_state(raw: str) -> str:
+    return {"OPEN": "open", "CLOSED": "closed", "MERGED": "merged"}.get(raw.upper(), "unknown")
+
+
+def _sanitize_check_identity(identity: str) -> str:
+    without_urls = _URL_IN_CHECK_IDENTITY_RE.sub("[provider-url]", identity)
+    return redact(without_urls)
+
+
+def _normalize_review_decision(raw: str | None) -> str:
+    if raw is None or raw == "":
+        return "none"
+    return {
+        "APPROVED": "approved",
+        "CHANGES_REQUESTED": "changes_requested",
+        "REVIEW_REQUIRED": "review_required",
+    }.get(raw.upper(), "unknown")
+
+
+def _normalize_mergeability(mergeable: str, merge_state: str) -> str:
+    normalized_mergeable = mergeable.upper()
+    normalized_state = merge_state.upper()
+    if normalized_mergeable == "CONFLICTING" or normalized_state == "DIRTY":
+        return "conflicting"
+    if normalized_state == "BEHIND":
+        return "behind"
+    if normalized_state == "BLOCKED":
+        return "blocked"
+    if normalized_mergeable != "MERGEABLE" or normalized_state not in _MERGEABLE_SETTLED_STATES:
+        return "pending"
+    return "mergeable"
+
+
+def _canonical_response(response: GitHubPullRequestResponse) -> dict[str, object]:
+    checks = {
+        state: sorted({check.identity for check in response.checks if check.state == state})
+        for state in ("failed", "passed", "pending", "unknown")
+    }
+    if response.review_decision == "changes_requested":
+        blocking_review = "changes_requested"
+    elif response.unresolved_review_threads:
+        blocking_review = "unresolved_threads"
+    elif not response.review_threads_complete:
+        blocking_review = "unknown"
+    else:
+        blocking_review = "none"
+    return {
+        "blocking_review": blocking_review,
+        "checks": checks,
+        "draft": response.draft,
+        "head_revision": response.head_revision,
+        "kind": "github_pull_request",
+        "mergeability": response.mergeability,
+        "review_decision": response.review_decision,
+        "review_threads_complete": response.review_threads_complete,
+        "state": response.state,
+        "target": response.target.identity,
+        "unresolved_review_threads": response.unresolved_review_threads,
+    }
+
+
+def _fingerprint(canonical: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _actionable_fingerprint_facts(canonical: Mapping[str, object]) -> dict[str, object]:
+    """Keep known blockers stable while unrelated unsettled facts continue changing."""
+    checks = canonical["checks"]
+    if not isinstance(checks, Mapping):
+        raise ValueError("canonical GitHub checks are malformed")
+    blocking_review = canonical["blocking_review"]
+    mergeability = canonical["mergeability"]
+    return {
+        "blocking_review": (
+            blocking_review
+            if blocking_review in {"changes_requested", "unresolved_threads"}
+            else "none"
+        ),
+        "failed_checks": checks["failed"],
+        "head_revision": canonical["head_revision"],
+        "kind": canonical["kind"],
+        "mergeability": (
+            mergeability if mergeability in {"conflicting", "behind", "blocked"} else "none"
+        ),
+        "state": canonical["state"],
+        "target": canonical["target"],
+    }
+
+
+def _classify_response(
+    response: GitHubPullRequestResponse,
+) -> tuple[MonitorObservationStatus, str]:
+    if response.state == "merged":
+        return MonitorObservationStatus.SUCCESS, "pull_request_merged"
+    if response.state == "closed":
+        return MonitorObservationStatus.BLOCKED, "pull_request_closed"
+    if response.state != "open" or not response.head_revision:
+        return MonitorObservationStatus.PENDING, "pull_request_state_unknown"
+    check_states = {check.state for check in response.checks}
+    if "failed" in check_states:
+        return MonitorObservationStatus.ACTIONABLE, "checks_failed"
+    if response.review_decision == "changes_requested":
+        return MonitorObservationStatus.ACTIONABLE, "changes_requested"
+    if response.unresolved_review_threads:
+        return MonitorObservationStatus.ACTIONABLE, "unresolved_review_threads"
+    if response.mergeability == "conflicting":
+        return MonitorObservationStatus.ACTIONABLE, "merge_conflict"
+    if response.mergeability == "behind":
+        return MonitorObservationStatus.ACTIONABLE, "branch_behind"
+    if response.mergeability == "blocked":
+        return MonitorObservationStatus.ACTIONABLE, "merge_blocked"
+    if response.draft:
+        return MonitorObservationStatus.PENDING, "pull_request_draft"
+    if "pending" in check_states:
+        return MonitorObservationStatus.PENDING, "checks_pending"
+    if "unknown" in check_states:
+        return MonitorObservationStatus.PENDING, "checks_unknown"
+    if not response.review_threads_complete:
+        return MonitorObservationStatus.PENDING, "review_threads_incomplete"
+    if response.review_decision == "unknown":
+        return MonitorObservationStatus.PENDING, "review_state_unknown"
+    if response.review_decision == "review_required":
+        return MonitorObservationStatus.PENDING, "review_required"
+    if response.mergeability == "pending":
+        return MonitorObservationStatus.PENDING, "mergeability_pending"
+    return MonitorObservationStatus.SUCCESS, "review_ready"
+
+
+def _process_failure(
+    proc: subprocess.CompletedProcess[str],
+) -> GitHubPullRequestProbeResult | None:
+    if proc.returncode == 0:
+        return None
+    kind = _classify_cli_error(proc.stderr if isinstance(proc.stderr, str) else "")
+    reasons = {
+        ProviderErrorKind.RATE_LIMITED: "provider_rate_limited",
+        ProviderErrorKind.AUTHENTICATION: "provider_authentication",
+        ProviderErrorKind.AUTHORIZATION: "provider_authorization",
+        ProviderErrorKind.NOT_FOUND: "provider_not_found",
+        ProviderErrorKind.TRANSIENT: "provider_transient",
+    }
+    return _provider_error(kind, reasons[kind])
+
+
+def _classify_cli_error(raw: str) -> ProviderErrorKind:
+    lowered = raw.lower()
+    if "could not resolve host" in lowered:
+        return ProviderErrorKind.TRANSIENT
+    if any(
+        marker in lowered
+        for marker in ("http 429", "rate limit", "abuse detection", "too many requests")
+    ):
+        return ProviderErrorKind.RATE_LIMITED
+    if any(
+        marker in lowered
+        for marker in (
+            "http 401",
+            "bad credentials",
+            "authentication",
+            "not logged into",
+            "gh auth login",
+        )
+    ):
+        return ProviderErrorKind.AUTHENTICATION
+    if any(
+        marker in lowered
+        for marker in ("http 404", "not found", "could not resolve to a repository")
+    ):
+        return ProviderErrorKind.NOT_FOUND
+    if any(
+        marker in lowered
+        for marker in ("http 403", "forbidden", "permission", "resource not accessible")
+    ):
+        return ProviderErrorKind.AUTHORIZATION
+    return ProviderErrorKind.TRANSIENT
+
+
+def _provider_error(kind: ProviderErrorKind, reason_code: str) -> GitHubPullRequestProbeResult:
+    return GitHubPullRequestProbeResult(
+        response=None,
+        canonical={},
+        observation=MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=kind,
+            reason_code=reason_code,
+        ),
+    )

--- a/src/kiro_crew/monitoring/github_pull_request.py
+++ b/src/kiro_crew/monitoring/github_pull_request.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import re
 import subprocess
+import unicodedata
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import PurePosixPath
@@ -14,6 +16,8 @@ from urllib.parse import urlparse
 
 from kiro_crew.github_runner import SetupError, resolve_gh, run_gh
 from kiro_crew.monitoring.models import (
+    MAX_MONITOR_CHECK_IDENTITIES_PER_BUCKET,
+    MAX_MONITOR_CHECK_IDENTITY_CHARS,
     MonitorObservation,
     MonitorObservationStatus,
     ProviderErrorKind,
@@ -23,23 +27,24 @@ from kiro_crew.security import redact
 _GITHUB_HOST = "github.com"
 _SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _URL_IN_CHECK_IDENTITY_RE = re.compile(r"https?://\S+", re.IGNORECASE)
-_ACTIONS_JOB_PATH_RE = re.compile(
-    r"^/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/actions/runs/([1-9][0-9]*)/job/[1-9][0-9]*$"
-)
+_RAW_URL_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+_HTTP_STATUS_RE = re.compile(r"\bhttp\s+(\d{3})\b", re.IGNORECASE)
+_HEAD_REVISION_RE = re.compile(r"^[0-9a-fA-F]{1,128}$")
 _PROBE_TIMEOUT_SECS = 30.0
 _REVIEW_THREAD_PAGE_SIZE = 100
 _REVIEW_THREAD_MAX_PAGES = 10
 _MERGEABLE_SETTLED_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE"})
-_PR_FIELDS = (
-    "number,state,isDraft,headRefOid,mergeable,mergeStateStatus," "reviewDecision,statusCheckRollup"
-)
+_PR_FIELDS = "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,reviewDecision"
+_CHECK_FIELDS = "statusCheckRollup,headRefOid"
+_MAX_PULL_REQUEST_NUMBER = 2_147_483_647
+_MAX_CHECK_ROWS = MAX_MONITOR_CHECK_IDENTITIES_PER_BUCKET * 4
 _REVIEW_THREADS_QUERY = """
 query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
   repository(owner:$owner,name:$repo){
     pullRequest(number:$number){
       reviewThreads(first:PAGE_SIZE,after:$cursor){
         pageInfo{hasNextPage endCursor}
-        nodes{isResolved}
+        nodes{isResolved isOutdated}
       }
     }
   }
@@ -86,6 +91,12 @@ class GitHubCheck:
     identity: str
     state: str
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, str) or not self.identity:
+            raise ValueError("GitHub check identity must be non-empty")
+        if self.state not in {"failed", "passed", "pending", "unknown"}:
+            raise ValueError("GitHub check state is malformed")
+
 
 @dataclass(frozen=True)
 class GitHubPullRequestResponse:
@@ -98,6 +109,7 @@ class GitHubPullRequestResponse:
     mergeability: str
     review_decision: str
     checks: tuple[GitHubCheck, ...]
+    checks_complete: bool
     unresolved_review_threads: int
     review_threads_complete: bool
 
@@ -130,8 +142,8 @@ class GitHubPullRequestProvider:
         previous_observation: Mapping[str, object] | None = None,
     ) -> GitHubPullRequestProbeResult:
         """Return one canonical review-ready observation."""
-        target = parse_github_pull_request_target(raw_target)
         try:
+            target = parse_github_pull_request_target(raw_target)
             gh = self._resolver()
             primary = self._runner(
                 [gh, "pr", "view", target.url, "--json", _PR_FIELDS],
@@ -143,23 +155,41 @@ class GitHubPullRequestProvider:
             if failure is not None:
                 return failure
             raw_primary = _json_object(primary.stdout)
-            response = _normalize_response(target, raw_primary, 0, False)
+            response = _normalize_response(
+                target,
+                raw_primary,
+                checks=(),
+                checks_complete=True,
+                unresolved_review_threads=0,
+                review_threads_complete=True,
+            )
+            supplemental_error: ProviderErrorKind | None = None
             if response.state not in {"merged", "closed"}:
-                unresolved, complete = self._review_threads(gh, target)
-                if isinstance(unresolved, GitHubPullRequestProbeResult):
-                    return unresolved
+                checks, checks_complete, checks_error = self._checks(
+                    gh,
+                    target,
+                    response.head_revision,
+                )
+                unresolved, complete, review_error = self._review_threads(gh, target)
+                supplemental_error = _combine_provider_errors(checks_error, review_error)
                 response = replace(
                     response,
+                    checks=checks,
+                    checks_complete=checks_complete,
                     unresolved_review_threads=unresolved,
                     review_threads_complete=complete,
                 )
-        except SetupError:
+        except SetupError as exc:
+            if _transient_os_error(exc.__cause__):
+                return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
             return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
         except FileNotFoundError:
             return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
         except subprocess.TimeoutExpired:
             return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
-        except OSError:
+        except OSError as exc:
+            if _transient_os_error(exc):
+                return _provider_error(ProviderErrorKind.TRANSIENT, "provider_transient")
             return _provider_error(ProviderErrorKind.SETUP, "provider_setup")
         except (TypeError, ValueError, KeyError):
             return _provider_error(
@@ -192,18 +222,55 @@ class GitHubPullRequestProvider:
             observation=MonitorObservation(
                 fingerprint,
                 status,
+                supplemental_provider_error=supplemental_error,
                 reason_code=reason_code,
                 head_changed=head_changed,
             ),
         )
 
+    def _checks(
+        self,
+        gh: str,
+        target: GitHubPullRequestTarget,
+        expected_head: str,
+    ) -> tuple[tuple[GitHubCheck, ...], bool, ProviderErrorKind | None]:
+        try:
+            proc = self._runner(
+                [gh, "pr", "view", target.url, "--json", _CHECK_FIELDS],
+                timeout=_PROBE_TIMEOUT_SECS,
+                audit_caller="core:monitor",
+                pin_host=_GITHUB_HOST,
+            )
+        except (SetupError, FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            return (), False, _provider_exception_kind(exc)
+        failure = _process_failure(proc)
+        if failure is not None:
+            return (), False, failure.observation.provider_error
+        try:
+            raw = _json_object(proc.stdout)
+            head = raw.get("headRefOid")
+            if not isinstance(head, str) or head != expected_head:
+                return (), False, ProviderErrorKind.TRANSIENT
+            rollup = raw.get("statusCheckRollup")
+            if rollup is None:
+                return (), True, None
+            if not isinstance(rollup, list):
+                raise ValueError("GitHub check rollup is malformed")
+            checks = _normalize_checks(rollup[:_MAX_CHECK_ROWS])
+            checks, buckets_complete = _bounded_checks(checks)
+            complete = len(rollup) <= _MAX_CHECK_ROWS and buckets_complete
+            return checks, complete, None
+        except (KeyError, TypeError, ValueError):
+            return (), False, ProviderErrorKind.TRANSIENT
+
     def _review_threads(
         self,
         gh: str,
         target: GitHubPullRequestTarget,
-    ) -> tuple[int | GitHubPullRequestProbeResult, bool]:
+    ) -> tuple[int, bool, ProviderErrorKind | None]:
         unresolved = 0
         cursor: str | None = None
+        seen_cursors: set[str] = set()
         for page in range(_REVIEW_THREAD_MAX_PAGES):
             argv = [
                 gh,
@@ -220,56 +287,64 @@ class GitHubPullRequestProvider:
             ]
             if cursor is not None:
                 argv.extend(("-f", f"cursor={cursor}"))
-            proc = self._runner(
-                argv,
-                timeout=_PROBE_TIMEOUT_SECS,
-                audit_caller="core:monitor",
-                pin_host=_GITHUB_HOST,
-            )
+            try:
+                proc = self._runner(
+                    argv,
+                    timeout=_PROBE_TIMEOUT_SECS,
+                    audit_caller="core:monitor",
+                    pin_host=_GITHUB_HOST,
+                )
+            except (SetupError, FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                return unresolved, False, _provider_exception_kind(exc)
             failure = _process_failure(proc)
-            if failure is not None:
-                return failure, False
-            raw = _json_object(proc.stdout)
+            failure_kind = failure.observation.provider_error if failure is not None else None
+            try:
+                raw = _json_object(proc.stdout)
+            except ValueError:
+                if failure_kind is not None:
+                    return unresolved, False, failure_kind
+                raise
             has_errors = bool(raw.get("errors"))
             try:
                 threads = raw["data"]["repository"]["pullRequest"]["reviewThreads"]
                 nodes = threads["nodes"]
                 page_info = threads["pageInfo"]
-            except (KeyError, TypeError) as exc:
-                if has_errors:
-                    return (
-                        _provider_error(
-                            ProviderErrorKind.TRANSIENT,
-                            "provider_malformed_response",
-                        ),
-                        False,
-                    )
-                raise ValueError("GitHub review-thread response is malformed") from exc
+            except (KeyError, TypeError):
+                return unresolved, False, failure_kind or ProviderErrorKind.TRANSIENT
             if not isinstance(nodes, list) or not isinstance(page_info, Mapping):
-                raise ValueError("GitHub review-thread response is malformed")
+                return unresolved, False, failure_kind or ProviderErrorKind.TRANSIENT
+            nodes_complete = True
             for node in nodes:
-                if not isinstance(node, Mapping) or not isinstance(node.get("isResolved"), bool):
-                    return unresolved, False
-                unresolved += int(not node["isResolved"])
-            if has_errors:
-                return unresolved, False
+                if (
+                    not isinstance(node, Mapping)
+                    or not isinstance(node.get("isResolved"), bool)
+                    or not isinstance(node.get("isOutdated"), bool)
+                ):
+                    nodes_complete = False
+                    continue
+                unresolved += int(not node["isResolved"] and not node["isOutdated"])
+            if failure_kind is not None or has_errors or not nodes_complete:
+                return unresolved, False, failure_kind or ProviderErrorKind.TRANSIENT
             has_next = page_info.get("hasNextPage")
             if has_next is False:
-                return unresolved, True
+                return unresolved, True, None
             if has_next is not True:
-                return unresolved, False
+                return unresolved, False, ProviderErrorKind.TRANSIENT
             next_cursor = page_info.get("endCursor")
             if not isinstance(next_cursor, str) or not next_cursor:
-                return unresolved, False
+                return unresolved, False, ProviderErrorKind.TRANSIENT
+            if next_cursor == cursor or next_cursor in seen_cursors:
+                return unresolved, False, ProviderErrorKind.TRANSIENT
+            seen_cursors.add(next_cursor)
             cursor = next_cursor
             if page + 1 == _REVIEW_THREAD_MAX_PAGES:
-                return unresolved, False
-        return unresolved, False
+                return unresolved, False, None
+        return unresolved, False, None
 
 
 def parse_github_pull_request_target(raw: str) -> GitHubPullRequestTarget:
     """Parse one exact public GitHub pull-request URL into a typed identity."""
-    if not isinstance(raw, str) or not raw:
+    if not isinstance(raw, str) or not raw or _RAW_URL_CONTROL_RE.search(raw):
         raise ValueError("target must be a GitHub pull request URL")
     parsed = urlparse(raw)
     try:
@@ -283,6 +358,7 @@ def parse_github_pull_request_target(raw: str) -> GitHubPullRequestTarget:
         or parsed.username is not None
         or parsed.password is not None
         or port is not None
+        or parsed.params
         or parsed.query
         or parsed.fragment
     ):
@@ -293,7 +369,12 @@ def parse_github_pull_request_target(raw: str) -> GitHubPullRequestTarget:
     owner, repo, raw_number = parts[1], parts[2], parts[4]
     if parsed.path != f"/{owner}/{repo}/pull/{raw_number}":
         raise ValueError("target must be a canonical GitHub pull request URL")
-    if not raw_number.isascii() or not raw_number.isdecimal():
+    if (
+        not raw_number.isascii()
+        or not raw_number.isdecimal()
+        or raw_number.startswith("0")
+        or int(raw_number, 10) > _MAX_PULL_REQUEST_NUMBER
+    ):
         raise ValueError("target must be a GitHub pull request with a positive number")
     try:
         return GitHubPullRequestTarget(_GITHUB_HOST, owner, repo, int(raw_number, 10))
@@ -316,6 +397,8 @@ def _json_object(raw: str | None) -> dict[str, Any]:
 def _normalize_response(
     target: GitHubPullRequestTarget,
     raw: Mapping[str, Any],
+    checks: tuple[GitHubCheck, ...],
+    checks_complete: bool,
     unresolved_review_threads: int,
     review_threads_complete: bool,
 ) -> GitHubPullRequestResponse:
@@ -327,7 +410,6 @@ def _normalize_response(
         "mergeable",
         "mergeStateStatus",
         "reviewDecision",
-        "statusCheckRollup",
     }
     if not required.issubset(raw):
         raise ValueError("GitHub pull request response is malformed")
@@ -339,21 +421,26 @@ def _normalize_response(
         or not isinstance(raw["isDraft"], bool)
     ):
         raise ValueError("GitHub pull request response is malformed")
-    for name in ("state", "headRefOid", "mergeable", "mergeStateStatus"):
+    for name in ("state", "mergeable", "mergeStateStatus"):
         if not isinstance(raw[name], str):
             raise ValueError("GitHub pull request response is malformed")
+    head_revision = raw["headRefOid"]
+    if not isinstance(head_revision, str) or (
+        head_revision and _HEAD_REVISION_RE.fullmatch(head_revision) is None
+    ):
+        raise ValueError("GitHub pull request response is malformed")
     review_decision = raw["reviewDecision"]
     if review_decision is not None and not isinstance(review_decision, str):
         raise ValueError("GitHub pull request response is malformed")
-    checks = _normalize_checks(raw["statusCheckRollup"])
     return GitHubPullRequestResponse(
         target=target,
         state=_normalize_pr_state(raw["state"]),
         draft=raw["isDraft"],
-        head_revision=raw["headRefOid"],
+        head_revision=head_revision,
         mergeability=_normalize_mergeability(raw["mergeable"], raw["mergeStateStatus"]),
         review_decision=_normalize_review_decision(review_decision),
         checks=checks,
+        checks_complete=checks_complete,
         unresolved_review_threads=unresolved_review_threads,
         review_threads_complete=review_threads_complete,
     )
@@ -362,28 +449,37 @@ def _normalize_response(
 def _normalize_checks(raw: object) -> tuple[GitHubCheck, ...]:
     if not isinstance(raw, list):
         raise ValueError("GitHub check rollup is malformed")
-    grouped: dict[tuple[str, ...], tuple[str, list[tuple[str, str]]]] = {}
+    grouped: dict[tuple[str, ...], tuple[str, list[str]]] = {}
     for row_index, item in enumerate(raw):
         if not isinstance(item, Mapping):
             raise ValueError("GitHub check rollup is malformed")
-        identity, state, recency, group_key = _normalize_check(item)
+        identity, state, group_key = _normalize_check(item)
         if group_key is None:
-            group_key = ("workflowless_check_run", str(row_index))
+            group_key = ("independent_check_run", str(row_index))
         _, candidates = grouped.setdefault(group_key, (identity, []))
-        candidates.append((recency, state))
+        candidates.append(state)
     normalized: list[GitHubCheck] = []
     for identity, candidates in grouped.values():
-        candidates.sort(key=lambda item: item[0], reverse=True)
-        latest_recency = candidates[0][0]
-        latest_states = {state for recency, state in candidates if recency == latest_recency}
-        state = next(iter(latest_states)) if len(latest_states) == 1 else "unknown"
+        state = min(candidates, key=("failed", "pending", "unknown", "passed").index)
         normalized.append(GitHubCheck(_sanitize_check_identity(identity), state))
     return tuple(sorted(normalized, key=lambda item: item.identity))
 
 
+def _bounded_checks(checks: tuple[GitHubCheck, ...]) -> tuple[tuple[GitHubCheck, ...], bool]:
+    """Bound each durable state bucket without letting one state consume the others."""
+    bounded: list[GitHubCheck] = []
+    complete = True
+    for state in ("failed", "passed", "pending", "unknown"):
+        matching = [check for check in checks if check.state == state]
+        if len(matching) > MAX_MONITOR_CHECK_IDENTITIES_PER_BUCKET:
+            complete = False
+        bounded.extend(matching[:MAX_MONITOR_CHECK_IDENTITIES_PER_BUCKET])
+    return tuple(sorted(bounded, key=lambda item: (item.identity, item.state))), complete
+
+
 def _normalize_check(
     raw: Mapping[str, object],
-) -> tuple[str, str, str, tuple[str, ...] | None]:
+) -> tuple[str, str, tuple[str, ...] | None]:
     typename = raw.get("__typename")
     if typename == "CheckRun":
         name = raw.get("name")
@@ -395,7 +491,7 @@ def _normalize_check(
         conclusion = raw.get("conclusion")
         if status != "COMPLETED":
             state = "pending" if isinstance(status, str) else "unknown"
-        elif conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+        elif conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED", "STALE"}:
             state = "passed"
         elif conclusion in {
             "FAILURE",
@@ -407,15 +503,7 @@ def _normalize_check(
             state = "failed"
         else:
             state = "unknown"
-        recency = raw.get("startedAt")
-        if not workflow:
-            normalized_recency = ""
-        elif isinstance(recency, str) and recency:
-            normalized_recency = recency
-        else:
-            normalized_recency = "\uffff" if state == "pending" else ""
-        group_key = _check_run_group_key(raw, name) if workflow else None
-        return identity, state, normalized_recency, group_key
+        return identity, state, None
     if typename == "StatusContext":
         context = raw.get("context")
         if not isinstance(context, str) or not context:
@@ -431,39 +519,8 @@ def _normalize_check(
             }.get(raw_state, "unknown")
         else:
             state = "unknown"
-        return context, state, "", ("status_context", context)
+        return context, state, ("status_context", context)
     raise ValueError("GitHub check rollup is malformed")
-
-
-def _check_run_group_key(
-    raw: Mapping[str, object],
-    name: str,
-) -> tuple[str, ...] | None:
-    """Return the GitHub Actions run identity shared by rerun attempts."""
-    details_url = raw.get("detailsUrl")
-    if not isinstance(details_url, str):
-        return None
-    parsed = urlparse(details_url)
-    try:
-        host = (parsed.hostname or "").lower()
-        port = parsed.port
-    except ValueError:
-        return None
-    if (
-        parsed.scheme != "https"
-        or host != _GITHUB_HOST
-        or parsed.username is not None
-        or parsed.password is not None
-        or port is not None
-        or parsed.query
-        or parsed.fragment
-    ):
-        return None
-    match = _ACTIONS_JOB_PATH_RE.fullmatch(parsed.path)
-    if match is None:
-        return None
-    owner, repo, run_id = match.groups()
-    return ("check_run", owner.casefold(), repo.casefold(), run_id, name)
 
 
 def _normalize_pr_state(raw: str) -> str:
@@ -471,8 +528,24 @@ def _normalize_pr_state(raw: str) -> str:
 
 
 def _sanitize_check_identity(identity: str) -> str:
-    without_urls = _URL_IN_CHECK_IDENTITY_RE.sub("[provider-url]", identity)
-    return redact(without_urls)
+    normalized = "".join(
+        (
+            " "
+            if unicodedata.category(character).startswith("C")
+            or unicodedata.category(character) in {"Zl", "Zp"}
+            else character
+        )
+        for character in identity
+    ).strip()
+    redacted = redact(_URL_IN_CHECK_IDENTITY_RE.sub("[provider-url]", normalized)).strip()
+    if not redacted:
+        digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+        return f"github_check:{digest}"
+    if len(redacted) <= MAX_MONITOR_CHECK_IDENTITY_CHARS:
+        return redacted
+    digest = hashlib.sha256(redacted.encode("utf-8")).hexdigest()[:16]
+    prefix_length = MAX_MONITOR_CHECK_IDENTITY_CHARS - len(digest) - 1
+    return f"{redacted[:prefix_length]}#{digest}"
 
 
 def _normalize_review_decision(raw: str | None) -> str:
@@ -501,7 +574,7 @@ def _normalize_mergeability(mergeable: str, merge_state: str) -> str:
 
 def _canonical_response(response: GitHubPullRequestResponse) -> dict[str, object]:
     checks = {
-        state: sorted({check.identity for check in response.checks if check.state == state})
+        state: sorted(check.identity for check in response.checks if check.state == state)
         for state in ("failed", "passed", "pending", "unknown")
     }
     if response.review_decision == "changes_requested":
@@ -515,6 +588,7 @@ def _canonical_response(response: GitHubPullRequestResponse) -> dict[str, object
     return {
         "blocking_review": blocking_review,
         "checks": checks,
+        "checks_complete": response.checks_complete,
         "draft": response.draft,
         "head_revision": response.head_revision,
         "kind": "github_pull_request",
@@ -550,14 +624,15 @@ def _actionable_fingerprint_facts(canonical: Mapping[str, object]) -> dict[str, 
             if blocking_review in {"changes_requested", "unresolved_threads"}
             else "none"
         ),
+        "checks_complete": canonical["checks_complete"],
         "failed_checks": checks["failed"],
         "head_revision": canonical["head_revision"],
         "kind": canonical["kind"],
-        "mergeability": (
-            mergeability if mergeability in {"conflicting", "behind", "blocked"} else "none"
-        ),
+        "mergeability": (mergeability if mergeability in {"conflicting", "behind"} else "none"),
+        "review_threads_complete": canonical["review_threads_complete"],
         "state": canonical["state"],
         "target": canonical["target"],
+        "unresolved_review_threads": canonical["unresolved_review_threads"],
     }
 
 
@@ -570,6 +645,8 @@ def _classify_response(
         return MonitorObservationStatus.BLOCKED, "pull_request_closed"
     if response.state != "open" or not response.head_revision:
         return MonitorObservationStatus.PENDING, "pull_request_state_unknown"
+    if response.draft:
+        return MonitorObservationStatus.PENDING, "pull_request_draft"
     check_states = {check.state for check in response.checks}
     if "failed" in check_states:
         return MonitorObservationStatus.ACTIONABLE, "checks_failed"
@@ -581,10 +658,8 @@ def _classify_response(
         return MonitorObservationStatus.ACTIONABLE, "merge_conflict"
     if response.mergeability == "behind":
         return MonitorObservationStatus.ACTIONABLE, "branch_behind"
-    if response.mergeability == "blocked":
-        return MonitorObservationStatus.ACTIONABLE, "merge_blocked"
-    if response.draft:
-        return MonitorObservationStatus.PENDING, "pull_request_draft"
+    if not response.checks_complete:
+        return MonitorObservationStatus.PENDING, "checks_incomplete"
     if "pending" in check_states:
         return MonitorObservationStatus.PENDING, "checks_pending"
     if "unknown" in check_states:
@@ -595,7 +670,7 @@ def _classify_response(
         return MonitorObservationStatus.PENDING, "review_state_unknown"
     if response.review_decision == "review_required":
         return MonitorObservationStatus.PENDING, "review_required"
-    if response.mergeability == "pending":
+    if response.mergeability in {"pending", "blocked"}:
         return MonitorObservationStatus.PENDING, "mergeability_pending"
     return MonitorObservationStatus.SUCCESS, "review_ready"
 
@@ -618,6 +693,21 @@ def _process_failure(
 
 def _classify_cli_error(raw: str) -> ProviderErrorKind:
     lowered = raw.lower()
+    if any(marker in lowered for marker in ("rate limit", "abuse detection", "too many requests")):
+        return ProviderErrorKind.RATE_LIMITED
+    status_match = _HTTP_STATUS_RE.search(raw)
+    if status_match is not None:
+        status = int(status_match.group(1), 10)
+        if status == 429:
+            return ProviderErrorKind.RATE_LIMITED
+        if status == 401:
+            return ProviderErrorKind.AUTHENTICATION
+        if status == 403:
+            return ProviderErrorKind.AUTHORIZATION
+        if status == 404:
+            return ProviderErrorKind.NOT_FOUND
+        if status >= 500:
+            return ProviderErrorKind.TRANSIENT
     if "could not resolve host" in lowered:
         return ProviderErrorKind.TRANSIENT
     if any(
@@ -628,7 +718,6 @@ def _classify_cli_error(raw: str) -> ProviderErrorKind:
     if any(
         marker in lowered
         for marker in (
-            "http 401",
             "bad credentials",
             "authentication",
             "not logged into",
@@ -638,15 +727,70 @@ def _classify_cli_error(raw: str) -> ProviderErrorKind:
         return ProviderErrorKind.AUTHENTICATION
     if any(
         marker in lowered
-        for marker in ("http 404", "not found", "could not resolve to a repository")
+        for marker in (
+            "not found",
+            "could not resolve to a repository",
+            "could not resolve to a pullrequest",
+        )
     ):
         return ProviderErrorKind.NOT_FOUND
     if any(
         marker in lowered
-        for marker in ("http 403", "forbidden", "permission", "resource not accessible")
+        for marker in (
+            "forbidden",
+            "permission",
+            "resource not accessible",
+            "saml",
+        )
     ):
         return ProviderErrorKind.AUTHORIZATION
     return ProviderErrorKind.TRANSIENT
+
+
+def _combine_provider_errors(
+    first: ProviderErrorKind | None,
+    second: ProviderErrorKind | None,
+) -> ProviderErrorKind | None:
+    """Keep the most specific supplemental failure when both evidence calls fail."""
+    priority = {
+        ProviderErrorKind.AUTHENTICATION: 0,
+        ProviderErrorKind.AUTHORIZATION: 1,
+        ProviderErrorKind.NOT_FOUND: 2,
+        ProviderErrorKind.RATE_LIMITED: 3,
+        ProviderErrorKind.TRANSIENT: 4,
+        ProviderErrorKind.SETUP: 5,
+    }
+    present = [error for error in (first, second) if error is not None]
+    return min(present, key=priority.__getitem__) if present else None
+
+
+def _transient_os_error(error: BaseException | None) -> bool:
+    """Classify bounded host-pressure and connection failures as retryable."""
+    return isinstance(error, OSError) and error.errno in {
+        errno.EAGAIN,
+        errno.EMFILE,
+        errno.ENFILE,
+        errno.ENOMEM,
+        errno.ECONNRESET,
+        errno.ETIMEDOUT,
+    }
+
+
+def _provider_exception_kind(error: BaseException) -> ProviderErrorKind:
+    """Map runner exceptions without letting supplemental reads erase primary facts."""
+    if isinstance(error, subprocess.TimeoutExpired):
+        return ProviderErrorKind.TRANSIENT
+    if isinstance(error, FileNotFoundError):
+        return ProviderErrorKind.SETUP
+    if isinstance(error, SetupError):
+        return (
+            ProviderErrorKind.TRANSIENT
+            if _transient_os_error(error.__cause__)
+            else ProviderErrorKind.SETUP
+        )
+    if isinstance(error, OSError) and _transient_os_error(error):
+        return ProviderErrorKind.TRANSIENT
+    return ProviderErrorKind.SETUP
 
 
 def _provider_error(kind: ProviderErrorKind, reason_code: str) -> GitHubPullRequestProbeResult:

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -68,6 +68,7 @@ class ProviderErrorKind(str, Enum):
     AUTHENTICATION = "authentication"
     AUTHORIZATION = "authorization"
     NOT_FOUND = "not_found"
+    SETUP = "setup"
 
 
 class MonitorOutcome(str, Enum):
@@ -158,6 +159,7 @@ class MonitorObservation:
     provider_error: ProviderErrorKind | None = None
     reason_code: str = ""
     summary: str = ""
+    head_changed: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.status, MonitorObservationStatus):
@@ -168,9 +170,13 @@ class MonitorObservation:
             raise ValueError("reason_code must be a string")
         if not isinstance(self.summary, str):
             raise ValueError("summary must be a string")
+        if not isinstance(self.head_changed, bool):
+            raise ValueError("head_changed must be a boolean")
         if self.status is MonitorObservationStatus.PROVIDER_ERROR:
             if not isinstance(self.provider_error, ProviderErrorKind):
                 raise ValueError("provider_error must be a ProviderErrorKind for a provider error")
+            if self.head_changed:
+                raise ValueError("head_changed is not valid for a provider error observation")
             return
         if not self.fingerprint:
             raise ValueError("fingerprint is required for a comparable observation")
@@ -202,6 +208,11 @@ class MonitorState:
     input_tokens: int = 0
     output_tokens: int = 0
     consecutive_provider_errors: int = 0
+    probe_count: int = 0
+    provider_error_count: int = 0
+    last_probe_at: float = 0.0
+    last_decision: MonitorDecision | None = None
+    last_provider_error: ProviderErrorKind | None = None
     next_probe_at: float = 0.0
     outcome: MonitorOutcome | None = None
     stopped_reason: str = ""
@@ -220,6 +231,7 @@ class MonitorState:
             "created_ts",
             "last_observed_at",
             "last_completed_at",
+            "last_probe_at",
             "next_probe_at",
             "stopped_at",
         ):
@@ -231,6 +243,8 @@ class MonitorState:
             "input_tokens",
             "output_tokens",
             "consecutive_provider_errors",
+            "probe_count",
+            "provider_error_count",
         ):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
@@ -263,6 +277,12 @@ class MonitorState:
             raise ValueError("last_completion_disposition must be a MonitorActionDisposition")
         if not isinstance(self.token_usage_known, bool):
             raise ValueError("token_usage_known must be a boolean")
+        if self.last_decision is not None and not isinstance(self.last_decision, MonitorDecision):
+            raise ValueError("last_decision must be a MonitorDecision")
+        if self.last_provider_error is not None and not isinstance(
+            self.last_provider_error, ProviderErrorKind
+        ):
+            raise ValueError("last_provider_error must be a ProviderErrorKind")
         if self.outcome is not None and not isinstance(self.outcome, MonitorOutcome):
             raise ValueError("outcome must be a MonitorOutcome")
         if not isinstance(self.stopped_reason, str):
@@ -329,6 +349,12 @@ def monitor_state_from_dict(raw: object) -> MonitorState:
     disposition = values.get("last_completion_disposition")
     if disposition is not None:
         values["last_completion_disposition"] = MonitorActionDisposition(disposition)
+    decision = values.get("last_decision")
+    if decision is not None:
+        values["last_decision"] = MonitorDecision(decision)
+    provider_error = values.get("last_provider_error")
+    if provider_error is not None:
+        values["last_provider_error"] = ProviderErrorKind(provider_error)
     return MonitorState(**values)
 
 

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -20,6 +20,8 @@ DEFAULT_MONITOR_AGENT_TURNS = 8
 DEFAULT_MONITOR_TOKENS = 250_000
 DEFAULT_MONITOR_PROVIDER_ERRORS = 3
 DEFAULT_MONITOR_CADENCE_SECS = 300
+MAX_MONITOR_CHECK_IDENTITIES_PER_BUCKET = 100
+MAX_MONITOR_CHECK_IDENTITY_CHARS = 200
 MONITOR_STOP_INVALID_RECORD = "invalid_monitor_record"
 MONITOR_STOP_RUNTIME_BUDGET = "runtime_budget"
 MONITOR_STOP_AGENT_TURN_BUDGET = "agent_turn_budget"
@@ -157,6 +159,7 @@ class MonitorObservation:
     fingerprint: str
     status: MonitorObservationStatus
     provider_error: ProviderErrorKind | None = None
+    supplemental_provider_error: ProviderErrorKind | None = None
     reason_code: str = ""
     summary: str = ""
     head_changed: bool = False
@@ -175,6 +178,8 @@ class MonitorObservation:
         if self.status is MonitorObservationStatus.PROVIDER_ERROR:
             if not isinstance(self.provider_error, ProviderErrorKind):
                 raise ValueError("provider_error must be a ProviderErrorKind for a provider error")
+            if self.supplemental_provider_error is not None:
+                raise ValueError("supplemental_provider_error is not valid for a provider error")
             if self.head_changed:
                 raise ValueError("head_changed is not valid for a provider error observation")
             return
@@ -182,6 +187,10 @@ class MonitorObservation:
             raise ValueError("fingerprint is required for a comparable observation")
         if self.provider_error is not None:
             raise ValueError("provider_error is only valid for a provider error observation")
+        if self.supplemental_provider_error is not None and not isinstance(
+            self.supplemental_provider_error, ProviderErrorKind
+        ):
+            raise ValueError("supplemental_provider_error must be a ProviderErrorKind")
 
 
 @dataclass

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -1,0 +1,85 @@
+"""Persistence-only monitor probing with no action-delivery dependency."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Awaitable, Callable, Mapping
+from copy import deepcopy
+from dataclasses import fields
+from typing import Protocol
+
+from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
+from kiro_crew.monitoring.models import (
+    MonitorDecision,
+    MonitorObservationStatus,
+    MonitorState,
+)
+
+ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
+
+
+class ShadowWakeDeliveryRefused(RuntimeError):
+    """Raised when a caller asks the persistence-only path to wake a session."""
+
+
+class GitHubShadowProvider(Protocol):
+    """External probe boundary required by the shadow controller."""
+
+    def probe(
+        self,
+        raw_target: str,
+        *,
+        previous_observation: Mapping[str, object] | None = None,
+    ) -> GitHubPullRequestProbeResult: ...
+
+
+async def run_shadow_probe(
+    state: MonitorState,
+    provider: GitHubShadowProvider,
+    persist: ShadowStatePersistence,
+    *,
+    now: float,
+    wake_delivery: bool = False,
+) -> MonitorDecision:
+    """Probe and persist one decision without acquiring a delivery capability."""
+    if wake_delivery:
+        raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
+    if state.kind != "github_pull_request" or state.objective != "review_ready":
+        raise ValueError("shadow mode supports only github_pull_request review_ready")
+    if (
+        isinstance(now, bool)
+        or not isinstance(now, (int, float))
+        or not math.isfinite(now)
+        or now < 0
+    ):
+        raise ValueError("now must be a finite non-negative number")
+    if not callable(persist):
+        raise ValueError("persist must be callable")
+
+    result = await asyncio.to_thread(
+        provider.probe,
+        state.target,
+        previous_observation=deepcopy(state.last_observation),
+    )
+    staged = deepcopy(state)
+    decision = decide_monitor(staged, result.observation, now=now)
+    staged.probe_count += 1
+    staged.last_probe_at = now
+    staged.last_decision = decision
+    staged.next_probe_at = now + staged.cadence_secs
+    if result.observation.status is MonitorObservationStatus.PROVIDER_ERROR:
+        staged.provider_error_count += 1
+        staged.consecutive_provider_errors += 1
+        staged.last_provider_error = result.observation.provider_error
+    else:
+        staged.last_observation = deepcopy(result.canonical)
+        staged.last_fingerprint = result.observation.fingerprint
+        staged.last_observed_at = now
+        staged.consecutive_provider_errors = 0
+        staged.last_provider_error = None
+    await persist(staged)
+    for state_field in fields(MonitorState):
+        setattr(state, state_field.name, deepcopy(getattr(staged, state_field.name)))
+    return decision

--- a/src/kiro_crew/monitoring/shadow.py
+++ b/src/kiro_crew/monitoring/shadow.py
@@ -9,12 +9,14 @@ from copy import deepcopy
 from dataclasses import fields
 from typing import Protocol
 
-from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.decision import decide_monitor, monitor_budget_reason
 from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
 from kiro_crew.monitoring.models import (
     MonitorDecision,
     MonitorObservationStatus,
+    MonitorOutcome,
     MonitorState,
+    ProviderErrorKind,
 )
 
 ShadowStatePersistence = Callable[[MonitorState], Awaitable[None]]
@@ -48,15 +50,30 @@ async def run_shadow_probe(
         raise ShadowWakeDeliveryRefused("wake delivery is unavailable in shadow mode")
     if state.kind != "github_pull_request" or state.objective != "review_ready":
         raise ValueError("shadow mode supports only github_pull_request review_ready")
-    if (
-        isinstance(now, bool)
-        or not isinstance(now, (int, float))
-        or not math.isfinite(now)
-        or now < 0
-    ):
+    if isinstance(now, bool) or not isinstance(now, (int, float)) or now < 0:
+        raise ValueError("now must be a finite non-negative number")
+    try:
+        now_is_finite = math.isfinite(now)
+    except OverflowError as exc:
+        raise ValueError("now must be a finite non-negative number") from exc
+    if not now_is_finite:
         raise ValueError("now must be a finite non-negative number")
     if not callable(persist):
         raise ValueError("persist must be callable")
+
+    terminal = _decision_for_outcome(state.outcome)
+    if terminal is not None:
+        return terminal
+    budget_reason = monitor_budget_reason(state, now=now)
+    if budget_reason:
+        staged = deepcopy(state)
+        staged.last_decision = MonitorDecision.STOP_BUDGET
+        staged.outcome = MonitorOutcome.BUDGET
+        staged.stopped_reason = budget_reason
+        staged.stopped_at = now
+        staged.next_probe_at = 0.0
+        await _persist_and_publish(state, staged, persist)
+        return MonitorDecision.STOP_BUDGET
 
     result = await asyncio.to_thread(
         provider.probe,
@@ -68,18 +85,63 @@ async def run_shadow_probe(
     staged.probe_count += 1
     staged.last_probe_at = now
     staged.last_decision = decision
-    staged.next_probe_at = now + staged.cadence_secs
-    if result.observation.status is MonitorObservationStatus.PROVIDER_ERROR:
+    observation = result.observation
+    provider_error = observation.provider_error or observation.supplemental_provider_error
+    if provider_error is not None:
         staged.provider_error_count += 1
         staged.consecutive_provider_errors += 1
-        staged.last_provider_error = result.observation.provider_error
+        staged.last_provider_error = provider_error
     else:
-        staged.last_observation = deepcopy(result.canonical)
-        staged.last_fingerprint = result.observation.fingerprint
-        staged.last_observed_at = now
         staged.consecutive_provider_errors = 0
         staged.last_provider_error = None
+    if observation.status is not MonitorObservationStatus.PROVIDER_ERROR:
+        staged.last_observation = deepcopy(result.canonical)
+        staged.last_fingerprint = observation.fingerprint
+        staged.last_observed_at = now
+    if decision in {
+        MonitorDecision.STOP_SUCCESS,
+        MonitorDecision.STOP_BLOCKED,
+        MonitorDecision.STOP_BUDGET,
+    }:
+        staged.outcome = _terminal_outcome(decision, observation.provider_error)
+        staged.stopped_reason = observation.reason_code or decision.value
+        staged.stopped_at = now
+        staged.next_probe_at = 0.0
+    else:
+        staged.next_probe_at = now + staged.cadence_secs
+    await _persist_and_publish(state, staged, persist)
+    return decision
+
+
+async def _persist_and_publish(
+    state: MonitorState,
+    staged: MonitorState,
+    persist: ShadowStatePersistence,
+) -> None:
+    """Publish only after the staged replacement is durable."""
     await persist(staged)
     for state_field in fields(MonitorState):
         setattr(state, state_field.name, deepcopy(getattr(staged, state_field.name)))
-    return decision
+
+
+def _terminal_outcome(
+    decision: MonitorDecision,
+    provider_error: ProviderErrorKind | None,
+) -> MonitorOutcome:
+    if decision is MonitorDecision.STOP_SUCCESS:
+        return MonitorOutcome.SUCCESS
+    if decision is MonitorDecision.STOP_BUDGET:
+        return MonitorOutcome.BUDGET
+    if provider_error is ProviderErrorKind.NOT_FOUND:
+        return MonitorOutcome.TARGET_UNAVAILABLE
+    return MonitorOutcome.BLOCKED
+
+
+def _decision_for_outcome(outcome: MonitorOutcome | None) -> MonitorDecision | None:
+    if outcome is MonitorOutcome.SUCCESS:
+        return MonitorDecision.STOP_SUCCESS
+    if outcome is MonitorOutcome.BUDGET:
+        return MonitorDecision.STOP_BUDGET
+    if outcome is not None:
+        return MonitorDecision.STOP_BLOCKED
+    return None

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1538,6 +1538,10 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # Redacts INBOUND attacker-controllable provider metadata before it is
         # stored/displayed — a sanitizer on the way in, not an output boundary.
         "dashboard/handlers/mcp_discover.py",
+        # Inbound provider sanitization: check identities are stripped of URLs and
+        # credentials before they enter canonical monitor state. The controller's
+        # later agent-session injection is the registered output boundary.
+        "monitoring/github_pull_request.py",
         # Computer use: the redaction pass runs on third-party desktop content
         # (window titles, accessibility values) on its way INTO the model's
         # context, exactly like the MCP tool-result paths above. `policy.py` owns

--- a/test/test_github_pull_request_monitor.py
+++ b/test/test_github_pull_request_monitor.py
@@ -1,0 +1,1354 @@
+"""GitHub pull-request monitor provider and canonicalization contracts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from copy import deepcopy
+
+import pytest
+
+from kiro_crew.github_runner import SetupError
+from kiro_crew.monitoring.decision import decide_monitor
+from kiro_crew.monitoring.github_pull_request import (
+    GitHubPullRequestProvider,
+    GitHubPullRequestTarget,
+    parse_github_pull_request_target,
+)
+from kiro_crew.monitoring.models import (
+    MonitorDecision,
+    MonitorObservationStatus,
+    MonitorState,
+    ProviderErrorKind,
+    monitor_state_to_dict,
+)
+from kiro_crew.monitoring.shadow import ShadowWakeDeliveryRefused, run_shadow_probe
+
+_HEAD = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _primary(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "number": 123,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": _HEAD,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "test",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-22T00:00:00Z",
+                "completedAt": "2026-08-22T00:01:00Z",
+            },
+            {
+                "__typename": "StatusContext",
+                "context": "lint",
+                "state": "SUCCESS",
+                "targetUrl": "https://github.com/owner/repo/statuses/sha",
+            },
+        ],
+    }
+    payload.update(changes)
+    return payload
+
+
+def _threads(
+    nodes: list[dict[str, object]] | None = None,
+    *,
+    has_next: bool = False,
+    cursor: str | None = None,
+) -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {
+                            "hasNextPage": has_next,
+                            "endCursor": cursor,
+                        },
+                        "nodes": (
+                            nodes
+                            if nodes is not None
+                            else [{"isResolved": True}, {"isResolved": True}]
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+
+class _FakeRunner:
+    def __init__(self, payloads: Sequence[dict[str, object]]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def __call__(self, argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        self.calls.append((list(argv), kwargs))
+        payload = self._payloads.pop(0)
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+
+def _provider(*payloads: dict[str, object]) -> tuple[GitHubPullRequestProvider, _FakeRunner]:
+    runner = _FakeRunner(payloads)
+    return (
+        GitHubPullRequestProvider(
+            resolver=lambda: "/trusted/bin/gh",
+            runner=runner,
+        ),
+        runner,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "https://github.com/owner/repo/pull/123",
+            GitHubPullRequestTarget("github.com", "owner", "repo", 123),
+        ),
+        (
+            "https://www.github.com/Owner-1/repo_name/pull/7",
+            GitHubPullRequestTarget("github.com", "Owner-1", "repo_name", 7),
+        ),
+    ],
+)
+def test_pull_request_target_normalizes_only_public_github_urls(
+    raw: str,
+    expected: GitHubPullRequestTarget,
+) -> None:
+    """Changing public-host normalization or typed identity breaks this contract."""
+    assert parse_github_pull_request_target(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "owner/repo#123",
+        "git@github.com:owner/repo.git",
+        "http://github.com/owner/repo/pull/123",
+        "https://github.example.com/owner/repo/pull/123",
+        "https://enterprise.github.com/owner/repo/pull/123",
+        "https://github.com/owner/repo",
+        "https://github.com/owner/repo/issues/123",
+        "https://github.com/owner/repo/pull/0",
+        "https://github.com/owner/repo/pull/-1",
+        "https://github.com/owner/repo/pull/not-a-number",
+        "https://github.com/owner/repo/pull/123/files",
+        "https://github.com/owner/repo/pull/123/",
+        "https://github.com/owner//repo/pull/123",
+        "https://github.com/owner/repo/pull/123?diff=split",
+        "https://github.com/owner/repo/pull/123#discussion",
+        "https://user@github.com/owner/repo/pull/123",
+        "https://github.com:443/owner/repo/pull/123",
+        "https://github.com:notaport/owner/repo/pull/123",
+        "https://github.com/../repo/pull/123",
+        "https://github.com/owner/repo;touch/pull/123",
+    ],
+)
+def test_pull_request_target_rejects_noncanonical_or_untrusted_input(raw: str) -> None:
+    """Weakening target validation would let input select a host or command shape."""
+    with pytest.raises(ValueError, match="GitHub pull request"):
+        parse_github_pull_request_target(raw)
+
+
+def test_clean_pull_request_has_allowlisted_canonical_observation_and_fingerprint() -> None:
+    """Adding provider payload fields or omitting a readiness fact breaks persistence."""
+    provider, runner = _provider(_primary(), _threads())
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical == {
+        "blocking_review": "none",
+        "checks": {
+            "failed": [],
+            "passed": ["CI / test", "lint"],
+            "pending": [],
+            "unknown": [],
+        },
+        "draft": False,
+        "head_revision": _HEAD,
+        "kind": "github_pull_request",
+        "mergeability": "mergeable",
+        "review_decision": "approved",
+        "review_threads_complete": True,
+        "state": "open",
+        "target": "github.com/owner/repo#123",
+        "unresolved_review_threads": 0,
+    }
+    assert result.observation.status is MonitorObservationStatus.SUCCESS
+    assert result.observation.reason_code == "review_ready"
+    assert result.observation.fingerprint == (
+        "8d7a3844c6c0c44350e62e7823a62c941b9484a140a517326c630e780a8be30f"
+    )
+    primary_argv, primary_kwargs = runner.calls[0]
+    assert primary_argv == [
+        "/trusted/bin/gh",
+        "pr",
+        "view",
+        "https://github.com/owner/repo/pull/123",
+        "--json",
+        (
+            "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,"
+            "reviewDecision,statusCheckRollup"
+        ),
+    ]
+    assert primary_kwargs["audit_caller"] == "core:monitor"
+    assert primary_kwargs["pin_host"] == "github.com"
+
+
+def test_reordered_and_volatile_provider_values_keep_the_fingerprint_stable() -> None:
+    """Ordering, URLs, request ids, bodies, logs, and timestamps are never durable facts."""
+    first_provider, _ = _provider(_primary(), _threads())
+    noisy_checks = list(reversed(_primary()["statusCheckRollup"]))
+    noisy_checks[0] = {
+        **noisy_checks[0],
+        "targetUrl": "https://github.com/owner/repo/statuses/different",
+        "requestId": "request-2",
+    }
+    noisy_checks[1] = {
+        **noisy_checks[1],
+        "startedAt": "2030-01-01T00:00:00Z",
+        "completedAt": "2030-01-01T00:01:00Z",
+        "detailsUrl": "https://github.com/owner/repo/actions/runs/999",
+        "logText": "credential-like provider output",
+    }
+    noisy_primary = _primary(
+        statusCheckRollup=noisy_checks,
+        title="volatile title",
+        body="volatile body",
+        url="https://github.com/owner/repo/pull/123",
+        requestId="request-1",
+        updatedAt="2030-01-01T00:00:00Z",
+    )
+    second_provider, _ = _provider(
+        noisy_primary,
+        _threads(nodes=[{"isResolved": True}, {"isResolved": True}]),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert second.canonical == first.canonical
+    assert second.observation.fingerprint == first.observation.fingerprint
+    serialized = json.dumps(second.canonical, sort_keys=True)
+    for forbidden in (
+        "request-1",
+        "request-2",
+        "volatile title",
+        "volatile body",
+        "credential-like",
+        "2030-01-01",
+        "https://",
+    ):
+        assert forbidden not in serialized
+
+
+def test_check_identity_is_redacted_before_it_enters_canonical_state() -> None:
+    """A provider-controlled check label cannot turn monitor state into a secret sink."""
+    token = "ghp_abcdefghijklmnopqrstuvwxyz1234567890ABCD"
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(),
+                    "workflowName": f"CI {token}",
+                    "name": "https://internal.example.test/run?id=secret",
+                }
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    serialized = json.dumps(result.canonical, sort_keys=True)
+    assert token not in serialized
+    assert "internal.example.test" not in serialized
+    assert "request?id" not in serialized
+
+
+def test_latest_check_rerun_wins_without_collection_order_affecting_fingerprint() -> None:
+    """Choosing list order instead of the latest run can hide or invent a failure."""
+    older_failure = {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": "COMPLETED",
+        "conclusion": "FAILURE",
+        "startedAt": "2026-08-21T00:00:00Z",
+        "completedAt": "2026-08-21T00:01:00Z",
+        "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/201",
+    }
+    newer_success = {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "startedAt": "2026-08-22T00:00:00Z",
+        "completedAt": "2026-08-22T00:01:00Z",
+        "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/202",
+    }
+    first_provider, _ = _provider(
+        _primary(statusCheckRollup=[older_failure, newer_success]),
+        _threads(),
+    )
+    second_provider, _ = _provider(
+        _primary(statusCheckRollup=[newer_success, older_failure]),
+        _threads(),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical["checks"] == {
+        "failed": [],
+        "passed": ["CI / test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert first.observation.fingerprint == second.observation.fingerprint
+
+
+def test_independent_same_named_workflows_remain_distinct() -> None:
+    """Display labels cannot collapse checks from separate workflow runs."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/201",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "startedAt": "2026-08-23T00:00:00Z",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/200/job/301",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": ["CI / test"],
+        "passed": ["CI / test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "checks_failed"
+
+
+def test_distinct_raw_check_identities_cannot_collapse_during_redaction() -> None:
+    """Sanitization must not let one provider check hide another check's failure."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "name": "https://failure.example.test/run",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "name": "https://success.example.test/run",
+                    "startedAt": "2026-08-23T00:00:00Z",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "checks_failed"
+    assert result.canonical["checks"]["failed"] == ["CI / [provider-url]"]
+    assert result.canonical["checks"]["passed"] == ["CI / [provider-url]"]
+
+
+def test_same_named_check_runs_without_stable_identity_remain_distinct() -> None:
+    """Rows without a stable run identity cannot be assumed to be reruns."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                _check_run(conclusion="SUCCESS"),
+                _check_run(conclusion="FAILURE"),
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": ["CI / test"],
+        "passed": ["CI / test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+
+
+def test_same_named_workflowless_check_runs_remain_distinct() -> None:
+    """Rows without workflow identity cannot safely be treated as one rerun chain."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "workflowName": "",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/201",
+                    "startedAt": "2026-08-21T00:00:00Z",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "workflowName": "",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/202",
+                    "startedAt": "2026-08-22T00:00:00Z",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": ["test"],
+        "passed": ["test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+
+
+def test_status_context_failure_cannot_be_hidden_by_same_named_check_run() -> None:
+    """Status contexts and check runs use distinct provider namespaces."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    "__typename": "StatusContext",
+                    "context": "test",
+                    "state": "FAILURE",
+                    "targetUrl": "https://github.com/owner/repo/statuses/sha",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "workflowName": "",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": ["test"],
+        "passed": ["test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+
+
+def test_startedless_queued_rerun_supersedes_an_older_completed_run() -> None:
+    """A newly queued run has no timestamp but must not expose a stale green state."""
+    queued = _check_run(status="QUEUED", conclusion="")
+    queued["startedAt"] = None
+    queued["detailsUrl"] = "https://github.com/owner/repo/actions/runs/100/job/202"
+    completed = _check_run(conclusion="SUCCESS")
+    completed["detailsUrl"] = "https://github.com/owner/repo/actions/runs/100/job/201"
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                completed,
+                queued,
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": [],
+        "passed": [],
+        "pending": ["CI / test"],
+        "unknown": [],
+    }
+    assert result.observation.reason_code == "checks_pending"
+
+
+def _check_run(*, status: str = "COMPLETED", conclusion: str = "SUCCESS") -> dict[str, object]:
+    return {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": status,
+        "conclusion": conclusion,
+        "startedAt": "2026-08-22T00:00:00Z",
+        "completedAt": "2026-08-22T00:01:00Z",
+    }
+
+
+@pytest.mark.parametrize(
+    ("primary_changes", "thread_nodes", "status", "reason"),
+    [
+        (
+            {"statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")]},
+            None,
+            MonitorObservationStatus.PENDING,
+            "checks_pending",
+        ),
+        (
+            {"statusCheckRollup": [_check_run(conclusion="FROBNICATED")]},
+            None,
+            MonitorObservationStatus.PENDING,
+            "checks_unknown",
+        ),
+        (
+            {"statusCheckRollup": [_check_run(conclusion="FAILURE")]},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "checks_failed",
+        ),
+        (
+            {"reviewDecision": "CHANGES_REQUESTED"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "changes_requested",
+        ),
+        (
+            {},
+            [{"isResolved": True}, {"isResolved": False}],
+            MonitorObservationStatus.ACTIONABLE,
+            "unresolved_review_threads",
+        ),
+        (
+            {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "merge_conflict",
+        ),
+        (
+            {"mergeStateStatus": "BEHIND"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "branch_behind",
+        ),
+        (
+            {"mergeStateStatus": "BLOCKED"},
+            None,
+            MonitorObservationStatus.ACTIONABLE,
+            "merge_blocked",
+        ),
+        (
+            {"isDraft": True},
+            None,
+            MonitorObservationStatus.PENDING,
+            "pull_request_draft",
+        ),
+        (
+            {"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"},
+            None,
+            MonitorObservationStatus.PENDING,
+            "mergeability_pending",
+        ),
+        (
+            {"reviewDecision": "UNKNOWN"},
+            None,
+            MonitorObservationStatus.PENDING,
+            "review_state_unknown",
+        ),
+        (
+            {"reviewDecision": "REVIEW_REQUIRED"},
+            None,
+            MonitorObservationStatus.PENDING,
+            "review_required",
+        ),
+        (
+            {"state": "CLOSED"},
+            None,
+            MonitorObservationStatus.BLOCKED,
+            "pull_request_closed",
+        ),
+        (
+            {"state": "MERGED"},
+            None,
+            MonitorObservationStatus.SUCCESS,
+            "pull_request_merged",
+        ),
+    ],
+)
+def test_pull_request_classification_matrix(
+    primary_changes: dict[str, object],
+    thread_nodes: list[dict[str, object]] | None,
+    status: MonitorObservationStatus,
+    reason: str,
+) -> None:
+    """Changing one readiness fact must select its conservative typed outcome."""
+    provider, _ = _provider(_primary(**primary_changes), _threads(nodes=thread_nodes))
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is status
+    assert result.observation.reason_code == reason
+
+
+@pytest.mark.parametrize(
+    ("primary_changes", "thread_nodes", "reason"),
+    [
+        (
+            {
+                "statusCheckRollup": [
+                    _check_run(conclusion="FAILURE"),
+                    {
+                        "__typename": "StatusContext",
+                        "context": "deploy",
+                        "state": "PENDING",
+                    },
+                ]
+            },
+            None,
+            "checks_failed",
+        ),
+        (
+            {
+                "reviewDecision": "CHANGES_REQUESTED",
+                "statusCheckRollup": [_check_run(conclusion="FROBNICATED")],
+            },
+            None,
+            "changes_requested",
+        ),
+        (
+            {"statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")]},
+            [{"isResolved": False}],
+            "unresolved_review_threads",
+        ),
+        (
+            {
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY",
+                "statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")],
+            },
+            None,
+            "merge_conflict",
+        ),
+    ],
+)
+def test_known_actionable_fact_precedes_simultaneous_pending_or_unknown_fact(
+    primary_changes: dict[str, object],
+    thread_nodes: list[dict[str, object]] | None,
+    reason: str,
+) -> None:
+    """Known work must wake the owner even when unrelated provider facts are unsettled."""
+    provider, _ = _provider(_primary(**primary_changes), _threads(nodes=thread_nodes))
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == reason
+
+
+def test_actionable_fingerprint_ignores_unrelated_pending_check_churn() -> None:
+    """Renaming an unsettled check cannot issue a second wake for the same known failure."""
+
+    def mixed_checks(pending_name: str) -> list[dict[str, object]]:
+        return [
+            _check_run(conclusion="FAILURE"),
+            {
+                "__typename": "StatusContext",
+                "context": pending_name,
+                "state": "PENDING",
+            },
+        ]
+
+    first_provider, _ = _provider(
+        _primary(statusCheckRollup=mixed_checks("deploy")),
+        _threads(),
+    )
+    second_provider, _ = _provider(
+        _primary(statusCheckRollup=mixed_checks("publish")),
+        _threads(),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical != second.canonical
+    assert first.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert second.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert first.observation.fingerprint == second.observation.fingerprint
+
+
+@pytest.mark.parametrize(
+    ("merge_state", "mergeability", "status"),
+    [
+        ("CLEAN", "mergeable", MonitorObservationStatus.SUCCESS),
+        ("HAS_HOOKS", "mergeable", MonitorObservationStatus.SUCCESS),
+        ("UNSTABLE", "mergeable", MonitorObservationStatus.SUCCESS),
+        ("", "pending", MonitorObservationStatus.PENDING),
+        ("FUTURE_STATE", "pending", MonitorObservationStatus.PENDING),
+    ],
+)
+def test_mergeability_only_accepts_known_settled_merge_states(
+    merge_state: str,
+    mergeability: str,
+    status: MonitorObservationStatus,
+) -> None:
+    """An empty or future provider enum cannot fall through to review-ready success."""
+    provider, _ = _provider(_primary(mergeStateStatus=merge_state), _threads())
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["mergeability"] == mergeability
+    assert result.observation.status is status
+
+
+def test_review_threads_paginate_and_fold_order_independently() -> None:
+    """Stopping after one page can falsely report no blocking review threads."""
+    first_provider, first_runner = _provider(
+        _primary(),
+        _threads([{"isResolved": True}], has_next=True, cursor="cursor-1"),
+        _threads([{"isResolved": False}], has_next=False),
+    )
+    second_provider, _ = _provider(
+        _primary(),
+        _threads([{"isResolved": False}], has_next=True, cursor="cursor-2"),
+        _threads([{"isResolved": True}], has_next=False),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical["unresolved_review_threads"] == 1
+    assert first.canonical["review_threads_complete"] is True
+    assert first.observation.fingerprint == second.observation.fingerprint
+    assert len(first_runner.calls) == 3
+    assert "cursor=cursor-1" in first_runner.calls[2][0]
+
+
+def test_review_thread_string_variables_use_raw_graphql_fields() -> None:
+    """Numeric-looking GitHub names and cursors must remain GraphQL strings."""
+    provider, runner = _provider(
+        _primary(),
+        _threads(has_next=True, cursor="false"),
+        _threads(),
+    )
+
+    provider.probe("https://github.com/123/true/pull/123")
+
+    first_page = runner.calls[1][0]
+    second_page = runner.calls[2][0]
+    assert ["-f", "owner=123"] == first_page[5:7]
+    assert ["-f", "repo=true"] == first_page[7:9]
+    assert ["-F", "number=123"] == first_page[9:11]
+    assert ["-f", "cursor=false"] == second_page[-2:]
+
+
+def test_review_thread_page_cap_is_pending_instead_of_success() -> None:
+    """An eleventh page cannot be silently treated as an empty complete tail."""
+    pages = [
+        _threads(
+            [{"isResolved": True}],
+            has_next=True,
+            cursor=f"cursor-{page}",
+        )
+        for page in range(1, 11)
+    ]
+    provider, runner = _provider(_primary(), *pages)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert len(runner.calls) == 11
+
+
+def test_review_thread_missing_next_cursor_is_pending_instead_of_success() -> None:
+    """A partial pagination envelope is not evidence that the unseen tail is empty."""
+    provider, runner = _provider(
+        _primary(),
+        _threads([{"isResolved": True}], has_next=True, cursor=None),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert len(runner.calls) == 2
+
+
+def test_review_thread_graphql_errors_make_partial_data_pending() -> None:
+    """GraphQL can return usable-looking data alongside errors; it is still incomplete."""
+    partial = _threads([{"isResolved": True}])
+    partial["errors"] = [{"message": "provider-controlled detail"}]
+    provider, _ = _provider(_primary(), partial)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert "provider-controlled detail" not in repr(result)
+
+
+def test_review_thread_graphql_errors_without_usable_data_are_provider_error() -> None:
+    """An error-only GraphQL envelope cannot replace the last valid observation."""
+    provider, _ = _provider(
+        _primary(),
+        {"data": None, "errors": [{"message": "provider-controlled detail"}]},
+    )
+
+    result = provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation={"head_revision": "previous-head"},
+    )
+
+    assert result.response is None
+    assert result.canonical == {}
+    assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
+    assert result.observation.reason_code == "provider_malformed_response"
+    assert "provider-controlled detail" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_shadow_graphql_error_without_data_preserves_last_observation() -> None:
+    """The error-only GraphQL path cannot overwrite durable readiness facts."""
+    provider, _ = _provider(
+        _primary(),
+        {"data": None, "errors": [{"message": "provider-controlled detail"}]},
+    )
+    previous = {"head_revision": "previous-head", "safe": "fact"}
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation=deepcopy(previous),
+        last_fingerprint="safe-fingerprint",
+    )
+    snapshots: list[dict[str, object]] = []
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(monitor_state_to_dict(updated)))
+
+    decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert decision is MonitorDecision.RETRY_PROVIDER
+    assert state.last_observation == previous
+    assert state.last_fingerprint == "safe-fingerprint"
+    assert state.provider_error_count == 1
+    assert state.consecutive_provider_errors == 1
+    assert "provider-controlled detail" not in repr(snapshots)
+
+
+def test_review_thread_graphql_errors_preserve_observed_unresolved_nodes() -> None:
+    """Partial GraphQL failure cannot erase a blocker returned in the same payload."""
+    partial = _threads([{"isResolved": False}])
+    partial["errors"] = [{"message": "partial review evidence"}]
+    provider, _ = _provider(_primary(), partial)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.canonical["unresolved_review_threads"] == 1
+    assert result.canonical["blocking_review"] == "unresolved_threads"
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "unresolved_review_threads"
+
+
+@pytest.mark.parametrize(
+    ("primary_changes", "thread_nodes", "reason", "blocking_review"),
+    [
+        (
+            {"reviewDecision": "CHANGES_REQUESTED"},
+            [{"isResolved": True}],
+            "changes_requested",
+            "changes_requested",
+        ),
+        (
+            {},
+            [{"isResolved": False}],
+            "unresolved_review_threads",
+            "unresolved_threads",
+        ),
+    ],
+)
+def test_known_review_blocker_precedes_incomplete_thread_evidence(
+    primary_changes: dict[str, object],
+    thread_nodes: list[dict[str, object]],
+    reason: str,
+    blocking_review: str,
+) -> None:
+    """A partial unseen tail cannot mask blocking review evidence already observed."""
+    nodes = [*thread_nodes]
+    partial = _threads(nodes)
+    if blocking_review == "unresolved_threads":
+        nodes.append({})
+        partial = _threads(nodes)
+    else:
+        partial["errors"] = [{"message": "partial review evidence"}]
+    provider, _ = _provider(_primary(**primary_changes), partial)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.canonical["blocking_review"] == blocking_review
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == reason
+
+
+def test_incomplete_review_fingerprint_distinguishes_known_blockers() -> None:
+    """Distinct known review work must not deduplicate behind one unknown fingerprint."""
+    changes = _threads([{"isResolved": True}])
+    changes["errors"] = [{"message": "partial review evidence"}]
+    unresolved = _threads([{"isResolved": False}, {}])
+    changes_provider, _ = _provider(
+        _primary(reviewDecision="CHANGES_REQUESTED"),
+        changes,
+    )
+    unresolved_provider, _ = _provider(_primary(), unresolved)
+
+    first = changes_provider.probe("https://github.com/owner/repo/pull/123")
+    second = unresolved_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.observation.fingerprint != second.observation.fingerprint
+
+
+def test_changed_head_is_explicitly_actionable_even_when_new_facts_are_green() -> None:
+    """A green new revision must not terminate before the owner can inspect it."""
+    previous_provider, _ = _provider(_primary(), _threads())
+    previous = previous_provider.probe("https://github.com/owner/repo/pull/123")
+    new_head = "fedcba9876543210fedcba9876543210fedcba98"
+    current_provider, _ = _provider(_primary(headRefOid=new_head), _threads())
+
+    current = current_provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation=previous.canonical,
+    )
+    state = MonitorState(
+        kind="github_pull_request",
+        target="github.com/owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation=deepcopy(previous.canonical),
+        last_fingerprint=previous.observation.fingerprint,
+    )
+
+    assert current.observation.head_changed is True
+    assert current.observation.status is MonitorObservationStatus.SUCCESS
+    assert current.observation.fingerprint != previous.observation.fingerprint
+    assert decide_monitor(state, current.observation, now=1_001.0) is (
+        MonitorDecision.WAKE_ACTIONABLE
+    )
+
+
+def test_missing_current_head_is_pending_without_a_changed_head_wake() -> None:
+    """A missing current SHA is provider uncertainty, not evidence of a new revision."""
+    provider, _ = _provider(_primary(headRefOid=""), _threads())
+    state = MonitorState(
+        kind="github_pull_request",
+        target="github.com/owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation={"head_revision": _HEAD},
+        last_fingerprint="previous-fingerprint",
+    )
+
+    result = provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation=state.last_observation,
+    )
+
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.head_changed is False
+    assert decide_monitor(state, result.observation, now=1_001.0) is MonitorDecision.RECORD_ONLY
+
+
+@pytest.mark.parametrize(
+    ("provider_state", "expected"),
+    [
+        ("MERGED", MonitorDecision.STOP_SUCCESS),
+        ("CLOSED", MonitorDecision.STOP_BLOCKED),
+    ],
+)
+def test_terminal_pull_request_state_precedes_a_head_revision_change(
+    provider_state: str,
+    expected: MonitorDecision,
+) -> None:
+    """A terminal lifecycle cannot reopen merely because its final head is new."""
+    provider, _ = _provider(_primary(state=provider_state), _threads())
+    state = MonitorState(
+        kind="github_pull_request",
+        target="github.com/owner/repo#123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation={"head_revision": "previous-head"},
+    )
+
+    result = provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation=state.last_observation,
+    )
+
+    assert result.observation.head_changed is False
+    assert decide_monitor(state, result.observation, now=1_001.0) is expected
+
+
+class _FailureRunner:
+    def __init__(
+        self,
+        *,
+        returncode: int = 1,
+        stderr: str = "",
+        error: BaseException | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.error = error
+
+    def __call__(self, argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if self.error is not None:
+            raise self.error
+        return subprocess.CompletedProcess(argv, self.returncode, stdout="", stderr=self.stderr)
+
+
+@pytest.mark.parametrize(
+    ("provider_state", "status", "reason"),
+    [
+        ("MERGED", MonitorObservationStatus.SUCCESS, "pull_request_merged"),
+        ("CLOSED", MonitorObservationStatus.BLOCKED, "pull_request_closed"),
+    ],
+)
+def test_terminal_lifecycle_does_not_query_review_threads(
+    provider_state: str,
+    status: MonitorObservationStatus,
+    reason: str,
+) -> None:
+    """Secondary GraphQL failure cannot override an already-terminal primary lifecycle."""
+    calls = 0
+
+    def runner(argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=json.dumps(_primary(state=provider_state)),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            argv,
+            1,
+            stdout="",
+            stderr="HTTP 503: secondary query unavailable",
+        )
+
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is status
+    assert result.observation.reason_code == reason
+    assert calls == 1
+
+
+def test_boolean_pull_request_number_is_a_malformed_primary_response() -> None:
+    """Python boolean equality must not let a non-integer provider number pass validation."""
+    provider, runner = _provider(_primary(number=True))
+
+    result = provider.probe("https://github.com/owner/repo/pull/1")
+
+    assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+    assert result.observation.reason_code == "provider_malformed_response"
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("stderr", "kind", "reason"),
+    [
+        ("HTTP 401: Bad credentials", ProviderErrorKind.AUTHENTICATION, "provider_authentication"),
+        (
+            "HTTP 403: secondary rate limit exceeded",
+            ProviderErrorKind.RATE_LIMITED,
+            "provider_rate_limited",
+        ),
+        (
+            "HTTP 403: resource not accessible",
+            ProviderErrorKind.AUTHORIZATION,
+            "provider_authorization",
+        ),
+        ("HTTP 404: Not Found", ProviderErrorKind.NOT_FOUND, "provider_not_found"),
+        ("HTTP 429: too many requests", ProviderErrorKind.RATE_LIMITED, "provider_rate_limited"),
+        ("HTTP 503: unavailable", ProviderErrorKind.TRANSIENT, "provider_transient"),
+        ("dial tcp: connection refused", ProviderErrorKind.TRANSIENT, "provider_transient"),
+        ("Could not resolve host: github.com", ProviderErrorKind.TRANSIENT, "provider_transient"),
+        (
+            "not logged into any GitHub hosts; run gh auth login",
+            ProviderErrorKind.AUTHENTICATION,
+            "provider_authentication",
+        ),
+        (
+            "Could not resolve to a Repository with the name 'owner/repo'",
+            ProviderErrorKind.NOT_FOUND,
+            "provider_not_found",
+        ),
+    ],
+)
+def test_provider_cli_failures_map_to_fixed_nonleaking_categories(
+    stderr: str,
+    kind: ProviderErrorKind,
+    reason: str,
+) -> None:
+    """Raw stderr cannot become durable or loggable monitor state."""
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr=stderr),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is None
+    assert result.canonical == {}
+    assert result.observation.status is MonitorObservationStatus.PROVIDER_ERROR
+    assert result.observation.provider_error is kind
+    assert result.observation.reason_code == reason
+    assert result.observation.fingerprint == ""
+    assert stderr not in repr(result)
+
+
+@pytest.mark.parametrize(
+    ("resolver", "runner", "kind"),
+    [
+        (
+            lambda: (_ for _ in ()).throw(SetupError("untrusted /tmp/gh")),
+            _FailureRunner(),
+            ProviderErrorKind.SETUP,
+        ),
+        (
+            lambda: "/trusted/bin/gh",
+            _FailureRunner(error=subprocess.TimeoutExpired(["gh"], 30)),
+            ProviderErrorKind.TRANSIENT,
+        ),
+        (
+            lambda: "/trusted/bin/gh",
+            _FailureRunner(error=FileNotFoundError("/private/path/gh")),
+            ProviderErrorKind.SETUP,
+        ),
+        (
+            lambda: "/trusted/bin/gh",
+            _FailureRunner(error=PermissionError("/private/path/gh")),
+            ProviderErrorKind.SETUP,
+        ),
+    ],
+)
+def test_provider_setup_and_transport_exceptions_have_typed_categories(
+    resolver: object,
+    runner: _FailureRunner,
+    kind: ProviderErrorKind,
+) -> None:
+    """Local setup is terminal while network timeouts remain retryable."""
+    provider = GitHubPullRequestProvider(resolver=resolver, runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.provider_error is kind
+    assert result.observation.reason_code in {"provider_setup", "provider_transient"}
+    assert "/tmp/gh" not in repr(result)
+    assert "/private/path/gh" not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "payloads",
+    [
+        ({"number": 123},),
+        (_primary(), {"data": {"repository": None}}),
+    ],
+)
+def test_malformed_provider_payload_is_a_retryable_nonleaking_error(
+    payloads: tuple[dict[str, object], ...],
+) -> None:
+    """Partial JSON is provider uncertainty, not evidence of readiness."""
+    provider, _ = _provider(*payloads)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is None
+    assert result.canonical == {}
+    assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
+    assert result.observation.reason_code == "provider_malformed_response"
+
+
+def test_secret_bearing_stderr_never_reaches_result_or_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Credentials, paths, URLs, and provider text are discarded after classification."""
+    raw = (
+        "HTTP 403 token ghp_abcdefghijklmnopqrstuvwxyz123456 "
+        "/home/user/private https://internal.example.test/request?id=secret"
+    )
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr=raw),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    combined = repr(result) + caplog.text
+    for forbidden in ("ghp_", "/home/user", "internal.example.test", "request?id"):
+        assert forbidden not in combined
+
+
+@pytest.mark.asyncio
+async def test_shadow_probe_persists_observation_decision_and_metrics_without_a_wake() -> None:
+    """An actionable shadow result records evidence but cannot claim or charge a turn."""
+    provider, _ = _provider(
+        _primary(statusCheckRollup=[_check_run(conclusion="FAILURE")]),
+        _threads(),
+    )
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+    snapshots: list[dict[str, object]] = []
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(monitor_state_to_dict(updated)))
+
+    decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert decision is MonitorDecision.WAKE_ACTIONABLE
+    assert state.last_decision is MonitorDecision.WAKE_ACTIONABLE
+    assert state.probe_count == 1
+    assert state.provider_error_count == 0
+    assert state.last_probe_at == 1_100.0
+    assert state.last_observed_at == 1_100.0
+    assert state.next_probe_at == 1_100.0 + state.cadence_secs
+    assert state.last_observation["checks"] == {
+        "failed": ["CI / test"],
+        "passed": [],
+        "pending": [],
+        "unknown": [],
+    }
+    assert state.last_fingerprint
+    assert state.last_wake_fingerprint == ""
+    assert state.wake_in_flight is False
+    assert state.agent_turns == 0
+    assert state.input_tokens == state.output_tokens == 0
+    assert len(snapshots) == 1
+    assert snapshots[0]["last_decision"] == MonitorDecision.WAKE_ACTIONABLE
+
+
+@pytest.mark.asyncio
+async def test_shadow_provider_error_persists_only_fixed_error_metrics() -> None:
+    """A retryable failure advances probe metrics without replacing the last good facts."""
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr="HTTP 429 token ghp_abcdefghijklmnopqrstuvwxyz123456"),
+    )
+    previous = {"head_revision": _HEAD, "safe": "fact"}
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_observation=deepcopy(previous),
+        last_fingerprint="safe-fingerprint",
+    )
+    snapshots: list[dict[str, object]] = []
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(monitor_state_to_dict(updated)))
+
+    decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert decision is MonitorDecision.RETRY_PROVIDER
+    assert state.last_observation == previous
+    assert state.last_fingerprint == "safe-fingerprint"
+    assert state.probe_count == 1
+    assert state.provider_error_count == 1
+    assert state.consecutive_provider_errors == 1
+    assert state.last_provider_error is ProviderErrorKind.RATE_LIMITED
+    assert state.last_decision is MonitorDecision.RETRY_PROVIDER
+    assert "ghp_" not in repr(snapshots)
+
+
+@pytest.mark.asyncio
+async def test_shadow_probe_leaves_live_state_unchanged_when_persistence_fails() -> None:
+    """A failed durable write must leave the same observation eligible for retry."""
+    provider, _ = _provider(_primary(), _threads())
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        last_fingerprint="previous-fingerprint",
+    )
+    before = deepcopy(state)
+
+    async def persist(updated: MonitorState) -> None:
+        raise OSError("disk full")
+
+    with pytest.raises(OSError, match="disk full"):
+        await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert state == before
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_refuses_wake_delivery_before_probe_or_persistence() -> None:
+    """Turning shadow mode into a dispatcher path must require a later controller change."""
+    probes = 0
+    persists = 0
+
+    class Provider:
+        def probe(self, raw_target: str, **kwargs: object) -> object:
+            nonlocal probes
+            probes += 1
+            raise AssertionError("shadow refusal must happen before the provider boundary")
+
+    async def persist(updated: MonitorState) -> None:
+        nonlocal persists
+        persists += 1
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ShadowWakeDeliveryRefused, match="shadow mode"):
+        await run_shadow_probe(
+            state,
+            Provider(),
+            persist,
+            now=1_100.0,
+            wake_delivery=True,
+        )
+
+    assert probes == 0
+    assert persists == 0
+    assert state.probe_count == 0
+    assert state.last_wake_fingerprint == ""
+    assert state.wake_in_flight is False

--- a/test/test_github_pull_request_monitor.py
+++ b/test/test_github_pull_request_monitor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import subprocess
 from collections.abc import Sequence
@@ -17,8 +18,10 @@ from kiro_crew.monitoring.github_pull_request import (
     parse_github_pull_request_target,
 )
 from kiro_crew.monitoring.models import (
+    MonitorBudgets,
     MonitorDecision,
     MonitorObservationStatus,
+    MonitorOutcome,
     MonitorState,
     ProviderErrorKind,
     monitor_state_to_dict,
@@ -60,11 +63,17 @@ def _primary(**changes: object) -> dict[str, object]:
 
 
 def _threads(
-    nodes: list[dict[str, object]] | None = None,
+    nodes: Sequence[object] | None = None,
     *,
     has_next: bool = False,
     cursor: str | None = None,
 ) -> dict[str, object]:
+    normalized_nodes: list[object] = []
+    source_nodes = list(nodes) if nodes is not None else [{"isResolved": True}] * 2
+    for node in source_nodes:
+        if isinstance(node, dict) and "isOutdated" not in node:
+            node = {**node, "isOutdated": False}
+        normalized_nodes.append(node)
     return {
         "data": {
             "repository": {
@@ -74,11 +83,7 @@ def _threads(
                             "hasNextPage": has_next,
                             "endCursor": cursor,
                         },
-                        "nodes": (
-                            nodes
-                            if nodes is not None
-                            else [{"isResolved": True}, {"isResolved": True}]
-                        ),
+                        "nodes": normalized_nodes,
                     }
                 }
             }
@@ -98,7 +103,20 @@ class _FakeRunner:
 
 
 def _provider(*payloads: dict[str, object]) -> tuple[GitHubPullRequestProvider, _FakeRunner]:
-    runner = _FakeRunner(payloads)
+    expanded: list[dict[str, object]] = []
+    for payload in payloads:
+        if payload.get("state") == "OPEN" and "statusCheckRollup" in payload:
+            primary = deepcopy(payload)
+            expanded.append(primary)
+            expanded.append(
+                {
+                    "headRefOid": primary["headRefOid"],
+                    "statusCheckRollup": primary.pop("statusCheckRollup"),
+                }
+            )
+        else:
+            expanded.append(payload)
+    runner = _FakeRunner(expanded)
     return (
         GitHubPullRequestProvider(
             resolver=lambda: "/trusted/bin/gh",
@@ -175,6 +193,7 @@ def test_clean_pull_request_has_allowlisted_canonical_observation_and_fingerprin
             "pending": [],
             "unknown": [],
         },
+        "checks_complete": True,
         "draft": False,
         "head_revision": _HEAD,
         "kind": "github_pull_request",
@@ -188,7 +207,7 @@ def test_clean_pull_request_has_allowlisted_canonical_observation_and_fingerprin
     assert result.observation.status is MonitorObservationStatus.SUCCESS
     assert result.observation.reason_code == "review_ready"
     assert result.observation.fingerprint == (
-        "8d7a3844c6c0c44350e62e7823a62c941b9484a140a517326c630e780a8be30f"
+        "fe6dc90df56bdd1b5f40dc900d3c8af145899e64fbeeac3c86f296cd481d63c5"
     )
     primary_argv, primary_kwargs = runner.calls[0]
     assert primary_argv == [
@@ -197,10 +216,7 @@ def test_clean_pull_request_has_allowlisted_canonical_observation_and_fingerprin
         "view",
         "https://github.com/owner/repo/pull/123",
         "--json",
-        (
-            "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,"
-            "reviewDecision,statusCheckRollup"
-        ),
+        ("number,state,isDraft,headRefOid,mergeable,mergeStateStatus," "reviewDecision"),
     ]
     assert primary_kwargs["audit_caller"] == "core:monitor"
     assert primary_kwargs["pin_host"] == "github.com"
@@ -274,11 +290,11 @@ def test_check_identity_is_redacted_before_it_enters_canonical_state() -> None:
     serialized = json.dumps(result.canonical, sort_keys=True)
     assert token not in serialized
     assert "internal.example.test" not in serialized
-    assert "request?id" not in serialized
+    assert "id=secret" not in serialized
 
 
-def test_latest_check_rerun_wins_without_collection_order_affecting_fingerprint() -> None:
-    """Choosing list order instead of the latest run can hide or invent a failure."""
+def test_same_label_check_runs_remain_independent_without_order_affecting_fingerprint() -> None:
+    """Display labels cannot prove that distinct workflow runs supersede each other."""
     older_failure = {
         "__typename": "CheckRun",
         "name": "test",
@@ -297,7 +313,7 @@ def test_latest_check_rerun_wins_without_collection_order_affecting_fingerprint(
         "conclusion": "SUCCESS",
         "startedAt": "2026-08-22T00:00:00Z",
         "completedAt": "2026-08-22T00:01:00Z",
-        "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/202",
+        "detailsUrl": "https://github.com/owner/repo/actions/runs/200/job/202",
     }
     first_provider, _ = _provider(
         _primary(statusCheckRollup=[older_failure, newer_success]),
@@ -312,16 +328,45 @@ def test_latest_check_rerun_wins_without_collection_order_affecting_fingerprint(
     second = second_provider.probe("https://github.com/owner/repo/pull/123")
 
     assert first.canonical["checks"] == {
-        "failed": [],
+        "failed": ["CI / test"],
         "passed": ["CI / test"],
         "pending": [],
         "unknown": [],
     }
+    assert first.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert first.observation.reason_code == "checks_failed"
     assert first.observation.fingerprint == second.observation.fingerprint
 
 
-def test_independent_same_named_workflows_remain_distinct() -> None:
-    """Display labels cannot collapse checks from separate workflow runs."""
+def test_duplicate_failed_check_rows_preserve_multiplicity_in_the_fingerprint() -> None:
+    """A second same-labelled blocker must change the durable observation."""
+    first_provider, _ = _provider(
+        _primary(statusCheckRollup=[_check_run(conclusion="FAILURE")]),
+        _threads(),
+    )
+    second_provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                _check_run(conclusion="FAILURE"),
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/200/job/202",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    first = first_provider.probe("https://github.com/owner/repo/pull/123")
+    second = second_provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert first.canonical["checks"]["failed"] == ["CI / test"]
+    assert second.canonical["checks"]["failed"] == ["CI / test", "CI / test"]
+    assert first.observation.fingerprint != second.observation.fingerprint
+
+
+def test_distinct_workflow_dispatches_with_same_labels_remain_independent() -> None:
+    """A new run id cannot identify which workflow definition produced a check."""
     provider, _ = _provider(
         _primary(
             statusCheckRollup=[
@@ -351,6 +396,68 @@ def test_independent_same_named_workflows_remain_distinct() -> None:
     assert result.observation.reason_code == "checks_failed"
 
 
+def test_independent_workflows_with_same_check_name_remain_distinct() -> None:
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "workflowName": "Backend",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/201",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "workflowName": "Frontend",
+                    "startedAt": "2026-08-23T00:00:00Z",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/200/job/301",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": ["Backend / test"],
+        "passed": ["Frontend / test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+
+
+def test_independent_same_workflow_jobs_with_same_name_remain_distinct() -> None:
+    """Display names cannot prove that two check runs are rerun attempts."""
+    provider, _ = _provider(
+        _primary(
+            statusCheckRollup=[
+                {
+                    **_check_run(conclusion="FAILURE"),
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/201",
+                    "startedAt": "2026-08-21T00:00:00Z",
+                },
+                {
+                    **_check_run(conclusion="SUCCESS"),
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/100/job/202",
+                    "startedAt": "2026-08-22T00:00:00Z",
+                },
+            ]
+        ),
+        _threads(),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": ["CI / test"],
+        "passed": ["CI / test"],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+
+
 def test_distinct_raw_check_identities_cannot_collapse_during_redaction() -> None:
     """Sanitization must not let one provider check hide another check's failure."""
     provider, _ = _provider(
@@ -378,8 +485,8 @@ def test_distinct_raw_check_identities_cannot_collapse_during_redaction() -> Non
     assert result.canonical["checks"]["passed"] == ["CI / [provider-url]"]
 
 
-def test_same_named_check_runs_without_stable_identity_remain_distinct() -> None:
-    """Rows without a stable run identity cannot be assumed to be reruns."""
+def test_same_workflow_checks_without_dispatch_identity_remain_independent() -> None:
+    """A display-name match alone cannot prove that one job supersedes another."""
     provider, _ = _provider(
         _primary(
             statusCheckRollup=[
@@ -465,8 +572,8 @@ def test_status_context_failure_cannot_be_hidden_by_same_named_check_run() -> No
     assert result.observation.status is MonitorObservationStatus.ACTIONABLE
 
 
-def test_startedless_queued_rerun_supersedes_an_older_completed_run() -> None:
-    """A newly queued run has no timestamp but must not expose a stale green state."""
+def test_same_dispatch_queued_attempt_cannot_hide_an_older_completion() -> None:
+    """Ambiguous same-dispatch attempts remain independent and fail closed."""
     queued = _check_run(status="QUEUED", conclusion="")
     queued["startedAt"] = None
     queued["detailsUrl"] = "https://github.com/owner/repo/actions/runs/100/job/202"
@@ -486,7 +593,7 @@ def test_startedless_queued_rerun_supersedes_an_older_completed_run() -> None:
 
     assert result.canonical["checks"] == {
         "failed": [],
-        "passed": [],
+        "passed": ["CI / test"],
         "pending": ["CI / test"],
         "unknown": [],
     }
@@ -553,8 +660,26 @@ def _check_run(*, status: str = "COMPLETED", conclusion: str = "SUCCESS") -> dic
         (
             {"mergeStateStatus": "BLOCKED"},
             None,
-            MonitorObservationStatus.ACTIONABLE,
-            "merge_blocked",
+            MonitorObservationStatus.PENDING,
+            "mergeability_pending",
+        ),
+        (
+            {
+                "mergeStateStatus": "BLOCKED",
+                "statusCheckRollup": [_check_run(status="IN_PROGRESS", conclusion="")],
+            },
+            None,
+            MonitorObservationStatus.PENDING,
+            "checks_pending",
+        ),
+        (
+            {
+                "mergeStateStatus": "BLOCKED",
+                "reviewDecision": "REVIEW_REQUIRED",
+            },
+            None,
+            MonitorObservationStatus.PENDING,
+            "review_required",
         ),
         (
             {"isDraft": True},
@@ -738,8 +863,8 @@ def test_review_threads_paginate_and_fold_order_independently() -> None:
     assert first.canonical["unresolved_review_threads"] == 1
     assert first.canonical["review_threads_complete"] is True
     assert first.observation.fingerprint == second.observation.fingerprint
-    assert len(first_runner.calls) == 3
-    assert "cursor=cursor-1" in first_runner.calls[2][0]
+    assert len(first_runner.calls) == 4
+    assert "cursor=cursor-1" in first_runner.calls[3][0]
 
 
 def test_review_thread_string_variables_use_raw_graphql_fields() -> None:
@@ -752,8 +877,8 @@ def test_review_thread_string_variables_use_raw_graphql_fields() -> None:
 
     provider.probe("https://github.com/123/true/pull/123")
 
-    first_page = runner.calls[1][0]
-    second_page = runner.calls[2][0]
+    first_page = runner.calls[2][0]
+    second_page = runner.calls[3][0]
     assert ["-f", "owner=123"] == first_page[5:7]
     assert ["-f", "repo=true"] == first_page[7:9]
     assert ["-F", "number=123"] == first_page[9:11]
@@ -777,7 +902,8 @@ def test_review_thread_page_cap_is_pending_instead_of_success() -> None:
     assert result.canonical["review_threads_complete"] is False
     assert result.observation.status is MonitorObservationStatus.PENDING
     assert result.observation.reason_code == "review_threads_incomplete"
-    assert len(runner.calls) == 11
+    assert result.observation.supplemental_provider_error is None
+    assert len(runner.calls) == 12
 
 
 def test_review_thread_missing_next_cursor_is_pending_instead_of_success() -> None:
@@ -792,7 +918,7 @@ def test_review_thread_missing_next_cursor_is_pending_instead_of_success() -> No
     assert result.canonical["review_threads_complete"] is False
     assert result.observation.status is MonitorObservationStatus.PENDING
     assert result.observation.reason_code == "review_threads_incomplete"
-    assert len(runner.calls) == 2
+    assert len(runner.calls) == 3
 
 
 def test_review_thread_graphql_errors_make_partial_data_pending() -> None:
@@ -809,8 +935,8 @@ def test_review_thread_graphql_errors_make_partial_data_pending() -> None:
     assert "provider-controlled detail" not in repr(result)
 
 
-def test_review_thread_graphql_errors_without_usable_data_are_provider_error() -> None:
-    """An error-only GraphQL envelope cannot replace the last valid observation."""
+def test_review_thread_graphql_errors_without_usable_data_preserve_primary_facts() -> None:
+    """An error-only supplemental envelope cannot erase a valid primary observation."""
     provider, _ = _provider(
         _primary(),
         {"data": None, "errors": [{"message": "provider-controlled detail"}]},
@@ -821,16 +947,37 @@ def test_review_thread_graphql_errors_without_usable_data_are_provider_error() -
         previous_observation={"head_revision": "previous-head"},
     )
 
-    assert result.response is None
-    assert result.canonical == {}
-    assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
-    assert result.observation.reason_code == "provider_malformed_response"
+    assert result.response is not None
+    assert result.canonical["head_revision"] == _HEAD
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.supplemental_provider_error is ProviderErrorKind.TRANSIENT
+    assert result.observation.reason_code == "review_threads_incomplete"
     assert "provider-controlled detail" not in repr(result)
 
 
+def test_generic_blocked_state_preserves_supplemental_provider_error() -> None:
+    """GitHub's generic BLOCKED state is uncertainty, not a known blocker."""
+    provider, _ = _provider(
+        _primary(mergeStateStatus="BLOCKED"),
+        {"data": None, "errors": [{"message": "provider-controlled detail"}]},
+    )
+
+    result = provider.probe(
+        "https://github.com/owner/repo/pull/123",
+        previous_observation={"head_revision": "previous-head"},
+    )
+
+    assert result.response is not None
+    assert result.canonical["mergeability"] == "blocked"
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.supplemental_provider_error is ProviderErrorKind.TRANSIENT
+    assert result.observation.reason_code == "review_threads_incomplete"
+
+
 @pytest.mark.asyncio
-async def test_shadow_graphql_error_without_data_preserves_last_observation() -> None:
-    """The error-only GraphQL path cannot overwrite durable readiness facts."""
+async def test_shadow_graphql_error_without_data_persists_new_primary_facts() -> None:
+    """Readable primary facts remain durable while supplemental evidence retries."""
     provider, _ = _provider(
         _primary(),
         {"data": None, "errors": [{"message": "provider-controlled detail"}]},
@@ -852,8 +999,9 @@ async def test_shadow_graphql_error_without_data_preserves_last_observation() ->
     decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
 
     assert decision is MonitorDecision.RETRY_PROVIDER
-    assert state.last_observation == previous
-    assert state.last_fingerprint == "safe-fingerprint"
+    assert state.last_observation["head_revision"] == _HEAD
+    assert state.last_observation["review_threads_complete"] is False
+    assert state.last_fingerprint != "safe-fingerprint"
     assert state.provider_error_count == 1
     assert state.consecutive_provider_errors == 1
     assert "provider-controlled detail" not in repr(snapshots)
@@ -864,6 +1012,201 @@ def test_review_thread_graphql_errors_preserve_observed_unresolved_nodes() -> No
     partial = _threads([{"isResolved": False}])
     partial["errors"] = [{"message": "partial review evidence"}]
     provider, _ = _provider(_primary(), partial)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.canonical["unresolved_review_threads"] == 1
+    assert result.canonical["blocking_review"] == "unresolved_threads"
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "unresolved_review_threads"
+
+
+def test_review_thread_request_failure_preserves_primary_failed_check() -> None:
+    """A secondary request failure cannot discard a blocker from the primary read."""
+    failed_check = {
+        "__typename": "CheckRun",
+        "name": "test",
+        "workflowName": "CI",
+        "status": "COMPLETED",
+        "conclusion": "FAILURE",
+    }
+    results = iter(
+        (
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(_primary(statusCheckRollup=[failed_check])),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps({"headRefOid": _HEAD, "statusCheckRollup": [failed_check]}),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(["gh"], 1, stdout="", stderr="provider failure"),
+        )
+    )
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=lambda *_args, **_kwargs: next(results),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.canonical["checks"]["failed"] == ["CI / test"]
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "checks_failed"
+
+
+def test_raised_check_timeout_preserves_primary_review_blocker() -> None:
+    """A raised supplemental timeout cannot replace readable primary review facts."""
+    steps = iter(
+        (
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(_primary(reviewDecision="CHANGES_REQUESTED")),
+                stderr="",
+            ),
+            subprocess.TimeoutExpired(["gh"], 30),
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(_threads()),
+                stderr="",
+            ),
+        )
+    )
+
+    def runner(argv: Sequence[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        step = next(steps)
+        if isinstance(step, BaseException):
+            raise step
+        assert isinstance(step, subprocess.CompletedProcess)
+        return step
+
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=runner,
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is not None
+    assert result.canonical["checks_complete"] is False
+    assert result.canonical["review_threads_complete"] is True
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "changes_requested"
+    assert result.observation.supplemental_provider_error is ProviderErrorKind.TRANSIENT
+
+
+def test_raised_review_setup_error_preserves_primary_review_blocker() -> None:
+    """A raised supplemental setup failure remains typed without erasing primary facts."""
+    primary = _primary(reviewDecision="CHANGES_REQUESTED")
+    steps = iter(
+        (
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(primary),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "headRefOid": primary["headRefOid"],
+                        "statusCheckRollup": primary["statusCheckRollup"],
+                    }
+                ),
+                stderr="",
+            ),
+            SetupError("supplemental audit unavailable"),
+        )
+    )
+
+    def runner(argv: Sequence[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        step = next(steps)
+        if isinstance(step, BaseException):
+            raise step
+        assert isinstance(step, subprocess.CompletedProcess)
+        return step
+
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=runner,
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is not None
+    assert result.canonical["checks_complete"] is True
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "changes_requested"
+    assert result.observation.supplemental_provider_error is ProviderErrorKind.SETUP
+
+
+def test_later_review_thread_request_failure_preserves_observed_blocker() -> None:
+    """A failed later page cannot erase an unresolved thread already returned."""
+    results = iter(
+        (
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(_primary()),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "headRefOid": _HEAD,
+                        "statusCheckRollup": _primary()["statusCheckRollup"],
+                    }
+                ),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                ["gh"],
+                0,
+                stdout=json.dumps(
+                    _threads(
+                        [{"isResolved": False}],
+                        has_next=True,
+                        cursor="cursor-1",
+                    )
+                ),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(["gh"], 1, stdout="", stderr="provider failure"),
+        )
+    )
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=lambda *_args, **_kwargs: next(results),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.canonical["unresolved_review_threads"] == 1
+    assert result.canonical["blocking_review"] == "unresolved_threads"
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.reason_code == "unresolved_review_threads"
+
+
+def test_malformed_review_thread_node_cannot_hide_a_later_blocker() -> None:
+    """Malformed evidence makes the page incomplete without discarding valid blockers."""
+    provider, _ = _provider(
+        _primary(),
+        _threads([None, {"isResolved": False}]),
+    )
 
     result = provider.probe("https://github.com/owner/repo/pull/123")
 
@@ -1180,7 +1523,6 @@ def test_provider_setup_and_transport_exceptions_have_typed_categories(
     "payloads",
     [
         ({"number": 123},),
-        (_primary(), {"data": {"repository": None}}),
     ],
 )
 def test_malformed_provider_payload_is_a_retryable_nonleaking_error(
@@ -1352,3 +1694,415 @@ async def test_shadow_mode_refuses_wake_delivery_before_probe_or_persistence() -
     assert state.probe_count == 0
     assert state.last_wake_fingerprint == ""
     assert state.wake_in_flight is False
+
+
+class _CompletedRunner:
+    def __init__(self, results: Sequence[subprocess.CompletedProcess[str]]) -> None:
+        self._results = list(results)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(argv))
+        return self._results.pop(0)
+
+
+def _completed(
+    payload: dict[str, object] | None = None,
+    *,
+    returncode: int = 0,
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        ["gh"],
+        returncode,
+        stdout=json.dumps(payload) if payload is not None else "",
+        stderr=stderr,
+    )
+
+
+def _core_and_rollup(**changes: object) -> tuple[dict[str, object], dict[str, object]]:
+    core = _primary(**changes)
+    rollup = {
+        "headRefOid": core["headRefOid"],
+        "statusCheckRollup": core.pop("statusCheckRollup"),
+    }
+    return core, rollup
+
+
+def test_probe_isolates_checks_from_the_primary_field_set() -> None:
+    """Missing Checks scope must not erase readable lifecycle and review facts."""
+    core, rollup = _core_and_rollup()
+    runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is MonitorObservationStatus.SUCCESS
+    assert "statusCheckRollup" not in runner.calls[0][-1]
+    assert runner.calls[1][-1] == "statusCheckRollup,headRefOid"
+    assert result.canonical["checks_complete"] is True
+
+
+def test_null_check_rollup_is_an_empty_complete_check_set() -> None:
+    core, rollup = _core_and_rollup()
+    rollup["statusCheckRollup"] = None
+    runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"] == {
+        "failed": [],
+        "passed": [],
+        "pending": [],
+        "unknown": [],
+    }
+    assert result.observation.status is MonitorObservationStatus.SUCCESS
+
+
+def test_supplemental_check_permission_failure_preserves_primary_facts() -> None:
+    core, _rollup = _core_and_rollup()
+    runner = _CompletedRunner(
+        [
+            _completed(core),
+            _completed(returncode=1, stderr="HTTP 403: Resource not accessible"),
+            _completed(_threads()),
+        ]
+    )
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.response is not None
+    assert result.canonical["review_decision"] == "approved"
+    assert result.canonical["checks_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "checks_incomplete"
+    assert result.observation.supplemental_provider_error is ProviderErrorKind.AUTHORIZATION
+
+
+def test_nonzero_graphql_with_usable_nodes_preserves_the_blocker_and_error() -> None:
+    core, rollup = _core_and_rollup()
+    partial = _threads(nodes=[{"isResolved": False, "isOutdated": False}])
+    partial["errors"] = [{"message": "partial"}]
+    runner = _CompletedRunner(
+        [
+            _completed(core),
+            _completed(rollup),
+            _completed(partial, returncode=1, stderr="GraphQL: partial response"),
+        ]
+    )
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["unresolved_review_threads"] == 1
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.supplemental_provider_error is ProviderErrorKind.TRANSIENT
+
+
+def test_outdated_unresolved_review_thread_is_not_a_current_blocker() -> None:
+    core, rollup = _core_and_rollup()
+    runner = _CompletedRunner(
+        [
+            _completed(core),
+            _completed(rollup),
+            _completed(_threads(nodes=[{"isResolved": False, "isOutdated": True}])),
+        ]
+    )
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["unresolved_review_threads"] == 0
+    assert result.observation.status is MonitorObservationStatus.SUCCESS
+    assert "isOutdated" in runner.calls[2][runner.calls[2].index("-f") + 1]
+
+
+def test_repeated_review_thread_cursor_is_incomplete_instead_of_looping() -> None:
+    core, rollup = _core_and_rollup()
+    repeated = _threads(has_next=True, cursor="same-cursor")
+    runner = _CompletedRunner(
+        [
+            _completed(core),
+            _completed(rollup),
+            _completed(repeated),
+            _completed(repeated),
+        ]
+    )
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["review_threads_complete"] is False
+    assert result.observation.reason_code == "review_threads_incomplete"
+    assert len(runner.calls) == 4
+
+
+def test_check_identity_and_bucket_sizes_are_bounded_before_persistence() -> None:
+    core, rollup = _core_and_rollup(
+        statusCheckRollup=[
+            {
+                **_check_run(conclusion="FAILURE"),
+                "name": f"failure-{index}-\n\u202e\u200b" + "x" * 400,
+            }
+            for index in range(101)
+        ]
+    )
+    runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    failed = result.canonical["checks"]["failed"]
+    assert len(failed) == 100
+    assert all(
+        len(identity) <= 200
+        and "\n" not in identity
+        and "\u202e" not in identity
+        and "\u200b" not in identity
+        for identity in failed
+    )
+    assert result.canonical["checks_complete"] is False
+    assert result.observation.status is MonitorObservationStatus.ACTIONABLE
+    assert result.observation.supplemental_provider_error is None
+
+
+def test_status_context_failure_outranks_duplicate_success_and_stale_is_nonblocking() -> None:
+    core, rollup = _core_and_rollup(
+        statusCheckRollup=[
+            {"__typename": "StatusContext", "context": "ci", "state": "SUCCESS"},
+            {"__typename": "StatusContext", "context": "ci", "state": "FAILURE"},
+            _check_run(conclusion="STALE"),
+        ]
+    )
+    runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.canonical["checks"]["failed"] == ["ci"]
+    assert result.canonical["checks"]["passed"] == ["CI / test"]
+    assert result.observation.reason_code == "checks_failed"
+
+
+def test_actionable_fingerprint_changes_when_unresolved_thread_count_changes() -> None:
+    first_core, first_rollup = _core_and_rollup()
+    second_core, second_rollup = _core_and_rollup()
+    first = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_CompletedRunner(
+            [
+                _completed(first_core),
+                _completed(first_rollup),
+                _completed(_threads(nodes=[{"isResolved": False, "isOutdated": False}])),
+            ]
+        ),
+    ).probe("https://github.com/owner/repo/pull/123")
+    second = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_CompletedRunner(
+            [
+                _completed(second_core),
+                _completed(second_rollup),
+                _completed(
+                    _threads(
+                        nodes=[
+                            {"isResolved": False, "isOutdated": False},
+                            {"isResolved": False, "isOutdated": False},
+                        ]
+                    )
+                ),
+            ]
+        ),
+    ).probe("https://github.com/owner/repo/pull/123")
+
+    assert first.observation.fingerprint != second.observation.fingerprint
+
+
+def test_draft_state_prevents_failed_checks_from_requesting_a_turn() -> None:
+    core, rollup = _core_and_rollup(
+        isDraft=True,
+        statusCheckRollup=[_check_run(conclusion="FAILURE")],
+    )
+    runner = _CompletedRunner([_completed(core), _completed(rollup), _completed(_threads())])
+    provider = GitHubPullRequestProvider(resolver=lambda: "/trusted/bin/gh", runner=runner)
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.status is MonitorObservationStatus.PENDING
+    assert result.observation.reason_code == "pull_request_draft"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OSError(errno.EMFILE, "too many open files"),
+        BlockingIOError(errno.EAGAIN, "temporarily unavailable"),
+        ConnectionResetError(errno.ECONNRESET, "connection reset"),
+    ],
+)
+def test_transient_spawn_os_errors_remain_retryable(error: OSError) -> None:
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(error=error),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.provider_error is ProviderErrorKind.TRANSIENT
+    assert result.observation.reason_code == "provider_transient"
+
+
+@pytest.mark.parametrize(
+    ("stderr", "kind"),
+    [
+        ("HTTP 503: unavailable for owner/authentication", ProviderErrorKind.TRANSIENT),
+        ("HTTP 502 bad gateway for acme/permission", ProviderErrorKind.TRANSIENT),
+        (
+            "GraphQL: Could not resolve to a PullRequest with the number of 999999.",
+            ProviderErrorKind.NOT_FOUND,
+        ),
+        ("Resource protected by SAML enforcement", ProviderErrorKind.AUTHORIZATION),
+    ],
+)
+def test_cli_error_classification_uses_structured_status_before_provider_text(
+    stderr: str,
+    kind: ProviderErrorKind,
+) -> None:
+    provider = GitHubPullRequestProvider(
+        resolver=lambda: "/trusted/bin/gh",
+        runner=_FailureRunner(stderr=stderr),
+    )
+
+    result = provider.probe("https://github.com/owner/repo/pull/123")
+
+    assert result.observation.provider_error is kind
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "https://github.com/owner/repo/pull/12\r\n3",
+        "https://github.com/owner/repo/pull/1\n23",
+        "https://github.com/owner/repo/pull/123;touch",
+        "https://github.com/owner/repo/pull/0123",
+        "https://github.com/owner/repo/pull/" + "9" * 400,
+    ],
+)
+def test_target_rejects_noncanonical_aliases_before_url_parsing(raw: str) -> None:
+    with pytest.raises(ValueError, match="GitHub pull request"):
+        parse_github_pull_request_target(raw)
+
+
+@pytest.mark.asyncio
+async def test_shadow_budget_gate_stops_before_provider_execution() -> None:
+    probes = 0
+    snapshots: list[MonitorState] = []
+
+    class Provider:
+        def probe(self, raw_target: str, **kwargs: object) -> object:
+            nonlocal probes
+            probes += 1
+            raise AssertionError("budget gate must precede provider execution")
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(updated))
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        budgets=MonitorBudgets(max_runtime_secs=100),
+    )
+
+    decision = await run_shadow_probe(state, Provider(), persist, now=1_100.0)
+
+    assert decision is MonitorDecision.STOP_BUDGET
+    assert probes == 0
+    assert len(snapshots) == 1
+    assert state.outcome is MonitorOutcome.BUDGET
+    assert state.stopped_reason == "runtime_budget"
+    assert state.stopped_at == 1_100.0
+    assert state.next_probe_at == 0.0
+
+
+@pytest.mark.asyncio
+async def test_shadow_rejects_unrepresentable_time_as_a_validation_error() -> None:
+    async def persist(_updated: MonitorState) -> None:
+        raise AssertionError("invalid time must fail before persistence")
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    with pytest.raises(ValueError, match="finite non-negative"):
+        await run_shadow_probe(
+            state,
+            object(),
+            persist,
+            now=10**400,
+        )
+
+
+@pytest.mark.asyncio
+async def test_shadow_terminal_probe_persists_terminal_outcome_without_rearming() -> None:
+    provider, _ = _provider(_primary(state="MERGED"))
+    snapshots: list[MonitorState] = []
+
+    async def persist(updated: MonitorState) -> None:
+        snapshots.append(deepcopy(updated))
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+    )
+
+    decision = await run_shadow_probe(state, provider, persist, now=1_100.0)
+
+    assert decision is MonitorDecision.STOP_SUCCESS
+    assert state.outcome is MonitorOutcome.SUCCESS
+    assert state.stopped_reason == "pull_request_merged"
+    assert state.stopped_at == 1_100.0
+    assert state.next_probe_at == 0.0
+    assert len(snapshots) == 1
+
+
+@pytest.mark.asyncio
+async def test_shadow_terminal_state_never_probes_again_or_changes_outcome() -> None:
+    probes = 0
+    persists = 0
+
+    class Provider:
+        def probe(self, raw_target: str, **kwargs: object) -> object:
+            nonlocal probes
+            probes += 1
+            raise AssertionError("terminal monitor must not probe")
+
+    async def persist(updated: MonitorState) -> None:
+        nonlocal persists
+        persists += 1
+
+    state = MonitorState(
+        kind="github_pull_request",
+        target="https://github.com/owner/repo/pull/123",
+        objective="review_ready",
+        created_ts=1_000.0,
+        outcome=MonitorOutcome.SUCCESS,
+        stopped_reason="review_ready",
+        stopped_at=1_050.0,
+    )
+
+    decision = await run_shadow_probe(state, Provider(), persist, now=10_000.0)
+
+    assert decision is MonitorDecision.STOP_SUCCESS
+    assert probes == 0
+    assert persists == 0
+    assert state.outcome is MonitorOutcome.SUCCESS

--- a/test/test_monitor_decision.py
+++ b/test/test_monitor_decision.py
@@ -86,6 +86,7 @@ def test_observation_changes_control_when_a_model_turn_is_allowed(
         (ProviderErrorKind.AUTHENTICATION, 0, MonitorDecision.STOP_BLOCKED),
         (ProviderErrorKind.AUTHORIZATION, 0, MonitorDecision.STOP_BLOCKED),
         (ProviderErrorKind.NOT_FOUND, 0, MonitorDecision.STOP_BLOCKED),
+        (ProviderErrorKind.SETUP, 0, MonitorDecision.STOP_BLOCKED),
     ],
 )
 def test_provider_failures_never_buy_a_model_turn(
@@ -197,6 +198,17 @@ def test_provider_error_observation_requires_a_string_fingerprint() -> None:
             [],
             MonitorObservationStatus.PROVIDER_ERROR,
             provider_error=ProviderErrorKind.TRANSIENT,
+        )
+
+
+def test_provider_error_observation_rejects_a_changed_head_fact() -> None:
+    """A failed provider call cannot claim to have observed a new revision."""
+    with pytest.raises(ValueError, match="head_changed"):
+        MonitorObservation(
+            "",
+            MonitorObservationStatus.PROVIDER_ERROR,
+            provider_error=ProviderErrorKind.TRANSIENT,
+            head_changed=True,
         )
 
 

--- a/test/test_monitor_decision.py
+++ b/test/test_monitor_decision.py
@@ -77,6 +77,37 @@ def test_observation_changes_control_when_a_model_turn_is_allowed(
     assert decide_monitor(state, observation, now=1_100.0) is expected
 
 
+def test_changed_head_does_not_wake_while_readiness_is_pending() -> None:
+    """A push with incomplete evidence must not spend a model turn."""
+    observation = MonitorObservation(
+        "pending-new-head",
+        MonitorObservationStatus.PENDING,
+        head_changed=True,
+    )
+
+    assert decide_monitor(_state(), observation, now=1_100.0) is MonitorDecision.RECORD_ONLY
+
+
+def test_success_after_a_changed_head_can_reach_terminal_success() -> None:
+    """The changed-head wake must not make a later identical green probe immortal."""
+    changed = MonitorObservation(
+        "green-new-head",
+        MonitorObservationStatus.SUCCESS,
+        head_changed=True,
+    )
+    settled = MonitorObservation("green-new-head", MonitorObservationStatus.SUCCESS)
+
+    assert decide_monitor(_state(), changed, now=1_100.0) is MonitorDecision.WAKE_ACTIONABLE
+    assert (
+        decide_monitor(
+            _state(last_fingerprint="green-new-head"),
+            settled,
+            now=1_101.0,
+        )
+        is MonitorDecision.STOP_SUCCESS
+    )
+
+
 @pytest.mark.parametrize(
     ("error", "consecutive_errors", "expected"),
     [

--- a/test/test_monitor_persistence.py
+++ b/test/test_monitor_persistence.py
@@ -10,8 +10,10 @@ from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
 from kiro_crew.monitoring.models import (
     DEFAULT_MONITOR_CADENCE_SECS,
     MonitorBudgets,
+    MonitorDecision,
     MonitorOutcome,
     MonitorState,
+    ProviderErrorKind,
     monitor_state_from_dict,
     monitor_state_to_dict,
 )
@@ -139,6 +141,11 @@ def test_monitor_state_survives_store_round_trip(tmp_path) -> None:
         input_tokens=12_000,
         output_tokens=3_000,
         consecutive_provider_errors=1,
+        probe_count=4,
+        provider_error_count=2,
+        last_probe_at=1_240.0,
+        last_decision=MonitorDecision.RETRY_PROVIDER,
+        last_provider_error=ProviderErrorKind.RATE_LIMITED,
         next_probe_at=1_500.0,
         outcome=MonitorOutcome.BUDGET,
         stopped_reason="token_budget",
@@ -173,6 +180,11 @@ def test_monitor_state_survives_store_round_trip(tmp_path) -> None:
     assert restored.cadence_secs == 120
     assert restored.agent_turns == 2
     assert restored.total_tokens == 15_000
+    assert restored.probe_count == 4
+    assert restored.provider_error_count == 2
+    assert restored.last_probe_at == 1_240.0
+    assert restored.last_decision is MonitorDecision.RETRY_PROVIDER
+    assert restored.last_provider_error is ProviderErrorKind.RATE_LIMITED
     assert restored.outcome is MonitorOutcome.BUDGET
     assert restored.stopped_reason == "token_budget"
 


### PR DESCRIPTION
> Stacked change: **PR 4 of 8**
>
> Stack: #5180 → #5181 → #5182 → #5183 → #5184 → #5185 → #5186 → #5305
> Base: #5182
> Next: #5184

## Problem / Motivation

The system has no low-cost provider probe that can determine whether a GitHub pull request changed or became actionable without invoking an agent turn.

## Why it matters

Review babysitting otherwise spends a model turn on every interval and may miss actionable blockers when unrelated checks remain pending.

## What changed (motivation → approach → change)

- Add an exact public github.com pull-request target and a hardened provider adapter using the shared GitHub runner.
- Persist a bounded allowlisted canonical observation and stable fingerprint instead of raw provider payloads or logs.
- Give known failed checks, requested changes, unresolved threads, merge conflicts, and behind branches precedence over unrelated pending or unknown facts, including incomplete review-thread pagination.
- Add bounded review-thread pagination, typed provider errors, new-head handling, and dispatcher-free shadow execution.
- Keep check-run and status-context namespaces distinct, retain every check-run row independently when GitHub exposes only display labels, and pass GraphQL string variables without typed coercion.

## Tests

- URL/identity parsing and hardened runner behavior
- Canonicalization, actionable fingerprinting, mixed pending/actionable classification, and new-head transitions
- Provider error taxonomy, pagination bounds, shadow persistence/refusal, and security posture

## Manual verification

N/A — provider calls are exercised through deterministic fixtures; no live GitHub credentials are required.

## Related Issues

N/A — implements the first provider described by #5180 and depends on #5182.

## Checklist

- [x] Commit count satisfies the stacked PR hygiene limit
- [x] Existing tests pass and new tests cover the new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not yet supply final CLA wording.