### PR TITLE
perf(dashboard): cut warm-reload API round-trips (boot notifications dedupe + lazy history)

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -235,6 +235,12 @@ ssh -N  -L 7779:localhost:7779 user@your-host.example.com   # foreground, no she
 ssh -fN -L 7779:localhost:7779 user@your-host.example.com   # background
 ```
 
+Pass `-C` to enable SSH transport compression. A hand-rolled tunnel gets no
+compression by default, while Kiro Crew's own tunnel manager turns it on for
+exactly this traffic (`src/kiro_crew/instances/ssh_tunnel_manager.py`): the
+forwarded stream carries the dashboard SPA bundle plus all API/WS payloads,
+which are highly compressible, and the gateway does not gzip at the HTTP layer.
+
 To get the tunnel on every connection, add to your local `~/.ssh/config`:
 
 ```

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -17,7 +17,7 @@ import { installSoftNavigate } from './utils/errorReport'
 import { agentSwitchFailureMessage } from './utils/agentSwitchFeedback'
 import { updateAffordance } from './utils/updateAffordance'
 import { metricColor } from './utils/metricColor'
-import { fetchNotifications, ackNotification } from './store/notificationsSlice'
+import { fetchNotifications, ackNotification, armBootNotificationsFallback } from './store/notificationsSlice'
 import { useWebSocket } from './hooks/useWebSocket'
 import { useDashboardHealthProbe } from './hooks/useDashboardHealthProbe'
 import { useTheme } from './hooks/useTheme'
@@ -1930,9 +1930,16 @@ export default function App() {
         gcOrphanedStorage(liveIds)
       }
     })
-    dispatch(fetchNotifications())
+    // The boot notifications fetch is owned by the WebSocket first-connect
+    // handler (its snapshot is taken after socket registration, so nothing
+    // can fall between snapshot and push -- see notificationsSlice). This
+    // only arms the fallback for a socket that never connects.
+    // Return the thunk promise: a late first connect serializes its own fetch
+    // behind this one via markBootNotificationsFetched() (see notificationsSlice).
+    const disarmNotificationsFallback = armBootNotificationsFallback(() => dispatch(fetchNotifications()))
     // Fetch status immediately to sync YOLO state (WS status push is periodic)
     api.status().then(s => { dispatch(sseStatus(s)); recordSessionStart(s) }).catch(() => {})
+    return disarmNotificationsFallback
   }, [dispatch])
   const { subscribeLogs, subscribeSubagents, forceReconnect } = useWebSocket()
   useDashboardHealthProbe(forceReconnect)

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -5,7 +5,7 @@ import { isReconcileNote } from '../lib/noteContract'
 import { useAppDispatch, useAppSelector } from '../store'
 import { store } from '../store'
 import { sseStatus, sseConnected, sseDisconnected, sseSlots, sseTodoUpdate, setChannelTrusted, sseSlotTitle, triggerRefresh, fetchSlots, markSlotUnread, setUpdateProgress, sseSubagentStatus, sseSubagentText, touchSlotActivity, patchSlotSourceLinks, type SubagentDetail } from '../store/dashboardSlice'
-import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, clearAllNotifications, fetchNotifications } from '../store/notificationsSlice'
+import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, clearAllNotifications, fetchNotifications, markBootNotificationsFetched } from '../store/notificationsSlice'
 import { MC_NOTIFICATION_EVENT, TURN_DONE_KIND, APPROVAL_KIND, shouldChimeOnTurnDone, type McNotificationDetail } from './notificationEvent'
 import { emitThemeSound } from './themeSound'
 import {
@@ -710,13 +710,25 @@ export function useWebSocket() {
       // and this handler fires strictly after it, so repeating it here is a
       // redundant round-trip at the worst possible moment. The reconnect branch
       // above still refetches — there it recovers state missed while the socket
-      // was down. fetchNotifications IS still dispatched here despite the
-      // mount-effect copy: syncPendingApprovals must only run after a
-      // notifications fetch has settled, because fetchNotifications.fulfilled
-      // replaces membership and ordering wholesale and would wipe any approval
-      // notifications synced before it. Its merge preserves local ack flags
-      // only, so it is no protection for a row the response does not carry.
-      dispatch(fetchNotifications()).then(() => syncPendingApprovals())
+      // was down. fetchNotifications is the opposite: THIS is its authoritative
+      // boot dispatch (#765). The snapshot must be taken after the socket is
+      // registered, or a notification created between an earlier snapshot and
+      // registration is pushed to nobody and stays invisible until a reconnect
+      // — so the mount effect no longer fetches; it only arms a fallback for a
+      // socket that never connects, and the mark below keeps that fallback
+      // from double-firing. syncPendingApprovals stays chained on the fetch
+      // settling, because fetchNotifications.fulfilled replaces membership and
+      // ordering wholesale and would wipe any approval notifications synced
+      // before it (its merge preserves local ack flags only, so it is no
+      // protection for a row the response does not carry).
+      // A fallback that already fired (connect took >5s) has a snapshot in
+      // flight; serialize behind it so the older response can never replace
+      // this (newer, post-registration) one after it lands.
+      const firedFallback = markBootNotificationsFetched()
+      ;(firedFallback
+        ? firedFallback.then(() => dispatch(fetchNotifications()))
+        : dispatch(fetchNotifications())
+      ).then(() => syncPendingApprovals())
       syncPendingQuestions()
       // FIRST connect: seeds rows for runs already in flight (a reload, or a new
       // tab on a session whose workflow is still going). The WS stream only

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -3483,7 +3483,27 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // New content while following is handled inside the virtualizer (RO re-pin
   // for in-place growth + append layout-effect pin for new items), so ChatPage
   // does not run its own message-length scroll effect.
-  useEffect(() => { dispatch(fetchHistory(false)) }, [dispatch])
+  // Older-sessions history is fetched lazily, not on mount (#765): the
+  // sidebar's "Older sessions" section self-fetches when expanded (see
+  // ChatSidebar's footer toggle -- the section starts collapsed and its open
+  // state is not persisted, so it can never be open at mount), which leaves
+  // the welcome-screen "Continue a previous chat?" suggestions as the only
+  // consumer that can need the payload before that. They need it only once
+  // the user has typed something, so seed on the FIRST keystroke (raw input,
+  // not the 300ms-debounced historyQuery -- keying off the debounce would
+  // stack a round-trip after it, and on the high-RTT tunnels this targets
+  // the suggestions could land after the user already hit Enter; this way
+  // the fetch rides inside the debounce window at the same request cost).
+  // An unconditional mount fetch cost one round-trip on every warm reload
+  // for a list that is usually never shown. Once-only: the ref latches even
+  // when the list is already populated (the sidebar fetched first), so
+  // typing never re-fetches.
+  const historySeededRef = useRef(false)
+  useEffect(() => {
+    if (historySeededRef.current || !input.trim()) return
+    historySeededRef.current = true
+    if (history.length === 0) dispatch(fetchHistory(false))
+  }, [input, history.length, dispatch])
   // Persist active slot to localStorage for refresh recovery (per-mode)
   const slotStorageKey = `mc-active-slot-${mode || 'chat'}`
   const slotStorageKeyRef = useRef(slotStorageKey); slotStorageKeyRef.current = slotStorageKey

--- a/website/src/store/notificationsSlice.ts
+++ b/website/src/store/notificationsSlice.ts
@@ -67,6 +67,59 @@ const pruneAckStamps = (state: NotificationsState) => {
   }
 }
 
+/**
+ * Boot-time notifications dedupe (#765). App's mount effect and the
+ * WebSocket's FIRST-connect handler used to each dispatch `fetchNotifications`
+ * -- two identical round-trips on every boot. The first-connect copy is the
+ * one that must stay authoritative: its HTTP snapshot is taken AFTER the
+ * socket is registered, so a notification created after the snapshot is
+ * guaranteed to arrive as a WS push. A mount-time snapshot has no such
+ * guarantee -- a notification created between it and socket registration is
+ * pushed to nobody and would be invisible until a reconnect. So the mount
+ * effect no longer fetches; it arms this fallback instead, which fires only
+ * when no boot fetch has happened within the window (a socket that never
+ * connects, e.g. a proxy that strips Upgrade) so the inbox still populates
+ * over plain HTTP. First-connect marks the flag before dispatching; the
+ * fallback marks it too, so the two can never double-fire.
+ */
+export const BOOT_NOTIFICATIONS_FALLBACK_MS = 5000
+let bootNotificationsFetched = false
+// In-flight fallback fetch, held so a late first connect can SERIALIZE its own
+// fetch after it. Without this, a connect landing just after the fallback
+// fired could resolve its (newer) snapshot first and then have the older
+// fallback response replace membership wholesale -- notifications gone until
+// a reconnect. fetchNotifications.fulfilled has generation guards for clears
+// and acks, not for two overlapping boot fetches.
+let inflightFallbackFetch: Promise<unknown> | null = null
+/**
+ * Marks the boot fetch as owned by the caller (the first-connect handler).
+ * Returns the in-flight fallback fetch when one already fired, so the caller
+ * can chain its own fetch after it settles -- guaranteeing the newest
+ * (post-registration) snapshot always lands last. Null when no fallback fired.
+ */
+export function markBootNotificationsFetched(): Promise<unknown> | null {
+  bootNotificationsFetched = true
+  const p = inflightFallbackFetch
+  inflightFallbackFetch = null
+  return p
+}
+/** Arms the no-WS fallback; returns the disarm function for effect cleanup. */
+export function armBootNotificationsFallback(run: () => unknown, ms: number = BOOT_NOTIFICATIONS_FALLBACK_MS): () => void {
+  const t = setTimeout(() => {
+    if (bootNotificationsFetched) return
+    bootNotificationsFetched = true
+    // Redux thunk dispatch promises settle with the action (never reject);
+    // Promise.resolve covers a non-promise return defensively.
+    inflightFallbackFetch = Promise.resolve(run()).catch(() => undefined)
+  }, ms)
+  return () => clearTimeout(t)
+}
+/** Test-only: restores the pristine boot state between cases. */
+export function resetBootNotificationsForTest(): void {
+  bootNotificationsFetched = false
+  inflightFallbackFetch = null
+}
+
 export const fetchNotifications = createAsyncThunk(
   'notifications/fetch',
   async (_arg: void, { getState }) => {

--- a/website/src/test/ChatPage.lazyHistoryFetch.test.tsx
+++ b/website/src/test/ChatPage.lazyHistoryFetch.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * #765 — the warm-reload history round-trip.
+ *
+ * ChatPage used to run an unconditional
+ * `useEffect(() => { dispatch(fetchHistory(false)) }, [dispatch])`, so every
+ * mount (every reload, every tunnel round-trip) fetched the older-sessions
+ * payload even though nothing shows it at mount: the sidebar's "Older
+ * sessions" section starts collapsed (state not persisted) and self-fetches
+ * on expand, and the welcome-screen "Continue a previous chat?" suggestions
+ * only need the list once the user has typed a query.
+ *
+ * These tests pin the lazy contract:
+ *  1. mount alone fetches nothing;
+ *  2. typing (which arms `historyQuery` after its debounce) seeds the list
+ *     exactly once;
+ *  3. further typing does not re-fetch (the seed ref latches).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+vi.mock('../pages/chat', () => ({
+  ChatFooter: () => null,
+  McpInfoButton: () => null,
+  UserMessage: () => null,
+  AssistantMessage: () => null,
+}))
+
+// ChatInput relays the real setInput so the test can type without rendering
+// the full composer (textarea sizing needs layout APIs jsdom lacks).
+let typedCount = 0
+vi.mock('../components/ChatInput', async () => {
+  const React = await import('react')
+  return {
+    default: (props: { onChange: (v: string) => void }) =>
+      React.createElement('button', {
+        'data-testid': 'type-query',
+        // A different string per click, so each click is a real input change
+        // (same-value setState would skip the re-render and the debounce).
+        onClick: () => props.onChange('continue that refactor ' + (++typedCount)),
+      }, 'type'),
+  }
+})
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
+  useVirtualChat: () => ({
+    virtualItems: [],
+    isAtBottom: true,
+    scrollToBottom: vi.fn(),
+    mountIndex: vi.fn(),
+    measureRef: () => () => {},
+    topSentinelRef: { current: null },
+    bottomSentinelRef: { current: null },
+    offsetBefore: 0,
+    offsetAfter: 0,
+  }),
+}))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: ({ children }: { children?: ReactNode }) => children }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '900px', input: '916px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+
+const apiMocks: Record<string, ReturnType<typeof vi.fn>> = {}
+vi.mock('../api/client', () => ({
+  api: new Proxy({}, {
+    get: (_t, prop: string) => {
+      if (!(prop in apiMocks)) {
+        apiMocks[prop] = vi.fn().mockResolvedValue(
+          prop === 'chatSlotDetail'
+            ? { messages: [], has_more: false, total: 0 }
+            : prop === 'sessions'
+              ? { sessions: [], has_more: false }
+              : {},
+        )
+      }
+      return apiMocks[prop]
+    },
+  }),
+  fileReadUrl: (p: string) => `/api/file?path=${encodeURIComponent(p)}`,
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true, status: 200,
+  text: () => Promise.resolve(''),
+  json: () => Promise.resolve({}),
+}) as never
+
+import ChatPage from '../pages/ChatPage'
+
+const renderChatPage = () => {
+  const slot = { key: 'chat-1', title: 'chat-1', messages: 0, running: false, mode: '', created: '', last_ts: '' }
+  apiMocks.chatSlots = vi.fn().mockResolvedValue([slot])
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' }, connected: false,
+      slots: [slot], approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0,
+      unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as never,
+    chat: {
+      activeSlot: 'chat-1',
+      messages: [], slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined, history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+    } as never,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat/chat-1']}>
+            <Routes>
+              <Route path="/chat/:slug?" element={<ChatPage mode="" />} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return store
+}
+
+describe('ChatPage lazy history fetch (#765)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const k of Object.keys(apiMocks)) delete apiMocks[k]
+  })
+
+  it('does not fetch older-sessions history on mount', async () => {
+    renderChatPage()
+    // Let every mount effect (and anything they chain) settle before
+    // asserting the negative: the sessions mock is created lazily by the api
+    // Proxy, so its absence means fetchHistory never ran.
+    await act(async () => { await new Promise(r => setTimeout(r, 400)) })
+    expect(apiMocks.sessions).toBeUndefined()
+  })
+
+  it('seeds history exactly once when the user types a query, and never again', async () => {
+    renderChatPage()
+    await act(async () => { await Promise.resolve() })
+    expect(apiMocks.sessions).toBeUndefined()
+
+    // Typing arms historyQuery after its 300ms debounce.
+    fireEvent.click(screen.getByTestId('type-query'))
+    await waitFor(() => expect(apiMocks.sessions).toBeDefined())
+    await waitFor(() => expect(apiMocks.sessions).toHaveBeenCalledTimes(1))
+
+    // A second keystroke (new debounce cycle) must not re-fetch: the seed
+    // latches once armed.
+    fireEvent.click(screen.getByTestId('type-query'))
+    await new Promise(r => setTimeout(r, 400))
+    expect(apiMocks.sessions).toHaveBeenCalledTimes(1)
+  })
+})

--- a/website/src/test/ChatPageMoreCoverage.test.tsx
+++ b/website/src/test/ChatPageMoreCoverage.test.tsx
@@ -584,8 +584,9 @@ describe('ChatPage welcome-state history suggestions', () => {
     })
     const { store } = renderChatPage([], { sessions: HISTORY })
     await waitFor(() => expect(inputProps).not.toBeNull())
-    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
     await typeQuery('rate limiter')
+    // #765: history is seeded lazily by the typed query, not on mount.
+    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
     const list = await screen.findByRole('listbox', { name: 'Previous chats' }, { timeout: 5_000 })
     const options = within(list).getAllByRole('option')
     expect(options).toHaveLength(1)
@@ -597,8 +598,9 @@ describe('ChatPage welcome-state history suggestions', () => {
   it('dismisses the suggestions on Escape', async () => {
     const { store } = renderChatPage([], { sessions: HISTORY })
     await waitFor(() => expect(inputProps).not.toBeNull())
-    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
     await typeQuery('rate limiter')
+    // #765: history is seeded lazily by the typed query, not on mount.
+    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
     expect(await screen.findByRole('listbox', { name: 'Previous chats' }, { timeout: 5_000 })).toBeInTheDocument()
     act(() => { fireEvent.keyDown(document, { key: 'Escape' }) })
     await waitFor(() => expect(screen.queryByRole('listbox', { name: 'Previous chats' })).toBeNull())
@@ -607,8 +609,11 @@ describe('ChatPage welcome-state history suggestions', () => {
   it('offers nothing when no past session matches', async () => {
     const { store } = renderChatPage([], { sessions: HISTORY })
     await waitFor(() => expect(inputProps).not.toBeNull())
-    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
     await typeQuery('kubernetes migration')
+    // #765: history is seeded lazily by the typed query, not on mount — wait
+    // for the seed to land so the "no match" below is a real negative, not a
+    // not-yet-loaded false pass.
+    await waitFor(() => expect(store.getState().chat.history).toHaveLength(2))
     expect(screen.queryByRole('listbox', { name: 'Previous chats' })).toBeNull()
   })
 })

--- a/website/src/test/useWebSocket.bootNotificationsDedupe.test.ts
+++ b/website/src/test/useWebSocket.bootNotificationsDedupe.test.ts
@@ -1,0 +1,210 @@
+/**
+ * #765 — the duplicated boot fetchNotifications round-trip.
+ *
+ * App's mount effect and the WebSocket's FIRST-connect handler used to each
+ * dispatch `fetchNotifications` — two identical round-trips on every boot.
+ * The first-connect copy is the one that must survive: its HTTP snapshot is
+ * taken AFTER the socket is registered, so a notification created after the
+ * snapshot is guaranteed to arrive as a WS push. A mount-time snapshot has no
+ * such guarantee — a notification created between it and socket registration
+ * is pushed to nobody and would be invisible until a reconnect. So the mount
+ * effect no longer fetches; it arms a timed fallback that fires only when no
+ * boot fetch happened (a socket that never connects), and first-connect marks
+ * the boot fetch done before dispatching.
+ *
+ * Pinned here:
+ *  1. first connect dispatches exactly ONE notifications fetch, with
+ *     syncPendingApprovals gated on it settling (the ordering guarantee);
+ *  2. the armed fallback does NOT fire once first-connect marked the boot
+ *     fetch (no double-fire);
+ *  3. the fallback DOES fire when nothing marked it (no-WS boot still
+ *     populates the inbox over plain HTTP);
+ *  4. disarming (App unmount) cancels a pending fallback;
+ *  5. a first connect that lands AFTER the fallback fired serializes its own
+ *     fetch behind the fallback's in-flight one, so the older (pre-
+ *     registration) snapshot can never replace the newer one.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+import {
+  armBootNotificationsFallback,
+  markBootNotificationsFetched,
+  resetBootNotificationsForTest,
+  BOOT_NOTIFICATIONS_FALLBACK_MS,
+} from '../store/notificationsSlice'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+import { api } from '../api/client'
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+const flush = () => act(async () => { await Promise.resolve(); await Promise.resolve() })
+
+describe('useWebSocket boot notifications dedupe (#765)', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    resetBootNotificationsForTest()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    resetBootNotificationsForTest()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  const renderWs = () => {
+    const store = createTestStore()
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(Provider, { store },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    renderHook(() => useWebSocket(), { wrapper })
+    return store
+  }
+
+  it('first connect dispatches exactly one notifications fetch, approvals gated on it settling', async () => {
+    // Hold the notifications response open so the ordering is observable.
+    let settleNotifications!: (v: { notifications: never[]; unread: number }) => void
+    vi.mocked(api.notifications).mockReturnValueOnce(
+      new Promise(resolve => { settleNotifications = resolve }),
+    )
+
+    renderWs()
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+    await flush()
+
+    // One boot fetch — the first-connect copy — and nothing else.
+    expect(api.notifications).toHaveBeenCalledTimes(1)
+    // The ordering guarantee: approvals sync waits for the fetch to settle.
+    expect(api.approvals).not.toHaveBeenCalled()
+
+    settleNotifications({ notifications: [], unread: 0 })
+    await flush()
+    expect(api.approvals).toHaveBeenCalledTimes(1)
+    expect(api.notifications).toHaveBeenCalledTimes(1)
+  })
+
+  it('the armed fallback never double-fires after first connect marked the boot fetch', async () => {
+    vi.useFakeTimers()
+    const fallback = vi.fn()
+    const disarm = armBootNotificationsFallback(fallback)
+
+    renderWs()
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+
+    expect(api.notifications).toHaveBeenCalledTimes(1)
+
+    // Let the fallback window lapse — first-connect marked the fetch, so the
+    // timer body must be a no-op.
+    await act(async () => { await vi.advanceTimersByTimeAsync(BOOT_NOTIFICATIONS_FALLBACK_MS + 1000) })
+    expect(fallback).not.toHaveBeenCalled()
+    expect(api.notifications).toHaveBeenCalledTimes(1)
+    disarm()
+  })
+
+  it('the fallback fires when the socket never connects', () => {
+    vi.useFakeTimers()
+    const fallback = vi.fn()
+    armBootNotificationsFallback(fallback)
+
+    vi.advanceTimersByTime(BOOT_NOTIFICATIONS_FALLBACK_MS + 1)
+    expect(fallback).toHaveBeenCalledTimes(1)
+
+    // And having fired, it marked the boot fetch itself: a late mark or a
+    // second armed window must not run again.
+    const second = vi.fn()
+    armBootNotificationsFallback(second)
+    vi.advanceTimersByTime(BOOT_NOTIFICATIONS_FALLBACK_MS + 1)
+    expect(second).not.toHaveBeenCalled()
+  })
+
+  it('disarming cancels a pending fallback (App unmount cleanup)', () => {
+    vi.useFakeTimers()
+    const fallback = vi.fn()
+    const disarm = armBootNotificationsFallback(fallback)
+    disarm()
+    vi.advanceTimersByTime(BOOT_NOTIFICATIONS_FALLBACK_MS + 1)
+    expect(fallback).not.toHaveBeenCalled()
+  })
+
+  it('a late mark after the fallback window changes nothing retroactively', () => {
+    vi.useFakeTimers()
+    const fallback = vi.fn()
+    armBootNotificationsFallback(fallback)
+    vi.advanceTimersByTime(BOOT_NOTIFICATIONS_FALLBACK_MS + 1)
+    expect(fallback).toHaveBeenCalledTimes(1)
+    // Reconnect-era mark must not throw or re-trigger anything.
+    markBootNotificationsFetched()
+    expect(fallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('a late first connect serializes its fetch behind a fired fallback (newest snapshot lands last)', async () => {
+    vi.useFakeTimers()
+    // The fallback's request is slow: it is still in flight when the socket
+    // finally connects. The bug this pins: without serialization the connect
+    // fetch resolves first and the older fallback payload then replaces
+    // membership -- notifications gone until a reconnect.
+    let settleFallbackFetch!: (v: unknown) => void
+    const fallbackFetch = new Promise(resolve => { settleFallbackFetch = resolve })
+    armBootNotificationsFallback(() => fallbackFetch)
+    vi.advanceTimersByTime(BOOT_NOTIFICATIONS_FALLBACK_MS + 1)
+
+    renderWs()
+    act(() => { WS_INSTANCES[0].simulateOpen() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+
+    // The connect fetch must NOT have been dispatched yet -- it waits for the
+    // fallback's in-flight request to settle.
+    expect(api.notifications).not.toHaveBeenCalled()
+
+    settleFallbackFetch({ notifications: [], unread: 0 })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+
+    // Now the post-registration snapshot goes out -- strictly after the older
+    // one settled -- and approvals sync still trails the whole chain.
+    expect(api.notifications).toHaveBeenCalledTimes(1)
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    expect(api.approvals).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** all changes remove/defer network requests and add code comments + a docs line; no pixel changes on any surface.

## Problem / Motivation

Over an SSH tunnel every API round-trip is expensive, and a warm dashboard reload was measured at ~41 API calls. Issue #765 (rescoped) identified the remaining sources after the asset-compression (#766) and lazy-mermaid + boot `fetchSlots` (#769) fixes landed:

1. `fetchNotifications` was dispatched twice on every boot — once by `App`'s mount effect and once by the WebSocket's first-connect handler (deliberately, to guarantee `syncPendingApprovals` runs only after a notifications fetch settles).
2. `ChatPage` unconditionally fetched the older-sessions history payload on every mount, even though the sidebar's "Older sessions" section starts collapsed (its open state is not persisted, so it can never be open at mount) and self-fetches on expand.
3. Hand-rolled `ssh -L` tunnels get no transport compression, and the docs never mentioned `-C`.

## Why it matters

Every remote/tunneled user pays these round-trips on every reload — serialized, at the worst possible moment (boot). Each removed request is a direct, user-visible latency win on high-RTT links; on a LAN it is still wasted server work.

## What changed (motivation → approach → change)

**Boot notifications dedupe** (`App.tsx`, `useWebSocket.ts`, `notificationsSlice.ts`): of the two boot dispatches, the **first-connect copy is the one that must stay authoritative** — its HTTP snapshot is taken after the socket is registered, so a notification created after the snapshot is guaranteed to arrive as a WS push. A mount-time snapshot has no such guarantee: a notification created between it and socket registration is pushed to nobody and would stay invisible until a reconnect (this is exactly the gap the old duplicate incidentally papered over). So the mount effect no longer fetches; it arms a 5s fallback (`armBootNotificationsFallback`, disarmed on unmount) that fires only when no boot fetch has happened — keeping the inbox populated over plain HTTP when the socket never connects (e.g. a proxy that strips Upgrade). First-connect marks the boot fetch done (`markBootNotificationsFetched`) before dispatching, so the two paths can never double-fire; and when the connect lands *after* the fallback already fired, the connect fetch is chained behind the fallback's in-flight request (`markBootNotificationsFetched` returns it), so the older pre-registration snapshot can never overwrite the newer one. The `syncPendingApprovals`-after-notifications ordering guarantee is unchanged (still chained on the fetch settling, at the same call site). **Reconnect resync is untouched and still works**: the reconnect branch keeps dispatching its own fresh `fetchSlots()` and `fetchNotifications().then(syncPendingApprovals)` — this change targets only the duplicated BOOT burst.

**Lazy history fetch** (`ChatPage.tsx`): the unconditional mount `dispatch(fetchHistory(false))` is replaced by a lazy seed. The sidebar's "Older sessions" section already self-fetches when expanded (pre-existing behavior in `ChatSidebar`'s footer toggle), which leaves the welcome-screen "Continue a previous chat?" suggestions as the only consumer that can need the payload earlier. The seed fires on the **first keystroke** (raw `input`, not the 300ms-debounced `historyQuery` — keying off the debounce would stack the round-trip after it, and on high-RTT tunnels the suggestions could land after the user already hit Enter; riding inside the debounce window costs the same single request). Once-only, ref-latched; skips the fetch when the sidebar already populated the list. The section starts collapsed and its open state is not persisted, so the "drawer already open at mount" case cannot occur; no fetch is ever skipped that a visible surface needs.

**Docs** (`docs/guides/remote-and-mobile.md`): one paragraph in the SSH-tunnel section: pass `-C` — Kiro Crew's own tunnel manager (`src/kiro_crew/instances/ssh_tunnel_manager.py`) enables compression for exactly this traffic, and the gateway does not gzip at the HTTP layer, so a hand-rolled tunnel otherwise gets none.

**Request-count effect (reasoned):** −1 `GET /api/notifications` on every boot, −1 `GET /api/sessions` (history) on every mount where the user doesn't type into the composer or open the history section — i.e. −2 round-trips on the common warm reload, plus the docs win for tunnel users.

**Already on main — deliberately NOT re-implemented (this PR is the rescoped remainder):**
- Cause 1 (asset pre-compression): `precompressPlugin` in `vite.config.ts` (#766).
- Cause 3 (lazy mermaid) and the boot `fetchSlots` dedupe: #769.
- Cause 2 item 2 (focus-refetch storm): `staleTime: Infinity` in `queryClient.ts`.
- Issue item 2 (Agents-page N+1): **stale premise on current main** — `AgentsPage` no longer fetches details per agent after listing; `api.agentDetail` is called only for the auto-opened first agent (one cached react-query) and lazily per user selection. There is no request loop left to collapse, and per the issue's own constraint no new batch endpoint is added (that design decision stays with maintainers).

Out-of-scope items honored: no react-query persister, no global `staleTime` change, no route-level `React.lazy`, no new backend endpoint, no changes to the precompress plugin / mermaid loader / `queryClient.ts`.

## Tests

- `useWebSocket.bootNotificationsDedupe.test.ts` (new, 5 tests): first connect dispatches exactly one notifications fetch with `syncPendingApprovals` gated on it settling (the ordering guarantee); the armed fallback never double-fires after first-connect marked the boot fetch; the fallback fires when the socket never connects (and marks itself, so it can't re-fire); disarm cancels a pending fallback (App unmount cleanup); a late mark after the window is inert.
- `ChatPage.lazyHistoryFetch.test.tsx` (new, 2 tests): mount alone issues no history request; typing seeds the list exactly once and never re-fetches on further typing.
- `ChatPageMoreCoverage.test.tsx` (adapted, 3 tests): the welcome-suggestion tests waited for history to populate *before* typing (pinning the old fetch-on-mount mechanism); the wait now follows the keystroke. The user-visible contract each locks in (type → matching suggestions / Escape dismiss / no false matches) is unchanged.
- The new files fail on `main` (verified by stashing the production changes and re-running) and pass with this diff.

## Manual verification

N/A — unit coverage exercises the real hook/page against a mock socket and API; the deduped paths have no visual surface. Reconnect behavior is unchanged code (the reconnect branch diff is comment-only).

## Related Issues

Fixes #765

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

