### PR TITLE
ci: pin the eslint warning ceiling to the measured count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1144,12 +1144,14 @@ jobs:
       - name: Lint
         working-directory: website
         # Blocking: fails on any eslint error and on any NEW warning above the
-        # current baseline. Ratchet --max-warnings down toward 0 as the ~1116
+        # current baseline. Ratchet --max-warnings down toward 0 as the
         # pre-existing warnings (no-explicit-any, jsx-a11y, no-console) are burned
-        # down; do not raise it. (Baseline bumped 1066 -> 1116 by the final
-        # Brazil->GitHub sync, which imported upstream warnings that never faced
-        # this gate; burn-down resumes from 1116.)
-        run: npx eslint src/ --max-warnings 1116
+        # down; do not raise it.
+        #
+        # The ceiling must EQUAL the measured count, not sit above it: slack is
+        # silent admission, and a warning that lands inside it never surfaces
+        # again. Re-measure with `cd website && npx eslint src/` when burning down.
+        run: npx eslint src/ --max-warnings 680
 
       - name: Copy/paste detection
         working-directory: website
@@ -1215,7 +1217,7 @@ jobs:
         #
         # `check-i18n-strings.mjs` drives a SECOND eslint invocation with its own config.
         # `no-literal-string` at `mode: 'all'` reports thousands of findings, and folding
-        # those into the 1116 budget above would make an i18n regression indistinguishable
+        # those into the budget above would make an i18n regression indistinguishable
         # from a new `no-explicit-any`.
         run: |
           # `actions/checkout` fetches depth 1, so the base branch is not present and

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -95,7 +95,7 @@ Every job here is blocking.
 | `backend-test-macos` | macos-14, deliberately SCOPED (gateway, socketsec, platform-compat, pod and MCP-apps suites via a glob). A full macOS run needs its own exclusion burn-down first, and a job that is red on arrival trains people to ignore it |
 | `backend-test-sandbox` | The one job that clears the AppArmor userns restriction, so the tests guarded by `skipif(not userns_available())` EXECUTE instead of skipping. Runs all eleven sandbox-dependent suites. The shards collect the same files — nothing is deselected — but there the sandbox-guarded tests skip, so this is the only lane where those 85 assertions (the `~/.kiro/crew` keystone among them) actually execute |
 | `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces the project line-rate floors, plus a per-file floor with a shrink-only baseline (all floors live in the job's `env:` block) |
-| `frontend-lint` | `tsc -b`, `eslint --max-warnings 1116`, `jscpd`, and `npm run i18n:check` |
+| `frontend-lint` | `tsc -b`, `eslint --max-warnings <measured count>`, `jscpd`, and `npm run i18n:check` |
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |
 | `frontend-test` | `vitest run --coverage` |
 | `cfn-lint` | Lints the artifact-deploy templates with a pinned `cfn-lint` |
@@ -135,8 +135,11 @@ Details worth knowing:
   places. Per-file enforcement is skipped for a lane whose suite ran as a
   coverage-free subset, because subset rates are not comparable to a baseline
   recorded on the full suite.
-- **`eslint --max-warnings 1116` is a ratchet baseline.** Burn it down, never raise
-  it.
+- **`eslint --max-warnings <n>` is a ratchet baseline, and `<n>` is the measured
+  count.** Burn it down, never raise it, and never leave it above what
+  `npx eslint src/` reports: the difference is a budget new warnings land inside
+  without anyone seeing them. `test_eslint_warning_ceiling.py` keeps the number in one place so a
+  burn-down cannot leave a stale copy behind.
 - **The i18n gates split into three tiers,** and only two can fail: diff-scoped
   zero-tolerance checks (a user-visible literal on a line this branch wrote, a
   file holding more than it did at the base, new English key shape, changed catalog

--- a/test/test_eslint_warning_ceiling.py
+++ b/test/test_eslint_warning_ceiling.py
@@ -1,0 +1,77 @@
+"""The frontend eslint warning ceiling has ONE numeric source.
+
+The ceiling is a ratchet: CI runs `eslint src/ --max-warnings <n>`, so a warning
+count at or below `<n>` is green and anything above is red. Two things make that
+ratchet stop ratcheting, and neither shows up as a failing check:
+
+* **Slack.** A ceiling above the measured count is a budget new warnings land
+  inside, silently, until it is exhausted. Only running eslint can measure that,
+  so it is not pinned here -- the gate itself is that test.
+* **Transcription.** Prose that repeats the number goes stale the first time
+  anyone burns the ceiling down, and then documents a gate that no longer
+  exists. That is what these tests pin, because it is cheap to pin and because a
+  stale ceiling in a doc is what makes the next burn-down look already done.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+#: Trees whose prose must not carry a copy of the ceiling.
+_PROSE = (
+    _REPO_ROOT / "docs",
+    _REPO_ROOT / "website" / "docs",
+    _REPO_ROOT / "AGENTS.md",
+    _REPO_ROOT / "website" / "AGENTS.md",
+)
+
+_CEILING = re.compile(r"--max-warnings\s+(\d+)")
+
+
+def _ci_text() -> str:
+    return _CI.read_text(encoding="utf-8")
+
+
+def test_the_lint_gate_declares_a_ceiling() -> None:
+    """Without one, `eslint` exits 0 on any number of warnings."""
+    ceilings = _CEILING.findall(_ci_text())
+
+    assert ceilings, (
+        "ci.yml's Lint step no longer passes --max-warnings, so eslint reports "
+        "warnings and exits 0 -- the ratchet is gone entirely"
+    )
+    assert len(ceilings) == 1, (
+        f"ci.yml declares {len(ceilings)} eslint ceilings ({ceilings}); keep one, "
+        "or a burn-down has to find them all and will miss one"
+    )
+
+
+def test_the_ceiling_is_not_transcribed_into_prose() -> None:
+    """Docs describe the ratchet; they must not restate its current value.
+
+    A number copied into prose is correct exactly until the ceiling moves, and
+    the reader who finds the stale copy concludes the burn-down already happened.
+    Refer to the gate instead, so there is one place to change.
+    """
+    ceiling = _CEILING.search(_ci_text())
+    assert ceiling is not None
+    value = ceiling.group(1)
+
+    offenders: list[str] = []
+    for root in _PROSE:
+        files = sorted(root.rglob("*.md")) if root.is_dir() else [root]
+        for path in files:
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if "max-warnings" in line and value in line:
+                    offenders.append(f"{path.relative_to(_REPO_ROOT)}:{lineno}")
+
+    assert offenders == [], (
+        "these lines transcribe the eslint ceiling's current value "
+        f"({value}) instead of referring to the gate: {offenders}. "
+        "The value belongs only in .github/workflows/ci.yml, so burning the "
+        "ratchet down is a one-line change that cannot leave a stale copy behind."
+    )


### PR DESCRIPTION
## Problem / Motivation

The frontend lint gate ran `eslint src/ --max-warnings 1116` against a tree that measures
**680** warnings and 0 errors. That is **436 free slots**, and a ratchet with slack is not a
ratchet: a warning that lands inside the gap is green forever, and nothing reports it again.

Proven rather than inferred. Appending one function with three `any` parameters and a
`console.log` to `src/App.tsx` takes the tree to 684:

```
npx eslint src/                       →  680 problems (0 errors, 680 warnings)
# with the probe appended → 684 warnings:
npx eslint src/ --max-warnings 1116   →  exit 0   ← four new warnings land GREEN
npx eslint src/ --max-warnings 680    →  exit 1   ← caught
# probe removed:
npx eslint src/ --max-warnings 680    →  exit 0
```

## Why it matters

This is the gate that is supposed to stop `no-explicit-any`, `jsx-a11y` and `no-console`
regressions reaching `main`. With 436 slots of headroom it stops roughly none of them until
the budget is exhausted — and because each one lands green, nobody learns the ceiling is
doing nothing. The gate's own comment says "do not raise it", which is the right instinct
applied to the wrong number: the problem was never that someone raised it, it is that it was
never lowered back to what the tree actually measures.

## What changed (motivation → approach → change)

- `.github/workflows/ci.yml` — ceiling `1116` → **680**, the measured count.
- The step comment explained a `1066 → 1116` bump from the final Brazil→GitHub sync. That is
  history, not current behaviour. It is replaced with the rule the old number violated — the
  ceiling must **equal** the measured count, because anything above it is silent admission —
  and with how to re-measure (`cd website && npx eslint src/`) when burning down.
- `docs/ci/ci-and-reviews.md` restated `1116` twice. Both now refer to the gate instead of
  copying its value: a number in prose is correct exactly until the ceiling moves, and the
  reader who finds the stale copy concludes the burn-down already happened.
- One further stale reference at `ci.yml:1218` ("folding those into the 1116 budget above")
  now says "the budget above", so the i18n rationale survives a future burn-down.

This lowers a ceiling to the current tree; it does **not** burn any warning down. The 680 are
still there and still want fixing — the point is that number 681 now goes red.

## Tests

`test/test_eslint_warning_ceiling.py` pins the two properties that are cheap to pin:

- **the gate declares exactly one ceiling** — remove `--max-warnings` and eslint reports
  warnings and exits 0, i.e. the ratchet disappears with no check going red;
- **no doc transcribes its value** — so burning it down is a one-line change that cannot
  leave a stale copy behind.

Both mutation-checked: transcribing `680` back into `ci-and-reviews.md` fails the second
test by file and line; deleting `--max-warnings` from `ci.yml` fails the first with *"the
ratchet is gone entirely"*.

The slack property itself can only be measured by running eslint, which is too slow for the
backend suite — so **the gate is its own test for that**, and the module docstring says so
explicitly rather than leaving it as a gap someone re-discovers.

## Manual verification

| check | result |
|---|---|
| `npx eslint src/` on a clean tree | 680 warnings, 0 errors |
| `npx eslint src/ --max-warnings 680` clean | exit 0 |
| same, with 4 injected warnings | exit 1 |
| `flake8`, `isort`, `check_black_formatting.py` | 0 |
| `docs-lint.sh` | 0 |
| `test/test_eslint_warning_ceiling.py` | 2 passed |

<!-- no-visual-delta -->
**Why no screenshot:** a CI ceiling, two doc lines and a new backend test. No frontend source
is touched and nothing renders.

## Related Issues

no linked issue: found by auditing which CI gates can pass while the thing they name is
broken.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
