### PR TITLE
fix(ci): fail the bundle-size gate when it measured no chunks

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -98,8 +98,10 @@ function fail(message, code = 1) {
 }
 
 // Exit-code mapping for this gate: 2 = report missing, 3 = report malformed or
-// unsupported version. The contract itself (existence/shape/version) lives in
-// the shared loadBundleSummary.
+// unsupported version, 4 = report valid but lists no chunks. The contract itself
+// (existence/shape/version) lives in the shared loadBundleSummary; 4 is checked
+// here rather than there because an empty report is legitimate for
+// bundle-report.mjs, which simply has nothing to render.
 function loadSummary(file) {
   const { summary, error } = loadBundleSummary(file, {
     hint:
@@ -117,6 +119,22 @@ export function main(argv = process.argv.slice(2)) {
     budgets: CHUNK_BUDGETS,
     defaultBudget: DEFAULT_BUDGET_BYTES,
   })
+
+  // A report that lists no chunks measured NOTHING, and the summary below would
+  // call that "0 chunks within budget" and exit 0 -- a green gate over an unbuilt
+  // tree. The build steps that feed it can fail this way silently: an analyze
+  // build whose plugin stops emitting, a config change that empties the chunk
+  // list, or a report written before the bundle exists. Refuse ahead of the
+  // unused-budget warnings, so the actionable line is not buried under one
+  // warning per allowlist entry (11 of them today).
+  if (checkedCount === 0) {
+    fail(
+      `no chunks in ${reportPath} -- the gate measured nothing, so it cannot ` +
+        'certify anything. Re-run `vite build --mode analyze` and check it ' +
+        'emitted a bundle.',
+      4
+    )
+  }
 
   for (const name of unusedBudgets) {
     process.stderr.write(

--- a/website/src/test/checkBundleSize.test.ts
+++ b/website/src/test/checkBundleSize.test.ts
@@ -139,6 +139,21 @@ describe('check-bundle-size.mjs as a process (the CI entry point)', () => {
     return spawnSync(process.execPath, [scriptPath, file], { encoding: 'utf-8' })
   }
 
+  it('refuses a valid report that lists no chunks, rather than certifying it', () => {
+    // The failure this closes is a GREEN one: with an empty chunk list the summary
+    // read "0 chunks within budget" and exited 0, so a build that emitted nothing
+    // measurable passed the gate that exists to measure it.
+    const res = run(JSON.stringify({ version: 1, chunks: [] }))
+
+    expect(res.status).toBe(4)
+    expect(res.stderr).toContain('measured nothing')
+    // Actionable: name the command that produces a real report.
+    expect(res.stderr).toContain('--mode analyze')
+    // The refusal must come BEFORE the unused-budget warnings, or it arrives
+    // under one warning per allowlist entry and reads as noise.
+    expect(res.stdout).not.toContain('within budget')
+  })
+
   it('exits non-zero on an over-budget non-allowlisted chunk, naming size, budget and overage', () => {
     const res = run(JSON.stringify(report([{ fileName: 'assets/rogue-AAAAAAAA.js', size: 700 * KB }])))
     expect(res.status).toBe(1)


### PR DESCRIPTION
## Problem / Motivation

The bundle-size gate passes — with a green summary — on a report that lists **no chunks**:

```
$ printf '{"version":1,"chunks":[]}' > /tmp/empty.json
$ node scripts/check-bundle-size.mjs /tmp/empty.json
bundle-size gate: 0 chunks within budget (default 500.0 KB, 11 allowlisted).
exit 0
```

A gate whose entire job is measuring chunk sizes cannot certify a build it measured nothing
about. `"0 chunks within budget"` is not a pass; it is the gate reporting that it had no
input and treating that as success.

## Why it matters

Every route to an empty report is silent:

- the analyze build's report plugin stops emitting (a Vite or plugin upgrade),
- a config change empties the chunk list,
- the checker runs before the bundle exists, or against a stale `dist/`.

In each case CI goes green and the per-chunk ceilings — including the 8.6 MB catalog chunk and
the six other allowlisted large chunks — stop being enforced, with nothing to notice it.
`loadBundleSummary` already validates existence, JSON shape and `version`, so
empty-but-valid is the one hole left in that contract.

## What changed (motivation → approach → change)

`website/scripts/check-bundle-size.mjs` refuses when `checkedCount === 0`, with a new exit
code **4** (existing map: 2 = missing, 3 = malformed/unsupported version).

Two placement decisions, both load-bearing:

- **Before the unused-budget warnings.** With an empty report *every* allowlist entry matches
  nothing, so all 11 emit a warning. Refusing afterwards would bury the one actionable line
  under eleven lines of noise.
- **In the checker, not in the shared `loadBundleSummary`.** An empty report is legitimate for
  `bundle-report.mjs`, which simply has nothing to render. Putting the guard in the shared
  loader would break a caller for which zero chunks is a valid state.

The message names the command that produces a real report (`vite build --mode analyze`),
since the person who hits this will not otherwise know a plain `npm run build` deliberately
writes none.

## Tests

`website/src/test/checkBundleSize.test.ts`, in the existing
`check-bundle-size.mjs as a process (the CI entry point)` describe — so it exercises the real
CI entry point rather than the exported helper:

- exit status is **4**;
- stderr says `measured nothing` and names `--mode analyze`;
- stdout does **not** contain `within budget` — i.e. the refusal precedes the warnings rather
  than following them.

**Mutation-checked:** neutering the guard (`if (false && checkedCount === 0)`) fails that
test and only that test — 1 failed, 15 passed. Restored: 16 passed.

## Manual verification

| check | result |
|---|---|
| empty report | **exit 4**, actionable message |
| real `vite build --mode analyze` + gate | exit 0, 661 chunks within budget |
| `npx eslint` on both changed files | 0 |
| `src/test/checkBundleSize.test.ts` | 16 passed |

<!-- no-visual-delta -->
**Why no screenshot:** a CI gate script and its test. No frontend source is touched and
nothing renders.

## Related Issues

no linked issue: found by auditing which CI gates can pass while the thing they name is
broken.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
