### PR TITLE
refactor(issue-radar): flatten two chained ternaries in azure_client

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/azure_client.py
@@ -58,7 +58,6 @@ import re
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, timedelta, timezone
 from urllib.parse import quote, unquote, urlparse
 
 from kiro_crew.apps.registry import minimal_env
@@ -1900,21 +1899,6 @@ def get_ref_summary(
     }
 
 
-def _cutoff_iso(window_days: int) -> str:
-    """ISO cutoff for a lookback window, or ``""`` when the window is unbounded.
-
-    Kept for parity with the other clients' helper (and used by the timeline's
-    bounded reads); Azure's repository list has no timestamp to compare against.
-    """
-    try:
-        days = int(window_days)
-    except (TypeError, ValueError):
-        return ""
-    if days <= 0 or days >= MAX_WINDOW_DAYS:
-        return ""
-    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-
-
 # ── timeline ────────────────────────────────────────────────────────────────
 #
 # GitHub serves one unified `issues/{n}/timeline`. Azure splits the same
@@ -2491,7 +2475,14 @@ def set_issue_state(
     )
     written = str(_field(_obj(data.get("fields")), "System.State", "") or "")
     closed_states = _closed_state_names(org, project, work_item_type, host=host, timeout=timeout)
-    resolved = "closed" if written in closed_states else "open" if written else state
+    if written in closed_states:
+        resolved = "closed"
+    elif written:
+        resolved = "open"
+    else:
+        # No usable System.State came back -- absent, null and "" all normalize to
+        # "" -- so report what was asked for rather than guessing a category.
+        resolved = state
     return {"state": resolved, "state_reason": None}
 
 
@@ -3670,8 +3661,16 @@ def set_pr_state(
         timeout=timeout,
     )
     status = str(data.get("status") or "").lower()
+    if status == "active":
+        resolved = "open"
+    elif status:
+        resolved = "closed"
+    else:
+        # No usable status came back -- absent, null and "" all normalize to "" --
+        # so report what was asked for rather than reading it as "closed".
+        resolved = state
     return {
-        "state": "open" if status == "active" else "closed" if status else state,
+        "state": resolved,
         "merged": status == "completed",
         "draft": bool(data.get("isDraft")),
     }


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to one Python forge client; nothing rendered in the browser changes.

## Problem / Motivation

The Azure DevOps forge client added in #4153 (`issue_radar/backend/azure_client.py`)
carries three readability defects that the module-simplification detector and a
judgment pass over the same file surface:

1. Two **chained ternaries** in the write paths that report a state back to the
   caller — `set_issue_state` and `set_pr_state`. Each packs a three-way decision
   into one expression, so the reader has to re-derive the precedence of
   `a if c1 else b if c2 else d` to learn what the third arm even means.
2. A **dead private helper**, `_cutoff_iso`, with no caller anywhere in the tree.
3. That helper's docstring asserted a use that does not exist — *"used by the
   timeline's bounded reads"* — so a reader looking for the timeline's window
   logic would be sent to a function nothing calls.

## Why it matters

The two rewritten sites are the ones that tell the dashboard whether an issue or
pull request actually closed. Their third arm — fall back to the state the caller
*requested* when the forge's response carried no state at all — is the least
obvious and most consequential branch, and in a chained ternary it is the one a
reader is most likely to misread as belonging to the preceding condition.

Dead code with a false docstring is worse than absent code: `_cutoff_iso` claimed
to serve the timeline, so the next person maintaining Azure's lookback windows
would read a function that has never run and draw conclusions from it.

## What changed (motivation → approach → change)

Behavior-preserving only. No wire request, no validation guard, and no returned
value changes for any input.

**Chained ternaries → `if`/`elif`/`else`** (2 sites, both in `azure_client.py`):

- `set_issue_state` — `"closed" if written in closed_states else "open" if written else state`
  becomes a three-branch statement in the same order. `written` is
  `str(_field(..., "System.State", "") or "")`, and `_closed_state_names` drops
  rows with a falsy `name`, so `""` can never be a member of `closed_states`; the
  `else` arm is therefore reached exactly when the response carried no state.
- `set_pr_state` — `"open" if status == "active" else "closed" if status else state`
  becomes the same shape, computed just above the returned dict instead of inside
  it. `status` is a plain local `str`, so hoisting the decision out of the dict
  literal evaluates nothing new and skips nothing.

Each site gains a one-line comment stating why the third arm exists, which is the
part the collapsed form hid.

**Dead code removal:** `_cutoff_iso` is deleted, along with the
`from datetime import datetime, timedelta, timezone` line that only it used.
Evidence it is dead: it is module-private, has zero callers in `src/`, `test/` and
the app's own `tests/`, is absent from the provider-parity `SURFACE` tuple in
`issue_radar/tests/test_gitlab.py` (which pins the *public* cross-client surface),
and is covered by no test. `test/test_gitlab_client_coverage.py` exercises
`gitlab_client._cutoff_iso`, a separate function that stays. `MAX_WINDOW_DAYS`
is deliberately **kept** even though it now has no in-file reader:
`issue_radar/backend/routes.py` reads it off whichever client is dispatched
(`client.MAX_WINDOW_DAYS`), so it is part of the cross-provider contract.

Nothing load-bearing is lost with the docstring. Its one true clause — that
Azure's repository payload has no timestamp to compare a cutoff against — is
already documented at the site it actually governs, `list_contributed_repos`,
where `within_days` is accepted, explained as unappliable, and `del`'d. Its
"parity with the other clients' helper" clause was also overstated:
`github_client.py` has no such helper at all (it inlines the cutoff at line 466),
so the parity was with one client, not two — and it was parity on a *private*
symbol that no parity test observes.

## Review before opening

Five read-only reviewers were run over the diff before this PR was opened, each on
a distinct lens: AUTOSDE blocking rules + the deterministic `code-review.yml`
greps; behavior preservation; import semantics and the dead-code deletion;
the security keystone and boot path; comment accuracy.

**One finding was applied.** Both added comments originally said the response
"carried no System.State" / "carried no status", but the branch is reached on any
*falsy* value — absent, `null`, `""` and `0` all normalize to `""` through
`str(... or "")`. The wording now says "no usable ... came back" and names the
normalization, so it is exact rather than approximately right.

**One finding was refuted.** A reviewer asked for a comment at
`azure_client.py:97` naming `routes.py`'s external `client.MAX_WINDOW_DAYS` read,
so a future in-file-only unused-constant sweep would not delete it. That comment
already exists two lines above the constant — *"Mirrors the other two clients'
constants so provider-agnostic routes can read any client's limits without
branching"* — so a second one would be redundant churn.

**One was a request for this description, now met:** that the PR say explicitly
why deleting a module-level function belongs in a behavior-preserving refactor.
That is the "Dead code removal" paragraph above.

Everything else came back clean: both rewrites were proved equivalent by
exhaustive enumeration of the reachable input space (`written` × `closed_states` ×
`state`, and `status` × `state`) with zero mismatches; no `sel` emit,
`redact_credentials` or `redact_exfiltration_urls` call site changed; no import
was hoisted or made eager; the file is on no gateway boot path and is not in the
campaign's keystone set; and the wire payloads plus the
`if state not in ("open", "closed"): raise` guards in both functions are
byte-identical.

**Not touched, on purpose:** the two-arm ternary at `azure_client.py:2788` (not a
chained ternary, so out of scope), and the depth-5 nesting in
`set_issue_assignees` — flattening it would move statements across a `try`/`except`
boundary, which is not a behavior-preserving edit.

## Tests

No new tests: this PR adds no behavior to lock in, and a test asserting the
rewritten branches would assert exactly what the pre-diff expression already
guaranteed. The existing suite is the equivalence check.

- `src/kiro_crew/apps/builtins/issue_radar/tests/` — 929 passed, 631 subtests
  passed. This includes `test_azure_writes.py` and `test_azure_actions.py`, which
  cover both rewritten functions, and `test_gitlab.py`'s cross-client parity
  assertions over the public surface.
- `test/test_gitlab_client_coverage.py`, `test/test_spawn_audit.py`,
  `test/test_builtin_app_assets.py` — 234 passed, 1 skipped.

## Manual verification

N/A — unit coverage sufficient. The change is a local control-flow rewrite plus a
dead-symbol deletion; both rewritten functions have existing test coverage, and
exercising them for real would require writing to a live Azure DevOps project.

## Related Issues

no linked issue: routine module-simplification sweep, not filed as an issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — no new
      behavior, so no new tests; the existing suite is the equivalence check
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented API, schema or
      behavior changes
- [x] No secrets, credentials, or internal references in the diff
