### PR TITLE
fix: lock credential writes to owner, de-corrupt Windows install cmd (#4987)

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -26,6 +26,7 @@ import aiohttp
 import yarl
 from aiohttp import web
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.backend import (
     get_app_backend_port,
     list_app_processes,
@@ -94,7 +95,13 @@ from kiro_crew.apps.spawn_sdk import build_spawn_impl
 from kiro_crew.apps.teardown import teardown_app_runtime
 from kiro_crew.apps.version import check_min_version as _check_min_version_str
 from kiro_crew.atomic_write import atomic_write
-from kiro_crew.config.loader import KiroCrewConfig, config_dir, config_path
+from kiro_crew.config.loader import (
+    ConfigReadError,
+    KiroCrewConfig,
+    config_dir,
+    config_path,
+    update_config_locked,
+)
 from kiro_crew.cron import CronStoreBusy
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.publish_governance import DEPLOY_WEB_PROVIDER_ID, publish_denied_reason
@@ -156,26 +163,45 @@ def _unregister_notification_channels(request: web.Request, name: str) -> None:
 
 
 def _sync_builtin_config(name: str, *, enabled: bool) -> None:
-    """Update config.json for a builtin app so gateway reads the right state on restart."""
+    """Update config.json for a builtin app so gateway reads the right state on restart.
+
+    Blocking: performs a file-locked read-modify-write of config.json and, on
+    Windows, spawns ``icacls`` (``restrict_to_owner``). Callers on the event
+    loop must offload this through ``asyncio.to_thread``.
+    """
     cfg_key, _ = _BUILTIN_SERVICE_APPS.get(name, (None, None))
     if cfg_key is None:
         return
-    path = config_path()
+
+    def _mutate(data: dict) -> dict:
+        data.setdefault(cfg_key, {})["enabled"] = enabled
+        return data
+
+    # update_config_locked, the required path for new config.json mutations:
+    # the whole read-modify-write runs under an advisory sidecar file lock, so
+    # this write is serialized against every other converted writer and other
+    # processes — not merely against itself, which is all an in-module lock
+    # could offer. The write itself is mode-preserving (an operator's
+    # tightened 0600 survives) and symlink-safe. A corrupt config fails
+    # closed; it is re-raised as OSError because that is the failure type the
+    # call sites catch and surface as a warning.
     try:
-        data = json.loads(path.read_text()) if path.exists() else {}
-    except (json.JSONDecodeError, OSError) as exc:
+        update_config_locked(config_path(), mutate=_mutate)
+    except ConfigReadError as exc:
         raise OSError(f"Could not read config.json: {exc}") from exc
-    section = data.setdefault(cfg_key, {})
-    section["enabled"] = enabled
-    tmp = path.with_suffix(".tmp")
-    try:
-        tmp.write_text(json.dumps(data, indent=2))
-        tmp.chmod(0o600)
-        tmp.replace(path)  # replace, not rename: Windows rename refuses to overwrite
-    except OSError:
-        if tmp.exists():
-            tmp.unlink(missing_ok=True)
-        raise
+    if not platform_compat.IS_POSIX:  # pragma: no cover — exercised on Windows CI
+        # POSIX mode bits are meaningless on Windows, so the preserved mode
+        # protects nothing there, and the shared helpers deliberately apply
+        # no DACL themselves because they are also called from loop-reachable
+        # paths (restrict_to_owner spawns icacls, a blocking subprocess).
+        # This caller runs off-loop (to_thread), so it applies the owner
+        # lockdown here: config.json can hold inline credentials. Warn rather
+        # than raise — the settings write itself succeeded, and the callers
+        # must still notify the service of the new enabled state.
+        try:
+            platform_compat.restrict_to_owner(config_path())
+        except OSError:
+            logger.warning("could not restrict config.json permissions", exc_info=True)
     logger.info("Synced config.json %s.enabled = %s", cfg_key, enabled)
 
 
@@ -1319,7 +1345,9 @@ async def handle_enable_app(request: web.Request) -> web.Response:
         origin = info.get("origin", "")
         if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
             try:
-                _sync_builtin_config(name, enabled=True)
+                # to_thread: the sync helper does file I/O and, on Windows,
+                # spawns icacls — neither may run on the event loop.
+                await asyncio.to_thread(_sync_builtin_config, name, enabled=True)
             except OSError as exc:
                 logger.warning("Failed to sync config.json for %s: %s", name, exc)
                 resp.setdefault("warnings", []).append(
@@ -1405,7 +1433,9 @@ async def handle_disable_app(request: web.Request) -> web.Response:
         origin = info.get("origin", "")
         if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
             try:
-                _sync_builtin_config(name, enabled=False)
+                # to_thread: the sync helper does file I/O and, on Windows,
+                # spawns icacls — neither may run on the event loop.
+                await asyncio.to_thread(_sync_builtin_config, name, enabled=False)
             except OSError as exc:
                 logger.warning("Failed to sync config.json for %s: %s", name, exc)
                 warnings.append(_redact_warning(f"config sync failed: {exc}"))

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 
 from kiro_crew import platform_compat, slack_manifest
 from kiro_crew.acp.client import KIRO_CLI_BIN
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.cli_chat import _ensure_default_agent_in_config
 from kiro_crew.conductor_skill import generate_conductor_skill
 from kiro_crew.config import KiroCrewConfig
@@ -498,8 +499,22 @@ def _setup_slack_tokens() -> None:
 
     cred_path.parent.mkdir(parents=True, exist_ok=True)
     lines = [f"{k}={v}" for k, v in existing.items()]
-    cred_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    cred_path.chmod(0o600)
+    # atomic_write with restrict_to_owner, not write_text + chmod(0o600): a
+    # bare chmod is a silent no-op for Windows ACLs, and applying any lockdown
+    # only AFTER the tokens are on disk leaves them readable through the
+    # directory's inherited DACL in the failure window. The helper locks its
+    # unique temp file down before any content reaches it and renames only on
+    # success, so the tokens never exist under a wider mode and a failure
+    # leaves the previous .env untouched. restrict_on_error="warn" matches the
+    # .env doctrine (enforce the lockdown, log a warning if it fails) and the
+    # dashboard credential writers: an ACL-refusing host still completes the
+    # wizard instead of aborting after the user typed their tokens.
+    atomic_write(
+        cred_path,
+        "\n".join(lines) + "\n",
+        restrict_to_owner=True,
+        restrict_on_error="warn",
+    )
     print(f"  ✅ Credentials saved to {cred_path}\n")
 
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -7404,9 +7404,19 @@ class KiroCrewConfig:
         creds: dict[str, str] = {}
         ep = env_path()
         if ep.exists():
-            # Enforce restrictive permissions on credential file
+            # Enforce restrictive permissions on the credential file. POSIX
+            # only: on Windows mode bits are meaningless (a chmod there
+            # toggles the read-only attribute and succeeds without narrowing
+            # who can read), and the real owner-only lockdown —
+            # ``platform_compat.restrict_to_owner`` — spawns ``icacls``, a
+            # blocking subprocess this reader must never run: it is called
+            # from async request handlers on the gateway's event loop (the
+            # same constraint ``write_config_atomically`` documents). Windows
+            # enforcement therefore lives where the file is WRITTEN — the
+            # setup wizard and the dashboard credential writers all apply
+            # ``restrict_to_owner`` off the loop at write time.
             try:
-                if ep.stat().st_mode & 0o077:
+                if platform_compat.IS_POSIX and ep.stat().st_mode & 0o077:
                     ep.chmod(0o600)
             except OSError:
                 logger.warning("Cannot enforce permissions on %s", ep)

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -769,9 +769,25 @@ def _stt_prereq_commands(provider: str = "whisper") -> list[str]:
             # happens in-process, so a system python or ``--user`` install is
             # not importable here.
             if os.name == "nt":
-                # POSIX quoting is wrong for Windows shells; ``&`` is
-                # PowerShell's call operator for a quoted executable path.
-                cmds.append(f'& "{sys.executable}" -m pip install "kirocrew[voice]"')
+                # The user's shell is unknowable here (they may paste this into
+                # PowerShell OR cmd), so the form must be SILENT-CORRUPTION-FREE
+                # in both, and PowerShell is the harder shell: a double-quoted
+                # string still expands ``$name`` and honours backtick escapes,
+                # and so does a bare unquoted token — both are legal path
+                # characters, so either form silently rewrites an interpreter
+                # under e.g. ``C:\tools\$python\...`` into a path that does not
+                # exist. Single quotes are PowerShell's LITERAL form (no
+                # expansion, no escapes, spaces included), with ``&`` invoking
+                # the quoted path, so the interpreter reaches pip byte-for-byte
+                # — including the all-users ``C:\Program Files\...`` layout an
+                # unquoted form cannot express. cmd performs no ``$`` or
+                # backtick processing at all and rejects the leading ``&``
+                # loudly ("... was unexpected"), so a cmd user gets a clear
+                # error to re-quote for, never a corrupted install. A literal
+                # single quote in the path is escaped by doubling, PowerShell's
+                # own rule.
+                exe = sys.executable.replace("'", "''")
+                cmds.append(f"& '{exe}' -m pip install kirocrew[voice]")
             else:
                 cmds.append(f"{shlex.quote(sys.executable)} -m pip install 'kirocrew[voice]'")
         # The non-streaming path remuxes the browser's .webm through ffmpeg, and

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -563,7 +563,13 @@ class SecurityEventLog:
             # can see that it has moved on.
             written = os.fstat(f.fileno())
         # Ensure permissions are correct even if file pre-existed with
-        # wrong mode (e.g. created by an older version).
+        # wrong mode (e.g. created by an older version). POSIX repair only,
+        # deliberately NOT ``platform_compat.restrict_to_owner``: that helper
+        # spawns ``icacls`` on Windows (a blocking subprocess), and this
+        # append path can run inline on a caller's thread that may be the
+        # asyncio event loop — the ``critical=True`` audit-or-deny write, and
+        # the fallback taken when the writer thread cannot start (see
+        # ``_may_rotate``) — where a blocking call freezes every gateway task.
         try:
             os.chmod(self._path, 0o600)
         except OSError:

--- a/src/kiro_crew/workflows/store.py
+++ b/src/kiro_crew/workflows/store.py
@@ -126,6 +126,14 @@ class WorkflowRunStore:
             tmp.write_text(payload, encoding="utf-8")
             os.replace(tmp, path)  # atomic on POSIX
             try:
+                # POSIX tightening only, deliberately NOT
+                # ``platform_compat.restrict_to_owner``: that helper spawns
+                # ``icacls`` on Windows (a blocking subprocess), and ``save``
+                # runs on the event loop via the registry's persist hooks,
+                # where a blocking call freezes every gateway task. The
+                # payload is already passed through ``_redact`` above, so
+                # what a wider Windows DACL could expose is the redacted
+                # run record, not credentials.
                 os.chmod(path, 0o600)
             except OSError:
                 pass

--- a/test/test_builtin_app_lifecycle.py
+++ b/test/test_builtin_app_lifecycle.py
@@ -8,7 +8,11 @@ on any specific bundled service (the former ``secretary`` builtin was removed).
 """
 from __future__ import annotations
 
+import inspect
 import json
+import os
+import re
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -90,6 +94,96 @@ class TestSyncBuiltinConfig:
                 _sync_builtin_config(_TEST_BUILTIN, enabled=False)
         # File should be untouched — not overwritten with empty dict
         assert cfg.read_text(encoding="utf-8") == "{corrupt json!!!"
+
+    def test_write_routes_through_update_config_locked(self, tmp_path, register_test_builtin):
+        """config.json can hold inline credentials and an operator may have
+        tightened its mode — the write must go through update_config_locked,
+        the required path for new config.json mutations: the whole
+        read-modify-write is serialized under an advisory sidecar file lock
+        (the call sites offload to worker threads, and the per-app lifecycle
+        lock does not serialize two DIFFERENT apps), the mode is carried over
+        rather than widened to a new-inode default, and a corrupt config
+        fails closed."""
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({_TEST_CFG_KEY: {"enabled": False}}))
+        cfg.chmod(0o640)
+        calls: list[Path] = []
+        real = routes.update_config_locked
+
+        def _spy(path=None, **kw):
+            calls.append(path)
+            return real(path, **kw)
+
+        with patch("kiro_crew.apps.routes.config_path", return_value=cfg):
+            with patch("kiro_crew.config.loader.config_path", return_value=cfg):
+                with patch("kiro_crew.apps.routes.update_config_locked", side_effect=_spy):
+                    _sync_builtin_config(_TEST_BUILTIN, enabled=True)
+        assert len(calls) == 1
+        assert json.loads(cfg.read_text(encoding="utf-8"))[_TEST_CFG_KEY]["enabled"] is True
+        assert not list(tmp_path.glob("*.tmp"))  # unique temp, cleaned up
+        if os.name == "posix":
+            # The property the helper exists for: the operator's mode survives.
+            assert cfg.stat().st_mode & 0o777 == 0o640
+
+    def test_windows_applies_the_owner_lockdown_off_loop_and_warns_on_refusal(
+        self, tmp_path, register_test_builtin
+    ):
+        """POSIX mode bits protect nothing on Windows, and the shared helper
+        deliberately applies no DACL (it is also called from loop-reachable
+        paths). This caller runs off-loop, so it applies restrict_to_owner
+        itself — and a refusal must warn, not fail a settings write that
+        already succeeded. Only routes' own platform_compat binding is
+        stubbed: flipping the real module's IS_POSIX would send the write
+        path's file lock down the msvcrt branch on POSIX hosts."""
+        from types import SimpleNamespace
+
+        cfg = tmp_path / "config.json"
+        seen: list[object] = []
+        win_ok = SimpleNamespace(IS_POSIX=False, restrict_to_owner=seen.append)
+
+        def _boom(_path):
+            raise OSError("icacls failed")
+
+        win_refuse = SimpleNamespace(IS_POSIX=False, restrict_to_owner=_boom)
+        with patch("kiro_crew.apps.routes.config_path", return_value=cfg):
+            with patch.object(routes, "platform_compat", win_ok):
+                _sync_builtin_config(_TEST_BUILTIN, enabled=True)
+            assert seen == [cfg]
+            with patch.object(routes, "platform_compat", win_refuse):
+                _sync_builtin_config(_TEST_BUILTIN, enabled=False)  # must not raise
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+        assert data[_TEST_CFG_KEY]["enabled"] is False
+
+    def test_failed_write_propagates_to_the_callers_warning_path(
+        self, tmp_path, register_test_builtin
+    ):
+        """A write failure is fail-loud: it must propagate (the callers catch
+        OSError and surface a warning) and leave the previous config
+        byte-identical."""
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({_TEST_CFG_KEY: {"enabled": False}}))
+        before = cfg.read_text(encoding="utf-8")
+        with patch("kiro_crew.apps.routes.config_path", return_value=cfg):
+            with patch(
+                "kiro_crew.apps.routes.update_config_locked",
+                side_effect=OSError("disk full"),
+            ):
+                with pytest.raises(OSError):
+                    _sync_builtin_config(_TEST_BUILTIN, enabled=True)
+        assert cfg.read_text(encoding="utf-8") == before
+
+    def test_async_call_sites_offload_off_the_event_loop(self):
+        """The helper does file I/O and, on Windows, spawns icacls via
+        restrict_to_owner — its async callers must route it through
+        asyncio.to_thread (no-blocking-call-on-event-loop). Any bare
+        direct call (statement, assignment, or nested argument) is a
+        violation; the to_thread form never matches because there the name is
+        followed by a comma, not a call paren."""
+        src = inspect.getsource(routes)
+        assert not re.findall(
+            r"(?<!def )_sync_builtin_config\(", src
+        ), "found a bare on-loop _sync_builtin_config call"
+        assert src.count("asyncio.to_thread(_sync_builtin_config, name") == 2
 
 
 # ── _notify_builtin_service ──

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3917,6 +3917,63 @@ class TestConfigDirOverride:
         content = (tmp_path / ".env").read_text(encoding="utf-8")
         assert "xapp-test" in content
 
+    def test_setup_slack_tokens_locks_env_to_owner(self, tmp_path, monkeypatch):
+        """The credential write must route through atomic_write's owner
+        lockdown: a bare chmod(0o600) is a silent no-op for Windows ACLs, and
+        any lockdown applied only AFTER the tokens are on disk leaves them
+        readable through the directory's inherited DACL in the failure window.
+        The lockdown therefore lands on the temp file, before any token byte
+        reaches it."""
+        import os as os_mod
+
+        import kiro_crew.cli_setup as cs
+        from kiro_crew import platform_compat as pc
+
+        env_file = tmp_path / ".env"
+        monkeypatch.setattr("kiro_crew.cli_setup.env_path", lambda: env_file)
+        inputs = iter(["y", "xapp-test", "xoxb-test", "U12345"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        seen: list[tuple[Path, bool]] = []
+        real = pc.restrict_to_owner
+
+        def _spy(path):
+            # Record what the lockdown saw: the path, and whether the tokens
+            # were already readable there at that moment.
+            p = Path(path)
+            seen.append((p.parent, "xoxb-test" in p.read_text(encoding="utf-8")))
+            return real(path)
+
+        monkeypatch.setattr(pc, "restrict_to_owner", _spy)
+        cs._setup_slack_tokens()
+        # Locked exactly once, on a file in the credential dir, while it was
+        # still empty of tokens.
+        assert seen == [(tmp_path, False)]
+        assert "xoxb-test" in env_file.read_text(encoding="utf-8")
+        assert not list(tmp_path.glob("*.tmp"))  # no temp residue
+        if os_mod.name == "posix":
+            assert env_file.stat().st_mode & 0o777 == 0o600
+
+    def test_setup_slack_tokens_survives_a_lockdown_refusal(self, tmp_path, monkeypatch):
+        """A host where the owner lockdown fails (e.g. SID resolution refused)
+        must not abort the wizard with a traceback after the user already
+        typed their tokens: the .env doctrine is enforce-and-warn, matching
+        the dashboard credential writers."""
+        import kiro_crew.cli_setup as cs
+        from kiro_crew import platform_compat as pc
+
+        env_file = tmp_path / ".env"
+        monkeypatch.setattr("kiro_crew.cli_setup.env_path", lambda: env_file)
+        inputs = iter(["y", "xapp-test", "xoxb-test", "U12345"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+        monkeypatch.setattr(
+            pc, "restrict_to_owner", MagicMock(side_effect=OSError("icacls failed"))
+        )
+
+        cs._setup_slack_tokens()  # must not raise
+        assert "xoxb-test" in env_file.read_text(encoding="utf-8")
+        assert not list(tmp_path.glob("*.tmp"))  # failure leaves no temp residue
+
 
 class TestSetupChannelGating:
     """`kirocrew setup` runs the Slack steps only with --slack.

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -309,15 +309,42 @@ class TestSttPrereqCommands:
         assert "-m pip install" in cmds[0]
         assert core_mod.shlex.quote(core_mod.sys.executable) in cmds[0]
 
-    def test_transcribe_prereq_windows_uses_call_operator(self, monkeypatch) -> None:
-        """POSIX single-quoting breaks on Windows shells; the PowerShell form
-        must be emitted there instead."""
+    def test_transcribe_prereq_windows_is_powershell_literal_quoted(self, monkeypatch) -> None:
+        """The user's shell is unknowable on Windows (the command may be pasted
+        into PowerShell OR cmd), so the emitted form must be free of SILENT
+        corruption in both. PowerShell is the harder shell: a double-quoted
+        string AND a bare unquoted token both expand ``$names`` and honour
+        backtick escapes — legal path characters — silently rewriting the
+        interpreter path. Single quotes are PowerShell's literal form (spaces
+        included, so the all-users ``C:\\Program Files`` layout works), and cmd
+        rejects the leading ``&`` loudly rather than corrupting anything."""
         monkeypatch.setattr(core_mod, "_pip_install_channel_available", lambda: True)
         monkeypatch.setattr(core_mod, "_voice_extra_importable", lambda: False)
         monkeypatch.setattr(core_mod.shutil, "which", lambda _n: "C:\\ffmpeg\\ffmpeg.exe")
         monkeypatch.setattr(core_mod.os, "name", "nt")
+        monkeypatch.setattr(
+            core_mod.sys, "executable", "C:\\Program Files\\Python312\\python.exe"
+        )
         cmds = core_mod._stt_prereq_commands("transcribe")
-        assert cmds == [f'& "{core_mod.sys.executable}" -m pip install "kirocrew[voice]"']
+        assert cmds == [
+            "& 'C:\\Program Files\\Python312\\python.exe' -m pip install kirocrew[voice]"
+        ]
+        # Named properties the exact match locks in:
+        assert '"' not in cmds[0]  # PS double quotes still expand $ and backtick
+        assert "`" not in cmds[0]  # never emit a PS escape character
+
+    def test_transcribe_prereq_windows_metachar_paths_survive_literally(self, monkeypatch) -> None:
+        """``$`` and a literal single quote are legal Windows path characters.
+        Inside PowerShell single quotes ``$python`` is NOT expanded, and a
+        quote in the path is escaped by doubling — PowerShell's own rule — so
+        the interpreter reaches pip byte-for-byte."""
+        monkeypatch.setattr(core_mod, "_pip_install_channel_available", lambda: True)
+        monkeypatch.setattr(core_mod, "_voice_extra_importable", lambda: False)
+        monkeypatch.setattr(core_mod.shutil, "which", lambda _n: "C:\\ffmpeg\\ffmpeg.exe")
+        monkeypatch.setattr(core_mod.os, "name", "nt")
+        monkeypatch.setattr(core_mod.sys, "executable", "C:\\tools\\$python\\o'brien.exe")
+        cmds = core_mod._stt_prereq_commands("transcribe")
+        assert cmds == ["& 'C:\\tools\\$python\\o''brien.exe' -m pip install kirocrew[voice]"]
 
     def test_transcribe_prereq_without_install_channel_is_empty(self, monkeypatch) -> None:
         """When no install channel can make the extra importable (bundled

--- a/test/test_review_fixes.py
+++ b/test/test_review_fixes.py
@@ -145,6 +145,36 @@ class TestEnvPermissions:
 
         assert env_file.stat().st_mode & 0o777 == 0o600
 
+    def test_env_permission_repair_is_posix_only(self, tmp_path: object, monkeypatch) -> None:
+        """On Windows the chmod is a silent no-op for ACLs, and the real
+        lockdown (platform_compat.restrict_to_owner) spawns icacls — a
+        blocking subprocess this loop-reachable reader must never run. The
+        repair must not even attempt a chmod there: Windows enforcement lives
+        where the file is written (setup wizard, dashboard credential
+        writers), all off the loop."""
+        from pathlib import Path
+
+        from kiro_crew.config import loader as loader_mod
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        tmp = Path(str(tmp_path))
+        env_file = tmp / ".env"
+        # A recognised key: an unknown key would land permanently in the
+        # module-global warned-keys set, a residue no fixture resets.
+        env_file.write_text("SLACK_BOT_TOKEN=xoxb-test\n")
+        env_file.chmod(0o644)
+
+        monkeypatch.setattr(loader_mod.platform_compat, "IS_POSIX", False)
+        chmods: list[int] = []
+        monkeypatch.setattr(Path, "chmod", lambda self, mode, **_kw: chmods.append(mode))
+
+        with patch("kiro_crew.config.loader.env_path", return_value=env_file):
+            cfg = KiroCrewConfig.__new__(KiroCrewConfig)
+            creds = cfg.load_credentials()
+
+        assert chmods == []
+        assert creds.get("SLACK_BOT_TOKEN") == "xoxb-test"  # reading still works
+
 
 class TestSelForwardCallback:
     """Tests for SEL forward callback (7b7feebd)."""


### PR DESCRIPTION
## What is the problem?

Two sibling call sites outside Code Review Sage carry the defects PR #4979 fixed inside it, found by that PR's review lanes and deliberately left out as unrelated scope (#4987):

1. `dashboard/handlers/core.py` rendered the Windows transcribe install command as `& "<sys.executable>" -m pip install "kirocrew[voice]"`. A double-quoted PowerShell string still expands `$name` and honours backtick escapes -- both legal Windows path characters -- so an interpreter under e.g. `C:\tools\$python\...` is silently rewritten into a path that does not exist.
2. Owner-only lockdowns expressed as raw `chmod(0o600)` at ~9 sites. On Windows that call only toggles the read-only attribute and *succeeds*, so the file stays readable through the directory's inherited DACL and nothing surfaces the gap. `platform_compat.restrict_to_owner` is the existing helper that applies a real owner-only DACL there -- but it spawns `icacls` (a blocking subprocess), so it must never run on the asyncio event loop.

## Why this issue matters to the user

Both defects are latent on POSIX and live on Windows. The copy-paste install command is the one user-visible surface for enabling Transcribe on Windows; when it silently corrupts the interpreter path the user gets an unexplained failure on a command the product told them to run. The chmod sites are worse than an absent guard: the source reads as if Slack tokens in `.env` and inline credentials in `config.json` are protected, and on Windows they are not.

## How our fix solves it

**Shell quoting** (`dashboard/handlers/core.py`): the user's shell is unknowable (PowerShell or cmd), so the emitted form must be free of *silent* corruption in both. PowerShell is the harder shell: a double-quoted string AND a bare unquoted token both expand `$names` and honour backticks. The command now uses PowerShell's literal form -- `& '<exe>' -m pip install kirocrew[voice]`, with a quote in the path escaped by doubling. Single quotes expand nothing and carry spaces (so the all-users `C:\Program Files\...` layout works); cmd performs no `$`/backtick processing and rejects the leading `&` loudly, so a cmd user gets a clear re-quote error, never a corrupted install. (A truly shell-neutral unquoted form was considered and rejected: unquoted tokens are still `$`-expanded by PowerShell, and spaces would break both shells.)

**Owner-only lockdown**, adjudicated per site as the issue asks ("this list is a starting point, not a verdict"):

| Site | Verdict | Rationale |
|---|---|---|
| `cli_setup.py` (.env Slack tokens) | converted | now `atomic_write(restrict_to_owner=True, restrict_on_error="warn")`: the unique temp is locked BEFORE any token byte reaches it, a lockdown refusal logs a warning instead of aborting the wizard after the user typed their tokens (the `.env` doctrine, matching the dashboard credential writers), and a failure leaves the previous `.env` untouched. Was the last `.env` writer not on the helper. |
| `apps/routes.py` `_sync_builtin_config` (config.json) | converted | hand-rolled fixed-name tmp+chmod+replace replaced by `update_config_locked`, the required path for new config.json mutations: the whole read-modify-write runs under an advisory sidecar FILE lock (serialized against every other converted writer and other processes, which an in-process lock could not offer), the write is mode-preserving and symlink-safe, and a corrupt config fails closed. Followed off-loop by the Windows `restrict_to_owner` lockdown the shared helpers deliberately leave to their callers (warn on refusal). Both async call sites offload via `asyncio.to_thread` (file I/O + icacls must not run on the loop). Known residual, stated plainly: the DACL lasts until any OTHER config.json writer replaces the inode -- the legacy `write_config_atomically` call sites apply no DACL, so on Windows the file periodically reverts to the directory-inherited ACL (the pre-PR posture for every writer); a systemic fix belongs in the shared helper, not this PR. |
| `config/loader.py` `load_credentials` | gated to POSIX | loop-reachable reader (async request handlers): the icacls spawn is forbidden there and the chmod was already a Windows no-op. Windows enforcement lives at the writers, all off the loop. |
| `workflows/store.py`, `sel.py:568` | documented keep | both loop-reachable (registry persist hooks; the critical audit-or-deny SEL write); workflow payload is redacted before serialization. |
| `mcp_gateway/apps.py:175` | no change | already applies `restrict_to_owner` on non-POSIX. |
| `sel.py:966` (rotation lock) | no change | the file holds no data (existing comment says so). |
| `pod/runtime.py` | no change | pod runtime is systemd-only, unreachable on Windows. |
| `metrics/local_exporter.py` | no change | aggregate telemetry with no content; its chmod runs on every export, where a per-export subprocess spawn is not worth a non-secret file. |

## What tests we did

- New/updated regression tests: PowerShell-literal command shape (exact match with a spaced `C:\Program Files` path; `$`-path and quote-doubling survival), lock-before-content ordering and warn-on-refusal wizard survival in `cli_setup`, `update_config_locked` routing with mode preservation, the Windows off-loop lockdown branch, and failure propagation in `_sync_builtin_config`, a source ratchet that both call sites stay on `asyncio.to_thread`, and the POSIX-only gate in `load_credentials`.
- All eight fix mechanisms mutation-verified: reverting each one (quoted form back, chmod back, lock removed, ordering swapped, POSIX gate dropped, warn flipped to raise, quote-doubling dropped, to_thread removed) turns its test red.
- Local gates: isort, flake8, black (touched non-baseline files), mypy clean on touched files; full pytest with failures confirmed host-environment-only by a pristine-main control run on the same host.
- Two model-pinned pre-push review lanes (GPT + Opus); every finding verified against code and fixed forward: the `.env` lockdown-failure exposure window, the wizard abort on ACL-refusing hosts, the fixed-temp-name race introduced by the to_thread offload, and the spaces regression in the first quoting attempt.

## Any other suggestions on the work

`workflows/store.py` and `sel.py`'s append path remain POSIX-tightening-only because they are loop-reachable; if a hard Windows owner-only guarantee is later wanted there, the write paths would need the same split-and-offload treatment #4979 applied (snapshot on the loop, write+lockdown in a thread) -- a larger change than this fix should carry.

Closes #4987
