### PR TITLE
fix(dashboard): refuse slot-less set_project as a decision, not a crash (#5208)

### DIFF
--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -153,6 +153,20 @@ async def apply_session_directive(
             f"sub-agents are refused (this turn is {session_key!r}). "
             "Nothing was changed."
         )
+    if kind in _USER_SURFACE_DIRECTIVES and slot is None:
+        # set_project mutates the SLOT (its project and session CWD). A
+        # slot-less caller — a channel transport's TurnDriver — holds no slot
+        # for the effect to land on, so refuse it as a decision here: letting
+        # it fall through would crash `_set_project` on the missing slot and
+        # the fail-soft wrapper would audit "error" for what is a permission
+        # boundary. Slot-BEARING channel sessions pass — the user-surface gate
+        # above already vetted the surface, and the applier can deliver the
+        # effect to a real slot.
+        _audit(session_key, kind, "denied")
+        return (
+            f"Error: {kind} targets this turn's chat slot, and this turn "
+            f"holds none (this turn is {session_key!r}). Nothing was changed."
+        )
     try:
         if kind == "monitor_start":
             result = await _monitor_start(state, session_key, args)

--- a/test/test_driver_session_directives.py
+++ b/test/test_driver_session_directives.py
@@ -496,13 +496,14 @@ class TestChannelApplierBoundary:
         assert [c["outcome"] for c in directive_calls] == ["denied"]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("kind", ["set_project", "suggest_followup", "ask_question"])
+    @pytest.mark.parametrize("kind", ["suggest_followup", "ask_question"])
     async def test_dashboard_only_directives_refused_on_channel_transport(
         self, kind, no_dashboard_tabs
     ):
         """SECURITY INVARIANT (#4540): _DASHBOARD_ONLY_DIRECTIVES stay DENIED
         for non-dashboard sessions — the channel consumer must not widen the
-        gate."""
+        gate. set_project left this set (#3543): it is refused on the channel
+        transport by the slot-less gate instead, pinned below."""
         state = _ChannelDirectiveState(sessions=_ChannelSessions("x"))
         result = await apply_session_directive(
             state, None, "slack:1755000000.123456", kind, {"project": "/tmp"}
@@ -532,7 +533,32 @@ class TestChannelApplierBoundary:
         finally:
             session_surface.set_dashboard_surfaced(before)
         assert result.startswith("Error:")
-        assert "only works from a dashboard chat session" in result
+        assert "targets this turn's chat slot" in result
+
+    @pytest.mark.asyncio
+    async def test_slotless_set_project_refusal_audits_denied(self, monkeypatch, no_dashboard_tabs):
+        """SEL truthfulness for the slot-less set_project refusal: it is a
+        permission DECISION, so it must audit ``denied`` — never ``error``
+        (the crash shape a missing slot-None guard would produce) and never
+        ``success``. Nothing may be mutated on the way out."""
+        calls: list[dict] = []
+
+        class _SelSpy:
+            def log_tool_invocation(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr("kiro_crew.sel.sel", lambda: _SelSpy())
+        result = await apply_session_directive(
+            _ChannelDirectiveState(sessions=_ChannelSessions("x")),
+            None,
+            "slack:1755000000.123456",
+            "set_project",
+            {"project": "/tmp"},
+        )
+        assert result.startswith("Error:")
+        assert "targets this turn's chat slot" in result
+        directive_calls = [c for c in calls if c.get("source") == "mcp-directive"]
+        assert [c["outcome"] for c in directive_calls] == ["denied"]
 
 
 # ── build_directive_consumer wiring ──────────────────────────────────────────


### PR DESCRIPTION
## Problem / Motivation

Main is red on every PR's merge-ref CI since 06:14 UTC today: `Backend Tests (3.10, 2)` and `Backend Tests (Windows) (2)` fail deterministically on

- `test_driver_session_directives.py::TestChannelApplierBoundary::test_dashboard_only_directives_refused_on_channel_transport[set_project]`
- `test_driver_session_directives.py::TestChannelApplierBoundary::test_dashboard_only_refused_for_slotless_caller_even_with_open_tab`

Mid-air collision: #5113 (merged first) added ChannelApplierBoundary tests pinning **set_project refused on channel transports**; #3543 (branched before those tests existed, merged 06:14 UTC) moved `set_project` out of `_DASHBOARD_ONLY_DIRECTIVES` onto a user-surface predicate and only updated the tests its branch could see (`test_mcp_core_set_project.py`). Each PR was green alone; together main is red.

## Why it matters

Beyond the red main: a slot-less `set_project` (a channel transport's TurnDriver caller, `slot=None`) now passes both gates and **crashes** `_set_project` (`slot.project` on `None`). The fail-soft wrapper converts that into a generic error and audits `"error"` — a permission boundary recorded as a malfunction — and #3543's stated goal does not actually work on slot-less transports. #3543's own gate comment still articulates the invariant it dropped: *"A slot-less caller (a channel transport's TurnDriver) is refused … the effect targets the SLOT, and this turn does not hold one."*

## What changed (motivation → approach → change)

Keep both PRs' intents:

- **Code**: add an explicit slot-None refusal for `_USER_SURFACE_DIRECTIVES` in the gate section of `apply_session_directive` — denied audit, clean message, nothing mutated. Slot-bearing channel sessions (what #3543's own tests exercise, with a real slot) keep the widened behavior.
- **Tests**: drop `set_project` from the dashboard-only parametrize (it is no longer dashboard-only — that is #3543's landed intent, and `suggest_followup`/`ask_question` keep the pin); the slot-less test keeps set_project as its subject and pins the new refusal message; a new SEL-truthfulness test asserts the refusal audits `denied` — never `error` (the crash shape) or `success`.

Out of scope: making set_project actually work for slot-less channel turns (a session-keyed project store) — that is feature work; #5208 stays the record if wanted.

## Tests

- `test_driver_session_directives.py` + `test_mcp_core_set_project.py`: 69 passed locally (includes #3543's own channel-session and headless tests, unchanged and still green).
- All other consumers of `session_directive_apply`: `test_mcp_followup_dispatch.py`, `test_autonudge_stop_auth.py`, `test_ask_question_mcp_tool.py` — 51 passed.
- isort / flake8 / mypy (1038 files) / black gate / brand gate all green.

## Manual verification

N/A — unit coverage sufficient: the refusal is a pure gate branch with both message and SEL outcome pinned.

## Related Issues

Closes #5208

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: gate behavior change is pinned in tests; no documented schema/API change
- [x] No secrets, credentials, or internal references in the diff
