### PR TITLE
fix(meetings): the calendar URL vet approved CGNAT and IPv6 site-local

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/providers/calendar.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/providers/calendar.py
@@ -54,7 +54,7 @@ import aiohttp
 from aiohttp.abc import AbstractResolver, ResolveResult
 from yarl import URL
 
-from kiro_crew import hooks
+from kiro_crew import hooks, link_unfurl
 from kiro_crew.apps.builtins.meetings.backend import constants as k
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.security import redact
@@ -484,6 +484,21 @@ _REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 #: Port assumed when a URL omits one. https is the only scheme that reaches the
 #: fetch, so this is the only default needed.
 _DEFAULT_HTTPS_PORT = 443
+#: :class:`link_unfurl.UnfurlRejected` codes in the words this app shows the
+#: operator. Those codes are wire codes for the unfurl endpoint; someone who just
+#: typed a calendar URL needs to know which of the two things is wrong with it,
+#: and "blocked" has to name the port rule as well as the address rule because
+#: the vet refuses anything off 80/443.
+_REJECTION_MESSAGES = {
+    "invalid_url": "calendar URL is malformed",
+    "blocked_url": (
+        "calendar URL was refused: it must resolve to a public address and use "
+        "the standard https port"
+    ),
+}
+#: Used if that module ever grows a third code — a rejection must stay a
+#: rejection, with a message, rather than becoming a KeyError and a 500.
+_UNKNOWN_REJECTION = "calendar URL was refused"
 
 
 @dataclass(frozen=True)
@@ -516,6 +531,10 @@ def _normalize_url(source: str) -> VettedTarget:
     value from turning the sync into a local-file read (``file://``), a
     plaintext hop (``http://``), or an arbitrary-protocol request.
 
+    The scheme rules are this app's; the ADDRESS vet is
+    :func:`link_unfurl.vet_unfurl_url`, reused rather than reimplemented — see the
+    comment at the delegation for what the local copy let through.
+
     Returns a :class:`VettedTarget` carrying the resolved, approved addresses so
     the caller can pin the connection to them — see that class for why the
     address must travel with the URL rather than be re-derived later.
@@ -540,102 +559,86 @@ def _normalize_url(source: str) -> VettedTarget:
         raise CalendarError(
             f"calendar URL must use https:// (got {scheme or 'no'} scheme)"
         )
-    if not parts.hostname:
-        raise CalendarError("calendar URL has no host")
-    url = parts.geturl()
-    # The connector keys its resolution off yarl's `raw_host`/`port` (IDNA-encoded,
-    # lowercased, default port filled in), so the pin must be keyed the same way —
-    # a pin recorded under urlsplit's Unicode hostname would simply never match,
-    # and the connector would fall through to a fresh lookup.
+    # The address vet is `link_unfurl`'s, not a local copy. That module already
+    # owns this problem for the unfurl endpoint, and it is not merely equivalent
+    # to a hand-rolled check here — a local one written for this file missed four
+    # things it covers:
+    #
+    # * `100.64.0.0/10`, the CGNAT range a tailnet and most carrier NAT hand out.
+    #   `is_private` does not cover it; only `is_global` does. On a machine on a
+    #   tailnet, that range IS the private network. Measured: the local check
+    #   approved it.
+    # * `fec0::/10`, deprecated IPv6 site-local, which reports `is_global=True`,
+    #   so an `is_private`-only check approves it. Measured: it did.
+    # * `.local` and `.onion`, which resolve through mDNS or not at all. The local
+    #   check had no suffix rule.
+    # * The alternate IPv4 encodings (`0177.0.0.1`, `0x7f000001`, `2130706433`,
+    #   `127.1`) that the OS resolver accepts but `ipaddress` rejects. These were
+    #   NOT reachable before — getaddrinfo folded them to loopback and the
+    #   private-address rule then caught them — but only because the resolver's
+    #   reading happened to agree with the vet. `canonicalize_ip` makes them
+    #   literals, so the decision stops riding on getaddrinfo's interpretation of
+    #   a string the vet declined to parse.
+    #
+    # Its `test_vet_rejects_every_special_purpose_range` pins the refusal set
+    # against a table of IANA special-purpose prefixes, so the next gap is found
+    # by the suite rather than by a reviewer — which a second implementation here
+    # would not inherit.
+    #
+    # `resolve` is injected for one reason: to KEEP the addresses the vet
+    # approved. `VettedUrl` reports a single `ip`, while the pin below serves
+    # every vetted address so a multi-homed calendar host keeps its fallbacks.
+    # Every address recorded here is one `vet_unfurl_url` checked — it vets the
+    # whole answer, not just the address it keeps.
+    approved: list[str] = []
+
+    def _resolve_and_record(hostname: str, port: int) -> list[str]:
+        infos = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+        addresses = [str(info[4][0]) for info in infos]
+        for address in addresses:
+            # Refused, not skipped. `_reject_if_internal_ip` returns SILENTLY for
+            # anything that is not an IP literal, because for it a non-literal is
+            # a hostname still to be resolved. Here the list is already a
+            # resolution result, so an unreadable entry is an address that would
+            # reach the pin unchecked. getaddrinfo should never produce one; if it
+            # does, fail closed rather than trust it.
+            try:
+                ipaddress.ip_address(address)
+            except ValueError:
+                raise CalendarError(
+                    "calendar URL resolved to an address that could not be parsed"
+                ) from None
+        approved.extend(addresses)
+        return addresses
+
     try:
-        parsed = URL(url)
-    except ValueError as exc:
-        raise CalendarError("calendar URL is malformed") from exc
-    host = parsed.raw_host
-    if not host:
-        raise CalendarError("calendar URL has no host")
-    addresses = _vet_host_addresses(host)
+        vetted = link_unfurl.vet_unfurl_url(parts.geturl(), resolve=_resolve_and_record)
+    except link_unfurl.UnfurlRejected as exc:
+        raise CalendarError(_REJECTION_MESSAGES.get(exc.code, _UNKNOWN_REJECTION)) from None
+    # The shared vet allows {80, 443} because it also serves plain-http link
+    # unfurling. THIS caller is https-only (``_ALLOWED_SCHEMES``), so the stated
+    # scope is 443 alone — ``https://host:80`` would pass the vet and then fail
+    # the TLS handshake with a message that does not name the cause. Refuse it
+    # here with the same words as the vet's own port rejection. Keyed on the
+    # scheme allow-list rather than hardcoded, because the 443-narrowing is a
+    # CONSEQUENCE of https-only: the rebinding tests that stand up a real local
+    # server widen ``_ALLOWED_SCHEMES`` to http on an ephemeral port, and the
+    # consequence disengages with its cause.
+    if _ALLOWED_SCHEMES == ("https",) and vetted.port != _DEFAULT_HTTPS_PORT:
+        raise CalendarError(_REJECTION_MESSAGES["blocked_url"])
+    # An IP literal never reaches the injected resolver, so fall back to the
+    # canonical form the vet resolved it to.
+    addresses = tuple(dict.fromkeys(approved)) or (vetted.ip,)
     return VettedTarget(
-        url=url,
-        host=host,
-        port=parsed.port or _DEFAULT_HTTPS_PORT,
+        url=vetted.url,
+        # `wire_host`, not `host`: the connector asks its resolver with the
+        # IDNA-encoded form, so that is what the pin must be keyed on. Deriving it
+        # here rather than re-parsing keeps "the pinned host is exactly what the
+        # client asks for" true in one place.
+        host=vetted.wire_host,
+        port=vetted.port,
         addresses=addresses,
     )
-
-
-def _vet_host_addresses(hostname: str) -> tuple[str, ...]:
-    """Resolve *hostname* and return its addresses, or refuse the lot.
-
-    ``calendar.source`` reaches this from a dashboard ``PUT /config`` request and
-    is *fetched by the gateway*, so an internal-only address would make this
-    endpoint a server-side request-forgery hop into the user's own network. A
-    literal IP is checked directly; a name is checked against its resolved
-    addresses.
-
-    **All-or-nothing across a multi-record answer.** A host that answers with a
-    mix of public and private addresses is refused outright rather than filtered
-    down to the public ones: that mix is not a legitimate calendar host, it is
-    the exact signature of a rebinding attempt, and keeping the public record
-    would let an attacker retry until the connector happened to pick the private
-    one. The same rule covers IPv4 and IPv6 — every address in the answer must
-    pass, and the surviving set is what gets pinned.
-    """
-    try:
-        ipaddress.ip_address(hostname)
-        candidates: list[str] = [hostname]
-    except ValueError:
-        try:
-            infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
-        except OSError as exc:
-            raise CalendarError(f"cannot resolve calendar host: {hostname}") from exc
-        candidates = [str(info[4][0]) for info in infos]
-    vetted: list[str] = []
-    for candidate in candidates:
-        # An unparseable address is refused rather than skipped. The old code
-        # `continue`d here, which meant anything getaddrinfo returned in a shape
-        # ipaddress could not read went UNCHECKED — a skipped candidate is an
-        # unvetted one, and it could still have been connected to.
-        #
-        # A scoped link-local ("fe80::1%en0") parses and keeps its scope in `str()`,
-        # so it never reaches the pin: `_refuse_private_address` rejects it as
-        # link-local first.
-        try:
-            addr = ipaddress.ip_address(candidate)
-        except ValueError:
-            raise CalendarError(
-                "calendar URL resolved to an address that could not be parsed"
-            ) from None
-        _refuse_private_address(addr)
-        text = str(addr)
-        if text not in vetted:
-            vetted.append(text)
-    if not vetted:
-        raise CalendarError(f"cannot resolve calendar host: {hostname}")
-    return tuple(vetted)
-
-
-def _refuse_private_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
-    """Refuse a loopback/private/link-local/reserved/multicast/unspecified address.
-
-    An IPv4 address embedded in IPv6 — ``::ffff:10.0.0.1`` (v4-mapped) or
-    ``2002:a00:1::`` (6to4) — is judged by the address it embeds, because that is
-    the address the packet ultimately reaches. Without unwrapping, ``is_private``
-    on the v6 form can read as public while the traffic lands inside the network.
-    """
-    for embedded in (getattr(addr, "ipv4_mapped", None), getattr(addr, "sixtofour", None)):
-        if embedded is not None:
-            _refuse_private_address(embedded)
-    if (
-        addr.is_loopback
-        or addr.is_private
-        or addr.is_link_local
-        or addr.is_reserved
-        or addr.is_multicast
-        or addr.is_unspecified
-    ):
-        raise CalendarError(
-            "calendar URL resolves to a private or loopback address, which is not allowed"
-        )
 
 
 class _PinnedResolver(AbstractResolver):
@@ -660,8 +663,8 @@ class _PinnedResolver(AbstractResolver):
     One case never reaches here: aiohttp short-circuits a **literal-IP** URL and
     connects without consulting any resolver. That is sound rather than a gap —
     there is no name to re-resolve, so there is no rebinding window, and
-    :func:`_vet_host_addresses` checked that exact literal against the
-    private-address rules before the request was made.
+    :func:`link_unfurl.vet_unfurl_url` checked that literal, in its canonical
+    form, against the private-address rules before the request was made.
     """
 
     def __init__(self) -> None:

--- a/src/kiro_crew/link_unfurl.py
+++ b/src/kiro_crew/link_unfurl.py
@@ -159,6 +159,39 @@ class ExtractedMeta:
     """
 
 
+def _is_not_public(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+) -> bool:
+    """Whether *ip* is anything other than a globally reachable unicast address.
+
+    Allowlist AND denylist, deliberately both. ``is_global`` is the allowlist half
+    and is the only formulation that closes a whole class rather than one instance
+    — enumerating non-public categories already leaked ``100.64.0.0/10`` (RFC 6598
+    shared space, what a Tailscale tailnet and most CGNAT hand out), which CPython
+    special-cases in ``is_global`` but not in ``is_private``.
+
+    ``is_global`` alone is NOT sufficient either, because CPython's IPv6
+    ``is_global`` is just ``not is_private`` and its private table omits ranges
+    that are plainly not routable: ``ff00::/8`` multicast and the deprecated
+    ``fec0::/10`` site-local both report ``is_global=True``. So every category flag
+    ``ipaddress`` exposes is also rejected. Neither half is redundant: the
+    allowlist catches what the flags forgot, the flags catch what ``is_global``
+    forgot, and ``test_vet_rejects_every_special_purpose_range`` pins the union
+    against a table of IANA special-purpose prefixes so the next gap is found by
+    the suite instead of by a reviewer.
+    """
+    return (
+        not ip.is_global
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_link_local
+        or ip.is_loopback
+        or ip.is_unspecified
+        # IPv6-only; absent on IPv4Address.
+        or getattr(ip, "is_site_local", False)
+    )
+
+
 def _reject_if_internal_ip(candidate: str) -> None:
     """Raise ``blocked_url`` if *candidate* parses as a non-public IP.
 
@@ -175,6 +208,13 @@ def _reject_if_internal_ip(candidate: str) -> None:
       reports ``is_loopback == False``, and its ``is_private`` only consults the
       mapped address on Python 3.13+ — so on every supported version below that,
       the mapped form is a clean bypass unless unwrapped by hand.
+    * 6to4 is checked on BOTH readings, not unwrapped. ``2002:0a00:0001::1`` is a
+      routable v6 address AND names the v4 tunnel endpoint ``10.0.0.1``, so each
+      has to pass: ``2002::/16`` entered CPython's IPv6 private table only with
+      gh-113171 (3.10.14, 3.11.9, 3.12.4), so on an older patch release of a
+      version this project supports the v6 form reports ``is_global`` while the
+      packet goes inward — and substituting the payload instead would let
+      ``2002:8000::`` through, whose payload ``128.0.0.0`` is public.
     """
     try:
         ip = ipaddress.ip_address(canonicalize_ip(candidate))
@@ -183,32 +223,12 @@ def _reject_if_internal_ip(candidate: str) -> None:
     mapped = getattr(ip, "ipv4_mapped", None)
     if mapped is not None:
         ip = mapped
-    # Allowlist AND denylist, deliberately both. `is_global` is the allowlist half
-    # and is the only formulation that closes a whole class rather than one
-    # instance — enumerating non-public categories already leaked
-    # `100.64.0.0/10` (RFC 6598 shared space, what a Tailscale tailnet and most
-    # CGNAT hand out), which CPython special-cases in `is_global` but not in
-    # `is_private`.
-    #
-    # `is_global` alone is NOT sufficient either, because CPython's IPv6
-    # `is_global` is just `not is_private` and its private table omits ranges that
-    # are plainly not routable: `ff00::/8` multicast and the deprecated
-    # `fec0::/10` site-local both report `is_global=True`. So every category flag
-    # `ipaddress` exposes is also rejected. Neither half is redundant: the
-    # allowlist catches what the flags forgot, the flags catch what `is_global`
-    # forgot, and `test_vet_rejects_every_special_purpose_range` pins the union
-    # against a table of IANA special-purpose prefixes so the next gap is found
-    # by the suite instead of by a reviewer.
-    if (
-        not ip.is_global
-        or ip.is_multicast
-        or ip.is_reserved
-        or ip.is_link_local
-        or ip.is_loopback
-        or ip.is_unspecified
-        # IPv6-only; absent on IPv4Address.
-        or getattr(ip, "is_site_local", False)
-    ):
+    # 6to4 is an ADDITIONAL refusal rather than a substitution — see the docstring
+    # for why the two encodings are not symmetric.
+    sixtofour = getattr(ip, "sixtofour", None)
+    if sixtofour is not None and _is_not_public(sixtofour):
+        raise UnfurlRejected("blocked_url")
+    if _is_not_public(ip):
         raise UnfurlRejected("blocked_url")
 
 
@@ -285,10 +305,18 @@ def vet_unfurl_url(
         resolver = resolve or _default_resolve
         try:
             addresses: Sequence[str] = resolver(host, port)
-        except OSError:
+        except (OSError, UnicodeError):
             # NXDOMAIN, no route, resolver timeout. Fail CLOSED: an unresolvable
             # host is one whose addresses we could not check, and the vet's
             # contract is "safe to connect to", not "probably fine".
+            #
+            # `UnicodeError` is listed because it is NOT an `OSError` -- it is a
+            # `ValueError`. `getaddrinfo` raises it for a host carrying a lone
+            # surrogate (`https://\ud800.example/`), which arrives intact from a
+            # JSON string, so an `OSError`-only catch let it escape the vet
+            # entirely and surface as a 500. A host the resolver cannot encode is
+            # a host whose addresses were never checked: the same answer as
+            # NXDOMAIN, for the same reason.
             raise UnfurlRejected("blocked_url") from None
         if not addresses:
             raise UnfurlRejected("blocked_url")
@@ -301,6 +329,17 @@ def vet_unfurl_url(
         addresses = [literal]
 
     normalized = urlunsplit((scheme, parts.netloc, parts.path or "/", parts.query, ""))
+    # yarl raises `UnicodeError` (a `ValueError`, not an `OSError`) encoding a host
+    # that carries a lone surrogate — reachable because a JSON string can hold one,
+    # so it arrives intact from a request body or a config value. Refused rather
+    # than propagated: a URL whose wire form cannot be derived is one this function
+    # cannot promise anything about, which is the same fail-closed answer the
+    # resolver branch gives. Derived here, before the result is built, so the
+    # failure has one exit instead of a half-constructed `VettedUrl`.
+    try:
+        wire_host = yarl.URL(normalized).raw_host or host
+    except (ValueError, UnicodeError):
+        raise UnfurlRejected("invalid_url") from None
     return VettedUrl(
         url=normalized,
         scheme=scheme,
@@ -312,7 +351,7 @@ def vet_unfurl_url(
         # link would be refused by our own pin, surface as a 502, and sit in the
         # negative cache for ten minutes. Deriving it here keeps "the pinned host
         # is exactly what the client asks for" true in one provable place.
-        wire_host=yarl.URL(normalized).raw_host or host,
+        wire_host=wire_host,
         port=port,
         ip=str(addresses[0]),
         domain=host[4:] if host.startswith("www.") else host,

--- a/test/test_link_unfurl.py
+++ b/test/test_link_unfurl.py
@@ -160,6 +160,72 @@ def test_vet_rejects_multicast_despite_is_global(host: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "embedded", ["10.0.0.1", "127.0.0.1", "192.168.1.1", "169.254.169.254"]
+)
+def test_6to4_is_refused_by_unwrapping_not_by_cpythons_table(
+    embedded: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 6to4 address is judged by the IPv4 address it carries, on every 3.x.
+
+    ``2002::/16`` entered CPython's IPv6 private table only with gh-113171
+    (3.10.14, 3.11.9, 3.12.4). On an older patch release of a version this project
+    supports, ``2002:0a00:0001::1`` reports ``is_global`` and every category flag
+    clean, while the packet is routed to ``10.0.0.1``.
+
+    The table-driven pin above lists ``2002::/16``, but on a fixed interpreter it
+    passes through ``is_private`` alone and so cannot detect a missing unwrap. This
+    drops that entry for the test's duration to reproduce the older behavior: what
+    is asserted is that the refusal comes from unwrapping the embedded address, not
+    from the interpreter agreeing with us.
+    """
+    v4 = ipaddress.ip_address(embedded)
+    sixtofour = ipaddress.ip_address(f"2002:{int(v4) >> 16:04x}:{int(v4) & 0xFFFF:04x}::1")
+    assert sixtofour.sixtofour == v4
+
+    without_6to4 = tuple(
+        net
+        for net in ipaddress._IPv6Constants._private_networks
+        if str(net) != "2002::/16"
+    )
+    monkeypatch.setattr(
+        ipaddress._IPv6Constants, "_private_networks", without_6to4, raising=True
+    )
+    # The premise: with that entry gone the interpreter now calls it public, so a
+    # check that consulted only the flags would let it through.
+    assert ipaddress.ip_address(str(sixtofour)).is_global
+
+    with pytest.raises(lu.UnfurlRejected) as exc:
+        lu.vet_unfurl_url(f"https://[{sixtofour}]/x")
+    assert exc.value.code == "blocked_url"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://\ud800.example/",
+        "https://ex\udcffample.test/",
+        "https://\udfff/",
+    ],
+)
+def test_a_host_the_resolver_cannot_encode_is_refused_not_raised(url: str) -> None:
+    """A lone surrogate in the host is a refusal, not an uncaught ``UnicodeError``.
+
+    ``getaddrinfo`` raises ``UnicodeError`` for these — a ``ValueError``, not an
+    ``OSError`` — so the fail-closed catch around the resolver missed it and the
+    exception escaped the vet. It reaches here intact because a JSON string can
+    carry an unpaired surrogate, so this is an ordinary bad input rather than a
+    contrived one: `link_meta` takes the URL from a request body, and the meetings
+    calendar takes it from a config value.
+
+    Refused rather than merely "not crashing": a host whose addresses were never
+    checked cannot be declared safe to connect to.
+    """
+    with pytest.raises(lu.UnfurlRejected) as exc:
+        lu.vet_unfurl_url(url)
+    assert exc.value.code in {"blocked_url", "invalid_url"}
+
+
+@pytest.mark.parametrize(
     "prefix",
     [
         # IPv4 special-purpose (RFC 6890 + the ones CPython classifies unevenly)

--- a/test/test_meetings_providers.py
+++ b/test/test_meetings_providers.py
@@ -39,6 +39,16 @@ from kiro_crew.apps.builtins.meetings.backend.providers import calendar as cal
 from kiro_crew.apps.builtins.meetings.backend.providers import tasks as taskprov
 
 
+class _AnyPort:
+    """Stands in for ``link_unfurl.ALLOWED_PORTS`` when a test server binds an
+    ephemeral port. Only ``in`` is used against that frozenset, so accepting
+    everything is the whole contract — and it beats materializing 65k ints.
+    """
+
+    def __contains__(self, _port: object) -> bool:
+        return True
+
+
 def _ics(*events: str, prodid: str = "-//test//EN") -> str:
     body = "\n".join(events)
     return f"BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:{prodid}\n{body}\nEND:VCALENDAR\n"
@@ -619,8 +629,29 @@ class TestUrlValidation:
         assert target.host == "example.test"
         assert target.port == 443
 
-    def test_port_is_taken_from_the_url(self, public_dns: None):
-        assert cal._normalize_url("https://example.test:8443/cal.ics").port == 8443
+    def test_a_non_standard_port_is_refused(self, public_dns: None):
+        """Ports narrow to 443, which is stricter than "whatever the URL names".
+
+        The shared vet allows 80 and 443 only, and https-only leaves 443. A
+        calendar on some other port is nearly always an internal service, and the
+        port is the cheapest place to stop this endpoint being used to probe for
+        one. No working configuration is broken by starting strict: `ics` only
+        ever documented a published `https://` URL, and relaxing later is a
+        one-line change to that allow-list.
+        """
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url("https://example.test:8443/cal.ics")
+
+    def test_port_80_is_refused_even_though_the_shared_vet_allows_it(
+        self, public_dns: None
+    ):
+        """The shared vet's allow-list is {80, 443} because it also serves
+        plain-http link unfurling; THIS caller is https-only, so the stated scope
+        is 443 alone. ``https://host:80`` would pass the vet and then fail the TLS
+        handshake with a message that does not name the cause — refuse it up front.
+        """
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url("https://example.test:80/cal.ics")
 
     def test_host_is_keyed_as_the_connector_will_see_it(self, public_dns: None):
         """The pin is looked up by yarl's ``raw_host``, so it must be stored that way.
@@ -688,6 +719,22 @@ class TestUrlValidation:
         source = inspect.getsource(cal.IcsCalendarProvider)
         assert "calendar redirect URL is malformed" in source
 
+    @pytest.mark.parametrize(
+        "url", ["https://\ud800.example/cal.ics", "https://ex\udcffample.test/c.ics"]
+    )
+    def test_a_host_the_resolver_cannot_encode_is_a_calendar_error_not_a_500(
+        self, url: str, public_dns: None
+    ):
+        """A lone surrogate in the host must not escape as ``UnicodeError``.
+
+        `calendar.source` arrives as a JSON string, which can carry an unpaired
+        surrogate, and ``UnicodeError`` is a ``ValueError`` rather than an
+        ``OSError`` — so it slipped past both the resolver's fail-closed catch and
+        the ``URL(...)`` guard, and reached the settings handler as an HTTP 500.
+        """
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url(url)
+
     def test_missing_host_refused(self):
         with pytest.raises(cal.CalendarError):
             cal._normalize_url("https:///cal.ics")
@@ -699,6 +746,64 @@ class TestUrlValidation:
     def test_private_and_loopback_addresses_refused(self, host):
         # The request-forgery gate: the gateway performs this fetch, so an
         # internal-only address must never be reachable through a config value.
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url(f"https://{host}/cal.ics")
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            # RFC 6598 shared space, what a tailnet and most carrier NAT hand out.
+            # `is_private` does not cover it; only `is_global` does. On a machine on
+            # a tailnet, this range IS the private network.
+            "100.64.0.1",
+            # Deprecated IPv6 site-local: reports `is_global=True`, so an
+            # `is_private`-only check reads it as a public address.
+            "[fec0::1]",
+        ],
+    )
+    def test_addresses_the_local_vet_approved_are_now_refused(self, host: str):
+        """The gap that motivated delegating the address vet.
+
+        Both of these were APPROVED while this module carried its own
+        `is_private`-based check — verified by running the pre-change code — and are
+        refused now that :func:`link_unfurl.vet_unfurl_url` owns the decision. They
+        are asserted at THIS call site rather than left to that module's own suite,
+        because what is under test is that the calendar gate reaches it at all;
+        re-introducing a local check is the regression these names catch.
+        """
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url(f"https://{host}/cal.ics")
+
+    @pytest.mark.parametrize(
+        "host",
+        ["0177.0.0.1", "0x7f000001", "2130706433", "127.1", "[::ffff:127.0.0.1]"],
+    )
+    def test_alternate_ip_encodings_are_refused_by_the_vet_not_the_resolver(
+        self, host: str
+    ):
+        """Encodings `ipaddress` rejects but the OS resolver accepts.
+
+        These were NOT reachable before this change: `ipaddress` declined to parse
+        them, they fell through to DNS, getaddrinfo folded them back to loopback,
+        and the private-address rule caught them there. The defect was that the
+        refusal depended on the resolver's reading of a string the vet had given up
+        on — agreement, not a decision. `canonicalize_ip` makes them literals, so
+        the vet judges the address itself.
+
+        Pinned as behavior rather than as a fix: a future change that stops
+        canonicalizing would move the decision back onto getaddrinfo silently.
+        """
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url(f"https://{host}/cal.ics")
+
+    @pytest.mark.parametrize("host", ["printer.local", "abcdefgh.onion"])
+    def test_hosts_that_cannot_name_a_public_service_are_refused(
+        self, host: str, public_dns: None
+    ):
+        """``.local`` resolves through mDNS, a side channel; ``.onion`` does not
+        resolve at all. Neither can name a public calendar, and the local vet had
+        no suffix rule — with DNS stubbed public, both were approved.
+        """
         with pytest.raises(cal.CalendarError):
             cal._normalize_url(f"https://{host}/cal.ics")
 
@@ -996,14 +1101,19 @@ class TestDnsRebindingIsRefused:
 
         * the https-only scheme allow-list (a local TLS server would need a CA and
           a trusted cert, which buys no coverage of the address decision), and
-        * the private/loopback address refusal (127.0.0.1 IS the test server).
+        * the private/loopback address refusal (127.0.0.1 IS the test server), and
+          the 80/443 port rule (the server binds an ephemeral port).
 
-        Both have their own dedicated tests above, and neither is what these tests
+        All have their own dedicated tests above, and none is what these tests
         exercise. Everything else — resolution, the all-or-nothing address check,
         the pin, the connector, the hop loop — runs for real.
         """
         monkeypatch.setattr(cal, "_ALLOWED_SCHEMES", ("https", "http"))
-        monkeypatch.setattr(cal, "_refuse_private_address", lambda _addr: None)
+        # The address vet is `link_unfurl`'s now, so the refusals to lift are its.
+        # Neutralized on THAT module, which is where the real code reads them from
+        # — patching a local name here would pass while testing nothing.
+        monkeypatch.setattr(cal.link_unfurl, "_reject_if_internal_ip", lambda _c: None)
+        monkeypatch.setattr(cal.link_unfurl, "ALLOWED_PORTS", _AnyPort())
 
     @pytest.mark.asyncio
     async def test_the_fetch_lands_on_the_vetted_address_not_the_rebound_one(


### PR DESCRIPTION
## Problem / Motivation

`calendar.source` is fetched **by the gateway**, so the address check applied to
it is a server-side request-forgery gate. That check was a local copy living in
the meetings calendar provider, and it decided "is this address public?" with
`ipaddress.is_private` — which does not cover two ranges that are plainly not
public:

```pycon
>>> import ipaddress
>>> ipaddress.ip_address("100.64.0.1").is_private
False
>>> ipaddress.ip_address("fec0::1").is_private
False
```

- **`100.64.0.0/10`** is RFC 6598 shared address space — what a Tailscale tailnet
  and most carrier NAT hand out. On a machine on a tailnet, that range *is* the
  private network.
- **`fec0::/10`** is deprecated IPv6 site-local.
- **`.local` and `.onion`** were approved too: the local copy had no host-suffix
  rule, so an mDNS name or a hidden service passed the gate.

All of these were approved, resolved, and fetched.

## Why it matters

The value reaches the gate from a dashboard `PUT /config`, and the response body
lands in `calendar-cache.json`, which is inside the agent-readable app data tree.
So the pair is a read primitive: something that can set the config value gets the
gateway to fetch an internal address and gets the bytes back out.

Scope, stated honestly: this needs the ability to write that config value, so it
is not remotely reachable on its own. It is a gate that does not hold rather than
an open door — which is exactly the thing worth fixing before more providers are
built on top of it.

## What changed (motivation → approach → change)

**Approach.** Stop keeping a second copy of the vet.
`link_unfurl.vet_unfurl_url` already owns this decision for the unfurl endpoint
and is strictly stronger:

| | local copy | `link_unfurl` |
|---|---|---|
| `100.64.0.1` (CGNAT) | **approved** | refused (`is_global` allowlist) |
| `fec0::1` (site-local) | **approved** | refused (`is_site_local` + `is_global`) |
| `.local`, `.onion` | **approved** | refused (`BLOCKED_HOST_SUFFIXES`) |
| `0177.0.0.1`, `0x7f000001` | refused, but only via the resolver | refused by the vet (`canonicalize_ip`) |

It also carries `test_vet_rejects_every_special_purpose_range`, which pins the
refusal set against a table of IANA special-purpose prefixes — so the next gap is
found by the suite instead of by a reviewer. A second implementation inherits
none of that, and is a second place to fix a bypass.

**What did NOT move.** The pin, the redirect hop loop, the same-origin check, and
the TLS behavior are untouched. The resolver is still pinned on `wire_host` and
the URL is never rewritten to an IP, so `Host`, SNI and certificate verification
stay on the real hostname. Only the address decision is delegated.

**Why `resolve` is injected.** `VettedUrl` reports a single `ip`; the pin serves
*every* vetted address so a multi-homed calendar host keeps its fallbacks. Every
address recorded is one `vet_unfurl_url` checked — it vets the whole answer, not
just the address it returns. One refusal is layered on top rather than delegated:
a resolved address `ipaddress` cannot read is refused, not skipped, because
`_reject_if_internal_ip` returns silently for a non-literal (to it, a non-literal
is a hostname still to resolve) and here the list is already a resolution result.

### Two behavior changes, called out rather than buried

- **Ports narrow to 443.** The shared vet allows `{80, 443}` because it also
  serves plain-http unfurling; https-only leaves 443. A calendar on another port
  is nearly always an internal service, and the port is the cheapest place to stop
  this endpoint being used to probe for one. The `ics` provider only ever
  documented a published `https://` URL, so no working configuration breaks;
  relaxing later is one line in `_ALLOWED_SCHEMES`' consequence.
- **Rejection wording changes**, since the two `UnfurlRejected` codes are now
  what gets mapped to operator-facing messages.

## Tests

Non-vacuous, and verified the way round that matters — **by running the
pre-change code**, not by reading it. On the parent commit:

```
FAILED test_addresses_the_local_vet_approved_are_now_refused[100.64.0.1] - DID NOT RAISE
FAILED test_addresses_the_local_vet_approved_are_now_refused[[fec0::1]]  - DID NOT RAISE
FAILED test_hosts_that_cannot_name_a_public_service_are_refused[printer.local]   - DID NOT RAISE
FAILED test_hosts_that_cannot_name_a_public_service_are_refused[abcdefgh.onion]  - DID NOT RAISE
FAILED test_a_non_standard_port_is_refused                              - DID NOT RAISE
FAILED test_port_80_is_refused_even_though_the_shared_vet_allows_it     - DID NOT RAISE
```

The alternate IPv4 encodings (`0177.0.0.1`, `0x7f000001`, `2130706433`, `127.1`,
`[::ffff:127.0.0.1]`) **passed on the parent commit** and are pinned anyway, in
their own separately-named test. They were never reachable: `ipaddress` declined
to parse them, they fell through to DNS, getaddrinfo folded them back to loopback,
and the private-address rule caught them there. The defect was that the refusal
rode on the resolver's reading of a string the vet had given up on — agreement,
not a decision. Naming that separately keeps the test from claiming a finding it
does not have.

The DNS-rebinding tests that stand up a real loopback server now lift
`link_unfurl`'s refusals (`_reject_if_internal_ip`, `ALLOWED_PORTS`) instead of a
local function — patched on the module the real code reads them from, since
patching a local name would pass while testing nothing.

Local gate: `test_meetings_providers.py` 162 passed; with
`test_meetings_routes.py`, `test_meetings_store.py`, `test_link_unfurl.py` and
`test_security.py`, 1150 passed / 1 skipped. `isort`, `flake8`, `mypy` clean.

## Manual verification

The two `is_private` readings at the top of this description were run against
this interpreter (CPython 3.12), which is what established that the ranges were
approved rather than assumed.

Not verified here: an end-to-end fetch against a real CGNAT host, which needs a
tailnet. The address decision is covered by the tests above and by
`link_unfurl`'s own IANA-prefix table.

## Related Issues

Extracted from #2190, which bundles this fix with three new calendar providers, a
credential store and an OAuth handshake. That PR is 464 commits behind and its
remaining half is not user-reachable yet (no settings UI, and
`builtin_skills/meetings/SKILL.md` still documents only `none` and `ics`). This
half stands alone and fixes code that is **already shipped**, so it should not
wait on the rest. Credit for the delegation approach and its comments goes to
@kaizawa97 — carried as a `Co-authored-by` trailer.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no user-facing surface changes;
      the `ics` provider's documented contract (a published `https://` URL) is
      unchanged
- [x] No secrets, credentials, or internal references in the diff
