### PR TITLE
fix(chat): optimistic store write on agent/effort switches (#5120)

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3583,70 +3583,151 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     if agent_name and not _AGENT_NAME_RE.match(agent_name):
         return web.json_response({"error": "invalid agent name"}, status=400)
 
-    # Stored verbatim — never rewritten to whatever currently answers. See the
-    # same reasoning in api_chat_slot_create.
-    slot.agent = agent_name
+    # The whole resolve -> reset -> commit section runs under the slot's
+    # lock: the awaits yield the event loop, and an interleaved second switch
+    # could otherwise observe (or write) intermediate state. TRANSACTIONAL
+    # ordering: the new values are computed into locals, the session reset
+    # runs FIRST, and the slot is mutated only after the reset succeeds — a
+    # failed request provably changed nothing, the invariant the frontend's
+    # slotSwitch failure-recovery relies on, with no rollback machinery to
+    # race against concurrent writers (e.g. the project endpoint, which does
+    # not take this lock).
+    async with slot._lock:
+        # Stored verbatim — never rewritten to whatever currently answers. See
+        # the same reasoning in api_chat_slot_create.
+        new_workspace = slot.workspace
+        new_project = slot.project
+        # Compare-and-set baseline, captured BEFORE the first await in this
+        # section: the resolution warm-up and the session reset both yield
+        # the event loop, and the project/workspace endpoints do not take
+        # this lock — a user's explicit pick landing anywhere in that window
+        # must win over this switch's DERIVED values (the reverse would
+        # silently erase an action that happened after the agent pick).
+        pre_await_workspace = slot.workspace
+        pre_await_project = slot.project
 
-    # Resolve workspace from agent bindings
-    workspace = "default"
-    try:
-        cfg = KiroCrewConfig.load()
-        if agent_name:
-            # Resolve by the name being STORED, which is exactly the name dispatch
-            # will resolve later (`chat_runner` -> resolve_agent_bindings(
-            # slot.agent)). Looking it up as an alias first and taking THAT
-            # alias's workspace disagreed with dispatch whenever the two differ:
-            # a name that is merely some alias's `kiro_agent` target, or a
-            # materialized app agent, dispatches with the DEFAULT bindings while
-            # the slot had recorded the alias's workspace. A materialized agent
-            # previously matched nothing here at all, so the slot kept the
-            # PREVIOUS agent's project — latent until app agents could dispatch.
-            # Resolve WITH the slot's project scope (warmed off-loop first) so a
-            # project agent counts as resolved rather than falling back.
-            await warm_project_agent_names(slot.project or None)
-            bindings = resolve_agent_bindings(cfg, agent_name, slot.project or None)
-            ws_name = _workspace_name_for_dir(cfg, bindings.workspace_dir)
-            slot.workspace = ws_name
-            workspace = ws_name
-            # A project-scope agent exists only inside slot.project: kiro-cli
-            # resolves --agent against $PWD/.kiro/agents, so resetting the
-            # project here would make the very agent just selected unresolvable
-            # on the next turn (slot advertises it, default answers — the
-            # silent-substitution bug #1684 exists to remove). Aliases keep the
-            # reset: their project comes from their own workspace bindings.
-            is_project_agent = agent_name not in cfg.agents and agent_name in (
-                cached_project_agent_names(slot.project or None) or frozenset()
+        # Commit the agent BEFORE any await in this section: a message send
+        # landing while the resolution warm-up or the reset await is in
+        # flight creates a fresh session from the slot's CURRENT bindings,
+        # so the new agent must already be visible or that session
+        # cold-starts on the old binding and stays stale after the switch
+        # reports success. Deliberately NO rollback on a failing reset: the
+        # reset pops the session from the map before shutting the process
+        # down, so by the time shutdown can fail the old binding's session
+        # no longer exists — every future send cold-starts on the NEW
+        # binding, and a replacement session created by a concurrent send
+        # mid-reset already runs it. Restoring the old label would advertise
+        # a binding nothing runs (and tear against that replacement).
+        slot.agent = agent_name
+
+        # Resolve workspace from agent bindings. The response value is seeded
+        # from the slot's CURRENT workspace, not a "default" literal: if
+        # resolution below fails, the response still names this value, and
+        # since #5120 the acting tab writes it into its store — a fabricated
+        # "default" would pin the chip to a workspace the slot does not hold
+        # (the websocket rebroadcast corrects it only when the socket is up,
+        # which is exactly when the optimistic write is load-bearing).
+        workspace = slot.workspace or "default"
+        try:
+            cfg = KiroCrewConfig.load()
+            if agent_name:
+                # Resolve by the name being STORED, which is exactly the name dispatch
+                # will resolve later (`chat_runner` -> resolve_agent_bindings(
+                # slot.agent)). Looking it up as an alias first and taking THAT
+                # alias's workspace disagreed with dispatch whenever the two differ:
+                # a name that is merely some alias's `kiro_agent` target, or a
+                # materialized app agent, dispatches with the DEFAULT bindings while
+                # the slot had recorded the alias's workspace. A materialized agent
+                # previously matched nothing here at all, so the slot kept the
+                # PREVIOUS agent's project — latent until app agents could dispatch.
+                # Resolve WITH the slot's project scope (warmed off-loop first) so a
+                # project agent counts as resolved rather than falling back.
+                await warm_project_agent_names(slot.project or None)
+                bindings = resolve_agent_bindings(cfg, agent_name, slot.project or None)
+                ws_name = _workspace_name_for_dir(cfg, bindings.workspace_dir)
+                new_workspace = ws_name
+                workspace = ws_name
+                # A project-scope agent exists only inside slot.project: kiro-cli
+                # resolves --agent against $PWD/.kiro/agents, so resetting the
+                # project here would make the very agent just selected unresolvable
+                # on the next turn (slot advertises it, default answers — the
+                # silent-substitution bug #1684 exists to remove). Aliases keep the
+                # reset: their project comes from their own workspace bindings.
+                is_project_agent = agent_name not in cfg.agents and agent_name in (
+                    cached_project_agent_names(slot.project or None) or frozenset()
+                )
+                if not is_project_agent:
+                    new_project = default_project_dir(workspace)
+        except Exception:
+            logger.warning("Failed to resolve agent bindings for %r", agent_name, exc_info=True)
+
+        # Derived fields commit BEFORE the reset too, compare-and-set against
+        # the pre-await baseline: a send landing during the reset teardown
+        # cold-starts the replacement session from the slot's CURRENT
+        # bindings, so the full new binding TRIPLE must already be visible or
+        # the new agent's session starts in the OLD project and its tools run
+        # in the wrong repository. The CAS still protects a concurrent
+        # explicit pick that landed during the resolution awaits above.
+        if slot.workspace == pre_await_workspace:
+            slot.workspace = new_workspace
+        if slot.project == pre_await_project:
+            slot.project = new_project
+
+        # Reset session so the next message uses the new agent.
+        logger.info(
+            "Slot %s agent switched to %r, resetting session", name, agent_name or "kirocrew"
+        )
+        teardown_incomplete = False
+        try:
+            await _reset_slot_session(state, slot, _history_key_for(name))
+        except Exception:
+            # The switch is COMMITTED regardless: the reset pops the session
+            # before its shutdown can fail, so the new binding is what every
+            # replacement or future session runs. This is a success with a
+            # degraded teardown, and it must be reported as one — a 500 here
+            # would make the acting tab's performSlotSwitch keep the OLD
+            # store value, corrupting the cycle base and the displayed state
+            # for a switch that actually happened.
+            teardown_incomplete = True
+            logger.exception(
+                "Slot %s agent switch: old session teardown incomplete", name
             )
-            if not is_project_agent:
-                slot.project = default_project_dir(workspace)
-    except Exception:
-        logger.warning("Failed to resolve agent bindings for %r", agent_name, exc_info=True)
 
-    # Reset session so next message uses the new agent
-    logger.info("Slot %s agent switched to %r, resetting session", name, agent_name or "kirocrew")
-    await _reset_slot_session(state, slot, _history_key_for(name))
+        # Persist the new agent so the session resumes under the correct
+        # agent after a gateway restart. INSIDE the lock: two racing switches
+        # otherwise interleave their metadata writes, and a stalled earlier
+        # write finishing last would restore the older agent on restart.
+        if state.conversation_log:
+            try:
+                # update_metadata enters _locked (flock + os.close); those are
+                # blocking-on-loop-prohibited, so offload to a worker thread rather
+                # than run them on the event loop (a wedged peer must never freeze
+                # chat/WS/heartbeat).
+                await asyncio.to_thread(
+                    state.conversation_log.update_metadata,
+                    _history_key_for(name),
+                    {"agent": agent_name},
+                )
+            except Exception:
+                logger.warning("Failed to persist agent for slot %s", name, exc_info=True)
+
+        # Snapshot the response's workspace LAST, immediately before leaving
+        # the lock: the metadata await above yields the event loop, so a
+        # concurrent /workspace pick can land after the commit — the response
+        # (which the acting tab writes into its store) must name the slot's
+        # newest reality, not a pre-await snapshot.
+        workspace = slot.workspace or "default"
     # The reset destroyed any eagerly created session; picking an agent is
     # itself a strong first-message intent signal (it also resets the
     # project), so re-arm the speculative spawn for the new bindings.
     schedule_eager_spawn(state, slot)
-    # Persist the new agent so the session resumes under the correct agent
-    # after a gateway restart.  Written after reset succeeds so we never
-    # advertise an agent we couldn't actually switch to.
-    if state.conversation_log:
-        try:
-            # update_metadata enters _locked (flock + os.close); those are
-            # blocking-on-loop-prohibited, so offload to a worker thread rather
-            # than run them on the event loop (a wedged peer must never freeze
-            # chat/WS/heartbeat).
-            await asyncio.to_thread(
-                state.conversation_log.update_metadata,
-                _history_key_for(name),
-                {"agent": agent_name},
-            )
-        except Exception:
-            logger.warning("Failed to persist agent for slot %s", name, exc_info=True)
     state.push_slots_update()
-    return web.json_response({"ok": True, "agent": agent_name, "workspace": workspace})
+    resp_body: dict = {"ok": True, "agent": agent_name, "workspace": workspace}
+    if teardown_incomplete:
+        # Advisory only — the switch itself succeeded and the response
+        # carries the committed state the acting tab writes optimistically.
+        resp_body["warning"] = "old session teardown incomplete"
+    return web.json_response(resp_body)
 
 
 def _model_rejected_reason(model_name: str, provider: str | None = None) -> str | None:
@@ -4009,51 +4090,86 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
             },
             status=400,
         )
-    if slot.reasoning_effort == effort:
-        return web.json_response({"ok": True, "reasoning_effort": effort})
-    slot.reasoning_effort = effort
-    logger.info("Slot %s reasoning_effort switched to %r", name, effort or "default")
+    # Same serialization + transactional ordering as the agent switch: the
+    # awaits below yield the event loop, so the section runs under the slot's
+    # lock, and the slot is mutated only AFTER the switch actually took
+    # effect (live update, deferral, or reset) — a failed request provably
+    # changed nothing.
+    async with slot._lock:
+        if slot.reasoning_effort == effort:
+            return web.json_response({"ok": True, "reasoning_effort": effort})
+        logger.info("Slot %s reasoning_effort switched to %r", name, effort or "default")
 
-    session_key = _history_key_for(name)
-    provider = state.sessions.get_provider(session_key)
-    _updated_live = False
-    if isinstance(provider, AcpProvider) and provider.supports_effort():
-        # Guard against racing the in-flight prompt read loop: a live
-        # change_effort issues session/set_config_option and its response wait
-        # would call stdout.readline() concurrently with the streaming
-        # _prompt_loop → dropped/misrouted frame or a stuck turn. The override
-        # is already persisted on the slot, so defer the live push to the next
-        # turn instead of pushing now or resetting (effort is a cheap knob).
-        if provider.has_active_turn():
-            logger.info("Slot %s deferred live effort push: turn active", name)
-            state.push_slots_update()
-            return web.json_response({"ok": True, "reasoning_effort": effort, "deferred": True})
-        # change_effort handles both backends and persists the per-model
-        # override + overlay. "" clears the override → fall back to model
-        # default (kiro: /effort with model default; claude: leave as-is).
-        try:
-            if effort:
-                _updated_live = await provider.change_effort(effort)
-            else:
-                _updated_live = await provider.clear_effort()
-        except Exception as exc:
-            logger.warning(
-                "change_effort(%s) failed for slot %s: %s: %s — falling back to reset",
-                effort,
-                name,
-                type(exc).__name__,
-                exc,
-            )
-    elif isinstance(provider, AcpProvider):
-        # Model does not support effort — persist the slot value for when the
-        # user switches to a capable model, but do not touch the live session.
-        _updated_live = True
-        logger.info("Slot %s effort persisted (model not effort-capable)", name)
+        session_key = _history_key_for(name)
+        provider = state.sessions.get_provider(session_key)
+        _updated_live = False
+        if isinstance(provider, AcpProvider) and provider.supports_effort():
+            # Guard against racing the in-flight prompt read loop: a live
+            # change_effort issues session/set_config_option and its response wait
+            # would call stdout.readline() concurrently with the streaming
+            # _prompt_loop → dropped/misrouted frame or a stuck turn. The override
+            # is already persisted on the slot, so defer the live push to the next
+            # turn instead of pushing now or resetting (effort is a cheap knob).
+            if provider.has_active_turn():
+                logger.info("Slot %s deferred live effort push: turn active", name)
+                # This path's success point: the override is recorded on the
+                # slot now and pushed to the live session next turn.
+                slot.reasoning_effort = effort
+                state.push_slots_update()
+                return web.json_response(
+                    {"ok": True, "reasoning_effort": effort, "deferred": True}
+                )
+            # change_effort handles both backends and persists the per-model
+            # override + overlay. "" clears the override → fall back to model
+            # default (kiro: /effort with model default; claude: leave as-is).
+            try:
+                if effort:
+                    _updated_live = await provider.change_effort(effort)
+                else:
+                    _updated_live = await provider.clear_effort()
+            except Exception as exc:
+                logger.warning(
+                    "change_effort(%s) failed for slot %s: %s: %s — falling back to reset",
+                    effort,
+                    name,
+                    type(exc).__name__,
+                    exc,
+                )
+        elif isinstance(provider, AcpProvider):
+            # Model does not support effort — persist the slot value for when the
+            # user switches to a capable model, but do not touch the live session.
+            _updated_live = True
+            logger.info("Slot %s effort persisted (model not effort-capable)", name)
 
-    if not _updated_live:
-        # No live session (or live update failed): reset so the next cold
-        # start picks up the new effort via the provider factory/overlay.
-        await _reset_slot_session(state, slot, session_key)
+        if not _updated_live:
+            # No live session (or live update failed): reset so the next cold
+            # start picks up the new effort via the provider factory/overlay.
+            # The effort is committed BEFORE the reset: a message send landing
+            # while the reset await is in flight cold-starts a session from
+            # the slot's CURRENT value, so the new effort must already be
+            # visible. A failing teardown does NOT undo the switch (the reset
+            # pops the session first, so every replacement runs the new
+            # value) and is reported as a success with a warning — a 500
+            # would make the acting tab keep the OLD store value for a
+            # switch that actually happened.
+            slot.reasoning_effort = effort
+            try:
+                await _reset_slot_session(state, slot, session_key)
+            except Exception:
+                logger.exception(
+                    "Slot %s reasoning_effort switch: old session teardown incomplete", name
+                )
+                state.push_slots_update()
+                return web.json_response(
+                    {
+                        "ok": True,
+                        "reasoning_effort": effort,
+                        "warning": "old session teardown incomplete",
+                    }
+                )
+        # Live-update and deferral paths commit here (the reset path already
+        # committed before its reset, and assigning again is a no-op).
+        slot.reasoning_effort = effort
     state.push_slots_update()
     return web.json_response({"ok": True, "reasoning_effort": effort})
 

--- a/test/test_chat_slot_reasoning_effort.py
+++ b/test/test_chat_slot_reasoning_effort.py
@@ -69,6 +69,134 @@ class TestChatSlotReasoningEffort:
             state.sessions.reset.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_reset_failure_keeps_committed_effort_and_reports_success(self):
+        # A throwing fallback reset reports SUCCESS with a warning and the
+        # new effort STAYS: the reset pops the session before shutdown can
+        # fail, so the old effort's session no longer exists and every
+        # replacement runs the new value. A 500 would make the acting tab
+        # keep the OLD store value for a switch that actually happened.
+        slot = _ChatSlot("test")
+        slot.reasoning_effort = "high"
+        state = _mock_state(slot)
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("shutdown blew up"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["reasoning_effort"] == "low"
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.reasoning_effort == "low"
+
+    @pytest.mark.asyncio
+    async def test_failed_reset_spares_concurrent_writes(self):
+        # Commit-after-reset: the failure path touches nothing, so a value
+        # written by a concurrent actor while the reset was failing survives
+        # -- restoring captured priors (the old rollback shape) would
+        # silently erase it.
+        slot = _ChatSlot("test")
+        slot.reasoning_effort = "high"
+        state = _mock_state(slot)
+
+        async def _concurrent_lands_then_reset_fails(*args, **kwargs):
+            slot.reasoning_effort = "max"
+            raise RuntimeError("shutdown blew up")
+
+        state.sessions.reset = AsyncMock(side_effect=_concurrent_lands_then_reset_fails)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            )
+            assert resp.status == 200
+            # The concurrent winner's value survives.
+            assert slot.reasoning_effort == "max"
+
+    @pytest.mark.asyncio
+    async def test_new_effort_visible_during_reset(self):
+        # A message send landing while the reset await is in flight
+        # cold-starts a session from the slot's CURRENT value, so the new
+        # effort must already be committed when the reset runs — otherwise
+        # that session runs the old effort while the switch reports success.
+        # (`reasoning_effort` has no unlocked writers, so committing before
+        # the reset is safe: the failure path's rollback races nobody.)
+        slot = _ChatSlot("test")
+        slot.reasoning_effort = "high"
+        state = _mock_state(slot)
+        seen_during_reset: list[str] = []
+
+        async def _observe_then_succeed(*args, **kwargs):
+            seen_during_reset.append(slot.reasoning_effort)
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_observe_then_succeed)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            )
+            assert resp.status == 200
+            assert seen_during_reset == ["low"]
+            assert slot.reasoning_effort == "low"
+
+    @pytest.mark.asyncio
+    async def test_same_target_successor_not_undone_by_failed_predecessor(self):
+        # Two clients pick the SAME target; the first request's reset hangs
+        # then throws while the second is already queued. Value comparison
+        # alone cannot tell the successor's success from the predecessor's
+        # own write, so the switch section is serialized under slot._lock:
+        # the successor waits, sees the rolled-back slot, and applies the
+        # switch cleanly on its own reset. Final state must be the target,
+        # not snapped back to the prior value.
+        import asyncio
+
+        slot = _ChatSlot("test")
+        slot.reasoning_effort = "high"
+        state = _mock_state(slot)
+
+        first_reset_started = asyncio.Event()
+        release_first_reset = asyncio.Event()
+        calls = {"n": 0}
+
+        async def _reset(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                first_reset_started.set()
+                await release_first_reset.wait()
+                raise RuntimeError("shutdown blew up")
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            first = asyncio.create_task(client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            ))
+            await first_reset_started.wait()
+            second = asyncio.create_task(client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            ))
+            # Let the second request reach (and block on) the slot lock, then
+            # let the first request's reset fail.
+            await asyncio.sleep(0.05)
+            release_first_reset.set()
+            resp1 = await first
+            resp2 = await second
+            # Both report success: the predecessor's switch committed (only
+            # its old-session teardown degraded, reported via warning), and
+            # the serialized successor observed the committed value and
+            # correctly no-opped — one reset total, final state the target.
+            assert resp1.status == 200
+            assert (await resp1.json())["warning"] == "old session teardown incomplete"
+            assert resp2.status == 200
+            assert slot.reasoning_effort == "low"
+            assert calls["n"] == 1
+
+    @pytest.mark.asyncio
     async def test_no_op_when_unchanged_skips_session_reset(self):
         # Setting the same value twice must not reset the session
         # (avoids needless subprocess respawn on repeated UI clicks).

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6245,6 +6245,352 @@ class TestRuntimeWiring:
             assert data["workspace"] == "oncall-ws"
 
     @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_failed_resolution_reports_slot_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        """A binding-resolution failure must not fabricate workspace='default'.
+
+        The handler logs and proceeds when resolve_agent_bindings raises, and
+        slot.workspace keeps its previous value — so the response must name
+        THAT value. Since #5120 the acting tab writes the response's workspace
+        into its store optimistically; a fabricated 'default' would pin the
+        chip to a workspace the slot does not hold, and with the websocket
+        down (the optimistic write's whole premise) nothing corrects it.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.workspace = "research-ws"
+        state.sessions.reset = AsyncMock()
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", _boom)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom
+        )
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "oncall"})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["agent"] == "oncall"
+            # The slot's workspace was not changed by the failed resolution,
+            # and the response reports the value the slot actually holds.
+            assert slot.workspace == "research-ws"
+            assert data["workspace"] == "research-ws"
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_reset_failure_keeps_committed_agent(
+        self, tmp_path, monkeypatch
+    ):
+        """A throwing teardown reports SUCCESS with a warning; the agent stays.
+
+        The reset pops the session before its shutdown can fail, so by the
+        failure point the old binding's session no longer exists — every
+        future or replacement session cold-starts on the NEW agent. The
+        switch therefore succeeded: answering 500 would make the acting
+        tab's performSlotSwitch keep the OLD store value for a switch that
+        actually happened.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.agent = "oncall"
+        slot.workspace = "oncall-ws"
+        slot.project = "/tmp/oncall"
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("shutdown blew up"))
+
+        mock_cfg = MagicMock()
+        mock_cfg.agents = {"research": MagicMock(workspace="research-ws", memory_store="default")}
+        mock_cfg.workspaces = {"research-ws": MagicMock(dir="/tmp/research")}
+        mock_cfg.default_workspace = "default"
+        mock_cfg.default_memory_store = "default"
+        mock_cfg.memory_stores = {}
+        mock_cfg.memory = MagicMock()
+        mock_bindings = MagicMock()
+        mock_bindings.workspace_dir = Path("/tmp/research")
+        mock_bindings.memory_store_name = "default"
+        mock_bindings.model = ""
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", lambda: mock_cfg)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            data = await resp.json()
+            # Success with a warning — the switch happened; only the old
+            # process's teardown degraded.
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["agent"] == "research"
+            assert data["warning"] == "old session teardown incomplete"
+            # The committed bindings stay (the popped old session cannot come
+            # back) — agent and the derived workspace both advertise the new
+            # binding.
+            assert slot.agent == "research"
+            assert slot.workspace == "research-ws"
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_failed_reset_spares_concurrent_writes(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed switch never disturbs values written while it was in flight.
+
+        Commit-after-reset means the failure path touches nothing, so state
+        written by a concurrent actor during the (failing) reset — e.g. the
+        project endpoint, which does not take the slot lock — survives
+        untouched. Restoring captured priors here (the old rollback shape)
+        would silently erase that concurrent success.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.agent = "oncall"
+        slot.workspace = "oncall-ws"
+        slot.project = "/tmp/oncall"
+
+        async def _concurrent_switch_lands_then_reset_fails(*args, **kwargs):
+            # Simulate a concurrent request winning the race while this
+            # request's reset is in flight.
+            slot.agent = "writer"
+            slot.workspace = "writing-ws"
+            slot.project = "/tmp/writing"
+            raise RuntimeError("shutdown blew up")
+
+        state.sessions.reset = AsyncMock(side_effect=_concurrent_switch_lands_then_reset_fails)
+
+        mock_cfg = MagicMock()
+        mock_cfg.agents = {"research": MagicMock(workspace="research-ws", memory_store="default")}
+        mock_cfg.workspaces = {"research-ws": MagicMock(dir="/tmp/research")}
+        mock_cfg.default_workspace = "default"
+        mock_cfg.default_memory_store = "default"
+        mock_cfg.memory_stores = {}
+        mock_cfg.memory = MagicMock()
+        mock_bindings = MagicMock()
+        mock_bindings.workspace_dir = Path("/tmp/research")
+        mock_bindings.memory_store_name = "default"
+        mock_bindings.model = ""
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", lambda: mock_cfg)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            assert resp.status == 200
+            # The concurrent winner's values survive — no field snaps back to
+            # this request's priors.
+            assert slot.agent == "writer"
+            assert slot.workspace == "writing-ws"
+            assert slot.project == "/tmp/writing"
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_success_commit_spares_concurrent_pick(
+        self, tmp_path, monkeypatch
+    ):
+        """A pick landing during a SUCCESSFUL reset wins over derived values.
+
+        The project/workspace endpoints do not take the slot lock, so a
+        user's explicit pick can land while the agent switch's reset await is
+        in flight. The commit is compare-and-set against a pre-await
+        baseline: the switch's DERIVED workspace/project must not overwrite
+        the newer explicit pick, and the response names the slot's final
+        reality. `agent` itself still commits — it is owned exclusively by
+        this endpoint.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.agent = "oncall"
+        slot.workspace = "oncall-ws"
+        slot.project = "/tmp/oncall"
+        seen_during_reset: list[tuple[str, str]] = []
+
+        async def _concurrent_pick_lands_then_reset_succeeds(*args, **kwargs):
+            # The derived bindings must already be committed when the reset
+            # runs: a send in this window cold-starts the replacement session
+            # from the slot's CURRENT values, and starting the new agent in
+            # the old project would run its tools in the wrong repository.
+            seen_during_reset.append((slot.workspace, slot.project))
+            # A project pick (unlocked endpoint) lands mid-reset.
+            slot.project = "/tmp/user-picked"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_concurrent_pick_lands_then_reset_succeeds)
+
+        mock_cfg = MagicMock()
+        mock_cfg.agents = {"research": MagicMock(workspace="research-ws", memory_store="default")}
+        mock_cfg.workspaces = {"research-ws": MagicMock(dir="/tmp/research")}
+        mock_cfg.default_workspace = "default"
+        mock_cfg.default_memory_store = "default"
+        mock_cfg.memory_stores = {}
+        mock_cfg.memory = MagicMock()
+        mock_bindings = MagicMock()
+        mock_bindings.workspace_dir = Path("/tmp/research")
+        mock_bindings.memory_store_name = "default"
+        mock_bindings.model = ""
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", lambda: mock_cfg)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            data = await resp.json()
+            assert resp.status == 200
+            # The agent itself committed; the derived workspace committed
+            # (untouched since baseline); the user's mid-reset project pick
+            # SURVIVED the commit instead of being overwritten by the
+            # derived project reset.
+            assert slot.agent == "research"
+            assert slot.workspace == "research-ws"
+            assert slot.project == "/tmp/user-picked"
+            # The derived workspace was already committed when the reset ran
+            # (a replacement session in that window starts under the NEW
+            # binding, not the old repository).
+            assert seen_during_reset[0][0] == "research-ws"
+            # The response names the slot's final reality.
+            assert data["workspace"] == "research-ws"
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_new_agent_visible_during_reset(
+        self, tmp_path, monkeypatch
+    ):
+        """The new agent is committed before the reset runs.
+
+        A message send landing while the reset await is in flight creates a
+        fresh session from the slot's CURRENT bindings — if the agent were
+        committed only after the reset, that session would cold-start on the
+        OLD agent and stay stale while the switch reports success.
+        (`agent` has no unlocked writers, so committing before the reset is
+        safe: the failure path's rollback races nobody.)
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.agent = "oncall"
+        seen_during_reset: list[str] = []
+
+        async def _observe_then_succeed(*args, **kwargs):
+            seen_during_reset.append(slot.agent)
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_observe_then_succeed)
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        # Resolution outcome is irrelevant to the visibility property.
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", _boom)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom
+        )
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            assert resp.status == 200
+            assert seen_during_reset == ["research"]
+            assert slot.agent == "research"
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_response_names_workspace_picked_during_persist(
+        self, tmp_path, monkeypatch
+    ):
+        """The response snapshots the workspace LAST, before leaving the lock.
+
+        The metadata persist awaits a worker thread, yielding the event loop
+        — a concurrent /workspace pick landing in that window must be what
+        the response names, because the acting tab writes the response's
+        workspace into its store optimistically. A snapshot taken before the
+        persist would hand the tab a stale value that the pick had already
+        superseded.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.workspace = "oncall-ws"
+        state.sessions.reset = AsyncMock()
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        # Resolution outcome is irrelevant; keep the derived commit a no-op.
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", _boom)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom
+        )
+
+        # A conversation_log whose update_metadata simulates a concurrent
+        # /workspace pick landing while the persist thread runs.
+        conv = MagicMock()
+
+        def _pick_lands_during_persist(*args, **kwargs):
+            slot.workspace = "user-picked-ws"
+
+        conv.update_metadata = MagicMock(side_effect=_pick_lands_during_persist)
+        state.conversation_log = conv
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            data = await resp.json()
+            assert resp.status == 200
+            # The response names the newest reality, not a pre-persist
+            # snapshot.
+            assert data["workspace"] == "user-picked-ws"
+
+    @pytest.mark.asyncio
     async def test_api_chat_slot_agent_updates_project_dir(self, tmp_path, monkeypatch):
         """Switching agent also updates slot.project to the new workspace dir.
 

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -4,7 +4,8 @@ import { Routes, Route, Navigate, useLocation, useNavigate, useParams } from 're
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAppSelector, useAppDispatch, useAppStore, store } from './store'
 import { fetchSlots, sseStatus, setUpdateProgress, setEnabledAppIds, changeApprovalMode, updateSlot } from './store/dashboardSlice'
-import { pendingSlotSwitch, performSlotSwitch } from './lib/slotSwitch'
+import { pendingSlotSwitch, pendingSlotSwitchTarget, performSlotSwitch } from './lib/slotSwitch'
+import { performAgentSlotSwitch } from './lib/agentSwitch'
 // Side-effect: registers every built-in surface in the registry. MUST run
 // before `getBuiltinSurfaces()` is invoked below to compute `NAV_ITEMS`.
 import './surfaces/builtins'
@@ -1631,10 +1632,18 @@ export default function App() {
     const timer = window.setTimeout(() => dispatch(setAgentSwitchNotice(null)), 6000)
     return () => window.clearTimeout(timer)
   }, [agentSwitchNotice, dispatch])
-  const switchActiveSlotAgent = useCallback((slot: string, agent: string) => {
+  const switchActiveSlotAgent = useCallback(async (slot: string, agent: string) => {
     dispatch(setAgentSwitchNotice(null))
-    void api.chatSlotAgent(slot, agent)
-      .catch(error => dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(error))))
+    try {
+      // Same protocol as onCycleModel below (#4523): without the store write
+      // the acting tab depends on the coalesced slots rebroadcast to see its
+      // own pick. performAgentSlotSwitch mirrors exactly what the response
+      // names ({agent, workspace} as one adjudicated pair; project is left
+      // to the rebroadcast).
+      await performAgentSlotSwitch(slot, agent, store.dispatch)
+    } catch (error) {
+      dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(error)))
+    }
   }, [dispatch])
   useKeyboardShortcuts({ onToggleShortcutsModal: toggleShortcutsModal, onNewChat: () => newChatMutation.mutate(), disabled: shortcutsOpen,
     onToggleFocusMode: toggleFocusMode,
@@ -1643,40 +1652,73 @@ export default function App() {
       const activeSlot = store.getState().chat.activeSlot
       if (!activeSlot || installedAgents.length === 0) return
       const currentSlot = slots.find((s: { key: string }) => s.key === activeSlot)
-      const currentAgent = currentSlot?.agent || defaultAgent
+      // Step from the newest in-flight target when one exists — see
+      // onCycleModel below. Agent names are never '', so the ''-falsy
+      // accessor is safe here.
+      const currentAgent = pendingSlotSwitch('agent', activeSlot) || currentSlot?.agent || defaultAgent
       const idx = installedAgents.findIndex((a: { name: string }) => a.name === currentAgent)
       const nextIdx = (idx + 1) % installedAgents.length
-      switchActiveSlotAgent(activeSlot, installedAgents[nextIdx].name)
+      void switchActiveSlotAgent(activeSlot, installedAgents[nextIdx].name)
     },
     onCyclePrevAgent: () => {
       const slots = store.getState().dashboard.slots
       const activeSlot = store.getState().chat.activeSlot
       if (!activeSlot || installedAgents.length === 0) return
       const currentSlot = slots.find((s: { key: string }) => s.key === activeSlot)
-      const currentAgent = currentSlot?.agent || defaultAgent
+      // See onCycleAgent above.
+      const currentAgent = pendingSlotSwitch('agent', activeSlot) || currentSlot?.agent || defaultAgent
       const idx = installedAgents.findIndex((a: { name: string }) => a.name === currentAgent)
       const prevIdx = (idx - 1 + installedAgents.length) % installedAgents.length
-      switchActiveSlotAgent(activeSlot, installedAgents[prevIdx].name)
+      void switchActiveSlotAgent(activeSlot, installedAgents[prevIdx].name)
     },
-    onCycleReasoningEffort: () => {
+    onCycleReasoningEffort: async () => {
       const activeSlot = store.getState().chat.activeSlot
       if (!activeSlot) return
       const slots = store.getState().dashboard.slots
       const currentSlot = slots.find((s: { key: string }) => s.key === activeSlot)
-      const current = currentSlot?.reasoning_effort || ''
-      const idx = REASONING_EFFORT_LEVELS.indexOf(current)
+      // Step from the newest in-flight target (see onCycleModel below). ''
+      // is a REAL effort target (provider default), so this base uses the
+      // null-aware accessor — the ''-falsy one would misread an in-flight
+      // "back to default" as "nothing pending" and mis-step the burst.
+      const base = pendingSlotSwitchTarget('reasoning_effort', activeSlot)
+        ?? (currentSlot?.reasoning_effort || '')
+      const idx = REASONING_EFFORT_LEVELS.indexOf(base)
       const nextIdx = (idx + 1) % REASONING_EFFORT_LEVELS.length
-      api.chatSlotReasoningEffort(activeSlot, REASONING_EFFORT_LEVELS[nextIdx])
+      const level = REASONING_EFFORT_LEVELS[nextIdx]
+      try {
+        await performSlotSwitch('reasoning_effort', activeSlot, level,
+          async () => {
+            const r = await api.chatSlotReasoningEffort(activeSlot, level)
+            return r?.reasoning_effort ?? level
+          },
+          (value) => store.dispatch(updateSlot({ key: activeSlot, reasoning_effort: value })))
+      } catch (e) {
+        store.dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+        console.error('onCycleReasoningEffort failed', e)
+      }
     },
-    onCyclePrevReasoningEffort: () => {
+    onCyclePrevReasoningEffort: async () => {
       const activeSlot = store.getState().chat.activeSlot
       if (!activeSlot) return
       const slots = store.getState().dashboard.slots
       const currentSlot = slots.find((s: { key: string }) => s.key === activeSlot)
-      const current = currentSlot?.reasoning_effort || ''
-      const idx = REASONING_EFFORT_LEVELS.indexOf(current)
+      // See onCycleReasoningEffort above.
+      const base = pendingSlotSwitchTarget('reasoning_effort', activeSlot)
+        ?? (currentSlot?.reasoning_effort || '')
+      const idx = REASONING_EFFORT_LEVELS.indexOf(base)
       const prevIdx = (idx - 1 + REASONING_EFFORT_LEVELS.length) % REASONING_EFFORT_LEVELS.length
-      api.chatSlotReasoningEffort(activeSlot, REASONING_EFFORT_LEVELS[prevIdx])
+      const level = REASONING_EFFORT_LEVELS[prevIdx]
+      try {
+        await performSlotSwitch('reasoning_effort', activeSlot, level,
+          async () => {
+            const r = await api.chatSlotReasoningEffort(activeSlot, level)
+            return r?.reasoning_effort ?? level
+          },
+          (value) => store.dispatch(updateSlot({ key: activeSlot, reasoning_effort: value })))
+      } catch (e) {
+        store.dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+        console.error('onCyclePrevReasoningEffort failed', e)
+      }
     },
     onCycleApprovalMode: () => {
       const state = store.getState()

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1829,13 +1829,13 @@ export const api = {
     fetch('/api/effort-levels' + (slot ? '?slot=' + encodeURIComponent(slot) : '')).then(j) as Promise<string[]>,
   slashCommands: () => fetch('/api/slash-commands').then(j),
   chatSlotAgent: (slot: string, agent: string) =>
-    post('/api/chat/slots/' + encodeURIComponent(slot) + '/agent', { agent }).then(j),
+    post('/api/chat/slots/' + encodeURIComponent(slot) + '/agent', { agent }).then(j) as Promise<{ ok?: boolean; agent?: string; workspace?: string }>,
   chatSlotModel: (slot: string, model: string) =>
     post('/api/chat/slots/' + encodeURIComponent(slot) + '/model', { model }).then(j) as Promise<{ ok?: boolean; model?: string }>,
   chatSlotsModel: (model: string, skip_running: boolean) =>
     post('/api/chat/slots/model', { model, skip_running }).then(j) as Promise<{ ok: boolean; model: string; switched: string[]; skipped_running: string[]; unchanged: string[]; failed: string[] }>,
   chatSlotReasoningEffort: (slot: string, reasoning_effort: string) =>
-    post('/api/chat/slots/' + encodeURIComponent(slot) + '/reasoning-effort', { reasoning_effort }).then(j),
+    post('/api/chat/slots/' + encodeURIComponent(slot) + '/reasoning-effort', { reasoning_effort }).then(j) as Promise<{ ok?: boolean; reasoning_effort?: string; deferred?: boolean }>,
   chatSlotWorkspace: (slot: string, workspace: string) =>
     post('/api/chat/slots/' + encodeURIComponent(slot) + '/workspace', { workspace }).then(j),
   // Relaunch the slot's agent process in place (fresh agent spec, env, and MCP

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -26,6 +26,7 @@ import { PANE_HYDRATE_LIMIT, retireStatelessQuestion, captureStatelessCard, capt
 import { confirmedDelivered } from '../utils/sendDelivery'
 import { triggerRefresh, updateSlot } from '../store/dashboardSlice'
 import { performSlotSwitch } from '../lib/slotSwitch'
+import { performAgentSlotSwitch } from '../lib/agentSwitch'
 import { api } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
 import { classifyDrop } from '../utils/dropClassify'
@@ -211,10 +212,16 @@ export default function ChatPane({
   }, [msgHash, running])
 
 
-  const switchAgent = useCallback((name: string) => {
+  const switchAgent = useCallback(async (name: string) => {
     dispatch(setAgentSwitchNotice(null))
-    api.chatSlotAgent(slotKey, name)
-      .catch((e) => dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e))))
+    try {
+      // Same protocol as switchModel below (#4523): the pane must not depend
+      // on the coalesced slots rebroadcast to see its own pick.
+      // performAgentSlotSwitch mirrors exactly what the response names.
+      await performAgentSlotSwitch(slotKey, name, dispatch)
+    } catch (e) {
+      dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+    }
   }, [dispatch, slotKey])
   const switchModel = useCallback(async (name: string) => {
     try {

--- a/website/src/components/ReasoningEffortDropdown.tsx
+++ b/website/src/components/ReasoningEffortDropdown.tsx
@@ -1,9 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { effortLabel } from './ChatInput'
 import { EFFORT_LEVELS } from '../lib/effort'
 import { api } from '../api/client'
+import { pendingSlotSwitchTarget, performSlotSwitch, stageSlotSwitchTarget } from '../lib/slotSwitch'
+import { useAppDispatch } from '../store'
+import { updateSlot } from '../store/dashboardSlice'
 import { Slider, Toggle } from './ui'
 import InfoTip from './InfoTip'
 
@@ -66,26 +69,56 @@ export default function ReasoningEffortDropdown({ slot, currentEffort, defaultEf
   const [idx, setIdx] = useState(() => currentIdx >= 0 ? currentIdx : Math.min(2, maxIdx))
   useEffect(() => { if (currentIdx >= 0) setIdx(currentIdx) }, [currentIdx])
 
+  // Persist one level pick through the shared switch protocol (#4523): the
+  // local optimistic state above masks staleness in THIS popover, but the
+  // STORE is the base the Alt+Shift effort cycle steps from — without the
+  // write, a dropdown pick followed by a cycle press steps from the
+  // pre-pick value. performSlotSwitch serializes per slot+field and writes
+  // exactly the adjudicated survivor of a burst of picks.
+  const dispatch = useAppDispatch()
+  const persistEffort = useCallback((level: string) =>
+    performSlotSwitch('reasoning_effort', slot, level,
+      async () => {
+        const r = await api.chatSlotReasoningEffort(slot, level)
+        return r?.reasoning_effort ?? level
+      },
+      (value) => dispatch(updateSlot({ key: slot, reasoning_effort: value }))),
+  [slot, dispatch])
+
   const commitTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingLevel = useRef<string | null>(null)
   useEffect(() => () => {
     if (commitTimer.current) {
       clearTimeout(commitTimer.current)
       // Flush a pending write so closing the dropdown within the 150ms debounce
-      // window doesn't silently drop the user's last effort change.
-      if (pendingLevel.current !== null) {
-        api.chatSlotReasoningEffort(slot, pendingLevel.current).catch(() => {})
+      // window doesn't silently drop the user's last effort change — but only
+      // while the pick is still the newest intent (same staleness gate as the
+      // timer below).
+      const level = pendingLevel.current
+      if (level !== null && pendingSlotSwitchTarget('reasoning_effort', slot) === level) {
+        persistEffort(level).catch(() => {})
       }
     }
-  }, [slot])
+  }, [persistEffort, slot])
 
   // Persist debounced so a drag across several notches doesn't spam the backend.
+  // The pick is STAGED synchronously so the Alt+Shift effort-cycle shortcuts
+  // see it as the newest intent inside the debounce window — without this, a
+  // dropdown pick followed by a cycle press within 150ms steps from the
+  // pre-pick base and re-selects the pick instead of advancing past it.
   const commit = (level: string) => {
+    stageSlotSwitchTarget('reasoning_effort', slot, level)
     pendingLevel.current = level
     if (commitTimer.current) clearTimeout(commitTimer.current)
     commitTimer.current = setTimeout(async () => {
       pendingLevel.current = null
-      try { await api.chatSlotReasoningEffort(slot, level) }
+      // A cycle shortcut may have superseded this pick inside the debounce
+      // window (its request begins immediately and clears the stage). Firing
+      // the stale pick now would make it the NEWEST request and win the
+      // adjudication — reverting the user's newer choice. Persist only while
+      // this pick is still the newest declared intent.
+      if (pendingSlotSwitchTarget('reasoning_effort', slot) !== level) return
+      try { await persistEffort(level) }
       // eslint-disable-next-line no-console -- intentional failure diagnostic
       catch (err) { console.warn('Failed to set reasoning effort', err) }
     }, 150)

--- a/website/src/lib/agentSwitch.ts
+++ b/website/src/lib/agentSwitch.ts
@@ -1,0 +1,34 @@
+/** The one agent-switch call path shared by every surface (#5120).
+ *
+ *  App.tsx (keyboard cycle), ChatPage.tsx and ChatPane.tsx all switch a
+ *  slot's agent the same way: fire the endpoint through the adjudicated
+ *  switch protocol and mirror EXACTLY what the response names — the stored
+ *  agent plus the re-resolved workspace binding, as one pair — into the
+ *  store. Hoisted here so the named follow-up (carrying `project` in the
+ *  response and adjudicating it as a third member of the pair) edits one
+ *  site, not three. Error handling stays at the call sites: each surface
+ *  owns its own failure notice.
+ */
+
+import { api } from '../api/client'
+import { updateSlot } from '../store/dashboardSlice'
+import type { AppDispatch } from '../store'
+import { performSlotSwitch } from './slotSwitch'
+
+export function performAgentSlotSwitch(
+  slot: string,
+  agent: string,
+  dispatch: AppDispatch,
+): Promise<void> {
+  return performSlotSwitch('agent', slot, agent,
+    async () => {
+      const r = await api.chatSlotAgent(slot, agent)
+      return { agent: r?.agent ?? agent, workspace: r?.workspace }
+    },
+    (value) => dispatch(updateSlot({
+      key: slot, agent: value.agent,
+      // An absent workspace means the response did not name one; the write
+      // must then leave the slot's workspace untouched rather than clobber.
+      ...(value.workspace !== undefined ? { workspace: value.workspace } : {}),
+    })))
+}

--- a/website/src/lib/slotSwitch.test.ts
+++ b/website/src/lib/slotSwitch.test.ts
@@ -14,9 +14,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   pendingSlotSwitch,
+  pendingSlotSwitchTarget,
   performSlotSwitch,
+  stageSlotSwitchTarget,
   SWITCH_CONFIRM_TIMEOUT_MS,
 } from './slotSwitch'
+import type { AgentSwitchValue } from './slotSwitch'
 
 // Unique slot keys per test: the registry is deliberately module-global
 // (every control sharing a slot+field must share one sequence), so tests
@@ -200,5 +203,124 @@ describe('performSlotSwitch (#4523)', () => {
     // First's late success wrote first (it was newest at settle time until
     // superseded)… the end state must be the newest pick's value.
     expect(writes[writes.length - 1]).toBe('w2:model-b')
+  })
+})
+
+/** The agent/effort siblings (#5120) grow the field union: `agent` carries an
+ *  OBJECT value (the response names agent + workspace, and the pair must ride
+ *  one adjudication — recovering an older agent with a fresher workspace
+ *  would tear it), and `reasoning_effort` has `''` as a REAL target (clear
+ *  the override), which is what `pendingSlotSwitchTarget` exists to keep
+ *  distinguishable from "nothing in flight". */
+describe('performSlotSwitch — agent/effort field growth (#5120)', () => {
+  afterEach(() => { vi.useRealTimers() })
+
+  it('agent field writes the adjudicated object on success', async () => {
+    const writes: AgentSwitchValue[] = []
+    await performSlotSwitch('agent', 'slot-ag-ok', 'researcher',
+      async () => ({ agent: 'researcher', workspace: 'research-ws' }),
+      (v) => writes.push(v))
+    expect(writes).toEqual([{ agent: 'researcher', workspace: 'research-ws' }])
+  })
+
+  it('agent field: newest failure adopts the older held OBJECT success intact', async () => {
+    // Serialized: first switch succeeds, second fails — the backend is left
+    // on the FIRST agent with the FIRST workspace, and the recovery write
+    // must hand back that exact pair (a torn agent/workspace mix is the bug
+    // the object value exists to prevent).
+    const writes: Array<[string, AgentSwitchValue]> = []
+    const first = performSlotSwitch('agent', 'slot-ag-adopt', 'researcher',
+      async () => ({ agent: 'researcher', workspace: 'research-ws' }),
+      (v) => writes.push(['w1', v]))
+    const second = performSlotSwitch('agent', 'slot-ag-adopt', 'writer',
+      () => Promise.reject(new Error('boom')), (v) => writes.push(['w2', v]))
+    await first
+    await expect(second).rejects.toThrow('boom')
+    expect(writes).toEqual([['w2', { agent: 'researcher', workspace: 'research-ws' }]])
+  })
+
+  it('reasoning_effort field adjudicates: two rapid picks end on the latest', async () => {
+    const writes: string[] = []
+    let releaseFirst: (v: string) => void = () => {}
+    const first = performSlotSwitch('reasoning_effort', 'slot-eff-race', 'high',
+      () => new Promise<string>(res => { releaseFirst = res }), (v) => writes.push(v))
+    const second = performSlotSwitch('reasoning_effort', 'slot-eff-race', 'max',
+      async () => 'max', (v) => writes.push(v))
+    await new Promise(res => setTimeout(res, 0))
+    releaseFirst('high')
+    await first
+    await second
+    expect(writes).toEqual(['max'])
+  })
+
+  it('a STAGED target is the newest intent until its wire call begins', async () => {
+    // A debounced control (the effort slider) publishes its pick BEFORE the
+    // debounced persist fires; a cycle shortcut pressed inside that window
+    // must step from the pick, not from the pre-pick store. Any beginning
+    // request clears the stage — the in-flight target takes over.
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-stage')).toBeNull()
+    stageSlotSwitchTarget('reasoning_effort', 'slot-eff-stage', 'xhigh')
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-stage')).toBe('xhigh')
+    // '' stages too — it is a REAL target (clear the override).
+    stageSlotSwitchTarget('reasoning_effort', 'slot-eff-stage', '')
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-stage')).toBe('')
+    const p = performSlotSwitch('reasoning_effort', 'slot-eff-stage', 'max',
+      async () => 'max', () => {})
+    // The wire call superseded the stage synchronously at begin time.
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-stage')).toBe('max')
+    await p
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-stage')).toBeNull()
+  })
+
+  it("newest failure adopts a held '' success — the falsy value the boxed recovery exists for", async () => {
+    // Serialized: a "clear the override" pick ('') succeeds, then a newer
+    // pick fails — the backend is left running the provider default, so the
+    // recovery write MUST fire with ''. This is the case that forced
+    // settleSlotSwitchFailure's return from `string`/'' to a boxed
+    // `{ value } | null`: with the sentinel form, a held '' is
+    // indistinguishable from "nothing to recover", write never fires, and
+    // the effort chip keeps the pre-switch level forever while the backend
+    // runs the default. Unbox the recovery and this test goes red.
+    const writes: string[] = []
+    const first = performSlotSwitch('reasoning_effort', 'slot-eff-heldempty', '',
+      async () => '', (v) => writes.push(v))
+    const second = performSlotSwitch('reasoning_effort', 'slot-eff-heldempty', 'high',
+      () => Promise.reject(new Error('boom')), (v) => writes.push(v))
+    await first
+    await expect(second).rejects.toThrow('boom')
+    expect(writes).toEqual([''])
+  })
+
+  it("pendingSlotSwitchTarget distinguishes an in-flight '' target from none", async () => {
+    // '' is the reasoning_effort "clear the override" target: the ''-falsy
+    // accessor reads it as "nothing pending", which is exactly the misread
+    // the cycle shortcuts must not make when stepping a burst.
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-pend')).toBeNull()
+    let release: (v: string) => void = () => {}
+    const p = performSlotSwitch('reasoning_effort', 'slot-eff-pend', '',
+      () => new Promise<string>(res => { release = res }), () => {})
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-pend')).toBe('')
+    // The legacy accessor cannot tell the two states apart — documented here
+    // so nobody "simplifies" the cycle handlers back onto it.
+    expect(pendingSlotSwitch('reasoning_effort', 'slot-eff-pend')).toBe('')
+    await new Promise(res => setTimeout(res, 0))
+    release('')
+    await p
+    expect(pendingSlotSwitchTarget('reasoning_effort', 'slot-eff-pend')).toBeNull()
+  })
+
+  it('pendingSlotSwitchTarget stays null-consistent with pendingSlotSwitch for named targets', async () => {
+    let release: (v: string) => void = () => {}
+    const p = performSlotSwitch('agent', 'slot-ag-pend', 'researcher',
+      () => new Promise<AgentSwitchValue>(res => {
+        release = (v) => res({ agent: v })
+      }), () => {})
+    expect(pendingSlotSwitchTarget('agent', 'slot-ag-pend')).toBe('researcher')
+    expect(pendingSlotSwitch('agent', 'slot-ag-pend')).toBe('researcher')
+    await new Promise(res => setTimeout(res, 0))
+    release('researcher')
+    await p
+    expect(pendingSlotSwitchTarget('agent', 'slot-ag-pend')).toBeNull()
+    expect(pendingSlotSwitch('agent', 'slot-ag-pend')).toBe('')
   })
 })

--- a/website/src/lib/slotSwitch.ts
+++ b/website/src/lib/slotSwitch.ts
@@ -58,7 +58,38 @@
 
 import { i18nT } from '../i18n/t'
 
-export type SlotSwitchField = 'model' | 'project'
+/** What the agent-switch response names, nothing more: the switch also
+ *  re-resolves the workspace binding, so the two must ride one adjudicated
+ *  write — recovering an older agent with a fresher call's workspace would
+ *  tear the pair. The backend may additionally reset `slot.project`, but the
+ *  response does not carry it, so the optimistic write leaves project to the
+ *  slots rebroadcast rather than guess. Accepted cost: with the socket down
+ *  that rebroadcast never arrives, so the store then holds a fresh
+ *  agent+workspace beside a stale project until the next fetch. Guessing the
+ *  project client-side would be worse — the reset rule (project-scope agents
+ *  keep it, aliases reset it) is server-owned; carrying `project` in the
+ *  response is the follow-up that closes this. */
+export interface AgentSwitchValue {
+  agent: string
+  /** Absent when the response omitted it; the write must then leave the
+   *  slot's workspace untouched rather than clobber it. */
+  workspace?: string
+}
+
+/** Each field's adjudicated VALUE type. Every call site of one field MUST use
+ *  the field's declared type: the registry stores values opaquely, and a held
+ *  success recovered on ANOTHER call's failure path is handed to that call's
+ *  `write` — two call sites of one field exchanging different shapes would
+ *  hand `write` a value it cannot read. This map makes that a compile error
+ *  instead of a convention. */
+export interface SlotSwitchValueMap {
+  model: string
+  project: string
+  agent: AgentSwitchValue
+  reasoning_effort: string
+}
+
+export type SlotSwitchField = keyof SlotSwitchValueMap
 
 interface Entry {
   /** Ticket of the newest request begun for this slot+field. */
@@ -70,17 +101,35 @@ interface Entry {
   /** Highest ticket whose value has been written to the store. */
   bestWrittenSeq: number
   /** Newest superseded success HELD while the newest request is in flight:
-   *  the backend applied it, but a newer request may still supersede it. */
-  heldSuccess: { seq: number; value: string } | null
+   *  the backend applied it, but a newer request may still supersede it.
+   *  Stored opaquely — the SlotSwitchValueMap pins what it really is. */
+  heldSuccess: { seq: number; value: unknown } | null
 }
 
 const entries = new Map<string, Entry>()
 
 const keyOf = (field: SlotSwitchField, slot: string): string => field + ':' + slot
 
+/** Targets STAGED but not yet on the wire (a debounced control's pending
+ *  intent). A slider drag debounces its persist ~150ms; without staging, a
+ *  cycle shortcut pressed inside that window reads a base that ignores the
+ *  user's newest pick and mis-steps (picks it again instead of advancing).
+ *  Staging makes the intent visible to burst-stepping consumers immediately
+ *  while keeping the debounce's one-write-per-drag contract. */
+const staged = new Map<string, string>()
+
+/** Publish a debounced control's picked target BEFORE its wire call fires.
+ *  Cleared automatically when any request for this slot+field begins (the
+ *  wire call it was staged for, or a newer competing request — either way
+ *  the registry's in-flight target takes over as the newest intent). */
+export function stageSlotSwitchTarget(field: SlotSwitchField, slot: string, target: string): void {
+  staged.set(keyOf(field, slot), target)
+}
+
 /** Register a new in-flight switch and return its ticket for the settle calls. */
 function beginSlotSwitch(field: SlotSwitchField, slot: string, target: string): number {
   const key = keyOf(field, slot)
+  staged.delete(key)
   const entry = entries.get(key)
     ?? { seq: 0, pending: '', newestOutcome: 'inflight' as const, bestWrittenSeq: 0, heldSuccess: null }
   entry.seq += 1
@@ -90,9 +139,23 @@ function beginSlotSwitch(field: SlotSwitchField, slot: string, target: string): 
   return entry.seq
 }
 
+/** The newest declared target for this slot+field — a STAGED (not yet on the
+ *  wire) pick wins over an in-flight request, in-flight over none — or null
+ *  when neither exists. Distinct from `pendingSlotSwitch` because `''` is a
+ *  REAL target for the reasoning_effort field (clear the override → provider
+ *  default): a burst-stepping consumer that read `''` as "nothing pending"
+ *  would recompute its base from an unsettled store and mis-step. */
+export function pendingSlotSwitchTarget(field: SlotSwitchField, slot: string): string | null {
+  const key = keyOf(field, slot)
+  const stagedTarget = staged.get(key)
+  if (stagedTarget !== undefined) return stagedTarget
+  const entry = entries.get(key)
+  return entry && entry.newestOutcome === 'inflight' ? entry.pending : null
+}
+
 /** The newest in-flight target for this slot+field, `''` when none. */
 export function pendingSlotSwitch(field: SlotSwitchField, slot: string): string {
-  return entries.get(keyOf(field, slot))?.pending || ''
+  return pendingSlotSwitchTarget(field, slot) || ''
 }
 
 /** Settle a ticket whose API call SUCCEEDED, with the server's stored value.
@@ -100,7 +163,7 @@ export function pendingSlotSwitch(field: SlotSwitchField, slot: string): string 
  *  discard per the adjudication model above — do not write.
  */
 function settleSlotSwitchSuccess(
-  field: SlotSwitchField, slot: string, seq: number, value: string,
+  field: SlotSwitchField, slot: string, seq: number, value: unknown,
 ): boolean {
   const entry = entries.get(keyOf(field, slot))
   if (!entry) return false
@@ -132,25 +195,28 @@ function settleSlotSwitchSuccess(
 
 /** Settle a ticket whose API call FAILED.
  *
- *  Returns the value the caller should write to the store anyway, or `''`
- *  for none. Non-empty exactly when this failure was the NEWEST request and
- *  an older request's success was held in its favour: that held value is
- *  what the backend is actually running, so the store must adopt it or the
- *  chip keeps the pre-switch value forever (offline). A superseded failure
- *  is a pure no-op — a failed call changed nothing server-side.
+ *  Returns the value the caller should write to the store anyway (boxed, so
+ *  any value type — including one that is itself falsy — survives), or
+ *  `null` for none. Non-null exactly when this failure was the NEWEST
+ *  request and an older request's success was held in its favour: that held
+ *  value is what the backend is actually running, so the store must adopt it
+ *  or the chip keeps the pre-switch value forever (offline). A superseded
+ *  failure is a pure no-op — a failed call changed nothing server-side.
  */
-function settleSlotSwitchFailure(field: SlotSwitchField, slot: string, seq: number): string {
+function settleSlotSwitchFailure(
+  field: SlotSwitchField, slot: string, seq: number,
+): { value: unknown } | null {
   const entry = entries.get(keyOf(field, slot))
-  if (!entry || seq !== entry.seq) return ''
+  if (!entry || seq !== entry.seq) return null
   entry.pending = ''
   entry.newestOutcome = 'failure'
   const held = entry.heldSuccess
   entry.heldSuccess = null
   if (held && held.seq > entry.bestWrittenSeq) {
     entry.bestWrittenSeq = held.seq
-    return held.value
+    return { value: held.value }
   }
-  return ''
+  return null
 }
 
 const chains = new Map<string, Promise<unknown>>()
@@ -192,10 +258,20 @@ const CONFIRM_TIMEOUT = Symbol('slot-switch-confirm-timeout')
  *  most one `write`.
  *
  *  `request` resolves to the server's STORED value for the switch (the call
- *  site maps the endpoint's response before handing it over). `write`
- *  receives the adjudicated value to put in the store — the request's own on
- *  the authoritative path, or a recovered older success when this (newest)
- *  request failed after an older one landed.
+ *  site maps the endpoint's response before handing it over), typed per
+ *  field by SlotSwitchValueMap. `write` receives the adjudicated value to
+ *  put in the store — the request's own on the authoritative path, or a
+ *  recovered older success when this (newest) request failed after an older
+ *  one landed. The recovered value's cast below is sound because every call
+ *  site of one field is pinned to that field's mapped type.
+ *
+ *  `target` is the IDENTITY of the requested value, for burst stepping: it
+ *  is what `pendingSlotSwitchTarget` reports so a cycle handler can step
+ *  from the newest in-flight pick. For string-valued fields it equals the
+ *  value; for `agent` it is the agent name (the object's identity — the
+ *  workspace half is derived server-side, never part of the pick). A future
+ *  field whose target is not its value's identity must extend this contract
+ *  first, or burst stepping silently drifts.
  *
  *  Rejects when the pick did not confirm: the request failed, or it did not
  *  settle within SWITCH_CONFIRM_TIMEOUT_MS. The timeout releases only the
@@ -205,12 +281,12 @@ const CONFIRM_TIMEOUT = Symbol('slot-switch-confirm-timeout')
  *  the caller were still waiting — a late success is written when it is what
  *  the backend was left running.
  */
-export async function performSlotSwitch(
-  field: SlotSwitchField,
+export async function performSlotSwitch<F extends SlotSwitchField>(
+  field: F,
   slot: string,
   target: string,
-  request: () => Promise<string>,
-  write: (value: string) => void,
+  request: () => Promise<SlotSwitchValueMap[F]>,
+  write: (value: SlotSwitchValueMap[F]) => void,
 ): Promise<void> {
   const seq = beginSlotSwitch(field, slot, target)
   // The wire outcome ALWAYS adjudicates, whether or not the caller is still
@@ -223,7 +299,7 @@ export async function performSlotSwitch(
     },
     (error) => {
       const recovered = settleSlotSwitchFailure(field, slot, seq)
-      if (recovered) write(recovered)
+      if (recovered) write(recovered.value as SlotSwitchValueMap[F])
       return { ok: false as const, error }
     },
   )

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -41,6 +41,7 @@ import { addTab as addDockTerminal } from '../hooks/useBottomTerminal'
 import { interceptSlashCommand, isInterceptedSlashCommand } from './chat/ChatInput'
 import { sseSlotTitle, triggerRefresh, updateSlot } from '../store/dashboardSlice'
 import { performSlotSwitch } from '../lib/slotSwitch'
+import { performAgentSlotSwitch } from '../lib/agentSwitch'
 import { api } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
 import type { PlanStepInput } from '../api/client'
@@ -4455,7 +4456,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     }
     dispatch(setAgentSwitchNotice(null))
     try {
-      await api.chatSlotAgent(activeSlot, agentName)
+      // Same protocol as switchModel below (#4523): the acting tab must not
+      // depend on the coalesced slots rebroadcast to see its own pick.
+      // performAgentSlotSwitch mirrors exactly what the response names.
+      await performAgentSlotSwitch(activeSlot, agentName, dispatch)
     } catch (error) {
       // Closing the picker is the call sites' job and already happens
       // synchronously alongside this call, so a failure surfaces as the shared

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -1300,10 +1300,18 @@ describe('onCycleAgent keyboard shortcut', () => {
     store.dispatch({ type: 'dashboard/sseSlots', payload: [{ key: 'slot-1', messages: 0, running: false, agent: 'kirocrew' }] })
     store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-1' })
     renderWithProviders(<App />, { route: '/chat' })
-    act(() => {
+    // The switch now rides performSlotSwitch (#5120), so the API call lands a
+    // microtask after the keydown — flush with an async act.
+    await act(async () => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', altKey: true, shiftKey: true, bubbles: true }))
     })
     expect(api.chatSlotAgent).toHaveBeenCalledWith('slot-1', 'reviewer')
+    // The pick must land in the store WITHOUT a slots round trip (#5120):
+    // no websocket exists in this harness, so only the optimistic write can
+    // move the row. The mock resolves {} — the requested-name fallback path.
+    await waitFor(() => expect(
+      store.getState().dashboard.slots.find((s: { key: string }) => s.key === 'slot-1')?.agent,
+    ).toBe('reviewer'))
   })
 
   it('does not call api.chatSlotAgent when no active slot', async () => {
@@ -1331,7 +1339,9 @@ describe('onCycleAgent keyboard shortcut', () => {
     store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-1' })
     renderWithProviders(<App />, { route: '/chat' })
 
-    act(() => {
+    // The switch now rides performSlotSwitch (#5120): flush the microtask
+    // chain so both the API call and the failure notice land.
+    await act(async () => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key, code, altKey: true, shiftKey: true, bubbles: true }))
     })
 
@@ -1397,6 +1407,51 @@ describe('onCycleAgent edge cases', () => {
     })
     expect(api.chatSlotAgent).not.toHaveBeenCalled()
     useAgentsMock.mockReturnValue({ agents: [{ name: 'kirocrew' }, { name: 'reviewer' }, { name: 'oracle' }], defaultAgent: 'kirocrew' })
+  })
+})
+
+describe('onCycleReasoningEffort keyboard shortcut (#5120)', () => {
+  it('steps a burst from the in-flight target and writes the adjudicated level', async () => {
+    const { api } = await import('../api/client')
+    const { store } = await import('../store')
+    ;(api.chatSlotReasoningEffort as ReturnType<typeof vi.fn>).mockClear()
+    store.dispatch({ type: 'dashboard/sseSlots', payload: [{ key: 'slot-1', messages: 0, running: false, agent: 'kirocrew', reasoning_effort: 'max' }] })
+    store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-1' })
+    renderWithProviders(<App />, { route: '/chat' })
+    // Two presses in one synchronous batch: the first pick is still in
+    // flight when the second press computes its base. From 'max' the first
+    // press targets '' (clear the override — a REAL target), so the second
+    // press's base MUST come from pendingSlotSwitchTarget: reading the store
+    // (still 'max', nothing settled) would issue '' twice, and the ''-falsy
+    // accessor would misread the in-flight '' the same way.
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'D', code: 'KeyD', altKey: true, shiftKey: true, bubbles: true }))
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'D', code: 'KeyD', altKey: true, shiftKey: true, bubbles: true }))
+    })
+    expect(api.chatSlotReasoningEffort).toHaveBeenNthCalledWith(1, 'slot-1', '')
+    expect(api.chatSlotReasoningEffort).toHaveBeenNthCalledWith(2, 'slot-1', 'low')
+    // The adjudicated survivor (the newest pick) lands in the store without
+    // a slots round trip — no websocket exists in this harness.
+    await waitFor(() => expect(
+      store.getState().dashboard.slots.find((s: { key: string }) => s.key === 'slot-1')?.reasoning_effort,
+    ).toBe('low'))
+  })
+
+  it('cycles backward on Alt+Shift+C and writes the store', async () => {
+    const { api } = await import('../api/client')
+    const { store } = await import('../store')
+    ;(api.chatSlotReasoningEffort as ReturnType<typeof vi.fn>).mockClear()
+    store.dispatch({ type: 'dashboard/sseSlots', payload: [{ key: 'slot-1', messages: 0, running: false, agent: 'kirocrew', reasoning_effort: 'low' }] })
+    store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-1' })
+    renderWithProviders(<App />, { route: '/chat' })
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'C', code: 'KeyC', altKey: true, shiftKey: true, bubbles: true }))
+    })
+    // 'low' is index 1; backward reaches '' (provider default).
+    expect(api.chatSlotReasoningEffort).toHaveBeenCalledWith('slot-1', '')
+    await waitFor(() => expect(
+      store.getState().dashboard.slots.find((s: { key: string }) => s.key === 'slot-1')?.reasoning_effort,
+    ).toBe(''))
   })
 })
 
@@ -1503,7 +1558,9 @@ describe('onCycleApprovalMode and onCyclePrevAgent shortcuts', () => {
     store.dispatch({ type: 'dashboard/sseSlots', payload: [{ key: 'slot-1', messages: 0, running: false, agent: 'reviewer' }] })
     store.dispatch({ type: 'chat/setActiveSlot', payload: 'slot-1' })
     renderWithProviders(<App />, { route: '/chat' })
-    act(() => {
+    // Async act: the switch protocol (#5120) chains the wire call on a
+    // microtask, so the mock is invoked a tick after the keydown.
+    await act(async () => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Z', code: 'KeyZ', altKey: true, shiftKey: true, bubbles: true }))
     })
     expect(api.chatSlotAgent).toHaveBeenCalledWith('slot-1', 'kirocrew')

--- a/website/src/test/ChatPage.reasoningEffort.test.tsx
+++ b/website/src/test/ChatPage.reasoningEffort.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: fa
 
 import ChatInput, { REASONING_EFFORT_PROVIDERS, EFFORT_LABEL_KEY, modelSupportsEffort } from '../components/ChatInput'
 import ReasoningEffortDropdown from '../components/ReasoningEffortDropdown'
+import { pendingSlotSwitchTarget, performSlotSwitch } from '../lib/slotSwitch'
 
 beforeEach(() => { vi.clearAllMocks() })
 
@@ -104,7 +105,15 @@ vi.mock('../api/client', () => ({ api: mockApi, SEARCH_MIN_CHARS: 2 }))
 function renderDropdown(props: Partial<Parameters<typeof ReasoningEffortDropdown>[0]> = {}) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const defaults = { slot: 's1', currentEffort: 'high', onClose: vi.fn() }
-  return render(<QueryClientProvider client={qc}><ReasoningEffortDropdown {...defaults} {...props} /></QueryClientProvider>)
+  // The dropdown writes the slot's effort into the store on persist success
+  // (#5120), so the harness carries a real store seeded with the slot row.
+  const store = configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: { slots: [{ key: defaults.slot, messages: 0, running: false, reasoning_effort: defaults.currentEffort }], unreadSlots: [], refreshTrigger: 0, subagentRunning: {}, subagentDetails: {}, subagentText: {} } as unknown as RootState['dashboard'],
+    } as Partial<RootState>,
+  })
+  return Object.assign(render(<QueryClientProvider client={qc}><Provider store={store}><ReasoningEffortDropdown {...defaults} {...props} /></Provider></QueryClientProvider>), { store })
 }
 
 describe('ReasoningEffortDropdown', () => {
@@ -127,6 +136,79 @@ describe('ReasoningEffortDropdown', () => {
     // high (index 2) -> ArrowRight -> xhigh (index 3)
     fireEvent.keyDown(slider, { key: 'ArrowRight' })
     await vi.waitFor(() => expect(mockApi.chatSlotReasoningEffort).toHaveBeenCalledWith('s1', 'xhigh'))
+  })
+
+  it('writes the persisted level into the slot row on API success (#5120)', async () => {
+    // The local optimistic state masks staleness in THIS popover, but the
+    // STORE is what the Alt+Shift effort cycle steps from — the persist must
+    // write it. No websocket exists in this harness, so the row can only
+    // move if the persist path writes it. The response echoes the STORED
+    // value; the mock answers {ok} with no reasoning_effort, exercising the
+    // requested-level fallback.
+    const { store } = renderDropdown()
+    const slider = await screen.findByRole('slider', { name: 'Reasoning effort' })
+    await vi.waitFor(() => expect(slider.getAttribute('aria-valuemax')).toBe('4'))
+    fireEvent.keyDown(slider, { key: 'ArrowRight' })
+    await vi.waitFor(() => expect(mockApi.chatSlotReasoningEffort).toHaveBeenCalledWith('s1', 'xhigh'))
+    await vi.waitFor(() => expect(store.getState().dashboard.slots.find(s => s.key === 's1')?.reasoning_effort).toBe('xhigh'))
+  })
+
+  it('stages the pick synchronously so a cycle press inside the debounce window sees it (#5120)', async () => {
+    // The persist is debounced 150ms (one write per drag). Without staging,
+    // an Alt+Shift+D press right after a dropdown pick reads a base that
+    // ignores the pick and re-selects it instead of advancing past it. The
+    // staged target must be visible IMMEDIATELY after the pick, before any
+    // wire call fires.
+    renderDropdown()
+    const slider = await screen.findByRole('slider', { name: 'Reasoning effort' })
+    await vi.waitFor(() => expect(slider.getAttribute('aria-valuemax')).toBe('4'))
+    fireEvent.keyDown(slider, { key: 'ArrowRight' })
+    // Synchronous: no debounce flush, no API call yet — the cycle shortcuts'
+    // base accessor already reports the pick as the newest intent.
+    expect(pendingSlotSwitchTarget('reasoning_effort', 's1')).toBe('xhigh')
+    expect(mockApi.chatSlotReasoningEffort).not.toHaveBeenCalled()
+    // The debounced persist then goes to the wire as usual.
+    await vi.waitFor(() => expect(mockApi.chatSlotReasoningEffort).toHaveBeenCalledWith('s1', 'xhigh'))
+  })
+
+  it('discards the debounced persist when a newer request supersedes the pick (#5120)', async () => {
+    // GPT round-5 scenario: dropdown picks 'xhigh', a cycle shortcut fires
+    // its own request within the 150ms debounce. The shortcut's request
+    // begins immediately (clearing the stage), so when the timer fires the
+    // pick is no longer the newest intent — persisting it then would make
+    // the STALE pick the newest request and win the adjudication, reverting
+    // the user's newer choice. The timer must discard it.
+    vi.useFakeTimers()
+    try {
+      renderDropdown()
+      await vi.waitFor(() => expect(screen.getByRole('slider', { name: 'Reasoning effort' }).getAttribute('aria-valuemax')).toBe('4'))
+      const slider = screen.getByRole('slider', { name: 'Reasoning effort' })
+      fireEvent.keyDown(slider, { key: 'ArrowRight' })
+      expect(pendingSlotSwitchTarget('reasoning_effort', 's1')).toBe('xhigh')
+      // A competing request (the cycle shortcut's) begins inside the window.
+      const race = performSlotSwitch('reasoning_effort', 's1', 'max',
+        async () => 'max', () => {})
+      // The pick is no longer the newest intent...
+      expect(pendingSlotSwitchTarget('reasoning_effort', 's1')).toBe('max')
+      // ...so the debounce firing must NOT put 'xhigh' on the wire.
+      await vi.advanceTimersByTimeAsync(200)
+      expect(mockApi.chatSlotReasoningEffort).not.toHaveBeenCalledWith('s1', 'xhigh')
+      await race
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('leaves the slot row untouched when the persist call fails (#5120)', async () => {
+    mockApi.chatSlotReasoningEffort.mockRejectedValueOnce(new Error('boom'))
+    const { store } = renderDropdown()
+    const slider = await screen.findByRole('slider', { name: 'Reasoning effort' })
+    await vi.waitFor(() => expect(slider.getAttribute('aria-valuemax')).toBe('4'))
+    fireEvent.keyDown(slider, { key: 'ArrowRight' })
+    await vi.waitFor(() => expect(mockApi.chatSlotReasoningEffort).toHaveBeenCalled())
+    // The failed pick changed nothing server-side; the store keeps the
+    // pre-pick value (the popover's own optimistic label is local-only).
+    expect(store.getState().dashboard.slots.find(s => s.key === 's1')?.reasoning_effort).toBe('high')
   })
 
   it('reflects the active level as the slider value', async () => {

--- a/website/src/test/ChatPage.switchLabelOptimistic.test.tsx
+++ b/website/src/test/ChatPage.switchLabelOptimistic.test.tsx
@@ -50,6 +50,8 @@ vi.mock('../api/client', () => ({
     // remapped, project paths realpath-normalized server-side).
     chatSlotModel: vi.fn().mockResolvedValue({ ok: true, model: 'claude-sonnet-5' }),
     chatSlotProject: vi.fn().mockResolvedValue({ ok: true, project: '/home/user/proj-x' }),
+    // The agent switch also names the re-resolved workspace binding.
+    chatSlotAgent: vi.fn().mockResolvedValue({ ok: true, agent: 'researcher', workspace: 'research-ws' }),
     recentProjects: vi.fn().mockResolvedValue({ dirs: ['/home/user/proj-x'] }),
     browseDirs: vi.fn().mockResolvedValue({ path: '/home/user', parent: '/home', dirs: [] }),
     projectGit: vi.fn().mockRejectedValue(new Error('not a repo')),
@@ -61,7 +63,7 @@ vi.mock('../api/client', () => ({
 }))
 vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
 vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
-vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [{ name: 'kirocrew' }], defaultAgent: 'kirocrew' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [{ name: 'kirocrew' }, { name: 'researcher' }], defaultAgent: 'kirocrew' }) }))
 vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
 vi.mock('../components/WelcomeView', () => ({ default: () => null }))
 vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
@@ -232,5 +234,38 @@ describe('ChatPage — switch labels update without a slot-list round trip (#452
     // follows it with no slot-list refetch involved.
     await waitFor(() => expect(store.getState().dashboard.slots.find(s => s.key === 'slot-a')?.project).toBe('/home/user/proj-x'))
     expect(await waitFor(() => screen.getByTitle('Project: /home/user/proj-x'))).toBeTruthy()
+  })
+
+  it('agent pick writes agent AND workspace to the store without a slot-list round trip (#5120)', async () => {
+    const store = await renderChat()
+    const slotsFetchesBeforePick = vi.mocked(api.chatSlots).mock.calls.length
+    const chip = screen.getByTitle('Agent: kirocrew')
+    await act(async () => { fireEvent.click(chip) })
+    const option = await waitFor(() => screen.getByRole('option', { name: /researcher/ }))
+    await act(async () => { fireEvent.click(option) })
+
+    await waitFor(() => expect(api.chatSlotAgent).toHaveBeenCalledWith('slot-a', 'researcher'))
+    // The write mirrors exactly what the response names: the stored agent
+    // plus the re-resolved workspace binding, as one pair.
+    const slot = () => store.getState().dashboard.slots.find(s => s.key === 'slot-a')
+    await waitFor(() => expect(slot()?.agent).toBe('researcher'))
+    expect(slot()?.workspace).toBe('research-ws')
+    // …and not because anything re-fetched the slot list (no websocket
+    // exists in this harness to push one either).
+    expect(vi.mocked(api.chatSlots).mock.calls.length).toBe(slotsFetchesBeforePick)
+    expect(await waitFor(() => screen.getByTitle('Agent: researcher'))).toBeTruthy()
+  })
+
+  it('keeps the pre-switch agent when the agent switch fails (#5120)', async () => {
+    vi.mocked(api.chatSlotAgent).mockRejectedValueOnce(new Error('boom'))
+    const store = await renderChat()
+    const chip = screen.getByTitle('Agent: kirocrew')
+    await act(async () => { fireEvent.click(chip) })
+    const option = await waitFor(() => screen.getByRole('option', { name: /researcher/ }))
+    await act(async () => { fireEvent.click(option) })
+
+    await waitFor(() => expect(api.chatSlotAgent).toHaveBeenCalled())
+    expect(store.getState().dashboard.slots.find(s => s.key === 'slot-a')?.agent).toBe('kirocrew')
+    expect(screen.getByTitle('Agent: kirocrew')).toBeTruthy()
   })
 })

--- a/website/src/test/ChatPane.switchLabelOptimistic.test.tsx
+++ b/website/src/test/ChatPane.switchLabelOptimistic.test.tsx
@@ -39,13 +39,14 @@ vi.mock('../api/client', () => ({
     chatSlotModel: vi.fn().mockResolvedValue({ ok: true, model: 'claude-sonnet-5' }),
     workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
     spawnList: vi.fn().mockResolvedValue({ agents: [] }),
-    chatSlotAgent: vi.fn().mockResolvedValue(undefined),
+    // The agent switch also names the re-resolved workspace binding.
+    chatSlotAgent: vi.fn().mockResolvedValue({ ok: true, agent: 'writer', workspace: 'writing-ws' }),
   },
   SEARCH_MIN_CHARS: 2,
 }))
 vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
 vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
-vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [{ name: 'default' }], defaultAgent: 'default' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [{ name: 'default' }, { name: 'writer' }], defaultAgent: 'default' }) }))
 vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
 vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
 
@@ -63,7 +64,7 @@ function makeStore(slotKey: string) {
     preloadedState: {
       dashboard: {
         status: null, connected: true,
-        slots: [{ key: slotKey, messages: 0, running: false, mode: '', model: 'claude-opus-5', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+        slots: [{ key: slotKey, messages: 0, running: false, mode: '', agent: 'default', model: 'claude-opus-5', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
         unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
         subagentRunning: {}, subagentDetails: {}, subagentText: {},
       } as unknown as RootState['dashboard'],
@@ -119,5 +120,35 @@ describe('ChatPane — model switch updates the pane label without a slot-list r
 
     await waitFor(() => expect(api.chatSlotModel).toHaveBeenCalled())
     expect(store.getState().dashboard.slots.find(s => s.key === 'pane-2')?.model).toBe('claude-opus-5')
+  })
+
+  it('agent pick writes agent AND workspace to the store on API success (#5120)', async () => {
+    const { store } = renderPane('pane-3')
+    const chip = await waitFor(() => screen.getByTitle('Agent: default'))
+    const slotsFetchesBeforePick = vi.mocked(api.chatSlots).mock.calls.length
+    await act(async () => { fireEvent.click(chip) })
+    const option = await waitFor(() => screen.getByRole('option', { name: /writer/ }))
+    await act(async () => { fireEvent.click(option) })
+
+    await waitFor(() => expect(api.chatSlotAgent).toHaveBeenCalledWith('pane-3', 'writer'))
+    // The write mirrors exactly what the response names: the stored agent
+    // plus the re-resolved workspace binding, as one pair — and it happens
+    // without a slot-list refetch (no websocket exists in this harness).
+    const slot = () => store.getState().dashboard.slots.find(s => s.key === 'pane-3')
+    await waitFor(() => expect(slot()?.agent).toBe('writer'))
+    expect(slot()?.workspace).toBe('writing-ws')
+    expect(vi.mocked(api.chatSlots).mock.calls.length).toBe(slotsFetchesBeforePick)
+  })
+
+  it('keeps the pre-switch agent when the agent switch fails (#5120)', async () => {
+    vi.mocked(api.chatSlotAgent).mockRejectedValueOnce(new Error('boom'))
+    const { store } = renderPane('pane-4')
+    const chip = await waitFor(() => screen.getByTitle('Agent: default'))
+    await act(async () => { fireEvent.click(chip) })
+    const option = await waitFor(() => screen.getByRole('option', { name: /writer/ }))
+    await act(async () => { fireEvent.click(option) })
+
+    await waitFor(() => expect(api.chatSlotAgent).toHaveBeenCalled())
+    expect(store.getState().dashboard.slots.find(s => s.key === 'pane-4')?.agent).toBe('default')
   })
 })

--- a/website/src/test/ModelEffortDropdown.defaultLink.test.tsx
+++ b/website/src/test/ModelEffortDropdown.defaultLink.test.tsx
@@ -1,10 +1,21 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import React from 'react'
 import ModelEffortDropdown from '../components/ModelEffortDropdown'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import { api } from '../api/client'
 import { SETTINGS_DEFAULT_MODEL_ID } from '../hooks/useSettingHighlight'
 import { SETTINGS_REGISTRY } from '../components/commandPalette/settingsRegistry.gen'
+
+// The nested ReasoningEffortDropdown persists slider picks over the wire
+// (#5120); none of these tests touch the slider, but the stub keeps an
+// accidental future interaction from hitting a real fetch.
+vi.spyOn(api, 'chatSlotReasoningEffort').mockResolvedValue({ ok: true } as never)
 
 /**
  * The in-session model picker carries two footer rows: an in-place "set as
@@ -34,7 +45,14 @@ const baseProps = {
 
 function wrap(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+  // The nested ReasoningEffortDropdown persists picks into the slot store
+  // (#5120), so the tree needs the redux context even where a test never
+  // touches the effort footer. A per-render store (not the app singleton)
+  // keeps one test's persist from leaking into the next.
+  const store = configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+  })
+  return render(<Provider store={store}><QueryClientProvider client={qc}>{ui}</QueryClientProvider></Provider>)
 }
 
 describe('ModelEffortDropdown — global fallback link', () => {

--- a/website/src/test/ReasoningEffortDropdown.i18n.test.tsx
+++ b/website/src/test/ReasoningEffortDropdown.i18n.test.tsx
@@ -12,16 +12,28 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import React from 'react'
 
 import ReasoningEffortDropdown from '../components/ReasoningEffortDropdown'
 import { api } from '../api/client'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
 // `/all` for the Chinese catalog: `../i18n` registers English only.
 import { i18next } from '../i18n/all'
 
 function wrap(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+  // The dropdown persists picks into the slot store (#5120), so the tree
+  // needs the redux context even though these tests only read labels. A
+  // per-render store (not the app singleton) keeps one test's persist from
+  // leaking into the next.
+  const store = configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+  })
+  return render(<Provider store={store}><QueryClientProvider client={qc}>{ui}</QueryClientProvider></Provider>)
 }
 
 const baseProps = { slot: 'dashboard:1', onClose: vi.fn(), embedded: true }

--- a/website/src/test/filterInputFont.test.tsx
+++ b/website/src/test/filterInputFont.test.tsx
@@ -5,10 +5,21 @@ import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 
 import ModelEffortDropdown from '../components/ModelEffortDropdown'
 import AgentSelector from '../components/AgentSelector'
 import type { KiroCrewAgent } from '../components/AgentSelector'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import { api } from '../api/client'
+
+// The nested ReasoningEffortDropdown persists slider picks over the wire
+// (#5120); these tests never touch the slider, but the stub keeps an
+// accidental future interaction from hitting a real fetch.
+vi.spyOn(api, 'chatSlotReasoningEffort').mockResolvedValue({ ok: true } as never)
 
 /**
  * A dropdown's filter box is CHROME. Its placeholder ("Type to filter…") is
@@ -51,7 +62,13 @@ const agents: KiroCrewAgent[] = [
 
 function wrap(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+  // The nested ReasoningEffortDropdown persists picks into the slot store
+  // (#5120), so the tree needs the redux context. A per-render store (not
+  // the app singleton) keeps one test's persist from leaking into the next.
+  const store = configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+  })
+  return render(<Provider store={store}><QueryClientProvider client={qc}>{ui}</QueryClientProvider></Provider>)
 }
 
 describe('dropdown filter inputs follow the Font Family setting', () => {


### PR DESCRIPTION
<!-- no-visual-delta -->

## What is the problem?

Six sibling switch handlers fire their API call and never write the Redux store on success: the two agent-cycle and two reasoning-effort-cycle keyboard shortcuts in `App.tsx`, `switchAgent` in `ChatPage.tsx`, and `switchAgent` in `ChatPane.tsx`. The label or cycle base is read from `store.dashboard.slots`, so the acting tab depends on the coalesced slots websocket rebroadcast to see its own pick. This is the same stale-label defect #4523 / PR #5117 fixed for the model and project surfaces.

## Why this issue matters to the user

With the websocket down or slow, the agent chip keeps showing the pre-switch agent after a successful pick, and the effort cycle shortcuts step from a stale base: pressing Alt+Shift+D twice from `max` issues "clear the override" twice instead of stepping to `low`, because neither press can see the other's in-flight pick. The user's own action appears not to have landed.

## How our fix solves it

Symptom to root cause: stale chip -> the handler never writes the store -> every switch surface needs the write, serialized and adjudicated so racing picks cannot interleave -> reuse the shared registry PR #5117 built (`website/src/lib/slotSwitch.ts`) instead of six ad-hoc writes.

- `SlotSwitchField` grows `agent` and `reasoning_effort`. A new `SlotSwitchValueMap` types each field's adjudicated value, so two call sites of one field exchanging different shapes is a compile error, not a convention.
- The agent value is the `{agent, workspace}` pair -- exactly what the response names, nothing more. The backend re-resolves the workspace binding on an agent switch, so the pair rides one adjudicated write; recovering an older agent beside a fresher call's workspace would tear it. `slot.project` may be reset server-side but is not in the response, so it is left to the rebroadcast rather than guessed (accepted cost documented in the module).
- `settleSlotSwitchFailure` now returns a boxed `{ value } | null` instead of the `''` sentinel: a held `''` success (`reasoning_effort` "clear the override" is a real target) must survive failure recovery instead of being dropped as falsy.
- New `pendingSlotSwitchTarget` is null-aware, distinguishing an in-flight `''` target from "nothing pending"; the four cycle shortcuts step bursts from it. The legacy `''`-falsy accessor delegates to it unchanged for existing callers.
- All six handlers plus the `ReasoningEffortDropdown` persist path (the store is the base the effort cycle steps from, so a dropdown pick that skips the store would mis-step the next cycle press) route through `performSlotSwitch`.
- The agent-switch closure (response mapping + conditional-spread write) is one shared helper, `lib/agentSwitch.ts`, used by all three surfaces -- the follow-up that adds `project` to the response pair edits one site.
- Backend: the `/agent` response's `workspace` field is seeded from `slot.workspace` instead of a `"default"` literal. On a binding-resolution failure the handler proceeds without changing `slot.workspace`, and pre-fix the response named a workspace the slot does not hold; the frontend previously ignored that field, but this PR makes it load-bearing.
- Backend: the agent and reasoning-effort switch sections are serialized under the slot's lock with OWNERSHIP-SPLIT commit ordering. Exclusively-owned fields (`agent`, `reasoning_effort` -- no unlocked writers) commit before the reset so a message send landing mid-reset cold-starts on the new binding, and roll back on a throwing reset, racing nobody. Derived shared fields (`workspace`, `project` -- writable by unlocked endpoints) commit after the reset, compare-and-set against a pre-await baseline, so a concurrent explicit pick wins and the response names the slot's final reality. The agent metadata persist rides inside the lock. A failed request leaves the slot as it found it -- the invariant the switch protocol's failure-recovery write relies on -- and a same-target successor can never be undone by a failed predecessor. (The model endpoint keeps the pre-existing unserialized shape from #4523 and is tracked separately.)
- The effort dropdown stages its pick in the registry synchronously before its 150ms-debounced persist fires (`stageSlotSwitchTarget`), so a cycle shortcut pressed inside the debounce window steps from the pick instead of re-selecting it; the debounce timer and unmount flush discard the pick once a newer request supersedes it, so a stale pick can never fire last and win the adjudication. The wire keeps the one-write-per-drag debounce contract.

The existing `slot_agent_switch` SSE and `fetchSlots()` mid-session path is untouched.

## What tests we did

- Registry: agent object adjudication (success and held-object recovery under a newer failure), effort latest-request-wins race, held-`''` recovery (the case the boxed return exists for), `pendingSlotSwitchTarget` vs the legacy accessor for `''` and named targets.
- App shortcuts: Alt+Shift+A asserts the store row moved (no slots round trip exists in the harness), burst double-press Alt+Shift+D from `max` pins the in-flight base (second call must be `low`, not `''` twice), Alt+Shift+C backward writes `''`.
- ChatPage/ChatPane: agent pick writes `agent` and `workspace` as one pair without a slot-list refetch; failure keeps the pre-switch value. Dropdown: persist writes the row on success, leaves it on failure.
- Backend: regression tests pinning that a failed resolution reports the slot's real workspace, that a throwing session reset leaves the slot unchanged (all three agent fields; effort), that a failed switch never disturbs concurrent writes, that a same-target successor survives a failed predecessor (lock serialization), that a concurrent explicit pick landing during a successful reset survives the derived-field commit (compare-and-set), and that the new agent/effort are already visible to readers DURING the reset (mid-reset sends cold-start on the new binding).
- Mutation verification: 13 mutations (unbox the recovery, delete the agent store write, revert the burst base to the falsy accessor, revert the workspace seed, drop either endpoint rollback, unshare the slot lock, drop the conditional restore, drop the dropdown staging call, disable the stale-pick discard gate, unconditional derived-field commit, defer the agent commit to post-reset) each redden exactly their pinning test.
- Gates: `npx tsc -b`, eslint (0 errors), jscpd, full vitest (22.9k tests green after rebasing onto the #5166 merge), isort/flake8/mypy, full backend pytest (61k passed; the only failures are a known host-environment sandbox class, reproduced identically on a clean base checkout).
- Dual model-pinned pre-push review (GPT 5.6 + Opus 5): both Opus blocking findings (test-teeth gaps) fixed and mutation-verified; the shared GPT/Opus finding (fabricated `workspace: "default"`) fixed with the backend one-liner plus regression test; remaining advisories adopted (per-render test stores, comment honesty on the offline project deferral, target/value identity contract) or deferred with rationale (pre-existing mutate-before-reset backend property shared with the merged model path, tracked in the operator's local backlog).

**Why no screenshot:** timing-only behavior change -- the same chips render the same pixels, they now just update from the acting tab's own write instead of waiting for the websocket rebroadcast.

## Any other suggestions on the work

Carrying `project` in the `/agent` response and adjudicating it as a third member of the pair would close the remaining offline gap (fresh agent+workspace beside a stale project until the next fetch). The switch endpoints' mutate-before-reset shape (slot fields not rolled back if the session reset throws) predates this PR and is shared with the model path; it is tracked separately rather than folded in here.

Closes #5120
