### PR TITLE
fix: guard slot-less set_project; repoint stale boundary tests (#5201)

### DIFF
--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -14,8 +14,11 @@ unrepresentable.
 ``slot`` is the dashboard chat slot when the caller has one (chat_runner) and
 ``None`` for a channel turn (TurnDriver). A missing slot NEVER weakens a
 boundary: the dashboard-only directives are refused outright for a slot-less
-caller (they act on a slot, so there is nothing to apply them to), and the
-monitor trio only reads ``slot`` through fail-safe ``getattr``.
+caller (they act on a slot, so there is nothing to apply them to),
+``set_project`` is refused for a slot-less caller by its own guard (it is
+user-surface-gated rather than dashboard-only since #3543, but its effect is
+still the slot mutation), and the monitor trio only reads ``slot`` through
+fail-safe ``getattr``.
 
 Every branch returns a human-readable confirmation string and NEVER raises into
 the runner. NOTE: gateway-off (the default), the MODEL already received the
@@ -125,12 +128,12 @@ async def apply_session_directive(
     if kind in _DASHBOARD_ONLY_DIRECTIVES and (
         slot is None or not has_dashboard_surface(session_key)
     ):
-        # These three act on a dashboard chat SLOT (its project/CWD, its
-        # follow-up card, its question card), so the boundary is whether an open
+        # These two act on a dashboard chat SLOT (its follow-up card, its
+        # question card), so the boundary is whether an open
         # tab exists to receive the effect — not where the conversation started.
         # A channel-born session displayed in a tab qualifies; a cron, sub-agent
-        # or otherwise tabless caller does not, and must not silently retarget a
-        # slot's project or address a card nothing will render. A slot-less
+        # or otherwise tabless caller does not, and must not address a card
+        # nothing will render. A slot-less
         # caller (a channel transport's TurnDriver) is refused for the same
         # reason even when a tab happens to be open: the effect targets the
         # SLOT, and this turn does not hold one. The consumer is the only layer
@@ -388,13 +391,30 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
     )
 
 
-# ── dashboard-only effects ───────────────────────────────────────────────────
+# ── slot-targeted effects (the dashboard-only pair + set_project) ────────────
 
 
 async def _set_project(state: Any, slot: Any, args: dict[str, Any]) -> str:
     from kiro_crew.dashboard.chat_utils import effective_session_key
     from kiro_crew.security import is_sensitive_path
 
+    if slot is None:
+        # A slot-less caller — a channel transport's TurnDriver turn always
+        # passes ``slot=None`` — can pass the user-surface gate (its session
+        # key IS a channel key), but set_project's entire effect is the slot
+        # mutation (``slot.project`` + the CWD/history reset), so there is
+        # nothing to retarget. Fail CLOSED before ANY mutation: the clear path
+        # below writes slot state too. This is a session-shape refusal, the
+        # same class as the monitor trio's "not supported from this session
+        # type" (see _DirectiveDenied: "an unsupported session type"), so raise
+        # for the wrapper to audit ``denied`` — the outcome this exact caller
+        # shape produced before #3543 moved set_project out of the
+        # dashboard-only set.
+        raise _DirectiveDenied(
+            "Error: set_project cannot be applied on this turn — it retargets "
+            "a chat slot's project/CWD, and this slot-less channel turn holds "
+            "no slot. Nothing was changed."
+        )
     clear = bool(args.get("clear"))
     project = str(args.get("project") or "").strip()
     old_project = getattr(slot, "project", "") or ""

--- a/test/test_driver_session_directives.py
+++ b/test/test_driver_session_directives.py
@@ -19,7 +19,11 @@ These tests lock the three halves of the fix:
 * **Channel applier boundary** — ``apply_session_directive`` with ``slot=None``
   (the channel-caller shape) applies the monitor trio on a nudge-able channel
   session and keeps refusing the ``_DASHBOARD_ONLY_DIRECTIVES``, including when
-  the session key would pass ``has_dashboard_surface``.
+  the session key would pass ``has_dashboard_surface``. ``set_project`` was
+  deliberately moved OUT of the dashboard-only set by #3543 (any user-facing
+  surface may retarget its own slot): with a slot it applies on a channel
+  session, and the slot-less TurnDriver shape gets an explicit clean refusal
+  (there is no slot to retarget) instead of the pre-guard ``AttributeError``.
 * **Consumer wiring** — ``build_directive_consumer`` funnels into the shared
   applier with the dispatcher's live ``dashboard_state`` when present, and a
   fail-closed ``sessions``-backed stand-in when not (the Slack shape).
@@ -496,26 +500,30 @@ class TestChannelApplierBoundary:
         assert [c["outcome"] for c in directive_calls] == ["denied"]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("kind", ["set_project", "suggest_followup", "ask_question"])
+    @pytest.mark.parametrize("kind", ["suggest_followup", "ask_question"])
     async def test_dashboard_only_directives_refused_on_channel_transport(
         self, kind, no_dashboard_tabs
     ):
         """SECURITY INVARIANT (#4540): _DASHBOARD_ONLY_DIRECTIVES stay DENIED
         for non-dashboard sessions — the channel consumer must not widen the
-        gate."""
+        gate. ``set_project`` is deliberately NOT parametrized here: #3543
+        removed it from the dashboard-only set (any user-facing surface may
+        retarget its own slot); its channel-transport semantics are pinned by
+        the ``test_set_project_*`` cases below — do not "restore" it."""
         state = _ChannelDirectiveState(sessions=_ChannelSessions("x"))
-        result = await apply_session_directive(
-            state, None, "slack:1755000000.123456", kind, {"project": "/tmp"}
-        )
+        result = await apply_session_directive(state, None, "slack:1755000000.123456", kind, {})
         assert result.startswith("Error:")
         assert "only works from a dashboard chat session" in result
 
     @pytest.mark.asyncio
-    async def test_dashboard_only_refused_for_slotless_caller_even_with_open_tab(self):
+    @pytest.mark.parametrize("kind", ["suggest_followup", "ask_question"])
+    async def test_dashboard_only_refused_for_slotless_caller_even_with_open_tab(self, kind):
         """A channel-born session CAN have an open dashboard tab
         (has_dashboard_surface True), but a slot-less channel turn still must
         not drive a slot-targeted effect — the effect targets the SLOT and this
-        turn holds none. Guards the slot=None tightening."""
+        turn holds none. Guards the slot=None tightening. ``set_project`` left
+        this parametrize with #3543 (no longer dashboard-only); its slot-less
+        refusal is pinned separately below."""
         from kiro_crew import session_surface
 
         session_key = "slack:1755000000.777"
@@ -526,13 +534,100 @@ class TestChannelApplierBoundary:
                 _ChannelDirectiveState(sessions=_ChannelSessions("x")),
                 None,
                 session_key,
-                "set_project",
-                {"project": "/tmp"},
+                kind,
+                {},
             )
         finally:
             session_surface.set_dashboard_surfaced(before)
         assert result.startswith("Error:")
         assert "only works from a dashboard chat session" in result
+
+    @pytest.mark.asyncio
+    async def test_set_project_applies_on_channel_transport_with_slot(
+        self, no_dashboard_tabs, tmp_path
+    ):
+        """Post-#3543 semantics: a channel session key passes the user-surface
+        gate, so a channel-born turn that DOES hold a slot (the chat_runner
+        shape, e.g. a Slack mirror riding a dashboard slot) retargets that
+        slot's project — even with no dashboard tab open. The history-reset
+        flag is load-bearing: it is what cold-starts the retargeted transcript
+        (and with ``linked_session_key`` empty it derives from ``slot.key``,
+        the channel-key fallback branch of ``effective_session_key``)."""
+        import os
+
+        session_key = "slack:1755000000.123456"
+
+        class _Slot:
+            key = session_key
+            linked_session_key = ""
+            project = ""
+            _pending_reset_history_key = None
+
+        class _State:
+            pushes = 0
+
+            def push_slots_update(self):
+                self.pushes += 1
+
+        slot, state = _Slot(), _State()
+        result = await apply_session_directive(
+            state, slot, session_key, "set_project", {"project": str(tmp_path)}
+        )
+        assert "Project set to" in result
+        assert slot.project == os.path.realpath(str(tmp_path))
+        assert slot._pending_reset_history_key
+        assert state.pushes == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tab_open", [False, True], ids=["no-tab", "open-tab"])
+    @pytest.mark.parametrize(
+        "args", [{"project": "/tmp"}, {"clear": True}], ids=["set-path", "clear"]
+    )
+    async def test_set_project_slotless_channel_caller_gets_clean_refusal(
+        self, args, tab_open, monkeypatch
+    ):
+        """The channel TurnDriver always passes slot=None: set_project passes
+        the user-surface gate there but has no slot to retarget. The applier
+        must answer with an explicit refusal — not the swallowed
+        ``AttributeError: 'NoneType' ...`` it crashed with before the guard —
+        audited as ``denied``, and must mutate nothing (the clear path writes
+        slot state before validation, so it is covered too). Pinned for BOTH
+        tab states: the guard is independent of the surface predicates, and an
+        open dashboard tab (has_dashboard_surface True) must not resurrect the
+        mutation path for a turn that holds no slot."""
+        from kiro_crew import session_surface
+
+        calls: list[dict] = []
+
+        class _SelSpy:
+            def log_tool_invocation(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr("kiro_crew.sel.sel", lambda: _SelSpy())
+
+        class _State:
+            pushes = 0
+
+            def push_slots_update(self):
+                self.pushes += 1
+
+        session_key = "slack:1755000000.123456"
+        state = _State()
+        before = session_surface.dashboard_surfaced_keys()
+        session_surface.set_dashboard_surfaced({session_key} if tab_open else ())
+        try:
+            result = await apply_session_directive(
+                state, None, session_key, "set_project", dict(args)
+            )
+        finally:
+            session_surface.set_dashboard_surfaced(before)
+        assert result.startswith("Error:")
+        assert "holds no slot" in result
+        assert "Nothing was changed" in result
+        assert "NoneType" not in result  # the clean refusal, not the old crash
+        assert state.pushes == 0  # fail closed: no slot push, no state written
+        directive_calls = [c for c in calls if c.get("source") == "mcp-directive"]
+        assert [c["outcome"] for c in directive_calls] == ["denied"]
 
 
 # ── build_directive_consumer wiring ──────────────────────────────────────────


### PR DESCRIPTION
Closes #5201

## What broke

`main` is RED at 410972a87: every open PR's merge-ref `Backend Tests` shard fails on two tests in `test/test_driver_session_directives.py::TestChannelApplierBoundary`, regardless of the PR's own diff.

PR #3543 (37089b1f9) deliberately moved `set_project` out of `_DASHBOARD_ONLY_DIRECTIVES` (any user-facing surface may retarget its own slot; the gate became the positive `_has_user_surface` predicate) and updated `test/test_mcp_core_set_project.py` accordingly — but never touched `test_driver_session_directives.py`, which still pinned the pre-#3543 invariant with `set_project` parametrized in the dashboard-only set.

The failures also exposed a **real defect**, not just a stale expectation: the channel `TurnDriver` consumer always passes `slot=None` (`messaging/dispatch.py:208`). Post-#3543 such a caller passes the user-surface gate (its key IS a channel key) and crashes at `slot.project = rp` with `AttributeError: 'NoneType' object has no attribute 'project'`, swallowed by the generic handler into an opaque `Error applying set_project: ...` audited as `error`. The clear path (`slot.project = ""`) had the same hole.

## The fix (minimal, main-red unblock scope)

1. **Slot-less guard** at the top of `_set_project`, before ANY mutation (the clear path writes slot state too — fail closed): an explicit refusal naming the condition (`... this slot-less channel turn holds no slot. Nothing was changed.`).
2. **Test repoint**: `set_project` removed from the two dashboard-only boundary tests (`suggest_followup`/`ask_question` stay pinned unchanged — that #4540 invariant is not weakened); docstrings now record that #3543 removed `set_project` deliberately, so it is not "restored" later.
3. **New tests pinning post-#3543 semantics**: channel key + slot → project applied, realpath'd, history-reset flag set, one push; `slot=None` (set-path AND clear, no-tab AND open-tab) → the clean refusal string, audited `denied`, zero pushes, no `NoneType` leak.

## Why `raise _DirectiveDenied` (audited `denied`) and not a plain `Error:` return (audited `error`)

The task allowed either and asked for the reasoning. The module's own audit contract decides it:

- `_DirectiveDenied`'s docstring names **"an unsupported session type"** as its case. A slot-less caller is a session/transport-shape condition (TurnDriver holds no slot), not an argument-validation failure like `not a directory` (which stays a plain return).
- The monitor trio's analogous session-shape refusal ("not supported from this session type") raises `_DirectiveDenied`, and `test_not_supported_paths_audit_denied_never_success` pins `outcome=denied` for exactly that class.
- **SEL continuity**: before #3543 this exact caller shape (slot-less channel calling `set_project`) was refused by the dashboard-only gate and audited `denied`. Keeping `denied` means the same refused attempt does not silently reclassify to `error` across #3543.

## Not done here (scope discipline)

- No refactor of the directive dispatch, no unification of the dashboard-only set.
- `test/test_mcp_core_set_project.py` untouched — #3543 updated it deliberately; it remains the authority on the new intent and passes as-is.
- Conflict awareness only (read-only): open PR #5184 also edits `session_directive_apply.py`, PR #5167 edits `session_directive.py`. This guard is a small localized hunk; landing this first unblocks their merge-ref CI too.

## Verified

- Fail-before baseline: both spec-named tests reproduced failing on clean main (AttributeError at `slot.project = rp` in the traceback).
- After: `test_driver_session_directives.py` + `test_mcp_core_set_project.py` + `test_session_directive.py` = 100 passed.
- Full backend suite: **61777 passed** (includes the repo-wide contract/ratchet suites); isort/flake8/mypy clean; changed test file black-clean (the src file is baseline-exempt, pre-existing).
- Pre-push dual model-pinned review: GPT 5.6 Sol PASS (zero findings); Opus 5 PASS + 1 Medium + 4 Low advisories, **all five adopted** (module-docstring third slot-less class, stale "These three" comment from #3543, open-tab × slot-less parametrize, `_pending_reset_history_key` assertion, removal of needless `is_sensitive_path` mocks).
