### PR TITLE
fix(memory): protect the memory files from other local users on Windows

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -268,6 +268,49 @@ DACL and — because Windows grants *Bypass Traverse Checking* to Everyone by
 default — stays reachable through the tightened parent, so repairing an
 existing install needs a per-file pass, not a parent tighten.
 
+### The memory store: why a per-file pass, not just the directory
+
+`memory.db` (semantic/episodic memories and their embeddings) is the first
+caller to need that repair pass, and it names every memory-bearing file rather
+than only the `.db`. It runs under `journal_mode=WAL`, so SQLite keeps
+`memory.db-wal` and `memory.db-shm` beside it, and a *committed* row lives in
+the `-wal` until a checkpoint moves it — locking the `.db` alone would leave
+committed memories readable under whatever DACL a pre-lockdown sidecar carries.
+The pass covers the `.db`, its `-wal`/`-shm` sidecars, and `memory.faiss` /
+`memory.ids.json` (the embedding index and its id map).
+
+`VectorMemoryStore.init()` calls `make_owner_only_dir` on the parent first, so
+everything SQLite and FAISS create from then on inherits owner-only access on
+both platforms. The per-file pass is for what already exists — a restored
+backup, a home migration, a manual edit, or simply an install predating this
+lockdown. It therefore runs on **every** init rather than only when init created
+the files: gating on creation would leave every pre-existing install permanently
+readable, which is most of them.
+
+It runs **twice**, once before `sqlite3.connect` and once after. The first call
+is what stops the schema migrations running against a file another local user
+can still write; the second covers whatever SQLite has just created.
+
+The Windows cost is up to 11 `icacls` spawns per init — one for the directory
+plus one per file on each of the two passes, and a file that does not exist
+still spawns (icacls exits non-zero and the caller warns). That is more than it
+sounds and still cheap in context: once per workspace per process, beside the
+`sqlite3.connect`, the migrations and the FAISS index load already in that
+function — and `context.get_memory_for` caches the store and is reached from a
+worker thread, not the gateway event loop.
+
+It is fail-soft (warn, keep going), which is the contract `restrict_to_owner`
+documents for its callers: memory being unavailable is a supported degraded
+state, so a read-only filesystem must not take init down.
+
+> **Scope note.** With the default `db_path`, "the directory" *is* the data home
+> (`config_dir()`), so a memory init tightens the whole home to owner-only. That
+> direction is right — the home also holds the security policy, sessions and
+> lessons, all private on the same boundary — but it is wider than memory and it
+> is the only place in the tree that does it today. `memory.py`'s FTS index
+> (`memory_index.db`) and its sidecars carry the same secrets and are **not** yet
+> covered by the per-file pass.
+
 ## File locking on Windows
 
 `platform_compat.file_lock` / `acquire_lock` provide a genuine *blocking*

--- a/src/kiro_crew/eval/runner.py
+++ b/src/kiro_crew/eval/runner.py
@@ -248,7 +248,11 @@ class EvalRunner:
             conv_log.init()
             lesson_store = LessonStore(base_dir=ws)
             vector_store = VectorMemoryStore(db_path=ws / "vector_memory.db")
-            vector_store.init()
+            # Off the loop: init() now tightens the DB and its sidecars to
+            # owner-only, which on Windows shells out to icacls up to 11 times.
+            # This runs once per scenario, so a synchronous call would freeze the
+            # loop for seconds on every one.
+            await asyncio.to_thread(vector_store.init)
 
             # Wrap provider factory so all sessions share the same workspace root
             # (default factory creates per-session subdirs, which isolates memory)

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -751,9 +751,90 @@ class VectorMemoryStore:
         # grows past _LAST_ACCESSED_CACHE_MAX.
         self._last_accessed_touch: dict[str, float] = {}
 
+    def _secret_bearing_files(self) -> tuple[Path, ...]:
+        """Every file beside the DB that carries the user's memories.
+
+        All of them, not just the DB, because on Windows the owner-only DIRECTORY is
+        not sufficient for a file that already exists: **Bypass Traverse Checking** is
+        granted to Everyone by default, so a permissive DACL on the file itself stays
+        reachable even inside a tightened directory. The directory governs what SQLite
+        and FAISS create from now on; this list is what repairs an existing install.
+
+        - ``-wal`` / ``-shm``: a COMMITTED row lives in the ``-wal`` until a
+          checkpoint moves it. Same suffix set ``memory.py`` uses to drop a corrupt
+          index.
+        - ``memory.faiss`` / ``memory.ids.json``: the embedding index and its
+          id map, written with no lockdown of their own.
+
+        Not exhaustive for the data home as a whole -- ``memory.py``'s FTS index
+        (``memory_index.db``) and its sidecars carry the same secrets and are not
+        this class's to open. Tracked separately rather than reached across a module
+        boundary from here.
+        """
+        return (
+            Path(f"{self._db_path}-wal"),
+            Path(f"{self._db_path}-shm"),
+            self._faiss_path,
+            self._faiss_path.with_suffix(".ids.json"),
+        )
+
+    def _restrict_memory_files(self) -> None:
+        """Make every memory-bearing file that exists owner-only.
+
+        Called TWICE by :meth:`init` -- once before the connect and once after -- and
+        the ordering is the point of the first call. The owner-only directory does not
+        cover a file that already EXISTS on Windows, because Bypass Traverse Checking
+        is granted to Everyone by default, so a permissive DACL on the file itself
+        stays reachable inside a tightened directory. Restricting before
+        ``sqlite3.connect`` means the migrations do not run against a file another
+        local user can still write; restricting again after covers whatever SQLite
+        just created.
+
+        Missing files are skipped BY AN EXISTENCE CHECK, not by catching the failure:
+        on Windows ``restrict_to_owner`` shells out, so a missing path raises plain
+        ``OSError`` (icacls exits non-zero) rather than ``FileNotFoundError``, which
+        only ever comes from the POSIX ``os.chmod``. Catching alone would spawn up to
+        five futile ``icacls`` processes on a clean init and log a false "may be
+        readable by other users" warning for each, twice per init. The race between
+        the check and the call is benign: a file that appears in between is created by
+        SQLite or FAISS inside the already-tightened directory, so it inherits
+        owner-only access on both platforms and the next init covers it regardless.
+
+        Any other failure warns rather than raising -- memory being unavailable is a
+        supported degraded state, and ``restrict_to_owner`` documents this
+        warn-and-continue handler as its caller contract.
+        """
+        for path in (self._db_path, *self._secret_bearing_files()):
+            if not path.exists():
+                continue  # SQLite and FAISS create theirs on demand
+            try:
+                platform_compat.restrict_to_owner(path)
+            except OSError:
+                logger.warning(
+                    "Cannot restrict %s to owner; it may be readable by other users",
+                    path,
+                    exc_info=True,
+                )
+
     def init(self) -> None:
         """Create DB, apply migrations, set permissions."""
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Owner-only lockdown, in two halves. This directory call covers everything
+        # SQLite and FAISS create from here on -- inheritable on Windows, because
+        # `make_owner_only_dir` routes through `restrict_dir_to_owner`. The per-file
+        # pass below repairs what already EXISTS, which a tightened parent cannot do:
+        # Windows grants *Bypass Traverse Checking* to Everyone by default, so a
+        # pre-lockdown file stays reachable through it. Full reasoning -- the sidecar
+        # file set, the every-init rationale, the Windows icacls cost, the fail-soft
+        # contract -- lives in docs/guides/windows-install.md, "The memory store".
+        #
+        # SCOPE: with the default `db_path` this directory IS the data home
+        # (`config_dir()`), so a memory init tightens the whole home. That is wider
+        # than this class and the only place in the tree that does it -- named here
+        # rather than left to be discovered.
+        platform_compat.make_owner_only_dir(self._db_path.parent)
+        # BEFORE the connect so the migrations do not run against a file another
+        # local user can still write; repeated after it to cover what SQLite created.
+        self._restrict_memory_files()
         self._db = sqlite3.connect(
             str(self._db_path), check_same_thread=False, isolation_level=None
         )
@@ -791,9 +872,23 @@ class VectorMemoryStore:
                 self._db.commit()
                 logger.info("Applied memory schema migration v%s", ver)
 
-        # Set file permissions (owner-only). chmod_safe already logs+swallows
-        # OSError internally and is a no-op on Windows, so no wrapper needed.
-        platform_compat.chmod_safe(self._db_path, 0o600)
+        # Second pass, after the connect: covers what SQLite has just created. Runs
+        # on EVERY init, not only when init created the files -- an existing DB is
+        # exactly the one that may have lost its protection since (restored backup,
+        # home migration, manual edit, or an install predating this lockdown).
+        # ``restrict_to_owner`` rather than ``chmod_safe``, which is a documented
+        # no-op on Windows. Cost, file set and fail-soft contract:
+        # docs/guides/windows-install.md, "The memory store".
+        #
+        # CALLER CONTRACT: an async caller must offload this. The Windows path shells
+        # out to icacls, so calling ``init()`` directly on an event loop freezes it
+        # for seconds. ``eval.runner`` offloads via ``asyncio.to_thread``. ONE known
+        # violator remains: ``dashboard/handlers/memory.py::_get_vector_store``'s
+        # standalone fallback inits on the loop. It is cached, so it costs at most one
+        # first-request stall per process and only when no context_builder supplied a
+        # store -- not fixed here because offloading it means making that sync helper
+        # async across ~15 handlers. Tracked in #5221.
+        self._restrict_memory_files()
 
         # Load persisted FAISS index (or rebuild from SQLite embeddings)
         try:

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -640,11 +640,253 @@ class TestSchemaInit:
     def test_file_permissions(self, tmp_path: Path) -> None:
         import stat
 
+        from kiro_crew import platform_compat
+
         db_path = tmp_path / "mem.db"
         store = VectorMemoryStore(db_path=db_path)
         store.init()
-        mode = stat.S_IMODE(db_path.stat().st_mode)
-        assert mode == 0o600
+        # NTFS reports 0o666 for any file regardless of its DACL, so the mode
+        # assertion is meaningful only on POSIX. The routing assertion below is
+        # what covers Windows.
+        if platform_compat.IS_POSIX:
+            assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+    def test_creation_routes_through_restrict_to_owner(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The lockdown must go through ``restrict_to_owner``, on every platform.
+
+        ``chmod_safe`` is a no-op on Windows, so a regression back to it would leave
+        the user's memories and embeddings under the DACL the file inherits — and no
+        mode assertion can catch that, because NTFS has no mode bits to read. This
+        asserts the call, which is observable everywhere.
+        """
+        from kiro_crew import vector_memory as vm
+
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+        db_path = tmp_path / "mem.db"
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()  # an open handle blocks tmp_path teardown on Windows
+        # The main DB, plus whatever else legitimately routes through this helper.
+        # Asserted as a set of ALLOWED paths rather than an exact list, because the
+        # membership is not fixed: the WAL sidecars may or may not exist yet on a
+        # fresh create. The parent DIRECTORY is listed but no longer expected on
+        # either platform -- `make_owner_only_dir` routes it through
+        # `restrict_dir_to_owner`, the directory twin, so it does not reach this
+        # helper at all. Kept in the set as a harmless superset entry so the
+        # assertion stays green if that routing changes back.
+        allowed = {
+            str(db_path),
+            f"{db_path}-wal",
+            f"{db_path}-shm",
+            str(db_path.parent / "memory.faiss"),
+            str(db_path.parent / "memory.ids.json"),
+            str(db_path.parent),
+        }
+        assert str(db_path) in seen, seen
+        assert set(seen) <= allowed, set(seen) - allowed
+
+    def test_the_directory_is_owner_only_so_wal_sidecars_inherit_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Locking the .db file alone does not protect the memories.
+
+        ``journal_mode=WAL`` makes SQLite create ``memory.db-wal`` and
+        ``memory.db-shm``, and a COMMITTED row lives in the ``-wal`` until a
+        checkpoint moves it. SQLite creates and destroys those files throughout the
+        DB's life, at moments no caller can hook, so the directory they inherit
+        access from is the only place it can be settled once. Without this, a
+        readable parent directory leaves committed memories readable on Windows even
+        though the .db file itself is locked down.
+        """
+        from kiro_crew import vector_memory as vm
+
+        dirs: list[str] = []
+        real = vm.platform_compat.make_owner_only_dir
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "make_owner_only_dir",
+            lambda p: (dirs.append(str(p)), real(p))[1],
+        )
+        db_path = tmp_path / "nested" / "mem.db"
+
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()  # an open handle blocks tmp_path teardown on Windows
+
+        assert dirs == [str(db_path.parent)], dirs
+
+    def test_an_existing_wal_sidecar_is_repaired_on_open(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The directory fixes new sidecars; this fixes the ones already there.
+
+        A ``-wal`` created before the directory was tightened keeps the access it was
+        born with, and it can hold committed rows indefinitely if no checkpoint has
+        run -- so an existing install is not repaired by the directory alone.
+        """
+        from kiro_crew import vector_memory as vm
+
+        db_path = tmp_path / "mem.db"
+        first = VectorMemoryStore(db_path=db_path)
+        first.init()
+        # CLOSED before the sidecar is touched: Windows refuses a write to a file
+        # another handle holds open, and SQLite keeps -wal open for the life of the
+        # connection. Closing is also what the scenario describes -- an install whose
+        # sidecar was left behind by an earlier process.
+        first.close()
+        wal = Path(f"{db_path}-wal")
+        wal.write_bytes(b"pretend committed rows")
+
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+        second = VectorMemoryStore(db_path=db_path)
+        try:
+            second.init()
+        finally:
+            second.close()
+
+        assert str(wal) in seen, seen
+
+    def test_the_faiss_index_is_repaired_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The embedding index carries the same secrets as the DB.
+
+        And the owner-only directory does not cover it on Windows: Bypass Traverse
+        Checking is granted to Everyone by default, so a permissive DACL on a file
+        that already exists stays reachable inside a tightened directory. An install
+        whose FAISS index predates the lockdown is therefore only fixed by naming the
+        file.
+        """
+        from kiro_crew import vector_memory as vm
+
+        db_path = tmp_path / "mem.db"
+        faiss = tmp_path / "memory.faiss"
+        faiss.write_bytes(b"pretend embeddings")
+
+        seen: list[str] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append(str(p)), real(p))[1],
+        )
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()
+
+        assert str(faiss) in seen, seen
+
+    def test_an_existing_db_is_restricted_before_the_migrations_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering, not just coverage: the migrations must not run on a writable file.
+
+        An existing DB may still carry a writable inherited DACL. If the lockdown only
+        happened at the end of ``init()``, every schema migration would run against a
+        file another local user could concurrently write.
+        """
+        from kiro_crew import vector_memory as vm
+
+        db_path = tmp_path / "mem.db"
+        first = VectorMemoryStore(db_path=db_path)
+        first.init()
+        first.close()
+
+        events: list[str] = []
+        real_restrict = vm.platform_compat.restrict_to_owner
+        real_connect = vm.sqlite3.connect
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (events.append(f"restrict:{Path(p).name}"), real_restrict(p))[1],
+        )
+        monkeypatch.setattr(
+            vm.sqlite3,
+            "connect",
+            lambda *a, **k: (events.append("connect"), real_connect(*a, **k))[1],
+        )
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()
+
+        assert "connect" in events, events
+        restricted_db_before = events.index("restrict:mem.db") < events.index("connect")
+        assert restricted_db_before, events
+
+    def test_relaxed_mode_is_retightened_on_reopen(self, tmp_path: Path) -> None:
+        """A DB whose mode was widened after creation is locked down again.
+
+        Covers the POSIX arm of the every-init re-tighten: a home migration or a
+        restored backup can land ``memory.db`` group-readable, and only re-applying
+        the lockdown on open closes it.
+        """
+        import stat
+
+        from kiro_crew import platform_compat
+
+        if not platform_compat.IS_POSIX:
+            pytest.skip("POSIX mode bits")
+        db_path = tmp_path / "mem.db"
+        VectorMemoryStore(db_path=db_path).init()
+        db_path.chmod(0o644)
+        VectorMemoryStore(db_path=db_path).init()
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+    def test_absent_sidecars_are_never_handed_to_the_helper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A file that does not exist is skipped by a check, not by catching.
+
+        On Windows ``restrict_to_owner`` shells out, so a missing path raises plain
+        ``OSError`` (icacls exits non-zero) rather than ``FileNotFoundError`` -- which
+        only ever comes from the POSIX ``os.chmod``. Catching alone therefore spawned
+        a futile ``icacls`` per absent file and logged a false "may be readable by
+        other users" warning for each, twice per init. Asserting on what reaches the
+        helper pins the check itself, which is observable on both platforms; a mode or
+        DACL assertion could not distinguish the two implementations.
+        """
+        from kiro_crew import vector_memory as vm
+
+        # Existence is recorded AT CALL TIME, not after init: the pass runs twice and
+        # ``close()`` checkpoints the ``-wal``/``-shm`` away, so a sidecar that existed
+        # when the helper saw it is legitimately gone by the end of the test.
+        seen: list[tuple[str, bool]] = []
+        real = vm.platform_compat.restrict_to_owner
+        monkeypatch.setattr(
+            vm.platform_compat,
+            "restrict_to_owner",
+            lambda p: (seen.append((str(p), Path(p).exists())), real(p))[1],
+        )
+        db_path = tmp_path / "mem.db"
+        store = VectorMemoryStore(db_path=db_path)
+        try:
+            store.init()
+        finally:
+            store.close()  # an open handle blocks tmp_path teardown on Windows
+        assert seen, "the lockdown pass never ran"
+        assert [p for p, existed in seen if not existed] == []
 
     def test_idempotent_init(self, tmp_path: Path) -> None:
         store = VectorMemoryStore(db_path=tmp_path / "mem.db")


### PR DESCRIPTION
## Problem / Motivation

`memory.db` holds the user's semantic and episodic memories and their embeddings.
It is locked down with `platform_compat.chmod_safe(self._db_path, 0o600)` — and
`chmod_safe` is a **documented no-op on Windows**, so on that platform the file
is left under whatever DACL it inherited from its parent, readable by anyone the
parent allows.

No existing test could catch it: the permission test asserts a POSIX mode, and
**NTFS reports `0o666` for any file regardless of its DACL**.

Two related holes, both live on `main` today:

- Only the `.db` was ever considered. Under `journal_mode=WAL` a *committed* row
  lives in `memory.db-wal` until a checkpoint moves it, so the `-wal`/`-shm`
  sidecars carry the same secrets — as do `memory.faiss` and `memory.ids.json`,
  written with no lockdown of their own.
- The lockdown ran *after* `sqlite3.connect`, so the schema migrations executed
  against a file another local user could still write.

## Why it matters

On a shared Windows host, another local user can read every memory the assistant
has stored about its user — and the embeddings that make them searchable. It is a
confidentiality boundary that silently did not exist on one platform, with a test
suite that reported success.

## What changed (motivation → approach → change)

**Approach.** `main` already has the mechanism: `restrict_to_owner` (fail-loud
owner-only file lockdown, `0o600` on POSIX / `icacls /inheritance:r` on Windows)
and `make_owner_only_dir`, which routes through the inheritable directory twin
`restrict_dir_to_owner`. What was missing was the *call site*. So this is a call-site
migration plus the coverage the file set needs — no new platform primitive.

**Change.**

1. `VectorMemoryStore.init()` calls `make_owner_only_dir` on the parent, so
   everything SQLite and FAISS create from then on inherits owner-only access.
2. A new `_restrict_memory_files()` pass runs `restrict_to_owner` over the `.db`,
   its `-wal`/`-shm` sidecars, and `memory.faiss` / `memory.ids.json`. It is for
   what **already exists**: inheritance governs only new children, and Windows
   grants *Bypass Traverse Checking* to Everyone by default, so a pre-lockdown
   file stays reachable through a tightened parent.
3. That pass runs **twice** — before `sqlite3.connect` so the migrations do not run
   against a writable file, and after it to cover what SQLite just created.
4. It runs on **every** init rather than only on creation. A DB that already exists
   is exactly the one that may have lost its protection: a restored backup, a home
   migration, a manual edit, or an install predating this lockdown.
5. The pass **skips a path that does not exist by checking, not by catching**. On
   Windows `restrict_to_owner` shells out, so a missing path raises plain `OSError`
   (icacls exits non-zero) rather than `FileNotFoundError`, which only ever comes
   from the POSIX `os.chmod`. Catching alone spawned a futile `icacls` per absent
   file on a clean init and logged a false "may be readable by other users"
   warning for each, twice.
6. Fail-soft (warn, keep going), which is the contract `restrict_to_owner`
   documents for callers: memory being unavailable is a supported degraded state,
   so a read-only filesystem must not take init down.
7. **`eval/runner.py` now inits vector memory off the event loop** via
   `asyncio.to_thread`. This rides along because item 2 makes `init()` spawn
   subprocesses on Windows, and `_run_scenario_in` is `async` and calls it once per
   scenario — a synchronous call would freeze the loop for seconds each time.

**Provenance.** This supersedes #4534, which carried the same three-file change
against a four-day-old base and had gone to merge-conflict. Two things were
re-checked against current `main` rather than ported verbatim:

- #4534's directory call is still correct — `make_owner_only_dir` now routes
  through `restrict_dir_to_owner`, so it picks up inheritable grants for free.
- #4534's rationale was **stale**: it argued the per-file pass was needed because
  the directory's grants are non-inheritable, and listed making them inheritable
  as tracked separately. That work has since landed. The code comment and the
  guide section are rewritten so the per-file pass is justified by the one reason
  that still holds — repairing files that already exist.

**Cost, stated because it is not free.** Up to 11 `icacls` spawns per init on
Windows in the worst case (one directory plus one per existing file on each of two
passes); item 5 removes the spawns for files that are absent. Once per workspace
per process, beside the `sqlite3.connect`, the migrations and the FAISS index load
already in that function.

**Declared not-covered.** `memory.py`'s FTS index (`memory_index.db`) and its
sidecars carry the same secrets and are not reached from here. With the default
`db_path` the tightened directory *is* the data home (`config_dir()`), which is
wider than memory and is called out in the guide rather than left to be found.
`dashboard/handlers/memory.py::_get_vector_store` still inits on the event loop in
its standalone fallback — the one in-tree violator of item 7's contract, cached so
it costs at most one first-request stall per process: **#5221**.

## Tests

`test/test_vector_memory.py`, seven tests, all executing on the Linux lane:

- `test_creation_routes_through_restrict_to_owner` — a fresh DB goes through the
  fail-loud helper, not `chmod_safe`.
- `test_the_directory_is_owner_only_so_wal_sidecars_inherit_it` — the parent is
  tightened, so newly created sidecars are covered.
- `test_an_existing_wal_sidecar_is_repaired_on_open` — a pre-existing permissive
  `-wal` is tightened on open. This is the case a parent tighten cannot fix.
- `test_the_faiss_index_is_repaired_too` — the embedding index and its id map are
  in the pass, not just the SQLite files.
- `test_an_existing_db_is_restricted_before_the_migrations_run` — pins the
  ordering, so a later refactor cannot move the lockdown after `connect`.
- `test_relaxed_mode_is_retightened_on_reopen` — pins that the pass is not gated
  on having created the file.
- `test_absent_sidecars_are_never_handed_to_the_helper` — pins item 5. Existence
  is recorded *at call time*, because the pass runs twice and `close()`
  checkpoints the `-wal`/`-shm` away; a mode or DACL assertion could not tell the
  check-first implementation from the catch-based one. Mutation-verified: removing
  the `path.exists()` guard fails it.

## Manual verification

**Not performed on Windows** — this host is Linux, and the defect's whole point is
that POSIX modes cannot express it. The POSIX half is covered by the tests above.
The Windows DACL behaviour rests on `platform_compat.restrict_to_owner` /
`restrict_dir_to_owner`, which are already `main`'s shipped, separately tested
helpers; this PR adds no new Windows primitive, only call sites. A reviewer on
Windows can confirm with `icacls %USERPROFILE%\.kiro\crew\memory.db` after a
gateway start — expect inheritance stripped and only Owner Rights granted.

Local gates: `scripts/check_black_formatting.py` (diff scope, pass),
`isort --check-only` (pass), `pytest test/test_vector_memory.py` (181 passed,
11 skipped). Local `flake8`/`mypy` reds are pre-existing and in files outside this
diff; the local `flake8` is additionally unreliable here — its pycodestyle 2.9.1
misfires `W604` (a Python 2 check) on lines CI passes, so CI's Backend Lint is the
authoritative signal.

## Screenshots / video

**Why no screenshot:** no user-visible UI change — this alters file permissions
and a documentation section only.

## Related Issues

Supersedes #4534 (same change, stale base, conflicted). Follow-up: #5221.
