### PR TITLE
fix(env): Add /usr/local/bin to the augmented PATH

### DIFF
--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -33,6 +33,7 @@ _EXTRA_PATH_DIRS = (
     "{mise_data}/shims",
     "{home}/.volta/bin",
     "/opt/homebrew/bin",  # Apple Silicon Homebrew node / global npm bins
+    "/usr/local/bin",  # Intel Homebrew + pkg-installer symlink dir
 )
 
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -111,6 +111,42 @@ class TestAugmentedPath:
         toolbox_idx = next(i for i, d in enumerate(dirs) if ".toolbox/bin" in d)
         assert local_idx < toolbox_idx
 
+    def test_includes_both_macos_install_prefixes(self) -> None:
+        """``/usr/local/bin`` belongs beside ``/opt/homebrew/bin``, not instead of it.
+
+        The two are different install locations, not alternatives: Homebrew uses
+        ``/opt/homebrew`` on Apple Silicon and ``/usr/local`` on Intel, and macOS
+        ``.pkg`` installers symlink into ``/usr/local/bin`` regardless of
+        architecture. A GUI-launched app inherits launchd's minimal
+        ``/usr/bin:/bin:/usr/sbin:/sbin``, so anything absent here is unresolvable
+        for an in-process ``shutil.which()`` even though it works in a shell.
+
+        Every other bin-dir list in the tree already pairs them -- see
+        ``deploy/engine._AWS_BIN_DIRS``, ``kiro_cli._kiro_cli_dirs`` and
+        ``dashboard/tailnet`` -- so omitting one here made this helper the
+        outlier those call sites had to compensate for locally.
+        """
+        # The declaration is platform-independent, so assert it directly rather
+        # than inferring it from a composed PATH.
+        assert "/opt/homebrew/bin" in env_mod._EXTRA_PATH_DIRS
+        assert "/usr/local/bin" in env_mod._EXTRA_PATH_DIRS
+        # Apple Silicon's prefix stays ahead of the Intel/pkg one, matching the
+        # ordering `_AWS_BIN_DIRS` uses.
+        assert env_mod._EXTRA_PATH_DIRS.index("/opt/homebrew/bin") < env_mod._EXTRA_PATH_DIRS.index(
+            "/usr/local/bin"
+        )
+
+        # Both reach the composed PATH ahead of the inherited base_path -- but only
+        # where they survive `_validated_bin_dir`, whose sole test is absoluteness.
+        # Gating on that same predicate keeps this assertion honest on a host whose
+        # os.path flavour does not consider a POSIX root path absolute, instead of
+        # encoding a Python version or platform name that would go stale.
+        if os.path.isabs("/usr/local/bin"):
+            dirs = augmented_path("/usr/bin").split(os.pathsep)
+            assert dirs.index("/opt/homebrew/bin") < dirs.index("/usr/bin")
+            assert dirs.index("/usr/local/bin") < dirs.index("/usr/bin")
+            assert dirs.index("/opt/homebrew/bin") < dirs.index("/usr/local/bin")
+
     def test_empty_base(self) -> None:
         result = augmented_path("")
         assert result  # not empty


### PR DESCRIPTION
## Problem / Motivation

`augmented_path()` prepends the well-known install prefixes so an in-process `shutil.which()` resolves the same binaries a login shell would. It included `/opt/homebrew/bin` but not `/usr/local/bin`.

Those are two different install locations, not alternatives:

- Homebrew's prefix is `/opt/homebrew` on Apple Silicon and `/usr/local` on Intel.
- macOS `.pkg` installers symlink into `/usr/local/bin` regardless of architecture.
- On Linux, `/usr/local/bin` is where a tarball install typically lands.

The symptom is a tool the gateway reports as **not installed while the exact same command works in the user's terminal**. A GUI-launched app (Finder, Dock, `open`) inherits launchd's minimal `/usr/bin:/bin:/usr/sbin:/sbin`, so any prefix missing from this helper is simply unresolvable in-process — and the failure reads as a missing dependency rather than a PATH problem, which sends people looking in the wrong place.

## Why it matters

`augmented_path()` was the **only** bin-dir list in the tree missing this prefix, so each call site had to compensate for the gap locally — and any that didn't inherited the bug:

- `deploy/engine._AWS_BIN_DIRS` pairs both prefixes, and its comment records the matching incident: the Artifact Deploy "Verify" step failed for Homebrew users until the gateway was relaunched from a shell carrying a full PATH.
- `kiro_cli._kiro_cli_dirs` adds `/opt/homebrew/bin` **and** `/usr/local/bin` for darwin and *then separately* extends with `augmented_path()` — i.e. it already patches this gap by hand.
- `dashboard/tailnet` documents `/usr/local/bin` as the Linux-tarball and Intel-Homebrew location.
- `github_runner`, `transcribe` and `pod/config` all list it too.

Fixing the shared helper removes the asymmetry rather than adding a seventh local workaround.

## What changed (motivation → approach → change)

Symptom: an installed CLI reported as missing by a GUI-launched gateway. Root cause: `_EXTRA_PATH_DIRS` carried the Apple-Silicon Homebrew prefix but not the Intel/pkg one, so in-process resolution saw neither `/usr/local/bin` nor anything installed there. Change: append `"/usr/local/bin"` to `_EXTRA_PATH_DIRS`.

Ordering follows the precedent in `deploy/engine._AWS_BIN_DIRS` — Apple Silicon's prefix stays ahead of the Intel/pkg one, and both stay ahead of the inherited `base_path`.

Considered and rejected: contributing it only to the MCP search path. That would leave every other in-process `shutil.which()` still unable to see it, which is the actual defect, and would keep the helper inconsistent with the six lists that already include it.

No behaviour change on hosts without the directory. Entries are filtered through `_validated_bin_dir`, whose test is absoluteness rather than existence, and a nonexistent PATH entry is ignored by resolution.

This adds no new trust boundary: `/opt/homebrew/bin` already occupies the same position and the same writability class in this tuple, so the Intel-mac twin of a prefix already present crosses nothing the existing entry did not. The ratchet that keeps operator/downstream-*contributed* dirs out of `augmented_path()` is unaffected — hardcoded well-known prefixes are by design present, and that test still passes.

## Tests

`TestAugmentedPath::test_includes_both_macos_install_prefixes` (new) locks in:

- both prefixes are declared in `_EXTRA_PATH_DIRS`, asserted against the constant so the check is platform-independent;
- their relative order (Apple Silicon ahead of Intel/pkg), matching `_AWS_BIN_DIRS`;
- both outrank the inherited `base_path` in the composed PATH.

The composed-PATH half is gated on `os.path.isabs("/usr/local/bin")` — the exact predicate `_validated_bin_dir` applies. That keeps the assertion honest on any host whose `os.path` flavour does not treat a POSIX root path as absolute, instead of encoding a platform name or Python version that would silently go stale. The test asserts only on fixed literals, so it does not depend on `$HOME`, the environment, or which node versions the host has installed.

Full `test/test_env.py`: 118 passed. Every module that consumes `augmented_path()` was also run — `test_kiro_prerequisite`, `test_browser_cli_install`, `test_acp_client`, `test_acp_runtime`, `test_pod`, `test_node_toolchain_resolution`, `test_dev_fleet_node_toolchain` — 1402 passed, 1 skipped, 0 failed. `isort` and `flake8` clean.

`mypy src/kiro_crew/` reports 4 errors, all pre-existing and none in this diff: they are macOS-only `os.listxattr` / `getxattr` / `setxattr` attribute errors in `hooks.py` and `acp/liveness.py`. Confirmed by stashing this change and re-running against pristine `origin/main`, which reports the identical count. CI's Linux runners have those attributes and do not see them.

## Manual verification

N/A — unit coverage sufficient. The change is one entry in a static tuple, and the new test asserts both the declaration and its effect on the composed PATH.

For what it's worth, the behaviour was also observed directly: with `PATH` forced to launchd's minimal `/usr/bin:/bin:/usr/sbin:/sbin`, a binary installed in `/usr/local/bin` is invisible to `shutil.which(name)` and resolvable via `shutil.which(name, path=augmented_path(...))` only after this change.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to a PATH-construction helper; no frontend path is touched and nothing rendered changes.

## Related Issues

no linked issue: found while debugging a GUI-launched gateway reporting an installed CLI as missing; no tracking issue was filed for the helper gap itself.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface describes this tuple
- [x] No secrets, credentials, or internal references in the diff
