### PR TITLE
feat: session work ledger - durable loop state on disk, not in context

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -255,7 +255,6 @@ src/kiro_crew/dashboard/handlers/notifications_push.py
 src/kiro_crew/dashboard/handlers/prompts.py
 src/kiro_crew/dashboard/handlers/security.py
 src/kiro_crew/dashboard/handlers/session_storage.py
-src/kiro_crew/dashboard/handlers/sessions.py
 src/kiro_crew/dashboard/handlers/side.py
 src/kiro_crew/dashboard/handlers/skill_budget.py
 src/kiro_crew/dashboard/handlers/source_providers.py

--- a/docs/system-specs/features/README.md
+++ b/docs/system-specs/features/README.md
@@ -6,6 +6,7 @@ single subsystem belongs in [../modules/](../modules/README.md) instead.
 | Spec | Covers |
 |---|---|
 | [dashboard-token-auth.md](dashboard-token-auth.md) | Signed, IP-pinned dashboard tokens, session TTLs, and token refresh. |
+| [session-work-ledger.md](session-work-ledger.md) | Per-session durable work state (goal, phase, tried, artifacts) on disk, its MCP tools, and monitor-loop snapshot injection. |
 | [prompt-optimizer.md](prompt-optimizer.md) | Rewriting a draft prompt on demand, and the paste-forwarding surface. |
 | [app-notifications.md](app-notifications.md) | How an app publishes a notification to the local bus. |
 | [inline-action-buttons.md](inline-action-buttons.md) | Agent-proposed buttons rendered inline in chat. |

--- a/docs/system-specs/features/session-work-ledger.md
+++ b/docs/system-specs/features/session-work-ledger.md
@@ -1,0 +1,186 @@
+# Session Work Ledger
+
+Status: implemented (this PR)
+Owners: gateway core (`session_ledger.py`), MCP tools (`mcp_tools/ledger.py`)
+
+## 1. Problem
+
+Long-horizon loops — `monitor_start` babysit loops, goal loops, any session that
+wakes dozens of times — carry their working state in the context window. Every
+cycle appends a full turn to the same session, so "what am I doing, what have I
+tried, where are my artifacts" survives only as prior transcript turns. When the
+context fills, compaction summarizes generically and the agent loses exactly the
+state it needs to keep going: approaches already rejected, the branch it was on,
+the reason a phase was entered.
+
+Compaction itself is out of scope: it is performed by the agent harness (the
+ACP/kiro-cli layer), not by this codebase, so the fix cannot be "compact
+better". The fix is to stop using the context window as the authoritative store
+for loop state.
+
+The pattern already exists in this repo — three times, hand-rolled per app:
+
+- Issue Radar's crew ledger (`apps/builtins/issue_radar/backend/crew_store.py`):
+  work items with `phase` / `next` / `tried[]`, an append-only content-addressed
+  event log, and the rule that a phase never moves without a logged event.
+- Ops Mission Control's knowledge ledger
+  (`apps/builtins/ops_mission_control/backend/ledger.py`): append-only JSONL,
+  content-addressed ids, locked read-modify-write.
+- The heartbeat/cron surfaces re-derive state per cycle from files.
+
+Each app that needs durable work state re-invents the primitive. Sessions that
+are not one of those apps get nothing.
+
+## 2. Solution overview
+
+A generic, per-session **work ledger** on disk:
+
+- One directory per session under the data home, created lazily on first write,
+  deleted when the session's history is permanently deleted.
+- A mutable **state record** (goal, phase, next intent, tried/rejected
+  approaches, artifact pointers) plus an append-only **event log**.
+- Two core MCP tools, `session_ledger_read` and `session_ledger_record`, with
+  session-resolved identity: a session can only ever touch its own ledger.
+- Auto-nudge integration: when a monitor loop fires on a session that has a
+  ledger, the nudge body carries a compact snapshot of the state record, so each
+  cycle starts from the ledger instead of from transcript memory.
+
+The context window becomes a cache; the ledger is the authority. A loop cycle
+needs the snapshot plus its check instructions — its cost no longer grows with
+the number of cycles that came before it.
+
+## 3. On-disk layout and lifecycle
+
+```
+<data_home>/ledger/<store-name>/
+    slot_key        # breadcrumb: the exact ledger key this dir belongs to
+    state.json      # the whole record, replaced atomically on every write
+    .lock           # cross-process mutex inode (never replaced by writes)
+```
+
+- **Identity is the exact key.** The ledger key is the session key with only
+  the dashboard prefixes stripped (one dashboard session is legitimately
+  spelled both `dashboard_chat-X` and `chat-X`, and both must reach one
+  ledger); nothing else is rewritten. `<store-name>` is a readable charset
+  fold of that key plus a sha256 prefix over the FULL key — the fold shapes
+  only legibility, the digest carries identity, so two distinct
+  colon-structured channel keys can never share a directory (a lossy charset
+  fold as the identity would let one session read and overwrite another's
+  state). Path safety mirrors `subagent_persistence._agent_dir`: hostile keys
+  refused, resolved path required to stay inside the ledger root.
+- **Not `/tmp`, not the scratch dir.** Scratch (`KIROCREW_SCRATCH`) is keyed to
+  process liveness and swept hourly once the owner process group dies; a ledger
+  must survive gateway restarts for as long as its session exists.
+- **Tab close keeps the ledger.** Closing a dashboard tab
+  (`api_chat_slot_delete`) deliberately preserves resumable session state, and
+  the ledger is part of that state.
+- **History deletion reaps the ledger.** Both permanent-delete endpoints
+  (`DELETE /api/sessions/{key}` and the bulk `DELETE /api/sessions`) funnel
+  through `_remove_slot_for_history_key`; the ledger purge runs at the END of
+  that funnel — after the slot's turn is cancelled and its session destroyed —
+  so an in-flight write from the dying turn cannot land after the purge. A
+  write racing in from another process can at worst recreate an orphan
+  directory that the next delete sweeps; ledger content is disposable
+  intermediate state, so that residue is accepted rather than buying a
+  tombstone protocol for data nothing reconstructs from.
+
+## 4. Data model
+
+`state.json` is ONE document — the mutable state record carrying a bounded
+event tail — replaced atomically (`atomic_write`: temp file + rename) on every
+write. Schema-versioned; unknown fields preserved, defaults coerced forward on
+read; a malformed or oversized file is treated as absent, never fatal.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schema` | int | record version, currently 1 |
+| `goal` | str | the binding objective of the workstream |
+| `phase` | str | current phase; free-form but see write discipline |
+| `next` | str | the resumable intent — a concrete next step, not a status word |
+| `tried` | list | `{approach, rejected_because, at}` — appended, never rewritten |
+| `artifacts` | dict | string-to-string pointers: worktree, branch, pr, paths |
+| `events` | list | bounded tail of `{ts, kind, text}` progress lines, oldest aged out |
+| `created_at` / `last_progress_at` / `finished_at` | str | ISO timestamps |
+
+### Write discipline (carried over from the crew ledger)
+
+- A `phase` change **requires** an event (`event` + a recognized `event_kind`)
+  in the same call. Because state and event land in the same atomic write,
+  the invariant is crash-atomic by construction: no failure between "phase
+  moved" and "event logged" can exist.
+- Every field is clamped at write time and the event tail is bounded, so the
+  document cannot grow without limit and every read is O(record), never
+  O(history).
+- `last_progress_at` advances on every accepted record call; `finished_at` is
+  set when `phase` enters a terminal value (`done`, `abandoned`).
+- Fields omitted from a record call keep their stored values: partial updates
+  are the norm and never a way to erase state.
+- Writes hold a per-ledger cross-process file lock with a **bounded** acquire:
+  a wedged holder costs one refused write (surfaced as a retryable error),
+  never a worker thread parked forever. Reads are lock-free — the atomic
+  replace means a reader sees the old or the new document, never a torn one,
+  and state + events always come from one transaction.
+
+## 5. MCP tools
+
+Registered as a core domain module (`mcp_tools/ledger.py`, listed in
+`DOMAIN_MODULES`), following the `learn.py` template: `schemas()` + `HANDLERS`,
+handlers reach the gateway over the loopback HTTP API with the session-resolved
+identity header. There is no slot-key argument — the backend resolves the
+calling session and refuses requests that carry no session identity, exactly
+like the Issue Radar crew routes (raw HTTP gets 403).
+
+- `session_ledger_read` — no arguments. Returns the state record plus the tail
+  of the event log. The tool description tells the agent this is its own
+  session's durable work state.
+- `session_ledger_record` — `goal?`, `phase?`, `next?`, `tried_approach?` +
+  `tried_rejected_because?`, `artifacts?` (string map, merged), `event?` +
+  `event_kind?`. Enforces the phase/event rule server-side.
+
+Subagent, cron, and channel sessions may call the tools; each writes the ledger
+of its own session key. The primitive is deliberately session-scoped — there is
+no cross-session read, which keeps the authorization story trivial.
+
+## 6. Auto-nudge snapshot injection
+
+`compose_nudge_body` (`dashboard/handlers/autonudge.py`) is the single
+composer used by all three fire callbacks (dashboard slot, Slack thread,
+Discord DM). When the loop's session has a ledger with a non-empty,
+non-terminal state record, the rendered body is prefixed with a bounded
+`[work ledger]` block — goal, phase, next, the last few tried entries,
+artifacts — capped in size so a runaway ledger cannot flood the turn. The
+ledger read runs in a worker thread: a slow or wedged filesystem costs one
+loop's snapshot, never the gateway event loop.
+
+No MCP schema or directive plumbing changes: the snapshot is derived
+server-side at fire time from the session key the loop already carries. Loops
+on sessions without a ledger render exactly as before. Cron and heartbeat
+composers are intentionally untouched — heartbeat is stateless-per-cycle by
+design, and cron sessions can call `session_ledger_read` themselves.
+
+## 7. Non-goals
+
+- **Compaction.** Owned by the agent harness (ACP/kiro-cli); this feature
+  reduces what compaction can lose, it does not change how compaction works.
+- **Turn-internal durability / operation log.** Journaling tool calls with
+  stable operation ids so an interrupted turn can resume without re-executing
+  side effects is a separate, finer-grained track. This ledger records state
+  *between* wakes, not execution *within* a turn.
+- **Multi-writer arbitration / fenced leases.** One gateway process owns a
+  session's turns; concurrent cross-process writes to the same ledger are
+  serialized by the file lock. There is no takeover semantic to protect, so
+  version-fenced execution tokens would be complexity without a customer.
+- **UI.** No dashboard surface in this iteration; the ledger is agent-facing.
+
+## 8. Failure modes
+
+- Ledger read/parse failure, or a state file past the size ceiling → treated
+  as absent; tools report empty state; nudge injection skips the block. Never
+  blocks the loop or the turn.
+- Lock contention → the acquire is a bounded poll; on expiry the record call
+  fails closed with a retryable error. Nudge-time reads are lock-free and
+  never wait on a writer.
+- Session deleted while a loop still points at it → purge wins; subsequent
+  reads see an empty ledger. A cross-process write racing the purge can
+  recreate an orphan directory, which the next delete sweeps — accepted for
+  disposable state (§3).

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -318,6 +318,12 @@ from kiro_crew.dashboard.handlers.prompts import (  # noqa: E402, F401
     api_skills_pending_dismiss_all,
 )
 
+# ── Session work ledger (handlers/session_ledger.py) ──
+from kiro_crew.dashboard.handlers.session_ledger import (  # noqa: E402, F401
+    api_session_ledger_get,
+    api_session_ledger_record,
+)
+
 # ── Sessions (extracted to handlers/sessions.py) ──
 from kiro_crew.dashboard.handlers.session_storage import (  # noqa: E402, F401
     api_session_inventory,

--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import asdict
 from typing import Any
@@ -20,6 +21,7 @@ from kiro_crew.autonudge_authz import (  # noqa: F401 - re-exported
 )
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.sel import sel
+from kiro_crew.session_ledger import ledger_key, render_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,33 @@ logger = logging.getLogger(__name__)
 def render_nudge_message(message: str, stop_sentinel_path: str | None) -> str:
     """Replace {{STOP_FILE}} template with the resolved sentinel path."""
     return message.replace("{{STOP_FILE}}", stop_sentinel_path or "")
+
+
+async def compose_nudge_body(
+    message: str, stop_sentinel_path: str | None, slot_key: str | None
+) -> str:
+    """Compose one nudge cycle's full body text — the shared fire-path composer.
+
+    Applies :func:`render_nudge_message`'s template substitution and, when the
+    loop's session has a non-empty, non-terminal work ledger, prefixes a
+    compact snapshot of it so every cycle starts from the durable state
+    instead of from transcript memory. Derived server-side at fire time;
+    sessions without a ledger render exactly as before.
+
+    The ledger read is filesystem I/O, so it runs in a worker thread — a slow
+    or wedged filesystem costs this loop's snapshot, never the event loop.
+    Best-effort throughout: a snapshot failure must not cost the nudge itself.
+    """
+    body = render_nudge_message(message, stop_sentinel_path)
+    if slot_key:
+        try:
+            snapshot = await asyncio.to_thread(render_snapshot, ledger_key(slot_key))
+        except Exception:
+            logger.debug("nudge: ledger snapshot failed for %s", slot_key, exc_info=True)
+            snapshot = ""
+        if snapshot:
+            return f"{snapshot}\n\n{body}"
+    return body
 
 
 def _serialize(loop: Any) -> dict:

--- a/src/kiro_crew/dashboard/handlers/session_ledger.py
+++ b/src/kiro_crew/dashboard/handlers/session_ledger.py
@@ -1,0 +1,153 @@
+"""HTTP routes for the per-session work ledger.
+
+Thin mapping over :mod:`kiro_crew.session_ledger`. The security contract is
+the Issue Radar crew-route one: the ledger a request touches is derived from
+the CALLING SESSION's identity (``X-Session-Key``, vetted by
+``_recognize_session``), never from the request body — so a session can only
+ever read or write its own ledger, and raw HTTP with no recognized session
+identity is refused. Restricted (incognito/temporary/guest) sessions are
+refused too: a ledger is durable on-disk state, which is exactly what those
+modes promise not to leave behind.
+
+Both routes are MCP-only (no browser caller) and listed in
+``server._STRICT_INTERNAL_API_PATHS`` — without that entry the internal-secret
+call falls through to cookie auth and every tool call fails with 403.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+from kiro_crew import session_ledger
+from kiro_crew.dashboard.handlers._shared import _is_restricted_session
+
+# Module-scope like memory.py's identical imports: the recognition gate and
+# incognito classifier are this module's own load-bearing dependencies.
+from kiro_crew.dashboard.handlers.cron import _recognize_session
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import is_incognito_transcript
+from kiro_crew.sel import sel
+from kiro_crew.validation import (
+    SESSION_LEDGER_RECORD_SCHEMA,
+    ValidationError,
+    validate_tool_args,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _resolve_ledger_key(
+    request: web.Request, operation: str
+) -> tuple[str, None] | tuple[None, web.Response]:
+    """Vet the calling session and fold its key to the ledger spelling.
+
+    Returns ``(key, None)`` on success or ``(None, refusal_response)``. The
+    fold is :func:`session_ledger.ledger_key` — a LOSSLESS dashboard-prefix
+    strip, so the spelling here matches what the nudge composer derives from a
+    loop's slot key, while distinct channel session keys can never collide.
+    """
+    state: DashboardState = request.app["state"]
+    sk = request.headers.get("X-Session-Key", "")
+    refusal = await _recognize_session(
+        state, sk, operation, blocks_persisted_mode=is_incognito_transcript
+    )
+    if refusal is not None:
+        return None, refusal
+    if _is_restricted_session(state, request):
+        sel().log_api_access(
+            caller=sk,
+            operation=operation,
+            outcome="denied",
+            source="dashboard",
+            resources="restricted_session_block",
+            error="Ledger writes are not allowed in this session mode.",
+        )
+        return None, web.json_response(
+            {
+                "error": "The work ledger is not available in this session mode.",
+                "code": "restricted_session",
+            },
+            status=403,
+        )
+    return session_ledger.ledger_key(sk), None
+
+
+async def api_session_ledger_get(request: web.Request) -> web.Response:
+    """GET /api/session-ledger — the calling session's state record + event tail.
+
+    One read: the event tail rides inside the state document, so state and
+    events always come from the same transaction (no torn pairing).
+    """
+    key, refusal = await _resolve_ledger_key(request, "session_ledger_read")
+    if refusal is not None:
+        return refusal
+    assert key is not None
+    state_record = await asyncio.to_thread(session_ledger.read_state, key)
+    events = state_record.get("events", [])[-session_ledger._MAX_EVENT_TAIL :]
+    return web.json_response({"state": state_record, "events": events})
+
+
+async def api_session_ledger_record(request: web.Request) -> web.Response:
+    """POST /api/session-ledger/record — one partial update, locked transaction."""
+    key, refusal = await _resolve_ledger_key(request, "session_ledger_record")
+    if refusal is not None:
+        return refusal
+    assert key is not None
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    if not isinstance(body, dict):
+        return web.json_response(
+            {"error": "request body must be a JSON object", "code": "invalid_body"},
+            status=400,
+        )
+    known = {f.name for f in SESSION_LEDGER_RECORD_SCHEMA.fields}
+    try:
+        cleaned = validate_tool_args(
+            {k: v for k, v in body.items() if k in known},
+            SESSION_LEDGER_RECORD_SCHEMA,
+        )
+    except ValidationError as exc:
+        return web.json_response({"error": str(exc), "code": "validation_error"}, status=400)
+    artifacts = cleaned.get("artifacts")
+    if artifacts is not None and not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in artifacts.items()
+    ):
+        return web.json_response(
+            {
+                "error": "artifacts must map strings to strings",
+                "code": "artifacts_not_string_map",
+            },
+            status=400,
+        )
+    try:
+        # record() takes the per-ledger file lock (bounded acquire + disk
+        # I/O); off-loop so a wedged cross-process peer cannot freeze
+        # chat/WS/heartbeat — the bounded lock then costs at most one refused
+        # write, never a parked worker thread.
+        state_record = await asyncio.to_thread(
+            session_ledger.record,
+            key,
+            goal=cleaned.get("goal"),
+            phase=cleaned.get("phase"),
+            next_step=cleaned.get("next"),
+            tried_approach=cleaned.get("tried_approach"),
+            tried_rejected_because=cleaned.get("tried_rejected_because"),
+            artifacts=artifacts,
+            event=cleaned.get("event"),
+            event_kind=cleaned.get("event_kind"),
+        )
+    except ValueError as exc:
+        # The phase-requires-event discipline (and key validation) surface here.
+        return web.json_response({"error": str(exc), "code": "ledger_discipline"}, status=400)
+    except OSError:
+        logger.warning("session ledger write failed for %s", key, exc_info=True)
+        return web.json_response(
+            {"error": "ledger write failed; try again", "code": "ledger_write_failed"},
+            status=503,
+        )
+    return web.json_response({"ok": True, "state": state_record})

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -22,6 +22,7 @@ from aiohttp import web
 # binds via sys.modules and defers attribute access to call time, which also
 # keeps tests' monkeypatching of handlers.redact_* effective (late binding).
 import kiro_crew.dashboard.handlers as _h
+from kiro_crew import session_ledger
 from kiro_crew.acp.client import _resolve_kiro_bin_for_spawn
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.dashboard.handlers import kiro_usage_api
@@ -127,9 +128,7 @@ _MAX_BONUS_NAME_CHARS = 100
 _MAX_BONUS_CREDITS = 1_000_000.0
 _MAX_BONUS_DAYS_LEFT = 3_650
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
-_BONUS_DASH_RE = re.compile(
-    r"^([\d.]+)/([\d.]+)\s+used\s+\((\d+)\s+days?\s+left\)$"
-)
+_BONUS_DASH_RE = re.compile(r"^([\d.]+)/([\d.]+)\s+used\s+\((\d+)\s+days?\s+left\)$")
 _BONUS_COLON_RE = re.compile(
     r"^(.+?):\s*([\d.]+)/([\d.]+)\s*\(expires\s+in\s+(\d+)\s+days?\)$",
     re.IGNORECASE,
@@ -371,9 +370,7 @@ def _parse_usage(raw: str) -> dict[str, object]:
             or not name.isprintable()
         ):
             continue
-        bonus_credits.append(
-            {"name": name, "used": used, "total": total, "days_left": days_left}
-        )
+        bonus_credits.append({"name": name, "used": used, "total": total, "days_left": days_left})
         if len(bonus_credits) >= _MAX_BONUS_GRANTS:
             break
     # Preserve an observed empty section as an explicit empty list, so callers
@@ -1145,9 +1142,7 @@ async def _summarize_one(state: DashboardState, key: str) -> str:
         try:
             await loop.run_in_executor(
                 None,
-                functools.partial(
-                    log.set_cached_summary, key, summary, sig, generation
-                ),
+                functools.partial(log.set_cached_summary, key, summary, sig, generation),
             )
         except Exception:
             logger.debug("Failed to persist summary cache for %s", key, exc_info=True)
@@ -1307,8 +1302,7 @@ async def _remove_slot_for_history_key(state: DashboardState, key: str) -> None:
             try:
                 await crew.purge_slot(candidate)
             except Exception:
-                logger.warning("History delete: crew purge failed for %s",
-                               candidate, exc_info=True)
+                logger.warning("History delete: crew purge failed for %s", candidate, exc_info=True)
     try:
         await state.remove_chat_pins_for_slots(pin_slot_keys)
     except Exception:
@@ -1345,6 +1339,43 @@ async def _remove_slot_for_history_key(state: DashboardState, key: str) -> None:
             await state.sessions.destroy(effective_session_key(slot))
         except Exception:
             pass
+    # The work ledger persists independently of the transcript too, and its
+    # content is disposable intermediate state (nothing reconstructs from it),
+    # so a permanent delete reaps it unconditionally. Runs LAST — after the
+    # slot's turn is cancelled and its session destroyed — so an in-flight
+    # ledger write from the dying turn cannot land after the purge; a write
+    # racing in from another process can at worst recreate an orphan directory
+    # the next delete sweeps (see session_ledger.purge). Tab close
+    # (api_chat_slot_delete) deliberately does NOT reach here: the ledger is
+    # part of a session's resumable state.
+    ledger_candidates = set(pin_slot_keys)
+    if slot is not None:
+        # The AUTHORITATIVE session key: a channel-born slot runs the
+        # channel's own session, whose exact key (the ledger's identity) may
+        # appear in pin_slot_keys only as a folded spelling.
+        try:
+            from kiro_crew.dashboard.chat_utils import effective_session_key
+
+            ledger_candidates.add(effective_session_key(slot))
+        except Exception:
+            pass
+    exact_keys = {session_ledger.ledger_key(k) for k in ledger_candidates if k}
+    for candidate in exact_keys:
+        try:
+            await asyncio.to_thread(session_ledger.purge, candidate)
+        except Exception:
+            logger.warning("History delete: ledger purge failed for %s", candidate, exc_info=True)
+    # Breadcrumb sweep: a channel session's ledger is keyed by its EXACT
+    # session key, but a slotless delete only holds the folded transcript
+    # spelling — match each ledger's breadcrumb under the same fold so the
+    # exact-key ledger cannot outlive its session.
+    folded_keys = {_normalize_slot_key(k) for k in ledger_candidates if k}
+    try:
+        await asyncio.to_thread(
+            session_ledger.purge_matching, exact_keys, folded_keys, _normalize_slot_key
+        )
+    except Exception:
+        logger.warning("History delete: ledger sweep failed for %s", key, exc_info=True)
 
 
 async def api_sessions_clear(request: web.Request) -> web.Response:
@@ -1874,9 +1905,7 @@ async def api_sessions_restart(request: web.Request) -> web.Response:
     synced = 0
     sync_ok = True
     try:
-        to_sync = await asyncio.wait_for(
-            asyncio.to_thread(sync_discovered_servers), timeout=30
-        )
+        to_sync = await asyncio.wait_for(asyncio.to_thread(sync_discovered_servers), timeout=30)
         synced = len(to_sync)
     except Exception:
         # The restart still proceeds (it applies whatever IS on disk), but the

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -314,6 +314,12 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         "/api/slack/reactions",
         "/api/slack-profile",  # MCP-only (slack_profile tool); no browser caller
         "/api/sessions/summarize",  # MCP-only (list_sessions summarize leg); internal-secret, no browser caller
+        # MCP-only (session_ledger_read / session_ledger_record tools); no
+        # browser caller. Prefix matching covers "/api/session-ledger/record".
+        # Without this entry the tools' internal-secret calls fall through to
+        # cookie auth and are refused before the handler's own session
+        # recognition can run.
+        "/api/session-ledger",
         # MCP-only (knowledge_add_document tool); no browser caller — the
         # dashboard ingests via its own cookie-authed knowledge routes. Same
         # wiring class as "/api/notifications/agent" above.
@@ -986,6 +992,8 @@ def _register_mcp_routes(app: web.Application) -> None:
     app.router.add_get("/api/lessons", handlers.api_lessons)
     app.router.add_post("/api/lessons", handlers.api_lessons_create)
     app.router.add_delete("/api/lessons", handlers.api_lessons_delete)
+    app.router.add_get("/api/session-ledger", handlers.api_session_ledger_get)
+    app.router.add_post("/api/session-ledger/record", handlers.api_session_ledger_record)
     app.router.add_get("/api/crons", handlers.api_crons)
     app.router.add_post("/api/crons", handlers.api_crons_create)
     app.router.add_delete("/api/crons", handlers.api_cron_batch_delete)

--- a/src/kiro_crew/mcp_tools/__init__.py
+++ b/src/kiro_crew/mcp_tools/__init__.py
@@ -18,6 +18,7 @@ from typing import Any
 DOMAIN_MODULES: tuple[str, ...] = (
     "spawn",
     "learn",
+    "ledger",
     "skills",
     "control",
     "messaging",

--- a/src/kiro_crew/mcp_tools/ledger.py
+++ b/src/kiro_crew/mcp_tools/ledger.py
@@ -1,0 +1,199 @@
+"""Session work-ledger tools — durable loop state on disk, not in context.
+
+``schemas()`` returns the advertisement half of each tool; ``HANDLERS`` maps
+names to behavior (see ``learn.py`` — this module follows the same template,
+including reaching shared plumbing as ``mcp_core`` attributes so tests that
+rebind them still intercept the handlers).
+
+The tools carry NO session/slot argument: the backend resolves the calling
+session's identity from the request and each session can only touch its own
+ledger. Raw HTTP without a recognized session identity is refused (403).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from kiro_crew import mcp_core
+from kiro_crew.session_ledger import EVENT_KINDS, TERMINAL_PHASES
+
+
+def schemas() -> list[dict[str, Any]]:
+    """Descriptors for the session-ledger tools."""
+    kinds = ", ".join(sorted(EVENT_KINDS))
+    terminal = ", ".join(sorted(TERMINAL_PHASES))
+    return [
+        {
+            "name": "session_ledger_read",
+            "description": (
+                "Read THIS session's durable work ledger: the state record "
+                "(goal, phase, next step, tried/rejected approaches, artifact "
+                "pointers) plus the recent event tail. The ledger lives on "
+                "disk and survives context compaction — treat it as "
+                "authoritative over your memory of prior cycles. Call it when "
+                "resuming long-running work (a monitor loop cycle, a return "
+                "after compaction) before re-deriving state from the "
+                "conversation."
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "session_ledger_record",
+            "description": (
+                "Record one step of long-running work into THIS session's "
+                "durable ledger, so the state survives context compaction and "
+                "is re-injected into monitor-loop cycles. Write what a cold "
+                "resume needs: `next` as a concrete intent (not a status "
+                "word), approaches you tried and rejected, and artifact "
+                "pointers (worktree, branch, PR). Fields you omit keep their "
+                "stored values — partial updates are the norm. Changing "
+                f"`phase` REQUIRES an `event` (+ `event_kind`); phases "
+                f"{terminal} mark the workstream finished and stop the "
+                "ledger's snapshot injection. Use it for genuinely "
+                "long-horizon work (babysit loops, goal loops, multi-wake "
+                "tasks), not for single-turn requests."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "goal": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "The binding objective of this workstream.",
+                    },
+                    "phase": {
+                        "type": "string",
+                        "maxLength": 128,
+                        "description": (
+                            "Current phase (free-form, e.g. 'implementing', "
+                            f"'awaiting-ci'; {terminal} are terminal). "
+                            "REQUIRES `event` AND a recognized `event_kind` "
+                            "in the same call — a phase never moves without "
+                            "a logged, classified reason."
+                        ),
+                    },
+                    "next": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": (
+                            "The resumable intent — the concrete next step, " "not a status word."
+                        ),
+                    },
+                    "tried_approach": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": (
+                            "An approach you tried and rejected — appended, so "
+                            "a resumed cycle does not re-walk it."
+                        ),
+                    },
+                    "tried_rejected_because": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "Why that approach was rejected.",
+                    },
+                    "artifacts": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                        "description": (
+                            "String-to-string pointers to where the work "
+                            "lives (worktree, branch, pr, paths). Merged into "
+                            "the stored map."
+                        ),
+                    },
+                    "event": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": (
+                            "One-line progress note appended to the event log. "
+                            "REQUIRED when `phase` changes."
+                        ),
+                    },
+                    "event_kind": {
+                        "type": "string",
+                        "maxLength": 32,
+                        "description": f"Kind of step this records: {kinds}.",
+                    },
+                },
+            },
+        },
+    ]
+
+
+def _strict_session_key() -> tuple[str, str]:
+    """Resolve the calling session strictly, refusing PID-walked identities.
+
+    Returns ``(key, "")`` or ``("", error)``. The lenient default resolver
+    includes a ``/proc`` ancestor walk, and a subagent lives under its parent
+    slot's process tree — the walk would silently resolve to the PARENT
+    session, disclosing or overwriting the parent's ledger. The strict
+    resolver only accepts gateway-authored identities, and the verified key is
+    passed explicitly to the transport so the value that was checked is the
+    value that is used.
+    """
+    sk = mcp_core._resolve_session_key_strict()
+    if not sk:
+        return "", (
+            "Error: this session's identity could not be verified strictly, "
+            "so the ledger is not reachable from here. Subagents inherit no "
+            "session identity of their own — record ledger updates from the "
+            "parent session instead."
+        )
+    return sk, ""
+
+
+def session_ledger_read(name: str, args: dict[str, Any]) -> str:
+    sk, err = _strict_session_key()
+    if err:
+        return err
+    d = mcp_core._get("/api/session-ledger", session_key=sk)
+    api_err = d.get("error")
+    if api_err:
+        return f"Error: {api_err}"
+    state = d.get("state") or {}
+    events = d.get("events") or []
+    if not any(state.get(k) for k in ("goal", "phase", "next", "tried", "artifacts")):
+        return (
+            "This session has no work ledger yet. Use session_ledger_record "
+            "to start one when doing long-horizon work."
+        )
+    return json.dumps({"state": state, "events": events}, indent=2)
+
+
+def session_ledger_record(name: str, args: dict[str, Any]) -> str:
+    payload = {
+        k: v
+        for k, v in args.items()
+        if k
+        in (
+            "goal",
+            "phase",
+            "next",
+            "tried_approach",
+            "tried_rejected_because",
+            "artifacts",
+            "event",
+            "event_kind",
+        )
+        and v is not None
+    }
+    if not payload:
+        return "Error: nothing to record — pass at least one field"
+    sk, err = _strict_session_key()
+    if err:
+        return err
+    d = mcp_core._post("/api/session-ledger/record", payload, session_key=sk)
+    api_err = d.get("error")
+    if api_err:
+        return f"Error: {api_err}"
+    state = d.get("state") or {}
+    phase = state.get("phase") or "(unset)"
+    return f"Recorded. phase={phase} next={state.get('next') or '(unset)'}"
+
+
+HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
+    "session_ledger_read": session_ledger_read,
+    "session_ledger_record": session_ledger_record,
+}

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4840,6 +4840,17 @@ _CREW_SECRET_LEAVES: list[str] = [
     "workspace/md-notebook/settings.json",
     "browser-cookies.txt",
     "playwright-storage-state.json",
+    # Per-session work ledgers (session_ledger.py). Not credentials, but each
+    # directory is one session's private work state, and the ledger's whole
+    # authorization model is "a session reaches only its OWN ledger" (the HTTP
+    # routes derive the target from the vetted caller identity). An agent's
+    # auto-approved file tools would bypass that boundary sideways — any
+    # session could read or corrupt any other session's ledger straight off
+    # disk. Unlike the transcript files beside it, the ledger has no
+    # legitimate file-tool reader: every legitimate access goes through the
+    # backend module, which opens paths directly rather than through this
+    # gate, so nothing breaks by fencing the whole subtree.
+    "ledger",
     # The optional Playwright extension token. It removes the browser-side approval
     # click for an attach, so a process that could read it could attach to the
     # operator's logged-in browser without them seeing a prompt. The gateway hands

--- a/src/kiro_crew/session_ledger.py
+++ b/src/kiro_crew/session_ledger.py
@@ -1,0 +1,537 @@
+"""Per-session work ledger — durable loop state that lives on disk, not in context.
+
+Long-horizon sessions (monitor loops, goal loops) accumulate their working
+state as prior transcript turns, which the harness-owned compaction then
+summarizes lossily. This module gives every session one small on-disk store
+for that state instead: a mutable **state record** (goal, phase, next intent,
+tried approaches, artifact pointers) carrying a bounded **event tail**. The
+context window becomes a cache; the ledger is the authority.
+
+Layout (see docs/system-specs/features/session-work-ledger.md):
+
+    <data_home>/ledger/<store-name>/
+        slot_key        # breadcrumb: the exact ledger key this dir belongs to
+        state.json      # the whole record, replaced atomically on every write
+        .lock           # cross-process mutex inode (never replaced by writes)
+
+Design notes, each earned by a review finding:
+
+- **One document, one atomic write.** State and its event land in the same
+  ``atomic_write`` (temp file + rename), so a crash between "phase moved" and
+  "event logged" cannot exist — the phase-requires-event invariant is
+  crash-atomic by construction, not by ordering. The event tail is bounded
+  (``_MAX_EVENTS``), so the file cannot grow without limit and every read is
+  O(record), never O(history).
+- **Exact-key identity.** :func:`ledger_key` only strips the dashboard
+  prefixes (the same strip the permanent-delete funnel applies); it never
+  folds the key's charset. Uniqueness comes from a digest over the exact key
+  inside :func:`_store_name` — a lossy charset fold as the identity would map
+  distinct channel session keys (colon-structured) onto one ledger.
+- **Bounded lock.** The per-ledger lock acquire is a bounded poll and fails
+  closed with ``OSError`` — a wedged cross-process holder costs one refused
+  write, never an executor thread parked forever.
+- **Size ceiling before parse.** A state file past ``_MAX_STATE_BYTES`` is
+  treated as corrupt/absent rather than parsed, so a hostile or damaged file
+  cannot make every nudge fire allocate its size.
+
+Callers pass keys through :func:`ledger_key`; this module never imports
+dashboard state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import time
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import data_home
+from kiro_crew.platform_compat import release_lock, try_acquire_lock
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+#: Phases that end a workstream. ``finished_at`` is stamped when the record
+#: enters one of these; anything else is an in-flight phase.
+TERMINAL_PHASES = frozenset({"done", "abandoned"})
+
+#: Vocabulary for event lines. A phase change REQUIRES one of these; an event
+#: without a phase change coerces an unrecognized kind to ``note`` (the text
+#: is the payload there, the kind only a filter).
+EVENT_KINDS = frozenset({"progress", "decision", "tried", "blocked", "unblocked", "phase", "note"})
+
+# Bounds. The ledger is injected into nudge turns and read back every cycle,
+# so every field is capped at write time; a runaway writer degrades to a
+# clamped record instead of an unbounded file.
+_MAX_TEXT = 2000
+_MAX_TRIED = 50
+_MAX_ARTIFACTS = 32
+_MAX_EVENTS = 100
+_MAX_EVENT_TAIL = 20
+#: Refuse to parse a state file past this size: with every field clamped the
+#: legitimate maximum is well under it, so anything bigger is damage or
+#: tampering, and parsing it would cost what the clamps exist to prevent.
+_MAX_STATE_BYTES = 1_000_000
+
+#: Lock acquire budget. Every in-tree critical section is a sub-millisecond
+#: read + atomic rename, so this is a ceiling against a wedged cross-process
+#: holder, not a normal wait. On expiry the write FAILS CLOSED with OSError.
+_LOCK_TIMEOUT_SECS = 5.0
+_LOCK_POLL_SECS = 0.05
+
+_STATE_FILE = "state.json"
+_KEY_FILE = "slot_key"
+_LOCK_FILE = ".lock"
+
+#: Identical fold to ``crew_chat._store_name`` — kept in lockstep so a slot
+#: key and its stores share one spelling family. Reimplemented rather than
+#: imported: ``crew_chat`` drags the whole crew orchestrator import graph into
+#: what must stay a leaf module usable from the gateway boot path. The fold
+#: shapes only the READABLE half of a directory name; identity is the digest
+#: over the exact key.
+_STORE_NAME_UNSAFE = re.compile(r"[^A-Za-z0-9_.-]")
+_STORE_NAME_READABLE_MAX = 80
+
+
+def ledger_key(session_key: str) -> str:
+    """Fold a session/slot key to the ledger's identity spelling — LOSSLESSLY.
+
+    Only the dashboard prefixes are stripped, because one dashboard session is
+    legitimately spelled both ``dashboard_chat-X`` (history/API) and
+    ``chat-X`` (live slot, nudge loop) and both must reach one ledger. Nothing
+    else is rewritten: a charset fold here would be lossy, and two distinct
+    channel session keys that fold to the same string would share a ledger —
+    one session reading and overwriting another's state.
+    """
+    key = session_key or ""
+    if key.startswith("dashboard:"):
+        key = key[len("dashboard:") :]
+    while key.startswith("dashboard_"):
+        key = key[len("dashboard_") :]
+    return key
+
+
+def _store_name(slot_key: str) -> str:
+    """Directory name for *slot_key*'s ledger — unique per EXACT key.
+
+    Readable fold capped for filesystem name limits; uniqueness comes from the
+    digest over the FULL key, so ``Foo``/``foo`` and long shared prefixes all
+    get distinct directories on every filesystem. The name is not decodable
+    back to the key — the key is persisted inside the store instead.
+    """
+    readable = _STORE_NAME_UNSAFE.sub("_", slot_key)[:_STORE_NAME_READABLE_MAX]
+    digest = hashlib.sha256(slot_key.encode("utf-8")).hexdigest()[:8]
+    return f"{readable}-{digest}"
+
+
+def _ledger_root() -> Path:
+    """Ledger root, resolved against the live data home per call.
+
+    Never captured at import: an import-time binding freezes the data home and
+    defeats pod isolation and test isolation (same rule as
+    ``subagent_persistence._subagents_dir``).
+    """
+    return data_home() / "ledger"
+
+
+def ledger_dir(slot_key: str) -> Path:
+    """Validated per-session ledger directory for *slot_key*.
+
+    Raises ``ValueError`` on an empty or path-hostile key. The fold in
+    :func:`_store_name` already removes separators, but the raw key is checked
+    too so a hostile key is refused loudly instead of silently folded, and the
+    resolved path is required to stay inside the ledger root (symlink-safe).
+    """
+    if not slot_key or "\0" in slot_key or "/" in slot_key or "\\" in slot_key:
+        raise ValueError(f"Invalid slot key for ledger: {slot_key!r}")
+    base = _ledger_root()
+    resolved = (base / _store_name(slot_key)).resolve()
+    parent = base.resolve()
+    if resolved == parent or not resolved.is_relative_to(parent):
+        raise ValueError(f"Path traversal blocked for slot key: {slot_key!r}")
+    return resolved
+
+
+def _now_iso() -> str:
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def _clamp(value: Any, limit: int = _MAX_TEXT) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value[:limit]
+
+
+@contextmanager
+def _locked(dir_path: Path) -> Iterator[None]:
+    """Bounded cross-process exclusive lock over one ledger directory.
+
+    The lock file is a dedicated inode that writes never replace (replacing
+    the locked inode would let a second writer lock the NEW inode and
+    interleave). The acquire is a bounded poll over
+    :func:`platform_compat.try_acquire_lock` — the repo's one non-blocking
+    acquire primitive, covering POSIX and Windows alike — and FAILS CLOSED
+    with ``OSError`` rather than entering the critical section unserialized
+    or parking a worker thread on a wedged holder forever.
+    """
+    dir_path.mkdir(parents=True, exist_ok=True)
+    lock_path = dir_path / _LOCK_FILE
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECS
+        while not try_acquire_lock(fd, exclusive=True):
+            if time.monotonic() >= deadline:
+                raise OSError("ledger lock is held by another process; try again")
+            time.sleep(_LOCK_POLL_SECS)
+        try:
+            yield
+        finally:
+            release_lock(fd)
+    finally:
+        os.close(fd)
+
+
+def _empty_state() -> dict[str, Any]:
+    return {
+        "schema": SCHEMA_VERSION,
+        "goal": "",
+        "phase": "",
+        "next": "",
+        "tried": [],
+        "artifacts": {},
+        "events": [],
+        "created_at": "",
+        "last_progress_at": "",
+        "finished_at": "",
+    }
+
+
+def _coerce_state(raw: Any) -> dict[str, Any]:
+    """Fold whatever is on disk into a well-typed state record.
+
+    Unknown fields are preserved (forward compatibility for a newer writer);
+    known fields with the wrong type are reset to their defaults. Never raises.
+    """
+    state = _empty_state()
+    if not isinstance(raw, dict):
+        return state
+    extra = {k: v for k, v in raw.items() if k not in state}
+    for key in ("goal", "phase", "next", "created_at", "last_progress_at", "finished_at"):
+        if isinstance(raw.get(key), str):
+            state[key] = _clamp(raw[key])
+    if isinstance(raw.get("tried"), list):
+        tried: list[dict[str, str]] = []
+        for item in raw["tried"]:
+            if isinstance(item, dict) and isinstance(item.get("approach"), str):
+                tried.append(
+                    {
+                        "approach": _clamp(item["approach"]),
+                        "rejected_because": _clamp(item.get("rejected_because", "")),
+                        "at": _clamp(item.get("at", ""), 64),
+                    }
+                )
+        state["tried"] = tried[-_MAX_TRIED:]
+    if isinstance(raw.get("artifacts"), dict):
+        arts: dict[str, str] = {}
+        for k, v in raw["artifacts"].items():
+            if isinstance(k, str) and isinstance(v, str) and len(arts) < _MAX_ARTIFACTS:
+                arts[_clamp(k, 128)] = _clamp(v)
+        state["artifacts"] = arts
+    if isinstance(raw.get("events"), list):
+        events: list[dict[str, str]] = []
+        for item in raw["events"]:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                events.append(
+                    {
+                        "ts": _clamp(item.get("ts", ""), 64),
+                        "kind": _clamp(item.get("kind", ""), 32),
+                        "text": _clamp(item["text"]),
+                    }
+                )
+        state["events"] = events[-_MAX_EVENTS:]
+    schema = raw.get("schema")
+    if isinstance(schema, int) and not isinstance(schema, bool) and schema > 0:
+        state["schema"] = schema
+    state.update(extra)
+    return state
+
+
+def _read_state_unlocked(dir_path: Path) -> dict[str, Any]:
+    path = dir_path / _STATE_FILE
+    try:
+        if path.stat().st_size > _MAX_STATE_BYTES:
+            logger.warning("ledger state file over size ceiling; treating as absent")
+            return _empty_state()
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return _empty_state()
+    return _coerce_state(raw)
+
+
+def read_state(slot_key: str) -> dict[str, Any]:
+    """Best-effort read of the state record. Absent/malformed reads as empty.
+
+    Lock-free by design: ``atomic_write`` means a reader sees the old or the
+    new document, never a torn one, and the events ride the same document so
+    state and event tail are always from one transaction.
+    """
+    try:
+        dir_path = ledger_dir(slot_key)
+    except ValueError:
+        return _empty_state()
+    return _read_state_unlocked(dir_path)
+
+
+def has_ledger(slot_key: str) -> bool:
+    """Whether *slot_key* has ever recorded anything (cheap existence probe)."""
+    try:
+        return (ledger_dir(slot_key) / _STATE_FILE).exists()
+    except ValueError:
+        return False
+
+
+def record(
+    slot_key: str,
+    *,
+    goal: str | None = None,
+    phase: str | None = None,
+    next_step: str | None = None,
+    tried_approach: str | None = None,
+    tried_rejected_because: str | None = None,
+    artifacts: dict[str, str] | None = None,
+    event: str | None = None,
+    event_kind: str | None = None,
+) -> dict[str, Any]:
+    """Apply one partial update to the state record, in one locked transaction.
+
+    Enforces the crew-ledger discipline: passing *phase* without *event* and a
+    recognized *event_kind* is refused with ``ValueError`` — a phase must
+    never move without a logged, classified reason. State and event land in
+    the SAME atomic write, so the invariant holds across crashes too.
+
+    Returns the resulting state record.
+    """
+    if phase is not None:
+        if not (event and event.strip()):
+            raise ValueError("phase change requires an event: pass event + event_kind")
+        if (event_kind or "").strip() not in EVENT_KINDS:
+            kinds = ", ".join(sorted(EVENT_KINDS))
+            raise ValueError(f"phase change requires event_kind (one of: {kinds})")
+    dir_path = ledger_dir(slot_key)
+    with _locked(dir_path):
+        state = _read_state_unlocked(dir_path)
+        now = _now_iso()
+        created = not state["created_at"]
+        if created:
+            state["created_at"] = now
+            # Breadcrumb so the folded directory name can be mapped back to
+            # its key by a human (the fold itself is not decodable).
+            try:
+                atomic_write(dir_path / _KEY_FILE, slot_key + "\n", mode=0o600)
+            except OSError:
+                logger.debug("ledger: slot_key breadcrumb write failed", exc_info=True)
+        if goal is not None:
+            state["goal"] = _clamp(goal)
+        if phase is not None:
+            state["phase"] = _clamp(phase, 128)
+            state["finished_at"] = now if state["phase"] in TERMINAL_PHASES else ""
+        if next_step is not None:
+            state["next"] = _clamp(next_step)
+        if tried_approach:
+            tried = list(state["tried"])
+            tried.append(
+                {
+                    "approach": _clamp(tried_approach),
+                    "rejected_because": _clamp(tried_rejected_because or ""),
+                    "at": now,
+                }
+            )
+            state["tried"] = tried[-_MAX_TRIED:]
+        if artifacts:
+            merged = dict(state["artifacts"])
+            for k, v in artifacts.items():
+                if isinstance(k, str) and isinstance(v, str):
+                    ck = _clamp(k, 128)
+                    # Pop before reassigning: a dict update keeps the key's
+                    # ORIGINAL insertion position, so updating the oldest
+                    # pointer on a full map would leave it first in line for
+                    # the age-out below — deleting the very artifact this call
+                    # just wrote. Re-inserting moves it to newest.
+                    merged.pop(ck, None)
+                    merged[ck] = _clamp(v)
+            # Cap by insertion order: oldest pointers age out first.
+            if len(merged) > _MAX_ARTIFACTS:
+                merged = dict(list(merged.items())[-_MAX_ARTIFACTS:])
+            state["artifacts"] = merged
+        if event and event.strip():
+            kind = (event_kind or "").strip()
+            if kind not in EVENT_KINDS:
+                kind = "note"
+            events = list(state["events"])
+            events.append({"ts": now, "kind": kind, "text": _clamp(event.strip())})
+            state["events"] = events[-_MAX_EVENTS:]
+        state["last_progress_at"] = now
+        state["schema"] = SCHEMA_VERSION
+        atomic_write(dir_path / _STATE_FILE, _serialize_bounded(state) + "\n", mode=0o600)
+        return state
+
+
+def _serialize_bounded(state: dict[str, Any]) -> str:
+    """Serialize the state document, guaranteeing it fits the read ceiling.
+
+    The reader treats a file past ``_MAX_STATE_BYTES`` as damage and reads it
+    as absent — so the WRITER must guarantee no accepted record ever crosses
+    it, or a large-but-legitimate document would be silently zeroed by its own
+    next read. Two measures: ``ensure_ascii=False`` stores text as UTF-8
+    (4 bytes/char worst case) instead of ``\\uXXXX`` escapes (12 bytes/char
+    for astral-plane characters, which alone could triple the size of a
+    clamped-but-full record past the ceiling); and if the document still does
+    not fit — every field is clamped, but events + tried + artifacts at their
+    joint maxima can exceed 1 MB in 4-byte script — the oldest events, then
+    the oldest tried entries, are evicted until it fits. History ages out;
+    the current state (goal/phase/next/artifacts) is never dropped and cannot
+    exceed the ceiling on its own.
+    """
+    budget = _MAX_STATE_BYTES - 4096  # headroom so the reader's check never ties
+    while True:
+        blob = json.dumps(state, ensure_ascii=False)
+        if len(blob.encode("utf-8")) <= budget:
+            return blob
+        if state["events"]:
+            state["events"] = state["events"][1:]
+        elif state["tried"]:
+            state["tried"] = state["tried"][1:]
+        else:
+            # History is gone and the document still does not fit. The known
+            # fields are all clamped well under the budget, so the excess can
+            # only live in UNKNOWN fields carried forward by ``_coerce_state``
+            # (a newer writer's data, or a corrupt/hostile file that parsed).
+            # Preserving unknown fields is best-effort forward compatibility;
+            # preserving THE LEDGER is the contract — a document past the
+            # reader's ceiling is discarded wholesale on the next read, which
+            # loses the known state too. Drop the extras and retry once.
+            extras = [k for k in state if k not in _empty_state()]
+            if extras:
+                for k in extras:
+                    state.pop(k, None)
+                continue
+            # Unreachable with the field clamps; refuse rather than write a
+            # document the reader is guaranteed to discard.
+            raise ValueError("record too large to store")
+
+
+def purge(slot_key: str) -> None:
+    """Delete *slot_key*'s ledger directory. Best-effort, never raises.
+
+    Ledger content is disposable intermediate state — nothing reconstructs
+    from it — so this runs unconditionally on permanent session deletion.
+    A write racing the delete can at worst recreate an orphan directory that
+    the next delete sweeps; it can never touch another session's ledger, so
+    the funnel narrows the window (purge after the slot's turn is torn down)
+    instead of buying a tombstone protocol for disposable state.
+    """
+    try:
+        dir_path = ledger_dir(slot_key)
+    except ValueError:
+        return
+    shutil.rmtree(dir_path, ignore_errors=True)
+
+
+def purge_matching(exact_keys: set[str], folded_keys: set[str], fold: Any) -> int:
+    """Purge every ledger whose breadcrumb key matches a delete candidate.
+
+    The delete funnel names a session by whatever spellings it has on hand
+    (history key, slot key, folded transcript spelling), but a channel
+    session's ledger is keyed by its EXACT session key — a spelling the
+    funnel may not hold once the slot is gone. This sweep closes that gap:
+    it walks the ledger root, reads each directory's ``slot_key`` breadcrumb,
+    and removes the ledger when the breadcrumb matches a candidate exactly or
+    under the caller-supplied *fold* (the transcript-filename fold, so the
+    folded history spelling the funnel does hold reaches the exact-key
+    ledger it names). The fold is used only to MATCH deletion targets, never
+    as storage identity; in the rare case two exact keys share a folded
+    spelling, both ledgers are removed — acceptable for disposable state,
+    where the alternative is one of them silently surviving its session.
+
+    Best-effort, never raises. Returns the number of ledgers removed. The
+    root holds one directory per session that ever recorded, so the walk is
+    small; a breadcrumbless directory (breadcrumb write is best-effort) is
+    still covered by the direct :func:`purge` calls the funnel makes first.
+    """
+    removed = 0
+    try:
+        root = _ledger_root()
+        if not root.is_dir():
+            return 0
+        children = list(root.iterdir())
+    except OSError:
+        return 0
+    for child in children:
+        try:
+            if not child.is_dir():
+                continue
+            key = (child / _KEY_FILE).read_text(encoding="utf-8").strip()
+            if not key:
+                continue
+            if key in exact_keys or fold(key) in folded_keys:
+                shutil.rmtree(child, ignore_errors=True)
+                removed += 1
+        except Exception:
+            continue
+    return removed
+
+
+#: Ceiling for the injected snapshot block. A nudge turn carries this every
+#: cycle, so it must stay small even against a clamped-but-full record.
+_SNAPSHOT_MAX_CHARS = 1600
+_SNAPSHOT_FIELD_MAX = 300
+_SNAPSHOT_TRIED_TAIL = 3
+
+
+def render_snapshot(slot_key: str) -> str:
+    """Compact ``[work ledger]`` block for per-cycle injection, or ``""``.
+
+    Empty when the session has no ledger, the record is empty, or the
+    workstream is finished — a terminal ledger has nothing to steer. Reads
+    are lock-free (see :func:`read_state`); callers on an event loop must
+    dispatch this to a worker thread — it does filesystem I/O.
+    """
+    if not has_ledger(slot_key):
+        return ""
+    state = read_state(slot_key)
+    if not any((state["goal"], state["phase"], state["next"], state["tried"], state["artifacts"])):
+        return ""
+    if state["phase"] in TERMINAL_PHASES:
+        return ""
+
+    def _field(v: str) -> str:
+        v = " ".join(v.split())
+        return v[:_SNAPSHOT_FIELD_MAX]
+
+    lines = [
+        "[work ledger — durable state for this session; authoritative over memory of prior cycles]"
+    ]
+    if state["goal"]:
+        lines.append(f"goal: {_field(state['goal'])}")
+    if state["phase"]:
+        lines.append(f"phase: {_field(state['phase'])}")
+    if state["next"]:
+        lines.append(f"next: {_field(state['next'])}")
+    for item in state["tried"][-_SNAPSHOT_TRIED_TAIL:]:
+        why = f" (rejected: {_field(item['rejected_because'])})" if item["rejected_because"] else ""
+        lines.append(f"tried: {_field(item['approach'])}{why}")
+    for k, v in state["artifacts"].items():
+        lines.append(f"artifact {k}: {_field(v)}")
+    block = "\n".join(lines)
+    if len(block) > _SNAPSHOT_MAX_CHARS:
+        block = block[: _SNAPSHOT_MAX_CHARS - 1] + "…"
+    return block

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -106,7 +106,7 @@ from kiro_crew.dashboard.cron_inject import (
     inject_cron_result_to_dashboard,
 )
 from kiro_crew.dashboard.handlers import MAX_PROMPT_BYTES
-from kiro_crew.dashboard.handlers.autonudge import render_nudge_message
+from kiro_crew.dashboard.handlers.autonudge import compose_nudge_body
 from kiro_crew.dashboard.handlers.messaging import _rehydrate_slot_from_history
 from kiro_crew.dashboard.handlers.updates import remediation_command as _remediation_command
 from kiro_crew.dashboard.handlers.usage import (
@@ -4815,7 +4815,7 @@ class GatewayOrchestrator:
             if self.autonudge_svc:
                 await self.autonudge_svc.remove(loop.id)
             return False
-        msg_body = render_nudge_message(loop.message, loop.stop_sentinel_path)
+        msg_body = await compose_nudge_body(loop.message, loop.stop_sentinel_path, loop.slot_key)
         tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg_body}"
         # Fail closed: an unattended turn MUST run under the HookManager
         # PreToolUse governance gate (mirrors cron's default approval path).
@@ -4996,7 +4996,7 @@ class GatewayOrchestrator:
         if sessions is not None and sessions.is_busy(key):
             logger.info("AutoNudge skip: discord session %s busy (loop %s)", key, loop.id)
             return False
-        msg_body = render_nudge_message(loop.message, loop.stop_sentinel_path)
+        msg_body = await compose_nudge_body(loop.message, loop.stop_sentinel_path, loop.slot_key)
         tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg_body}"
         try:
             conversation_id = await transport.resolve_conversation(user_id)
@@ -5087,7 +5087,7 @@ class GatewayOrchestrator:
                 loop.slot_key,
                 loop.id,
             )
-        msg = render_nudge_message(loop.message, loop.stop_sentinel_path)
+        msg = await compose_nudge_body(loop.message, loop.stop_sentinel_path, loop.slot_key)
         tagged = f"[auto-nudge cycle {loop.cycle_count + 1}]\n{msg}"
         from kiro_crew.dashboard.chat import (
             _run_chat,  # circular import: gateway -> dashboard.chat -> gateway (chat dispatch references GatewayOrchestrator)

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -1068,6 +1068,31 @@ LEARN_REMOVE_SCHEMA = ToolSchema(
     ],
 )
 
+# Session work ledger (session_ledger.py). Field caps mirror the core module's
+# own clamps so the route refuses loudly what the primitive would otherwise
+# truncate silently. ``artifacts`` inner shape (str->str, bounded) is enforced
+# by the core module's merge. No slot-key field on purpose: the backend
+# resolves the calling session's identity from the request, never the body.
+SESSION_LEDGER_RECORD_SCHEMA = ToolSchema(
+    tool_name="session_ledger_record",
+    fields=[
+        FieldSpec("goal", str, max_len=2000),
+        FieldSpec("phase", str, max_len=128),
+        FieldSpec("next", str, max_len=2000),
+        FieldSpec("tried_approach", str, max_len=2000),
+        FieldSpec("tried_rejected_because", str, max_len=2000),
+        FieldSpec("artifacts", dict),
+        FieldSpec("event", str, max_len=2000),
+        FieldSpec("event_kind", str, max_len=32),
+    ],
+)
+# Empty on purpose, and REGISTERED on purpose: with no schema in
+# MCP_CORE_SCHEMAS an unexpected argument passes through unvalidated
+# (the learn_list gap), while an empty registered schema rejects it
+# (the spawn_list / resource_status precedent). The tool takes no
+# arguments; the schema's job is to enforce exactly that.
+SESSION_LEDGER_READ_SCHEMA = ToolSchema(tool_name="session_ledger_read")
+
 SPAWN_STATUS_SCHEMA = ToolSchema(
     tool_name="spawn_status",
     fields=[
@@ -2523,6 +2548,8 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "spawn_status": SPAWN_STATUS_SCHEMA,
     "learn_add": LEARN_ADD_SCHEMA,
     "learn_remove": LEARN_REMOVE_SCHEMA,
+    "session_ledger_read": SESSION_LEDGER_READ_SCHEMA,
+    "session_ledger_record": SESSION_LEDGER_RECORD_SCHEMA,
     "skill_search": SKILL_SEARCH_SCHEMA,
     "skill_discover": SKILL_DISCOVER_SCHEMA,
     "skill_fetch": SKILL_FETCH_SCHEMA,

--- a/test/test_session_ledger.py
+++ b/test/test_session_ledger.py
@@ -1,0 +1,588 @@
+"""Session work ledger — core primitive, nudge injection, routes, cleanup.
+
+Covers the contracts docs/system-specs/features/session-work-ledger.md pins:
+exact-key identity (lossless fold, no channel-key collisions), directory
+guarding, the crash-atomic phase-requires-event discipline, partial updates
+preserving stored state, bounds (tried/events/artifacts/state-file size), the
+bounded cross-process lock, snapshot rendering and its caps, the async nudge
+composer, the route layer's session-identity gating, and the permanent-delete
+purge.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew import session_ledger as sl
+from kiro_crew.platform_compat import IS_POSIX
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Every test writes into its own data home, never the live one."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    yield
+
+
+# ── key identity ──────────────────────────────────────────────────────────
+
+
+def test_ledger_key_strips_dashboard_prefixes_only():
+    assert sl.ledger_key("dashboard_chat-1-111") == "chat-1-111"
+    assert sl.ledger_key("dashboard:chat-1-111") == "chat-1-111"
+    assert sl.ledger_key("chat-1-111") == "chat-1-111"
+    # Channel keys pass through UNTOUCHED — no charset fold.
+    assert sl.ledger_key("slack:C123:456.789") == "slack:C123:456.789"
+
+
+def test_distinct_channel_keys_never_share_a_ledger():
+    """A lossy charset fold would map both of these onto one directory —
+    one session reading and overwriting another's state."""
+    a = sl.ledger_dir("wecom:agent:direct:user_gen1")
+    b = sl.ledger_dir("wecom:agent:direct:user:gen1")
+    assert a != b
+
+
+def test_ledger_dir_distinct_per_exact_key():
+    assert sl.ledger_dir("chat-1-111") != sl.ledger_dir("chat-1-112")
+    # Case-insensitive-FS safety: Foo and foo must not share a directory.
+    assert sl.ledger_dir("Foo") != sl.ledger_dir("foo")
+
+
+def test_ledger_dir_stays_inside_root():
+    root = sl._ledger_root().resolve()
+    d = sl.ledger_dir("weird key with spaces and ünïcødé")
+    assert d.is_relative_to(root)
+
+
+@pytest.mark.parametrize("bad", ["", "a/b", "a\\b", "x\0y"])
+def test_ledger_dir_refuses_hostile_keys(bad):
+    with pytest.raises(ValueError):
+        sl.ledger_dir(bad)
+
+
+def test_long_key_dir_name_bounded():
+    d = sl.ledger_dir("k" * 500)
+    assert len(d.name) <= sl._STORE_NAME_READABLE_MAX + 1 + 8
+
+
+# ── record / read ─────────────────────────────────────────────────────────
+
+
+def test_record_roundtrip_and_partial_update():
+    key = "chat-1-111"
+    sl.record(key, goal="ship the ledger", next_step="write tests")
+    state = sl.read_state(key)
+    assert state["goal"] == "ship the ledger"
+    assert state["next"] == "write tests"
+    assert state["created_at"]
+    # Partial update: untouched fields keep their stored values.
+    sl.record(key, next_step="run gates")
+    state = sl.read_state(key)
+    assert state["goal"] == "ship the ledger"
+    assert state["next"] == "run gates"
+    # Breadcrumb maps the folded dir name back to the key.
+    assert (sl.ledger_dir(key) / "slot_key").read_text().strip() == key
+
+
+def test_phase_change_requires_event_and_kind():
+    with pytest.raises(ValueError, match="requires an event"):
+        sl.record("chat-2-222", phase="implementing")
+    with pytest.raises(ValueError, match="event_kind"):
+        sl.record("chat-2-222", phase="implementing", event="started")
+    with pytest.raises(ValueError, match="event_kind"):
+        sl.record("chat-2-222", phase="implementing", event="started", event_kind="bogus")
+
+
+def test_phase_and_event_land_in_one_document():
+    """State and event share one atomic write: after any accepted phase
+    change, the on-disk document holds BOTH — there is no observable state
+    where the phase moved and the event is missing."""
+    key = "chat-3-333"
+    sl.record(key, phase="implementing", event="started the fix", event_kind="phase")
+    raw = json.loads((sl.ledger_dir(key) / "state.json").read_text())
+    assert raw["phase"] == "implementing"
+    assert raw["events"][-1]["text"] == "started the fix"
+    assert raw["events"][-1]["kind"] == "phase"
+
+
+def test_terminal_phase_sets_finished_at_and_reopening_clears_it():
+    key = "chat-4-444"
+    sl.record(key, phase="done", event="all green", event_kind="progress")
+    assert sl.read_state(key)["finished_at"]
+    sl.record(key, phase="implementing", event="reopened", event_kind="phase")
+    assert sl.read_state(key)["finished_at"] == ""
+
+
+def test_tried_appends_and_caps():
+    key = "chat-5-555"
+    for i in range(sl._MAX_TRIED + 5):
+        sl.record(key, tried_approach=f"approach {i}", tried_rejected_because="no")
+    tried = sl.read_state(key)["tried"]
+    assert len(tried) == sl._MAX_TRIED
+    assert tried[-1]["approach"] == f"approach {sl._MAX_TRIED + 4}"
+    assert tried[-1]["rejected_because"] == "no"
+
+
+def test_events_tail_bounded():
+    key = "chat-5-556"
+    for i in range(sl._MAX_EVENTS + 10):
+        sl.record(key, event=f"event {i}", event_kind="progress")
+    events = sl.read_state(key)["events"]
+    assert len(events) == sl._MAX_EVENTS
+    assert events[-1]["text"] == f"event {sl._MAX_EVENTS + 9}"
+
+
+def test_artifacts_merge_and_clamp():
+    key = "chat-6-666"
+    sl.record(key, artifacts={"branch": "feat/x"})
+    sl.record(key, artifacts={"pr": "123"})
+    arts = sl.read_state(key)["artifacts"]
+    assert arts == {"branch": "feat/x", "pr": "123"}
+    sl.record(key, goal="g" * 10_000)
+    assert len(sl.read_state(key)["goal"]) == sl._MAX_TEXT
+
+
+def test_updating_oldest_artifact_on_full_map_survives_the_cap():
+    """A dict update keeps the key's original insertion position, so without
+    the pop-before-reassign an update to the oldest pointer on a full map
+    would age out the very artifact the call just wrote."""
+    key = "chat-6-667"
+    for i in range(sl._MAX_ARTIFACTS):
+        sl.record(key, artifacts={f"k{i}": "v"})
+    # Map is full; update the OLDEST key and add one new key in the same call.
+    sl.record(key, artifacts={"k0": "updated", "brand-new": "v"})
+    arts = sl.read_state(key)["artifacts"]
+    assert arts["k0"] == "updated"
+    assert "brand-new" in arts
+    assert len(arts) == sl._MAX_ARTIFACTS
+
+
+def test_unknown_event_kind_without_phase_coerced_to_note():
+    key = "chat-7-777"
+    sl.record(key, event="something happened", event_kind="bogus")
+    assert sl.read_state(key)["events"][0]["kind"] == "note"
+
+
+def test_read_state_malformed_oversized_or_undecodable_reads_empty():
+    key = "chat-9-999"
+    sl.record(key, goal="x")
+    path = sl.ledger_dir(key) / "state.json"
+    path.write_text("{broken", encoding="utf-8")
+    assert sl.read_state(key)["goal"] == ""
+    path.write_bytes(b"\xff\xfe\x00garbage")
+    assert sl.read_state(key)["goal"] == ""
+    # A file past the size ceiling is refused BEFORE parsing.
+    path.write_text(json.dumps({"goal": "big", "junk": "j" * sl._MAX_STATE_BYTES}))
+    assert sl.read_state(key)["goal"] == ""
+
+
+def test_writer_guarantees_the_read_ceiling_for_legitimate_records():
+    """An accepted record must never produce a file its own reader zeroes.
+
+    Worst legitimate case: clamped-but-full events of astral-plane characters
+    (4 bytes each in UTF-8; 12 each if escaped). The writer serializes UTF-8
+    and evicts the oldest history until the document fits, so the state
+    survives and reads back intact."""
+    key = "chat-9-998"
+    glyph = "\N{PILE OF POO}" * sl._MAX_TEXT  # clamps to _MAX_TEXT astral chars
+    for i in range(sl._MAX_EVENTS):
+        sl.record(key, event=glyph, event_kind="progress")
+    sl.record(key, goal="still here", next_step="keep going")
+    size = (sl.ledger_dir(key) / "state.json").stat().st_size
+    assert size <= sl._MAX_STATE_BYTES
+    state = sl.read_state(key)
+    assert state["goal"] == "still here"  # NOT zeroed by the ceiling
+    assert state["events"]  # history trimmed, not destroyed
+
+
+def test_oversized_unknown_fields_are_dropped_not_self_corrupting():
+    """Unknown fields are unclamped forward-compat baggage; when history
+    eviction cannot bring the document under the budget, they are dropped
+    rather than written past the ceiling (which would make the next read
+    discard the whole ledger, known state included)."""
+    key = "chat-9-997"
+    sl.record(key, goal="protect me")
+    path = sl.ledger_dir(key) / "state.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["future_blob"] = "z" * (sl._MAX_STATE_BYTES - 2_000)  # parses, but over the write budget
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    # The next record must neither fail nor write an over-ceiling document.
+    sl.record(key, next_step="still writable")
+    assert (sl.ledger_dir(key) / "state.json").stat().st_size <= sl._MAX_STATE_BYTES
+    state = sl.read_state(key)
+    assert state["goal"] == "protect me"
+    assert state["next"] == "still writable"
+    assert "future_blob" not in state
+
+
+def test_ledger_root_is_behind_the_agent_file_gate():
+    """The ledger's authorization model is session-scoped routes; the agent
+    file-tool gate must fence the on-disk subtree or any session could read
+    another's ledger sideways. Home-anchored like every matcher in that list,
+    so probe with home-relative spellings."""
+    from pathlib import Path
+
+    from kiro_crew.security import is_sensitive_path
+
+    home = Path.home()
+    assert is_sensitive_path(str(home / ".kiro/crew/ledger/chat-1-abc12345/state.json"))
+    assert is_sensitive_path(str(home / ".kirocrew/ledger/x-deadbeef/state.json"))
+
+
+def test_coerce_preserves_unknown_fields():
+    raw = {"goal": "g", "future_field": {"a": 1}, "tried": "wrong-type"}
+    state = sl._coerce_state(raw)
+    assert state["goal"] == "g"
+    assert state["future_field"] == {"a": 1}
+    assert state["tried"] == []
+
+
+def test_purge_removes_dir_and_tolerates_bad_keys():
+    key = "chat-10-000"
+    sl.record(key, goal="x")
+    assert sl.has_ledger(key)
+    sl.purge(key)
+    assert not sl.has_ledger(key)
+    sl.purge("")  # hostile key: no-op, never raises
+    sl.purge("a/b")
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="flock-based holder simulation is POSIX-only")
+def test_record_fails_closed_on_held_lock(monkeypatch):
+    """A wedged cross-process holder costs one refused write (OSError), never
+    an unbounded wait — and removing the lock entirely would break this test,
+    because an unlocked record would succeed while the lock is held."""
+    import fcntl
+
+    key = "chat-lock-1"
+    sl.record(key, goal="x")  # create the dir + lock inode
+    monkeypatch.setattr(sl, "_LOCK_TIMEOUT_SECS", 0.2)
+    fd = os.open(str(sl.ledger_dir(key) / ".lock"), os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        with pytest.raises(OSError, match="held by another process"):
+            sl.record(key, goal="y")
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    # Holder released: the next write goes through.
+    sl.record(key, goal="z")
+    assert sl.read_state(key)["goal"] == "z"
+
+
+# ── snapshot rendering ────────────────────────────────────────────────────
+
+
+def test_snapshot_empty_without_ledger_or_when_terminal():
+    assert sl.render_snapshot("no-such-session") == ""
+    key = "chat-11-111"
+    sl.record(key, goal="g", phase="done", event="done", event_kind="progress")
+    assert sl.render_snapshot(key) == ""
+
+
+def test_snapshot_includes_artifact_only_ledger():
+    key = "chat-11-222"
+    sl.record(key, artifacts={"branch": "feat/x"})
+    snap = sl.render_snapshot(key)
+    assert "feat/x" in snap
+
+
+def test_snapshot_contains_state_and_is_capped():
+    key = "chat-12-222"
+    sl.record(
+        key,
+        goal="ship it",
+        phase="implementing",
+        next_step="fix the test",
+        event="e",
+        event_kind="phase",
+        artifacts={"branch": "feat/x"},
+        tried_approach="approach A",
+        tried_rejected_because="too slow",
+    )
+    snap = sl.render_snapshot(key)
+    assert snap.startswith("[work ledger")
+    for needle in (
+        "ship it",
+        "implementing",
+        "fix the test",
+        "feat/x",
+        "approach A",
+        "too slow",
+    ):
+        assert needle in snap
+    # Cap holds even against a clamped-but-full record.
+    for i in range(10):
+        sl.record(
+            key,
+            tried_approach=("x" * sl._MAX_TEXT),
+            tried_rejected_because="y" * 500,
+        )
+    assert len(sl.render_snapshot(key)) <= sl._SNAPSHOT_MAX_CHARS
+
+
+# ── nudge composer integration ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_compose_nudge_body_prefixes_snapshot():
+    from kiro_crew.dashboard.handlers.autonudge import compose_nudge_body
+
+    slot_key = "chat-13-333"
+    sl.record(sl.ledger_key(slot_key), goal="babysit PR 42", next_step="check CI")
+    out = await compose_nudge_body("check {{STOP_FILE}}", "/x/.stop", slot_key)
+    assert out.startswith("[work ledger")
+    assert "babysit PR 42" in out
+    assert out.endswith("check /x/.stop")
+
+
+@pytest.mark.asyncio
+async def test_compose_nudge_body_folds_key_like_the_write_path():
+    """A ledger written under the route's fold of `dashboard_chat-X` must be
+    the one a loop keyed `chat-X` reads — changing either side's fold breaks
+    this pairing."""
+    from kiro_crew.dashboard.handlers.autonudge import compose_nudge_body
+
+    sl.record(sl.ledger_key("dashboard_chat-15-555"), goal="paired")
+    out = await compose_nudge_body("m", None, "chat-15-555")
+    assert "paired" in out
+
+
+@pytest.mark.asyncio
+async def test_compose_nudge_body_unchanged_without_ledger():
+    from kiro_crew.dashboard.handlers.autonudge import compose_nudge_body
+
+    assert await compose_nudge_body("m {{STOP_FILE}}", "/x", "chat-none-1") == "m /x"
+    assert await compose_nudge_body("m {{STOP_FILE}}", "/x", None) == "m /x"
+
+
+@pytest.mark.asyncio
+async def test_compose_nudge_body_survives_snapshot_failure(monkeypatch):
+    from kiro_crew.dashboard.handlers.autonudge import compose_nudge_body
+
+    monkeypatch.setattr(sl, "render_snapshot", MagicMock(side_effect=RuntimeError("boom")))
+    assert await compose_nudge_body("m", None, "chat-14-444") == "m"
+
+
+def test_gateway_fire_callbacks_use_the_composer():
+    """All three fire paths must go through compose_nudge_body — reverting a
+    call site to the snapshot-less render_nudge_message drops ledger
+    injection for that surface silently."""
+    import inspect
+
+    from kiro_crew.slack import gateway
+
+    src = inspect.getsource(gateway)
+    assert (
+        src.count("compose_nudge_body(loop.message, loop.stop_sentinel_path, loop.slot_key)") == 3
+    )
+
+
+# ── HTTP routes ───────────────────────────────────────────────────────────
+
+
+def _mk_request(method: str, path: str, *, body: Any = ..., sk: str = "chat-r-1") -> web.Request:
+    app = web.Application()
+    app["state"] = MagicMock()
+    req = make_mocked_request(method, path, app=app, headers={"X-Session-Key": sk})
+    if body is not ...:
+        req.json = AsyncMock(return_value=body)  # type: ignore[method-assign]
+    return req
+
+
+@pytest.fixture()
+def _open_route(monkeypatch):
+    """Bypass session recognition/restriction (their own suites cover them)."""
+    from kiro_crew.dashboard.handlers import session_ledger as routes
+
+    async def _recognized(*a: Any, **k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(routes, "_recognize_session", _recognized)
+    monkeypatch.setattr(routes, "_is_restricted_session", lambda *a: False)
+    return routes
+
+
+@pytest.mark.asyncio
+async def test_route_record_and_get_roundtrip(_open_route):
+    routes = _open_route
+    req = _mk_request(
+        "POST",
+        "/api/session-ledger/record",
+        body={"goal": "route goal", "next": "route next"},
+    )
+    resp = await routes.api_session_ledger_record(req)
+    assert resp.status == 200
+    resp2 = await routes.api_session_ledger_get(_mk_request("GET", "/api/session-ledger"))
+    data = json.loads(resp2.text)
+    assert data["state"]["goal"] == "route goal"
+
+
+@pytest.mark.asyncio
+async def test_route_phase_without_event_is_400(_open_route):
+    routes = _open_route
+    req = _mk_request("POST", "/api/session-ledger/record", body={"phase": "implementing"})
+    resp = await routes.api_session_ledger_record(req)
+    assert resp.status == 400
+    assert "event" in json.loads(resp.text)["error"]
+
+
+@pytest.mark.asyncio
+async def test_route_rejects_non_string_artifacts(_open_route):
+    routes = _open_route
+    req = _mk_request("POST", "/api/session-ledger/record", body={"artifacts": {"pr": 123}})
+    resp = await routes.api_session_ledger_record(req)
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_route_refuses_unrecognized_session(monkeypatch):
+    from kiro_crew.dashboard.handlers import session_ledger as routes
+
+    async def _refused(*a: Any, **k: Any) -> web.Response:
+        return web.json_response({"error": "unknown session"}, status=403)
+
+    monkeypatch.setattr(routes, "_recognize_session", _refused)
+    resp = await routes.api_session_ledger_record(
+        _mk_request("POST", "/api/session-ledger/record", body={"goal": "x"})
+    )
+    assert resp.status == 403
+
+
+@pytest.mark.asyncio
+async def test_route_refuses_restricted_session(monkeypatch, _open_route):
+    routes = _open_route
+    monkeypatch.setattr(routes, "_is_restricted_session", lambda *a: True)
+    resp = await routes.api_session_ledger_record(
+        _mk_request("POST", "/api/session-ledger/record", body={"goal": "x"})
+    )
+    assert resp.status == 403
+
+
+@pytest.mark.asyncio
+async def test_route_write_lands_under_ledger_key(_open_route):
+    """The route folds the header key exactly like the nudge composer does —
+    losslessly, dashboard prefixes only."""
+    routes = _open_route
+    sk = "dashboard_chat-77-999"
+    req = _mk_request("POST", "/api/session-ledger/record", body={"goal": "fold me"}, sk=sk)
+    assert (await routes.api_session_ledger_record(req)).status == 200
+    assert sl.read_state(sl.ledger_key(sk))["goal"] == "fold me"
+    # And a colon-structured channel key writes to its own exact-key ledger.
+    sk2 = "slack:C123:456.789"
+    req2 = _mk_request("POST", "/api/session-ledger/record", body={"goal": "channel"}, sk=sk2)
+    assert (await routes.api_session_ledger_record(req2)).status == 200
+    assert sl.read_state(sk2)["goal"] == "channel"
+
+
+def test_routes_are_on_the_strict_internal_allowlist():
+    """The tools authenticate with the internal secret; without this entry the
+    call falls through to cookie auth and every tool call 403s."""
+    from kiro_crew.dashboard.server import _STRICT_INTERNAL_API_PATHS
+
+    assert "/api/session-ledger" in _STRICT_INTERNAL_API_PATHS
+
+
+# ── permanent-delete purge funnel ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remove_slot_for_history_key_purges_ledger():
+    from kiro_crew.dashboard.handlers.sessions import _remove_slot_for_history_key
+
+    history_key = "dashboard_chat-88-123"
+    ledger_key = sl.ledger_key(history_key)
+    sl.record(ledger_key, goal="doomed")
+    assert sl.has_ledger(ledger_key)
+
+    state = MagicMock()
+    state._slots = {}
+    state.crew = None
+    state.remove_chat_pins_for_slots = AsyncMock()
+    await _remove_slot_for_history_key(state, history_key)
+    assert not sl.has_ledger(ledger_key)
+
+
+@pytest.mark.asyncio
+async def test_delete_with_folded_spelling_reaps_exact_channel_key_ledger():
+    """A channel session's ledger is keyed by its EXACT session key, but a
+    slotless permanent delete may only hold the folded transcript spelling —
+    the breadcrumb sweep must still reap the exact-key ledger."""
+    from kiro_crew.dashboard.handlers.sessions import _remove_slot_for_history_key
+    from kiro_crew.dashboard.state import _normalize_slot_key
+
+    channel_key = "slack:C042:1712793600.123456"
+    sl.record(channel_key, goal="channel state")
+    assert sl.has_ledger(channel_key)
+
+    state = MagicMock()
+    state._slots = {}
+    state.crew = None
+    state.remove_chat_pins_for_slots = AsyncMock()
+    # The funnel is handed only the folded spelling (what the transcript
+    # filename layer uses); the raw colon-structured key is not among the
+    # candidates.
+    await _remove_slot_for_history_key(state, _normalize_slot_key(channel_key))
+    assert not sl.has_ledger(channel_key)
+
+
+def test_purge_matching_exact_and_folded_and_nonmatch():
+    from kiro_crew.dashboard.state import _normalize_slot_key
+
+    sl.record("slack:C1:1.1", goal="a")
+    sl.record("slack:C2:2.2", goal="b")
+    sl.record("chat-keep-1", goal="keep")
+    removed = sl.purge_matching(
+        {"slack:C1:1.1"},
+        {_normalize_slot_key("slack:C2:2.2")},
+        _normalize_slot_key,
+    )
+    assert removed == 2
+    assert not sl.has_ledger("slack:C1:1.1")
+    assert not sl.has_ledger("slack:C2:2.2")
+    assert sl.has_ledger("chat-keep-1")
+
+
+# ── MCP tool identity ─────────────────────────────────────────────────────
+
+
+def test_mcp_tools_refuse_without_strict_identity(monkeypatch):
+    """A subagent's lenient PID-walk identity resolves to the PARENT session;
+    the tools must refuse rather than read/write the parent's ledger."""
+    from kiro_crew import mcp_core
+    from kiro_crew.mcp_tools import ledger as tools
+
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+    transport = MagicMock()
+    monkeypatch.setattr(mcp_core, "_get", transport)
+    monkeypatch.setattr(mcp_core, "_post", transport)
+    assert "could not be verified" in tools.session_ledger_read("x", {})
+    assert "could not be verified" in tools.session_ledger_record("x", {"goal": "g"})
+    transport.assert_not_called()
+
+
+def test_mcp_tools_pass_the_verified_key_to_transport(monkeypatch):
+    """The key that was CHECKED must be the key that is USED — the transport
+    must not re-resolve leniently."""
+    from kiro_crew import mcp_core
+    from kiro_crew.mcp_tools import ledger as tools
+
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "chat-v-1")
+    get = MagicMock(return_value={"state": {}, "events": []})
+    post = MagicMock(return_value={"ok": True, "state": {"phase": "", "next": ""}})
+    monkeypatch.setattr(mcp_core, "_get", get)
+    monkeypatch.setattr(mcp_core, "_post", post)
+    tools.session_ledger_read("x", {})
+    get.assert_called_once_with("/api/session-ledger", session_key="chat-v-1")
+    tools.session_ledger_record("x", {"goal": "g"})
+    post.assert_called_once_with(
+        "/api/session-ledger/record", {"goal": "g"}, session_key="chat-v-1"
+    )


### PR DESCRIPTION
## What is the problem?

Long-horizon sessions -- `monitor_start` babysit loops, goal loops, any session that wakes dozens of times -- carry their working state in the context window. Every cycle appends a full turn, and when the context fills, compaction (owned by the agent harness, not this codebase) summarizes generically. The agent loses exactly the state it needs to continue: approaches already rejected, the branch it was on, why a phase was entered. The pattern for fixing this already exists in-repo -- Issue Radar's crew ledger and Ops Mission Control's knowledge ledger both persist work state to disk -- but each app hand-rolled it, and plain sessions get nothing.

## Why this issue matters to the user

A babysit loop on cycle 40 costs 40 cycles of transcript to run cycle 41, and after a compaction it can re-walk approaches it already rejected or lose track of its own PR. Loop cost grows with loop history; long-running autonomy degrades precisely when it has been running long enough to be useful.

## How our fix solves it

The context window becomes a cache; a per-session on-disk **work ledger** becomes the authority.

- **Core primitive** (`session_ledger.py`): one directory per session under `<data_home>/ledger/`, holding a single `state.json` -- goal, phase, next intent, tried/rejected approaches, artifact pointers, and a bounded event tail -- replaced atomically on every write. State and its event land in the same `atomic_write`, so the crew-ledger discipline "a phase never moves without a logged event" is crash-atomic by construction. Every field is clamped and the event tail bounded: reads are O(record), never O(history).
- **Identity is the exact session key** (dashboard prefixes stripped losslessly; digest over the full key names the directory), so distinct colon-structured channel keys can never collide into a shared ledger. A session can only reach its own ledger: the routes resolve identity from the vetted `X-Session-Key`, never from the body; raw HTTP without a recognized session is refused, as are incognito/temporary sessions.
- **MCP tools** `session_ledger_read` / `session_ledger_record` (core domain module, `learn.py` template; routes on the strict internal-auth allowlist).
- **Loop integration**: the shared nudge composer prefixes each cycle with a compact, size-capped `[work ledger]` snapshot, read off-loop in a worker thread. Per-cycle cost stops growing with loop history. Cron/heartbeat composers deliberately untouched.
- **Lifecycle**: tab close preserves the ledger (resumable state); permanent history deletion purges it at the end of the delete funnel, after the slot's turn is torn down. Ledger content is disposable intermediate state -- a cross-process write racing the purge can at worst recreate an orphan directory the next delete sweeps, which we accept instead of a tombstone protocol for data nothing reconstructs from.
- **Bounded lock**: per-ledger cross-process lock with a bounded acquire that fails closed (retryable 503), so a wedged holder can never park gateway worker threads.

Spec: `docs/system-specs/features/session-work-ledger.md` (includes non-goals: compaction itself, turn-internal operation logs, multi-writer fenced leases).

## What tests we did

37 new tests in `test/test_session_ledger.py`: exact-key identity (channel-key collision pair pinned), directory guard/traversal, crash-atomic phase+event single-document write, partial-update preservation, all bounds (tried/events/artifacts/state-file size ceiling), bounded-lock fail-closed under a held flock, snapshot caps and terminal-phase suppression, async composer (including the write-path/read-path key-fold pairing and a 3-call-site pin on the gateway fire paths), route auth gating (unrecognized + restricted session refusals), strict-allowlist membership, and the permanent-delete purge funnel. Full affected sweep green: 304 tests across the autonudge, fire-path, MCP-registry, sessions-clear, and delete-funnel suites. Local gates green: black gate, isort, flake8, mypy, brand, inclusive-language.

Two pre-push reviewer passes were run on the diff; every blocking finding was fixed before this PR was opened (internal-auth allowlist registration, lossy-fold session collision, crash-atomicity of phase+event, unbounded event log, event-loop filesystem I/O, unbounded lock wait, purge/write race narrowed).

## Any other suggestions on the work

Two adjacent tracks deliberately out of scope: (1) turn-internal operation journaling (stable operation ids + check-result-before-retry for interrupted turns) -- a finer-grained durability layer this ledger does not attempt; (2) migrating Issue Radar / Ops Mission Control onto the shared primitive -- both predate it and have app-specific schemas; convergence is worth a separate discussion.
