### PR TITLE
fix: write zombie diagnostic records through a single open (#5146)

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -3313,8 +3313,15 @@ def _snapshot_state(
     }
 
 
-def _write_diagnostic(path: Path, record: dict[str, Any]) -> None:
-    """Append one JSONL line to the diagnostic side-channel.
+def _write_diagnostic(path: Path, *records: dict[str, Any]) -> None:
+    """Append one JSONL line per record to the diagnostic side-channel.
+
+    Records that belong to the same event MUST be passed in a single call:
+    they share one open-append-close cycle. Back-to-back appends from
+    separate calls can collide on Windows — an open that lands while the
+    previous writer's handle is still closing fails with a sharing
+    violation — and the never-raises contract below turns that transient
+    collision into a silently dropped record.
 
     Never raises — the diagnostic task is defensive enough that a missing
     directory or EROFS on the log volume must not crash gatewayd itself.
@@ -3322,7 +3329,8 @@ def _write_diagnostic(path: Path, record: dict[str, Any]) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+            for record in records:
+                fh.write(json.dumps(record, separators=(",", ":")) + "\n")
     except OSError as exc:  # pragma: no cover — defensive
         logger.warning("zombie diagnostic write failed: %s", exc)
 
@@ -3337,13 +3345,14 @@ async def _zombie_diagnostic(
 
     Every :data:`_ZOMBIE_PROBE_INTERVAL_SECS` seconds:
 
-    1. Collect a health snapshot via :func:`_snapshot_state`.
-    2. Append the snapshot to the diagnostic JSONL under the ``probe`` tag
-       so there is a continuous baseline to correlate against.
-    3. If ``server.is_serving()`` is ``False`` while ``stop_event`` is
-       still unset, the accept loop has died silently — dump every live
-       task stack, log at error level, and set ``stop_event`` so the
-       process exits cleanly and the watchdog respawns us.
+    1. Collect a health snapshot via :func:`_snapshot_state`, tagged
+       ``probe`` — the continuous baseline to correlate against.
+    2. If ``server.is_serving()`` is ``False`` while ``stop_event`` is
+       still unset, the accept loop has died silently — append the probe
+       baseline and a ``zombie_detected`` dump of every live task stack
+       through a single write, log at error level, and set ``stop_event``
+       so the process exits cleanly and the watchdog respawns us.
+    3. Otherwise append just the probe baseline.
     """
     diag_path = _zombie_diagnostic_path()
     try:
@@ -3367,23 +3376,31 @@ async def _zombie_diagnostic(
                 task_count=task_count,
             )
             snap["tag"] = "probe"
-            await asyncio.to_thread(_write_diagnostic, diag_path, snap)
 
             if snap["is_serving"] is False and not stop_event.is_set():
-                snap["tag"] = "zombie_detected"
-                snap["tasks"] = _collect_task_stacks()
-                snap["traceback"] = traceback.format_stack()
-                await asyncio.to_thread(_write_diagnostic, diag_path, snap)
+                # The accept loop died silently. The probe baseline and the
+                # zombie dump go through ONE _write_diagnostic call (a single
+                # open) — two back-to-back appends race on Windows, where the
+                # second open can hit a sharing violation while the first
+                # writer's handle is still closing, silently dropping the
+                # zombie_detected record.
+                dump = dict(snap)
+                dump["tag"] = "zombie_detected"
+                dump["tasks"] = _collect_task_stacks()
+                dump["traceback"] = traceback.format_stack()
+                await asyncio.to_thread(_write_diagnostic, diag_path, snap, dump)
                 logger.error(
                     "zombie gatewayd detected: is_serving=False while stop_event unset; "
                     "tasks=%d fd=%d rss_kb=%d — diagnostic dumped to %s; setting stop_event",
-                    snap["task_count"],
-                    snap["fd_count"],
-                    snap["rss_kb"],
+                    dump["task_count"],
+                    dump["fd_count"],
+                    dump["rss_kb"],
                     diag_path,
                 )
                 stop_event.set()
                 return
+
+            await asyncio.to_thread(_write_diagnostic, diag_path, snap)
     except asyncio.CancelledError:
         pass
 

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -1310,6 +1310,26 @@ class TestWriteDiagnostic:
         lines = path.read_text(encoding="utf-8").strip().splitlines()
         assert [json.loads(line)["n"] for line in lines] == [1, 2]
 
+    def test_multiple_records_share_a_single_open(self, monkeypatch, tmp_path):
+        # Records passed in one call MUST go through one open-append-close
+        # cycle: a second append that lands while the first writer's handle is
+        # still closing fails with a sharing violation on Windows, and the
+        # never-raises contract would silently drop the record.
+        path = tmp_path / "diag.jsonl"
+        opens: list[str] = []
+        real_open = Path.open
+
+        def counting_open(self, *args, **kwargs):
+            if self == path:
+                opens.append(str(args))
+            return real_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", counting_open)
+        gw._write_diagnostic(path, {"tag": "probe", "n": 1}, {"tag": "zombie_detected", "n": 2})
+        assert len(opens) == 1
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert [json.loads(line)["tag"] for line in lines] == ["probe", "zombie_detected"]
+
 
 class TestZombieDiagnostic:
     @pytest.mark.asyncio
@@ -1353,6 +1373,49 @@ class TestZombieDiagnostic:
         assert isinstance(records[-1]["tasks"], list)
         assert isinstance(records[-1]["traceback"], list)
         # Setting stop_event is what lets the watchdog respawn a clean daemon.
+        assert stop.is_set()
+
+    @pytest.mark.asyncio
+    async def test_zombie_dump_survives_a_windows_sharing_violation(self, monkeypatch, tmp_path):
+        # Regression for the Windows write race: the probe baseline and the
+        # zombie dump used to be two back-to-back open-append-close cycles,
+        # and on Windows the second open can land while the first writer's
+        # handle is still closing, failing with a sharing violation
+        # (a PermissionError) that the never-raises writer swallows — losing
+        # the zombie_detected record. Simulate that deterministically by
+        # failing every open of the diagnostic file after the first: with the
+        # records batched through a single open, the dump still lands; with
+        # the old unserialized double-write, it is dropped and this test reds.
+        diag = tmp_path / "diag.jsonl"
+        monkeypatch.setattr(gw, "_zombie_diagnostic_path", lambda: diag)
+        monkeypatch.setattr(gw, "_ZOMBIE_PROBE_INTERVAL_SECS", 0.01)
+        server = MagicMock()
+        server.is_serving.return_value = False
+        stop = asyncio.Event()
+
+        opened = []
+        real_open = Path.open
+
+        def sharing_violation_open(self, *args, **kwargs):
+            mode = args[0] if args else kwargs.get("mode", "r")
+            if self == diag and "a" in mode:
+                opened.append(mode)
+                if len(opened) > 1:
+                    raise PermissionError(
+                        13, "The process cannot access the file because it is "
+                        "being used by another process"
+                    )
+            return real_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", sharing_violation_open)
+        await asyncio.wait_for(
+            gw._zombie_diagnostic(cast(Any, server), BackendPool(max_backends=1), set(), stop),
+            timeout=5,
+        )
+
+        records = [json.loads(line) for line in diag.read_text().strip().splitlines()]
+        tags = [record["tag"] for record in records]
+        assert tags == ["probe", "zombie_detected"]
         assert stop.is_set()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
# What is the problem?

`TestZombieDiagnostic` flakes on Windows: the test reads a `probe` record where it expects `zombie_detected`. The zombie watchdog (`_zombie_diagnostic` in `src/kiro_crew/mcp_gateway/gatewayd.py`) wrote the probe baseline and the zombie dump as two back-to-back `asyncio.to_thread(_write_diagnostic, ...)` calls -- two rapid open-append-close cycles on the same JSONL file. On Windows, an append open that lands while the previous writer's handle is still closing fails with a sharing violation (`PermissionError`). `_write_diagnostic` is deliberately never-raises -- it swallows every `OSError` with a warning -- so the second record (`zombie_detected`) was silently dropped. Deterministic under load, not a pure timing flake: the swallow is what turns the transient sharing violation into lost data.

# Why this issue matters to the user

The `zombie_detected` record is the entire point of the watchdog: it is the only artifact that captures live task stacks and a traceback at the moment the accept loop dies silently. When it is dropped, a Windows operator debugging a zombie gatewayd finds a diagnostic file full of healthy `probe` baselines and nothing about the death -- the incident evidence is gone precisely on the platform where it was lost. Plus a red `TestZombieDiagnostic` in every affected Windows CI run.

# How our fix solves it

Chain from symptom to root cause: lost record -> swallowed `OSError` -> Windows sharing violation -> second append open racing the first close -> two separate open-append-close cycles for records that belong to one event.

The fix removes the second open instead of tolerating it:

- `_write_diagnostic` now accepts multiple records (`*records`) and writes them all through ONE open-append-close cycle. Its never-raises contract is unchanged for genuinely-unwritable cases.
- The detection path batches the probe baseline and the `zombie_detected` dump into a single call, so no second open exists to collide with the first close.
- The dump is a copy of the snapshot (`dict(snap)`), so the probe record is no longer mutated after being handed to the writer thread.
- POSIX behaviour is unchanged: same records, same order, same file, in all three loop branches (healthy probe, pre-fired stop event, detection).

# What tests we did

- New regression test `test_zombie_dump_survives_a_windows_sharing_violation`: deterministically simulates the sharing violation on any platform by failing every append-mode open of the diagnostic file after the first, then asserts both `probe` and `zombie_detected` land. Mutation-verified: reintroducing the unserialized double-write reds it with exactly the issue's failure shape (`['probe'] != ['probe', 'zombie_detected']`).
- New unit test `test_multiple_records_share_a_single_open`: pins that a multi-record call opens the file exactly once and preserves record order.
- Local gates all green: black gate script, `isort --check-only`, `flake8`, `mypy` (1038 files), full `pytest` (61702 passed; the only failures are pre-existing host-environment classes, verified identical with this diff stashed). Touched test file: 135/135 passed.
- Pre-push review fleet: GPT lane PASS with zero findings; Opus lane PASS with zero blocking findings and one LOW docstring-drift note, fixed in this commit.

# Any other suggestions on the work

Cross-iteration probe writes (30s apart) still use one open each; an external handle holder (antivirus, indexer) could in principle drop one probe baseline. That is a different, much lower-value record than the detection dump and retrying appends would complicate the never-raises contract, so it is deliberately out of scope here.

Closes #5146
