### PR TITLE
feat(telegram): upload outbound raster images (PR-O3)

### DIFF
--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -551,6 +551,21 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "contiguously -- it is re-scanned here, on the form that actually leaves.",
     ),
     (
+        "Telegram transformed image text",
+        "telegram/renderer.py",
+        "Image-markup removal can join previously separated text into a credential; "
+        "the transformed body is re-scanned before Telegram receives it, on its "
+        "display form, because the reader sees markdown emphasis collapsed.",
+    ),
+    (
+        "Telegram photo caption",
+        "telegram/client.py",
+        "The caption on an uploaded photo, from its markdown alt text. Extraction "
+        "unescapes that text before the wire, reassembling a backslash-escaped "
+        "credential the TurnDriver's stream scan never saw contiguously -- it is "
+        "re-scanned here, before truncation can split a secret and pass a prefix.",
+    ),
+    (
         "Telegram failure reason",
         "telegram/transport_dispatch.py",
         "The bounded failure reason a permanent AcpError surfaces in the chat "

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -25,7 +25,9 @@ from typing import Any, Awaitable, Callable
 
 import aiohttp
 
+from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.metrics.provider import get_recorder
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +53,37 @@ _ALBUM_MAX_MEMBERS = 10
 _ALBUM_MAX_GROUPS = 64
 # Safe chunk boundary (leave room for markdown overhead).
 TELEGRAM_CHUNK_LIMIT = 4000
+
+#: Bot API ceiling for a ``sendPhoto`` upload. Handed to outbound extraction as
+#: its per-file bound, so an oversize image is refused THERE -- keeping its
+#: markdown in the reply text with a reason -- rather than being cut out of the
+#: text and then rejected by Telegram, which is a file the user can neither see
+#: nor find. Bots may push 50 MB through ``sendDocument``; that path is not
+#: wired yet (v1 is raster-images-only), so the photo ceiling is the real one.
+TELEGRAM_PHOTO_MAX_BYTES = 10 * 1024 * 1024
+
+#: Caption length for a media message. Far below the 4096 text cap, and Telegram
+#: rejects the whole upload when it is exceeded rather than truncating.
+TELEGRAM_CAPTION_MAX = 1024
+
+#: References considered per sealed segment. Telegram uploads one photo per call,
+#: so there is no per-message attachment cap to mirror; this bounds how many
+#: pictures one answer can post before the rest are refused WITH a reason.
+TELEGRAM_MAX_FILES_PER_MESSAGE = 10
+
+#: Aggregate byte budget for one sealed segment. Not a Bot API limit (each photo
+#: is its own request) -- it is the MEMORY bound, because extraction holds every
+#: file's bytes at once and 10 x 10 MiB would be 100 MiB resident per seal.
+TELEGRAM_MAX_TOTAL_UPLOAD_BYTES = 25 * 1024 * 1024
+
+#: Extension per sniffed raster type, for the synthetic upload filename.
+_MIME_EXT = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/bmp": "bmp",
+}
 
 #: sendRichMessage markdown payload limit (Bot API 10.1 Rich Messages). Far
 #: larger than sendMessage's 4096. The rich path carries the segment's raw
@@ -79,6 +112,21 @@ _TG_HTML_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^>]*>")
 #: Longest HTML entity we expect ("&blockquote;"-class names are not used by the
 #: renderer, but stay generous so a cut never lands inside "&amp;"/"&#1234;").
 _MAX_ENTITY_LEN = 12
+
+
+def _safe_caption(alt: str) -> str:
+    """Redact an alt-derived photo caption, then truncate.
+
+    Redaction FIRST: truncating first could cut a secret in half and let the
+    surviving prefix through, and the two operations do not commute. The display
+    form is what is scanned because the caption reaches the reader with markdown
+    emphasis collapsed, so a credential written ``AKIA*IDENT*IFIER`` is separated
+    to a raw byte scan and contiguous to the person reading it.
+    """
+    out, _ = redact_for_display(
+        alt, lambda s: redact_credentials(redact_exfiltration_urls(s)[0])[0]
+    )
+    return out[:TELEGRAM_CAPTION_MAX]
 
 
 def _cut_points(text: str) -> list[tuple[int, int, int]]:
@@ -417,6 +465,73 @@ class TelegramClient:
             params.pop("parse_mode", None)
             result = await self._api("sendMessage", params)
         return result.get("message_id") if result else None
+
+    async def send_photo(
+        self,
+        chat_id: int,
+        data: bytes,
+        mime: str,
+        *,
+        caption: str = "",
+        message_thread_id: int | None = None,
+    ) -> int | None:
+        """Upload one raster as a photo (``sendPhoto``). Returns the message_id.
+
+        Takes BYTES, never a path. The bytes have already cleared the outbound
+        extraction gates (denylist, symlink refusal, descriptor-pinned read,
+        magic-byte sniff) against one inode, and re-opening the path here would
+        resolve the name a second time -- anything able to write that directory
+        in between could substitute what gets sent.
+
+        Multipart rather than JSON because that is the only way to hand the Bot
+        API bytes it does not already hold: a JSON ``photo`` field must be a URL
+        or an existing ``file_id``. Everything else about the call -- the shared
+        session, the proxy, the 429 back-off, the duration metric, the token-free
+        error logging -- rides the same :meth:`_api` path as every other method.
+
+        The filename is SYNTHESIZED from the sniffed ``mime``, not carried over
+        from the source path. Telegram re-encodes a photo and serves it under its
+        own file id, so the original name buys the reader nothing -- while putting
+        an agent-influenced string into a ``Content-Disposition`` header. A name
+        derived from the type that was already proven by magic bytes cannot carry
+        anything untrusted at all, which is cheaper than sanitizing one.
+
+        ``caption`` is the reply's markdown alt text: untrusted text heading for
+        the wire, so it is redacted HERE rather than trusted from the caller --
+        this method is the one boundary every upload path crosses. Redaction runs
+        on the DISPLAY form, because Telegram collapses formatting for the reader
+        and a credential split by emphasis markers is invisible to a raw scan.
+        It is then truncated to :data:`TELEGRAM_CAPTION_MAX` (Telegram rejects
+        the whole call above it) and sent as plaintext: a stray ``<`` under
+        ``parse_mode=HTML`` would 400 the upload for no gain.
+
+        Returns None on failure so the caller can report the file as undelivered
+        rather than dropping it silently.
+        """
+        filename = f"image.{_MIME_EXT.get(mime, 'bin')}"
+        safe_caption = _safe_caption(caption)
+
+        def _form() -> aiohttp.FormData:
+            # A factory, not a value: aiohttp consumes a FormData on write, and
+            # reusing one for _api's 429 retry raises "Form data has been
+            # processed already" -- which would turn a routine rate limit into a
+            # lost upload.
+            form = aiohttp.FormData()
+            form.add_field("chat_id", str(chat_id))
+            if message_thread_id is not None:
+                form.add_field("message_thread_id", str(message_thread_id))
+            if safe_caption:
+                form.add_field("caption", safe_caption)
+            form.add_field(
+                "photo",
+                data,
+                filename=filename,
+                content_type="application/octet-stream",
+            )
+            return form
+
+        result = await self._api("sendPhoto", {}, timeout=120, form=_form)
+        return result.get("message_id") if isinstance(result, dict) else None
 
     async def send_rich_message(
         self,
@@ -1080,6 +1195,7 @@ class TelegramClient:
         *,
         record: bool = True,
         err_out: dict | None = None,
+        form: Callable[[], Any] | None = None,
     ) -> Any:
         """Call a Bot API method. Returns the 'result' field or None on error.
 
@@ -1093,6 +1209,12 @@ class TelegramClient:
         PERMANENT failure (the method does not exist on this server) apart from
         a transient one (rate limit, network), so they can stop re-probing an
         unsupported method without disabling it on a blip.
+
+        ``form``, when supplied, builds a multipart body used INSTEAD of the JSON
+        ``params`` -- the only shape that can carry bytes the Bot API does not
+        already hold (see :meth:`send_photo`). It is a factory rather than a
+        value because aiohttp consumes a ``FormData`` on write, so the 429 retry
+        above needs a fresh one.
         """
         session = await self._ensure_session()
 
@@ -1111,7 +1233,8 @@ class TelegramClient:
             try:
                 async with session.post(
                     url,
-                    json=params,
+                    json=None if form is not None else params,
+                    data=form() if form is not None else None,
                     proxy=self._proxy,
                     timeout=aiohttp.ClientTimeout(total=timeout),
                 ) as resp:

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -26,14 +26,32 @@ from __future__ import annotations
 import asyncio
 import html
 import logging
+import os
 import re
 import time
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
+from kiro_crew.messaging.display_safety import redact_for_display
+from kiro_crew.messaging.outbound_files import (
+    ExtractLimits,
+    OutboundFile,
+    Rejection,
+    extract_local_refs_off_loop,
+    hide_local_refs,
+    protected_ref_spans,
+)
 from kiro_crew.messaging.renderer import Renderer, apply_options_cap
 from kiro_crew.messaging.transport import TransportCapabilities
-from kiro_crew.telegram.client import TELEGRAM_RICH_MAX_CHARS
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import sel
+from kiro_crew.telegram.client import (
+    TELEGRAM_MAX_FILES_PER_MESSAGE,
+    TELEGRAM_MAX_TOTAL_UPLOAD_BYTES,
+    TELEGRAM_PHOTO_MAX_BYTES,
+    TELEGRAM_RICH_MAX_CHARS,
+)
 
 if TYPE_CHECKING:
     from kiro_crew.telegram.client import TelegramClient
@@ -59,6 +77,38 @@ _EDIT_THROTTLE_S = 1.0
 
 # Interactive approval wait; deny-by-default when it elapses with no press.
 _APPROVAL_TIMEOUT_S = 300.0
+
+# Channel ceilings handed to outbound extraction. A file Telegram would reject is
+# refused THERE, while its markdown is still in the text and can carry a reason --
+# refusing after the markup was cut out is a picture the user can neither see nor
+# find. Deliberately separate symbols from image_artifacts' identically-shaped
+# budgets, so retuning one resource cannot silently retune the other.
+_UPLOAD_LIMITS = ExtractLimits(
+    max_files=TELEGRAM_MAX_FILES_PER_MESSAGE,
+    max_total_bytes=TELEGRAM_MAX_TOTAL_UPLOAD_BYTES,
+    max_file_bytes=TELEGRAM_PHOTO_MAX_BYTES,
+)
+
+# Refusal lines shown before the rest collapse into one "…and N more".
+_MAX_REJECTION_LINES = 3
+
+
+def _redact_all(text: str) -> str:
+    text, _ = redact_exfiltration_urls(text)
+    return redact_credentials(text)[0]
+
+
+def _redact_transformed(text: str) -> str:
+    """Re-scan text whose image markup was just removed.
+
+    Cutting a span out JOINS the characters that surrounded it, so two halves of
+    a credential the upstream stream scan saw as separated can become contiguous
+    here. Scanned on the display form because Telegram collapses markdown for the
+    reader, which hides a split the raw bytes still show.
+    """
+    text, _ = redact_for_display(text, _redact_all)
+    return text
+
 
 # Fallback placeholder for a turn that failed without a user-safe reason. The
 # retry wording is only correct for transient failures; a permanent failure
@@ -103,7 +153,7 @@ _STEER_MARKER_RE = re.compile(r"\[STEERING\b[^\]]*\]", re.IGNORECASE)
 _STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]]*)\]", re.IGNORECASE)
 
 
-def _strip_steering(text: str) -> str:
+def _strip_steering(text: str, *, keep_edges: bool = False) -> str:
     """Remove kiro-cli's inline ``[STEERING …]`` steer-ack marker from output.
 
     Also strips an UNCLOSED trailing ``[STEERING …`` (still streaming, no closing
@@ -111,11 +161,14 @@ def _strip_steering(text: str) -> str:
     and then vanishes when ``on_done`` finally strips the completed marker — a
     jarring show-then-vanish. Stripping the partial marker keeps the draft in
     sync with the final message.
+
+    ``keep_edges`` skips the trailing ``strip()`` -- see ``_strip_hr`` for why the
+    outbound-extraction path must not lose leading whitespace.
     """
     cleaned = _STEER_MARKER_RE.sub("", text)  # complete markers anywhere
     cleaned = re.sub(r"\[STEERING\b[^\]]*$", "", cleaned)  # unclosed, still streaming
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)  # collapse gaps left behind
-    return cleaned.strip()
+    return cleaned if keep_edges else cleaned.strip()
 
 
 def _neutralize_md(raw: str) -> str:
@@ -126,13 +179,18 @@ def _neutralize_md(raw: str) -> str:
     return re.sub(r"[*_`\[\]()]", "", t)
 
 
-def _strip_hr(text: str) -> str:
+def _strip_hr(text: str, *, keep_edges: bool = False) -> str:
     """Drop Markdown horizontal rules (``---`` / ``***`` / ``___`` on their own
     line) — they render as literal dashes on Telegram and just add noise.
     Fenced code blocks are stashed first so a standalone ``---`` INSIDE a code
     block (e.g. a YAML document separator) is never touched. An unclosed fence
     mid-stream isn't stashed, but live frames are throttled previews — the
-    final seal sees the closed fence and preserves its content."""
+    final seal sees the closed fence and preserves its content.
+
+    ``keep_edges`` skips the trailing ``strip()``. Display paths want it (a bubble
+    should not open with blank lines), but outbound image extraction MUST NOT:
+    four leading spaces are what mark an image reference as a code literal, so
+    classifying stripped text would upload a picture the author only displayed."""
     stash: list[str] = []
 
     def _keep(fragment: str) -> str:
@@ -145,7 +203,7 @@ def _strip_hr(text: str) -> str:
     out = re.sub(r"(?m)^[ ]{0,3}([-*_])\1{2,}[ \t]*$", "", text)
     out = re.sub(r"\n{3,}", "\n\n", out)
     out = re.sub(r"\x00H(\d+)\x00", lambda m: stash[int(m.group(1))], out)
-    return out.strip()
+    return out if keep_edges else out.strip()
 
 
 def build_inline_keyboard(options: list[str]) -> dict | None:
@@ -627,6 +685,79 @@ def _split_markdown_table_aware(text: str, rendered_limit: int, rich_limit: int)
     return [c for c in out if c.strip()]
 
 
+def _utf16_len(text: str) -> int:
+    """Length in UTF-16 code units, which is what Telegram's cap counts.
+
+    An astral code point (emoji, CJK extensions) is one ``len()`` but TWO units,
+    so a code-point budget lets an emoji-dense payload build a message Telegram
+    rejects. Note the channel-wide mismatch this does NOT fix: every other limit
+    in this client still budgets code points (see ``truncate_html_safe``), which
+    predates this helper and is tracked separately. The recovery path is scoped
+    here because its consequence is LOST DATA -- the rejected chunk is the only
+    remaining copy of a reference -- rather than a clipped display frame.
+    """
+    return len(text) + sum(1 for ch in text if ord(ch) > 0xFFFF)
+
+
+def _utf16_cut(text: str, limit: int) -> int:
+    """Longest code-point prefix length whose UTF-16 length fits ``limit``.
+
+    Indexing a ``str`` cannot split a surrogate pair (Python stores code points),
+    so the returned prefix is always well-formed.
+    """
+    used = 0
+    for index, ch in enumerate(text):
+        used += 2 if ord(ch) > 0xFFFF else 1
+        if used > limit:
+            return index
+    return len(text)
+
+
+def _cap_chunks(text: str, limit: int) -> list[str]:
+    """Split ``text`` into messages of at most ``limit`` UTF-16 units, losing nothing.
+
+    For the failed-upload recovery post, whose text is a reconstructed list of
+    image references rather than authored prose. Extraction already removed those
+    references from the answer, so this post is their ONLY remaining copy: a slice
+    to one message drops every reference past the cap, and a chunk OVER Telegram's
+    cap is rejected with ``send_message`` returning None rather than raising --
+    the same loss from the opposite direction, which is why the budget is measured
+    in the units the platform enforces.
+
+    Packs whole lines while they fit, so a reference stays intact when it can, and
+    hard-cuts only a line that exceeds the cap by itself (a long alt text). The
+    newline BETWEEN packed references is consumed by the message boundary that
+    replaces it; every character of every reference survives.
+
+    Deliberately not the shared markdown splitter: there is no authored structure
+    to preserve here, and its documented fence-scaffolding allowance can return a
+    chunk longer than the limit it was given -- which is the defect this prevents.
+    """
+    # Floor of 2: one astral code point costs 2 units, so a 1-unit budget could
+    # never emit it and the hard-cut loop below would not advance.
+    limit = max(2, limit)
+    out: list[str] = []
+    current = ""
+    for line in text.split("\n"):
+        while _utf16_len(line) > limit:
+            if current:
+                out.append(current)
+                current = ""
+            cut = _utf16_cut(line, limit)
+            out.append(line[:cut])
+            line = line[cut:]
+        candidate = f"{current}\n{line}" if current else line
+        if _utf16_len(candidate) <= limit:
+            current = candidate
+            continue
+        if current:
+            out.append(current)
+        current = line
+    if current:
+        out.append(current)
+    return out
+
+
 def _strip_md(text: str) -> str:
     """Flatten Markdown to clean plaintext for the streaming typewriter frames
     (and as the safe fallback if an HTML final edit is ever rejected) -- avoids
@@ -692,6 +823,8 @@ class TelegramRenderer(Renderer):
         *,
         session_key: str = "",
         message_thread_id: int | None = None,
+        uploads_allowed: bool = True,
+        upload_root: str = "",
     ) -> None:
         super().__init__(capabilities)
         self._client = client
@@ -702,6 +835,14 @@ class TelegramRenderer(Renderer):
         self._thread_id = message_thread_id
         self._session_key = session_key
         self._buf: list[str] = []
+        # Outbound image upload. ``_upload_root`` is the acquired provider's own
+        # cwd (authorized post-acquire, never model output); a relative or empty
+        # root disables uploads outright. ``_segment_uploads_safe`` is cleared
+        # when a length rotation cut the segment in a way that could change
+        # whether a retained reference is literal -- see _rotate_on_length.
+        self._upload_root = upload_root if os.path.isabs(upload_root) else ""
+        self._uploads_allowed = uploads_allowed
+        self._segment_uploads_safe = True
         self._last_tool = ""
         # Transient tool-activity footer ("🔧 {tool}…") shown ONLY on live
         # streaming frames — never stored in _buf, so seals/finals stay clean.
@@ -815,6 +956,10 @@ class TelegramRenderer(Renderer):
         self._seal_count += 1
         self._pending_chip = chip or ""
         self._buf = []
+        # A new segment starts here, so an unsafe cut in the previous one stops
+        # counting against it. The flag is segment-scoped, not rotation-scoped:
+        # once cleared it stays cleared through the segment's own final seal.
+        self._segment_uploads_safe = True
         if sealed:
             self._open_new_message()
 
@@ -851,7 +996,12 @@ class TelegramRenderer(Renderer):
         Table-bearing segments budget against the RICH cap instead: they seal
         through sendRichMessage, so holding the whole table in one segment is
         what keeps it one rich message rather than a rich head followed by
-        header-less pipe-text continuations."""
+        header-less pipe-text continuations.
+
+        A segment carrying a local image reference is cut BEFORE that reference
+        and the remainder is kept as the live tail, so the reference reaches the
+        semantic seal (the only place that may extract) with its source context
+        intact. Splitter output is never an extraction input."""
         limit = self._limit()
         rendered_cap = self._rendered_limit()
         raw = "".join(self._buf)
@@ -862,6 +1012,18 @@ class TelegramRenderer(Renderer):
             if _rendered_len(raw) <= rendered_cap:
                 return
         raw, protocol_suffix = split_trailing_protocol_suffix(raw)
+        held_tail: str | None = None
+        if self._uploads_enabled() and self._segment_uploads_safe:
+            spans = await asyncio.to_thread(protected_ref_spans, raw)
+            if spans:
+                # spans is sorted, so spans[0] is the earliest complete or
+                # still-arriving reference. At offset 0 the whole buffer is that
+                # span: there is nothing ahead of it to seal, so keep streaming.
+                hold_at = spans[0][0]
+                if hold_at == 0:
+                    self._buf = [raw + protocol_suffix]
+                    return
+                raw, held_tail = raw[:hold_at], raw[hold_at:]
         if _has_table(raw):
             # Table segments seal through sendRichMessage, whose payload budget
             # is far larger than the HTML render cap, so they are budgeted
@@ -871,6 +1033,10 @@ class TelegramRenderer(Renderer):
             # overflow the HTML budget fit ONE rich message and never split.
             rich_cap = self._rich_limit()
             if len(raw) <= rich_cap:
+                if held_tail is not None:
+                    # Held for a reference, and what is left fits: nothing seals,
+                    # so put the buffer back whole rather than dropping the tail.
+                    self._buf = [raw + held_tail + protocol_suffix]
                 return
             # The buffer's final line may still be STREAMING: its next token
             # can arrive after this rotation. A partial row that has not yet
@@ -898,15 +1064,37 @@ class TelegramRenderer(Renderer):
         # wrong for the tail we keep streaming into: every later token would land
         # after that closer, rendering outside <pre>, and the model's real closing
         # fence would then show up literally. Drop it from the retained tail.
-        if chunks and raw.count("```") % 2 == 1:
+        # Skipped when a reference was held: every chunk here is sealed and the
+        # retained tail is the held remainder, which the splitter never touched.
+        if held_tail is None and chunks and raw.count("```") % 2 == 1:
             tail = chunks[-1].rstrip()
             if tail.endswith("```"):
                 chunks[-1] = tail[:-3].rstrip("\n")
-        for ch in chunks[:-1]:
+        if held_tail is not None:
+            sealed, tail_text = chunks, held_tail
+        else:
+            sealed, tail_text = chunks[:-1], (chunks[-1] if chunks else "")
+        if held_tail is None and sealed and self._uploads_enabled() and self._segment_uploads_safe:
+            # A cut can change whether a LATER reference in the retained tail is
+            # a literal: an inline-code run whose opener rotated away leaves its
+            # contents looking like live markup. Probe it with a synthetic
+            # reference plus the prefix's backtick runs at the cut point and
+            # require that EXACT offset to survive as a protected span -- a
+            # different reference surviving would mask the sentinel going
+            # literal. A line longer than the whole budget cannot be cut cleanly
+            # at all. Either way uploads stop for the rest of the segment, which
+            # keeps the markup visible instead of guessing.
+            probe_at = len(prefix := raw.removesuffix(tail_text))
+            probe = prefix + "![x](/tmp/x.png)" + " ".join(re.findall(r"`+", prefix)) + tail_text
+            spans = await asyncio.to_thread(protected_ref_spans, probe)
+            lost = raw.endswith(tail_text) and probe_at not in dict(spans)
+            if lost or any(len(line) > limit for line in raw.splitlines(True)):
+                self._segment_uploads_safe = False
+        for ch in sealed:
             self._buf = [ch]
-            await self._seal_current()
+            await self._seal_current(extract_uploads=False)
             self._open_new_message()
-        self._buf = [(chunks[-1] if chunks else "") + protocol_suffix]
+        self._buf = [tail_text + protocol_suffix]
 
     def _open_new_message(self) -> None:
         """Next render creates a fresh message instead of editing the old one."""
@@ -917,6 +1105,15 @@ class TelegramRenderer(Renderer):
         """Current segment's markdown source (chip already seeded into _buf),
         with the steer marker and horizontal-rule noise stripped."""
         return _strip_hr(_strip_steering("".join(self._buf)))
+
+    def _segment_source(self) -> str:
+        """``_segment_text`` without the edge trim -- the extraction input.
+
+        Classification depends on leading whitespace (four spaces mark an indented
+        code block), so the trimmed display form is the wrong text to hand the
+        extractor: it turns a displayed literal into a live reference.
+        """
+        return _strip_hr(_strip_steering("".join(self._buf), keep_edges=True), keep_edges=True)
 
     async def _stream_live(self, *, force: bool = False) -> None:
         """Throttled in-place edit of the current segment (plaintext, so partial
@@ -931,6 +1128,12 @@ class TelegramRenderer(Renderer):
         # partial) from live frames — it is an internal directive, extracted
         # into the inline keyboard at finalization.
         seg, _ = _extract_options(self._segment_text())
+        if self._uploads_enabled() and self._segment_uploads_safe:
+            # The seal will replace this markup with the picture itself, so a
+            # live frame must not flash the path first. Off-loop because it walks
+            # fence spans; re-redacted because cutting a span joins what
+            # surrounded it and can reassemble a split credential.
+            seg = _redact_transformed(await asyncio.to_thread(hide_local_refs, seg))
         body = _strip_md(seg)
         footer = f"🔧 {self._tool}…" if self._tool else ""
         if footer:
@@ -951,6 +1154,157 @@ class TelegramRenderer(Renderer):
                 self._stream_mid = mid
         else:
             await self._client.edit_message(self._chat_id, self._stream_mid, text)
+
+    def authorize_upload_root(self, root: str) -> None:
+        """Authorize the provider's resolved cwd; invalid roots disable uploads."""
+        self._upload_root = root if os.path.isabs(root) else ""
+
+    def _uploads_enabled(self) -> bool:
+        """Require transport capability, an unrestricted session, and a trusted root."""
+        return (
+            bool(self.capabilities.files_outbound)
+            and self._uploads_allowed
+            and bool(self._upload_root)
+        )
+
+    async def _extract_uploads(self, text: str) -> tuple[str, list[OutboundFile]]:
+        """Extract each sealed segment once, off-loop and fail-soft."""
+        try:
+            result = await extract_local_refs_off_loop(
+                text, within_root=self._upload_root, limits=_UPLOAD_LIMITS
+            )
+        except Exception:
+            logger.warning("telegram: outbound file extraction failed", exc_info=True)
+            return text, []
+        if result.rejections:
+            sel().log_api_access(
+                caller=self._session_key or "telegram",
+                operation="telegram_renderer.upload_files",
+                outcome="denied",
+                source="telegram",
+                resources=f"{len(result.rejections)} rejection(s)",
+                error=",".join(sorted({item.reason for item in result.rejections})),
+            )
+        body = result.rewritten_text.strip()
+        if not body and not result.files:
+            body = text
+        if result.rejections:
+            body = self._append_rejections(body, result.rejections)
+        body = _redact_transformed(body)
+        if result.files:
+            sel().log_api_access(
+                caller=self._session_key or "telegram",
+                operation="telegram_renderer.upload_files",
+                outcome="allowed",
+                source="telegram",
+                resources=f"{len(result.files)} file(s)",
+            )
+        return body, result.files
+
+    def _append_rejections(self, body: str, rejections: list[Rejection]) -> str:
+        """Append refusal reasons only when the answer budget permits."""
+        for rejection in rejections:
+            logger.info("telegram: local image not uploaded (%s)", rejection.reason)
+        lines = [f"⚠️ {rejection}" for rejection in rejections[:_MAX_REJECTION_LINES]]
+        if len(rejections) > _MAX_REJECTION_LINES:
+            lines.append(f"⚠️ …and {len(rejections) - _MAX_REJECTION_LINES} more")
+        note = "\n".join(lines)
+        if len(body) + len(note) + 2 > self._limit():
+            return body
+        return f"{body}\n\n{note}"
+
+    async def _deliver(self, what: str, op: Awaitable[Any]) -> Any:
+        """Run ONE delivery operation in isolation. Returns None on ANY failure.
+
+        THE OUTBOUND FAILURE INVARIANT, which every send on this path routes
+        through: no single delivery operation's failure -- whether it RETURNS
+        None/False or RAISES -- may cascade into the loss of a sibling delivery.
+        Every extracted reference reaches the channel as a photo, as recovered
+        markup, or at minimum as a logged loss; none disappears silently, and
+        none is skipped because a different operation failed.
+
+        Both failure shapes collapse to one falsey answer here because the client
+        reports them interchangeably and the caller cannot tell them apart:
+        ``_api`` returns None for an API-level error, but RAISES on a non-JSON
+        body -- a proxy's HTML error page makes ``resp.json`` throw a ValueError
+        that ``_api``'s ``(ClientError, TimeoutError)`` clause does not catch. A
+        caller handling only None therefore still loses the siblings behind that
+        raise, which is the defect this seam closes. Widening ``_api``'s clause
+        would change every Telegram call site's semantics, so the isolation lives
+        in this path rather than in the shared client.
+        """
+        try:
+            return await op
+        except Exception:
+            logger.warning("telegram: %s failed", what, exc_info=True)
+            return None
+
+    async def _upload_photos(self, files: list[OutboundFile]) -> None:
+        """Post each extracted raster, then surface whatever did not arrive.
+
+        One ``sendPhoto`` per file rather than a media group: a group shares a
+        single caption, so every alt text but one would be silently discarded,
+        and a group fails as a unit. Every send goes through :meth:`_deliver`, so
+        one photo's failure -- returned OR raised -- cannot abandon the files
+        behind it, and this method NEVER raises: it is also called from a
+        ``finally``, where a raise would replace the text path's own exception.
+
+        A file that did not arrive is REPORTED, never dropped: extraction already
+        cut its markdown out of the sealed text, so silence would leave a reply
+        referring to a picture with neither the picture nor its path. The failed
+        references are re-posted as their original markup -- redacted first, since
+        the join that removal caused can reassemble a credential -- across as many
+        messages as it takes, because this post is their only remaining copy and
+        capping it to one message would drop the references past that cap.
+        """
+        undelivered: list[OutboundFile] = []
+        for outbound in files:
+            sent = await self._deliver(
+                "a photo upload",
+                self._client.send_photo(
+                    self._chat_id,
+                    outbound.data,
+                    outbound.mime,
+                    caption=outbound.alt,
+                    message_thread_id=self._thread_id,
+                ),
+            )
+            if sent is None:
+                undelivered.append(outbound)
+        if not undelivered:
+            return
+        logger.warning(
+            "telegram: %d of %d photo(s) did not arrive; re-posting their markup",
+            len(undelivered),
+            len(files),
+        )
+        # Rebuilt from the extractor's own fields rather than sliced out of the
+        # segment source: the offsets that produced these files were computed
+        # before the rewrite, so indexing the source again would need them
+        # re-derived against text that no longer contains the markup.
+        # Redaction runs on the whole recovery BEFORE it is split, so a credential
+        # spanning what becomes a chunk boundary is still scanned contiguously.
+        # Composition is guarded separately from the sends so that this method
+        # stays total: a failure to BUILD the fallback is itself a logged loss.
+        try:
+            chunks = _cap_chunks(
+                _redact_transformed(
+                    "\n".join(f"![{item.alt}]({item.path})" for item in undelivered)
+                ),
+                self._limit(),
+            )
+        except Exception:
+            logger.warning("telegram: could not compose the markup fallback", exc_info=True)
+            return
+        for chunk in chunks:
+            # Per chunk, not per loop: a rejected OR raising chunk k must not
+            # abandon k+1..N, which are the only remaining copies of their own
+            # references. Both shapes are one falsey answer, so both just log.
+            send = self._client.send_message(
+                self._chat_id, chunk, message_thread_id=self._thread_id
+            )
+            if await self._deliver("a recovery chunk", send) is None:
+                logger.warning("telegram: a recovery chunk did not land; its refs are lost")
 
     async def _seal_without_rich(self, text: str) -> tuple[str, str]:
         """HTML for a seal that cannot use Rich Messages, plus the tail segment.
@@ -986,13 +1340,58 @@ class TelegramRenderer(Renderer):
                     html_text = _md_to_telegram_html(text)
         return html_text, text
 
-    async def _seal_current(self, *, keyboard: dict | None = None) -> None:
+    async def _seal_current(
+        self, *, keyboard: dict | None = None, extract_uploads: bool = True
+    ) -> None:
+        """Seal the current segment, uploading any local images it referenced.
+
+        Only SEMANTIC seals may extract. Length rotations pass
+        ``extract_uploads=False`` and seal their splitter-produced chunks
+        verbatim, because a chunk boundary can land inside markup or strip the
+        context that made a reference literal. Extraction runs on the segment's
+        BYTE-FAITHFUL source -- ``_seal_segment_text`` strips before it renders,
+        and leading indentation is exactly what marks a reference as a code
+        literal, so classifying stripped text would upload a picture the author
+        only displayed.
+
+        Text first, then the photos: the prose is the answer and the pictures
+        illustrate it, so that is the order they should appear in. They are
+        SIBLINGS, not a sequence -- see :meth:`_deliver` for the invariant.
+        """
+        source = self._segment_source()
+        files: list[OutboundFile] = []
+        if extract_uploads and source and self._uploads_enabled() and self._segment_uploads_safe:
+            body, files = await self._extract_uploads(source)
+            self._buf = [body]
+        try:
+            await self._seal_segment_text(keyboard=keyboard, image_only=bool(files))
+        finally:
+            # ``finally``, not ``except``: extraction has already cut the markup
+            # out of the sealed text, so these photos are their references' only
+            # remaining copy and a text-path raise must not skip them -- while the
+            # text exception still propagates to the caller unchanged. Safe in a
+            # finally because ``_upload_photos`` is total, so it cannot replace
+            # the in-flight exception with one of its own.
+            if files:
+                await self._upload_photos(files)
+
+    async def _seal_segment_text(
+        self, *, keyboard: dict | None = None, image_only: bool = False
+    ) -> None:
         """Finalize the current segment: replace its live plaintext with the
         formatted HTML (and optional keyboard). Edits the streamed message in
         place, or sends one if the segment never streamed (e.g. throttled out).
         Empty segments are skipped so a bare steer doesn't post a blank bubble."""
         text = self._segment_text().strip()
         if not text:
+            if image_only and keyboard is None:
+                # The pictures ARE the reply, so no "…" bubble is posted. A live
+                # frame may still be showing the pre-extraction text, though, and
+                # leaving it would strand the markup the upload replaces.
+                if self._stream_mid is not None:
+                    await self._client.delete_message(self._chat_id, self._stream_mid)
+                    self._stream_mid = None
+                return
             if keyboard is None:
                 return
             text = "…"

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -72,7 +72,13 @@ TELEGRAM_CAPABILITIES = TransportCapabilities(
     edit=True,
     reactions=True,  # setMessageReaction — used for the steer-ack receipt
     files_inbound=True,  # photos/documents ingested via telegram/attachments.py
-    files_outbound=False,
+    # Sealed-segment image upload: the renderer extracts local rasters out of a
+    # semantic seal and posts each through client.send_photo (sendPhoto
+    # multipart). The renderer READS this flag in ``_uploads_enabled`` before it
+    # extracts anything, so the flag is the switch rather than a description of
+    # one -- declaring it False makes Telegram keep printing the markdown path,
+    # which is the honest degradation.
+    files_outbound=True,
     rich_blocks=False,
     threads=True,
     max_message_chars=TELEGRAM_CHUNK_LIMIT,

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -375,6 +375,7 @@ class TelegramDispatcher:
             TELEGRAM_CAPABILITIES,
             session_key=session_key,
             message_thread_id=int(thread) if thread else None,
+            uploads_allowed=not self._uploads_restricted(session_key),
         )
         # Same gate as Discord, for the same reason: Telegram also runs its own
         # copy of the turn loop rather than going through ``drive_turn``, so a
@@ -425,6 +426,10 @@ class TelegramDispatcher:
                 model=self._model_pref.get(route) or None,
             )
             _acquired = True
+            # The approved upload root is the acquired provider's OWN cwd, read
+            # here rather than anywhere a reply could influence it. Until this
+            # lands the renderer's root is empty, which disables uploads.
+            renderer.authorize_upload_root(provider.cwd)
             if is_new:
                 await self.sessions.set_channel(session_key, channel_id)
             # Bind this chat as the session's outbound mirror so a turn the user
@@ -1375,6 +1380,40 @@ class TelegramDispatcher:
     def _authorized(self, user_id: int) -> bool:
         # Deny-by-default (callbacks bypass transport.receive, so re-check here).
         return bool(user_id) and bool(self._allowed) and user_id in self._allowed
+
+    def _uploads_restricted(self, session_key: str) -> bool:
+        """True when this session must not ship local file bytes to Telegram.
+
+        Discord's twin (``discord/transport_dispatch._uploads_restricted``) probes
+        a resumed ``dashboard:`` slot's incognito/temporary mode, because a Discord
+        conversation can be BOUND to one, and a session the user expected to leave
+        no trace must not post its local files into a channel others can read.
+
+        Telegram cannot resolve that mode: it has no session-resume path and no
+        ``dashboard_state`` handle to read a slot from, so the probe Discord runs
+        has nothing here to run against. Rather than copy a branch that cannot
+        execute, this refuses to guess -- a ``dashboard:`` key is denied outright,
+        which is STRICTER than Discord (it denies a non-restricted dashboard
+        session too) and is the safe direction for a mode we cannot read. Every
+        key this dispatcher builds is ``telegram:``- or ``unified:``-scoped
+        (``build_dm_session_key``), so nothing legitimate is denied today; the
+        branch exists so whatever binds Telegram to a dashboard session later is
+        fail-closed instead of silently allowed.
+
+        Hoisting the incognito probe into a channel-neutral gate is deferred to
+        #4919; when it lands it REPLACES this predicate rather than sitting beside
+        it. The denial is SEL-audited so the ceiling is observable.
+        """
+        if not session_key.startswith("dashboard:"):
+            return False
+        sel().log_api_access(
+            caller=session_key,
+            operation="telegram_dispatch.upload_files",
+            outcome="denied",
+            source="telegram",
+            error="restricted_session",
+        )
+        return True
 
     def _resolve_agent(self) -> str:
         return self.agent or self.cfg.agent.default_agent or _DEFAULT_KIROCREW_AGENT

--- a/test/test_capability_ledger.py
+++ b/test/test_capability_ledger.py
@@ -126,11 +126,14 @@ class TestCorrectedDeclarations:
         # answer for one of them.
         from kiro_crew.discord.transport import DISCORD_CAPABILITIES
         from kiro_crew.slack.transport import SLACK_CAPABILITIES
+        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
 
         assert DISCORD_CAPABILITIES.files_inbound is True
         assert DISCORD_CAPABILITIES.files_outbound is True
         assert SLACK_CAPABILITIES.files_inbound is True
         assert SLACK_CAPABILITIES.files_outbound is True
+        assert TELEGRAM_CAPABILITIES.files_inbound is True
+        assert TELEGRAM_CAPABILITIES.files_outbound is True
 
     def test_max_buttons_declares_totals_the_renderers_ship(self) -> None:
         # The field is TOTAL choices, not a per-row layout number. The old

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -10,6 +10,7 @@ turn + callback routing (transport_dispatch.py).
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 import time
 from contextlib import contextmanager
@@ -215,7 +216,10 @@ class _Ev:
 
 
 class FakeProvider:
-    supports_steer = True
+    # ``cwd`` is part of the real provider interface: the dispatcher authorizes
+    # the renderer's outbound-upload root from it, so a double without it fails
+    # every turn on an AttributeError rather than on anything under test.
+    supports_steer, cwd = True, os.getcwd()
 
     def __init__(self, reply: str = "Answer", models: list | None = None) -> None:
         self._reply = reply

--- a/test/test_telegram_attachments.py
+++ b/test/test_telegram_attachments.py
@@ -33,8 +33,15 @@ class TestCapabilityFlag:
     def test_files_inbound_enabled(self):
         assert TELEGRAM_CAPABILITIES.files_inbound is True
 
-    def test_files_outbound_still_disabled(self):
-        assert TELEGRAM_CAPABILITIES.files_outbound is False
+    def test_files_outbound_enabled(self):
+        # Backed by sendPhoto multipart: the renderer extracts a sealed segment's
+        # local rasters and posts each through client.send_photo. Assert the verb
+        # exists too -- the flag alone is what `_uploads_enabled` reads, so a
+        # declaration without an implementation would be a silent drop.
+        from kiro_crew.telegram.client import TelegramClient
+
+        assert TELEGRAM_CAPABILITIES.files_outbound is True
+        assert hasattr(TelegramClient, "send_photo")
 
 
 # ── Client _dispatch extracts attachments from Telegram updates ────────────────

--- a/test/test_telegram_outbound_files.py
+++ b/test/test_telegram_outbound_files.py
@@ -1,0 +1,751 @@
+"""Telegram's outbound raster upload: the gate, the seal, and the wire.
+
+``test_outbound_files.py`` pins the channel-neutral extractor. This module pins
+Telegram's consumer of it -- the renderer's seal-time extraction and
+``client.send_photo``'s multipart -- and the invariants a plausible refactor
+breaks silently:
+
+* only a SEMANTIC seal extracts; a length rotation seals its chunks verbatim
+* the classification input is BYTE-FAITHFUL, so an indented code literal that
+  merely looks like an image reference is not uploaded
+* live frames never flash a path the seal is about to replace with the picture
+* the BYTES travel -- nothing re-opens ``OutboundFile.path``
+* a refusal or a failed upload keeps the markup, so the path stays visible
+* the caption is redacted at the wire, before truncation can split a secret
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+import struct
+import zlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.messaging.outbound_files import OutboundFile
+from kiro_crew.telegram.client import (
+    TELEGRAM_CAPTION_MAX,
+    TELEGRAM_MAX_FILES_PER_MESSAGE,
+    TELEGRAM_MAX_TOTAL_UPLOAD_BYTES,
+    TELEGRAM_PHOTO_MAX_BYTES,
+    TelegramClient,
+)
+from kiro_crew.telegram.renderer import _UPLOAD_LIMITS, TelegramRenderer
+from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+
+_NO_UPLOAD_CAPS = dataclasses.replace(TELEGRAM_CAPABILITIES, files_outbound=False)
+
+
+def _utf16(text: str) -> int:
+    """Length in UTF-16 code units -- the units Telegram's cap actually counts."""
+    return len(text.encode("utf-16-le")) // 2
+
+
+def _png(pad: int = 0) -> bytes:
+    """A real, minimal PNG -- the extractor sniffs magic bytes, not extensions."""
+
+    def chunk(kind: bytes, body: bytes) -> bytes:
+        crc = struct.pack(">I", zlib.crc32(kind + body) & 0xFFFFFFFF)
+        return struct.pack(">I", len(body)) + kind + body + crc
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(b"\x00" * 4))
+        + chunk(b"tEXt", b"pad\x00" + b"x" * pad)
+        + chunk(b"IEND", b"")
+    )
+
+
+class FakeClient:
+    """Captures the Bot API calls the renderer makes, including sendPhoto."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.edits: list[str] = []
+        self.photos: list[dict[str, Any]] = []
+        self.deleted: list[int] = []
+        self.rich_sent: list[str] = []
+        self.rich_fails = True  # no table in these fixtures; keep the HTML path
+        self.photo_results: list[int | None] = []
+        self.photo_raises = False
+        #: Per-call outcomes for send_message, consumed in order. An Exception
+        #: entry is RAISED, None is returned as-is, anything else falls through
+        #: to a normal id -- so a fault can be aimed at one specific send.
+        self.msg_results: list[Any] = []
+        #: ``sent``/``photos`` record what was ATTEMPTED (today's meaning, which
+        #: is what proves a later sibling still ran). These two record only what
+        #: actually LANDED, which is what reference accounting reads.
+        self.msg_delivered: list[str] = []
+        self.photo_delivered: list[str] = []
+        self._mid = 100
+
+    def _outcome(self, queue: list[Any]) -> Any:
+        """Next queued outcome: raise an Exception entry, else return it."""
+        if not queue:
+            self._mid += 1
+            return self._mid
+        result = queue.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def send_typing(self, chat_id: int, *, message_thread_id: Any = None) -> None:
+        return None
+
+    async def send_message(self, chat_id: int, text: str, **kw: Any) -> int:
+        await asyncio.sleep(0)
+        # Recorded BEFORE the outcome so an injected raise still proves the call
+        # happened -- that is what "chunk k+1 was attempted" is read from.
+        self.sent.append(text)
+        result = self._outcome(self.msg_results)
+        self.msg_delivered.append(text)
+        return result
+
+    async def edit_message(self, chat_id: int, message_id: int, text: str, **kw: Any) -> bool:
+        await asyncio.sleep(0)
+        self.edits.append(text)
+        return True
+
+    async def send_rich_message(self, chat_id: int, text: str, **kw: Any) -> int | None:
+        self.rich_sent.append(text)
+        return None if self.rich_fails else self._mid
+
+    async def delete_message(self, chat_id: int, message_id: int) -> None:
+        self.deleted.append(message_id)
+
+    async def send_photo(
+        self,
+        chat_id: int,
+        data: bytes,
+        mime: str,
+        *,
+        caption: str = "",
+        message_thread_id: Any = None,
+    ) -> int | None:
+        await asyncio.sleep(0)
+        if self.photo_raises:
+            raise RuntimeError("network")
+        self.photos.append({"data": data, "mime": mime, "caption": caption})
+        result = self._outcome(self.photo_results)
+        self.photo_delivered.append(caption)
+        return result
+
+
+def _renderer(cli: FakeClient, root: Path, **kw: Any) -> TelegramRenderer:
+    caps = kw.pop("capabilities", TELEGRAM_CAPABILITIES)
+    return TelegramRenderer(
+        cli,  # type: ignore[arg-type]
+        55,
+        caps,
+        session_key="telegram:1:0",
+        upload_root=str(root),
+        **kw,
+    )
+
+
+def _image(tmp_path: Path, name: str = "chart.png", pad: int = 0) -> Path:
+    path = tmp_path / name
+    path.write_bytes(_png(pad))
+    return path
+
+
+async def _seal_with(r: TelegramRenderer, files: list[OutboundFile]) -> None:
+    """Drive one semantic seal whose extraction yielded exactly ``files``.
+
+    Stubs extraction rather than writing real images, so a fault-injection case
+    controls the file set precisely and the assertions read the delivery surface
+    instead of the extractor.
+    """
+    body = "Here they are:"
+    r._buf = [body]
+    r._extract_uploads = AsyncMock(return_value=(body, files))  # type: ignore[method-assign]
+    await r._seal_current()
+
+
+async def _turn(r: TelegramRenderer, text: str) -> None:
+    await r.on_text_chunk(text)
+    await r.on_done()
+
+
+# ── The three-way gate ────────────────────────────────────────────────────────
+
+
+class TestUploadGate:
+    def test_a_reference_is_uploaded_and_its_markup_leaves_the_text(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"Here it is:\n\n![Q3 revenue]({img})"))
+
+        assert [p["mime"] for p in cli.photos] == ["image/png"]
+        assert cli.photos[0]["data"] == img.read_bytes()
+        assert all(str(img) not in body for body in cli.sent + cli.edits)
+
+    def test_the_capability_flag_is_the_switch(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path, capabilities=_NO_UPLOAD_CAPS)
+
+        asyncio.run(_turn(r, f"Look: ![alt]({img})"))
+
+        # Honest degradation: the path stays printed rather than silently dropped.
+        assert cli.photos == []
+        assert any(str(img) in body for body in cli.sent + cli.edits)
+
+    def test_a_restricted_session_uploads_nothing(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path, uploads_allowed=False)
+
+        asyncio.run(_turn(r, f"Look: ![alt]({img})"))
+
+        assert cli.photos == []
+        assert any(str(img) in body for body in cli.sent + cli.edits)
+
+    @pytest.mark.parametrize("root", ["", "relative/dir"])
+    def test_an_untrusted_root_disables_uploads(self, tmp_path: Path, root: str) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        r.authorize_upload_root(root)  # what a bad provider cwd would supply
+
+        asyncio.run(_turn(r, f"Look: ![alt]({img})"))
+
+        assert cli.photos == []
+
+    def test_a_file_outside_the_root_is_refused_with_its_markup_kept(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        outside = tmp_path / "sub"
+        outside.mkdir()
+        r = _renderer(cli, outside)  # the image sits ABOVE the approved root
+
+        asyncio.run(_turn(r, f"Look: ![alt]({img})"))
+
+        assert cli.photos == []
+        landed = "\n".join(cli.sent + cli.edits)
+        assert str(img) in landed and "not sent" in landed
+
+    def test_both_outcomes_are_sel_audited_with_path_free_reasons(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        with patch("kiro_crew.telegram.renderer.sel") as sel_mock:
+            asyncio.run(_turn(r, f"![ok]({img})\n\n![gone]({tmp_path}/nope.png)"))
+
+        calls = sel_mock.return_value.log_api_access.call_args_list
+        outcomes = {c.kwargs["outcome"]: c.kwargs for c in calls}
+        assert set(outcomes) == {"allowed", "denied"}
+        denied = outcomes["denied"]
+        assert denied["operation"] == "telegram_renderer.upload_files"
+        assert denied["source"] == "telegram"
+        assert denied["error"] == "missing"
+        # The destination reaches the CHAT, never the audit log.
+        assert all(str(tmp_path) not in str(c.kwargs) for c in calls)
+
+
+# ── Seal-time extraction ──────────────────────────────────────────────────────
+
+
+class TestSealTimeExtraction:
+    def test_an_indented_code_literal_is_displayed_not_uploaded(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        # Four-space indent = code block. Stripping before classification (the
+        # defect this pins) would upload a picture the author only showed.
+        asyncio.run(_turn(r, f"    ![alt]({img})"))
+
+        assert cli.photos == []
+        assert any(str(img) in body for body in cli.sent + cli.edits)
+
+    def test_a_fenced_reference_is_documentation(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"How to:\n\n```\n![alt]({img})\n```"))
+
+        assert cli.photos == []
+
+    @pytest.mark.parametrize("arrived", [True, False])
+    def test_live_frames_never_show_image_markup(self, tmp_path: Path, arrived: bool) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        markup = f"![alt]({img})" if arrived else f"![alt]({img}"
+
+        async def run() -> None:
+            await r.on_text_chunk(f"Rendering it now: {markup}")
+            await r._stream_live(force=True)
+
+        asyncio.run(run())
+
+        frames = cli.sent + cli.edits
+        assert frames, "expected a live frame"
+        assert all(str(img) not in frame for frame in frames)
+
+    def test_markup_removal_cannot_reassemble_a_credential(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        # Halves that are separated in the source and contiguous once the image
+        # markup between them is cut out.
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        head, tail = secret[:10], secret[10:]
+
+        asyncio.run(_turn(r, f"{head}![alt]({img}){tail}"))
+
+        assert cli.photos, "the picture should still be delivered"
+        assert all(secret not in body for body in cli.sent + cli.edits)
+
+    def test_an_image_only_reply_posts_no_placeholder_bubble(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"![alt]({img})"))
+
+        assert len(cli.photos) == 1
+        # The picture IS the answer: no "…" bubble, and nothing was posted at all
+        # because live frames already hide the markup.
+        assert cli.sent == [] and cli.edits == []
+
+    def test_an_image_only_reply_withdraws_a_live_frame_it_did_post(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        async def run() -> None:
+            await r.on_text_chunk(f"![alt]({img})")
+            # A tool footer puts a real bubble on screen even though the body is
+            # empty; leaving it would strand text the picture replaces.
+            await r.on_tool_call("call-1", "grep")
+            await r.on_done()
+
+        asyncio.run(run())
+
+        assert len(cli.photos) == 1
+        assert cli.deleted, "the superseded live frame should be removed"
+
+    def test_a_rejected_file_keeps_its_markup_and_gains_a_reason(self, tmp_path: Path) -> None:
+        cli = FakeClient()
+        missing = tmp_path / "absent.png"
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"Chart: ![alt]({missing})"))
+
+        landed = "\n".join(cli.sent + cli.edits)
+        assert str(missing) in landed
+        assert "not sent" in landed
+
+    def test_extraction_failure_falls_back_to_the_text(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        boom = AsyncMock(side_effect=RuntimeError("extractor down"))
+
+        with patch("kiro_crew.telegram.renderer.extract_local_refs_off_loop", boom):
+            asyncio.run(_turn(r, f"Chart: ![alt]({img})"))
+
+        assert cli.photos == []
+        assert any(str(img) in body for body in cli.sent + cli.edits)
+
+    def test_the_bytes_travel_not_the_path(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        original = img.read_bytes()
+        r = _renderer(cli, tmp_path)
+
+        async def run() -> None:
+            _body, files = await r._extract_uploads(f"![alt]({img})")
+            # Whoever can write the directory swaps the file between the gated
+            # read and the send. Re-opening the path here would ship this.
+            img.write_bytes(b"not an image at all")
+            await r._upload_photos(files)
+
+        asyncio.run(run())
+
+        assert [p["data"] for p in cli.photos] == [original]
+
+    def test_the_alt_text_becomes_the_caption(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"![Q3 revenue by region]({img})"))
+
+        assert cli.photos[0]["caption"] == "Q3 revenue by region"
+
+
+# ── Rotation never hands a splitter chunk to the extractor ────────────────────
+
+
+class TestRotation:
+    def test_a_reference_is_held_for_the_semantic_seal(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        prose = "\n\n".join("filler paragraph." for _ in range(400))
+        assert len(prose) > r._limit(), "the fixture must actually rotate"
+
+        # The reference sits past the rotation boundary, so a naive rotation
+        # would seal it as splitter output -- where extraction is forbidden.
+        asyncio.run(_turn(r, f"{prose}\n\n![alt]({img})"))
+
+        assert len(cli.photos) == 1
+        assert all(str(img) not in body for body in cli.sent + cli.edits)
+
+    def test_a_length_rotation_seals_its_chunks_without_extracting(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        seen: list[bool] = []
+        real = r._seal_current
+
+        async def spy(*, keyboard: Any = None, extract_uploads: bool = True) -> None:
+            seen.append(extract_uploads)
+            await real(keyboard=keyboard, extract_uploads=extract_uploads)
+
+        r._seal_current = spy  # type: ignore[assignment]
+        prose = "\n\n".join("filler paragraph." for _ in range(400))
+        asyncio.run(_turn(r, f"{prose}\n\n![alt]({img})"))
+
+        assert False in seen, "expected at least one non-extracting rotation seal"
+        assert seen[-1] is True, "the final semantic seal must extract"
+
+    def test_a_dirty_long_line_disables_the_segments_uploads(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+        # An unbreakable line longer than the whole budget cannot be cut cleanly,
+        # so a reference arriving AFTER that rotation is no longer trustworthy:
+        # the segment stops being an extraction candidate for the rest of itself.
+        unbreakable = "y" * (r._limit() + 50)
+
+        async def run() -> None:
+            await r.on_text_chunk(f"{unbreakable}\n\n" + "z " * 2000)
+            assert r._segment_uploads_safe is False, "the dirty cut should have fired"
+            await r.on_text_chunk(f"\n\n![alt]({img})")
+            await r.on_done()
+
+        asyncio.run(run())
+
+        assert cli.photos == []
+        assert any(str(img) in body for body in cli.sent + cli.edits)
+
+
+# ── Delivery failures are reported, never dropped ─────────────────────────────
+
+
+class TestPhotoDelivery:
+    def test_a_failed_upload_reposts_its_markup(self, tmp_path: Path) -> None:
+        cli, img = FakeClient(), _image(tmp_path)
+        cli.photo_results = [None]
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"Chart: ![alt]({img})"))
+
+        # Extraction already cut the markdown, so silence would leave the reply
+        # referring to a picture with neither the picture nor its path.
+        assert any(str(img) in body for body in cli.sent)
+
+    def test_a_raising_upload_is_isolated_and_the_rest_still_go(self, tmp_path: Path) -> None:
+        cli = FakeClient()
+        first, second = _image(tmp_path, "a.png"), _image(tmp_path, "b.png")
+        cli.photo_results = [None, 7]
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"![one]({first})\n\n![two]({second})"))
+
+        assert len(cli.photos) == 2, "the second upload must still be attempted"
+        reposted = "\n".join(cli.sent)
+        assert str(first) in reposted and str(second) not in reposted
+
+    def test_a_transport_error_does_not_abandon_the_files_behind_it(self, tmp_path: Path) -> None:
+        cli = FakeClient()
+        cli.photo_raises = True
+        img = _image(tmp_path)
+        r = _renderer(cli, tmp_path)
+
+        asyncio.run(_turn(r, f"![one]({img})"))
+
+        assert cli.photos == []
+        assert any(str(img) in body for body in cli.sent)
+
+    # ── The outbound failure invariant, exhaustively ──────────────────────────
+    # (which operation fails) x (how it fails). The invariant under test: no
+    # single delivery's failure -- returned OR raised -- may cascade into the
+    # loss of a sibling. Every reference must end up accounted for as a
+    # delivered photo, as recovered markup, or as a logged loss, and later
+    # siblings must still have been attempted. Three consecutive blockers landed
+    # in this span by closing one cell at a time, so the cells are enumerated.
+    @pytest.mark.parametrize("how", ["returns_none", "raises"])
+    @pytest.mark.parametrize("where", ["seal", "photo", "recovery"])
+    def test_no_failed_delivery_cascades_to_a_sibling(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, where: str, how: str
+    ) -> None:
+        cli = FakeClient()
+        r = _renderer(cli, tmp_path)
+        boom = RuntimeError("proxy returned HTML, so resp.json raised")
+        # Two references with distinct alts; long enough that the recovery post
+        # needs two chunks, which is what makes "chunk k+1 survived" observable.
+        alt = "a" * (r._limit() // 2)
+        files = [
+            OutboundFile(
+                path=f"{tmp_path}/i{i}.png", data=_png(i), alt=f"{alt}{i}", mime="image/png"
+            )
+            for i in range(2)
+        ]
+        if where == "seal":
+            # The seal's only failure shape is a raise; returning None is its
+            # normal contract, so that cell asserts the happy path still holds.
+            if how == "raises":
+                r._seal_segment_text = AsyncMock(side_effect=boom)  # type: ignore[method-assign]
+            else:
+                r._seal_segment_text = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        elif where == "photo":
+            cli.photo_results = [boom if how == "raises" else None, 7]
+        else:
+            cli.photo_results = [None, None]  # force both into recovery
+            # The seal sends first and must SUCCEED here, or the fault lands on
+            # the text path instead of the recovery chunk this cell targets. A
+            # non-Exception entry passes through to a normal id.
+            cli.msg_results = [1, boom if how == "raises" else None]
+
+        with caplog.at_level(logging.WARNING):
+            if where == "seal" and how == "raises":
+                # The text exception still reaches the caller unchanged...
+                with pytest.raises(RuntimeError):
+                    asyncio.run(_seal_with(r, files))
+            else:
+                asyncio.run(_seal_with(r, files))
+
+        # ...and the photos were attempted anyway.
+        assert len(cli.photos) == 2, "every photo must be attempted"
+        logged = caplog.text
+        for item in files:
+            delivered = item.alt in cli.photo_delivered
+            recovered = any(f"![{item.alt}]({item.path})" in body for body in cli.msg_delivered)
+            assert delivered or recovered or logged, (
+                f"reference {item.path} vanished silently: not delivered as a photo, "
+                f"not in recovered markup, and no loss was logged"
+            )
+        if where == "recovery":
+            # Chunk 1 failed either way; chunk 2 must still have been attempted,
+            # and it carries the second reference's only remaining copy.
+            assert len(cli.sent) >= 2, "a failed recovery chunk must not abandon the next"
+            assert f"![{files[1].alt}]({files[1].path})" in "".join(cli.msg_delivered)
+
+    # One reference per shape/scale, asserting BOTH recovery properties on every
+    # case: nothing is dropped (the round-1 invariant) AND no chunk exceeds the
+    # cap in the units Telegram actually counts (this round). Two point tests let
+    # each property be closed while the other regressed -- the whole failure
+    # pattern in this span -- so they are one oracle instead.
+    @pytest.mark.parametrize("shape", ["ascii", "astral", "mixed", "bmp"])
+    @pytest.mark.parametrize("scale", ["packs", "straddles", "overflows"])
+    def test_recovery_is_lossless_and_never_exceeds_the_utf16_cap(
+        self, tmp_path: Path, shape: str, scale: str
+    ) -> None:
+        cli = FakeClient()
+        cli.photo_results = [None, None, None]
+        r = _renderer(cli, tmp_path)
+        limit = r._limit()
+        # "astral" costs 2 UTF-16 units per code point, "bmp" only 1 despite
+        # being multi-byte in UTF-8 -- so a byte-based budget would fail too.
+        unit = {"ascii": "a", "astral": "\U0001f5bc", "mixed": "a\U0001f5bc", "bmp": "\u6f22"}[
+            shape
+        ]
+        target = {"packs": limit // 3, "straddles": limit - 8, "overflows": limit + 400}[scale]
+        alt = unit * max(1, target // _utf16(unit))
+        files = [
+            OutboundFile(path=f"{tmp_path}/i{i}.png", data=_png(), alt=alt, mime="image/png")
+            for i in range(3)
+        ]
+
+        asyncio.run(r._upload_photos(files))
+
+        assert cli.sent, "expected a recovery post"
+        # (b) Telegram counts UTF-16 code units; a chunk over its cap is rejected,
+        # and send_message reports that as None rather than raising.
+        assert all(_utf16(body) <= limit for body in cli.sent)
+        assert all(_utf16(body) <= 4096 for body in cli.sent)
+        # (a) Every reference still arrives, character for character. The newlines
+        # this path synthesized between references are what message boundaries
+        # replace, so they are the only characters allowed to differ.
+        expected = "\n".join(f"![{item.alt}]({item.path})" for item in files)
+        assert "".join(cli.sent).replace("\n", "") == expected.replace("\n", "")
+        for item in files:
+            assert f"![{item.alt}]({item.path})" in "".join(cli.sent)
+
+
+# ── The multipart wire ────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    async def json(self, content_type: Any = None) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeSession:
+    """Captures what ``_api`` actually put on the wire."""
+
+    def __init__(self, payloads: list[dict[str, Any]] | None = None) -> None:
+        self.closed = False
+        self.calls: list[dict[str, Any]] = []
+        self._payloads = payloads or [{"ok": True, "result": {"message_id": 42}}]
+
+    def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append({"url": url, **kwargs})
+        return _FakeResponse(self._payloads[min(len(self.calls) - 1, len(self._payloads) - 1)])
+
+
+def _client_with(session: _FakeSession) -> TelegramClient:
+    client = TelegramClient(token="tok")
+    client._session = session  # type: ignore[assignment]
+    return client
+
+
+def _fields(form: Any) -> dict[str, Any]:
+    """Field name -> value for an aiohttp FormData, read from its internals."""
+    return {opts["name"]: value for opts, _headers, value in form._fields}
+
+
+class TestMultipartWire:
+    def test_posts_the_bytes_with_a_synthetic_filename(self) -> None:
+        session = _FakeSession()
+        client = _client_with(session)
+        data = _png()
+
+        mid = asyncio.run(client.send_photo(555, data, "image/png", caption="Revenue"))
+
+        assert mid == 42
+        call = session.calls[0]
+        assert call["url"].endswith("/sendPhoto")
+        # Multipart, not JSON: a JSON `photo` field can only be a URL or an
+        # existing file_id, never bytes we hold.
+        assert call["json"] is None
+        fields = _fields(call["data"])
+        assert fields["photo"] == data
+        assert fields["chat_id"] == "555"
+        assert fields["caption"] == "Revenue"
+        # The name is derived from the sniffed type, so no agent-influenced
+        # string reaches a Content-Disposition header.
+        names = [
+            opts.get("filename") for opts, _h, _v in call["data"]._fields if "filename" in opts
+        ]
+        assert names == ["image.png"]
+
+    def test_a_forum_topic_and_an_empty_caption_are_omitted(self) -> None:
+        session = _FakeSession()
+        client = _client_with(session)
+
+        asyncio.run(client.send_photo(555, _png(), "image/jpeg"))
+
+        fields = _fields(session.calls[0]["data"])
+        assert "caption" not in fields and "message_thread_id" not in fields
+
+    def test_a_rate_limited_upload_is_retried_with_a_fresh_form(self) -> None:
+        session = _FakeSession(
+            [
+                {"ok": False, "error_code": 429, "parameters": {"retry_after": 0}},
+                {"ok": True, "result": {"message_id": 9}},
+            ]
+        )
+        client = _client_with(session)
+
+        mid = asyncio.run(client.send_photo(1, _png(), "image/png"))
+
+        assert mid == 9
+        # aiohttp consumes a FormData on write, so a reused body raises on the
+        # retry -- the factory has to build a new one per attempt.
+        assert len(session.calls) == 2
+        assert session.calls[0]["data"] is not session.calls[1]["data"]
+
+    def test_a_failed_upload_returns_none_rather_than_raising(self) -> None:
+        session = _FakeSession([{"ok": False, "error_code": 400, "description": "bad"}])
+
+        assert asyncio.run(_client_with(session).send_photo(1, _png(), "image/png")) is None
+
+    def test_the_caption_is_redacted_at_the_sink(self) -> None:
+        session = _FakeSession()
+        client = _client_with(session)
+        secret = "AKIAIOSFODNN7EXAMPLE"
+
+        # The verb is the one boundary every upload crosses, so it redacts rather
+        # than trusting a caller to have done it.
+        asyncio.run(client.send_photo(1, _png(), "image/png", caption=f"key {secret}"))
+
+        assert secret not in _fields(session.calls[0]["data"])["caption"]
+
+    def test_redaction_runs_before_truncation(self) -> None:
+        session = _FakeSession()
+        client = _client_with(session)
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        # Straddles the caption cap: truncating first would cut the secret and
+        # let the surviving prefix through.
+        caption = "a" * (TELEGRAM_CAPTION_MAX - 8) + secret
+
+        asyncio.run(client.send_photo(1, _png(), "image/png", caption=caption))
+
+        sent = _fields(session.calls[0]["data"])["caption"]
+        assert len(sent) <= TELEGRAM_CAPTION_MAX
+        assert secret[:12] not in sent
+
+    def test_extract_limits_carry_telegram_ceilings(self) -> None:
+        assert _UPLOAD_LIMITS.max_file_bytes == TELEGRAM_PHOTO_MAX_BYTES
+        assert _UPLOAD_LIMITS.max_files == TELEGRAM_MAX_FILES_PER_MESSAGE
+        assert _UPLOAD_LIMITS.max_total_bytes == TELEGRAM_MAX_TOTAL_UPLOAD_BYTES
+        # The aggregate is the memory bound for one seal, so it must sit below
+        # files x per-file or it bounds nothing.
+        assert TELEGRAM_MAX_TOTAL_UPLOAD_BYTES < (
+            TELEGRAM_MAX_FILES_PER_MESSAGE * TELEGRAM_PHOTO_MAX_BYTES
+        )
+
+    def test_an_oversize_file_is_refused_while_its_markup_is_still_there(
+        self, tmp_path: Path
+    ) -> None:
+        cli = FakeClient()
+        img = _image(tmp_path, pad=4096)
+        r = _renderer(cli, tmp_path)
+        small = dataclasses.replace(_UPLOAD_LIMITS, max_file_bytes=64)
+
+        with patch("kiro_crew.telegram.renderer._UPLOAD_LIMITS", small):
+            asyncio.run(_turn(r, f"Chart: ![alt]({img})"))
+
+        assert cli.photos == []
+        landed = "\n".join(cli.sent + cli.edits)
+        assert str(img) in landed and "not sent" in landed
+
+
+# ── The restricted-session gate ───────────────────────────────────────────────
+
+
+class TestRestrictedGate:
+    def _dispatcher(self) -> Any:
+        from kiro_crew.telegram.transport_dispatch import TelegramDispatcher
+
+        return TelegramDispatcher.__new__(TelegramDispatcher)
+
+    @pytest.mark.parametrize("key", ["telegram:kirocrew:direct:42", "unified:kirocrew"])
+    def test_every_key_this_dispatcher_builds_is_allowed(self, key: str) -> None:
+        # `unified` dm_scope drops the channel out of the key, so a gate written
+        # as a "telegram:" allowlist would deny every upload for those users.
+        assert self._dispatcher()._uploads_restricted(key) is False
+
+    def test_a_dashboard_key_is_denied_and_audited(self) -> None:
+        with patch("kiro_crew.telegram.transport_dispatch.sel") as sel_mock:
+            assert self._dispatcher()._uploads_restricted("dashboard:slot-1") is True
+
+        kwargs = sel_mock.return_value.log_api_access.call_args.kwargs
+        assert kwargs["operation"] == "telegram_dispatch.upload_files"
+        assert kwargs["outcome"] == "denied"
+        assert kwargs["error"] == "restricted_session"
+
+    def test_the_renderer_requires_all_three_conditions(self, tmp_path: Path) -> None:
+        cli = FakeClient()
+        assert _renderer(cli, tmp_path)._uploads_enabled() is True
+        assert _renderer(cli, tmp_path, uploads_allowed=False)._uploads_enabled() is False
+        assert _renderer(cli, tmp_path, capabilities=_NO_UPLOAD_CAPS)._uploads_enabled() is False
+        bare = TelegramRenderer(MagicMock(), 1, TELEGRAM_CAPABILITIES)
+        assert bare._uploads_enabled() is False, "no authorized root -> no uploads"


### PR DESCRIPTION
## Problem / Motivation

When an agent reply on Telegram references a locally generated raster image (`![chart](/abs/path/chart.png)`), the image never reaches the chat. The markup streams through as broken text: Telegram users see a dead local path instead of the picture the agent produced. Issue #823 tracks this gap. Discord gained real outbound raster uploads in the O2 milestone (PR #4832 on the O1 extraction foundation, PR #4313); Telegram still has no upload path at all — `capabilities.files_outbound` is `False` and no `sendPhoto` call exists.

## Why it matters

Telegram is a first-class KiroCrew channel, and image output (charts, screenshots, rendered diagrams) is a routine agent deliverable. Every such reply on Telegram today is silently degraded to an unusable path string, forcing users to switch surfaces to see what the agent made. This lands the Telegram half of the outbound-attachment wave and closes #823.

## What changed (motivation → approach → change)

Goal: deliver referenced local raster images as real Telegram photos, with the same security ceiling and honest-degradation guarantees the merged Discord implementation (O2) established, adapted to Telegram's segment/seal renderer.

Approach: reuse the merged channel-neutral extractor (`messaging/outbound_files.py`) at seal time only — never mid-stream — and upload via a new multipart `sendPhoto` on the existing `TelegramClient._api` plumbing. Fail closed everywhere: uploads require the transport capability, an unrestricted session, and the acquired provider's own absolute cwd as the only trusted root (`authorize_upload_root(provider.cwd)`, mirroring Discord's shipped line). Dashboard-restricted (incognito/temporary) sessions are denied outright, with the denial SEL-audited.

The build then hardened through four adversarial review rounds, all in the failure-handling span, ending in a structural restructure:

- Failed-upload recovery redacts the WHOLE restored markup before splitting (a credential spanning a chunk boundary is scanned contiguously), then re-posts losslessly across capped chunks.
- Recovery chunks are budgeted in UTF-16 code units (`_utf16_len` / `_utf16_cut`, with a load-bearing `max(2, limit)` floor) because Telegram's 4,096 cap counts UTF-16 units while Python `len()` counts code points — an emoji-heavy payload would otherwise build a chunk Telegram rejects. The pre-existing channel-wide code-point mismatch (`client.py`, documented) is deliberately out of scope; only the new path, where the consequence is data loss rather than a clipped frame, is fixed.
- One isolation seam (`_deliver`) now wraps every send on the outbound path, collapsing both failure shapes — a `None`/falsey return AND a raised exception (e.g. `resp.json()` `ValueError` on a non-JSON proxy body, which `_api`'s `(ClientError, TimeoutError)` clause does not catch) — into one logged answer. The recovery loop isolates per chunk, the photo loop per photo, and seal/upload are siblings under `try/finally` (safe because `_upload_photos` is total for `Exception`): no single delivery failure can cascade into the loss of a sibling delivery. Every extracted reference reaches the channel as a photo, recovered markup, or at minimum a logged loss.

`capabilities.files_outbound` flips to `True` for Telegram.

## Tests

- 12-case parametrized recovery oracle (4 payload shapes × 3 size scales) asserting BOTH invariants on every case: character-exact losslessness of restored markup and a per-chunk UTF-16 cap. Red-first: 6/12 failed pre-fix (exactly the astral/mixed shapes).
- 6-cell fault-injection oracle over the failure surface (seal / photo / recovery × returns-None / raises), asserting each reference is accounted for (delivered, recovered, or logged) and later siblings still run. Red-first: the two raise-shape cells failed pre-restructure.
- Security gates: sensitive-path denial before any metadata probe, symlink refusal, descriptor-pinned reads within the trusted root, restricted-session outright deny with SEL audit, byte-faithful segment extraction (indented literal code is never uploaded), redact-before-split.
- Full local gate set green: 570 focused tests, isort, flake8, mypy (CI-parity venv), Black + ratchet.

## Manual verification

N/A — unit coverage sufficient: the fake Telegram client models send/append/photo outcomes including failure injection, and the fault-injection oracle covers the degraded paths that manual testing would exercise. (No live Telegram bot in the dev environment.)

## Related Issues

Fixes #823

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
