### PR TITLE
refactor: route babysit through structured monitors

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -998,7 +998,6 @@ test/test_slack_thread_sync.py
 test/test_slack_transport_integration.py
 test/test_slack_upload_binary.py
 test/test_slash_task_tracking.py
-test/test_slot_close_nudge_race.py
 test/test_slot_detail_offload.py
 test/test_slot_needs_input_status.py
 test/test_slot_sync_on_create.py

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -1270,7 +1270,18 @@ unavailable when strict identity is absent; it never falls back to the
 process-ancestor resolver. Every structured-monitor tool refusal caused by a
 missing or unsupported session binding returns an `Error:` result and writes an
 explicit `denied` SEL event; the shared MCP wrapper therefore records the call as
-failed rather than completed.
+failed rather than completed. The structured tool exposes no caller-declared
+evidence scope: requests that need comments or advisory findings route directly
+to the finite legacy tool whose agent turn can inspect them.
+Structured creation is admitted only from dashboard, Slack, and Discord sessions,
+the surfaces with typed wake dispatch and completion correlation. Webex retains
+finite legacy prompt loops but refuses `monitor_watch` at both the stateless tool
+and authoritative consumer boundaries.
+The legacy `monitor_start` descriptor routes public GitHub pull-request readiness
+through `monitor_watch` only when typed provider facts fully determine the
+objective. Objectives that require interpreting comments or advisory review
+evidence keep a finite legacy loop instead of claiming the structured probe
+observes those facts.
 
 ### The one allowed exception: caller-agnostic process caches
 

--- a/docs/request-for-change/rfc-token-efficient-monitors.md
+++ b/docs/request-for-change/rfc-token-efficient-monitors.md
@@ -312,7 +312,8 @@ Probe execution never enters the owning chat session. `WAKE_ACTIONABLE` requests
 one normal turn on the existing session. The monitor marks that fingerprint as
 in-flight before dispatch so another timer cannot enqueue a duplicate.
 Probe decisions are staged and fsynced before changing the live record or timer,
-so persistence failure cannot leave an actionable claim only in memory. The
+and pre-probe budget stops persist their terminal replacement before disarming
+the live record, so persistence failure cannot diverge memory from restart state. The
 claim is revalidated both before transport handoff and at each surface's final,
 yield-free turn-start boundary. Dashboard performs that final check in its runner
 after pre-turn setup, then crosses SessionManager's synchronous shutdown gate
@@ -590,7 +591,8 @@ Primary areas:
 
 - replace the pull-request babysit recipe with `monitor_watch` instructions;
 - remove the prompt-owned sidecar progress protocol;
-- retain legacy guidance only for unsupported targets, clearly marked as costly;
+- retain costly legacy guidance for unsupported targets and objectives whose
+  required evidence the typed provider does not observe;
 - add product documentation and migration notes;
 - evaluate legacy goal-loop deprecation from collected metrics.
 
@@ -605,8 +607,8 @@ Exit criteria:
 - The supported pull-request path contains no repeated polling turns.
 - Completion is controller-owned rather than dependent on the model remembering to
   stop itself.
-- Legacy prompt loops remain functional for unsupported use cases until a separate
-  removal decision is approved.
+- Legacy prompt loops remain functional for unsupported targets and unobserved
+  evidence until a separate removal decision is approved.
 
 ## Backward compatibility and rollout
 

--- a/docs/system-specs/modules/babysit-pr-watch.md
+++ b/docs/system-specs/modules/babysit-pr-watch.md
@@ -2,37 +2,28 @@
 
 ## Purpose
 
-The babysit feature offers two current monitoring modes.
+The agent-facing babysit flow prefers `monitor_watch`. It creates a durable,
+typed structured monitor through a session-bound directive. The controller probes
+the provider before invoking the model, persists canonical observations and
+budgets, and wakes the owning session only for a new actionable fingerprint.
+Provider-fact-only GitHub review readiness therefore spends no agent turn while
+the pull request is unchanged.
 
-* `monitor_start` creates a same-session AutoNudge loop. Its stateless MCP
-  directive is validated by `mcp_tools.control.monitor_start`, then applied by
-  `dashboard.session_directive_apply._monitor_start` through
-  `autonudge_authz.authorize_and_add_nudge`. `AutoNudgeService` persists and
-  schedules the loop. When the loop's own instruction names exactly one public
-  GitHub pull request, the service attaches a monitor and OBSERVES that pull
-  request on each tick instead of firing: a tick the probe calls quiet spends no
-  agent turn at all. That is the default for `monitor_start`, whose directive asks
-  for the gate; `gate: false` is its opt-out. Every OTHER caller defaults to
-  UNGATED and must ask for the gate explicitly -- the generic REST route included --
-  because gating is the state that can silently STOP work, so an uncertain caller
-  must resolve toward spending rather than toward a watch that deactivates itself.
-* `pr_watch.py:watch` is a script cron for a quiet pull-request waiting phase.
-  `probes.gh_pr.PrWatchProbe` holds the GitHub knowledge and is driven two ways:
-  `builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py:watch` is a thin cron
-  adapter over it via `irq.run`, and the AutoNudge scheduler drives the same
-  probe in-process via `irq.poll`. The probe lives in the package because a
-  hyphenated skill directory is not importable, so a copy beside each driver
-  would have meant two copies of one classifier.
+`monitor_start` creates a finite same-session AutoNudge loop for objectives or
+evidence the structured provider cannot decide, including generic comments and
+advisory review text. Its stateless directive is validated by
+`mcp_tools.control.monitor_start`, then applied by
+`dashboard.session_directive_apply._monitor_start` through
+`autonudge_authz.authorize_and_add_nudge`. `AutoNudgeService` persists and
+schedules the loop. A loop whose instruction names exactly one public GitHub pull
+request may still attach `PrWatchProbe` as a compatibility gate, but that path is
+the bounded legacy fallback rather than the babysit recipe.
 
-The modes are not interchangeable, but they no longer overlap for the common
-case. A gated `monitor_start` loop re-injects its instruction only on a cycle
-the probe judged worth a turn, so a manual `pr_watch` cron is now for what the
-gate cannot reach: an enterprise host, detection with no owning loop, or the
-cron's own `known_reds` / `note` / `wake_on_green` knobs. `PrWatchProbe` reports
-only a state that needs judgment. This boundary is load-bearing: repeated quiet
-CI polls do not grow the session transcript, while a wake retains the session
-that owns the work and its tools. The babysit skill documents when to use each
-mode.
+The bundled `pr_watch.py:watch` cron adapter remains a compatibility asset for
+existing registered jobs. New babysit requests do not copy or register it; they
+use `monitor_watch` or a finite `monitor_start` loop owned by the session that can
+inspect and act on a wake. `probes.gh_pr.PrWatchProbe` stays in the package because
+the legacy AutoNudge gate and existing script jobs share its classifier.
 
 ### What a gated loop changes about the numbers
 
@@ -74,10 +65,11 @@ declare about its `rawInput`. The consumer-side failure paths log at `warning`
 (`session-directive NOT APPLIED`, `NO CALL INPUT`, `CLAIM MISS`, `DENIED`), which
 is what makes this class of drop visible in `gateway.log` instead of silent.
 
-`monitor_start` binds one loop to the calling session. `AutoNudgeService._add_unserialized`
-replaces an existing loop on that binding before it persists and arms the new
-one. `test_autonudge_stop_auth.py::test_applier_monitor_start_arms_via_the_session_binding_key`
-pins that the binding comes from the session rather than tool input.
+`monitor_start` binds one loop to the calling session and is create-only. It
+refuses when either automation kind already occupies the binding, preserving the
+existing record and its evidence. `monitor_update` is the only way to revise or
+re-arm the bound legacy loop. The binding-key and collision tests in
+`test_autonudge_stop_auth.py` pin that behavior.
 
 `NudgeLoop.next_due_ts`, `notify_user_input`, and `notify_turn_complete` make
 dashboard-loop cadence deadline-preserving: user activity cancels a pending
@@ -92,12 +84,11 @@ turn-lifecycle hooks.
 
 The schemas in `validation.MONITOR_START_SCHEMA` and
 `validation.MONITOR_UPDATE_SCHEMA` bound the message, interval, cycle cap, and
-wall-clock budget. `mcp_tools.control.monitor_start` supplies the bounded
-cycle-cap default from `mcp_tools._limits`; its default and explicit unlimited
-form are pinned by `test_autonudge_stop_auth.py::test_monitor_start_defaults_interval_300_and_bounded_cap`
-and `test_monitor_start_explicit_zero_cap_stays_zero`. The cap is a runaway
-backstop, not evidence that the watched work completed: `AutoNudgeService._timer`
-deactivates a capped loop and emits `expired`.
+wall-clock budget. `mcp_tools.control.monitor_start` supplies bounded positive
+defaults from `mcp_tools._limits`; zero and negative cycle or runtime limits are
+rejected. The cap is a runaway backstop, not evidence that the watched work
+completed: `AutoNudgeService._timer` deactivates a capped loop and emits
+`expired`.
 
 `AutoNudgeService.runtime_budget_exceeded` measures a configured wall-clock
 budget from the persisted creation time. `_timer` checks it before a fire and
@@ -214,17 +205,17 @@ a closed slot from history when possible. If no slot is available, it sends a
 notification instead. This makes the arming session the normal wake target
 without claiming that headless delivery can start a session.
 
-The bundled script is a source asset, not a gateway import. `cron_script.resolve_script_path`
-requires a registered script file under the configured cron directory, so the
-babysit skill's watch recipe copies the bundled `pr_watch.py` there before
-registering it. The cron gateway revalidates and scans the current script body
-at fire time, then executes it through the script sandbox.
+The bundled script is a source asset, not a gateway import. Existing jobs must
+still resolve a registered copy under the configured cron directory through
+`cron_script.resolve_script_path`. The cron gateway revalidates and scans that
+current script body at fire time, then executes it through the script sandbox.
+The babysit skill no longer registers new script jobs.
 
 ## Non-goals
 
-The PR watch does not parse comment bodies or decide whether a review finding
-is valid. It reports a change and leaves judgment, source inspection, and any
-reply to the reactivated babysit session. It also watches one pull request per
-cron job. `monitor_start` remains the appropriate mechanism when each cycle
-requires the agent to make progress or when the watched subject is not a pull
-request.
+The structured GitHub monitor does not parse generic comment bodies or decide
+whether an advisory finding is valid. It reports typed provider facts and leaves
+judgment, source inspection, and any reply to the reactivated babysit session.
+`monitor_start` remains appropriate when each delivered cycle requires the agent
+to make progress, the objective requires untyped evidence, or the watched subject
+is unsupported by a structured provider.

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -2251,10 +2251,15 @@ completion deadline and resumes its existing `next_due_ts` retry after restart.
 Before a spent BUSY claim becomes terminal, its settlement path also clears any
 late transport-acceptance marker, so an inactive budget record cannot retain an
 accepted turn that no completion timer owns.
-Terminal dashboard-notification delivery is a separate persisted bit on the
-monitor record. The service marks it only for the exact `(id, outcome, stopped_at)`
-generation still retained, so a delayed delivery acknowledgement cannot mark a
-new terminal generation or replacement monitor as notified.
+Terminal dashboard-notification delivery is recorded against the exact
+`(id, outcome, stopped_at)` generation on the stable outer loop record, with the
+current monitor-version bit retained for compatibility. The outer record lets a
+gateway persist the acknowledgement without rewriting an opaque future-version
+monitor payload. The gateway subscribes before startup can arm timers and then
+schedules retained-terminal replay as supervised background work, so notification
+persistence cannot delay gateway readiness and a transition during startup cannot
+escape both the live observer and replay. A delayed acknowledgement cannot mark a new
+terminal generation or replacement monitor as notified.
 Future versions also fail closed, are persisted inactive, and are never armed;
 their opaque monitor payload remains preserved for a newer gateway. Malformed
 current-version payloads load through a valid, inactive

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -2248,6 +2248,13 @@ restart. An accepted in-flight wake persists its finite completion-evidence
 deadline and resumes that deadline after restart; an older claim with no deadline
 is retained, inactive, and blocked. A persisted `BUSY` claim intentionally has no
 completion deadline and resumes its existing `next_due_ts` retry after restart.
+Before a spent BUSY claim becomes terminal, its settlement path also clears any
+late transport-acceptance marker, so an inactive budget record cannot retain an
+accepted turn that no completion timer owns.
+Terminal dashboard-notification delivery is a separate persisted bit on the
+monitor record. The service marks it only for the exact `(id, outcome, stopped_at)`
+generation still retained, so a delayed delivery acknowledgement cannot mark a
+new terminal generation or replacement monitor as notified.
 Future versions also fail closed, are persisted inactive, and are never armed;
 their opaque monitor payload remains preserved for a newer gateway. Malformed
 current-version payloads load through a valid, inactive
@@ -2268,7 +2275,20 @@ assembles its HTTP application.
 
 `MonitorController` currently accepts only a public GitHub pull request with the
 `review_ready` objective. The typed provider probe runs off the event loop. The
-controller persists canonical allowlisted facts, fingerprint, dedicated latest
+provider observes pull-request lifecycle, mergeability, review decision,
+unresolved review threads, and check conclusions. Generic issue/pull-request
+comments and advisory review findings that are not represented by those typed
+facts remain outside its completion predicate; a babysit objective that depends
+on them routes directly to a finite legacy loop instead of asking the structured
+tool to represent an evidence scope it cannot enforce. The fallback recipe
+sets `gate: false` so provider-fact gating cannot suppress cycles that must inspect
+unobserved comments or advisory feedback. The prepare-pr recipe likewise disables
+provider gating and pairs its 80-cycle poll budget with an explicit 24-hour runtime
+cap, so the four-hour default does not truncate its longer review loop.
+Legacy monitor MCP
+calls require positive cycle and runtime caps; omitted caps default to 24 cycles
+and 14,400 seconds. The controller persists canonical allowlisted facts,
+fingerprint, dedicated latest
 classification/reason fields, error counters, decision, and next deadline
 before returning. `last_observation` remains the GitHub fact snapshot; it never
 contains the typed fingerprint, status, reason, or summary. A provider error updates
@@ -2277,6 +2297,14 @@ fingerprint. `NO_CHANGE`, `RECORD_ONLY`,
 `RETRY_PROVIDER`, and all terminal decisions dispatch zero agent turns. Retryable
 provider errors use bounded exponential backoff; terminal provider, success,
 blocked, and budget outcomes remain inspectable with stable reason codes.
+The gateway emits one dashboard notification when a structured record first
+reaches success, blocked, budget, or target-unavailable. This reports a terminal
+outcome without waking the owning conversation or spending another agent turn.
+Each notice names the target pull request and uses the retained stop reason:
+merged, ready for review, closed unmerged, and provider or delivery problems
+carry different recovery guidance rather than a generic completion claim.
+The complete notification body, including its retained target, is URL- and
+credential-redacted before it reaches dashboard notification persistence.
 An incomplete persisted or cancelled handoff with no typed delivery marker is
 normalized onto the bounded BUSY retry path; an untyped dispatcher result fails
 closed as unavailable instead of orphaning the durable claim. Transient Slack or
@@ -2299,11 +2327,26 @@ Monitor wake instructions are length-checked again after credential and URL
 redaction, so a replacement marker cannot expand a valid input into an invalid
 persisted record. An active record loaded without a wired controller is retained
 as a terminal blocked outcome instead of an inactive nonterminal state.
+The controller's pre-probe budget stop uses the same replacement-first ordering,
+so a failed terminal write leaves the active record armed and restart-consistent
+instead of resurrecting work the live process considered exhausted.
+The shared direct budget helper records `STOP_BUDGET` and retains a finite
+completion timer when a transport already accepted the current wake; it never
+cancels the only remaining owner of that completion evidence.
 Known actionable GitHub facts (failed checks, requested changes, unresolved
 review threads, and merge blockers) take precedence over simultaneous pending or
 unknown facts. For an actionable classification its deduplication fingerprint
 contains the known blockers but excludes unrelated pending/unknown check churn;
 the full allowlisted canonical observation remains available for inspection.
+Before any fresh provider probe or persisted `BUSY` redispatch, the controller
+persists a terminal budget outcome when a positive runtime, completed-turn, or
+reported-token limit is already spent; an exhausted monitor therefore performs
+neither another provider request nor another action attempt. A previously
+accepted `DISPATCHED` wake still waits for its completion evidence or its bounded
+evidence deadline instead of being cancelled by this check. Token enforcement
+uses the usage values the provider reports; the public `token_usage_known` field
+states whether every completed turn supplied them, while runtime and completed-
+turn limits remain hard fallbacks.
 
 A new actionable fingerprint atomically records `last_wake_fingerprint` and
 `wake_in_flight=True` before delivery. Concurrent or restarted ticks cannot
@@ -2514,7 +2557,10 @@ unsupported, refused by authorization, or otherwise not applied records a
 `denied` directive outcome rather than a successful application.
 The same rule covers a structured stop whose authorization or audit-before-stop
 step fails; only an idempotent stop with no structured record is a success.
-`monitor_inspect` alone is a direct read: it requires a
+A create acknowledgement is therefore only pending until the current turn ends; the
+operator may confirm application in the dashboard, while the agent can inspect
+only from a later user/wake turn. `monitor_inspect` alone is a direct read: it
+requires a
 strict authenticated session key and reports unavailable rather than using
 ancestor fallback. Inspect, structured stop, its directive consumer, and the
 strict-internal session read all use the narrower structured binding resolver,
@@ -2669,9 +2715,9 @@ After a successful legacy stop, the chat clears that slot's REST snapshot before
 the Redux record, so reopening the editor while WebSocket delivery is unavailable cannot
 revive the stopped loop from cached state.
 The public monitor projection used by list, slot, WebSocket, and authenticated
-`monitor_inspect` reads includes the canonical `last_observation` plus the dedicated
-`last_observation_status` and `last_observation_reason_code`; persistence-only and raw
-provider fields remain excluded.
+`monitor_inspect` reads includes `token_usage_known`, the canonical `last_observation`,
+and the dedicated `last_observation_status` and `last_observation_reason_code`;
+persistence-only and raw provider fields remain excluded.
 The projection reconstructs GitHub facts from fixed root and check-bucket allowlists
 with a deep copy. Unknown persisted keys are omitted, and an incomplete or malformed
 canonical shape projects as an empty observation; non-string enum fields fail

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -2968,6 +2968,22 @@ comprehension over the assembled rows, and an end-to-end test drives two agents 
 real endpoint in both orders to keep that true rather than merely currently-true — a join that
 ever shared the FILTERED result would fail whichever agent asked second.
 
+The bundled `kirocrew-dev/babysit` skill is an on-demand, pointer-on-trigger recipe.
+Its explicit trigger vocabulary covers babysit/watch/monitor phrasing for pull
+requests, so ordinary requests reach the recipe without placing the whole body in
+every prompt. The base prompt points long-lived pull-request readiness requests to
+this skill and prefers the structured path whenever typed provider facts fully
+determine the objective.
+For a public GitHub pull request with the `review_ready` objective it gives the
+agent one exact bounded `monitor_watch` call and makes retained inspection state
+authoritative; its acknowledgement remains pending until the current turn ends,
+so agent inspection happens only at the start of a later user/wake turn. It also
+explains that reported-token enforcement may be incomplete while runtime and
+completed-turn limits remain hard fallbacks. It does not reproduce provider
+polling policy in the prompt. Its legacy `monitor_start` recipe is limited to
+unsupported targets and requires a positive cadence, cycle cap, and runtime
+bound while naming the full-turn/token cost and ordinary approval policy.
+
 **Loading:**
 1. **Always-on**: skills with `always: true` have full content injected every new session
 2. **On-demand**: skill summaries (name + description + dir path) in session context; LLM can `cat` the file when relevant

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -673,6 +673,26 @@ in-flight claim, and calls the Slack/Discord or dashboard adapter only for
 not add the legacy cycle tag. Every non-actionable, retry, and terminal decision
 dispatches zero turns.
 
+Terminal observer notifications are deduplicated for structured monitors within
+one gateway process. The retained monitor record also stores whether the dashboard
+accepted its terminal notice. Startup replays every terminal notice without that
+delivery marker and persists the marker only after acceptance, giving the
+persist-then-notify boundary at-least-once crash semantics: a crash can repeat a
+notice, but cannot suppress the only notice permanently. Gated
+legacy loops use only their existing `expired` notification; the following `fired`
+event must not deliver the same terminal notification again.
+Terminal notices identify the watched pull request by its stored target URL,
+including channel-bound watches with no dashboard jump link. The completed body,
+including the retained target, passes through shared URL and credential redaction
+before dashboard notification persistence. The stored stop
+reason distinguishes a merged pull request from one ready for review: only a
+merge says no action is needed. A `pull_request_closed` blocker states that the
+pull request was closed unmerged and offers reopen-or-abandon recovery. Other
+known blockers name the credentials, permission, setup, approval, completion,
+conversation, or saved-record problem; unknown reasons point to retained details
+without guessing that the pull request closed. An unavailable-session notice
+directs the operator to start a new watch from an active conversation.
+
 Slack's structured inline nudge runs through `TurnDriver` with the shared,
 session-bound directive consumer. Genuine core-MCP `monitor_update`,
 `monitor_stop`, and structured `autonudge_stop` tool results therefore mutate

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -675,10 +675,14 @@ dispatches zero turns.
 
 Terminal observer notifications are deduplicated for structured monitors within
 one gateway process. The retained monitor record also stores whether the dashboard
-accepted its terminal notice. Startup replays every terminal notice without that
-delivery marker and persists the marker only after acceptance, giving the
-persist-then-notify boundary at-least-once crash semantics: a crash can repeat a
-notice, but cannot suppress the only notice permanently. Gated
+durably appended its terminal notice. Startup schedules every terminal notice without
+that delivery marker as a supervised background task, so notification persistence
+cannot delay gateway readiness. The task persists the marker only after the captured
+notification append future succeeds, giving the persist-then-notify boundary at-least-once crash
+semantics: a crash or append failure can repeat a notice, but cannot suppress the
+only notice permanently. A failed notification creation or append releases the
+process-local deduplication claim, allowing a later observer event to retry without
+requiring a gateway restart. Gated
 legacy loops use only their existing `expired` notification; the following `fired`
 event must not deliver the same terminal notification again.
 Terminal notices identify the watched pull request by its stored target URL,

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -571,6 +571,12 @@ class NudgeLoop:
     # Optional observation/controller state. ``gate=True`` records belong to the
     # prompt path; controller-owned records carry state with ``gate=False``.
     monitor: MonitorState | None = None
+    # Durable delivery generation outside MonitorState. A future-version monitor
+    # is retained as an opaque payload, so mutating a field inside its local view
+    # cannot survive serialization. Keeping the exact terminal identity on the
+    # stable outer record preserves both the opaque bytes and restart dedupe.
+    terminal_notification_outcome: str = ""
+    terminal_notification_stopped_at: float = 0.0
     # Optional SHORT stand-in for ``message`` in the VISIBLE dashboard
     # transcript row. Empty (the default) means the row is byte-identical to
     # what it has always been, so no existing loop changes behaviour.
@@ -620,6 +626,21 @@ class NudgeLoop:
 def is_structured_monitor_loop(loop: NudgeLoop) -> bool:
     """Distinguish controller records from prompt loops carrying probe state."""
     return getattr(loop, "monitor", None) is not None and not getattr(loop, "gate", False)
+
+
+def terminal_notification_delivery_matches(
+    loop: NudgeLoop,
+    outcome: MonitorOutcome,
+    stopped_at: float,
+) -> bool:
+    """Whether this exact terminal generation has a durable delivery record."""
+    if loop.terminal_notification_outcome:
+        return (
+            loop.terminal_notification_outcome == outcome.value
+            and loop.terminal_notification_stopped_at == stopped_at
+        )
+    state = loop.monitor
+    return state is not None and state.terminal_notification_delivered
 
 
 class MonitorUpdateConflict(ValueError):
@@ -1002,6 +1023,37 @@ class AutoNudgeService:
                     loop.monitor.next_probe_at = loop.next_due_ts
                     self._store_dirty = True
                 if due_repaired or idle_repaired:
+                    self._store_dirty = True
+                notification_stopped_at, notification_time_repaired = _repair_number(
+                    loop.terminal_notification_stopped_at,
+                    lo=0.0,
+                    fallback=0.0,
+                )
+                loop.terminal_notification_stopped_at = notification_stopped_at
+                notification_outcome = loop.terminal_notification_outcome
+                valid_notification_outcomes = {item.value for item in MonitorOutcome}
+                if (
+                    not isinstance(notification_outcome, str)
+                    or notification_outcome not in valid_notification_outcomes
+                ):
+                    if (
+                        notification_outcome
+                        or notification_stopped_at
+                        or notification_time_repaired
+                    ):
+                        self._store_dirty = True
+                    loop.terminal_notification_outcome = ""
+                    loop.terminal_notification_stopped_at = 0.0
+                elif notification_time_repaired:
+                    self._store_dirty = True
+                if (
+                    loop.monitor is not None
+                    and loop.monitor.outcome is not None
+                    and loop.monitor.terminal_notification_delivered
+                    and not loop.terminal_notification_outcome
+                ):
+                    loop.terminal_notification_outcome = loop.monitor.outcome.value
+                    loop.terminal_notification_stopped_at = loop.monitor.stopped_at
                     self._store_dirty = True
                 # ``banner`` is display-only, but it is ``.strip()``ed on the
                 # fire path, so a non-string value there raises AttributeError
@@ -2592,13 +2644,15 @@ class AutoNudgeService:
                 or loop.active
                 or state.outcome is not outcome
                 or state.stopped_at != stopped_at
-                or state.terminal_notification_delivered
+                or terminal_notification_delivery_matches(loop, outcome, stopped_at)
             ):
                 return False
             staged = deepcopy(loop)
             staged_state = staged.monitor
             assert staged_state is not None
             staged_state.terminal_notification_delivered = True
+            staged.terminal_notification_outcome = outcome.value
+            staged.terminal_notification_stopped_at = stopped_at
             await self._persist_staged_monitor_locked(loop, staged)
         return True
 

--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -2516,6 +2516,31 @@ class AutoNudgeService:
         self._emit("updated", loop)
         return verdict
 
+    async def stop_monitor_if_budget_exhausted(
+        self,
+        monitor_id: str,
+        *,
+        now: float,
+    ) -> bool:
+        """Stop a spent structured monitor before starting another provider probe."""
+        stopped_loop: NudgeLoop | None = None
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if loop is not None and state is not None and loop.active and state.outcome is None:
+                reason = monitor_budget_reason(state, now=now)
+                if reason:
+                    stopped = deepcopy(loop)
+                    if stopped.monitor is not None:
+                        stopped.monitor.last_decision = MonitorDecision.STOP_BUDGET
+                    self._apply_monitor_budget_stop(stopped, reason, stopped_at=now)
+                    await self._persist_staged_monitor_locked(loop, stopped)
+                    self._sync_terminal_completion_timer(loop)
+                    stopped_loop = loop
+        if stopped_loop is not None:
+            self._emit("updated", stopped_loop)
+        return stopped_loop is not None
+
     def _set_monitor_deadline(self, loop: NudgeLoop, deadline: float) -> None:
         """Write the scheduler authority and inspection mirror together."""
         loop.next_due_ts = deadline
@@ -2550,6 +2575,32 @@ class AutoNudgeService:
             self._sync_terminal_completion_timer(loop)
         self._emit("updated", loop)
         return loop
+
+    async def mark_terminal_notification_delivered(
+        self,
+        monitor_id: str,
+        outcome: MonitorOutcome,
+        stopped_at: float,
+    ) -> bool:
+        """Persist delivery only when the same terminal generation still exists."""
+        async with self._lock:
+            loop = self._loops.get(monitor_id)
+            state = loop.monitor if loop is not None else None
+            if (
+                loop is None
+                or state is None
+                or loop.active
+                or state.outcome is not outcome
+                or state.stopped_at != stopped_at
+                or state.terminal_notification_delivered
+            ):
+                return False
+            staged = deepcopy(loop)
+            staged_state = staged.monitor
+            assert staged_state is not None
+            staged_state.terminal_notification_delivered = True
+            await self._persist_staged_monitor_locked(loop, staged)
+        return True
 
     async def retire_monitor_for_session_close(
         self, monitor_id: str, *, now: float | None = None

--- a/src/kiro_crew/autonudge_authz.py
+++ b/src/kiro_crew/autonudge_authz.py
@@ -842,6 +842,7 @@ async def authorize_and_add_nudge(
             return (
                 current is authorized_slot
                 and mode_ok
+                and not bool(getattr(authorized_slot, "_closing", False))
                 and str(getattr(current, "memory_mode", "persistent")) == "persistent"
             )
 

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -140,7 +140,11 @@ says "running" for a session that never got its seed is the worse failure.
 ### Patrol
 
 After dispatching, arm a loop on your own session with `monitor_start`. Put the
-check AND the exit condition in the message. Then end your turn.
+check AND the exit condition in the message and pass explicit positive
+`max_cycles` and `max_runtime_secs` from the operator's round/time budget. When
+no tighter budget exists, use 240 cycles and 86,400 seconds. If live work needs a
+larger bound, re-arm it with `monitor_update`; `monitor_start` is create-only.
+Then end your turn.
 
 Each cycle:
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
@@ -1,38 +1,29 @@
 ---
 name: babysit
-description: Use when the user says "babysit", "monitor", "keep checking", "keep an eye on", "loop on this PR", "let me know when", or wants polling that outlives a wait+poll window. Same-session monitoring loop for PRs, CI runs, tickets, and deployments using the monitor_start / monitor_update / autonudge_stop MCP tools. The loop re-injects your check instructions into THIS session on an idle interval — same context, same tools — and works from dashboard chat, Slack threads, and Discord DMs. NOT for fresh-session work (use cron_add) or external-system callbacks (use register_hook).
-tags: [skill, kirocrew, monitor, babysit, autonudge, loop]
+description: Use when a user asks to babysit, monitor, keep checking, keep an eye on, or report when a pull request, CI run, ticket, deployment, or other changing target reaches an outcome.
+inject_on_trigger: false
+triggers: babysit, keep checking, keep an eye on, let me know when, monitor pull request, monitor pr, watch pull request, watch pr
+tags: [skill, kirocrew, monitor, babysit]
 ---
 
-# Babysit (same-session monitoring loop)
+# Babysit
 
 ## Overview
 
-`monitor_start(message, interval_secs?, max_cycles?)` binds a monitoring loop
-to **your current session**. Every `interval_secs` the message is re-injected
-as your next turn. User messages defer a due fire until their turn ends but do
-NOT restart the countdown, so the loop stays on schedule even in a session the
-user is actively chatting in. You keep the full conversation context, memory,
-and tools on every cycle. Loops persist to `~/.kiro/crew/autonudge.json` and
-survive gateway restarts (the countdown resumes where it left off).
+Use a structured monitor when its typed provider observes every fact needed to
+decide the objective. Kiro Crew probes before invoking the model, so unchanged
+polling does not consume agent turns. Use the finite legacy path when required
+evidence is outside the structured provider.
 
-Works from:
+Structured watches can be created only from dashboard, Slack, and Discord
+sessions. On Webex, use the finite legacy path even for a supported pull request;
+Webex does not have structured wake delivery and completion correlation.
 
-| Surface | Binding | Cadence |
-|---|---|---|
-| Dashboard chat | bare slot key | deadline timer (user turns defer, never reset) |
-| Slack thread | `slack:<thread_ts>` | fixed interval after each unattended turn |
-| Discord DM | `discord:{agent}:direct:{user}` | fixed interval after each unattended turn |
+## GitHub pull request: one bounded watch
 
-`autonudge_stop(reason?)` stops the loop bound to the current session from
-any of those surfaces.
-`monitor_update(message?, interval_secs?, max_cycles?, max_runtime_secs?, banner?)`
-revises the loop already bound to this session in place, keeping its cycle
-count — use it when the instruction you armed has gone stale, or to raise the
-cap on a loop that is still doing useful work. For a structured monitor it also
-takes `target?`, `objective?`, `max_agent_turns?`, `max_tokens?`,
-`max_provider_errors?` and `wake_instructions?`; every field is
-omit-to-leave-unchanged.
+Call this once with the canonical pull-request URL when review readiness depends
+only on pull-request lifecycle, mergeability, review decision, unresolved review
+threads, and check conclusions:
 
 Two `monitor_start` parameters are worth naming because their defaults are easy
 to inherit by accident:
@@ -278,467 +269,63 @@ script cron (zero tokens, every ~5 min)
         · a comment or review someone else posted)
 ```
 
-**Why the interval can be small.** A tick of this cron costs one bounded `gh`
-call and no tokens at all, so the interval is limited by API politeness rather
-than by spend -- 60s is reasonable, and 300s is a default rather than a floor.
-An UNGATED `monitor_start` cycle, by contrast, costs a full agent turn on the
-session's whole context, which is what forces its interval up.
+The reply is a pending application request, not proof that the monitor armed.
+End the turn so the session-aware consumer can apply it. The operator can then
+confirm it in the dashboard. The agent cannot inspect after ending that same
+turn; at the start of a later user/wake turn, call `monitor_inspect({})` before
+acting or reporting. Its retained session-bound state is authoritative and it
+takes no monitor id, target, or session key.
 
-Arm it **from the session that owns the babysit** — the cron captures that
-session as its wake target; armed anywhere else, the wake lands in the wrong
-chat. Cron scripts must live under `~/.kiro/crew/crons/`, so copy the synced
-skill asset there first (re-copy on every arm — it keeps the copy current
-with skill updates):
+The server performs ordinary probes. Unchanged state, provider retry, success,
+and terminal blockers use zero model turns. A new actionable fingerprint wakes
+the session at most once with a compact, bounded summary. Only then fetch logs,
+comments, or diffs needed to act. The token cap applies only when the provider
+reports usage; `token_usage_known` exposes whether it did. Positive runtime and
+completed-turn caps remain hard fallbacks. Provider errors are also bounded.
 
-```
-CREW_HOME="${KIROCREW_HOME:-$HOME/.kiro/crew}"
-cp "$CREW_HOME/skills/kirocrew-dev/babysit/scripts/pr_watch.py" \
-   "$CREW_HOME/crons/pr_watch.py"
+A terminal success uses zero model turns, so a structured watch does not create
+a final reporting turn. If the user requires a final report or notification even
+when no action is needed, use the finite legacy path.
 
-cron_add(
-  name="pr-watch #1234",
-  script="~/.kiro/crew/crons/pr_watch.py:watch",
-  every=300,
-  timeout=120,
-  message='{"repo": "owner/name", "pr": 1234,
-            "known_reds": ["Frontend Tests (4)"],
-            "note": "worktree ~/oss/wt-foo, branch fix/foo"}'
-)
-```
+Use `monitor_update({...})` without an id to change `interval_secs`, positive
+budgets, or `wake_instructions`. Those edits preserve the comparison baseline;
+changing `target` or `objective` starts a new baseline. Terminal records are
+read-only, so start an explicit new watch to restart. Use
+`monitor_stop({"reason": "User ended the watch."})` for a deliberate stop; the
+retained outcome is `user_stop`. `autonudge_stop` remains a compatibility alias.
 
-The `cp` runs in your shell, so it has to resolve `KIROCREW_HOME` -- an install
-that moved its data home has no `~/.kiro/crew/skills` at all and a hardcoded
-path fails with `No such file or directory`. The `script=` value is different:
-the gateway resolves it against its OWN config directory (and forces the
-`crons/` root), so the conventional spelling there is correct as written.
+The GitHub provider does not observe generic issue or pull-request comments or
+advisory review findings that are not represented by a review thread or check
+conclusion. When the user's definition of readiness depends on that evidence,
+call the finite legacy path directly. Do not ask `monitor_watch` to represent
+evidence its typed provider cannot observe.
 
-- `known_reds` — check names that are red on the BASE branch (inherited
-  breakage). The watch never wakes for them and treats "everything else
-  green" as review-ready. Populate it from what you verified against main's
-  own CI, and update the cron message if main's condition changes.
-- `note` — one line of context echoed into the wake brief. Put the worktree
-  and branch here so the woken turn starts oriented; if this session keeps a
-  work ledger, the brief also tells the woken turn to read it.
-- `coalesce_secs` — optional convergence window, default 240, `0` disables it.
-  Reds arriving while checks are still running are **coalesced into one
-  wake** instead of one wake each. This matters on a repository whose checks
-  finish over many minutes: a 34-second body gate and a five-minute reviewer
-  lane both flipping red on one head used to be two separate wakes, each
-  arriving before the other checks had even started. The window opens on the
-  first anomaly and fires once `coalesce_secs` has elapsed AND either everything
-  has settled or a 30-minute hard cap is hit — so a `pending` count that
-  never drains costs a delayed wake, never a lost one.
-- **A grace-gated wake always costs at least one extra tick**, because a
-  window cannot open and fire within the same tick. On a 60s cron that is at
-  least 60s of added latency. Set `coalesce_secs: 0` when latency matters more
-  than coalescing.
-- A merge conflict and a merged/closed PR **bypass the window** and fire
-  immediately: a dirty PR dispatches no checks, so `pending` never drains and
-  waiting observes nothing at all.
-- Wakes are deduplicated **per head SHA**: one wake per conflict, per new red
-  check name, per all-green. A force-push resets the memory, so the next
-  anomaly on the new head wakes again. Quiet ticks deliver nothing at all.
-- A conversation signal older than five hours is never treated as new. That bound
-  is a constant in the script, deliberately not a cron parameter: the probe keeps
-  no memory of its own, so without it arming a watch on a PR with forty comments
-  would report all forty on the first tick — and as a knob it had no caller while
-  its one real constraint (stay under the kernel's six-hour re-alert window) is
-  now asserted in code rather than merely documented. The value sits close to that
-  ceiling on purpose: too large costs one coalesced arm-time wake, while too small
-  costs a silent permanent MISS whenever the watch stops ticking for longer than
-  the horizon (laptop asleep, gateway down, cron auto-paused). Those two prices are
-  not equal, so the horizon is pushed as high as the kernel allows.
-- The watch reads PR state, the check rollup, AND the conversation: comments and
-  submitted reviews. It reports **that**
-  something was said -- who, and when -- and never quotes the body. Reading the
-  text, judging whether it is a real finding, and deciding what to do stay the
-  woken agent's job, done with this session's trust rather than a cron script's.
-  This is what closes the gap `monitor_start` used to cover: a comment moves no
-  check, and on this repository a reviewer lane can report success while its
-  comment body carries findings, so a rollup-only watch would sit quiet on a
-  green PR nobody had read.
-- Conversation signals are deduplicated per comment/review id and **survive a
-  force-push**, because a comment belongs to the pull request rather than to the
-  commit under review. Check-derived signals still reset per head. Your own
-  comments are ignored, or the watch would wake you to read the disposition you
-  just posted.
-- Merged or closed → the cron delivers a final message and removes itself.
-  If you finish the babysit early, remove it yourself (`cron_remove`).
-- Typical composition: drive the active-fix phase with `monitor_start`; when
-  the PR goes quiet (checks running, awaiting review), stop the loop
-  (`autonudge_stop`) and arm the watch. When a wake arrives, act on it; if
-  heavy fixing resumes, re-arm `monitor_start` and remove the watch until
-  things go quiet again.
+## Example: legacy comment-aware watch
 
-### Never use an agent cron or heartbeat to react to reviewer feedback
+Use a prompt loop when `monitor_watch` does not support the target/objective, or
+when required evidence is outside the structured provider:
 
-Both are structurally incapable of it, and both fail in ways that look like
-success:
-
-- **Cron.** A cron job has no owning chat slot, so it can never earn per-slot
-  trust: its tool calls land on a deny-by-default approval path and time out
-  after 180 seconds unless a global auto-approve grant happens to be active.
-  Worse, a denied *tool* inside a *completed* turn still records
-  `last_status: ok`, so the job registry reports health while the job does
-  nothing. Measured on a real PR watcher: 101 runs over 25 hours, 23 blocked at
-  approval, hours of model time, zero commits pushed, and a green-looking
-  registry throughout.
-- **Heartbeat.** Its approval path is a strict name allowlist
-  (`HEARTBEAT_SAFE_TOOLS`), deny-by-default, with no shell and no `git push`.
-  It cannot amend a commit or push a revision, so it can never close the loop
-  it was asked to watch.
-
-Cron *is* the right tool for post-merge cleanup — but as a `script` cron, which
-bypasses the LLM approval layer entirely, at roughly a 5-minute interval. An
-hourly job loses the race: one observed merge-to-teardown window was 17
-minutes.
-
-## Reading PR/MR state — ask the host for its verdict, don't hand-roll a filter
-
-Whatever you are babysitting, the read step is **not** yours to invent. These
-five rules hold on GitHub, GitLab and Bitbucket alike; only the command changes.
-
-1. **Ask the host for its own aggregate verdict.** Do not reduce a list of
-   individual checks into a pass/fail yourself. Every host computes a merge
-   verdict and exposes it; a filter you write over the raw list is a second,
-   worse implementation of it that silently disagrees.
-2. **Classify every state you see, and fail closed on the ones you don't.** An
-   unrecognized or unmapped status must count as *not passing*, never as
-   passing. Collapse superseded runs to the newest attempt per check identity
-   before counting failures, or a stale cancelled run reads as a live failure.
-3. **"Checks are green" is not "nothing is outstanding."** Unresolved review
-   threads and *advisory* (non-blocking) results are separate axes that the
-   aggregate verdict does not cover, by design. Read them separately, every
-   cycle, or the loop will declare readiness over an open thread.
-4. **Lifecycle state is terminal — read it every cycle.** Merged, closed, or
-   declined means stop, report the real outcome, and call `autonudge_stop`.
-   Do not infer this from the checks; ask for the state field.
-5. **Mergeability is computed asynchronously.** "Unknown", "checking" or
-   "unchecked" means **wait**, not pass — and on a non-open object it may never
-   resolve at all (see the GitHub limits below).
-6. **A conflicted PR's checks are stale, not signal — so a conflict means rebase
-   NOW, not wait.** This is the mechanism behind rule 1, worth knowing because it
-   is invisible in the status list: a conflicted PR cannot produce a merge ref, so
-   the host dispatches **no** `pull_request` workflows at all, and every check you
-   can see belongs to the old head. A status-only loop therefore reports "nothing
-   new" indefinitely while the clock runs. On GitHub you do not read these fields
-   yourself — `pr_status.py` already reads `mergeable`, `mergeStateStatus` and
-   `reviewDecision`, and it ranks a conflict **above** in-flight checks precisely
-   so this cannot happen: a conflicted PR exits **20** on the first poll rather
-   than reporting "running" forever while nothing can complete. The same holds
-   for `BEHIND`, a draft, and `CHANGES_REQUESTED` — each survives any amount of
-   waiting, so each is surfaced immediately. What this rule adds is the
-   response: on a conflict or `BEHIND`, re-sync and re-push instead of polling,
-   and never report the previous head's green.
-7. **A fully green PR can still be terminally blocked by a human decision.**
-   `reviewDecision == CHANGES_REQUESTED` survives every push and is invisible to
-   the checks rollup; `pr_status.py` reports it as 20 ahead of any in-flight
-   check, so it surfaces on the first poll. The judgment the exit code cannot
-   make is *what kind* of block it is: when the content is a product hold rather
-   than a defect, there is nothing to converge on, so report it **once**, quoting
-   the blocking reviewer, and stop rather than cycling.
-
-### Where each host keeps those answers
-
-| host | one-shot verdict | unresolved-thread axis | the local trap |
-|---|---|---|---|
-| **GitHub** | `pr_status.py` (below); optionally an aggregate status context | review threads via GraphQL (`pr_status.py` prints the count) | `statusCheckRollup` is a `CheckRun \| StatusContext` union — `.conclusion` vs `.state` |
-| **GitLab** | `detailed_merge_status` on the MR (`glab mr view <iid>`, or `glab api projects/:id/merge_requests/:iid`) | `glab mr view <iid> --unresolved`, or the Discussions API | a pipeline reports `success` while its `allow_failure: true` jobs failed |
-| **Bitbucket Cloud** | none — combine PR `state` with the commit's build statuses (`/2.0/repositories/{ws}/{repo}/commit/{sha}/statuses`) | PR comments/tasks on the PR resource | below Premium, unresolved merge checks only **warn**; the host still allows the merge |
-
-GitLab specifics worth knowing: use `detailed_merge_status`, not `merge_status`
-(deprecated since 15.6 and it does not account for every state). Its values are
-themselves the loop's decision — `ci_still_running` / `checking` / `preparing` /
-`unchecked` are *wait*; `mergeable` is clean; `conflict`, `need_rebase`,
-`not_approved`, `draft_status`, `discussions_not_resolved`,
-`status_checks_must_pass` and `requested_changes` are each a distinct blocked
-reason worth reporting as itself. Note that `blocking_discussions_resolved` is
-**not** an unresolved-thread count: it only tells you whether resolution is
-required *and* satisfied, so on a project that does not require resolution it can
-be `true` with threads still open. Count threads from the discussions, and treat
-external status checks as their own axis, separate from the pipeline.
-
-Bitbucket specifics: there is no single "can this merge" field to poll, so rule 1
-becomes "combine the two sources the host does give you" — the PR's `state`
-(non-`OPEN` is terminal) and the head commit's build statuses. And because merge
-checks are advisory below Premium, a Bitbucket "green" is weaker evidence than
-elsewhere: rule 3 is not optional there.
-
-Provenance: the GitHub path below is exercised (including against an unrelated
-public repo); the GitLab and Bitbucket rows come from those vendors' API docs and
-are **not** something this skill has run. Verify the exact flag or field against
-your host before trusting a value you have not seen come back.
-
-### On GitHub: use `pr_status.py`
-
-The `prepare-pr` skill owns the tool, and it is project-agnostic — stdlib Python
-over `gh`, no repo-specific assumptions baked in. Call it by path from the target
-repo (do **not** `cd` into the skill folder; the scripts read which repo they are
-talking about from your cwd):
-
-```bash
-SKILL_DIR="${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr"
-python3 "$SKILL_DIR/scripts/pr_status.py" <pr#>     # exit 0 clean / 10 running / 20 blocked / 2 env
-python3 "$SKILL_DIR/scripts/pr_status.py" <pr#> --json   # same exit code, plus the progress key on stdout
-python3 "$SKILL_DIR/scripts/pr_findings.py" <pr#>   # only after 20: failed steps, log tails, threads
+```text
+monitor_start({
+  "message": "Watch https://github.com/kirodotdev/KiroCrew/pull/123. On each injected cycle, inspect current review comments and checks. Act only on a real change. If the pull request is ready, terminal, or needs a human decision, report the outcome and call autonudge_stop with a reason.",
+  "interval_secs": 300,
+  "max_cycles": 24,
+  "max_runtime_secs": 14400,
+  "gate": false
+})
 ```
 
-`--json` adds one machine-readable object to stdout and changes nothing else —
-same exit codes, same prose above it. Use it for the stall tripwire: the object
-carries the full 40-char `head_sha` (the prose only ever prints 12), the sorted
-`failing_checks` list, and `readiness_kind`, so two cycles can be compared
-byte-for-byte instead of by eyeballing a diff of human text.
+Keep `gate: false` for this fallback: provider-fact gating cannot observe the
+missing evidence and could suppress cycles while new comments await review.
+The finite loop checks that evidence on every scheduled cycle.
 
-Its `advisory` half is what you read when checking the exit conditions below:
-`unresolved_threads` (`null` there is the same "could not establish" as a `?`),
-`findings` per reviewer, `stale_reviewers` / `blocking_reviewers`, and
-`elided_stamp_reviewers` — lanes whose freshness stamp MANGLED the head SHA
-(the workflows have the model retype it, so a lane can drop the middle and
-splice the head's prefix to its suffix). The gate verifies such a stamp against
-the current head and accepts it, which is why it is not a stale reviewer; the
-list exists so the emitter defect is still visible. Report it ONCE per head as
-a lane-quality note — it never blocks, and re-running that workflow usually
-produces a clean stamp. Nothing else is emitted — ambient PR state (mergeable,
-merge state, review decision, check totals) stays in the prose above, which is
-where those conditions already read it, so there is no second copy to keep in
-sync.
+All three limits must be nonzero; use a larger finite value, never `0`, for a
+longer request. Every delivered legacy cycle is a full agent turn that extends
+session context and spends model/tool tokens even when nothing changed. The reply
+is only an arm request; verify the loop through the dashboard monitor/goal-loop
+surface or `GET /api/autonudge`.
 
-Drive the cycle off the **exit code**, not off prose: `10` → report nothing and
-wait for the next cycle; `20` → drill in with `pr_findings.py` and act; `2` →
-environment problem, escalate rather than loop on it.
-
-**Exit `0` is necessary but not sufficient — do not stop on it alone** (rule 3).
-The script's decision is fail-closed about *checks*, but the unresolved-thread
-count it prints is **advisory: it is not part of the exit code**, so a PR with
-open review threads still exits `0`. Before you declare review-ready and call
-`autonudge_stop`, confirm all five:
-
-1. `pr_status.py` exits `0`;
-2. its `unresolved threads (advisory)` line reads `0` — a `?` means the count
-   could not be retrieved, which is not a zero, so treat it as unresolved and
-   check the threads yourself with `pr_findings.py`;
-3. every reviewer that raised something has an answer from you on the PR. An
-   **advisory** reviewer posts its concerns *and* passes its own check, so its
-   verdict appears in neither the exit code nor the aggregate. In this repo that
-   is `Design Review` / `UX Review` reporting `🟡 CONCERNS` while green; in
-   another repo it is whatever non-blocking bots and human reviewers comment
-   there. See `prepare-pr`'s "Answer every concern".
-4. its `mergeable=` / `mergeState=` / `reviewDecision=` line (the script prints
-   all three) shows no conflict, no `BEHIND`, and no `CHANGES_REQUESTED` — exit 0
-   already implies this, so read the line to know *which* to report, not to
-   re-decide it (rules 6-7);
-5. **no finding on the current head lacks a disposition.** Not "zero findings" —
-   that can never be reached. A **fixed** finding disappears from the bot's
-   in-place-updated body on the next review, but one you **rebutted** or
-   **accepted-and-deferred** (or **needs-a-decision**) keeps being re-raised, so a zero-findings test
-   deadlocks the loop against your own correct answer. The test is *unanswered*,
-   which is also what the `autonudge_stop` prohibition below is keyed on. The
-   mechanical half of this condition is the script's, not yours: `pr_status.py`
-   reads the bot comments itself, holds every `[<NAME>-REVIEWED]` stamp to the
-   current head SHA, and folds a stale stamp or a `[BLOCK-MERGE]` marker for
-   the current head into exit `20` — so exit `0` already proves reviewer
-   freshness and the absence of a blocking finding. On a repo with a known
-   reviewer fleet, PIN it (`--reviewers NAME1,NAME2` /
-   `PREPARE_PR_REVIEWERS`): a pinned reviewer must have a fresh stamp, so a
-   bot that fails to post — or an emitter drift that stops stamps appearing at
-   all — blocks instead of silently un-gating; unpinned discovery mode holds
-   whatever stamps it finds to freshness but does not require presence. One reading note: a stale stamp maps onto exit `20`, and
-   on a repo whose reviewer bots are comment- or cron-triggered (not in the
-   check rollup) that `20` can mean "the bot has not posted for this head yet"
-   rather than "author action needed" -- the reason string names the stale
-   reviewer, so read it before treating the exit code as a fix signal. What stays yours is the judgment half: the script prints
-   each fresh reviewer's advisory `FINDING` count but deliberately never gates
-   on it, so read those from `pr_findings.py` (which lists each one with a
-   stable `span=` identity), subtract the ones your own `ai-review-disposition`
-   comments already answer, and disposition what remains.
-
-**Never call `autonudge_stop` while an un-dispositioned finding exists for the
-current head SHA.** If you must stop for another reason, post the open-finding
-list so the handoff is visible to a human — otherwise findings sit unread for
-hours while the loop looks healthy.
-
-### Verify what your reviewer's conclusion actually means — once per repo
-
-Rule 1 says ask the host for its verdict. That holds for CI, but a **review bot is
-not a build**: its check conclusion is whatever its workflow chose to exit with, and
-that is a per-repo implementation detail. So before you build an exit condition on
-it, establish once what it means in the repo you are in, and re-check if the review
-fleet is renamed or replaced. The failure modes to look for, any of which makes a
-status-only loop unsound:
-
-- **Red that only means "found something."** The workflow exits nonzero when the
-  review succeeded and produced a finding. Red becomes its normal state.
-- **A verdict that never posted.** An empty comment while the job log holds the
-  finding — the loop sees no findings and concludes clean.
-- **Green with findings in the body.** Worse than red, because red at least wakes a
-  watch loop.
-- **A verdict that is not reproducible.** Re-dispatch on an identical tree flips it,
-  so bot-green is not terminal and one red is not a stable fact about the diff.
-- **Inflated failure counts.** Per-SHA double dispatch, or runs reporting `failure`
-  with zero failed jobs. Collapse to the newest run per (workflow, SHA) — rule 2 —
-  before counting anything.
-
-> **Establish this per repo before trusting a conclusion, and write down what you
-> found.** If any of the five holds, resolve reviewer state from the **comment
-> body for the current head SHA** instead — which is exactly what `pr_status.py`
-> does mechanically: it never reads the review workflow's conclusion, only the
-> per-SHA stamps and blocking markers in the bodies, so "stamp matches head AND
-> no blocking marker" is already folded into its exit code. Which repos are
-> affected, and the evidence for each, belongs in that repo's issue tracker — not
-> in this skill, which ships to every install and cannot be corrected in copies
-> already distributed. For kirodotdev/KiroCrew that record is #2548; #2550 moved
-> the check itself into the script so the conditional is data, not prose.
-
-Where a reviewer's conclusion *is* trustworthy, none of the above applies and reading
-job logs every cycle is wasted work: check first, then decide.
-
-If any of the five is unmet, the loop has not reached its exit condition —
-keep cycling (or escalate), and do not report the PR as review-ready.
-
-Two GitHub-shaped traps this closes, both of which produce a confidently wrong
-reading:
-
-- **`.conclusion` is not universal — this is a GitHub API shape, not a
-  per-repo quirk.** `statusCheckRollup` is a union: **CheckRun** entries carry
-  `.conclusion`, while **StatusContext** entries (the legacy commit-status API,
-  still how many third-party integrations and any home-grown aggregate report)
-  carry `.state` instead. So
-  `gh pr view --jq '.statusCheckRollup[] | select(.conclusion==...)'` silently
-  drops every status context in any repo that has one, and the PR reads cleaner
-  than it is. `pr_status.py` classifies both shapes, and treats an aggregate
-  status as authoritative over the individual rollup when one is published —
-  naming it with `--readiness-context NAME` (or `PREPARE_PR_READINESS_CONTEXT`;
-  the default is this repo's `PR Readiness`, and `resolve_profile.py` reports
-  the right name for another project, which you then pass in). With no aggregate
-  published it falls back to the full rollup, so it still works on a repo that
-  publishes none.
-- **The failing count is fail-closed, not a bug count** (rule 2). Any
-  unrecognized COMPLETED conclusion counts as a failure, and superseded re-run
-  attempts are collapsed to the newest run per check identity before counting —
-  so every remaining `[fail]` line is live. Read the per-check lines before
-  naming causes to the user.
-
-Two limits worth knowing before you trust it on an arbitrary PR:
-
-- **Run it from a checkout of the target repo.** A bare PR number resolves
-  against your cwd's repo. A full PR URL works for any repo, but the
-  unresolved-thread count re-resolves the repo from cwd (`gh repo view`), so a
-  URL from a foreign checkout mixes two repos: usually that prints `?` (the
-  number does not exist there), but if the cwd repo happens to have a PR with
-  the same number you get a thread count for the *wrong* PR with nothing marking
-  it as such.
-- **A merged, closed or declined PR exits `20`** with `PR state is ... (not
-  OPEN; terminal)` — that satisfies rule 4, so on that message report the real
-  outcome and stop the loop rather than triaging it as a failure.
-- **`?` is not `0`.** It means the count could not be established (auth, page
-  cap, wrong repo). Treat it as unresolved.
-
-## Workflow
-
-1. **Write the message as instructions to your future self.** Include:
-   - what to check (PR URL, job id, ticket),
-   - what to do with findings (fix + push, summarize, escalate),
-   - the exit condition, ending with: "when met, tell the user and call
-     `autonudge_stop`".
-2. **Call `monitor_start`, and always pass a wall-clock budget.**
-   `interval_secs` default 300 suits CI/review polling. `max_cycles` defaults to
-   24 (≈2h of idle gaps at 300s); raise it for longer work, and pass `0` for
-   unlimited only when the user explicitly asks for an unbounded loop.
-   **Set `max_runtime_secs` too.** It is the only bound that holds when
-   per-cycle work grows: measured cycles ran 124s–823s of model time *on top of*
-   the idle gap, so a 12-cycle cap took 4.1 hours. Cycle count does not bound
-   spend. Budget the wall clock you would actually accept (e.g. `14400` for four
-   hours) so a stalled loop dies on time rather than on arithmetic.
-3. **Confirm it armed.** Read `~/.kiro/crew/autonudge.json` and check your
-   loop is there. The tool's reply is not evidence — see above.
-4. **Tell the user monitoring is active and END YOUR TURN.** The loop wakes
-   you — do not wait+poll on top of it.
-5. **Each cycle:** do the check, act, and report only real signals. Don't
-   post "nothing new" every cycle. If the instruction no longer matches
-   reality, `monitor_update` it rather than working around it.
-   **Keep a no-signal cycle cheap.** On exit `10` the correct cycle is: read the
-   exit code, write nothing, end the turn. Do not re-read review-bot bodies, job
-   logs, or diffs on a cycle whose own status call already said nothing changed —
-   that is where a watch loop turns into a spend loop. One `pr_status.py` run is
-   6–8 `gh` invocations; the expensive reads belong to exit `20`.
-6. **Persist the progress key and its streak count to a file** (not session
-   memory — compaction eats both) and apply the stall tripwire above: 3
-   byte-identical keys on *settled* cycles (exit `0` or `20`) with no push means
-   stop and escalate. Exit-`10` cycles are skipped, not counted and not reset;
-   exit `2` escalates.
-7. **On the exit condition** (or the user saying stop): report, then call
-   `autonudge_stop` with a reason. Do not let the cap do this for you.
-
-## Example
-
-User: "babysit PR #247 until it's review-ready"
-
-Note what the message does with that: the user said `PR #247`, and the armed
-instruction names the pull request by FULL URL. That is what makes the loop
-observation-gated -- copy the user's bare number into the message and it is not.
-
-```
-monitor_start(
-  message="Check https://github.com/owner/repo/pull/247. FIRST read
-           gh pr view 247 --json mergeable,mergeStateStatus,reviewDecision —
-           rules 6 and 7 of the babysit skill govern what each value means.
-           Then run
-           python3 \"${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/kirocrew-dev/prepare-pr/scripts/pr_status.py\" 247
-           and act on its exit code, passing --json so the progress key is
-           machine-comparable (10 = still running, report nothing and do not
-           read bot bodies or job logs;
-           20 = drill in with pr_findings.py, or stop if the reason is a
-           terminal PR state). Keep the progress_key AND a consecutive-match
-           count in the data home beside the loop's stop sentinel, reading that
-           file rather than trusting memory: 3 byte-identical keys on settled
-           cycles (exit 0 or 20) with no push in that span means stop and
-           escalate. If this repo's reviewer conclusions are on the
-           unreliable list you established for it, resolve the AI review lane
-           from the job log plus the comment body for the current head SHA
-           rather than the conclusion; where the conclusion is trustworthy, use
-           it. Fix legitimate
-           High/Medium findings and push, following this repo's history
-           convention; before rebutting a finding that has returned a 3rd time,
-           re-run the reviewer once on the unchanged SHA and re-derive the claim.
-           Stop ONLY when all five exit conditions in the babysit skill hold, and
-           never while an UN-DISPOSITIONED finding exists for the current head
-           SHA — a finding you rebutted or deferred stays visible in the bot's
-           body, so "any finding at all" would never let the loop finish. Then
-           tell the
-           user the PR is review-ready and call autonudge_stop.",
-  interval_secs=300,
-  max_cycles=20,
-  max_runtime_secs=14400,
-)
-```
-
-The example deliberately **points at** the five conditions rather than restating
-them; a re-serialized copy inside the prompt drifts from the list above.
-
-On GitLab or Bitbucket the shape is identical — only the first line changes (the
-host's own verdict call from the table above), plus its own thread axis and its
-own "green is weaker than it looks" caveat.
-
-## Rules & gotchas
-
-- **One automation per session** — `monitor_start` is **create-only**: it refuses
-  while a loop (or a structured monitor) already occupies this session. To change
-  a running loop use `monitor_update`; to replace it, `autonudge_stop` first, then
-  arm again.
-- **Busy sessions skip a cycle** (never queue) — a long-running turn delays
-  the next check to the following interval; skipped cycles don't count
-  toward `max_cycles`.
-- **Unattended turns are bounded to 30 min** on Slack/Discord; keep each
-  cycle's work small and incremental.
-- **Slack/Discord loops auto-approve tools** on the unattended turn
-  (Slack always; Discord follows the gateway approval mode — under
-  interactive approval a Discord cycle cannot use tools, so prefer
-  dashboard/Slack for tool-heavy babysitting or run the gateway with
-  `--approval yolo`/`auto`).
-- **Kill switches:** `autonudge_stop` (preferred), the dashboard 🎯 popover
-  (dashboard loops), `max_cycles`, or `max_runtime_secs`. A STOP sentinel file
-  only exists for a loop armed with an explicit `stop_sentinel_path` (the HTTP
-  `POST /api/autonudge` path accepts one); a loop armed through `monitor_start`
-  has none.
-- Loops fire `[auto-nudge cycle N]`-tagged messages — treat them as your own
-  scheduled wake-ups, not user input.
+Legacy tool calls remain under normal PreToolUse governance and approval policy.
+An unattended Slack or Discord turn has no blanket grant: approval may be
+requested, rejected, or time out, and the loop records an approval stall instead
+of silently succeeding.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -550,7 +550,8 @@ re-runs them on the new head.
                "and only once no unanswered concern remains, tell the user and call autonudge_stop.",
        interval_secs=300,
        max_cycles=80,
-       max_runtime_secs=43200,
+       max_runtime_secs=86400,
+       gate=False,
        banner="prepare-pr: polling PR #<n>")
      ```
 
@@ -587,7 +588,7 @@ re-runs them on the new head.
      the way `babysit`'s "Verify the loop armed" section prescribes. A loop that is
      present but frozen at the same count is also a fallback case.
 
-     **`max_cycles` is a poll budget, not a round budget.** One 20–40 minute round costs several 5-minute cycles, so the default expires after two or three rounds — silently. `max_cycles=80` is roughly ten rounds and is the loop's budget (see "Iteration budget"); when it is spent, stop and report — the user, not the loop, decides on a second eighty. See `babysit` for the loop's own semantics.
+     **`max_cycles` is a poll budget, not a round budget.** One 20–40 minute round costs several 5-minute cycles. The recipe pairs `max_cycles=80` (roughly ten rounds) with an explicit 24-hour runtime cap, allowing time for agent work between polls; an omitted runtime defaults to four hours and can stop it before the cycle cap. Both bounds remain finite: inspect elapsed runtime as well as cycles and raise the relevant bound via `monitor_update` if the work is still live near either cap. `gate=False` keeps comment/advisory checks running even when typed provider facts are unchanged. See `babysit` for the loop's own semantics.
 
      **`interval_secs=300` is FIXED for the whole run — raise `max_cycles`, never
      the interval.** Lengthening it is the wrong lever for every state this loop
@@ -886,11 +887,10 @@ owning slot, so its tool calls hit a deny-by-default approval path and time out,
 while a denied tool inside a completed turn still records `last_status: ok`;
 heartbeat runs under a name allowlist with no shell and no `git push`.
 
-**One narrow exception.** `babysit`'s `pr_watch` script cron costs zero tokens per
-quiet cycle, so it is the better driver during a *pure-watch* stretch — but only
-when you have **nothing to answer**: no open concern, and no bot post still
-expected. `pr_watch` reads no comment bodies, so it cannot see the "every bot has
-posted" half of round completion. Any doubt → `monitor_start`.
+`monitor_watch` is the zero-turn choice for a provider-fact-only watch, but this
+fix-and-push loop depends on generic reviewer posts and must stay on the bounded
+`monitor_start` path. Do not register the compatibility `pr_watch` script cron for
+new work.
 
 Cron *is* correct for post-merge cleanup, as a `script` cron at roughly a 5-minute
 interval — an hourly one loses the merge-to-teardown race.

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -117,15 +117,12 @@ never relabel it success in the friction report.
    provenance entry and for the whole-map write rule.
 3. Open your own status file beside the spec — `conductor-status/v1`, schema
    below. The ledger tracks the items; the status file tracks YOU.
-4. Arm the patrol: `monitor_start` (interval ~90s) with the standing
-   instruction below. **Patrol with `monitor_start`, never `wait`.** Pass
-   `max_cycles` explicitly — the default is 24, so a 90-second patrol expires in
-   well under an hour, long before a fleet drains, and the loop simply stops
-   with no symptom. Size it to the run, raise it mid-run with `monitor_update`,
-   or pass `max_runtime_secs` when a wall-clock bound fits better than a cycle
-   count. Call
-   `autonudge_stop` yourself when the exit condition fires — coasting into the
-   cycle cap is a failure, not a finish.
+4. Arm the patrol with `monitor_start` using an interval near 90 seconds, an
+   explicit `max_cycles=960`, and an explicit `max_runtime_secs=259200`. **Patrol
+   with `monitor_start`, never `wait`.** If live work needs a larger or renewed
+   bound, raise it with `monitor_update` before it expires; `monitor_start` is
+   create-only. Call `autonudge_stop` yourself when the exit condition fires —
+   coasting into the cycle cap is a failure, not a finish.
 
 Standing patrol instruction template (keep it CURRENT — steering edits go here
 via `monitor_update`, see "Live steering"):

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -130,33 +130,71 @@ When the user asks you to submit code for review and address automated comments 
 5. If no comments or only false positives: report done to the user
 6. Stop the loop and report remaining issues to the user if EITHER: you've iterated 3+ times without the comment count decreasing, OR you've completed 5 total iterations.
 
-**Long task or "keep an eye on it" / "babysit" / "monitor":** use `monitor_start`.
+**Long task or "keep an eye on it" / "babysit" / "monitor":** read the
+`babysit` skill. For a supported pull request whose objective is fully decided
+by provider lifecycle, checks, mergeability, review decision, and review
+threads, use the bounded `monitor_watch` path. It probes without model turns and
+wakes this session only for a new actionable fingerprint. Use `monitor_start`
+only for unsupported targets or evidence the structured provider cannot see,
+and always give that legacy path positive cycle and runtime bounds.
 
-`monitor_start(message, interval_secs?, gate?, max_cycles?, max_runtime_secs?, banner?)` starts a monitoring loop on YOUR CURRENT session — the message is re-injected as your next turn (same context, same tools, same conversation). Works from dashboard chat, Slack threads, Discord DMs and Webex sessions, and survives gateway restarts; other messaging channels are refused outright rather than armed into a loop that never fires.
+`monitor_watch(kind, target, objective, interval_secs?, positive budgets...)`
+requests a structured monitor on YOUR CURRENT dashboard, Slack, or Discord
+session. When comments or advisory findings are required, call a finite
+`monitor_start` loop directly. The request applies after the turn ends; inspect
+it on a later turn.
+
+`monitor_start(message, interval_secs?, gate?, max_cycles?, max_runtime_secs?, banner?)` starts a
+legacy monitoring loop on YOUR CURRENT session — after your turn completes and
+the session idles for `interval_secs`, the message is re-injected as your next
+turn (same context, same tools, same conversation). It works from dashboard
+chat, Slack threads, Discord DMs, and Webex conversations, and survives gateway
+restarts.
 
 `interval_secs` is counted from the loop's last cycle toward a fixed deadline, and the countdown is deadline-preserving: a user message defers a due fire until their turn ends but does NOT restart the interval, so checks stay on schedule even in an actively-used session. A cycle whose own work runs long does push the next deadline out, so real cadence is at least `interval_secs` plus turn time. Range 15-86400, default 300.
 
 **Watching one GitHub pull request to review-ready? Prefer `monitor_watch` over `monitor_start`.** `monitor_watch(kind='github_pull_request', target=<full PR URL>, objective='review_ready')` probes the pull request itself, so unchanged, pending, retrying and terminal probes cost NO agent turn, and it carries real budgets. Put what to do on an actionable revision in `wake_instructions`, read its state with `monitor_inspect`, and end it with `monitor_stop`, not `autonudge_stop`. One structured monitor per session. The structured tools cover dashboard, Slack and Discord sessions only — a Webex session can arm `monitor_start` but not `monitor_watch`, because structured wake delivery has no Webex route. Use `monitor_start` when the loop must act on a schedule rather than on a pull-request revision.
 
 **When to use monitor_start:**
-- User says "keep checking", "monitor", "babysit", "let me know when"
+- The structured provider cannot observe a fact in the user's exit condition
 - Task may take longer than 30 minutes (beyond wait+poll territory)
-- You need to poll an external system until a condition is met (CR analysis, deployment, ticket resolution)
+- You need to poll an unsupported external system until a condition is met
 
 **Using monitor_start:**
-1. Put the full check instructions AND the exit condition in the message, and when the subject is a GitHub pull request name it BY FULL URL: `Check https://github.com/owner/repo/pull/123 for new CI results and review comments. Fix legitimate findings and push. When the PR is review-ready (checks green, threads resolved), tell the user and call autonudge_stop.` Naming exactly ONE pull request by full URL is what turns on observation-gating — the loop re-injects your message only when that PR actually changed, so quiet cycles cost no model turn and `max_cycles` counts turns DELIVERED rather than intervals elapsed. A bare `PR #123` leaves the loop on the plain timer and spends a turn every interval; the user will say "babysit PR #123", and you write the URL. Pass `gate=false` (or name no single pull request) for a loop that must run every interval even while its subject is quiet — refreshing a heartbeat, chasing a silent reviewer, rebasing on a moving base — because continued silence is invisible to the observation.
-2. Call `monitor_start` with a sensible interval (300s for CI/review polling), then tell the user monitoring is active and END YOUR TURN — the loop wakes you. Whenever `message` is long, also pass `banner` — a short line like "watching PR #123 for CI" — which is what gets stored and displayed each cycle while you still receive `message` whole; omit it on a Slack, Discord or Webex loop, where a banner is refused with a 400. Pass `max_runtime_secs` whenever the user gives a time limit: it stops on schedule where a cycle cap cannot.
+1. Put the full check instructions AND the exit condition in the message. Name a
+   watched pull request by its full URL, for example
+   `https://github.com/kirodotdev/KiroCrew/pull/123`. Pass `gate=false` when
+   generic comments or advisory findings matter because the typed provider
+   fingerprint cannot observe them.
+2. Call `monitor_start` with a sensible interval (300s for CI/review polling),
+   a positive `max_cycles`, and a positive `max_runtime_secs`. Pass a short
+   `banner` for a long dashboard instruction so the full prompt is not stored as
+   a transcript row every cycle. Then tell the user monitoring was requested and
+   END YOUR TURN — the loop wakes you after it is applied.
 3. Each cycle: do the check, act on findings, report only real signals (don't post "nothing new" every cycle). Every cycle appends a full turn to this same session, so keep per-cycle output small — a chatty loop burns its own context.
 4. When the exit condition is met or the user says stop, call `autonudge_stop`. **This is on you**: `max_cycles` (default 24) is a runaway backstop, and a loop that coasts into its cap did not finish — it ran out of rope. Check the exit condition every cycle and stop deliberately.
 5. If what you are watching moves on and your armed instruction is now stale, call `monitor_update(message?, interval_secs?, max_cycles?)` to revise it in place — it keeps the loop and its cycle count, and only ever touches your own session's loop. If the loop has already PAUSED, `monitor_update` resumes it only when your patch raises the bound that stopped it (`max_cycles` above the cap, or `max_runtime_secs` above the loop's age), and a monitor whose pull request already merged or closed is terminal: arm a new loop only for a new subject.
 
-If `monitor_start` reports it could NOT arm a loop, believe it: that is an arming failure, not the transient MCP reconnect you retry through. No monitoring is running, so fall back to an in-turn wait+poll loop and say so.
+If either monitor tool reports it could NOT arm, believe it: that is an arming
+failure, not the transient MCP reconnect you retry through. No monitoring is
+running. Report the refusal and preserve the user's next safe action; do not
+silently substitute an unbounded in-turn polling loop.
 
-One automation may occupy a session, and `monitor_start` is CREATE-ONLY: while an ACTIVE loop or structured monitor exists here the call is refused rather than silently replacing it, so revise a live loop with `monitor_update` and call `autonudge_stop` first to swap subjects. (A loop the system already stopped — a spent cap or budget, a finished subject — is replaced by a new arm; a manual pause or a user stop is preserved.) The user can also stop dashboard loops from the 🎯 popover.
+One automation per session — a create cannot replace another automation. Stop
+the existing record deliberately before switching paths. The user can also stop
+dashboard loops from the monitor popover.
 
-**Durable loop state:** record each step with `session_ledger_record` and read it back with `session_ledger_read`. The ledger survives context compaction and is re-injected into monitor cycles as a `[work ledger]` snapshot that outranks your recollection — start from its `next` step rather than re-deriving state from a truncated conversation.
+**Durable loop state:** record each step with `session_ledger_record` and read it
+back with `session_ledger_read`. The ledger survives context compaction and is
+re-injected into monitor cycles as a `[work ledger]` snapshot.
 
-**Heartbeat (fallback):** the `~/.kiro/crew/workspace/HEARTBEAT.md` task queue still exists for cases monitor_start can't cover: work that should run OUTSIDE this session (fresh context each cycle), or contexts where monitor_start is unavailable (cron/webhook sessions). Append checklist entries by calling `kiro_crew.heartbeat.append_heartbeat_task(entry)` from Python; never edit the file directly, because the helper shares the service's cross-process lock. Tasks are processed on the heartbeat tick (60s by default, operator-configurable); include `HEARTBEAT_KEEP` in the response to retain a task for the next cycle, omit it when complete. Route completion with `<!-- deliver:dashboard -->` / `<!-- deliver:slack -->` tags. Notify only on real signals.
+**Heartbeat (fallback):** the `~/.kiro/crew/workspace/HEARTBEAT.md` task queue
+still exists for work that should run outside this session with fresh context,
+or contexts where monitor tools are unavailable (cron/webhook sessions). Append
+checklist entries with `kiro_crew.heartbeat.append_heartbeat_task(entry)`; never
+edit the file directly because the helper shares the service's cross-process
+lock. Include `HEARTBEAT_KEEP` to retain a task for another cycle, omit it when
+complete, and notify only on real signals.
 
 ### Webhook-Triggered Sessions
 

--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -874,7 +874,8 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
     # shape, while the slot's persisted app provenance cannot be user-selected.
     # Ordinary dashboard/channel monitors have no tombstone consumer, so retain
     # their historical removal behavior instead of leaving a paused loop.
-    if is_structured_monitor_loop(loop):
+    structured = is_structured_monitor_loop(loop)
+    if structured:
         from kiro_crew.autonudge_authz import authorize_and_stop_monitor
 
         _loop, error, _status = await authorize_and_stop_monitor(
@@ -891,6 +892,12 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
         await svc.update(loop_id, active=False, stopped_reason=AUTONUDGE_STOP_REASON)
     else:
         await svc.remove(loop_id)
+    if structured:
+        return (
+            f"Structured monitor {loop_id} stopped and retained for inspection"
+            + (f" (reason: {reason})" if reason else "")
+            + ". No further monitor wakes will fire."
+        )
     return (
         f"Auto-nudge loop {loop_id} stopped on this session"
         + (f" (reason: {reason})" if reason else "")

--- a/src/kiro_crew/docs/README.md
+++ b/src/kiro_crew/docs/README.md
@@ -23,6 +23,7 @@ organized for someone browsing the repository.
 |---|---|
 | [agents.md](agents.md) | Switching between specialized agents per conversation, thread, or cron job. |
 | [skills.md](skills.md) | Drop-in markdown knowledge packs for domain-specific workflows. |
+| [monitoring.md](monitoring.md) | Token-efficient pull-request monitoring and finite legacy fallbacks. |
 | [cron-and-scheduling.md](cron-and-scheduling.md) | Scheduling recurring tasks. |
 | [subagents.md](subagents.md) | Spawning parallel background workers for fan-out work. |
 | [dynamic-subagent-sizing.md](dynamic-subagent-sizing.md) | How the concurrent sub-agent cap is sized from host memory and CPU. |

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -28,6 +28,7 @@ index, first-time setup, and connecting messaging channels.
 | Capability | Description |
 |------------|-------------|
 | [Cron Jobs](cron-and-scheduling.md) | Schedule recurring tasks, e.g. "every weekday at 9am give me a pipeline briefing" |
+| [Monitoring](monitoring.md) | Watch a public GitHub pull request with zero-turn unchanged probes and bounded action wakes |
 | [Subagents](subagents.md) | Spawn parallel background workers for fan-out research and multi-package work |
 | [Dynamic Sub-Agent Sizing](dynamic-subagent-sizing.md) | Auto-size the concurrent sub-agent cap from host memory/CPU and a learned per-agent cost |
 | [Memory](memory-and-learning.md) | Persistent preferences, project context, and learned corrections across sessions, plus per-session persistent / incognito / temporary memory modes |

--- a/src/kiro_crew/docs/monitoring.md
+++ b/src/kiro_crew/docs/monitoring.md
@@ -1,0 +1,97 @@
+# Monitor a pull request
+
+Use a pull-request monitor when you want Kiro Crew to keep checking a public
+GitHub pull request without spending a model turn on every poll. Kiro Crew wakes
+the owning conversation only when a new revision needs action.
+
+## Before you start
+
+A structured monitor supports public `github.com` pull requests whose goal is
+`review_ready`. It checks pull-request state, mergeability, review decisions,
+unresolved review threads, and check conclusions. Start it from a dashboard,
+Slack, or Discord conversation.
+
+Use a finite legacy loop instead when the decision depends on generic comments,
+advisory findings, another forge, a deployment, a ticket, or a custom objective.
+
+## Start the monitor
+
+1. Open the conversation that should own the watch.
+2. Ask Kiro Crew to monitor the full pull-request URL until it is review-ready.
+3. End the turn after the tool reports that application is pending.
+4. Confirm the active monitor in the dashboard.
+
+The tool reply is an application request, not proof that the monitor started.
+The owning session applies it only after the turn ends. At the start of a later
+user turn or monitor wake, the agent can call `monitor_inspect` to read the
+authoritative retained state.
+
+Unless you choose different positive limits, the monitor uses:
+
+| Limit | Default |
+|---|---:|
+| Probe interval | 5 minutes |
+| Runtime | 4 hours |
+| Completed agent turns | 8 |
+| Reported aggregate input and output tokens | 250,000 |
+| Consecutive provider errors | 3 |
+
+The token cap applies only to usage reported by the model provider.
+`token_usage_known` tells you whether every completed turn included usage. The
+runtime and completed-turn limits remain hard fallbacks when usage is unknown.
+
+## Understand when the agent runs
+
+Kiro Crew probes and compares provider facts before it invokes the conversation:
+
+| Observation | Agent turns |
+|---|---:|
+| No material change | 0 |
+| Checks still pending | 0 |
+| Provider retry | 0 |
+| Review-ready success or terminal blocker | 0 |
+| New actionable fingerprint | At most 1 |
+
+An actionable wake includes a compact summary. The agent can then fetch only the
+logs, comments, or diff needed for that change. Kiro Crew retains accepted
+fingerprints across restart, so the same revision is not handled twice.
+
+Terminal success does not wake the conversation. The dashboard instead reports
+success, a terminal blocker, an exhausted budget, or an unavailable owning
+session. Use a finite legacy loop when you require a final conversational report
+even if the pull request needs no action.
+
+## Inspect or change a monitor
+
+Use `monitor_inspect` on a later turn to see the target, objective, next probe,
+limits, latest classification, usage, and final outcome.
+
+You can change the cadence, positive limits, and wake instructions without
+discarding the comparison baseline. Changing the target or objective starts a
+new baseline and is refused while an action is in flight.
+
+Monitoring never grants extra tool authority. An action turn uses the normal
+governance and approval policy of its conversation.
+
+## Stop or restart a monitor
+
+Stop the monitor from the dashboard or ask the agent to stop it. The stop is
+durable: inspection retains a `user_stop` outcome instead of deleting the
+evidence. Success, provider or authentication blocks, exhausted budgets,
+unavailable sessions, and missing completion evidence also retain specific
+terminal reasons.
+
+Terminal records are read-only. Choose Restart in the dashboard or ask the agent
+to start a new watch.
+
+## Use a finite legacy loop
+
+For unsupported evidence or targets, ask Kiro Crew to run a same-session goal
+loop with a positive interval, cycle cap, and runtime limit. Every delivered
+cycle is a full agent turn, extends the conversation, and spends model and tool
+tokens even when nothing changed.
+
+The acknowledgement is only an arm request, so confirm the active goal loop in
+the dashboard. Stop it when the objective is met, the target becomes terminal,
+or a person must decide. Normal approval rules still apply; an unattended action
+may request approval, be rejected, or time out.

--- a/src/kiro_crew/mcp_tools/_limits.py
+++ b/src/kiro_crew/mcp_tools/_limits.py
@@ -12,3 +12,4 @@ from __future__ import annotations
 # A loop that reaches it ran out of rope rather than finishing, so the value
 # is a runaway guard, not a target.
 _MONITOR_DEFAULT_MAX_CYCLES = 24
+_MONITOR_DEFAULT_MAX_RUNTIME_SECS = 14_400

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -27,7 +27,10 @@ from urllib.parse import urlparse
 
 from kiro_crew import autonudge, mcp_core, platform_compat, session_directive
 from kiro_crew.mcp_shared import ToolCancelled, is_tool_cancelled
-from kiro_crew.mcp_tools._limits import _MONITOR_DEFAULT_MAX_CYCLES
+from kiro_crew.mcp_tools._limits import (
+    _MONITOR_DEFAULT_MAX_CYCLES,
+    _MONITOR_DEFAULT_MAX_RUNTIME_SECS,
+)
 from kiro_crew.monitoring.github_pull_request import parse_github_pull_request_target
 from kiro_crew.monitoring.models import (
     DEFAULT_MONITOR_AGENT_TURNS,
@@ -208,9 +211,9 @@ def schemas() -> list[dict[str, Any]]:
                 "Stop the auto-nudge loop driving your current session. Call this "
                 "when you determine the loop should halt (e.g. goal complete, "
                 "blocked on user input, or a STOP sentinel file indicates shutdown). "
-                "Removes the loop from the AutoNudgeService so no further nudges "
-                "fire into this session. Safe to call even if no loop is active — "
-                "returns a no-op message."
+                "Legacy loops are removed. For a structured monitor, this compatibility "
+                "alias records a durable user-stop outcome and retains the record for "
+                "inspection. Safe to call even if no loop is active."
             ),
             "inputSchema": {
                 "type": "object",
@@ -303,7 +306,8 @@ def schemas() -> list[dict[str, Any]]:
             "description": (
                 "Watch a GitHub pull request with cheap provider probes. The owning session "
                 "is woken only when a new revision needs action; unchanged, pending, retry, "
-                "and terminal probes use no agent turn. One structured monitor per session."
+                "and terminal probes use no agent turn. Available from dashboard, Slack, and "
+                "Discord sessions. One structured monitor per session."
             ),
             "inputSchema": {
                 "type": "object",
@@ -367,22 +371,30 @@ def schemas() -> list[dict[str, Any]]:
         {
             "name": "monitor_start",
             "description": (
-                "Start a monitoring loop on YOUR CURRENT session: every "
+                "Start a finite prompt loop for repeated work on YOUR CURRENT session, "
+                "including first-class self-session patrol by conductor agents. For "
+                "monitoring targets, this is also the legacy fallback for targets, "
+                "objectives, or required evidence unsupported by monitor_watch. "
+                "Use monitor_watch for public GitHub pull-request review readiness only when "
+                "the objective is fully determined by typed provider facts. Use the prompt "
+                "loop when comments or advisory review evidence must be interpreted. "
+                "Start a prompt loop on YOUR CURRENT session: every "
                 "interval_secs the given message is re-injected into this same "
                 "session as your next turn — same context, same tools, same "
                 "conversation. The countdown is deadline-preserving: user "
                 "messages defer a due fire until their turn ends but do NOT "
                 "restart the interval, so checks stay on schedule even in an "
                 "actively-used session. Works from dashboard chat, Slack "
-                "threads, and Discord DMs. Use when the user asks to babysit / "
-                "monitor / keep checking something (a PR, CI run, ticket, "
-                "deployment): put the check instructions and the exit condition "
-                "in the message, then END YOUR TURN — the loop wakes you on the "
+                "threads, Discord DMs, and Webex conversations. Put the check instructions and "
+                "the exit "
+                "condition in the message, then END YOUR TURN — the loop wakes you on the "
                 "interval. When the exit condition is met (or the user says "
                 "stop), call autonudge_stop — reaching max_cycles is a runaway "
-                "backstop, NOT a successful finish. Use monitor_update to "
-                "revise or re-arm the instruction if what you are watching "
-                "changes. One automation may occupy a session; monitor_start "
+                "backstop, NOT a successful finish. From dashboard, Slack, or "
+                "Discord, use monitor_update to revise or re-arm the instruction "
+                "if what you are watching changes. On Webex, stop the loop and "
+                "create a new finite one instead. One automation may occupy a "
+                "session; monitor_start "
                 "is create-only and refuses while an ACTIVE one exists (a "
                 "system-stopped or expired automation — an approval stall, a "
                 "spent cap or budget, a finished subject — is replaced by the "
@@ -445,20 +457,23 @@ def schemas() -> list[dict[str, Any]]:
                     },
                     "max_cycles": {
                         "type": "integer",
+                        "minimum": 1,
+                        "maximum": 1000,
                         "description": (
                             "Safety cap on delivered cycles (default "
-                            f"{_MONITOR_DEFAULT_MAX_CYCLES}). Pass 0 for "
-                            "unlimited only when the user explicitly wants an "
-                            "unbounded loop — an unbounded loop whose exit "
-                            "condition is never recognised runs forever"
+                            f"{_MONITOR_DEFAULT_MAX_CYCLES}). Use a larger finite "
+                            "value for a longer watch"
                         ),
                     },
                     "max_runtime_secs": {
                         "type": "integer",
+                        "minimum": 1,
+                        "maximum": 604800,
                         "description": (
                             "Wall-clock budget in seconds, measured from when "
-                            "the loop is armed (0 = unlimited, the default; "
-                            "max 604800 = 7 days). Unlike max_cycles this "
+                            "the loop is armed (default "
+                            f"{_MONITOR_DEFAULT_MAX_RUNTIME_SECS}; max 604800 = 7 days). "
+                            "Unlike max_cycles this "
                             "bounds elapsed TIME, so a loop with slow turns or "
                             "a long interval still stops on schedule. The "
                             "budget gates when turns START and re-checks the "
@@ -523,6 +538,8 @@ def schemas() -> list[dict[str, Any]]:
                     },
                     "max_cycles": {
                         "type": "integer",
+                        "minimum": 1,
+                        "maximum": 1000,
                         "description": (
                             "New cap on delivered cycles; raise it when a loop "
                             "is close to its cap but the work is still live. "
@@ -531,10 +548,12 @@ def schemas() -> list[dict[str, Any]]:
                     },
                     "max_runtime_secs": {
                         "type": "integer",
+                        "minimum": 1,
+                        "maximum": 604800,
                         "description": (
                             "New wall-clock budget in seconds, measured from "
-                            "when the loop was first armed (0 = unlimited, max "
-                            "604800 = 7 days). Omit to leave unchanged"
+                            "when the loop was first armed (max 604800 = 7 days). "
+                            "Omit to leave unchanged"
                         ),
                     },
                     "target": {
@@ -1089,7 +1108,7 @@ def autonudge_stop(name: str, args: dict[str, Any]) -> str:
     if mcp_core._autonudge_binding_key(sk) is None and sk:
         return (
             "No auto-nudge loop to stop: this tool only works from within "
-            "a dashboard, Slack, or Discord session "
+            "a dashboard, Slack, Discord, or Webex session "
             f"(current session_key={sk!r})."
         )
     return _emit_directive(
@@ -1166,25 +1185,22 @@ def monitor_start(name: str, args: dict[str, Any]) -> str:
     # (chat_runner) supplies the binding key and arms the loop.
     if mcp_core._autonudge_binding_key(sk) is None and sk:
         return (
-            "monitor_start only works from within a dashboard, Slack, or "
-            f"Discord session (current session_key={sk!r}). For other "
+            "monitor_start only works from within a dashboard, Slack, Discord, "
+            f"or Webex session (current session_key={sk!r}). For other "
             "contexts use cron_add or a HEARTBEAT.md task."
         )
     message = args["message"].strip()
     if not message:
         return "monitor_start: message must not be empty."
     interval_secs = int(args.get("interval_secs") or 300)
-    # Default to a BOUNDED cap. An unbounded loop only ever stops when the
-    # model volunteers an autonudge_stop, and observed loop stores show that
-    # is not reliable: real babysit loops ran to 24/24 and 20/20 cycles and
-    # terminated solely because a cap happened to be set. ``max_cycles=0``
-    # (explicit unlimited) is still honoured for callers that mean it.
+    # Default to bounded cycle and runtime caps. A loop without either bound
+    # only ever stops when the model volunteers an autonudge_stop, and observed
+    # loop stores show that is not reliable.
     raw_max = args.get("max_cycles")
     max_cycles = _MONITOR_DEFAULT_MAX_CYCLES if raw_max is None else int(raw_max)
-    # Wall-clock budget: opt-in (0 = unlimited). The cycle-cap default is
-    # the runaway backstop; the runtime budget is for callers that need a
-    # hard TIME bound (e.g. "babysit this for at most 2 hours").
-    max_runtime_secs = int(args.get("max_runtime_secs") or 0)
+    # The runtime budget is bounded by default alongside the cycle cap, so a
+    # quiet or slow loop cannot survive indefinitely without a fresh decision.
+    max_runtime_secs = int(args.get("max_runtime_secs") or _MONITOR_DEFAULT_MAX_RUNTIME_SECS)
     # The one escape from gating, and deliberately an opt-OUT. An opt-IN is what
     # An opt-out is used rather than opt-in: an opt-in default gates everything
     # and releases nothing (every opt-in mechanism sees zero adoption because
@@ -1249,21 +1265,30 @@ def monitor_start(name: str, args: dict[str, Any]) -> str:
             'loop <id> … next wake …" or "Automation loop NOT armed: <reason> '
             "[status N]\" — and the applier's own result replaces this text in "
             "the transcript. If the notice says NOT armed, read the reason "
-            "before trying again. Call autonudge_stop when the exit condition is "
-            "met; hitting the cap is a runaway backstop, not a finish. Use "
-            "monitor_update if the instruction goes stale."
+            "before trying again. Only a live dashboard/Slack/Discord/Webex "
+            "session can host a loop. Call autonudge_stop when "
+            "the exit condition is met; hitting the cap is a runaway backstop, "
+            "not a finish. From dashboard, Slack, or Discord, use monitor_update "
+            "if the instruction goes stale; on Webex, stop this loop and create "
+            "a new finite one instead."
         ),
     )
 
 
-def _monitor_context_refusal(tool_name: str, session_key: str, message: str) -> str:
+def _monitor_context_refusal(
+    tool_name: str,
+    session_key: str,
+    message: str,
+    *,
+    error: str = "unsupported_session_binding",
+) -> str:
     """Return a failed tool result and retain the security-relevant refusal."""
     mcp_core.sel().log_tool_invocation(
         session_key=session_key or "mcp_core",
         source="mcp",
         tool_name=tool_name,
         outcome="denied",
-        error="unsupported_session_binding",
+        error=error,
     )
     return f"Error: {message}"
 
@@ -1321,8 +1346,10 @@ def monitor_watch(name: str, args: dict[str, Any]) -> str:
     return _emit_directive(
         "monitor_watch",
         payload,
-        "Structured monitor requested for this session. End your turn; inspect the monitor "
-        "to confirm the authoritative consumer armed it.",
+        "Structured monitor requested for this session; application is still pending. "
+        "End your turn so the owning session can apply it. The operator can confirm it in "
+        "the dashboard; the agent can call monitor_inspect only at the start of a later "
+        "turn or in response to a later wake.",
     )
 
 
@@ -1377,6 +1404,7 @@ def _compact_monitor_inspection(result: dict[str, Any]) -> dict[str, Any]:
         "last_wake_fingerprint",
         "wake_in_flight",
         "wake_count",
+        "token_usage_known",
         "agent_turns",
         "input_tokens",
         "output_tokens",

--- a/src/kiro_crew/monitoring/controller.py
+++ b/src/kiro_crew/monitoring/controller.py
@@ -36,6 +36,13 @@ class _Loop(Protocol):
 
 
 class _Service(Protocol):
+    async def stop_monitor_if_budget_exhausted(
+        self,
+        monitor_id: str,
+        *,
+        now: float,
+    ) -> bool: ...
+
     async def apply_monitor_probe(
         self,
         monitor_id: str,
@@ -149,6 +156,8 @@ class MonitorController:
                     now=now,
                 )
             return MonitorVerdict(decision=MonitorDecision.NO_CHANGE)
+        if await self._service.stop_monitor_if_budget_exhausted(loop.id, now=now):
+            return MonitorVerdict(decision=MonitorDecision.STOP_BUDGET)
         config_generation = state.config_generation
         target = state.target
         previous_observation = deepcopy(state.last_observation)

--- a/src/kiro_crew/monitoring/models.py
+++ b/src/kiro_crew/monitoring/models.py
@@ -595,6 +595,9 @@ class MonitorState:
     stopped_reason: str = ""
     user_stop_reason: str = ""
     stopped_at: float = 0.0
+    # Persisted only after the dashboard accepts the terminal notice. False is
+    # fail-safe: a restart may repeat a notice, but it cannot lose the only one.
+    terminal_notification_delivered: bool = False
     extra_fields: dict[str, object] = field(default_factory=dict, repr=False)
     _raw_payload: dict[str, object] | None = field(default=None, repr=False, compare=False)
 
@@ -709,6 +712,8 @@ class MonitorState:
             raise ValueError("user_stop_reason must be a string")
         if len(self.user_stop_reason) > MAX_MONITOR_STOP_REASON_CHARS:
             raise ValueError("user_stop_reason is too long")
+        if not isinstance(self.terminal_notification_delivered, bool):
+            self.terminal_notification_delivered = False
         if not isinstance(self.extra_fields, dict):
             raise ValueError("extra_fields must be an object")
         _validate_strict_json_object("extra_fields", self.extra_fields)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -238,8 +238,14 @@ from kiro_crew.monitoring.completion import (
     is_monitor_completion_evidence,
 )
 from kiro_crew.monitoring.models import (
+    MONITOR_STOP_APPROVAL_STALL,
+    MONITOR_STOP_COMPLETION_UNAVAILABLE,
+    MONITOR_STOP_INVALID_RECORD,
+    MONITOR_STOP_SESSION_UNAVAILABLE,
+    MONITOR_STOP_UNSUPPORTED_VERSION,
     MonitorActionDisposition,
     MonitorDispatchResult,
+    MonitorOutcome,
     monitor_state_public_dict,
 )
 from kiro_crew.platform import boot_platform
@@ -6817,6 +6823,39 @@ class GatewayOrchestrator:
             return result
 
         controller: MonitorController | None = None
+        notified_monitor_terminals: set[tuple[str, MonitorOutcome, float]] = set()
+
+        async def _record_terminal_notification_delivery(
+            monitor_id: str,
+            outcome: MonitorOutcome,
+            stopped_at: float,
+        ) -> None:
+            try:
+                assert self.autonudge_svc is not None
+                await self.autonudge_svc.mark_terminal_notification_delivered(
+                    monitor_id,
+                    outcome,
+                    stopped_at,
+                )
+            except Exception:
+                # Delivery already happened. Leaving the marker unset makes a
+                # later restart retry the notice instead of losing it forever.
+                logger.warning(
+                    "AutoNudge: could not persist terminal notification delivery for %s",
+                    monitor_id,
+                    exc_info=True,
+                )
+
+        def _schedule_terminal_notification_delivery(
+            monitor_id: str,
+            outcome: MonitorOutcome,
+            stopped_at: float,
+        ) -> None:
+            task = asyncio.create_task(
+                _record_terminal_notification_delivery(monitor_id, outcome, stopped_at)
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         async def _monitor_tick(loop: NudgeLoop) -> None:
             if controller is not None:
@@ -6825,6 +6864,24 @@ class GatewayOrchestrator:
         def _observer(event: str, loop: NudgeLoop | None) -> None:
             if event == "expired" and loop is not None:
                 self._notify_nudge_expired(loop)
+            elif (
+                loop is not None
+                and is_structured_monitor_loop(loop)
+                and loop.monitor is not None
+                and not loop.active
+            ):
+                state = loop.monitor
+                if state.outcome in {
+                    MonitorOutcome.SUCCESS,
+                    MonitorOutcome.BLOCKED,
+                    MonitorOutcome.BUDGET,
+                    MonitorOutcome.TARGET_UNAVAILABLE,
+                }:
+                    terminal_key = (loop.id, state.outcome, state.stopped_at)
+                    if terminal_key not in notified_monitor_terminals:
+                        notified_monitor_terminals.add(terminal_key)
+                        if self._notify_nudge_expired(loop):
+                            _schedule_terminal_notification_delivery(*terminal_key)
             if self.dashboard_state and loop is not None:
                 loop_payload: dict[str, Any] = {
                     "id": loop.id,
@@ -6864,10 +6921,32 @@ class GatewayOrchestrator:
             on_monitor_tick=_monitor_tick,
         )
         controller = MonitorController(self.autonudge_svc, _fire_monitor)
-        self.autonudge_svc.subscribe(_observer)
         await self.autonudge_svc.start()
+        # A persisted terminal transition and its notification are separate
+        # durable steps. Replay any notice not proven delivered; marking only
+        # after delivery gives this boundary at-least-once crash semantics.
+        for loop in self.autonudge_svc.list_all():
+            if (
+                is_structured_monitor_loop(loop)
+                and loop.monitor is not None
+                and not loop.active
+                and loop.monitor.outcome
+                in {
+                    MonitorOutcome.SUCCESS,
+                    MonitorOutcome.BLOCKED,
+                    MonitorOutcome.BUDGET,
+                    MonitorOutcome.TARGET_UNAVAILABLE,
+                }
+            ):
+                terminal_key = (loop.id, loop.monitor.outcome, loop.monitor.stopped_at)
+                notified_monitor_terminals.add(terminal_key)
+                if not loop.monitor.terminal_notification_delivered and self._notify_nudge_expired(
+                    loop
+                ):
+                    await _record_terminal_notification_delivery(*terminal_key)
+        self.autonudge_svc.subscribe(_observer)
 
-    def _notify_nudge_expired(self, loop: NudgeLoop) -> None:
+    def _notify_nudge_expired(self, loop: NudgeLoop) -> bool:
         """Notify the user that a monitoring loop stopped at a terminal bound.
 
         Reaching ``max_cycles`` or spending ``max_runtime_secs`` is a runaway
@@ -6893,7 +6972,7 @@ class GatewayOrchestrator:
         follows it.
         """
         if not self.dashboard_state:
-            return
+            return False
         try:
             key = loop.slot_key
             # Channel-bound loops get NO synthesized meta: _notif_meta's generic
@@ -6902,6 +6981,81 @@ class GatewayOrchestrator:
             # Dashboard loops bind on the BARE slot key, so re-qualify those to
             # get a working jump-to-source slot link.
             meta = None if is_channel_key(key) else self._notif_meta(f"dashboard:{key}")
+            if is_structured_monitor_loop(loop):
+                monitor = loop.monitor
+                assert monitor is not None
+                outcome = monitor.outcome
+                reason = monitor.stopped_reason
+                if outcome is MonitorOutcome.SUCCESS and reason == "pull_request_merged":
+                    title = "Pull request monitor finished — pull request merged"
+                    body = "The pull request was merged. No action needed for this watch."
+                elif outcome is MonitorOutcome.SUCCESS:
+                    title = "Pull request monitor finished — review readiness reached"
+                    body = "The pull request is ready for review."
+                elif outcome is MonitorOutcome.BUDGET:
+                    title = "Pull request monitor spent its budget"
+                    body = (
+                        "The monitor stopped at its configured budget "
+                        "before the pull request became review-ready. "
+                        "Start a new watch with a larger budget to keep monitoring."
+                    )
+                elif outcome is MonitorOutcome.TARGET_UNAVAILABLE:
+                    title = "Pull request monitor could not deliver an action"
+                    body = (
+                        "This monitor's conversation could not accept work. "
+                        "Start a new watch from an active conversation."
+                    )
+                elif reason == "pull_request_closed":
+                    title = "Pull request monitor stopped — pull request closed unmerged"
+                    body = (
+                        "The pull request was closed without merging. Decide whether "
+                        "to reopen it or abandon this watch. Restart the monitor if you reopen it."
+                    )
+                else:
+                    title = "Pull request monitor stopped on a terminal blocker"
+                    body = {
+                        "provider_authentication": (
+                            "The provider rejected the monitor's credentials. "
+                            "Restore its credentials before restarting."
+                        ),
+                        "provider_authorization": (
+                            "The monitor no longer has permission to read this pull request. "
+                            "Restore provider access before restarting."
+                        ),
+                        "provider_setup": (
+                            "The monitor's provider setup is unavailable. "
+                            "Repair the provider configuration before restarting."
+                        ),
+                        MONITOR_STOP_APPROVAL_STALL: (
+                            "The monitor could not get tool approval. "
+                            "Restore approval access before restarting."
+                        ),
+                        MONITOR_STOP_COMPLETION_UNAVAILABLE: (
+                            "The monitor could not confirm completion of its last action. "
+                            "Check the conversation before restarting to avoid repeating work."
+                        ),
+                        MONITOR_STOP_SESSION_UNAVAILABLE: (
+                            "This monitor's conversation is unavailable. "
+                            "Start a new watch from an active conversation."
+                        ),
+                        MONITOR_STOP_UNSUPPORTED_VERSION: (
+                            "This watch was created by a newer Kiro Crew version. "
+                            "Update Kiro Crew to inspect or restart it."
+                        ),
+                        MONITOR_STOP_INVALID_RECORD: (
+                            "The saved monitor record is invalid. "
+                            "Inspect its details before starting a new watch."
+                        ),
+                    }.get(
+                        reason,
+                        "The monitor stopped before review readiness. Open its details "
+                        "in the dashboard and resolve the reported problem before restarting.",
+                    )
+                body = f"{body}\n\n{monitor.target}"
+                body, _ = redact_exfiltration_urls(body)
+                body, _ = redact_credentials(body)
+                self.dashboard_state.notify("agent", title, body, meta=meta)
+                return True
             capped_out = loop.max_cycles and loop.cycle_count >= loop.max_cycles
             # Every branch below except the terminal one explains why the loop stopped
             # SHORT of its goal. A terminal subject is not short of anything, so it
@@ -6952,37 +7106,7 @@ class GatewayOrchestrator:
                     "has no timed expiry."
                 )
             elif terminal:
-                # Reached only when no earlier branch claimed the notice, which the two
-                # ``not terminal`` guards above guarantee. FIRST in effect, ahead of every "why it stopped early" reading. Removing the cap
-                # guard from this branch was not enough: the runtime-budget and
-                # approval-stall branches are evaluated before it, so a terminal
-                # delivery that also exhausted the wall-clock budget still reported
-                # "its budget ran out without reporting done, its goal may still be
-                # unmet" about a finished subject. Every other branch here explains why
-                # the loop stopped SHORT of its goal; a terminal subject is not short of
-                # anything, so it outranks all of them rather than needing a guard added
-                # to each one as that one is found.
-                #
-                # It also cannot depend on ``capped_out``: the delivery that CARRIES the
-                # terminal news increments ``cycle_count`` before the settlement records
-                # the reason -- deliberately, so a cancelled write cannot lose the turn's
-                # accounting -- so a subject merging on the capping delivery would
-                # otherwise be announced as a cap with the goal possibly unmet.
-                #
-                # MERGED and CLOSED-UNMERGED are both terminal but they are not the same
-                # news. "No action needed" is true of the first and false of the second,
-                # which stopped on a question the operator has to answer: reopen, or
-                # abandon. The monitor's outcome carries the distinction (SUCCESS vs
-                # BLOCKED), so the wording follows it rather than lumping both under a
-                # finish.
                 settled = getattr(loop.monitor, "outcome", None) if loop.monitor else None
-                # A settled outcome wins. An UNSETTLED one falls back to the owed turn,
-                # which draws the same distinction from the same vocabulary -- the probe
-                # records ``"success" if merged else "blocked"``, matching
-                # ``MonitorOutcome.SUCCESS``/``BLOCKED``. Without this fallback a merged
-                # subject reaching here on the debt alone would take the else branch and
-                # be announced as closed-unmerged: the misleading-ending defect moved
-                # rather than fixed.
                 decided = getattr(settled, "value", settled) or owed
                 if decided == "success":
                     title = "Monitoring loop finished — what it was watching is done"
@@ -6992,7 +7116,7 @@ class GatewayOrchestrator:
                         "nothing left to observe. No action needed; arm a new loop "
                         "if you want to watch something else."
                     )
-                else:
+                elif decided == "blocked":
                     title = "Monitoring loop stopped — its subject was closed unmerged"
                     body = (
                         f"The loop stopped after {loop.cycle_count} cycles because "
@@ -7000,6 +7124,12 @@ class GatewayOrchestrator:
                         "merged. Nothing is left to observe, but the work is not "
                         "finished: decide whether to reopen it or abandon it, then "
                         "arm a new loop if you reopen."
+                    )
+                else:
+                    title = "Monitoring loop finished — it reported done"
+                    body = (
+                        f"The loop stopped after {loop.cycle_count} cycles because its "
+                        "goal reported completion. Open the session for the final details."
                     )
             else:
                 title = "Monitoring loop hit its cycle cap"
@@ -7010,8 +7140,10 @@ class GatewayOrchestrator:
                     "the cap or restart it."
                 )
             self.dashboard_state.notify("agent", title, body, meta=meta)
+            return True
         except Exception:
             logger.debug("AutoNudge expiry notification failed", exc_info=True)
+            return False
 
     @staticmethod
     def _defer_queued_delivery(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -65,6 +65,7 @@ from kiro_crew.autonudge import (
     is_channel_key,
     is_structured_monitor_loop,
     runtime_budget_exceeded,
+    terminal_notification_delivery_matches,
 )
 from kiro_crew.beacon import distribution
 from kiro_crew.channel_history import ChannelHistory
@@ -6567,7 +6568,7 @@ class GatewayOrchestrator:
                     await self._audit_fire_refused(loop, turn_slot)
                 if (
                     current_slot is not turn_slot
-                    or getattr(turn_slot, "_closing", False)
+                    or bool(getattr(turn_slot, "_closing", False))
                     or mode_refused
                     or str(getattr(turn_slot, "memory_mode", "persistent")) != "persistent"
                 ):
@@ -6846,14 +6847,46 @@ class GatewayOrchestrator:
                     exc_info=True,
                 )
 
-        def _schedule_terminal_notification_delivery(
-            monitor_id: str,
-            outcome: MonitorOutcome,
-            stopped_at: float,
+        async def _deliver_terminal_notification(
+            loop: NudgeLoop,
+            terminal_key: tuple[str, MonitorOutcome, float],
         ) -> None:
-            task = asyncio.create_task(
-                _record_terminal_notification_delivery(monitor_id, outcome, stopped_at)
-            )
+            notification_persisted = False
+            try:
+                if not self._notify_nudge_expired(loop):
+                    return
+                assert self.dashboard_state is not None
+                # notify() synchronously installs the append future before it
+                # returns. Capture that exact future before yielding so another
+                # notification cannot replace the state-wide pointer underneath
+                # this terminal generation.
+                persisted = self.dashboard_state.last_notification_persist
+                if persisted is not None and not await persisted:
+                    logger.warning(
+                        "AutoNudge: terminal notification persistence failed for %s",
+                        terminal_key[0],
+                    )
+                    return
+                notification_persisted = True
+            except Exception:
+                logger.warning(
+                    "AutoNudge: terminal notification persistence raised for %s",
+                    terminal_key[0],
+                    exc_info=True,
+                )
+                return
+            finally:
+                # The observer may emit the same terminal generation again.
+                # Release its in-process claim until a durable notice exists.
+                if not notification_persisted:
+                    notified_monitor_terminals.discard(terminal_key)
+            await _record_terminal_notification_delivery(*terminal_key)
+
+        def _schedule_terminal_notification(
+            loop: NudgeLoop,
+            terminal_key: tuple[str, MonitorOutcome, float],
+        ) -> None:
+            task = asyncio.create_task(_deliver_terminal_notification(loop, terminal_key))
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
 
@@ -6880,8 +6913,7 @@ class GatewayOrchestrator:
                     terminal_key = (loop.id, state.outcome, state.stopped_at)
                     if terminal_key not in notified_monitor_terminals:
                         notified_monitor_terminals.add(terminal_key)
-                        if self._notify_nudge_expired(loop):
-                            _schedule_terminal_notification_delivery(*terminal_key)
+                        _schedule_terminal_notification(loop, terminal_key)
             if self.dashboard_state and loop is not None:
                 loop_payload: dict[str, Any] = {
                     "id": loop.id,
@@ -6921,6 +6953,10 @@ class GatewayOrchestrator:
             on_monitor_tick=_monitor_tick,
         )
         controller = MonitorController(self.autonudge_svc, _fire_monitor)
+        # Timers can complete while start() awaits store repair. Install the
+        # observer first so that transition cannot fall between startup and
+        # terminal replay.
+        self.autonudge_svc.subscribe(_observer)
         await self.autonudge_svc.start()
         # A persisted terminal transition and its notification are separate
         # durable steps. Replay any notice not proven delivered; marking only
@@ -6939,12 +6975,14 @@ class GatewayOrchestrator:
                 }
             ):
                 terminal_key = (loop.id, loop.monitor.outcome, loop.monitor.stopped_at)
-                notified_monitor_terminals.add(terminal_key)
-                if not loop.monitor.terminal_notification_delivered and self._notify_nudge_expired(
-                    loop
-                ):
-                    await _record_terminal_notification_delivery(*terminal_key)
-        self.autonudge_svc.subscribe(_observer)
+                if terminal_key not in notified_monitor_terminals:
+                    notified_monitor_terminals.add(terminal_key)
+                    if not terminal_notification_delivery_matches(
+                        loop,
+                        loop.monitor.outcome,
+                        loop.monitor.stopped_at,
+                    ):
+                        _schedule_terminal_notification(loop, terminal_key)
 
     def _notify_nudge_expired(self, loop: NudgeLoop) -> bool:
         """Notify the user that a monitoring loop stopped at a terminal bound.

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -1244,16 +1244,16 @@ MONITOR_STOP_SCHEMA = ToolSchema(
 # monitor_start creates an AutoNudge loop bound to the calling session (the
 # agent-facing "babysit this PR" primitive). message caps match the REST
 # endpoint's 8000-char limit; interval bounds mirror autonudge's
-# _MIN_IDLE_SECS/_MAX_IDLE_SECS clamp. max_runtime_secs is the wall-clock
-# budget (0 = unlimited); the 7-day ceiling keeps a typo like 6e9 from arming
-# an effectively-unbounded loop while still covering week-long babysits.
+# _MIN_IDLE_SECS/_MAX_IDLE_SECS clamp. Both caps must be positive; the 7-day
+# runtime ceiling keeps a typo like 6e9 from arming an effectively unbounded
+# loop while still covering week-long babysits.
 MONITOR_START_SCHEMA = ToolSchema(
     tool_name="monitor_start",
     fields=[
         FieldSpec("message", str, required=True, max_len=8000),
         FieldSpec("interval_secs", int, min_val=15, max_val=86400),
-        FieldSpec("max_cycles", int, min_val=0, max_val=1000),
-        FieldSpec("max_runtime_secs", int, min_val=0, max_val=604800),
+        FieldSpec("max_cycles", int, min_val=1, max_val=1000),
+        FieldSpec("max_runtime_secs", int, min_val=1, max_val=604800),
         # Opt-OUT of observation gating. Absent means gated, matching the tool's
         # default, so a caller written before this field existed keeps the
         # default behaviour rather than silently escaping it.
@@ -1275,8 +1275,8 @@ MONITOR_UPDATE_SCHEMA = ToolSchema(
     fields=[
         FieldSpec("message", str, max_len=8000),
         FieldSpec("interval_secs", int, min_val=15, max_val=86400),
-        FieldSpec("max_cycles", int, min_val=0, max_val=1000),
-        FieldSpec("max_runtime_secs", int, min_val=0, max_val=604800),
+        FieldSpec("max_cycles", int, min_val=1, max_val=1000),
+        FieldSpec("max_runtime_secs", int, min_val=1, max_val=604800),
         FieldSpec("target", str, max_len=MAX_SHORT_STRING),
         FieldSpec("objective", str, allowed=publicly_armable_objectives()),
         FieldSpec("max_agent_turns", int, min_val=1, max_val=MAX_MONITOR_AGENT_TURNS),

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -67,6 +67,37 @@ def _structured_monitor(**changes: object) -> MonitorState:
 
 
 @pytest.mark.asyncio
+async def test_terminal_notification_delivery_is_persisted_for_exact_terminal(svc):
+    loop = NudgeLoop(
+        id="monitor1",
+        slot_key="chat-1-123",
+        message="watch it",
+        active=False,
+        monitor=_structured_monitor(
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=1_250.0,
+        ),
+    )
+    svc._loops[loop.id] = loop
+
+    assert await svc.mark_terminal_notification_delivered(
+        loop.id,
+        MonitorOutcome.SUCCESS,
+        1_250.0,
+    )
+
+    restored = AutoNudgeService(base_dir=svc._base_dir)
+    restored._load()
+    assert restored._loops[loop.id].monitor is not None
+    assert restored._loops[loop.id].monitor.terminal_notification_delivered
+    assert not await svc.mark_terminal_notification_delivered(
+        loop.id,
+        MonitorOutcome.BLOCKED,
+        1_250.0,
+    )
+
+
+@pytest.mark.asyncio
 async def test_add_and_fire_on_idle(svc, monkeypatch):
     """Arming a timer and letting it elapse triggers the fire callback."""
     fired: list[NudgeLoop] = []

--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -98,6 +98,42 @@ async def test_terminal_notification_delivery_is_persisted_for_exact_terminal(sv
 
 
 @pytest.mark.asyncio
+async def test_terminal_notification_delivery_survives_opaque_monitor_reload(svc):
+    monitor = _structured_monitor(
+        outcome=MonitorOutcome.SUCCESS,
+        stopped_at=1_250.0,
+    )
+    monitor.version = MONITOR_STATE_VERSION + 1
+    loop = NudgeLoop(
+        id="monitor-future",
+        slot_key="chat-1-123",
+        message="watch it",
+        active=False,
+        monitor=monitor,
+    )
+    svc._loops[loop.id] = loop
+    svc._save()
+    raw_monitor = json.loads(svc._path.read_text())["loops"][0]["monitor"]
+
+    first_reload = AutoNudgeService(base_dir=svc._base_dir)
+    first_reload._load()
+    assert await first_reload.mark_terminal_notification_delivered(
+        loop.id,
+        MonitorOutcome.BLOCKED,
+        0.0,
+    )
+    assert json.loads(svc._path.read_text())["loops"][0]["monitor"] == raw_monitor
+
+    second_reload = AutoNudgeService(base_dir=svc._base_dir)
+    second_reload._load()
+    assert not await second_reload.mark_terminal_notification_delivered(
+        loop.id,
+        MonitorOutcome.BLOCKED,
+        0.0,
+    )
+
+
+@pytest.mark.asyncio
 async def test_add_and_fire_on_idle(svc, monkeypatch):
     """Arming a timer and letting it elapse triggers the fire callback."""
     fired: list[NudgeLoop] = []

--- a/test/test_autonudge_banner.py
+++ b/test/test_autonudge_banner.py
@@ -1075,8 +1075,8 @@ class TestMonitorToolsCanSetTheBanner:
 
         ``test_autonudge_stop_auth.py`` pins the monitor_start payload with EXACT
         dict equality, so emitting ``banner`` unconditionally would break a
-        contract test belonging to another file. A caller that sets no banner must
-        see the payload it saw before.
+        contract test belonging to another file. This assertion follows the
+        finite-runtime default while keeping the banner absent.
         """
         result = _call_tool_inner("monitor_start", {"message": "watch CI", "max_cycles": 5})
         args = session_directive.decode(result, "monitor_start")
@@ -1084,7 +1084,7 @@ class TestMonitorToolsCanSetTheBanner:
             "message": "watch CI",
             "idle_secs": 300,
             "max_cycles": 5,
-            "max_runtime_secs": 0,
+            "max_runtime_secs": 14400,
             "gate": True,
         }, "the no-banner payload shape changed (banner must stay absent; gate is the tool default)"
 

--- a/test/test_autonudge_handlers_cov80.py
+++ b/test/test_autonudge_handlers_cov80.py
@@ -708,6 +708,8 @@ async def test_structured_legacy_row_carries_exactly_the_entitled_keys(
         "approval_stalled",
         "next_due_ts",
         "self_armed",
+        "terminal_notification_outcome",
+        "terminal_notification_stopped_at",
         # Mapped from the monitor's own accounting, not withheld -- withholding
         # them handed the component a default whose label reads "0 = infinity".
         "max_cycles",

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -75,7 +75,7 @@ def test_monitor_start_returns_directive_with_validated_payload(default_install,
         "message": "check PR #1 until green",
         "idle_secs": 300,
         "max_cycles": 5,
-        "max_runtime_secs": 0,
+        "max_runtime_secs": 14_400,
         # Whether the loop may be observation-gated. Always present and True
         # unless the caller opted out, so whichever surface applies this
         # directive reads the same decision the ack reported.
@@ -100,7 +100,7 @@ def test_monitor_start_returns_directive_with_validated_payload(default_install,
 
 def test_monitor_start_runtime_budget_passes_through(default_install):
     """An explicit wall-clock budget lands in the directive payload and is
-    echoed in the confirmation; omitting it defaults to 0 (unlimited)."""
+    echoed in the confirmation."""
     result = _call_tool_inner(
         "monitor_start",
         {"message": "watch CI", "max_runtime_secs": 7200},
@@ -121,12 +121,10 @@ def test_monitor_start_defaults_interval_300_and_bounded_cap(default_install):
     assert "no cycle cap" not in result.lower()
 
 
-def test_monitor_start_explicit_zero_cap_stays_zero(default_install):
-    """An explicit 0 means the caller really wants unlimited — 0 stays 0 and the
-    confirmation says so."""
-    result = _call_tool_inner("monitor_start", {"message": "watch PR", "max_cycles": 0})
-    assert session_directive.decode(result, "monitor_start")["max_cycles"] == 0
-    assert "no cycle cap" in result.lower()
+@pytest.mark.parametrize("field", ["max_cycles", "max_runtime_secs"])
+def test_monitor_start_rejects_unbounded_zero_limits(default_install, field):
+    with pytest.raises(ValidationError):
+        _call_tool_inner("monitor_start", {"message": "watch PR", field: 0})
 
 
 def test_monitor_start_interval_maps_to_idle_secs(default_install):

--- a/test/test_babysit_monitor_scenarios.py
+++ b/test/test_babysit_monitor_scenarios.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import ast
+import json
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import mcp_core, session_directive
+from kiro_crew.autonudge import AutoNudgeService, NudgeLoop, runtime_budget_exceeded
+from kiro_crew.dashboard.session_directive_apply import apply_session_directive
+from kiro_crew.mcp_tools import control
+from kiro_crew.monitoring.controller import MonitorController
+from kiro_crew.monitoring.github_pull_request import GitHubPullRequestProbeResult
+from kiro_crew.monitoring.models import (
+    MonitorDecision,
+    MonitorDispatchResult,
+    MonitorObservation,
+    MonitorObservationStatus,
+    MonitorOutcome,
+    ProviderErrorKind,
+    monitor_state_public_dict,
+)
+
+_SESSION_KEY = "dashboard:chat-1"
+_BINDING = "chat-1"
+_TARGET = "https://github.com/acme/widgets/pull/7"
+_BABYSIT_SKILL = (
+    Path(__file__).parents[1] / "src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md"
+)
+_SYSTEM_PROMPT = Path(__file__).parents[1] / "src/kiro_crew/config/prompt.md"
+
+
+def test_babysit_is_reachable_and_the_system_prompt_prefers_structured_watch() -> None:
+    skill = _BABYSIT_SKILL.read_text(encoding="utf-8")
+    prompt = _SYSTEM_PROMPT.read_text(encoding="utf-8")
+
+    assert "triggers: babysit" in skill
+    assert "monitor_watch" in prompt
+    assert "Use `monitor_start`" in prompt
+    assert "only for unsupported targets" in prompt
+    assert "HEARTBEAT.md" in prompt
+    assert "kiro_crew.heartbeat.append_heartbeat_task(entry)" in prompt
+
+
+def test_babysit_keeps_finite_legacy_path_for_unobserved_review_evidence() -> None:
+    skill = _BABYSIT_SKILL.read_text(encoding="utf-8")
+    legacy_recipe, _ = json.JSONDecoder().raw_decode(skill.split("monitor_start(", 1)[1])
+    legacy_recipe["message"] = legacy_recipe["message"].replace("<unsupported target>", _TARGET)
+    with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=_SESSION_KEY):
+        legacy = control.monitor_start(
+            "monitor_start",
+            legacy_recipe,
+        )
+
+    legacy_args = session_directive.decode(legacy, "monitor_start")
+    assert legacy_args is not None
+    assert legacy_args["max_cycles"] == 24
+    assert legacy_args["max_runtime_secs"] == 14_400
+    assert legacy_args["gate"] is False
+    assert "call the finite legacy path directly" in skill
+
+
+def test_babysit_keeps_finite_legacy_path_when_terminal_success_must_report() -> None:
+    skill = _BABYSIT_SKILL.read_text(encoding="utf-8")
+
+    assert "terminal success uses zero model turns" in skill
+    assert "final report or notification" in skill
+    assert "use the finite legacy path" in skill
+
+
+def test_prepare_pr_recipe_covers_its_poll_budget_without_provider_gating() -> None:
+    skill_path = _BABYSIT_SKILL.parent.parent / "prepare-pr/SKILL.md"
+    skill = skill_path.read_text(encoding="utf-8")
+    recipe = next(
+        textwrap.dedent(block).strip()
+        for block in skill.split("```")
+        if textwrap.dedent(block).strip().startswith("monitor_start(")
+    )
+    call = ast.parse(recipe, mode="eval").body
+    assert isinstance(call, ast.Call)
+    args = {kw.arg: ast.literal_eval(kw.value) for kw in call.keywords}
+    args["message"] = args["message"].replace("#<n>", _TARGET)
+    with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=_SESSION_KEY):
+        result = control.monitor_start("monitor_start", args)
+    applied = session_directive.decode(result, "monitor_start")
+    assert applied is not None
+    loop = NudgeLoop(
+        id="prepare-pr",
+        slot_key=_BINDING,
+        message=applied["message"],
+        idle_secs=applied["idle_secs"],
+        max_cycles=applied["max_cycles"],
+        max_runtime_secs=applied["max_runtime_secs"],
+        created_ts=1.0,
+    )
+    assert loop.max_runtime_secs > 0
+    assert not runtime_budget_exceeded(loop, now=loop.created_ts + loop.idle_secs * loop.max_cycles)
+    assert applied["gate"] is False
+
+
+def test_babysit_routes_webex_sessions_to_the_finite_legacy_path() -> None:
+    skill = _BABYSIT_SKILL.read_text(encoding="utf-8")
+
+    assert "dashboard, Slack, and Discord" in skill
+    assert "On Webex, use the finite legacy path" in skill
+
+
+def test_legacy_tool_description_scopes_structured_review_evidence() -> None:
+    descriptor = next(item for item in control.schemas() if item["name"] == "monitor_start")
+    description = descriptor["description"]
+
+    assert "fully determined by typed provider facts" in description
+    assert "pull-request review-readiness watch must use monitor_watch" not in description
+    assert "Webex" in description
+    assert "On Webex, stop the loop and create a new finite one instead" in description
+
+
+@pytest.fixture
+def monitor_service(tmp_path):
+    service = AutoNudgeService(base_dir=tmp_path)
+    yield service
+    service.stop()
+
+
+def _canonical(*, head_revision: str = "abc123") -> dict[str, object]:
+    return {
+        "kind": "github_pull_request",
+        "target": "github.com/acme/widgets#7",
+        "state": "open",
+        "draft": False,
+        "head_revision": head_revision,
+        "mergeability": "mergeable",
+        "review_decision": "approved",
+        "blocking_review": "none",
+        "unresolved_review_threads": 0,
+        "review_threads_complete": True,
+        "checks": {"failed": [], "passed": ["ci"], "pending": [], "unknown": []},
+    }
+
+
+def _probe_result(
+    status: MonitorObservationStatus,
+    *,
+    fingerprint: str = "fp-1",
+    reason_code: str = "checks_pending",
+    provider_error: ProviderErrorKind | None = None,
+) -> GitHubPullRequestProbeResult:
+    return GitHubPullRequestProbeResult(
+        response=None,
+        canonical={} if provider_error is not None else _canonical(),
+        observation=MonitorObservation(
+            "" if provider_error is not None else fingerprint,
+            status,
+            provider_error=provider_error,
+            reason_code=reason_code,
+            summary="Safe monitor summary.",
+        ),
+    )
+
+
+@dataclass
+class _Provider:
+    results: list[GitHubPullRequestProbeResult]
+    probe_count: int = 0
+
+    def probe(self, target: str, *, previous_observation=None):
+        del target, previous_observation
+        result = self.results[min(self.probe_count, len(self.results) - 1)]
+        self.probe_count += 1
+        return result
+
+
+def _state_and_slot():
+    state = SimpleNamespace(
+        _slots={_BINDING: SimpleNamespace(workspace="default")},
+        sessions=None,
+        channel_transports={},
+    )
+    return state, SimpleNamespace(key=_BINDING, _app="")
+
+
+def _call_directive(tool_name: str, args: dict[str, object]) -> tuple[str, dict[str, object]]:
+    with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=_SESSION_KEY):
+        result = mcp_core._call_tool_inner(tool_name, args)
+    directive = session_directive.decode(result, tool_name)
+    assert directive is not None
+    return result, directive
+
+
+async def _apply(
+    service: AutoNudgeService,
+    tool_name: str,
+    directive: dict[str, object],
+) -> str:
+    state, slot = _state_and_slot()
+    with (
+        patch("kiro_crew.autonudge.get_instance", return_value=service),
+        patch("kiro_crew.autonudge_authz.sel", return_value=MagicMock()),
+    ):
+        return await apply_session_directive(state, slot, _SESSION_KEY, tool_name, directive)
+
+
+async def _arm_via_session_consumer(
+    service: AutoNudgeService,
+    *,
+    max_runtime_secs: int = 14_400,
+) -> tuple[str, dict[str, object]]:
+    acknowledgement, directive = _call_directive(
+        "monitor_watch",
+        {
+            "kind": "github_pull_request",
+            "target": _TARGET,
+            "objective": "review_ready",
+            "interval_secs": 300,
+            "max_runtime_secs": max_runtime_secs,
+            "max_agent_turns": 8,
+            "max_tokens": 250_000,
+            "max_provider_errors": 3,
+            "wake_instructions": "Inspect the named blocker and act only if needed.",
+        },
+    )
+    assert service.get_by_slot(_BINDING) is None
+    applied = await _apply(service, "monitor_watch", directive)
+    assert "started" in applied
+    return acknowledgement, directive
+
+
+def _inspection(service: AutoNudgeService) -> dict[str, object]:
+    loop = service.get_by_slot(_BINDING)
+    response: dict[str, object] = {"enabled": True, "monitor": None}
+    if loop is not None and loop.monitor is not None:
+        response.update(
+            {
+                "active": loop.active,
+                "monitor_id": loop.id,
+                "monitor": monitor_state_public_dict(loop.monitor),
+            }
+        )
+    with (
+        patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=_SESSION_KEY),
+        patch("kiro_crew.mcp_core._get", return_value=response),
+    ):
+        return json.loads(mcp_core._call_tool_inner("monitor_inspect", {}))
+
+
+@pytest.mark.asyncio
+async def test_babysit_create_requires_application_before_state_is_authoritative(
+    monitor_service,
+):
+    acknowledgement, directive = _call_directive(
+        "monitor_watch",
+        {
+            "kind": "github_pull_request",
+            "target": _TARGET,
+            "objective": "review_ready",
+        },
+    )
+
+    assert "requested" in acknowledgement.lower()
+    assert "later turn" in acknowledgement.lower()
+    assert "session_key" not in directive
+    assert _inspection(monitor_service)["monitor"] is None
+
+    applied = await _apply(monitor_service, "monitor_watch", directive)
+    assert "started" in applied
+    inspection = _inspection(monitor_service)
+    monitor = inspection["monitor"]
+    assert inspection["active"] is True
+    assert isinstance(monitor, dict)
+    assert monitor["target"] == _TARGET
+    assert monitor["objective"] == "review_ready"
+    assert monitor["cadence_secs"] == 300
+    assert monitor["token_usage_known"] is True
+    assert monitor["budgets"] == {
+        "max_runtime_secs": 14_400,
+        "max_agent_turns": 8,
+        "max_tokens": 250_000,
+        "max_provider_errors": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_babysit_unchanged_observations_probe_without_agent_turns(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    created = loop.monitor.created_ts
+    provider = _Provider([_probe_result(MonitorObservationStatus.PENDING)])
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    first = await controller.tick(loop, now=created + 10)
+    second = await controller.tick(loop, now=created + 310)
+
+    assert first is MonitorDecision.RECORD_ONLY
+    assert second is MonitorDecision.NO_CHANGE
+    assert provider.probe_count == 2
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["probe_count"] == 2
+    assert inspection["wake_count"] == inspection["agent_turns"] == 0
+    assert inspection["next_probe_at"] == created + 610
+
+
+@pytest.mark.asyncio
+async def test_babysit_actionable_fingerprint_wakes_once_across_restart(monitor_service, tmp_path):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider(
+        [
+            _probe_result(
+                MonitorObservationStatus.ACTIONABLE,
+                fingerprint="head-2",
+                reason_code="new_head_revision",
+            )
+        ]
+    )
+    dispatch = AsyncMock(return_value=MonitorDispatchResult.DISPATCHED)
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+    now = loop.monitor.created_ts + 10
+
+    first = await controller.tick(loop, now=now)
+    second = await controller.tick(loop, now=now + 1)
+
+    assert first is MonitorDecision.WAKE_ACTIONABLE
+    assert second is MonitorDecision.NO_CHANGE
+    assert provider.probe_count == 1
+    dispatch.assert_awaited_once()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["last_wake_fingerprint"] == "head-2"
+    assert inspection["wake_count"] == 1
+    assert inspection["agent_turns"] == 0
+
+    monitor_service.stop()
+    restarted = AutoNudgeService(base_dir=tmp_path, on_monitor_tick=AsyncMock())
+    await restarted.start()
+    try:
+        restored = restarted.get_by_slot(_BINDING)
+        assert restored is not None and restored.monitor is not None
+        restarted_provider = _Provider(
+            [_probe_result(MonitorObservationStatus.ACTIONABLE, fingerprint="head-2")]
+        )
+        restarted_dispatch = AsyncMock(return_value=MonitorDispatchResult.DISPATCHED)
+        restarted_controller = MonitorController(
+            restarted,
+            restarted_dispatch,
+            provider=restarted_provider,
+        )
+
+        decision = await restarted_controller.tick(restored, now=now + 2)
+
+        assert decision is MonitorDecision.NO_CHANGE
+        assert restarted_provider.probe_count == 0
+        restarted_dispatch.assert_not_awaited()
+        assert restored.monitor.wake_count == 1
+    finally:
+        restarted.stop()
+
+
+@pytest.mark.asyncio
+async def test_babysit_success_stops_without_an_agent_turn(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider(
+        [
+            _probe_result(
+                MonitorObservationStatus.SUCCESS,
+                reason_code="review_ready",
+            )
+        ]
+    )
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.created_ts + 10)
+
+    assert decision is MonitorDecision.STOP_SUCCESS
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)
+    monitor = inspection["monitor"]
+    assert inspection["active"] is False
+    assert isinstance(monitor, dict)
+    assert monitor["outcome"] == MonitorOutcome.SUCCESS.value
+    assert monitor["stopped_reason"] == "review_ready"
+    assert monitor["agent_turns"] == 0
+
+
+@pytest.mark.asyncio
+async def test_babysit_provider_block_is_safe_and_turn_free(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider(
+        [
+            _probe_result(
+                MonitorObservationStatus.PROVIDER_ERROR,
+                reason_code="github_authentication_failed",
+                provider_error=ProviderErrorKind.AUTHENTICATION,
+            )
+        ]
+    )
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.created_ts + 10)
+
+    assert decision is MonitorDecision.STOP_BLOCKED
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["outcome"] == MonitorOutcome.BLOCKED.value
+    assert inspection["stopped_reason"] == "github_authentication_failed"
+    assert "stderr" not in json.dumps(inspection).lower()
+
+
+@pytest.mark.asyncio
+async def test_babysit_runtime_budget_stops_before_another_probe_or_turn(monitor_service):
+    await _arm_via_session_consumer(monitor_service, max_runtime_secs=60)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider([_probe_result(MonitorObservationStatus.ACTIONABLE)])
+    dispatch = AsyncMock()
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.created_ts + 60)
+
+    assert decision is MonitorDecision.STOP_BUDGET
+    assert provider.probe_count == 0
+    dispatch.assert_not_awaited()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["outcome"] == MonitorOutcome.BUDGET.value
+    assert inspection["stopped_reason"] == "runtime_budget"
+    assert inspection["wake_count"] == inspection["agent_turns"] == 0
+
+
+@pytest.mark.asyncio
+async def test_babysit_busy_retry_stops_at_runtime_without_another_action_attempt(
+    monitor_service,
+):
+    await _arm_via_session_consumer(monitor_service, max_runtime_secs=20)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    provider = _Provider([_probe_result(MonitorObservationStatus.ACTIONABLE)])
+    dispatch = AsyncMock(return_value=MonitorDispatchResult.BUSY)
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    first = await controller.tick(loop, now=loop.monitor.created_ts + 10)
+    expired = await controller.tick(loop, now=loop.monitor.created_ts + 25)
+
+    assert first is MonitorDecision.WAKE_ACTIONABLE
+    assert expired is MonitorDecision.STOP_BUDGET
+    assert provider.probe_count == 1
+    dispatch.assert_awaited_once()
+    inspection = _inspection(monitor_service)["monitor"]
+    assert isinstance(inspection, dict)
+    assert inspection["outcome"] == MonitorOutcome.BUDGET.value
+    assert inspection["stopped_reason"] == "runtime_budget"
+    assert inspection["wake_count"] == inspection["agent_turns"] == 0
+
+
+@pytest.mark.asyncio
+async def test_babysit_user_stop_uses_real_tool_and_retains_terminal_state(monitor_service):
+    await _arm_via_session_consumer(monitor_service)
+    _acknowledgement, directive = _call_directive(
+        "monitor_stop", {"reason": "User ended the watch."}
+    )
+
+    applied = await _apply(monitor_service, "monitor_stop", directive)
+
+    assert "retained" in applied
+    inspection = _inspection(monitor_service)
+    monitor = inspection["monitor"]
+    assert inspection["active"] is False
+    assert isinstance(monitor, dict)
+    assert monitor["outcome"] == MonitorOutcome.USER_STOP.value
+    assert monitor["stopped_reason"] == "user_stop"
+
+    provider = _Provider([_probe_result(MonitorObservationStatus.ACTIONABLE)])
+    dispatch = AsyncMock(return_value=MonitorDispatchResult.DISPATCHED)
+    loop = monitor_service.get_by_slot(_BINDING)
+    assert loop is not None and loop.monitor is not None
+    controller = MonitorController(monitor_service, dispatch, provider=provider)
+
+    decision = await controller.tick(loop, now=loop.monitor.stopped_at + 1)
+
+    assert decision is MonitorDecision.STOP_BLOCKED
+    dispatch.assert_not_awaited()

--- a/test/test_babysit_monitor_scenarios.py
+++ b/test/test_babysit_monitor_scenarios.py
@@ -29,10 +29,9 @@ from kiro_crew.monitoring.models import (
 _SESSION_KEY = "dashboard:chat-1"
 _BINDING = "chat-1"
 _TARGET = "https://github.com/acme/widgets/pull/7"
-_BABYSIT_SKILL = (
-    Path(__file__).parents[1] / "src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md"
-)
-_SYSTEM_PROMPT = Path(__file__).parents[1] / "src/kiro_crew/config/prompt.md"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BABYSIT_SKILL = _REPO_ROOT / "src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md"
+_SYSTEM_PROMPT = _REPO_ROOT / "src/kiro_crew/config/prompt.md"
 
 
 def test_babysit_is_reachable_and_the_system_prompt_prefers_structured_watch() -> None:
@@ -168,11 +167,11 @@ class _Provider:
     results: list[GitHubPullRequestProbeResult]
     probe_count: int = 0
 
-    def probe(self, target: str, *, previous_observation=None):
-        del target, previous_observation
+    def probe(self, subjects, *, previous_observations=None):
+        del previous_observations
         result = self.results[min(self.probe_count, len(self.results) - 1)]
         self.probe_count += 1
-        return result
+        return {subject: result for subject in subjects}
 
 
 def _state_and_slot():
@@ -297,8 +296,8 @@ async def test_babysit_unchanged_observations_probe_without_agent_turns(monitor_
     first = await controller.tick(loop, now=created + 10)
     second = await controller.tick(loop, now=created + 310)
 
-    assert first is MonitorDecision.RECORD_ONLY
-    assert second is MonitorDecision.NO_CHANGE
+    assert first.decision is MonitorDecision.RECORD_ONLY
+    assert second.decision is MonitorDecision.NO_CHANGE
     assert provider.probe_count == 2
     dispatch.assert_not_awaited()
     inspection = _inspection(monitor_service)["monitor"]
@@ -329,8 +328,8 @@ async def test_babysit_actionable_fingerprint_wakes_once_across_restart(monitor_
     first = await controller.tick(loop, now=now)
     second = await controller.tick(loop, now=now + 1)
 
-    assert first is MonitorDecision.WAKE_ACTIONABLE
-    assert second is MonitorDecision.NO_CHANGE
+    assert first.decision is MonitorDecision.WAKE_ACTIONABLE
+    assert second.decision is MonitorDecision.NO_CHANGE
     assert provider.probe_count == 1
     dispatch.assert_awaited_once()
     inspection = _inspection(monitor_service)["monitor"]
@@ -357,7 +356,7 @@ async def test_babysit_actionable_fingerprint_wakes_once_across_restart(monitor_
 
         decision = await restarted_controller.tick(restored, now=now + 2)
 
-        assert decision is MonitorDecision.NO_CHANGE
+        assert decision.decision is MonitorDecision.NO_CHANGE
         assert restarted_provider.probe_count == 0
         restarted_dispatch.assert_not_awaited()
         assert restored.monitor.wake_count == 1
@@ -383,7 +382,7 @@ async def test_babysit_success_stops_without_an_agent_turn(monitor_service):
 
     decision = await controller.tick(loop, now=loop.monitor.created_ts + 10)
 
-    assert decision is MonitorDecision.STOP_SUCCESS
+    assert decision.decision is MonitorDecision.STOP_SUCCESS
     dispatch.assert_not_awaited()
     inspection = _inspection(monitor_service)
     monitor = inspection["monitor"]
@@ -413,7 +412,7 @@ async def test_babysit_provider_block_is_safe_and_turn_free(monitor_service):
 
     decision = await controller.tick(loop, now=loop.monitor.created_ts + 10)
 
-    assert decision is MonitorDecision.STOP_BLOCKED
+    assert decision.decision is MonitorDecision.STOP_BLOCKED
     dispatch.assert_not_awaited()
     inspection = _inspection(monitor_service)["monitor"]
     assert isinstance(inspection, dict)
@@ -433,7 +432,7 @@ async def test_babysit_runtime_budget_stops_before_another_probe_or_turn(monitor
 
     decision = await controller.tick(loop, now=loop.monitor.created_ts + 60)
 
-    assert decision is MonitorDecision.STOP_BUDGET
+    assert decision.decision is MonitorDecision.STOP_BUDGET
     assert provider.probe_count == 0
     dispatch.assert_not_awaited()
     inspection = _inspection(monitor_service)["monitor"]
@@ -457,8 +456,8 @@ async def test_babysit_busy_retry_stops_at_runtime_without_another_action_attemp
     first = await controller.tick(loop, now=loop.monitor.created_ts + 10)
     expired = await controller.tick(loop, now=loop.monitor.created_ts + 25)
 
-    assert first is MonitorDecision.WAKE_ACTIONABLE
-    assert expired is MonitorDecision.STOP_BUDGET
+    assert first.decision is MonitorDecision.WAKE_ACTIONABLE
+    assert expired.decision is MonitorDecision.STOP_BUDGET
     assert provider.probe_count == 1
     dispatch.assert_awaited_once()
     inspection = _inspection(monitor_service)["monitor"]
@@ -493,5 +492,5 @@ async def test_babysit_user_stop_uses_real_tool_and_retains_terminal_state(monit
 
     decision = await controller.tick(loop, now=loop.monitor.stopped_at + 1)
 
-    assert decision is MonitorDecision.STOP_BLOCKED
+    assert decision.decision is MonitorDecision.STOP_BLOCKED
     dispatch.assert_not_awaited()

--- a/test/test_mcp_tool_registry.py
+++ b/test/test_mcp_tool_registry.py
@@ -63,6 +63,21 @@ def test_tool_names_are_unique_across_domains() -> None:
     assert sorted(names) == sorted(set(names))
 
 
+def test_legacy_monitor_descriptors_route_structured_watches_correctly() -> None:
+    """Model-facing compatibility tools must not steal supported PR watches."""
+    descriptors = {tool["name"]: tool["description"] for tool in _domain("control").schemas()}
+
+    start = descriptors["monitor_start"].lower()
+    assert "unsupported" in start
+    assert "monitor_watch" in start
+    assert "github" in start
+
+    stop = descriptors["autonudge_stop"].lower()
+    assert "structured" in stop
+    assert "durable" in stop
+    assert "retain" in stop
+
+
 @pytest.mark.parametrize("domain", DOMAIN_MODULES)
 def test_descriptor_shape(domain: str) -> None:
     """kiro-cli drops a tool whose descriptor is missing any of the three keys."""

--- a/test/test_monitor_controller.py
+++ b/test/test_monitor_controller.py
@@ -559,9 +559,11 @@ async def test_busy_delivery_retry_is_bounded_by_monitor_runtime(tmp_path):
     )
     controller = MonitorController(service, dispatched, provider=provider)
 
-    await controller.tick(loop, now=110.0)
-    await controller.tick(loop, now=125.0)
+    first = await controller.tick(loop, now=110.0)
+    expired = await controller.tick(loop, now=125.0)
 
+    assert first is MonitorDecision.WAKE_ACTIONABLE
+    assert expired is MonitorDecision.STOP_BUDGET
     assert len(provider.previous) == 1
     assert dispatched.await_count == 1
     assert loop.monitor is not None
@@ -862,6 +864,43 @@ async def test_dispatch_persistence_failure_leaves_live_claim_and_timer_unchange
 
 
 @pytest.mark.asyncio
+async def test_budget_stop_persistence_failure_leaves_active_monitor_armed(tmp_path, monkeypatch):
+    """A failed budget snapshot cannot make live state diverge from restart state."""
+    service = AutoNudgeService(base_dir=tmp_path, on_monitor_tick=AsyncMock())
+    loop = await service.add_monitor(
+        slot_key="chat-1",
+        kind="github_pull_request",
+        target="https://github.com/acme/widgets/pull/7",
+        objective="review_ready",
+        cadence_secs=60,
+        budgets=MonitorBudgets(max_runtime_secs=600),
+        now=100.0,
+    )
+    assert loop.monitor is not None
+    deadline_before = loop.next_due_ts
+    persisted_before = service._path.read_bytes()
+    timer_before = service._timers[loop.id]
+
+    async def fail_snapshot(_payload=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(service, "_write_monitor_snapshot_locked", fail_snapshot)
+
+    with pytest.raises(OSError, match="disk full"):
+        await service.stop_monitor_if_budget_exhausted(loop.id, now=701.0)
+
+    assert loop.active
+    assert loop.monitor.outcome is None
+    assert loop.monitor.stopped_reason == ""
+    assert loop.next_due_ts == loop.monitor.next_probe_at == deadline_before
+    assert service._path.read_bytes() == persisted_before
+    restored_timer = service._timers[loop.id]
+    assert restored_timer is timer_before
+    assert not restored_timer.done()
+    service.stop()
+
+
+@pytest.mark.asyncio
 async def test_cadence_edits_during_busy_preserve_retry_and_runtime_bound(tmp_path):
     """A large cadence cannot postpone the claimed retry beyond its runtime."""
     dispatched = AsyncMock(return_value=monitor_models.MonitorDispatchResult.BUSY)
@@ -891,13 +930,75 @@ async def test_cadence_edits_during_busy_preserve_retry_and_runtime_bound(tmp_pa
     assert loop.monitor.completion_evidence_deadline == 0.0
     assert service._timers.get(loop.id) is retry_timer
 
-    await controller.tick(loop, now=retry_at)
+    expired = await controller.tick(loop, now=retry_at)
 
+    assert expired is MonitorDecision.STOP_BUDGET
     assert len(provider.previous) == 1
     assert dispatched.await_count == 1
     assert not loop.active
     assert loop.monitor.outcome is MonitorOutcome.BUDGET
     assert loop.next_due_ts == loop.monitor.next_probe_at == 0.0
+
+
+@pytest.mark.asyncio
+async def test_busy_budget_stop_clears_late_acceptance_before_terminating(tmp_path):
+    """A BUSY settlement followed by provider acceptance cannot retain a dead claim."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = await service.add_monitor(
+        slot_key="chat-1",
+        kind="github_pull_request",
+        target="https://github.com/acme/widgets/pull/7",
+        objective="review_ready",
+        cadence_secs=60,
+        budgets=MonitorBudgets(max_runtime_secs=20),
+        now=100.0,
+    )
+    assert await service.mark_monitor_action_in_flight(loop.id, "fp-1", now=110.0)
+    await service.record_monitor_dispatch_busy(loop.id, "fp-1", now=110.0)
+    service.mark_monitor_turn_accepted(loop.id, "fp-1")
+    controller = MonitorController(
+        service,
+        AsyncMock(),
+        provider=_Provider(_result(MonitorObservationStatus.PENDING)),
+    )
+
+    assert await controller.tick(loop, now=124.0) is MonitorDecision.NO_CHANGE
+    retry_at = loop.next_due_ts
+    assert await controller.tick(loop, now=retry_at) is MonitorDecision.STOP_BUDGET
+
+    assert loop.monitor is not None
+    assert loop.monitor.outcome is MonitorOutcome.BUDGET
+    assert not loop.monitor.wake_in_flight
+    assert loop.monitor.completion_evidence_deadline == 0.0
+    assert loop.id not in service._accepted_monitor_turns
+    service.stop()
+
+
+@pytest.mark.asyncio
+async def test_direct_budget_stop_keeps_terminal_completion_timer(tmp_path):
+    """The shared budget helper must preserve an accepted turn's finite expiry."""
+    service = AutoNudgeService(base_dir=tmp_path)
+    loop = await service.add_monitor(
+        slot_key="chat-1",
+        kind="github_pull_request",
+        target="https://github.com/acme/widgets/pull/7",
+        objective="review_ready",
+        cadence_secs=60,
+        budgets=MonitorBudgets(max_runtime_secs=20),
+        now=100.0,
+    )
+    assert await service.mark_monitor_action_in_flight(loop.id, "fp-1", now=110.0)
+    service.mark_monitor_turn_accepted(loop.id, "fp-1")
+
+    assert await service.stop_monitor_if_budget_exhausted(loop.id, now=121.0)
+
+    assert loop.monitor is not None
+    assert loop.monitor.outcome is MonitorOutcome.BUDGET
+    assert loop.monitor.last_decision is MonitorDecision.STOP_BUDGET
+    assert loop.monitor.wake_in_flight
+    assert loop.monitor.completion_evidence_deadline > 121.0
+    assert loop.id in service._timers
+    service.stop()
 
 
 @pytest.mark.asyncio

--- a/test/test_monitor_controller.py
+++ b/test/test_monitor_controller.py
@@ -562,8 +562,8 @@ async def test_busy_delivery_retry_is_bounded_by_monitor_runtime(tmp_path):
     first = await controller.tick(loop, now=110.0)
     expired = await controller.tick(loop, now=125.0)
 
-    assert first is MonitorDecision.WAKE_ACTIONABLE
-    assert expired is MonitorDecision.STOP_BUDGET
+    assert first.decision is MonitorDecision.WAKE_ACTIONABLE
+    assert expired.decision is MonitorDecision.STOP_BUDGET
     assert len(provider.previous) == 1
     assert dispatched.await_count == 1
     assert loop.monitor is not None
@@ -932,7 +932,7 @@ async def test_cadence_edits_during_busy_preserve_retry_and_runtime_bound(tmp_pa
 
     expired = await controller.tick(loop, now=retry_at)
 
-    assert expired is MonitorDecision.STOP_BUDGET
+    assert expired.decision is MonitorDecision.STOP_BUDGET
     assert len(provider.previous) == 1
     assert dispatched.await_count == 1
     assert not loop.active
@@ -962,9 +962,9 @@ async def test_busy_budget_stop_clears_late_acceptance_before_terminating(tmp_pa
         provider=_Provider(_result(MonitorObservationStatus.PENDING)),
     )
 
-    assert await controller.tick(loop, now=124.0) is MonitorDecision.NO_CHANGE
+    assert (await controller.tick(loop, now=124.0)).decision is MonitorDecision.NO_CHANGE
     retry_at = loop.next_due_ts
-    assert await controller.tick(loop, now=retry_at) is MonitorDecision.STOP_BUDGET
+    assert (await controller.tick(loop, now=retry_at)).decision is MonitorDecision.STOP_BUDGET
 
     assert loop.monitor is not None
     assert loop.monitor.outcome is MonitorOutcome.BUDGET

--- a/test/test_monitor_directive_apply.py
+++ b/test/test_monitor_directive_apply.py
@@ -291,9 +291,11 @@ async def test_legacy_autonudge_stop_retains_only_structured_records(tmp_path):
     state = SimpleNamespace(_slots={}, sessions=None, channel_transports={})
     slot = SimpleNamespace(key="chat-1", _app="")
     with patch("kiro_crew.autonudge.get_instance", return_value=service):
-        await apply_session_directive(
+        result = await apply_session_directive(
             state, slot, "dashboard:chat-1", "autonudge_stop", {"reason": "legacy caller"}
         )
+    assert result.startswith(f"Structured monitor {structured.id} stopped and retained")
+    assert "No further monitor wakes" in result
     assert service.get_by_slot("chat-1") is structured
     assert structured.monitor is not None
     assert structured.monitor.outcome is MonitorOutcome.USER_STOP

--- a/test/test_monitor_mcp.py
+++ b/test/test_monitor_mcp.py
@@ -9,6 +9,12 @@ from kiro_crew import mcp_core, session_directive
 from kiro_crew.mcp_tools import control
 
 
+def test_monitor_watch_does_not_offer_an_unenforced_evidence_scope():
+    schema = next(item for item in control.schemas() if item["name"] == "monitor_watch")
+
+    assert "evidence_scope" not in schema["inputSchema"]["properties"]
+
+
 def test_monitor_watch_is_stateless_and_canonical(gateway_posts):
     with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value="dashboard:chat-1"):
         result = mcp_core._call_tool(
@@ -185,6 +191,7 @@ def test_monitor_inspect_passes_strict_identity_without_fallback():
                     "kind": "github_pull_request",
                     "created_ts": 123.0,
                     "wake_count": 3,
+                    "token_usage_known": False,
                     "wake_instructions": "large prompt omitted from inspect",
                     "last_wake_reason_code": "checks_failed",
                     "user_stop_reason": "operator stopped",
@@ -208,6 +215,7 @@ def test_monitor_inspect_passes_strict_identity_without_fallback():
     assert payload["monitor"]["wake_count"] == 3
     assert payload["monitor"]["last_wake_reason_code"] == "checks_failed"
     assert payload["monitor"]["user_stop_reason"] == "operator stopped"
+    assert payload["monitor"]["token_usage_known"] is False
     assert payload["monitor"]["last_observation_status"] == "pending"
     assert payload["monitor"]["last_observation_reason_code"] == "checks_pending"
     assert "last_observation_summary" not in payload["monitor"]

--- a/test/test_monitor_start_ack.py
+++ b/test/test_monitor_start_ack.py
@@ -13,6 +13,7 @@ import pytest
 
 from kiro_crew import mcp_core
 from kiro_crew.mcp_tools import control
+from kiro_crew.validation import ValidationError
 
 
 @pytest.fixture()
@@ -76,34 +77,17 @@ def test_the_ack_carries_the_opt_out_to_the_scheduler(bound_session):
     assert gated is not None and gated.get("gate") is True, "absent means gated"
 
 
-def test_a_gated_loop_with_zero_max_cycles_does_not_contradict_itself(bound_session):
-    """max_cycles=0 means "unlimited", so the ack must describe the cap exactly once.
-
-    The cap clause and the "NO cycle cap" clause live far apart in the ack
-    expression, so an explicit zero renders BOTH unless the cadence clause shares
-    the tail's truthiness guard -- asserting the loop both counts a cap and has
-    none -- on the one parameter that decides whether an unattended loop can spend
-    without limit.
-    """
-    out = _ack("Watch https://github.com/acme/widgets/pull/42", max_cycles=0)
-    assert not (
-        "cap counts" in out and "NO cycle cap" in out
-    ), "an unlimited gated loop must not both count a cap and declare none"
-    # The unlimited loop must POSITIVELY declare it has no cap, not just omit the
-    # contradiction: silence here would let a bounded-sounding ack ship for a loop
-    # that can actually spend without limit.
-    assert "NO cycle cap" in out, "a zero-cap gated loop must declare it has no cap"
-    assert "cap counts" not in out, "and must not also claim a cap counts turns"
+@pytest.mark.parametrize("max_cycles", [0, -1])
+def test_a_gated_loop_rejects_an_unbounded_cycle_budget(bound_session, max_cycles):
+    """A monitor must carry a positive finite cycle budget."""
+    with pytest.raises(ValidationError, match=r"max_cycles: must be >= 1"):
+        _ack("Watch https://github.com/acme/widgets/pull/42", max_cycles=max_cycles)
 
 
-def test_a_gated_loop_with_a_truthy_max_cycles_states_the_cap(bound_session):
-    """A truthy cap is the counterpart: the ack must state the cap and NOT deny it.
-
-    The zero-cap case proves the "unlimited" branch renders alone; this proves the
-    bounded branch does too, so the two clauses never both appear -- the same
-    contradiction, guarded from the other side.
-    """
-    out = _ack("Watch https://github.com/acme/widgets/pull/42", max_cycles=5)
+@pytest.mark.parametrize("max_cycles", [1, 5])
+def test_a_gated_loop_with_a_positive_max_cycles_states_the_cap(bound_session, max_cycles):
+    """A positive cap must be reported without an unlimited-budget claim."""
+    out = _ack("Watch https://github.com/acme/widgets/pull/42", max_cycles=max_cycles)
     assert "cap counts" in out, "a bounded gated loop must state its cap counts turns"
     assert "NO cycle cap" not in out, "and must not also declare it has no cap"
 

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2439,7 +2439,7 @@ class TestNotifyNudgeExpired:
         monitor's recorded outcome rather than lumping both under a finish.
         """
         import kiro_crew.autonudge as _an
-        from kiro_crew.monitoring.models import MonitorOutcome
+        from kiro_crew.monitoring.models import MonitorOutcome, MonitorState
 
         for outcome, expect_no_action in ((MonitorOutcome.SUCCESS, True), (MonitorOutcome.BLOCKED, False)):
             loop = self._loop()
@@ -2447,7 +2447,15 @@ class TestNotifyNudgeExpired:
             # loop would exercise the wrong case entirely.
             loop.cycle_count = 3
             loop.stopped_reason = _an.MONITOR_TERMINAL_REASON
-            loop.monitor = SimpleNamespace(outcome=outcome)
+            loop.monitor = MonitorState(
+                kind="github_pull_request",
+                target="https://github.com/acme/widgets/pull/7",
+                objective="review_ready",
+                created_ts=1.0,
+                outcome=outcome,
+                stopped_at=2.0,
+                stopped_reason="pull_request_merged" if expect_no_action else "pull_request_closed",
+            )
             state = MagicMock()
             GatewayOrchestrator._notify_nudge_expired(self._orch(state), loop)
             _args, _kwargs = state.notify.call_args

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -1005,7 +1005,7 @@ class TestFireSlackNudgeGuards:
 class TestAutonudgeRouterAndObserver:
     """``_init_autonudge`` builds the key-namespace router and the WS observer."""
 
-    async def _wire(self, orch: Any):
+    async def _wire(self, orch: Any, *, existing_loops: list[NudgeLoop] | None = None):
         with patch("kiro_crew.slack.gateway.autonudge_enabled", return_value=True):
             with (
                 patch("kiro_crew.slack.gateway.AutoNudgeService") as mock_svc,
@@ -1015,6 +1015,8 @@ class TestAutonudgeRouterAndObserver:
                 inst.start = AsyncMock()
                 inst.subscribe = MagicMock()
                 inst.remove = AsyncMock()
+                inst.mark_terminal_notification_delivered = AsyncMock()
+                inst.list_all.return_value = existing_loops or []
                 mock_svc.return_value = inst
                 await orch._init_autonudge()
                 inst.monitor_dispatch = mock_controller.call_args.args[1]
@@ -1155,6 +1157,100 @@ class TestAutonudgeRouterAndObserver:
 
         loop = _loop("chat-1-1721")
         observer("expired", loop)
+        orch._notify_nudge_expired.assert_called_once_with(loop)
+
+    @pytest.mark.asyncio
+    async def test_observer_notifies_one_structured_terminal_transition(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._notify_nudge_expired = MagicMock()
+        _on_fire, observer, _inst = await self._wire(orch)
+        loop = _loop("chat-1-1721")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+        )
+
+        observer("updated", loop)
+        observer("updated", loop)
+
+        orch._notify_nudge_expired.assert_called_once_with(loop)
+
+    @pytest.mark.asyncio
+    async def test_restart_replays_terminal_notice_without_delivery_record(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._notify_nudge_expired = MagicMock()
+        loop = _loop("chat-1-1721")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+        )
+        _on_fire, observer, inst = await self._wire(orch, existing_loops=[loop])
+
+        observer("updated", loop)
+
+        orch._notify_nudge_expired.assert_called_once_with(loop)
+        inst.mark_terminal_notification_delivered.assert_awaited_once_with(
+            loop.id,
+            MonitorOutcome.SUCCESS,
+            2.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_restart_deduplicates_terminal_notice_with_delivery_record(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._notify_nudge_expired = MagicMock()
+        loop = _loop("chat-1-1721")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+            terminal_notification_delivered=True,
+        )
+        _on_fire, observer, inst = await self._wire(orch, existing_loops=[loop])
+
+        observer("updated", loop)
+
+        orch._notify_nudge_expired.assert_not_called()
+        inst.mark_terminal_notification_delivered.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_observer_does_not_repeat_a_gated_legacy_terminal_notification(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._notify_nudge_expired = MagicMock()
+        _on_fire, observer, _inst = await self._wire(orch)
+        loop = _loop("slack:111.222")
+        loop.gate = True
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+        )
+
+        observer("expired", loop)
+        observer("fired", loop)
+
         orch._notify_nudge_expired.assert_called_once_with(loop)
 
     @pytest.mark.asyncio

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -78,6 +78,7 @@ def _make_orchestrator(**kwargs: Any) -> Any:
 def _mock_dashboard_state() -> MagicMock:
     ds = MagicMock()
     ds._slots = {}
+    ds.last_notification_persist = None
     ds.notify = MagicMock()
     ds.push_slots_update = MagicMock()
     ds.push_refresh = MagicMock()
@@ -1005,15 +1006,27 @@ class TestFireSlackNudgeGuards:
 class TestAutonudgeRouterAndObserver:
     """``_init_autonudge`` builds the key-namespace router and the WS observer."""
 
-    async def _wire(self, orch: Any, *, existing_loops: list[NudgeLoop] | None = None):
+    async def _wire(
+        self,
+        orch: Any,
+        *,
+        existing_loops: list[NudgeLoop] | None = None,
+        emit_during_start: NudgeLoop | None = None,
+    ):
         with patch("kiro_crew.slack.gateway.autonudge_enabled", return_value=True):
             with (
                 patch("kiro_crew.slack.gateway.AutoNudgeService") as mock_svc,
                 patch("kiro_crew.monitoring.controller.MonitorController") as mock_controller,
             ):
                 inst = MagicMock()
-                inst.start = AsyncMock()
                 inst.subscribe = MagicMock()
+
+                async def _start():
+                    if emit_during_start is not None and inst.subscribe.call_args is not None:
+                        observer = inst.subscribe.call_args.args[0]
+                        observer("updated", emit_during_start)
+
+                inst.start = AsyncMock(side_effect=_start)
                 inst.remove = AsyncMock()
                 inst.mark_terminal_notification_delivered = AsyncMock()
                 inst.list_all.return_value = existing_loops or []
@@ -1178,14 +1191,18 @@ class TestAutonudgeRouterAndObserver:
 
         observer("updated", loop)
         observer("updated", loop)
+        await asyncio.sleep(0)
 
         orch._notify_nudge_expired.assert_called_once_with(loop)
 
     @pytest.mark.asyncio
-    async def test_restart_replays_terminal_notice_without_delivery_record(self):
+    async def test_observer_marks_delivery_only_after_notification_persistence(self):
         orch = _make_orchestrator()
         orch.dashboard_state = _mock_dashboard_state()
-        orch._notify_nudge_expired = MagicMock()
+        persisted = asyncio.get_running_loop().create_future()
+        orch.dashboard_state.last_notification_persist = persisted
+        orch._notify_nudge_expired = MagicMock(return_value=True)
+        _on_fire, observer, inst = await self._wire(orch)
         loop = _loop("chat-1-1721")
         loop.active = False
         loop.monitor = MonitorState(
@@ -1196,16 +1213,115 @@ class TestAutonudgeRouterAndObserver:
             outcome=MonitorOutcome.SUCCESS,
             stopped_at=2.0,
         )
-        _on_fire, observer, inst = await self._wire(orch, existing_loops=[loop])
+
+        observer("updated", loop)
+        await asyncio.sleep(0)
+
+        inst.mark_terminal_notification_delivered.assert_not_awaited()
+        persisted.set_result(True)
+        await asyncio.sleep(0)
+
+        inst.mark_terminal_notification_delivered.assert_awaited_once_with(
+            loop.id,
+            MonitorOutcome.SUCCESS,
+            2.0,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("persistence_result", [False, RuntimeError("write failed")])
+    async def test_observer_retries_when_notification_persistence_fails(self, persistence_result):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        persisted = asyncio.get_running_loop().create_future()
+        if isinstance(persistence_result, Exception):
+            persisted.set_exception(persistence_result)
+        else:
+            persisted.set_result(persistence_result)
+        orch.dashboard_state.last_notification_persist = persisted
+        orch._notify_nudge_expired = MagicMock(return_value=True)
+        _on_fire, observer, inst = await self._wire(orch)
+        loop = _loop("chat-1-1721")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+        )
+
+        observer("updated", loop)
+        await asyncio.sleep(0)
+        observer("updated", loop)
+        await asyncio.sleep(0)
+
+        inst.mark_terminal_notification_delivered.assert_not_awaited()
+        assert orch._notify_nudge_expired.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_restart_replays_terminal_notice_without_delivery_record(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        notification_started = asyncio.Event()
+
+        def _notify(_loop: NudgeLoop) -> bool:
+            notification_started.set()
+            return True
+
+        orch._notify_nudge_expired = MagicMock(side_effect=_notify)
+        persisted = asyncio.get_running_loop().create_future()
+        orch.dashboard_state.last_notification_persist = persisted
+        loop = _loop("chat-1-1721")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+        )
+
+        startup = asyncio.create_task(self._wire(orch, existing_loops=[loop]))
+        await notification_started.wait()
+        await asyncio.sleep(0)
+        startup_blocked = not startup.done()
+
+        persisted.set_result(True)
+        _on_fire, observer, inst = await startup
+        await asyncio.sleep(0)
 
         observer("updated", loop)
 
+        assert not startup_blocked
         orch._notify_nudge_expired.assert_called_once_with(loop)
         inst.mark_terminal_notification_delivered.assert_awaited_once_with(
             loop.id,
             MonitorOutcome.SUCCESS,
             2.0,
         )
+
+    @pytest.mark.asyncio
+    async def test_terminal_transition_during_start_is_not_lost(self):
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch._notify_nudge_expired = MagicMock(return_value=True)
+        loop = _loop("chat-1-1721")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+        )
+
+        await self._wire(orch, emit_during_start=loop)
+        await asyncio.sleep(0)
+
+        orch._notify_nudge_expired.assert_called_once_with(loop)
 
     @pytest.mark.asyncio
     async def test_restart_deduplicates_terminal_notice_with_delivery_record(self):

--- a/test/test_slack_gateway_more_coverage.py
+++ b/test/test_slack_gateway_more_coverage.py
@@ -47,6 +47,7 @@ import pytest
 
 from kiro_crew.autonudge import APPROVAL_STALL_REASON, NudgeLoop
 from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.monitoring.models import MonitorOutcome, MonitorState
 from kiro_crew.slack import gateway as gw
 
 # ─── Helpers ─────────────────────────────────────────────────────────────
@@ -829,6 +830,139 @@ class TestNotifyNudgeExpired:
         assert title == "Monitoring loop spent its time budget"
         assert "60s wall-clock budget" in body
 
+    @pytest.mark.parametrize(
+        ("outcome", "title"),
+        [
+            (
+                MonitorOutcome.SUCCESS,
+                "Pull request monitor finished — review readiness reached",
+            ),
+            (MonitorOutcome.BUDGET, "Pull request monitor spent its budget"),
+            (MonitorOutcome.BLOCKED, "Pull request monitor stopped on a terminal blocker"),
+            (
+                MonitorOutcome.TARGET_UNAVAILABLE,
+                "Pull request monitor could not deliver an action",
+            ),
+        ],
+    )
+    def test_structured_terminal_wording(self, outcome: MonitorOutcome, title: str):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        loop = NudgeLoop(id="monitor-1", slot_key="chat-1", message="")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=outcome,
+            stopped_at=2.0,
+        )
+
+        orch._notify_nudge_expired(loop)
+
+        assert ds.notify.call_args.args[1] == title
+        assert loop.monitor.target in ds.notify.call_args.args[2]
+
+    @pytest.mark.parametrize(
+        ("outcome", "reason", "expected", "forbidden"),
+        [
+            (MonitorOutcome.BLOCKED, "pull_request_closed", "was closed without merging", "If"),
+            (MonitorOutcome.BLOCKED, "provider_authentication", "credentials", "reopen"),
+            (MonitorOutcome.BLOCKED, "provider_authorization", "permission", "reopen"),
+            (MonitorOutcome.BLOCKED, "provider_setup", "setup", "reopen"),
+            (MonitorOutcome.BLOCKED, "approval_stall", "approval", "reopen"),
+            (MonitorOutcome.BLOCKED, "completion_evidence_unavailable", "completion", "reopen"),
+            (MonitorOutcome.BLOCKED, "session_unavailable", "conversation", "reopen"),
+            (
+                MonitorOutcome.BLOCKED,
+                "unsupported_monitor_version",
+                "Update Kiro Crew",
+                "reopen",
+            ),
+            (MonitorOutcome.BLOCKED, "invalid_monitor_record", "record", "reopen"),
+            (MonitorOutcome.BLOCKED, "future_reason", "details", "reopen"),
+            (MonitorOutcome.SUCCESS, "pull_request_merged", "was merged", "review-ready"),
+            (MonitorOutcome.SUCCESS, "review_ready", "ready for review", "decide the next step"),
+        ],
+    )
+    def test_structured_notice_uses_the_recorded_reason(self, outcome, reason, expected, forbidden):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        loop = NudgeLoop(id="monitor-1", slot_key="discord:kirocrew:direct:42", message="")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=outcome,
+            stopped_at=2.0,
+            stopped_reason=reason,
+        )
+
+        orch._notify_nudge_expired(loop)
+
+        ds.notify.assert_called_once()
+        body = ds.notify.call_args.args[2]
+        assert expected in body
+        assert forbidden not in body
+        assert loop.monitor.target in body
+        assert ds.notify.call_args.kwargs["meta"] is None
+
+    def test_budget_notice_explains_how_to_continue(self):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        loop = NudgeLoop(id="monitor-1", slot_key="chat-1", message="")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target="https://github.com/acme/widgets/pull/7",
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.BUDGET,
+            stopped_at=2.0,
+        )
+
+        orch._notify_nudge_expired(loop)
+
+        assert "Start a new watch with a larger budget" in ds.notify.call_args.args[2]
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "https://github.com/acme/ghp_" + "a" * 36 + "/pull/7",
+            "https://example.com/?data=%67%68%70%5F" + "a" * 36,
+            "ghp_" + "a" * 36,
+        ],
+    )
+    def test_structured_notice_redacts_unsafe_retained_target(self, target):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        loop = NudgeLoop(id="monitor-1", slot_key="chat-1", message="")
+        loop.active = False
+        loop.monitor = MonitorState(
+            kind="github_pull_request",
+            target=target,
+            objective="review_ready",
+            created_ts=1.0,
+            outcome=MonitorOutcome.SUCCESS,
+            stopped_at=2.0,
+            stopped_reason="pull_request_merged",
+        )
+
+        orch._notify_nudge_expired(loop)
+
+        body = ds.notify.call_args.args[2]
+        assert "was merged" in body
+        assert target not in body
+        assert "ghp_" not in body
+        assert "REDACTED" in body
+
     def test_cycle_cap_wording(self):
         orch = _make_orchestrator()
         ds = _mock_dashboard_state()
@@ -853,7 +987,6 @@ class TestNotifyNudgeExpired:
         flag the earlier branches defer to.
         """
         from kiro_crew.autonudge import MONITOR_TERMINAL_REASON
-        from kiro_crew.monitoring.models import MonitorOutcome, MonitorState
 
         orch = _make_orchestrator()
         ds = _mock_dashboard_state()
@@ -867,18 +1000,11 @@ class TestNotifyNudgeExpired:
             max_runtime_secs=60,
             created_ts=time.time() - 600,
             stopped_reason=MONITOR_TERMINAL_REASON,
-            monitor=MonitorState(
-                kind="gh-pr",
-                target="acme/widgets#42",
-                objective="watch until green",
-                created_ts=0.0,
-                outcome=MonitorOutcome.SUCCESS,
-            ),
         )
         orch._notify_nudge_expired(loop)
         title = ds.notify.call_args.args[1]
         assert "time budget" not in title, "a finished subject is not a spent budget"
-        assert "finished" in title
+        assert title == "Monitoring loop finished — it reported done"
 
     def test_a_terminal_subject_outranks_the_cycle_cap(self):
         """A merge that lands ON the capping delivery must not read as an unmet goal.
@@ -891,7 +1017,6 @@ class TestNotifyNudgeExpired:
         a watch whose subject had merged.
         """
         from kiro_crew.autonudge import MONITOR_TERMINAL_REASON
-        from kiro_crew.monitoring.models import MonitorOutcome, MonitorState
 
         orch = _make_orchestrator()
         ds = _mock_dashboard_state()
@@ -903,114 +1028,49 @@ class TestNotifyNudgeExpired:
             max_cycles=4,
             cycle_count=4,
             stopped_reason=MONITOR_TERMINAL_REASON,
-            monitor=MonitorState(
-                kind="gh-pr",
-                target="acme/widgets#42",
-                objective="watch until green",
-                created_ts=0.0,
-                outcome=MonitorOutcome.SUCCESS,
-            ),
         )
         orch._notify_nudge_expired(loop)
         title = ds.notify.call_args.args[1]
         assert "cycle cap" not in title, "a finished subject is terminal, cap or no cap"
-        assert "finished" in title, "and a merged one is reported as done"
+        assert title == "Monitoring loop finished — it reported done"
 
-    def test_an_owed_terminal_turn_outranks_the_cycle_cap(self):
-        """A channel loop's UNSETTLED terminal subject must not read as a spent cap.
-
-        The third instance of the class the two tests above closed, and the one they
-        cannot cover: both of those settle first, so ``stopped_reason`` already carries
-        ``MONITOR_TERMINAL_REASON``. A CHANNEL-bound loop deliberately does NOT settle
-        on observation -- it learns its watch finished from a delivered turn, so the
-        probe records the OWED turn in ``monitor.terminal_pending`` and leaves the loop
-        active with no outcome. If that final turn is refused (a busy thread, the
-        ordinary case) and the retry finds the cap spent, ``_timer`` deactivates with
-        ``stopped_reason="cycle_cap"`` before the settlement that would have promoted
-        the debt ever runs.
-
-        So the truth is already durably persisted on disk and the notice contradicts
-        it: a watch whose subject MERGED reports the same signal as one that ran out of
-        cycles with its goal unmet. ``terminal`` therefore cannot be read from
-        ``stopped_reason`` alone -- an owed terminal turn is terminal news too.
-        """
-        from kiro_crew.monitoring.models import MonitorState
-
+    @pytest.mark.parametrize(
+        ("pending", "expected_title", "expected_body"),
+        [
+            ("success", "Monitoring loop finished — what it was watching is done", "merged"),
+            ("blocked", "Monitoring loop stopped — its subject was closed unmerged", "WITHOUT"),
+        ],
+    )
+    def test_an_owed_legacy_terminal_turn_outranks_the_cycle_cap(
+        self, pending, expected_title, expected_body
+    ):
+        """A gated legacy loop keeps terminal truth even when its cap wins the race."""
         orch = _make_orchestrator()
         ds = _mock_dashboard_state()
         orch.dashboard_state = ds
         loop = NudgeLoop(
-            id="loop-owed-terminal-at-cap",
+            id=f"loop-owed-{pending}",
             slot_key="slack:C123:456.789",
             message="watch https://github.com/acme/widgets/pull/42 until green",
             max_cycles=4,
             cycle_count=4,
             stopped_reason="cycle_cap",
+            gate=True,
             monitor=MonitorState(
                 kind="gh-pr",
                 target="acme/widgets#42",
                 objective="watch until green",
                 created_ts=0.0,
-                # The settlement never ran, so there is no ``outcome`` and no
-                # ``MONITOR_TERMINAL_REASON`` -- only the owed turn, on disk.
-                terminal_pending="success",
+                terminal_pending=pending,
             ),
         )
+
         orch._notify_nudge_expired(loop)
-        title = ds.notify.call_args.args[1]
-        body = ds.notify.call_args.args[2]
-        assert "cycle cap" not in title, (
-            "the subject merged and the debt says so on disk -- reporting a spent cap "
-            "is a false status report"
-        )
-        assert "finished" in title
-        assert "merged" in body
 
-    def test_an_owed_blocked_turn_is_not_reported_as_a_merge(self):
-        """The debt carries SUCCESS vs BLOCKED, and the wording must follow it.
+        assert ds.notify.call_args.args[1] == expected_title
+        assert expected_body in ds.notify.call_args.args[2]
 
-        ``terminal_pending`` is set to ``"success" if merged else "blocked"``, the same
-        vocabulary as ``MonitorOutcome``. Treating any owed turn as a finish would tell
-        the operator "no action needed" about a pull request that was closed UNMERGED --
-        which stopped on a question only they can answer.
-        """
-        from kiro_crew.monitoring.models import MonitorState
-
-        orch = _make_orchestrator()
-        ds = _mock_dashboard_state()
-        orch.dashboard_state = ds
-        loop = NudgeLoop(
-            id="loop-owed-blocked-at-cap",
-            slot_key="slack:C123:456.790",
-            message="watch https://github.com/acme/widgets/pull/43 until green",
-            max_cycles=4,
-            cycle_count=4,
-            stopped_reason="cycle_cap",
-            monitor=MonitorState(
-                kind="gh-pr",
-                target="acme/widgets#43",
-                objective="watch until green",
-                created_ts=0.0,
-                terminal_pending="blocked",
-            ),
-        )
-        orch._notify_nudge_expired(loop)
-        title = ds.notify.call_args.args[1]
-        body = ds.notify.call_args.args[2]
-        assert "cycle cap" not in title
-        assert "closed unmerged" in title
-        assert "WITHOUT being" in body
-
-    def test_a_spent_cap_with_no_owed_turn_still_reports_the_cap(self):
-        """The control: the carve-out must not swallow a genuine cap.
-
-        A loop that really did run out of cycles has an empty ``terminal_pending``, and
-        must keep the cap wording -- otherwise the fix for a misleading finish would
-        manufacture a finish that never happened, which is the same defect pointing the
-        other way.
-        """
-        from kiro_crew.monitoring.models import MonitorState
-
+    def test_a_legacy_cap_with_no_owed_turn_still_reports_the_cap(self):
         orch = _make_orchestrator()
         ds = _mock_dashboard_state()
         orch.dashboard_state = ds
@@ -1021,6 +1081,7 @@ class TestNotifyNudgeExpired:
             max_cycles=4,
             cycle_count=4,
             stopped_reason="cycle_cap",
+            gate=True,
             monitor=MonitorState(
                 kind="gh-pr",
                 target="acme/widgets#44",
@@ -1029,7 +1090,9 @@ class TestNotifyNudgeExpired:
                 terminal_pending="",
             ),
         )
+
         orch._notify_nudge_expired(loop)
+
         assert ds.notify.call_args.args[1] == "Monitoring loop hit its cycle cap"
 
     def test_approval_stall_names_its_own_remedy(self):


### PR DESCRIPTION
> Stacked change: **PR 7 of 8**
>
> Stack: #5180 → #5181 → #5182 → #5183 → #5184 → #5185 → #5186 → #5305
> Base: #5185
> Next: #5305

## Problem / Motivation

The shipped babysit guidance teaches prompt-owned polling, voluntary completion detection, and manually managed progress state for GitHub pull requests.

## Why it matters

That guidance spends a full agent turn on unchanged state and empirically tends to stop at its cap instead of stopping because the objective was actually observed.

## What changed (motivation → approach → change)

- Replace GitHub polling instructions with one bounded `monitor_watch` call, later authoritative `monitor_inspect` calls, and explicit `monitor_update` re-arming.
- Document conductor self-patrol as a first-class monitor use while keeping the compatibility watcher finite and secondary.
- Document zero-turn unchanged probes, one wake per actionable fingerprint, finite budgets, completed-turn accounting, durable stop, and explicit restart.
- Persist pre-probe budget exhaustion before disarming the live monitor, keeping memory and restart state aligned when a terminal write fails.
- Route Webex sessions through the finite legacy path because structured wake delivery and completion correlation are unavailable there.
- Keep a clearly labeled finite legacy fallback for unsupported targets and readiness definitions that depend on generic PR comments or advisory findings outside the typed provider facts.
- Add packaged monitoring guidance and executable lifecycle scenarios using the real tool-to-directive-to-controller path.
- Scope the legacy tool advertisement to public GitHub at this layer and to the same evidence boundary: structured review readiness is preferred only when typed provider facts fully determine it.
- Route requests that require a final report or notification through the finite legacy path, because terminal structured success deliberately consumes zero model turns.

- Deliver gated legacy Slack terminal notifications with durable at-least-once acknowledgement: terminal state is persisted before delivery, startup replays retained undelivered notifications, and the exact monitor generation is marked only after emission; audit unsupported evidence scopes separately from unsupported session bindings.

- Render terminal notifications from the stored stop reason: state closed-unmerged PRs directly, distinguish merged from ready-for-review success, name known provider/delivery blockers, and identify the watched PR URL even for channel-bound watches. Unknown reasons retain a safe details fallback; unavailable conversations point to a new watch from an active conversation.

- Scope the finite-budget policy to the legacy MCP tools: shared REST/workflow AutoNudge helpers retain `0 = unlimited`, with the seven-day ceiling applying to positive runtime grants.

## Tests

- Eight executable babysit lifecycle scenarios
- Tool schema and authoritative application boundaries
- No-change, actionable deduplication, success, blocked, budget, BUSY-expiry, user-stop, and restart behavior
- Fresh instruction pressure samples using the exact bounded tool schema
- Policy contracts for comment-only and advisory review evidence outside the provider, plus the terminal-report boundary

Previous notification verification: all 32 focused notification/observer tests pass, including 12 reason-specific regressions and target identification for dashboard and channel-bound watches. Merged success alone says no action is needed; review readiness asks the operator to review the PR, and only a recorded closed-unmerged reason offers reopening. Focused Linux-platform mypy, Black, flake8, isort, docs lint, brand, and diff checks pass. The notification-only follow-up does not change budgets, delivery, or terminal-wake policy. The overall PR does change legacy MCP defaults: 24 cycles and 4 hours, with explicit zero/unlimited caps rejected. Long-interval watches need an explicitly larger runtime (up to 7 days); the runtime limit can stop the watch before all 24 cycles are used. Shared REST/workflow helpers retain zero/unlimited compatibility. Fresh CI and UX review on the pushed head are pending.

Previous recipe follow-up: the finite legacy recipe explicitly sets `gate: false`, so unchanged typed provider facts cannot suppress cycles that must inspect generic comments or advisory feedback. The executable recipe regression failed with the old omitted flag and passes with the correction; a fresh reader also includes the opt-out. All 22 focused babysit/ack tests pass. The specification now accurately distinguishes positive MCP budgets from REST/workflow zero/unlimited compatibility. Docs lint, Black, flake8, brand, and diff checks pass. Screenshot bytes and runtime implementation are unchanged by this follow-up; fresh CI is pending on the restacked head.

Previous security follow-up: redact the completed terminal notification body, including retained targets, through the shared URL and credential redactors before dashboard persistence. Three regressions cover credential-shaped GitHub paths, encoded credentials in URLs, and malformed retained plain credentials; all three fail without the fix. All 54 focused notification, gateway-initialization, babysit, and acknowledgement tests pass on this layer. Black, isort, flake8, docs lint, and diff checks pass. The composed top also passes all 187 focused tests and Linux-targeted handler mypy. Screenshot bytes are unchanged; fresh CI and review on `5c975cb4467f15bdde12340785f4680908ec5fe3` are pending. No manual CI rerun.

Latest main-restack verification on `c3169529b90019775a65cecdfd7429556ba01926`: all 112 focused monitor, babysit, acknowledgement, directive, dashboard-handler, and Slack notification tests passed. Docs lint and diff checks also passed. The documentation conflict preserves `main`'s shared loop-by-id accessor invariant while retaining this layer's structured-monitor contract. Screenshot bytes are unchanged. Fresh CI and reviews are pending; no manual CI rerun was made.

## Manual verification

N/A — executable lifecycle scenarios cover runtime outcomes, and a focused policy contract pins the skill's structured-versus-legacy evidence boundary.

## Related Issues

N/A — completes the migration specified in #5180 and depends on #5185.

## Checklist

- [x] Commit count satisfies the stacked PR hygiene limit
- [x] Existing tests pass and new tests cover the new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not yet supply final CLA wording.

Current review/CI follow-up on `a46b9635bc317874b4a28d8d274da9b9e3cecbad`: restore the documentation tail lost during conflict reconstruction; use inferable pull-request URLs in both monitor examples; distinguish Webex's stop-and-recreate path from monitor_update; and align the banner regression with this layer's intentional four-hour finite default while continuing to require the banner field to be absent. All 300 focused monitor, babysit, acknowledgement, directive, and registry tests pass. Docs lint, Black, flake8, and diff checks pass. Screenshot bytes are unchanged. Fresh CI and reviews are pending; no manual CI rerun was made.

Current main-restack verification on `c0056fdc0b4457f148876457c528985aeae0b1d9`: this layer is directly based on #5185 at `85e0baa2c4e24b322e9fa1c1af8e08a21fe6589a`. Terminal notification delivery is durable and replay-safe for the exact monitor generation. The composed stack passes all 2,430 changed backend tests and all 101 focused sidebar/popover frontend tests; TypeScript compilation and the production frontend build also pass. Screenshot bytes are unchanged. Fresh CI and reviews are running; no manual CI rerun was made.


Current durability/restack verification on `3b5f883a3721d35179b1b7d7caeb14c8df6dd317`: this layer is directly based on #5185 at `c5688956f5159c509895e7e1a96a3aad96ef1bfb`. Terminal notification persistence is awaited successfully before the exact generation is marked delivered, so failed writes remain replayable. The composed open stack passes all 446 focused controller, provider, AutoNudge, and Slack gateway tests; focused Linux mypy, flake8, and docs lint pass. Screenshot bytes are unchanged. Fresh CI and reviews are running; no manual CI rerun was made.

Current main-restack verification on `b2e22498966e2c2aa4f016e85426a5facb616c6f`: this two-commit layer is directly based on #5185 at `d3dfa8d704b8e48b90bb5d60a49b432115fb2728`. The test overlap retains dashboard directive-delivery assertions and the structured babysit evidence-scope contract. The composed open tail passes all 373 focused backend tests and all 218 focused frontend tests; TypeScript compilation, focused Black, and flake8 pass. Screenshot bytes are unchanged. Fresh CI and reviews are running; no manual CI rerun was made.

Current review-fix/restack verification on `e8ddb34e3211e8c417dabfa0b543773d0bec72a9`: this two-commit layer is directly based on #5185 at `0085af85de0c715529148d61fea3eb4c6f87791e`. The introduced `test/test_monitor_mcp.py` formatting failure is corrected in its owning commit; Black leaves the file unchanged and all 19 monitor MCP tests pass. Screenshot bytes are unchanged. Fresh CI and reviews are running; no manual CI rerun was made.

Current main-restack verification on `7e2a294b73b34eb5e9300a8a5755c03ea0884c1f`: this two-commit layer is directly based on #5185 at `12eecef59dcb20f1f973969d91aea2df0c4ec1cf`. The sole conflict preserves main’s concurrent skill-catalog scan contract alongside this layer’s structured babysit recipe. The composed top passes 125 focused frontend tests, TypeScript compilation, all 19 i18n gates against `origin/main`, 117 focused monitor/provider tests, and docs lint. Screenshot bytes are unchanged. Fresh CI and reviews are running; no manual CI rerun was made.

Current review-fix\/restack verification on edc01d9a1b72c896384e9f3176a37e2ecc9b60e8: this two-commit layer is directly based on #5185 at 5866cc109087a51e83fad8870411297afd8ef77b; its notification-persistence commit is patch-equivalent to the prior head, while the first commit inherits #5185's raw-quarantine specification. The composed open tail passes 284 focused backend tests and 160 focused frontend tests, plus TypeScript, targeted ESLint, all 19 i18n gates, and docs lint. Fresh CI and reviews are running; no manual CI rerun was made.

Current hygiene-clean verification on 51f975e7957a9867ab3a5b609e8ede00d0a18fa5: this PR is exactly two commits and is directly based on #5185 at 6d4630aa2. The composed top tree remains byte-for-byte identical to the already verified pre-fold tree. No CI job was manually rerun.

Current inherited-fix restack verification on 03cb97fb3509b9cd3d8710f36657629635145523: this two-commit layer is directly based on #5185 at 5afa6d3f3fa3e09894f2ac0cc3982b3c804bb224 and inherits its non-finite quarantine fix without changing this layer’s own patch. The composed open tail passes all 285 focused monitor, MCP, GitHub, and source-provider tests. Fresh CI and reviews are running; no manual CI rerun was made.

Current main-restack verification on a3284eb911a2d2448979811562074c747eeaa694: this two-commit layer is directly based on #5185 at 47fede7bcc59c83789f4f27c318a6896c60c0c72, preserving the linear stack on main at 8aef8fe3f0c1f9046020f4fe1f7ca2cca2bfb921. Its own patch is unchanged; the composed top passes TypeScript, the analyze build, the 812-chunk bundle gate, and all 19 base-aware i18n checks. Fresh CI and reviews are running; no manual CI rerun was made.

Current main-restack verification on e444ec9fc8eaca00a8c2e55b1683e6239deaa7f0: this two-commit layer is directly based on #5185 at e677cac03373f9187ad079d01882af599afe5261. Its structured-monitor and durable terminal-notification patches replay cleanly on main at 630938241270721b0db47139ad0c0dc66aeb08c8. The composed top passes 1,013 focused backend tests, 145 focused dashboard/WebSocket tests, TypeScript, all 19 i18n gates, docs lint, focused flake8 and Linux mypy, the analyze build, and the 812-chunk bundle gate. Fresh CI and reviews are running; no manual CI rerun was made.

Current guidance-fix verification on 2ea5aa62aef006194da9d7bf5cc618c220e1e1df: the shipped monitor_start instructions again include a concrete full GitHub pull-request URL that the real subject inference accepts, so copied legacy examples activate observation gating. The regression reproduced on the prior head and all 3 guidance-gate tests now pass; all 92 focused guidance, babysit, controller, and monitor-MCP tests plus docs lint and diff checks pass. This layer remains exactly two commits on #5185 at e677cac03373f9187ad079d01882af599afe5261. #5305 was restacked with an explicit lease. Fresh CI and reviews are running; no manual CI rerun was made.

Current source-path review fix on 33893785d: babysit scenario fixtures now derive repository files from `Path(__file__).resolve()`, clearing the current GPT blocking finding without changing runtime behavior. All 502 focused babysit and monitor tests pass, along with docs lint. This layer remains exactly two commits directly on #5185; #5305 was restacked and pushed bottom-up with explicit leases. Fresh CI and reviews are running; no manual CI rerun was made.

Current source-path gate fix on f904536be75125747ea206ee0813a9284431c957: babysit scenario fixtures derive repository files from an absolute resolved root and the touched test is Black-clean. All 502 focused babysit and monitor tests pass, plus focused Black and docs lint. This layer remains exactly two commits directly on #5185; #5305 was restacked and pushed bottom-up with explicit leases. Fresh CI and reviews are running; no manual CI rerun was made.

Current main-restack verification on fc34b5d6c740ed674a3aca8818929bb6caa48f2d: this two-commit PR is directly based on #5185 at e9931424410453f472d636389856fdee508a83af. The prepare-pr guidance resolution preserves main’s current babysit verification wording and this layer’s finite runtime/cycle budget, explicit monitor_update re-arm, and gate:false fallback requirements. #5305 was restacked on this head with an explicit lease. The composed top passes 314 focused backend tests, the production website build, all 19 base-aware i18n gates, Black, subprocess encoding, brand, and docs lint. Fresh CI and reviews are running; no manual CI rerun was made.

Current inherited main-restack verification on 950ee1222f2a4d2cbf703969183c04dded30d377: this two-commit PR is directly based on #5185 at 8c0de58f6d03e27cc749ad5be96c1e83d9d2aaa9, preserving the linear open tail. Its babysit patch is unchanged. The composed top passes the 3,628-test selected backend run, all 1,344 focused frontend tests, the production website build, all 19 base-aware i18n gates, Black, subprocess encoding, brand, and docs lint. Fresh CI and reviews are running; no manual CI rerun was made.

Current inherited main-restack verification on 950ee1222f2a4d2cbf703969183c04dded30d377: this two-commit PR is directly based on #5185 at 8c0de58f6d03e27cc749ad5be96c1e83d9d2aaa9, preserving the linear open tail. Its babysit patch is unchanged. The composed top passes the 3,628-test selected backend run, all 1,344 focused frontend tests, the production website build, all 19 base-aware i18n gates, Black, subprocess encoding, brand, and docs lint. Fresh CI and reviews are running; no manual CI rerun was made.

Current terminal-delivery review fix on 91ce5df11fd8adb89579ac9a0263c4b06276f767: the Slack observer is installed before service startup, so a terminal transition during startup cannot escape both live delivery and replay. Delivery acknowledgements now persist the exact terminal generation on the stable outer loop record, preserving opaque future-version monitor payloads while preventing repeat notices after restart. Both regressions failed on the prior head and pass after the fix; all 348 focused AutoNudge, persistence, and Slack gateway tests pass, plus 410 broader Slack/babysit tests. Focused Black, subprocess encoding, flake8, Linux mypy, docs lint, brand, and diff checks pass. Screenshot bytes are unchanged. #5305 was restacked and pushed bottom-up with explicit leases. Fresh CI and reviews are running; no manual CI rerun was made.


Current inherited main-restack verification on `0de1af3e4bdb993b3137478b9db6276f4e8277cb`: this two-commit layer is directly based on #5185 at `8cb33d195d3e91dbf18b595f038e5238641b26fa`. All 426 focused AutoNudge, monitor, directive, and terminal-notification tests pass. #5305 was restacked and force-pushed above it with an explicit lease. Screenshot bytes are unchanged and any immutable screenshot URL now names the current composed top. Fresh CI and reviews are running; no CI job was manually rerun.




Current inherited dashboard review fix on `e2a3efceed983ede5ded0333052e17b461569943`: this two-commit layer is directly based on #5185 at `9f55d44ad993f46c63b9517aa7775eec077cc5ee` and inherits its live legacy-editor reseed and full-registry removal invalidation. Git range-diff confirms both babysit patches are unchanged. #5305 was restacked and force-pushed above it with an explicit lease. Screenshot bytes are unchanged. Fresh CI and reviews are running; no CI job was manually rerun.

Current inherited main-restack verification on `fbd19a2b70e0d1ae647dc9a2c45fd90e7e3baf3b`: this two-commit PR is directly based on #5185 at `2534f95361c6e1e8f9a833cb2e199925a9887aea`; both of its patches replayed without conflicts. #5305 was restacked above it. The composed top passes 876 focused backend tests and 275 focused frontend tests, TypeScript, targeted ESLint, Black, subprocess encoding, all 19 base-aware i18n gates, docs lint, and brand lint. Screenshot bytes are unchanged. Fresh CI and reviews are running; no CI job was manually rerun.

Current final main-restack verification on `be1a2de18a0bd15a3afa51abba6b3f9e4edaeff7`: this two-commit PR is directly based on #5185 at `ee3e3a232d5ef7687c227a839aa6bd1d340c5869`. The AutoNudge resolution preserves main’s trusted crew/member self-arm and visible arm outcome together with this layer’s channel-specific monitor guidance; closing-slot admission retains the authoritative `_closing` fence. The composed top passes 1,264 focused self-arm, directive, provider, dashboard, and Slack tests with 2 platform skips, plus TypeScript, i18n, Black, isort, flake8, Linux-targeted mypy, docs, brand, and repository gates. Fresh CI and reviews are running; no CI job was manually rerun.


Current main-restack verification on `f93c40c10f01327fad422a3a35c53ba2e3c8bc01`: this two-commit PR is directly based on #5185 at `bc9105c4497d976920b384b8ea00928112c26ca4`, preserving the linear open tail; #5305 was restacked on this head with an explicit lease. The composed top passes 1,265 focused self-arm, directive, provider, dashboard, and Slack tests with 2 platform skips, plus focused Black, isort, flake8, Linux-targeted mypy, docs, subprocess-encoding, and brand gates. Fresh CI and reviews are running; no CI job was manually rerun.


Current main-restack verification on `f28639e3fb614b314a46f2d81e5c827220be70c3`: this two-commit PR is directly based on #5185 at `89dc2b30051e8af39d828824dce08e8169cc5122`; #5305 was restacked on this head with an explicit lease and no conflicts. The composed top passes all 134 focused monitor, provider, directive, AutoNudge, and Slack tests plus all 42 security-conductor contract tests; focused Black, isort, flake8, Linux mypy, subprocess encoding, and brand gates pass. Screenshot bytes are unchanged and the immutable URL names the current composed top. Fresh CI and reviews are running; no CI job was manually rerun.

Current main-restack verification on `ba1d991cf`: this babysit layer is based exactly on #5185 at `38f9ead96`, and #5305 is restacked directly on this head. The composed open tail passes 485 focused backend tests, all 30,540 website tests, and the 127 directly affected frontend tests, plus the scoped repository gates. The unrelated Electron packaging suite is unavailable because its nested package fixtures are absent. Fresh CI and reviews are running; no CI job was manually rerun.


Current inherited main-restack verification on `530e2fa2f80f2b4cd433d83df093ec118f155c3f`: this two-commit layer is based exactly on #5185 at `0b1f2c091c18937b1ef76fc709330746bae853c0`, preserving the linear open tail on current main. Its two patches replayed unchanged; the composed top passes the comment-history gate and all 180 focused provider, controller, provenance, and persistence tests. Fresh CI and reviews are running; no CI job was manually rerun.

Restacked 2026-09-08 after main advanced. Patch content is unchanged; focused backend tests (180), frontend tests (295), TypeScript, i18n, and comment-history validation pass.

Restacked 2026-09-08 on the #5185 i18n-runtime bundle-headroom fix. This PR’s own patches are unchanged; ancestry and range-diff verification pass.

Restacked 2026-09-08 after #5185 folded its bundle-budget adjustment into the existing fix commit. This PR’s own two patches remain unchanged by range-diff.

Current main-restack verification on `db49860bf6707f52bd201bee93731c2553c06dda`: this two-commit babysit layer is based exactly on #5185 at `4bcf34afb4e2ff77c080b956a33dfe950328ac2a`; #5305 is based exactly on this head. The restack preserves current `MonitorVerdict` semantics, budget-before-probe behavior, and bounded BUSY retries. The composed top passes all 519 focused backend tests, the analyze build, the 825-chunk bundle gate, and all 16 bundle-gate tests. GitHub reports the open tail MERGEABLE with no current unresolved review threads. Fresh CI and reviews are running; no CI job was manually rerun.

Current CI-fix verification on `8154e2c02bdf1ae5e8e396133d61e19e48153b30`: all babysit scenario assertions now inspect `MonitorVerdict.decision`, matching the controller contract and clearing the seven Windows failures. All 67 focused babysit/controller tests and the composed 533-test monitor suite pass. The separate Windows work-ledger race is outside this stack’s diff. This layer remains exactly two commits on #5185; #5305 was restacked with an explicit lease. Fresh CI is running; no CI job was manually rerun.

Current conflict-free main restack on `28226e76c`: this two-commit babysit layer is based exactly on #5185 at `bceafa4c8`; its `MonitorVerdict` scenario corrections replay unchanged. #5305 is based exactly on this head. TypeScript and 329 focused frontend tests pass on the composed top, along with the comment-history and stack-integrity checks. Fresh CI is running; no CI job was manually rerun.

Current main-restack verification on `7f7bf81bf3115c0db32d76ba833866c64f3b3a97`: this two-commit babysit layer is based exactly on #5185 at `1139ee82a348c4a93440348cb70aefa3389038ba`, and #5305 is based exactly on this head. The terminal-notification projection contract now explicitly accounts for both terminal bookkeeping fields inherited by the legacy read shape. The composed top passes 145 focused tests plus comment-history, docs, formatting, lint, Linux mypy, agent-SDK-boundary, and diff checks. Fresh CI is running; no CI job was manually rerun.

Current terminal-retry review fix on `e0f75dad2195867693b338142d73c2506bfdde68`: a failed terminal-notification creation or durable append now releases the exact process-local deduplication claim, so a later observer event retries the same terminal generation without requiring a gateway restart. The regression fails on the prior head for both a false append result and an exception, and passes on this head. The composed top passes all 269 focused Slack, provider-trust, source-provider, and dashboard-handler tests, plus Black, isort, flake8, Linux mypy, and docs lint. #5305 was restacked directly onto this head with an explicit lease; no CI job was manually rerun.


Current inherited compatibility-feed fix on `8e4882bfa921f5ad299ded1493f0832034faf62a`: this two-commit babysit layer is based exactly on #5185 at `8c5f023a4110468280570d5c1f01492b888c25c4`, inheriting its reduced-row filtering without changing this layer’s behavior. The focused composed automation suite passes 151 tests, plus TypeScript, ESLint, docs lint, and diff checks. #5305 was restacked directly onto this head with an explicit lease; no CI job was manually rerun.