### PR TITLE
fix(dashboard): add meta.mid tier to save-side foreign fold (#5152)

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -273,7 +273,7 @@ no longer destroy older turns.
   set by rewind/regenerate after they truncate the window and cleared only on a
   successful rewrite save, so a failed inline rewrite still gets retried as an
   archive-safe rewrite by the next flush (never silently overwritten).
-- **Foreign-append merge & timestamp-first dedup** (`_frozen_prefix_and_foreign_appends`):
+- **Foreign-append merge & id-first dedup** (`_frozen_prefix_and_foreign_appends`):
   a default save captures its `window` snapshot BEFORE taking `_locked`, so a
   cross-process writer (subagent / cron / CLI) can fully append + release the
   lock in that gap. A bare `meta + frozen + window` replace would then delete
@@ -282,60 +282,85 @@ no longer destroy older turns.
   represent and carries them into the payload as `foreign_lines`. Matching is
   **count-bounded** (deques of window-entry indices; each disk line matches at
   most one window entry and each window entry absorbs at most one disk line) and
-  runs in TWO passes so the outcome is independent of disk-line order:
-  - **Pass 1 — exact `(ts, role, content)`** across all disk lines: an unchanged
-    re-serialization, unambiguously **ours** (dropped — the window re-writes it).
-    Resolving these first is what makes a burst of messages sharing ONE `ts`
-    (coarse clocks — notably Windows' ~15 ms tick — stamp rapid appends with an
-    identical `datetime.now().isoformat()`) match one-for-one instead of being
+  runs in ordered passes so the outcome is independent of disk-line order:
+  - **Pass 0 — `meta.mid`** across all disk lines, resolved before every
+    heuristic tier: every window append mints a stable per-message id
+    (`meta.mid`, read via `row_mid`), a save persists it, and the durable-copy
+    writers carry the window row's id onto their copy. An id match folds only
+    when **corroborated** by body or `ts` (same `(role, content)` — a durable
+    copy — or same `ts` — an in-place edit): `meta.mid` is caller-suppliable
+    (`_ChatSlot.append` preserves a pre-existing id), so bare id equality
+    could pair two genuinely distinct messages. A corroborated match IS the
+    same message — the line is dropped (the window re-serializes it) and,
+    being exact, it is **not** a dedup drop and never churns the
+    `foreign-dedup` archive. An id match with **no** corroborating entry
+    falls through to the legacy ladder as if id-less (typically preserved).
+    An id-carrying line whose id matches **no** available window entry is
+    **foreign regardless of body equality** — two genuinely distinct
+    identical-content messages carry distinct ids, which is exactly the case
+    the body tiebreak below could never tell apart — and bypasses the
+    heuristic tiers; it still **counts in the ts-ambiguity accounting**, so
+    its `ts` group stays contested and an id-less line sharing that `ts` is
+    preserved (a rare stale duplicate) rather than silently ts-folded — the
+    same favour-duplication-over-loss direction as the ambiguity gate itself.
+    Id-less lines (pre-id transcripts, writers that pass no id) fall through
+    to the legacy ladder below, unchanged.
+  - **Pass 1 — exact `(ts, role, content)`** across the id-less disk lines: an
+    unchanged re-serialization, unambiguously **ours** (dropped — the window
+    re-writes it). Resolving these before the ts/rc passes is what makes a
+    burst of messages sharing ONE `ts` (coarse clocks — notably Windows'
+    ~15 ms tick — stamp rapid appends with an identical
+    `datetime.now().isoformat()`) match one-for-one instead of being
     mis-classified and duplicated on disk.
   - **Pass 2**, for each still-unmatched disk line, in order: (a) a **ts-only**
     match — an in-place edit keeps `ts` but changes content, so the window's
     version wins and the disk line is dropped — but applied ONLY when the `ts`
     group is an unambiguous 1:1 (exactly one unmatched window entry AND exactly
     one unmatched disk line share it); OR (b) a bounded `(role, content)`
-    tiebreak against an as-yet-unconsumed window entry — covers a same-process
+    tiebreak against an as-yet-unconsumed window entry — covers an id-less
     `append_if_absent` durable copy persisted with a fresh `ts` (the workflow/
     cron-result injectors reflect the message in the slot AND write it via
     `append_if_absent_off_loop`, so the same message legitimately exists twice
     with different timestamps and must NOT be double-persisted; both copies
     carry one `meta.mid` — the injectors pass the window row's minted id
-    through the append path — though this fold matches by `(role, content)`,
-    not by id). A line matching
+    through the append path — so those copies fold in pass 0 and reach this
+    tiebreak only when the id is missing). A line matching
     NEITHER is foreign and preserved.
   - **Count-bounded, exact-first identity (the fix for GPT 5.6's HIGH data-loss
     findings).** `(role, content)` is only a bounded tiebreak in which **each
     window entry absorbs at most ONE disk copy**. So if the on-disk window region
-    holds two lines with identical `(role, content)` but distinct timestamps —
-    the window's own persisted copy PLUS a *genuinely distinct* event from
-    another process (e.g. a cron that reports the same status text twice) — the
-    first is folded and the **second is preserved as a foreign append** (an
-    earlier plain-`(role, content)`-set match collapsed both real events into
-    one). Symmetrically, because colliding timestamps make a ts-only match
-    AMBIGUOUS (a foreign append that happens to share the `ts` is
+    holds two id-less lines with identical `(role, content)` but distinct
+    timestamps — the window's own persisted copy PLUS a *genuinely distinct*
+    event from another process (e.g. a cron that reports the same status text
+    twice) — the first is folded and the **second is preserved as a foreign
+    append** (an earlier plain-`(role, content)`-set match collapsed both real
+    events into one). Symmetrically, because colliding timestamps make a
+    ts-only match AMBIGUOUS (a foreign append that happens to share the `ts` is
     indistinguishable from an edited window entry), ts-only matching is applied
     ONLY to unambiguous 1:1 `ts` groups; an ambiguous group preserves its disk
     lines as foreign — favouring a rare stale duplicate over irreversibly
     dropping an acknowledged cross-process append.
-  - **Archive of ambiguous drops (no permanent loss).** A fresh-`ts` copy folded
-    by tiebreak (b) is the genuinely ambiguous case (indistinguishable from a
-    distinct same-content message without a stable id), so those drops are
-    returned as `dedup_dropped` and routed through `_archive_lines`
-    (`reason="foreign-dedup"`) by `_save_slot_to_history` before the atomic
-    replace — the trade-off loses no data permanently. (A ts-less / ts-matched
-    plain re-serialization is a normal window copy and is dropped silently to
-    avoid archive spam.)
-  - **Intended successor identity.** Timestamp is the closest thing to a stable
-    per-message id available today. The intended successor is a **creation-time
-    per-message uuid** (stamped when the message is created, carried through the
-    slot and onto disk) so identity is *exact* rather than inferred; the bounded
-    heuristic above is the bridge until that lands. This is a tracked, committed
-    follow-up — see
-    [issue #381](https://github.com/kirodotdev/KiroCrew/issues/381) — not an
-    open-ended aspiration: when the uuid lands it **demotes this heuristic to a
-    legacy fallback** used only for un-stamped (pre-uuid) lines, and both this
-    paragraph and the `test_foreign_append_content_identity_dedup_semantics`
-    contract test must be updated in the same commit.
+  - **Archive of ambiguous drops (no permanent loss).** A fresh-`ts` id-less
+    copy folded by tiebreak (b) is the genuinely ambiguous case
+    (indistinguishable from a distinct same-content message without a stable
+    id), so those drops are returned as `dedup_dropped` and routed through
+    `_archive_lines` (`reason="foreign-dedup"`) by `_save_slot_to_history`
+    before the atomic replace — the trade-off loses no data permanently. (A
+    ts-less / ts-matched plain re-serialization is a normal window copy and is
+    dropped silently to avoid archive spam; a corroborated id-matched pass-0
+    fold is exact, not ambiguous, and is likewise silent.)
+  - **Successor identity, landed on the save side.** The **creation-time
+    per-message uuid** (`meta.mid`, minted by `_ChatSlot.append`, persisted by
+    the save, carried onto durable copies — the successor identity tracked by
+    [issue #381](https://github.com/kirodotdev/KiroCrew/issues/381)) is now the
+    fold's pass-0 identity, so for stamped lines identity is *exact* rather
+    than inferred. The bounded timestamp-first heuristic above is thereby
+    **demoted to a legacy fallback** for un-stamped lines: pre-id transcripts
+    are never migrated, and writers that persist id-less copies (e.g. the
+    Discord/Slack dashboard mirrors) still resolve through it until they thread
+    the id through. The
+    `test_foreign_append_content_identity_dedup_semantics` contract test pins
+    that fallback; the `TestForeignFoldMidIdentity` cases pin pass 0.
   - **Residual window (rewrite saves).** The scan runs only for default saves
     (`collect_foreign = not rewrite`). Rewrite saves (rewind / regenerate / fork)
     intentionally truncate the window and are same-session/same-process, so they

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -32,6 +32,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _normalize_slot_key,
     _note_authorized_elsewhere,
+    row_mid,
 )
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
@@ -1438,28 +1439,44 @@ def _frozen_prefix_and_foreign_appends(
     fully append + release between the snapshot and this save acquiring the lock;
     a bare ``meta + frozen + window`` replace would then silently delete that
     acknowledged message. Carrying these lines into the payload makes the save
-    non-destructive against cross-process appends. A
-    disk line is treated as ours (dropped; the window re-serializes it) when its
-    ``ts`` matches a window entry (covers in-place edits, which keep ``ts`` but
-    change content) OR — as a COUNT-BOUNDED tiebreak — its ``(role, content)``
-    matches an as-yet-unconsumed window entry (covers a same-process
-    ``append_if_absent`` copy persisted with a FRESH ``ts`` distinct from the
-    window entry's in-memory ``ts``). The tiebreak is bounded so each window
-    entry absorbs AT MOST ONE disk copy: if the on-disk window region holds two
-    lines with identical ``(role, content)`` but distinct timestamps — the
-    window's own persisted copy PLUS a genuinely distinct event from another
-    process (e.g. a repeated identical cron / workflow result) — only the first
-    is folded into the window and the second is preserved as a foreign append.
-    A plain ``(role, content)`` set collapsed those two real events into one;
-    the bounded, timestamp-first identity
-    fixes it. Timestamp is the closest thing to a stable per-message id today;
-    the intended successor is a creation-time per-message uuid that demotes this
-    heuristic to a legacy fallback for un-stamped lines (see also
-    ``docs/system-specs/modules/history.md``). ``dedup_dropped`` returns any
-    fresh-``ts`` content-tiebreak drops so the caller can route them through the
-    archive — even the residual ambiguous case (a distinct message
-    indistinguishable from an ``append_if_absent`` copy without a stable id)
-    then loses no data permanently.
+    non-destructive against cross-process appends. Identity is **id-first**: a
+    disk line whose ``meta.mid`` (read via :func:`row_mid`) matches a window
+    entry's id, corroborated by body or ``ts`` (same ``(role, content)`` — a
+    durable copy — or same ``ts`` — an in-place edit), IS that entry's
+    persisted copy, so it is dropped silently (the window re-serializes it)
+    and never archived. The corroboration is required because ``meta.mid`` is
+    caller-suppliable (``_ChatSlot.append`` preserves a pre-existing id), so a
+    bare id equality could pair two genuinely distinct messages; an id match
+    with NO corroborating entry falls back to the legacy ladder as if id-less,
+    which typically preserves the line. A disk line whose ``meta.mid`` matches
+    NO available window entry is a foreign append regardless of body equality,
+    which is what tells two genuinely distinct identical-content messages
+    apart — it still keeps its ``ts`` group ambiguous for the ts-only tier, so
+    its presence can never convert a contested group into a silent id-less
+    fold. Only an **id-less** disk line resolves
+    through the legacy timestamp-first ladder, unchanged: it is treated as
+    ours when
+    its ``ts`` matches a window entry (covers in-place edits, which keep ``ts``
+    but change content) OR — as a COUNT-BOUNDED tiebreak — its
+    ``(role, content)`` matches an as-yet-unconsumed window entry (covers a
+    same-process ``append_if_absent`` copy persisted with a FRESH ``ts``
+    distinct from the window entry's in-memory ``ts``). The tiebreak is bounded
+    so each window entry absorbs AT MOST ONE disk copy: if the on-disk window
+    region holds two id-less lines with identical ``(role, content)`` but
+    distinct timestamps — the window's own persisted copy PLUS a genuinely
+    distinct event from another process (e.g. a repeated identical cron /
+    workflow result) — only the first is folded into the window and the second
+    is preserved as a foreign append. A plain ``(role, content)`` set collapsed
+    those two real events into one; the bounded, timestamp-first identity
+    fixes it for id-less lines, and the ``meta.mid`` tier resolves it exactly
+    for stamped lines (see also ``docs/system-specs/modules/history.md``).
+    ``dedup_dropped`` returns any fresh-``ts`` content-tiebreak drops so the
+    caller can route them through the archive — even the residual ambiguous
+    case (an id-less distinct message indistinguishable from an
+    ``append_if_absent`` copy without a stable id) then loses no data
+    permanently. A corroborated id-matched fold is NOT such a drop: the ids
+    plus body/``ts`` agreeing makes it unambiguous, so it does not churn the
+    archive.
 
     Fast path: when BOTH the on-disk mtime AND size match the frozen-prefix
     cache, THIS slot was the last writer and nothing has landed since, so the
@@ -1515,20 +1532,32 @@ def _frozen_prefix_and_foreign_appends(
         return (prefix, [], [])
     # Scan the on-disk window region for lines the in-memory window does not
     # carry — those are cross-process appends we must preserve. Identity is
-    # timestamp-first (the closest thing to a stable per-message id today), with
-    # (role, content) used only as a COUNT-BOUNDED tiebreak so each window entry
-    # absorbs at most ONE disk copy (see the module docstring / history.md).
+    # id-first (``meta.mid``, the stable per-message id every window append
+    # mints and every durable-copy writer carries through), with the legacy
+    # timestamp-first ladder — exact triple, ts, then a COUNT-BOUNDED
+    # (role, content) tiebreak — retained unchanged for id-less lines (see the
+    # module docstring / history.md).
     #
     # Build COUNT-BOUNDED consumption budgets over the window entries so each
     # on-disk window-region line is matched to AT MOST ONE window entry and each
-    # window entry absorbs AT MOST ONE disk line. Identity is checked in three
+    # window entry absorbs AT MOST ONE disk line. Identity is checked in four
     # tiers of decreasing confidence:
+    #   (0) ``meta.mid`` — the stable id stamped at append time and carried onto
+    #       durable copies (PR #5133); an id match IS the same message, resolved
+    #       first across ALL disk lines so no heuristic tier can steal the
+    #       entry, and an id-carrying line whose id matches NO entry is foreign
+    #       regardless of body (two distinct identical-content messages carry
+    #       distinct ids);
     #   (a) exact (ts, role, content) — an unchanged re-serialization (the common
-    #       steady-save case), resolved first across ALL disk lines so a greedy
+    #       steady-save case), resolved before the ts/rc passes so a greedy
     #       edit/tiebreak match can never steal an entry a later exact line needs;
     #   (b) ts only — an in-place edit (same ``ts``, changed content: window wins);
     #   (c) (role, content) only — a same-content copy persisted with a FRESH
     #       ``ts`` (the ``append_if_absent`` case), routed to the archive.
+    # Tiers (a)-(c) see only id-less disk lines, but every window entry stays
+    # indexed in all of them regardless of whether it carries an id: a legacy
+    # (pre-id) disk line must still fold into its window row even though the
+    # restore minted that row a fresh id.
     # Keying every tier by COUNT (deques of entry indices guarded by a shared
     # ``consumed`` flag) — rather than a ``ts -> entry`` dict plus a per-``ts``
     # ``set`` — is what makes this correct when several messages share one ``ts``.
@@ -1538,6 +1567,7 @@ def _frozen_prefix_and_foreign_appends(
     # genuine window line was mis-classified as a foreign append and DUPLICATED on
     # disk. The bounded multiset below matches them one-for-one regardless of
     # ``ts`` collisions.
+    mid_idx: dict[str, "deque[int]"] = {}
     exact_idx: dict[tuple[object, object, object], "deque[int]"] = {}
     ts_idx: dict[object, "deque[int]"] = {}
     rc_idx: dict[tuple[object, object], "deque[int]"] = {}
@@ -1545,6 +1575,9 @@ def _frozen_prefix_and_foreign_appends(
         _ets = e.get("ts")
         _erole = e.get("role")
         _econtent = e.get("content", "")
+        _emid = row_mid(e)
+        if _emid:
+            mid_idx.setdefault(_emid, deque()).append(_i)
         if _ets:
             exact_idx.setdefault((_ets, _erole, _econtent), deque()).append(_i)
             ts_idx.setdefault(_ets, deque()).append(_i)
@@ -1563,8 +1596,10 @@ def _frozen_prefix_and_foreign_appends(
         return False
 
     # Parse the on-disk window-region lines once (skipping blank/corrupt/transient
-    # lines exactly as before), so the two matching passes share one parse.
-    disk_msgs: list[tuple[str, object, object, object]] = []  # (norm, ts, role, content)
+    # lines exactly as before), so the matching passes share one parse.
+    disk_msgs: list[
+        tuple[str, object, object, object, str | None]
+    ] = []  # (norm, ts, role, content, mid)
     for ln in body[disk_older:]:
         if not ln.strip():
             continue
@@ -1578,14 +1613,61 @@ def _frozen_prefix_and_foreign_appends(
         if role is None or role in _TRANSIENT_ROLES:
             continue
         norm = ln if ln.endswith("\n") else ln + "\n"
-        disk_msgs.append((norm, entry.get("ts"), role, entry.get("content", "")))
+        disk_msgs.append(
+            (norm, entry.get("ts"), role, entry.get("content", ""), row_mid(entry))
+        )
 
-    # Pass 1 — exact (ts, role, content): unambiguously our own unchanged
-    # re-serialization. Resolving these first makes the result independent of the
-    # disk-line order (an earlier edit/tiebreak match can no longer consume an
-    # entry that a later exact line requires).
+    # Pass 0 — ``meta.mid``: id-first identity, resolved across ALL disk lines
+    # before any heuristic tier so a greedy lower-confidence match can never
+    # steal a window entry whose persisted copy is identified by id. An id
+    # match folds ONLY when corroborated by body or ``ts`` — ``meta.mid`` is
+    # caller-suppliable (``_ChatSlot.append`` preserves a pre-existing id, and
+    # the ``/api/chat`` meta rides through), so a bare id equality is not proof
+    # of sameness the way a minted-uuid contract would suggest:
+    #   * corroborated (same (role, content) — a durable copy — or same ``ts``
+    #     — an in-place edit): consume the entry and drop the line (the window
+    #     re-serializes it). The ids matching exactly makes this NOT a dedup
+    #     drop, so it is not routed to the ``foreign-dedup`` archive.
+    #   * id matches an unconsumed entry but NEITHER body nor ``ts`` agrees
+    #     (an id reused across two genuinely distinct messages): leave the
+    #     entry unconsumed and let the line fall through to the legacy tiers
+    #     as if id-less — typically preserved as foreign, so the distinct
+    #     message stays in the transcript rather than being silently folded.
+    #   * id matches NO available window entry (unknown id, or every same-id
+    #     entry already absorbed its one copy): FOREIGN regardless of body
+    #     equality — two genuinely distinct identical-content messages (e.g. a
+    #     cron reporting the same status text twice) carry distinct ids, which
+    #     is exactly what the body tiebreak could never tell apart — so it is
+    #     excluded from the heuristic tiers below (``mid_foreign``) and
+    #     preserved, in disk order, by pass 2.
+    # Id-less lines fall through with tier (a)-(c) behaviour unchanged.
     handled = [False] * len(disk_msgs)
-    for _j, (_norm, ts, role, content) in enumerate(disk_msgs):
+    mid_foreign = [False] * len(disk_msgs)
+    for _j, (_norm, _ts, _role, _content, mid) in enumerate(disk_msgs):
+        if mid is None:
+            continue
+        _live = [_i for _i in mid_idx.get(mid, ()) if not consumed[_i]]
+        if not _live:
+            mid_foreign[_j] = True
+            continue
+        for _i in _live:
+            _e = window_entries[_i]
+            if (_role, _content) == (_e.get("role"), _e.get("content", "")) or (
+                _ts and _ts == _e.get("ts")
+            ):
+                consumed[_i] = True
+                handled[_j] = True
+                break
+        # No corroborated entry → deliberate fallthrough to the legacy tiers.
+
+    # Pass 1 — exact (ts, role, content) over id-less lines: unambiguously our
+    # own unchanged re-serialization. Resolving these before the ts/rc passes
+    # makes the result independent of the disk-line order (an earlier
+    # edit/tiebreak match can no longer consume an entry that a later exact
+    # line requires).
+    for _j, (_norm, ts, role, content, _mid) in enumerate(disk_msgs):
+        if handled[_j] or mid_foreign[_j]:
+            continue
         if ts and _take(exact_idx.get((ts, role, content))):
             handled[_j] = True
 
@@ -1611,14 +1693,26 @@ def _frozen_prefix_and_foreign_appends(
         if _wt and not consumed[_i]:
             w_unmatched_ts[_wt] = w_unmatched_ts.get(_wt, 0) + 1
     d_unmatched_ts: dict[object, int] = {}
-    for _j, (_norm, ts, _role, _content) in enumerate(disk_msgs):
+    for _j, (_norm, ts, _role, _content, _mid) in enumerate(disk_msgs):
         if ts and not handled[_j]:
             d_unmatched_ts[ts] = d_unmatched_ts.get(ts, 0) + 1
 
     # Pass 2 — for still-unmatched disk lines: ts-only (UNAMBIGUOUS in-place edit)
-    # then the bounded (role, content) tiebreak, else genuinely foreign.
-    for _j, (norm, ts, role, content) in enumerate(disk_msgs):
+    # then the bounded (role, content) tiebreak, else genuinely foreign. A line
+    # pass 0 already ruled foreign by id bypasses both heuristics (its identity
+    # is settled) but is emitted HERE so ``foreign`` keeps disk order — the
+    # interleave that re-merges these lines breaks ts ties by adjacency, so
+    # reordering them relative to other foreign lines is not harmless. Such a
+    # line still counts in ``d_unmatched_ts`` above: it keeps its ``ts`` group
+    # ambiguous exactly as it did before the id tier existed, so an id-less
+    # line sharing the ``ts`` is preserved (a rare stale duplicate) rather
+    # than silently ts-folded into an entry the id-foreign line proves
+    # contested (an irreversible drop of an acknowledged append).
+    for _j, (norm, ts, role, content, _mid) in enumerate(disk_msgs):
         if handled[_j]:
+            continue
+        if mid_foreign[_j]:
+            foreign.append(norm)
             continue
         # ts-match: an in-place edit keeps the ``ts`` but changes content, so the
         # window's version wins and the disk line is dropped silently — but ONLY

--- a/test/test_history_locking_remediation.py
+++ b/test/test_history_locking_remediation.py
@@ -1565,21 +1565,29 @@ class TestDashboardSaveHoldsLock:
     def test_foreign_append_content_identity_dedup_semantics(
         self, tmp_path, monkeypatch
     ):
-        """Pin the narrowed, timestamp-first foreign-append identity (GPT 5.6
-        HIGH + arbiter long-term item 2).
+        """Pin the LEGACY id-less fallback: the narrowed, timestamp-first
+        foreign-append identity (GPT 5.6 HIGH + arbiter long-term item 2).
 
-        ``_frozen_prefix_and_foreign_appends`` classifies a disk window-region
-        line as "ours" (drops it — the window re-serializes it) when EITHER its
-        ``ts`` matches a window entry (in-place edit) OR — as a COUNT-BOUNDED
-        tiebreak — its ``(role, content)`` matches an as-yet-unconsumed window
-        entry (a same-process ``append_if_absent`` copy persisted with a fresh
-        ``ts``). Because the tiebreak is bounded, each window entry absorbs AT
-        MOST one disk copy: a second same-content line with a DISTINCT ts (a
-        genuinely distinct event from another process, e.g. a repeated identical
-        cron/workflow result) is PRESERVED as foreign rather than collapsed. This
-        verifies both no-loss (the distinct event survives) and no-duplication
-        (the append_if_absent fresh-ts copy is folded once, not re-appended).
-        See docs/system-specs/modules/history.md.
+        Since the ``meta.mid`` tier landed (#5152), this ladder is the fallback
+        for disk lines that carry NO stable id — pre-id transcripts and writers
+        that persist id-less durable copies. Every disk line and window entry
+        here is deliberately id-less, so the input must reproduce the pre-id
+        behaviour EXACTLY (pass 0 never fires; nothing about tiers a-c moved).
+
+        For id-less lines ``_frozen_prefix_and_foreign_appends`` classifies a
+        disk window-region line as "ours" (drops it — the window re-serializes
+        it) when EITHER its ``ts`` matches a window entry (in-place edit) OR —
+        as a COUNT-BOUNDED tiebreak — its ``(role, content)`` matches an
+        as-yet-unconsumed window entry (a same-process ``append_if_absent`` copy
+        persisted with a fresh ``ts``). Because the tiebreak is bounded, each
+        window entry absorbs AT MOST one disk copy: a second same-content line
+        with a DISTINCT ts (a genuinely distinct event from another process,
+        e.g. a repeated identical cron/workflow result) is PRESERVED as foreign
+        rather than collapsed. This verifies both no-loss (the distinct event
+        survives) and no-duplication (the append_if_absent fresh-ts copy is
+        folded once, not re-appended). Stamped lines resolve exactly in the id
+        tier instead — see ``TestForeignFoldMidIdentity`` and
+        docs/system-specs/modules/history.md.
         """
         import json
 
@@ -1655,6 +1663,346 @@ class TestDashboardSaveHoldsLock:
             "fresh-ts content-tiebreak drops must be surfaced for archiving "
             f"(got {dropped_contents!r})"
         )
+
+
+class TestForeignFoldMidIdentity:
+    """Pin the ``meta.mid`` tier (pass 0) of the save-side foreign-merge fold
+    (#5152, the save-side slice of the #381 successor identity).
+
+    Every window append mints a stable per-message id (``meta.mid``), a save
+    persists it, and the durable-copy writers (workflow/cron injectors, CLI)
+    carry the window row's id onto their copy — so since #5133 the id is on
+    BOTH sides of the fold's comparison. Pass 0 uses it: an id match IS the
+    same message (folded silently, never archived); an id-carrying disk line
+    whose id matches NO window entry is foreign regardless of body equality
+    (two genuinely distinct identical-content messages carry distinct ids);
+    id-less lines keep the legacy timestamp-first ladder byte-identically
+    (pinned by ``test_foreign_append_content_identity_dedup_semantics``).
+    """
+
+    def _make_state(self, tmp_path: Path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from kiro_crew.dashboard.state import DashboardState
+
+        sessions = MagicMock(count=0)
+        sessions.get_pid = MagicMock(return_value=None)
+        sessions.remove = AsyncMock()
+        return DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+
+    def _fold(self, tmp_path, monkeypatch, slot_name, disk_entries, window_entries):
+        """Write *disk_entries* (after a metadata line) and run the fold."""
+        import json
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import (
+            _frozen_prefix_and_foreign_appends,
+        )
+        from kiro_crew.dashboard.chat_utils import _history_key_for
+
+        state = self._make_state(tmp_path)
+        slot = state.get_or_create_slot(slot_name)
+        history_key = _history_key_for(slot.key)
+        path = state.conversation_log._path(history_key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [json.dumps({"_type": "metadata", "created": "2026-01-01T00:00:00Z"})]
+        lines.extend(json.dumps(e) for e in disk_entries)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        slot._frozen_prefix_cache = None
+        return _frozen_prefix_and_foreign_appends(slot, path, 0, window_entries)
+
+    def test_id_matched_durable_copy_folds_without_archive_churn(
+        self, tmp_path, monkeypatch
+    ):
+        """An injector's durable copy (fresh ts, SAME ``meta.mid`` as its window
+        row) folds in pass 0 with an EMPTY ``dedup_dropped``: the ids matching
+        exactly makes it unambiguous, so it must not be routed to the
+        ``foreign-dedup`` archive the way the id-less fresh-ts tiebreak is
+        (issue #5152 consequence 1 — archive churn on every injection+save).
+        """
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "midfold",
+            disk_entries=[
+                # Durable copy: fresh ts TY (window's in-memory ts is TZ), same id.
+                {
+                    "role": "assistant",
+                    "content": "inj",
+                    "ts": "TY",
+                    "meta": {"mid": "m-inj"},
+                }
+            ],
+            window_entries=[
+                {
+                    "role": "assistant",
+                    "content": "inj",
+                    "ts": "TZ",
+                    "meta": {"mid": "m-inj"},
+                }
+            ],
+        )
+        assert foreign == [], "id-matched durable copy must fold into the window"
+        assert dedup_dropped == [], (
+            "an id-matched fold is exact, not ambiguous — it must not churn "
+            f"the foreign-dedup archive (got {dedup_dropped!r})"
+        )
+
+    def test_distinct_ids_with_identical_content_stay_distinct(
+        self, tmp_path, monkeypatch
+    ):
+        """Two identical-content rows with DISTINCT ids resolve exactly: the
+        window row's copy (same id) folds silently, the genuinely distinct row
+        (different id) is preserved as foreign (issue #5152 consequence 2 — the
+        residual ambiguity the count-bounded tiebreak could only bound).
+        """
+        import json
+
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "mid2",
+            disk_entries=[
+                # The window row's own durable copy (fresh ts, same id) → folded.
+                {
+                    "role": "assistant",
+                    "content": "status ok",
+                    "ts": "TA",
+                    "meta": {"mid": "m-ours"},
+                },
+                # A distinct cron result with the SAME text but its OWN id →
+                # foreign, even though the body tiebreak budget is exhausted
+                # only after the fold above.
+                {
+                    "role": "assistant",
+                    "content": "status ok",
+                    "ts": "TB",
+                    "meta": {"mid": "m-theirs"},
+                },
+            ],
+            window_entries=[
+                {
+                    "role": "assistant",
+                    "content": "status ok",
+                    "ts": "TW",
+                    "meta": {"mid": "m-ours"},
+                }
+            ],
+        )
+        foreign_mids = [json.loads(ln)["meta"]["mid"] for ln in foreign]
+        assert foreign_mids == ["m-theirs"], (
+            "the distinct-id row must be preserved as foreign and the same-id "
+            f"copy folded (got foreign mids {foreign_mids!r})"
+        )
+        assert dedup_dropped == [], "id-tier resolutions must not archive anything"
+
+    def test_unmatched_id_beats_body_tiebreak(self, tmp_path, monkeypatch):
+        """An id-carrying disk line whose id is absent from the window is
+        FOREIGN even though its body matches an unconsumed window entry — the
+        distinct id is authoritative, so the tier-(c) body tiebreak must not
+        absorb it (and must not archive it as an ambiguous drop).
+        """
+        import json
+
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "midforeign",
+            disk_entries=[
+                {
+                    "role": "assistant",
+                    "content": "same text",
+                    "ts": "TB",
+                    "meta": {"mid": "m-other"},
+                }
+            ],
+            window_entries=[
+                # Unconsumed window entry with matching body but a different id:
+                # its (role, content) budget is AVAILABLE, and must still not
+                # absorb the distinct-id line.
+                {
+                    "role": "assistant",
+                    "content": "same text",
+                    "ts": "TW",
+                    "meta": {"mid": "m-mine"},
+                }
+            ],
+        )
+        assert [json.loads(ln)["meta"]["mid"] for ln in foreign] == ["m-other"], (
+            "a disk line whose id matches no window entry must be preserved as "
+            "foreign regardless of body equality"
+        )
+        assert dedup_dropped == [], (
+            "an id-settled foreign line is not an ambiguous drop"
+        )
+
+    def test_legacy_line_still_folds_into_id_carrying_window_entry(
+        self, tmp_path, monkeypatch
+    ):
+        """A restored legacy transcript: the on-disk line is id-less, but the
+        restore minted the window row a fresh id. The exact (ts, role, content)
+        tier must still fold the line — an id-carrying window entry stays
+        indexed in the legacy tiers, or every save after a restart would
+        duplicate the whole pre-id transcript.
+        """
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "midlegacy",
+            disk_entries=[
+                {"role": "assistant", "content": "old row", "ts": "T1"},
+            ],
+            window_entries=[
+                # The same row post-restore: identical triple, restore-minted id.
+                {
+                    "role": "assistant",
+                    "content": "old row",
+                    "ts": "T1",
+                    "meta": {"mid": "m-minted"},
+                }
+            ],
+        )
+        assert foreign == [], (
+            "an id-less legacy line must still exact-fold into its restored "
+            "window row (else every post-restart save duplicates the transcript)"
+        )
+        assert dedup_dropped == [], "an exact fold is silent"
+
+    def test_mixed_id_and_idless_lines_in_one_ts_group_lose_nothing(
+        self, tmp_path, monkeypatch
+    ):
+        """Opus 5 review HIGH: an id-foreign line must keep its ``ts`` group
+        AMBIGUOUS. If it were excluded from the disk-side counter, a group
+        holding an id-carrying foreign line PLUS an id-less foreign line and
+        exactly one unmatched window entry with the same ``ts`` (coarse-clock
+        collision) would read as an unambiguous 1:1, and the ts-only tier
+        would silently DROP the id-less acknowledged append — the exact
+        data-loss class the ambiguity gate exists to prevent. Both lines must
+        be preserved as foreign, matching the pre-id-tier behaviour.
+        """
+        import json
+
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "midmixts",
+            disk_entries=[
+                # Id-carrying foreign line (unknown id) colliding on ts T.
+                {
+                    "role": "assistant",
+                    "content": "x",
+                    "ts": "T",
+                    "meta": {"mid": "m-2"},
+                },
+                # Id-less foreign line sharing the same coarse-clock ts T.
+                {"role": "assistant", "content": "y", "ts": "T"},
+            ],
+            window_entries=[
+                {
+                    "role": "assistant",
+                    "content": "a",
+                    "ts": "T",
+                    "meta": {"mid": "m-1"},
+                }
+            ],
+        )
+        foreign_contents = [json.loads(ln)["content"] for ln in foreign]
+        assert foreign_contents == ["x", "y"], (
+            "both foreign lines in the contested ts group must survive — the "
+            "id-foreign line may not convert the group into a silent 1:1 fold "
+            f"(got {foreign_contents!r})"
+        )
+        assert dedup_dropped == []
+
+    def test_reused_mid_with_distinct_body_falls_back_conservatively(
+        self, tmp_path, monkeypatch
+    ):
+        """GPT 5.6 review HIGH: ``meta.mid`` is caller-suppliable
+        (``_ChatSlot.append`` preserves a pre-existing id, and ``/api/chat``
+        meta rides through), so bare id equality may pair two genuinely
+        distinct messages. An id match corroborated by NEITHER body nor ``ts``
+        must not consume the window entry: the line falls back to the legacy
+        ladder (preserved as foreign here), and a later id-less exact copy of
+        the entry still folds — the outcome cannot depend on the reused-id
+        line stealing the entry's budget.
+        """
+        import json
+
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "midreuse",
+            disk_entries=[
+                # Reused id, but different body AND different ts: a genuinely
+                # distinct message that happens to carry the window row's id.
+                {
+                    "role": "assistant",
+                    "content": "distinct msg",
+                    "ts": "T2",
+                    "meta": {"mid": "m-reused"},
+                },
+                # The window row's own id-less exact persisted copy — must
+                # still fold into the entry the reused-id line did not steal.
+                {"role": "assistant", "content": "a", "ts": "T1"},
+            ],
+            window_entries=[
+                {
+                    "role": "assistant",
+                    "content": "a",
+                    "ts": "T1",
+                    "meta": {"mid": "m-reused"},
+                }
+            ],
+        )
+        foreign_contents = [json.loads(ln)["content"] for ln in foreign]
+        assert foreign_contents == ["distinct msg"], (
+            "an uncorroborated id match must not silently drop a distinct "
+            f"message (got {foreign_contents!r})"
+        )
+        assert dedup_dropped == [], (
+            "the exact copy folds via the exact tier, not the archive tiebreak"
+        )
+
+    def test_id_match_corroborated_by_ts_folds_silently(
+        self, tmp_path, monkeypatch
+    ):
+        """The ``ts`` half of the corroboration rule: an id-matched line whose
+        ``ts`` equals the entry's (an in-place edit of a durably-copied row —
+        same id, same ts, superseded body) is the entry's own persisted copy
+        and folds silently, window version winning, no archive churn.
+        """
+        _prefix, foreign, dedup_dropped = self._fold(
+            tmp_path,
+            monkeypatch,
+            "midtscorr",
+            disk_entries=[
+                {
+                    "role": "assistant",
+                    "content": "OLD body",
+                    "ts": "T1",
+                    "meta": {"mid": "m-edit"},
+                }
+            ],
+            window_entries=[
+                # Same id, same ts, edited content: the window wins.
+                {
+                    "role": "assistant",
+                    "content": "NEW body",
+                    "ts": "T1",
+                    "meta": {"mid": "m-edit"},
+                }
+            ],
+        )
+        assert foreign == [], "the stale persisted copy must fold, window wins"
+        assert dedup_dropped == [], "an id+ts corroborated fold is silent"
 
 
 class TestBestEffortSaveMarksDirty:


### PR DESCRIPTION
## Summary

`_frozen_prefix_and_foreign_appends` — the save-side fold that decides, for each on-disk window-region line, whether it is the slot's own row (drop; the window re-serializes it) or a cross-process append (preserve) — matched with a three-tier heuristic ladder (exact `(ts, role, content)`, ts-only 1:1, count-bounded `(role, content)` tiebreak) and never read `meta.mid`, even though since #5133 the stable per-message id is present on **both** sides of the comparison.

This PR adds **pass 0**, an id tier resolved ahead of every heuristic tier:

- **Corroborated id match folds silently.** A disk line whose `meta.mid` (read via the shared `row_mid()` accessor) matches a window entry's id, corroborated by body (`(role, content)` equal — a durable copy) **or** ts (equal — an in-place edit), is that entry's persisted copy: the entry is consumed, the line dropped, and — the match being exact — it is **not** routed to the `foreign-dedup` archive. This removes the archive churn on every injection+save (issue consequence 1).
- **Unmatched id ⇒ foreign regardless of body.** A disk line whose id matches no available window entry is preserved as a foreign append even when its body equals a window entry — distinct ids are authoritative, which is what finally tells two genuinely distinct identical-content rows apart (issue consequence 2). Such a line still **counts in the ts-ambiguity accounting**, so a colliding-ts group stays contested and an id-less line sharing the ts is preserved rather than silently ts-folded.
- **Uncorroborated id match falls back conservatively.** `meta.mid` is caller-suppliable (`_ChatSlot.append` preserves a pre-existing id; `/api/chat` meta rides through), so bare id equality could pair two genuinely distinct messages. An id match corroborated by neither body nor ts leaves the entry unconsumed and the line resolves through the legacy ladder as if id-less (typically preserved as foreign).
- **Id-less lines are byte-identical to today.** The legacy exact/ts/body ladder, its count-bounded tiebreak, and its `dedup_dropped` archive routing are unchanged. Window entries stay indexed in the legacy tiers regardless of carrying an id, so a restored pre-id transcript still exact-folds instead of duplicating on every save. Pre-id transcripts are never migrated.

The fold docstring and `docs/system-specs/modules/history.md` are updated in the same commit: the id tier is documented as the landed save-side slice of the successor identity tracked by #381 (closed 2026-08-05; referenced as context, not reopened), and the timestamp-first heuristic is demoted to the documented legacy fallback for un-stamped lines.

Closes #5152

## Scope discipline

The issue names sibling work — Discord's `_mirror_turn_to_live_slot` → `_persist_turn` and Slack's dashboard mirror still writing id-less durable copies. Per the issue, threading the id through them belongs to the same effort but is **not** this PR; those writers keep resolving through the (unchanged) legacy ladder.

## Pre-push review (dual model-pinned subagents)

- **GPT 5.6 (BLOCKING, High):** bare id equality is unsound because `meta.mid` is caller-suppliable — a reused id across two distinct messages would silently drop an acknowledged append without archive. **Fixed** with the corroboration rule (fold only on id + body-or-ts agreement; uncorroborated matches fall back to the legacy path without consuming the entry), plus a regression test where a reused-id line with distinct body is preserved and a later id-less exact copy still folds.
- **Opus 5 (BLOCKING, High, empirically reproduced):** excluding id-foreign lines from the disk-side ts counter converted a previously ambiguous colliding-ts group into a false 1:1, silently ts-folding an id-less acknowledged append (base preserved `x, y`; the draft dropped `y`). **Fixed** by keeping id-foreign lines in the ts-ambiguity accounting (favour-duplication-over-loss, the gate's documented direction), plus a mixed id/id-less colliding-ts regression test asserting both lines survive.
- Opus MEDIUM (id-alone fold) is subsumed by the corroboration rule; both LOW findings (doc divergence on the counter effect, test-coverage gaps) are addressed in the docs paragraph and the three added tests.

## Tests

`TestForeignFoldMidIdentity` (7 cases): id-matched durable copy folds with **empty** `dedup_dropped`; two identical-content rows with distinct ids stay distinct; an unmatched-id line beats an available body-tiebreak budget; an id-less legacy line still exact-folds into an id-carrying restored window row; a mixed id/id-less colliding-ts group loses nothing; a reused id with distinct body falls back conservatively without stealing the entry's budget; an id+ts corroborated fold of a superseded body is silent. The existing `test_foreign_append_content_identity_dedup_semantics` contract test is repointed in the same commit as the pinned legacy id-less fallback (all-id-less input reproduces today's behaviour exactly).

## Verification

- Full backend suite: **61266 passed, 0 failed** (335 skipped, 6 xfailed)
- `isort` / `flake8` / `mypy` clean (full tree); black gate green
- No frontend files changed


## Known main-red (not this PR)

`Backend Tests (3.10, 2)` fails on the merge ref via two `TestChannelApplierBoundary` tests in `test/test_driver_session_directives.py`. Reproduced on a clean `main` checkout (37089b1f9): #3543 widened `set_project` to non-dashboard surfaces without repointing those invariant tests, and a slot-less channel caller crashes with `AttributeError` instead of a clean refusal. Tracked in #5201; this PR's diff does not touch session directives. Will re-run CI once the main fix lands.
