### PR TITLE
fix(update): refuse the version-floor auto-update on a checkout with local commits

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -8290,6 +8290,91 @@ class GatewayOrchestrator:
                     self.dashboard_state.clear_update_progress()
                 return
 
+            # Fast-forward-only gate, checked after the fetch so the counts are
+            # against the revision this would reset to.
+            #
+            # The ordinary `auto_update` trigger cannot reach here with local
+            # commits: it requires the update check's `can_fast_forward` verdict,
+            # which is `behind > 0 AND ahead == 0`. The mandatory version-floor
+            # trigger deliberately bypasses `available` and gates only on
+            # `can_apply` -- and `can_apply` reports the INSTALL SHAPE (a git
+            # checkout has an apply command; a wheel or a .deb does not), so it
+            # says nothing at all about how this tree relates to the remote.
+            # Every git checkout below the floor therefore reaches the reset,
+            # diverged or merely ahead.
+            #
+            # Neither check above stops that: a tree carrying local commits has a
+            # content diff like any other, and the porcelain check below only
+            # warns about UNCOMMITTED edits before proceeding -- so
+            # `git reset --hard` discards committed local work unattended,
+            # leaving only a log line.
+            #
+            # The condition is therefore `ahead > 0`, not `ahead > 0 and
+            # behind > 0`. Mirroring `can_fast_forward` means refusing whenever
+            # the tree is ahead: an ahead-only checkout (local commits, remote
+            # unmoved) loses them to this reset exactly as a diverged one does,
+            # and is the more likely shape on a developer box that has simply
+            # not pushed yet.
+            #
+            # The floor mandate does not need the reset to be its mechanism: a
+            # violation that can only be resolved by discarding committed work
+            # needs a human. Refuse, report the counts through the update-status
+            # surface, and leave the host below the floor.
+            #
+            # Fail CLOSED. This is the most privileged path in the product (no
+            # auth, no click, `reset --hard` + pip + execv on boot), so a tree
+            # whose divergence cannot be established is not one to hard-reset.
+            ahead = behind = -1
+            counts_proc = await asyncio.create_subprocess_exec(
+                "git",
+                "rev-list",
+                "--left-right",
+                "--count",
+                f"HEAD...origin/{branch}",
+                cwd=proj,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            counts_out, _ = await asyncio.wait_for(counts_proc.communicate(), timeout=10)
+            if counts_proc.returncode == 0 and counts_out:
+                parts = counts_out.decode(errors="replace").split()
+                if len(parts) == 2 and all(p.isdigit() for p in parts):
+                    ahead, behind = int(parts[0]), int(parts[1])
+            if ahead < 0 or behind < 0:
+                logger.error(
+                    "Auto-update refused: could not determine how %s relates to "
+                    "origin/%s, so a hard reset cannot be shown to be safe",
+                    proj,
+                    branch,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.push_update_progress(
+                        "failed",
+                        "Update refused: could not determine whether the local "
+                        "checkout has diverged. Check the logs.",
+                    )
+                return
+            if ahead > 0:
+                logger.warning(
+                    "Auto-update refused: %s carries %d commit(s) that origin/%s "
+                    "does not (%d behind). A hard reset would discard committed "
+                    "local work, so this host stays below the version floor until "
+                    "the branch is reconciled by hand.",
+                    proj,
+                    ahead,
+                    branch,
+                    behind,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.push_update_progress(
+                        "failed",
+                        f"Update refused: this checkout has {ahead} commit(s) "
+                        f"that origin/{branch} does not ({behind} behind). "
+                        "Updating would discard committed local work — "
+                        "reconcile the branch manually.",
+                    )
+                return
+
             # Warn if local tracked-file edits will be discarded
             status_proc = await asyncio.create_subprocess_exec(
                 "git",

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -2466,6 +2466,151 @@ class TestAutoApplyUpdateGitPath:
         ds.clear_update_progress.assert_called()
 
 
+class TestAutoApplyUpdateDivergenceGuard:
+    """The version-floor trigger must not hard-reset away committed local work.
+
+    ``_auto_apply_update`` ends in ``git reset --hard origin/<branch>``. The
+    ordinary ``auto_update`` trigger can only reach it with the update check's
+    ``can_fast_forward`` verdict (``behind > 0 and ahead == 0``), but the
+    mandatory version-floor trigger gates only on ``can_apply`` -- which reports
+    the INSTALL SHAPE, not how the tree relates to the remote -- so any git
+    checkout below the floor reaches the reset, whether it is diverged or merely
+    ahead. Either way the reset discards committed local work. Neither pre-existing check stops it: the content diff is
+    present for a diverged tree like any other, and the porcelain check only
+    warns about UNCOMMITTED edits before proceeding.
+
+    Every test drives the real method and asserts on the argv actually handed to
+    ``create_subprocess_exec``, so "no reset happened" is observed at the process
+    boundary rather than inferred from a return value.
+    """
+
+    @staticmethod
+    def _exec_recorder(counts_stdout: bytes, counts_rc: int = 0):
+        """Fake ``create_subprocess_exec`` driving the git sequence to the reset.
+
+        Dispatches on the git subcommand rather than a call counter, so
+        inserting or reordering an unrelated git call cannot silently make a
+        test assert against the wrong process.
+        """
+        calls: list[tuple] = []
+
+        async def _fake_exec(*args, **kwargs):
+            calls.append(args)
+            proc = AsyncMock()
+            proc.returncode = 0
+            if "rev-parse" in args:
+                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
+            elif "fetch" in args:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+            elif "diff" in args:
+                # 1 == there IS a diff, so the update proceeds past the
+                # already-up-to-date early return.
+                proc.returncode = 1
+            elif "rev-list" in args:
+                proc.returncode = counts_rc
+                proc.communicate = AsyncMock(return_value=(counts_stdout, b""))
+            elif "status" in args:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+            else:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.wait = AsyncMock(return_value=proc.returncode)
+            return proc
+
+        return calls, _fake_exec
+
+    @staticmethod
+    def _reset_calls(calls: list[tuple]) -> list[tuple]:
+        return [c for c in calls if "reset" in c and "--hard" in c]
+
+    async def _run(self, counts_stdout: bytes, counts_rc: int = 0):
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        calls, fake_exec = self._exec_recorder(counts_stdout, counts_rc)
+        with patch("kiro_crew.env.is_toolbox_install", return_value=False):
+            with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+                with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+                    await orch._auto_apply_update()
+        return orch, ds, calls
+
+    @pytest.mark.asyncio
+    async def test_diverged_checkout_is_not_reset(self):
+        """3 ahead / 5 behind: committed local work must survive."""
+        _orch, ds, calls = await self._run(b"3\t5\n")
+
+        assert self._reset_calls(calls) == [], (
+            "git reset --hard ran on a checkout with 3 committed local commits: "
+            "the version-floor trigger discarded work no human agreed to lose"
+        )
+        failed = [
+            c.args
+            for c in ds.push_update_progress.call_args_list
+            if c.args and c.args[0] == "failed"
+        ]
+        assert failed, (
+            "the refusal never reached the update-status surface, so the user "
+            "sees a silently stalled update rather than a reason"
+        )
+        assert "3 commit" in failed[-1][1] and "5 behind" in failed[-1][1], failed
+
+    @pytest.mark.asyncio
+    async def test_ahead_only_checkout_is_not_reset(self):
+        """2 ahead / 0 behind: local commits the remote does not have.
+
+        Reachable for the same reason the diverged case is -- `can_apply` reports
+        the INSTALL SHAPE, not the tree's relation to the remote -- and the reset
+        discards those commits just as thoroughly. This is the likelier shape on
+        a developer box that simply has not pushed.
+        """
+        _orch, ds, calls = await self._run(b"2\t0\n")
+
+        assert self._reset_calls(calls) == [], (
+            "git reset --hard ran on a checkout holding 2 unpushed commits"
+        )
+        failed = [
+            c.args
+            for c in ds.push_update_progress.call_args_list
+            if c.args and c.args[0] == "failed"
+        ]
+        assert failed and "2 commit" in failed[-1][1], failed
+
+    @pytest.mark.asyncio
+    async def test_fast_forward_checkout_still_updates(self):
+        """Preservation: 0 ahead / 5 behind is the normal case and must proceed."""
+        _orch, _ds, calls = await self._run(b"0\t5\n")
+
+        assert self._reset_calls(calls), (
+            "a clean fast-forwardable checkout was refused; the guard is not "
+            "supposed to narrow the ordinary auto-update path"
+        )
+
+    @pytest.mark.asyncio
+    async def test_identical_checkout_still_updates(self):
+        """Preservation: 0/0 (diff present, no commit divergence) still proceeds."""
+        _orch, _ds, calls = await self._run(b"0\t0\n")
+
+        assert self._reset_calls(calls), "an undiverged checkout was refused"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_counts_fail_closed(self):
+        """rev-list failing must refuse, not fall through to the reset."""
+        _orch, ds, calls = await self._run(b"", counts_rc=128)
+
+        assert self._reset_calls(calls) == [], (
+            "the reset ran while the tree's relation to the remote was unknown; "
+            "this path must fail closed"
+        )
+        assert ds.push_update_progress.call_args_list
+
+    @pytest.mark.asyncio
+    async def test_unparseable_counts_fail_closed(self):
+        """rev-list succeeding with output nobody can parse must also refuse."""
+        _orch, _ds, calls = await self._run(b"not-a-count\n")
+
+        assert self._reset_calls(calls) == [], (
+            "unparseable rev-list output was treated as 'not diverged'"
+        )
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Tests: run method (partial — covers init sequence)
 # ═══════════════════════════════════════════════════════════════════════════
@@ -3314,6 +3459,16 @@ class TestAutoApplyUpdateVenvPath:
         call_count = [0]
 
         async def _fake_exec(*args, **kwargs):
+            # The fast-forward-only gate runs `git rev-list --left-right
+            # --count` between the diff check and the reset. Answered by ARGS
+            # and returned before `call_count` is touched, so every position
+            # in the sequence below keeps the meaning it already had.
+            if "rev-list" in args:
+                _rl = AsyncMock()
+                _rl.returncode = 0
+                _rl.communicate = AsyncMock(return_value=(b"0\t5\n", b""))
+                _rl.wait = AsyncMock(return_value=0)
+                return _rl
             call_count[0] += 1
             proc = AsyncMock()
             proc.kill = MagicMock()
@@ -3915,6 +4070,16 @@ class TestAutoApplyUpdateResetPath:
         call_count = [0]
 
         async def _fake_exec(*args, **kwargs):
+            # The fast-forward-only gate runs `git rev-list --left-right
+            # --count` between the diff check and the reset. Answered by ARGS
+            # and returned before `call_count` is touched, so every position
+            # in the sequence below keeps the meaning it already had.
+            if "rev-list" in args:
+                _rl = AsyncMock()
+                _rl.returncode = 0
+                _rl.communicate = AsyncMock(return_value=(b"0\t5\n", b""))
+                _rl.wait = AsyncMock(return_value=0)
+                return _rl
             call_count[0] += 1
             proc = AsyncMock()
             proc.kill = MagicMock()
@@ -4029,6 +4194,16 @@ class TestAutoApplyUpdateResetPath:
         call_count = [0]
 
         async def _fake_exec(*args, **kwargs):
+            # The fast-forward-only gate runs `git rev-list --left-right
+            # --count` between the diff check and the reset. Answered by ARGS
+            # and returned before `call_count` is touched, so every position
+            # in the sequence below keeps the meaning it already had.
+            if "rev-list" in args:
+                _rl = AsyncMock()
+                _rl.returncode = 0
+                _rl.communicate = AsyncMock(return_value=(b"0\t5\n", b""))
+                _rl.wait = AsyncMock(return_value=0)
+                return _rl
             call_count[0] += 1
             proc = AsyncMock()
             proc.kill = MagicMock()
@@ -4075,6 +4250,16 @@ class TestAutoApplyUpdateResetPath:
         call_count = [0]
 
         async def _fake_exec(*args, **kwargs):
+            # The fast-forward-only gate runs `git rev-list --left-right
+            # --count` between the diff check and the reset. Answered by ARGS
+            # and returned before `call_count` is touched, so every position
+            # in the sequence below keeps the meaning it already had.
+            if "rev-list" in args:
+                _rl = AsyncMock()
+                _rl.returncode = 0
+                _rl.communicate = AsyncMock(return_value=(b"0\t5\n", b""))
+                _rl.wait = AsyncMock(return_value=0)
+                return _rl
             call_count[0] += 1
             proc = AsyncMock()
             proc.kill = MagicMock()


### PR DESCRIPTION
## Problem / Motivation

`GatewayOrchestrator._auto_apply_update` (`src/kiro_crew/slack/gateway.py`) ends in `git reset --hard origin/<branch>`. Reached through the **mandatory policy version-floor trigger**, it does that to a checkout carrying **committed local work** — and the work is gone.

The two triggers do not carry the same guarantee:

- The ordinary `auto_update` trigger is safe by construction. It requires the update check's `can_fast_forward` verdict (`behind > 0 and ahead == 0`, `dashboard/handlers/updates.py:691`), so a checkout with local commits is never offered to it.
- The **version-floor** trigger (`update_required(_running_version)` branch) deliberately bypasses `available` and gates only on `can_apply`. `can_apply` mirrors `CommandProvider.can_apply()` — *an apply command exists and can run* — so it reports the **install shape** (a git checkout can apply; a wheel or `.deb` cannot). It says nothing about how the tree relates to the remote. **Every git checkout below the floor reaches the reset.**

Neither pre-existing check in `_auto_apply_update` stops it:

| Check | Why a tree with local commits passes |
|---|---|
| `git diff HEAD origin/<branch> --quiet` | such a tree has a content diff like any other — that is what "there are new commits" looks like |
| `git status --porcelain` | only warns, and only about **uncommitted** edits, then proceeds |

So a developer checkout running below a policy `min_version` loses committed local work unattended, with only a tracked-file log line as evidence.

## Why it matters

Unattended, unrecoverable loss of committed work on the most privileged path in the product: no auth, no click, `git reset --hard` + `pip install` + `os.execv` on boot. The user never sees a prompt, and `reset --hard` leaves nothing to recover from the working tree — only the reflog, which the affected user has no reason to know to check.

The trigger is a *policy* floor, so the hosts most likely to hit it are exactly the ones with local commits: a developer machine below the org's `min_version`.

## What changed (motivation → approach → change)

**Motivation** — the destructive step must not run on a tree where it destroys committed work.

**Approach** — mirror the verdict the safe trigger already relies on, at the site that actually performs the reset, rather than at the callers. `can_fast_forward` lives in the update *check*; the version-floor path never consults it. Putting the equivalent test inside `_auto_apply_update` means every future caller inherits it, and no caller has to remember to.

**Change** — after the fetch (so the counts are against the revision this would reset to) and before the reset:

- count `git rev-list --left-right --count HEAD...origin/<branch>`;
- when `ahead > 0`, refuse: log the counts and report them through the existing update-status surface (`push_update_progress("failed", …)`, the same surface `handlers/updates.py` uses for every other refusal), then return without resetting;
- otherwise proceed exactly as before.

**The condition is `ahead > 0`, not `ahead > 0 and behind > 0`.** The issue proposed the diverged case, and the diverged case is real — but `can_fast_forward` is `behind > 0 **AND ahead == 0**`, so mirroring it faithfully means refusing whenever the tree is ahead. An **ahead-only** checkout (local commits, remote unmoved) reaches this reset for exactly the same reason a diverged one does — `can_apply` gates on install shape — and loses its commits just as thoroughly. On a developer box that has simply not pushed yet, ahead-only is the *likelier* shape. Narrowing to the diverged case would have left the more common half of the same defect open, so it is covered and separately tested.

The floor mandate stands without the reset being its mechanism. "This host must not stay below the floor" and "discard this developer's committed work to get there" are different statements, and only the first is policy — a violation that can only be cleared by discarding committed work needs a human, so the host stays below the floor and says why.

**The gate fails CLOSED.** If `rev-list` fails, or returns output that does not parse as two counts, the update is refused rather than proceeding. On a path this privileged, "we could not establish that the reset is safe" is not a reason to reset; it is the same posture as the existing source-pin check above it, which refuses a blocked host rather than assuming.

**Not changed, deliberately.** `#4503` already covers this site's handling of *uncommitted* tracked edits; that path is left exactly as it was so this diff shows one behaviour change.

One production file, 84 lines.

## Tests

`test/test_slack_gateway.py::TestAutoApplyUpdateDivergenceGuard` — six cases, all driving the real `_auto_apply_update` and asserting on the argv actually handed to `create_subprocess_exec`, so "no reset happened" is observed at the process boundary rather than inferred from a return value. The fake dispatches on the git subcommand rather than a call index, so reordering an unrelated git call cannot make it assert against the wrong process.

| Test | Behavior locked in |
|---|---|
| `test_diverged_checkout_is_not_reset` | 3 ahead / 5 behind: no `reset --hard` runs, and the refusal reaches the update-status surface carrying both counts |
| `test_ahead_only_checkout_is_not_reset` | 2 ahead / 0 behind: unpushed commits are equally protected — the half the narrow reading would have missed |
| `test_fast_forward_checkout_still_updates` | preservation: 0 ahead / 5 behind — the ordinary path is not narrowed |
| `test_identical_checkout_still_updates` | preservation: 0/0 with a content diff still proceeds |
| `test_unreadable_counts_fail_closed` | `rev-list` exiting non-zero refuses instead of falling through |
| `test_unparseable_counts_fail_closed` | `rev-list` succeeding with junk is not read as "no local commits" |

Fail-before / pass-after, with the production file reverted to `origin/main` and the tests left in place:

```
FAILED ...::test_diverged_checkout_is_not_reset
  - AssertionError: git reset --hard ran on a checkout with 3 committed local commits:
    the version-floor trigger discarded work no human agreed to lose
FAILED ...::test_ahead_only_checkout_is_not_reset
  - AssertionError: git reset --hard ran on a checkout holding 2 unpushed commits
FAILED ...::test_unreadable_counts_fail_closed
FAILED ...::test_unparseable_counts_fail_closed

4 failed, 2 passed
```

The two preservation tests pass on **both** trees by design — they are the guard against over-correcting into refusing every update, not evidence of a defect, and are reported as such rather than folded into the fail-before count.

```
pytest test/test_slack_gateway.py -q                     238 passed, 8 skipped
pytest test/test_spawn_audit.py \
       test/test_update_check_install_aware.py -q                     81 passed
```

**Four existing `_fake_exec` helpers were taught the new call** (`test_venv_update_full_path`, `test_reset_then_frontend_then_pip`, `test_no_restart_after_any_unclean_sync_even_when_the_repair_works`, `test_a_failed_install_with_a_failed_repair_does_not_restart`). They dispatch on a call counter, so a new git call in the sequence would have shifted every position after it. Rather than renumber them, each answers `rev-list` **by args and returns before the counter is touched**, so every existing position keeps the meaning it already had — and all four still pass against pristine `origin/main`, which the control run above confirms.

Gates: `flake8` · `isort --check-only` — both clean on the two changed files. `black --diff` reports no hunk overlapping any changed region in either file; both are pre-existing baseline offenders on `origin/main`, so they are left unformatted rather than graduated off `.github/black-baseline.txt`.

## Manual verification

N/A — unit coverage sufficient: the assertion is on the exact argv the method hands to `create_subprocess_exec`, so the property under test ("no `git reset --hard` is issued") is checked at the boundary where the damage would occur. Reproducing by hand means building a checkout with local commits on a host below a policy `min_version` and waiting for the floor trigger to fire on boot, which is what these tests drive directly.

## Related Issues

Refs #5163.

Surfaced by the First Principles review on #5158 (the CLI divergence guard for #5143), which guards the *other* reset-to-origin apply site, `cli_server.py::_update`. That PR is still open; this change touches a different file and does not depend on it.

`#4503` covers the same site's handling of *uncommitted* tracked edits — deliberately not addressed here.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no user-facing doc describes the auto-update reset preconditions
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
