### PR TITLE
fix(imessage): stop a self-chat answering itself forever

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -854,13 +854,43 @@ while over-declaring risks a send the platform silently refuses.
 authorizes nobody, which is the correct posture for a channel with no org
 boundary in front of it. Handles are normalized before comparison (email folds
 to lowercase, phone loses formatting) so `+61 400 000 000` and `+61400000000`
-are one handle. Own messages (`is_from_me`) are dropped without an audit event
-— the all-chat watch sees the agent's own replies, and auditing them would log
-one entry per outbound message. **Group chats fail closed** with a
+are one handle. **Group chats fail closed** with a
 `denied_group_chat` audit: a reply there would deliver tool output to members who
 are not on the allowlist, the same reasoning that makes Telegram and Webex
 direct-only. Unauthorized inbound is dropped with no reply, so an unknown sender
 learns nothing about what they reached.
+
+**Own-message suppression is TWO signals, and the gate order is load-bearing.**
+Neither part is a defensive extra: a self-chat loop that answered its own replies
+without bound shipped once (issue #5246), and each rule below is what closes it.
+
+1. `is_from_me` drops the rows the bridge already attributes to the agent, without
+   an audit event — the all-chat watch sees its own replies, and auditing them
+   would log one entry per outbound message.
+2. That flag is not sufficient on its own. In a **self-chat** the allow-listed
+   handle IS the identity the agent sends as, and the bridge writes the
+   attribution asynchronously (`watch.subscribe` defaults to a 500ms debounce
+   expressly so an `is_from_me` correction can land), so an echo can arrive
+   looking exactly like user input. The client therefore keeps a short-lived
+   **ledger of what it sent** — one record per sent message, holding both the
+   body it went out with and the guid the bridge reported, consumed whole on a
+   match — and the transport consults it as the LAST gate before dispatch.
+
+The ordering constraints are the part a refactor must preserve:
+
+* The ledger check runs **after** the `is_from_me` drop, so a copy the platform
+  already attributes to the agent cannot consume the record that the
+  *unattributed* echo needs.
+* It runs **after** the group and allowlist gates, because consuming is a side
+  effect: a row that will be dropped anyway must not spend the record on its way
+  out.
+* A record's TTL starts when the send **resolves**, not when it is issued, and an
+  unresolved record is never pruned or evicted — the echo of a slow send arrives
+  before its result does.
+
+Reordering any of those reintroduces the loop. The accepted cost is a bounded
+one: an allow-listed sender who repeats the agent's exact text within the TTL has
+that message suppressed once, in any chat rather than only a self-chat.
 
 **Rendering.** Only the final answer is delivered; reasoning and tool activity
 stay in the gateway. There is no placeholder message, because there is no edit

--- a/src/kiro_crew/docs/imessage-integration.md
+++ b/src/kiro_crew/docs/imessage-integration.md
@@ -40,7 +40,8 @@ deliberately does not use one.
      "allowed_handles": ["+15551234567"]
    }
    ```
-3. **Restart the gateway**, then message yourself from another device and say hi.
+3. **Restart the gateway**, then send it a message and say hi. Messaging your own
+   handle from another device works — see [Messaging yourself](#messaging-yourself).
 
 If the gateway is not on your Mac, or `imsg` is missing, the channel reports why
 in **Settings → Channels → iMessage** instead of failing silently.
@@ -59,6 +60,28 @@ Formatting is ignored when handles are compared, so `+1 (555) 123-4567` and
 **Group chats are refused**, and this is deliberate: a reply in a group would
 deliver the agent's output — including tool results — to everyone in the thread,
 allow-listed or not. Direct messages only.
+
+### Messaging yourself
+
+Listing your **own** handle and messaging it from another device is supported,
+and it is the most convenient setup: no second number, no second Apple Account.
+It is also the one chat where the agent is talking to its own identity, so the
+channel needs a way to tell your words from its own.
+
+It does not use the platform's own outbound flag alone for that. In a self-chat
+every message belongs to your account in both directions, and Messages writes
+that attribution asynchronously — the bridge's watch waits 500ms expressly so a
+correction can land — so a reply can come back looking exactly like something you
+typed. The channel instead remembers what it just sent, for 30 seconds, and
+ignores that coming back. Without it the agent answers its own reply and the
+conversation never stops.
+
+**One consequence, and it applies to every chat rather than only this one:** if
+you send the agent back the **exact** text it has just sent you, within those 30
+seconds, that message is read as the echo and ignored — no reply, and nothing
+said about it. Send anything else, or wait, and it goes through normally. The
+alternative is worse: the only way to tell a returning message from the agent's
+own is the platform's attribution, and trusting that is what produced the loop.
 
 ## What a conversation looks like
 
@@ -125,6 +148,12 @@ not.
 mistyped `allowed_handles` is the common cause, and by design it produces
 silence rather than an error. **Settings → Channels → iMessage** shows whether
 the channel is connected and why not.
+
+**It answers its own messages / the conversation never stops.** A self-chat where
+the echo guard is not doing its job — [Messaging yourself](#messaging-yourself)
+explains the mechanism. Turn the channel off in **Settings → Channels →
+iMessage** to stop it immediately (every cycle is a real turn), and please report
+it: the log records the handle, redacted, the first time it suppresses an echo.
 
 **"Messages database unavailable".** Full Disk Access is missing for the process
 running the gateway. Grant it, then quit and relaunch — macOS only re-reads that

--- a/src/kiro_crew/imessage/client.py
+++ b/src/kiro_crew/imessage/client.py
@@ -17,6 +17,11 @@ not as defensive extras:
   ENDS when its buffer fills; a client that ignores the notification goes
   permanently silent under a burst rather than losing one message.
 
+It also keeps a short-lived **ledger of what it has sent**, because the watch is
+an all-chat stream and the bridge's own attribution is not sufficient to
+recognise the channel's own traffic in every chat. See
+:meth:`IMessageClient.is_own_echo`.
+
 Handles are normalized before comparison so an allowlist entry written as
 ``+61 400 000 000`` matches the ``+61400000000`` the bridge reports.
 """
@@ -27,6 +32,8 @@ import asyncio
 import json
 import logging
 import re
+import time
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
@@ -50,6 +57,21 @@ PROTOCOL_VERSION = 1
 #: end: a window smaller than the buffer would let part of the replay through.
 DEDUPE_WINDOW = 1024
 
+#: How long a message this client sent stays recognisable as its own echo.
+#: This single number balances the two failures, in opposite directions: too
+#: short and an echo arriving late is answered, which is the unbounded loop this
+#: guard exists to stop; too long and the window in which a user's genuine
+#: repeat of the agent's exact words is read as that echo grows. So it is sized
+#: at the smallest value comfortably above a delivery round trip -- the bridge's
+#: own watch debounce is 500ms, and the echo is a local database row appearing
+#: after a local send -- rather than at anything to do with a conversation's
+#: length.
+ECHO_TTL_S = 30.0
+
+#: Bound on remembered outbound messages. A long answer is delivered as several
+#: sends, so this is entries, not turns; the oldest are evicted first.
+ECHO_WINDOW = 256
+
 #: Watch buffer size requested from the bridge (its own default is 256).
 WATCH_BUFFER_LIMIT = 256
 
@@ -60,6 +82,13 @@ RECONNECT_MAX_S = 30.0
 #: Bridge error code for "configured database currently unavailable" --
 #: retryable, and the usual symptom of missing Full Disk Access.
 ERR_DATABASE_UNAVAILABLE = -32002
+
+#: JSON-RPC invalid params. The bridge rejects at validation, before dispatch.
+ERR_INVALID_PARAMS = -32602
+
+#: The only failures that PROVE a send never reached Messages, when the bridge
+#: did not spell out a delivery disposition of its own.
+_DEFINITIVE_REJECTIONS = frozenset({ERR_DATABASE_UNAVAILABLE, ERR_INVALID_PARAMS})
 
 #: Non-digit characters to drop when comparing phone-shaped handles.
 _PHONE_NOISE = re.compile(r"[\s()\-.]")
@@ -78,6 +107,71 @@ def normalize_handle(handle: str) -> str:
     if "@" in value:
         return value.lower()
     return _PHONE_NOISE.sub("", value)
+
+
+def _echo_key(handle: str, text: str) -> str:
+    """The ledger key for one (handle, body) pair.
+
+    The body is NFC-normalized and stripped before comparison because the text
+    makes a round trip through Messages and back out of the database, and a
+    composed/decomposed mismatch on a single accented character would silently
+    stop an echo being recognised as one. Handle and body are joined on a
+    newline, which ``normalize_handle`` can never produce, so no pair of
+    distinct inputs can collide on one key.
+    """
+    return f"{normalize_handle(handle)}\n{unicodedata.normalize('NFC', text).strip()}"
+
+
+def _proves_nothing_was_sent(exc: BaseException) -> bool:
+    """Whether ``exc`` PROVES the send never reached Messages.
+
+    Fails closed, because the two mistakes do not cost the same. Dropping the
+    echo guard for a message that DID go out lets its echo be answered, which is
+    the unbounded loop this whole mechanism exists to stop. Keeping a guard for a
+    message that never went out only suppresses one identical inbound for the
+    rest of the TTL. So anything not recognisably definitive is treated as
+    possibly delivered.
+
+    The bridge's own delivery disposition is the authority when it gives one: it
+    documents ``retry_safe`` and ``disposition`` on a delivery failure's ``data``,
+    where ``not_started`` is the one value that proves the transport never
+    dispatched. Absent that, only a rejection that happens before dispatch
+    counts. A transport failure, a timeout and a cancellation prove nothing --
+    the request may already have been written to the bridge's stdin.
+    """
+    if not isinstance(exc, RpcError):
+        return False
+    if isinstance(exc.data, dict):
+        return exc.data.get("retry_safe") is True or exc.data.get("disposition") == "not_started"
+    return exc.code in _DEFINITIVE_REJECTIONS
+
+
+@dataclass
+class _OwnSend:
+    """One message this client sent, remembered long enough to recognise its echo.
+
+    A sent message is recognisable two ways -- by the body it was sent with, and
+    by the GUID the bridge reports for it -- and they are held together in ONE
+    record on purpose. As two independent entries, matching on either left the
+    other alive to swallow the next genuine message carrying it.
+
+    The lifetime rule is the other half, and it is why ``expires_at`` is optional
+    rather than a timestamp computed up front: **the TTL clock starts when the
+    send's outcome is known, and a record with no outcome yet never expires.** A
+    pre-computed expiry cannot express "not counting yet", and overloading one
+    absolute timestamp with both meanings is what let a slow send outlive its own
+    guard -- ``_call`` waits up to 30s and the TTL is 30s, so a send that reached
+    its timeout left a record already eligible for pruning at the moment its echo
+    could arrive, and the echo was answered.
+    """
+
+    body_key: str
+    #: ``None`` while the send is in flight: an unresolved record never expires,
+    #: because the echo can arrive before the call returns. Set once, to
+    #: ``monotonic() + ECHO_TTL_S``, when the send succeeds or fails ambiguously.
+    expires_at: float | None = None
+    #: Set once the send returns, since the bridge reports it best-effort.
+    guid: str = ""
 
 
 @dataclass
@@ -157,6 +251,12 @@ class IMessageClient:
         self._subscription: int | None = None
         self._since_rowid: int = 0
         self._seen_guids: dict[str, None] = {}
+        #: Ledger of what THIS client sent, oldest first. One record per sent
+        #: message, carrying both of the keys it can be recognised by.
+        self._own_sends: list[_OwnSend] = []
+        #: Handles already reported as looping, so the warning is written once
+        #: per handle instead of once per suppressed message.
+        self._echo_reported: set[str] = set()
         self._resubscribe_task: Optional[asyncio.Task[None]] = None
         self._closing = False
 
@@ -294,8 +394,143 @@ class IMessageClient:
         # exercises the SMS-fallback path by accident.
         if self._service != "imessage":
             params["service"] = self._service
-        result = await self._call("send", params)
-        return _str(result.get("guid"))
+        # Recorded BEFORE the call, not after: the watch can emit the row for
+        # this message while `send` is still awaiting its own result (the bridge
+        # verifies the inserted row before answering, and its watch debounce is
+        # only 500ms), and an echo that arrives before it is remembered is an
+        # echo that gets answered. A send that then fails leaves one stale entry
+        # behind, which costs no more than the TTL already does.
+        # Recorded BEFORE the call, and with NO expiry: the watch can emit the row
+        # for this message while `send` is still awaiting its own result (the
+        # bridge verifies the inserted row before answering, and its watch
+        # debounce is only 500ms), so an echo that arrives before the record
+        # exists -- or after a pre-computed TTL would already have pruned it --
+        # is an echo that gets answered. The clock starts below, once the outcome
+        # is known.
+        record = self._remember_own_send(_echo_key(to, text))
+        try:
+            result = await self._call("send", params)
+        except BaseException as exc:
+            if _proves_nothing_was_sent(exc):
+                # Definitively rejected, so nothing can echo -- and leaving the
+                # record would have the undelivered body suppress a genuine
+                # message carrying those words for the rest of the TTL.
+                self._forget_own_send(record)
+            else:
+                # Ambiguous: the bridge documents -32001 as "may have completed
+                # or remains in flight", and a timeout, a cancellation or a dead
+                # child says nothing about what it did with a request already
+                # written to its stdin. The message may still arrive and echo, so
+                # the guard stays and its clock starts here.
+                record.expires_at = time.monotonic() + ECHO_TTL_S
+            raise
+        record.expires_at = time.monotonic() + ECHO_TTL_S
+        guid = _str(result.get("guid"))
+        # `id`/`guid` are best-effort in the bridge's contract, so this is an
+        # additional key on the same record rather than the mechanism. It is the
+        # stronger of the two -- a GUID this client sent can never legitimately
+        # arrive as user input, so unlike the body it has no false positive.
+        if guid:
+            record.guid = guid
+        return guid
+
+    def _remember_own_send(self, body_key: str) -> _OwnSend:
+        """Record one outbound message, evicting the oldest RESOLVED record if needed.
+
+        The record starts with no expiry -- see :class:`_OwnSend` -- and eviction
+        skips unresolved records for the same reason pruning does: an unresolved
+        record is the guard for a send that has not returned, so dropping it is
+        exactly the loop this ledger exists to prevent. Reaching that needs many
+        sends outstanding at once, which this channel does not do today (``send``
+        awaits its own call, so one conversation has one send in flight), but the
+        invariant is cheaper to hold than to reason about per caller.
+
+        The list can therefore overshoot ``ECHO_WINDOW`` while sends are in
+        flight. That is bounded by concurrent sends rather than by conversation
+        length, and it always drains, because every send resolves: success and an
+        ambiguous failure both set an expiry, and a definitive rejection removes
+        the record outright.
+        """
+        record = _OwnSend(body_key=body_key)
+        self._own_sends.append(record)
+        # A long answer is delivered as several sends, so the bound is entries,
+        # not turns; the oldest RESOLVED ones go first.
+        overflow = len(self._own_sends) - ECHO_WINDOW
+        if overflow > 0:
+            kept: list[_OwnSend] = []
+            for held in self._own_sends:
+                if overflow > 0 and held.expires_at is not None:
+                    overflow -= 1
+                    continue
+                kept.append(held)
+            self._own_sends = kept
+        return record
+
+    def _forget_own_send(self, record: _OwnSend) -> None:
+        """Drop one record. Identity, not equality -- two sends can be identical."""
+        for index, held in enumerate(self._own_sends):
+            if held is record:
+                del self._own_sends[index]
+                return
+
+    def is_own_echo(self, inbound: IMessageInbound) -> bool:
+        """Whether ``inbound`` is this channel's own outbound message coming back.
+
+        The all-chat watch sees every row, including the ones this client caused,
+        and ``is_from_me`` alone does not separate them in every chat. In a
+        **self-chat** -- the user's own handle, which the docs used to prescribe
+        for the first run -- the allow-listed sender IS the identity the agent
+        sends as, so an echo of the agent's reply is indistinguishable from user
+        input unless that flag is both present and correct on the row. The
+        bridge's contract says it need not be: ``watch.subscribe`` defaults to a
+        500ms debounce expressly so an ``is_from_me`` *correction* can land
+        first, and ``sender`` is documented as empty for some self-sent
+        messages. Trusting it as the only guard is what let the channel answer
+        itself without limit (issue #5246).
+
+        So the guard is a record of what this client itself sent, which is the
+        one signal it fully owns. The matching record is CONSUMED WHOLE, so the
+        ledger suppresses each sent message exactly once and a genuine later
+        repeat of the same words is delivered normally. Rows the bridge already
+        attributes to us (``is_from_me``) are dropped by the transport before
+        they reach here, so they never consume the entry the real echo needs.
+        """
+        now = time.monotonic()
+        # Expired records are dropped rather than skipped: an expired entry can
+        # never legitimately match again, and pruning here is what keeps a run of
+        # failed sends from holding the list at its bound. A record with no expiry
+        # is still IN FLIGHT and is never pruned -- that is the whole point of the
+        # optional expiry, since the echo of a slow send arrives before its
+        # outcome does.
+        self._own_sends = [r for r in self._own_sends if r.expires_at is None or r.expires_at > now]
+        body_key = _echo_key(inbound.handle, inbound.text)
+        for index, record in enumerate(self._own_sends):
+            if not ((inbound.guid and record.guid == inbound.guid) or record.body_key == body_key):
+                continue
+            del self._own_sends[index]
+            handle = normalize_handle(inbound.handle)
+            # Every suppression is recorded, because a drop with no signal at all
+            # is indistinguishable from a message that never arrived -- and this
+            # one is silent to the user by construction (replying would be the
+            # loop). The WARNING fires once per handle so a self-chat announces
+            # itself without writing a line per outbound message; the rest land
+            # at debug so a support question has something to read.
+            if handle not in self._echo_reported:
+                self._echo_reported.add(handle)
+                logger.warning(
+                    "imessage: dropping this channel's own message echoed back from %s. "
+                    "This is what a self-chat looks like -- the handle the agent "
+                    "replies to is its own -- and without this the channel would "
+                    "answer itself in a loop.",
+                    redact_handle(inbound.handle),
+                )
+            else:
+                logger.debug(
+                    "imessage: suppressed an echo of this channel's own message from %s",
+                    redact_handle(inbound.handle),
+                )
+            return True
+        return False
 
     async def send_typing(self, selector: dict[str, Any]) -> None:
         """Show a typing indicator, if the bridge offers one.

--- a/src/kiro_crew/imessage/transport.py
+++ b/src/kiro_crew/imessage/transport.py
@@ -14,8 +14,12 @@ on the other end is a phone number rather than a workspace member:
 * **Handle allowlist, deny-by-default.** An empty allowlist authorizes nobody.
   There is no org boundary to fall back on -- anyone who knows the user's
   number can send to it.
-* **Own messages are ignored.** The watch is an all-chat stream and sees the
-  agent's own replies; without this the channel answers itself in a loop.
+* **Own messages are ignored**, on two signals rather than one. The watch is an
+  all-chat stream and sees the agent's own replies; without this the channel
+  answers itself in a loop. The bridge's ``is_from_me`` covers the rows it has
+  already attributed to us, and the client's ledger of what it sent covers the
+  self-chat case, where the allow-listed handle is the identity the agent sends
+  as and that flag is not dependable on its own (issue #5246).
 * **DM only, fail closed.** A reply in a group chat would deliver tool output
   to members who are not on the allowlist, the same reasoning that already
   makes Telegram and Webex direct-only.
@@ -192,6 +196,24 @@ class IMessageTransport(MessagingTransport):
             thread_id=None,
         )
         if not self.authorize(msg):
+            return
+        # LAST gate, and its position is load-bearing in both directions.
+        #
+        # After `is_from_me`, because a copy the bridge already attributes to us
+        # must not consume the ledger record that the UNattributed echo needs --
+        # consuming it there would restore the loop while looking fixed.
+        #
+        # After the group and allow-list gates, because this one has a side
+        # effect: it consumes the record. A row that is going to be dropped
+        # anyway -- a group message, an unlisted sender -- must not be able to
+        # spend the record on its way out, or the real echo that follows finds
+        # nothing and is answered.
+        #
+        # `is_from_me` alone cannot carry this: in a self-chat the allow-listed
+        # sender IS the identity the agent replies as, and the bridge writes that
+        # flag asynchronously (its 500ms watch debounce exists so a correction
+        # can land first). See `is_own_echo`.
+        if self._client.is_own_echo(inbound):
             return
         if self._dispatch is not None:
             await self._dispatch(inbound)

--- a/test/test_imessage_client.py
+++ b/test/test_imessage_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -16,13 +17,21 @@ import pytest
 from kiro_crew.imessage import client as client_mod
 from kiro_crew.imessage.client import (
     DEDUPE_WINDOW,
+    ECHO_TTL_S,
+    ECHO_WINDOW,
     WATCH_BUFFER_LIMIT,
     IMessageClient,
+    _echo_key,
     normalize_handle,
     parse_inbound,
     redact_handle,
 )
 from kiro_crew.imessage.rpc import RpcError, RpcTransportError
+from kiro_crew.imessage.transport import IMessageTransport
+
+#: The handle every fixture message comes from, and the one the self-chat tests
+#: put on the allowlist -- in that case it is the user's OWN handle.
+OWNER = "+15551234567"
 
 #: A realistic bridge readiness snapshot for a DEFAULT install: the injected
 #: helper is absent (bridge.ready false) yet typing and read are still listed,
@@ -851,6 +860,431 @@ class TestLifecycle:
         await imc.close()
         await imc._on_notification("watch.overflow", {"resume_after_rowid": 5})
         assert imc._resubscribe_task is None
+
+
+class TestOwnEchoLedger:
+    """The self-chat guard of issue #5246.
+
+    In a self-chat the allow-listed handle is the identity the agent sends as, so
+    ``is_from_me`` is the only thing separating the user's words from the agent's
+    -- and the bridge writes it asynchronously (its 500ms watch debounce exists so
+    a correction can land first) and documents ``sender`` as empty for some
+    self-sent messages. These pin the one signal the client fully owns: a record
+    of what it sent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_sent_body_coming_back_is_recognised_as_our_own(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        imc = await _client(tmp_path)
+        await imc.send("+1 (555) 123-4567", "on it")
+        # Same body, same handle written differently, and the platform calling it
+        # inbound -- which is exactly the shape that produced the loop.
+        echoed = parse_inbound(_message(guid="OTHER", text="on it", is_from_me=False))
+        assert echoed is not None
+        assert imc.is_own_echo(echoed) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_the_sent_guid_is_recognised_even_if_the_body_differs(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # `guid` is best-effort in the bridge's contract, so it is a second key
+        # rather than the mechanism -- but a guid this client sent can never
+        # legitimately arrive as user input, so it has no false positive.
+        imc = await _client(tmp_path)
+        peers[0].replies["send"] = [{"ok": True, "id": 9, "guid": "SENT-GUID"}]
+        assert await imc.send(OWNER, "on it") == "SENT-GUID"
+        surprising = parse_inbound(_message(guid="SENT-GUID", text="not what we sent"))
+        assert surprising is not None
+        assert imc.is_own_echo(surprising) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_match_is_consumed_so_a_genuine_repeat_gets_through(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # Consume-once is what keeps the guard from swallowing a conversation:
+        # the echo is suppressed, and the user deliberately saying the same words
+        # afterwards is ordinary input.
+        imc = await _client(tmp_path)
+        await imc.send(OWNER, "on it")
+        echoed = parse_inbound(_message(guid="A", text="on it"))
+        repeat = parse_inbound(_message(guid="B", text="on it"))
+        assert echoed is not None and repeat is not None
+        assert imc.is_own_echo(echoed) is True
+        assert imc.is_own_echo(repeat) is False
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_guid_match_does_not_leave_the_body_live(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # A sent message is recognisable by GUID and by body. While those were
+        # two independent entries, matching on the GUID left the body entry
+        # alive, and the user's genuine repeat of those words inside the TTL was
+        # then silently discarded -- no reply, no error (local GPT review of
+        # b19990c9). One record per send is what makes that unreachable.
+        imc = await _client(tmp_path)
+        peers[0].replies["send"] = [{"ok": True, "id": 9, "guid": "SENT-GUID"}]
+        await imc.send(OWNER, "on it")
+        echoed = parse_inbound(_message(guid="SENT-GUID", text="on it"))
+        genuine = parse_inbound(_message(guid="LATER", text="on it"))
+        assert echoed is not None and genuine is not None
+        assert imc.is_own_echo(echoed) is True
+        assert imc.is_own_echo(genuine) is False, "the body alias outlived the GUID match"
+        assert imc._own_sends == []
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_body_match_does_not_leave_the_guid_live(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The mirror image, which the narrow fix for the above would have left
+        # open: consume on the body, and the GUID of that same send must go too.
+        imc = await _client(tmp_path)
+        peers[0].replies["send"] = [{"ok": True, "id": 9, "guid": "SENT-GUID"}]
+        await imc.send(OWNER, "on it")
+        echoed = parse_inbound(_message(guid="", text="on it"))
+        assert echoed is not None
+        assert imc.is_own_echo(echoed) is True
+        assert imc._own_sends == []
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_definitively_rejected_send_leaves_no_record_behind(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # Rejected at validation, so nothing was delivered and nothing can echo.
+        # Keeping the record would have the undelivered body suppress a genuine
+        # message carrying those words for the rest of the TTL (local Opus
+        # review of b19990c9).
+        imc = await _client(tmp_path)
+        peers[0].replies["send"] = [RpcError(-32602, "invalid params")]
+        with pytest.raises(RpcError):
+            await imc.send(OWNER, "on it")
+        assert imc._own_sends == []
+        undelivered = parse_inbound(_message(text="on it"))
+        assert undelivered is not None
+        assert imc.is_own_echo(undelivered) is False
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_an_ambiguous_failure_keeps_the_guard_and_extends_it(
+        self, tmp_path: Path, peers: list[StubPeer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The opposite failure mode of the cleanup above, and the one that
+        # matters more (server GPT review of 20febaeb): the bridge documents
+        # -32001 as "may have completed or remains in flight", so the message may
+        # still be delivered and echo after this call failed. Dropping the record
+        # there reopens the loop.
+        #
+        # The clock advances INSIDE the call, which is what a call that times out
+        # actually does. The record is taken before the call, so by the time the
+        # failure is handled its original expiry has passed -- advancing the clock
+        # AROUND the call instead would make the refresh a no-op and this
+        # assertion vacuous, which is how the first version of this test passed
+        # against a mutation that deleted the refresh.
+        clock = [1000.0]
+        monkeypatch.setattr(client_mod.time, "monotonic", lambda: clock[0])
+        imc = await _client(tmp_path)
+
+        async def slow_failing_send(method: str, params: dict[str, Any], **_kw: Any) -> Any:
+            if method == "send":
+                clock[0] += ECHO_TTL_S + 5  # the call outlived the window
+                raise RpcError(
+                    -32001,
+                    "delivery uncertain",
+                    {"retry_safe": False, "disposition": "may_have_completed"},
+                )
+            return {"ok": True}
+
+        imc._call = slow_failing_send  # type: ignore[method-assign]
+        with pytest.raises(RpcError):
+            await imc.send(OWNER, "on it")
+        assert imc._own_sends != [], "an unproven failure must keep the guard"
+        # A late delivery, past the expiry the record was originally given.
+        late_echo = parse_inbound(_message(text="on it"))
+        assert late_echo is not None
+        assert imc.is_own_echo(late_echo) is True
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_or_dead_bridge_keeps_the_guard(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # A transport failure proves nothing about what the bridge did with a
+        # request already written to its stdin, so it is treated as delivered.
+        imc = await _client(tmp_path)
+        peers[0].replies["send"] = [RpcTransportError("bridge stopped answering")]
+        with pytest.raises(RpcTransportError):
+            await imc.send(OWNER, "on it")
+        assert imc._own_sends != []
+        echoed = parse_inbound(_message(text="on it"))
+        assert echoed is not None
+        assert imc.is_own_echo(echoed) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_bridge_proven_not_started_send_is_forgotten(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The bridge's own disposition is the authority when it gives one.
+        imc = await _client(tmp_path)
+        peers[0].replies["send"] = [
+            RpcError(-32001, "not dispatched", {"retry_safe": True, "disposition": "not_started"})
+        ]
+        with pytest.raises(RpcError):
+            await imc.send(OWNER, "on it")
+        assert imc._own_sends == []
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_an_exact_repeat_inside_the_window_is_suppressed_on_purpose(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The accepted cost, pinned so it is not "fixed" by accident. In an
+        # ORDINARY chat the echo is dropped by is_from_me before the ledger is
+        # consulted, so the record lives its full TTL and a user who sends the
+        # agent's exact words back inside it is read as that echo.
+        #
+        # The obvious repair -- let the is_from_me copy consume the record -- is
+        # what must NOT be done: in a self-chat that copy may arrive alongside the
+        # unattributed echo, and spending the record on it reopens the loop. A
+        # bounded silent drop is the deliberate trade against an unbounded one.
+        imc = await _client(tmp_path)
+        await imc.send(OWNER, "on it")
+        attributed = parse_inbound(_message(text="on it", is_from_me=True))
+        assert attributed is not None
+        assert imc._own_sends != [], "the record must outlive the attributed copy"
+        repeat = parse_inbound(_message(text="on it"))
+        assert repeat is not None
+        assert imc.is_own_echo(repeat) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_slow_send_does_not_outlive_its_own_guard(
+        self, tmp_path: Path, peers: list[StubPeer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Third finding in this span, and the one the optional expiry exists for
+        # (local GPT review of 8091b0e9). `_call` waits up to 30s and the TTL is
+        # 30s, so with a pre-computed expiry a send that reached its timeout left
+        # a record already eligible for pruning at the moment its echo arrived --
+        # and the echo was answered, restoring the loop. An in-flight record has
+        # no expiry at all, so there is nothing to prune.
+        clock = [1000.0]
+        monkeypatch.setattr(client_mod.time, "monotonic", lambda: clock[0])
+        imc = await _client(tmp_path)
+        verdicts: list[bool] = []
+
+        async def slow_send(method: str, params: dict[str, Any], **_kw: Any) -> Any:
+            if method == "send":
+                # The call outlives the whole TTL, then the echo lands while it
+                # is still awaiting a result.
+                clock[0] += ECHO_TTL_S * 3
+                mid_flight = parse_inbound(_message(text="on it"))
+                assert mid_flight is not None
+                verdicts.append(imc.is_own_echo(mid_flight))
+            return {"ok": True}
+
+        imc._call = slow_send  # type: ignore[method-assign]
+        await imc.send(OWNER, "on it")
+        assert verdicts == [True], "the guard expired while its own send was in flight"
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_the_clock_starts_when_the_send_resolves_not_when_it_began(
+        self, tmp_path: Path, peers: list[StubPeer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The corollary: a send that took a long time still gets a full window
+        # afterwards, measured from its outcome rather than from its start.
+        clock = [1000.0]
+        monkeypatch.setattr(client_mod.time, "monotonic", lambda: clock[0])
+        imc = await _client(tmp_path)
+
+        async def slow_send(method: str, params: dict[str, Any], **_kw: Any) -> Any:
+            if method == "send":
+                clock[0] += ECHO_TTL_S * 3
+            return {"ok": True}
+
+        imc._call = slow_send  # type: ignore[method-assign]
+        await imc.send(OWNER, "on it")
+        clock[0] += ECHO_TTL_S - 1  # inside the window, counted from the outcome
+        echoed = parse_inbound(_message(text="on it"))
+        assert echoed is not None
+        assert imc.is_own_echo(echoed) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_eviction_never_drops_an_unresolved_record(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # Fourth finding in this span (local GPT review of 1582c06f1), and the one
+        # the two lanes disagreed on: eviction deleted from the front regardless of
+        # state, so an unresolved record could be evicted and its echo answered --
+        # while `is_own_echo` was carefully skipping exactly those records. The
+        # input needs many sends outstanding at once, which this channel does not
+        # do today, but the invariant is held rather than argued: unresolved
+        # records are removed ONLY by their own resolution.
+        imc = await _client(tmp_path)
+        peers[0].default_result = {"ok": True}
+        in_flight = imc._remember_own_send(_echo_key(OWNER, "unresolved reply"))
+        assert in_flight.expires_at is None
+        for i in range(ECHO_WINDOW + 20):
+            await imc.send(OWNER, f"chunk {i}")
+        assert in_flight in imc._own_sends, "the in-flight guard was evicted"
+        echo = parse_inbound(_message(text="unresolved reply"))
+        assert echo is not None
+        assert imc.is_own_echo(echo) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_resolved_records_are_still_bounded(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The other half: exempting in-flight records must not stop the cap from
+        # bounding the resolved ones, or a long conversation grows the list.
+        imc = await _client(tmp_path)
+        peers[0].default_result = {"ok": True}
+        for i in range(ECHO_WINDOW + 40):
+            await imc.send(OWNER, f"chunk {i}")
+        assert len(imc._own_sends) <= ECHO_WINDOW
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_every_suppression_is_logged_not_only_the_first(
+        self, tmp_path: Path, peers: list[StubPeer], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The drop is silent to the USER by construction -- replying would be the
+        # loop -- so the log is the only signal it happened. Design Review flagged
+        # that only the first suppression per handle was recorded, which leaves a
+        # later drop indistinguishable from a message that never arrived.
+        imc = await _client(tmp_path)
+        peers[0].default_result = {"ok": True}
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.imessage.client"):
+            for i in range(3):
+                await imc.send(OWNER, "same words")
+                echo = parse_inbound(_message(guid=f"E{i}", text="same words"))
+                assert echo is not None
+                assert imc.is_own_echo(echo) is True
+        suppressed = [r for r in caplog.records if "echo" in r.getMessage()]
+        assert len(suppressed) == 3, "a later suppression left no signal at all"
+        # The loud one fires once; the rest stay at debug so a long conversation
+        # does not write a warning per outbound message.
+        assert sum(1 for r in suppressed if r.levelno == logging.WARNING) == 1
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_the_body_key_is_scoped_to_the_handle_it_was_sent_to(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        imc = await _client(tmp_path)
+        await imc.send("+15559876543", "on it")
+        from_someone_else = parse_inbound(_message(sender=OWNER, text="on it"))
+        assert from_someone_else is not None
+        assert imc.is_own_echo(from_someone_else) is False
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_an_entry_older_than_the_ttl_no_longer_suppresses(
+        self, tmp_path: Path, peers: list[StubPeer], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The TTL is the exposure of the body key's false positive, so it has to
+        # actually expire rather than pin the text forever.
+        clock = [1000.0]
+        monkeypatch.setattr(client_mod.time, "monotonic", lambda: clock[0])
+        imc = await _client(tmp_path)
+        await imc.send(OWNER, "on it")
+        clock[0] += ECHO_TTL_S + 1
+        stale = parse_inbound(_message(text="on it"))
+        assert stale is not None
+        assert imc.is_own_echo(stale) is False
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_composed_and_decomposed_body_compare_equal(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The body makes a round trip through Messages and back out of the
+        # database; a normalization difference on one accented character would
+        # silently reopen the loop.
+        imc = await _client(tmp_path)
+        await imc.send(OWNER, "caf\u00e9 ready")
+        decomposed = parse_inbound(_message(text="cafe\u0301 ready"))
+        assert decomposed is not None
+        assert imc.is_own_echo(decomposed) is True
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_the_ledger_is_bounded(self, tmp_path: Path, peers: list[StubPeer]) -> None:
+        # A long answer is delivered as many sends, so the ledger must not grow
+        # with the conversation.
+        imc = await _client(tmp_path)
+        peers[0].default_result = {"ok": True}
+        for i in range(ECHO_WINDOW + 40):
+            await imc.send(OWNER, f"chunk {i}")
+        assert len(imc._own_sends) <= ECHO_WINDOW
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_the_body_is_remembered_before_the_send_returns(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The watch can emit the row for this message while `send` is still
+        # awaiting its result, and an echo that arrives before it is remembered
+        # is an echo that gets answered. Recording after the call would leave
+        # that window open, so the test pins the ordering rather than the state.
+        seen: list[bool] = []
+
+        async def slow_send(method: str, params: dict[str, Any], **_kw: Any) -> Any:
+            if method == "send":
+                mid_flight = parse_inbound(_message(text="on it"))
+                assert mid_flight is not None
+                seen.append(imc.is_own_echo(mid_flight))
+            return {"ok": True}
+
+        imc = await _client(tmp_path)
+        imc._call = slow_send  # type: ignore[method-assign]
+        await imc.send(OWNER, "on it")
+        assert seen == [True]
+        await imc.close()
+
+    @pytest.mark.asyncio
+    async def test_a_self_chat_reply_does_not_come_back_as_a_new_turn(
+        self, tmp_path: Path, peers: list[StubPeer]
+    ) -> None:
+        # The whole loop, end to end, through the real transport: the user's own
+        # handle is the allowlist, the agent answers, and the answer arrives back
+        # on the watch as an ordinary inbound row. Before the ledger this second
+        # row started another turn, and that turn's reply started another.
+        dispatched: list[Any] = []
+
+        async def dispatch(inbound: Any) -> None:
+            dispatched.append(inbound)
+
+        imc = IMessageClient(cursor_path=tmp_path / "cursor.json")
+        transport = IMessageTransport(imc, allowed_handles=[OWNER], dispatch=dispatch)
+        imc.set_message_handler(transport.receive)
+        await imc.start()
+
+        await peers[0].notify(
+            "message", {"subscription": 1, "message": _message(id=1, guid="IN", text="hi")}
+        )
+        assert len(dispatched) == 1
+
+        peers[0].replies["send"] = [{"ok": True, "id": 2, "guid": "OUT"}]
+        await transport.send_message(OWNER, "hello back")
+        # The delivered copy: our own words, our own handle, and NOT attributed
+        # to us by the platform.
+        await peers[0].notify(
+            "message",
+            {
+                "subscription": 1,
+                "message": _message(id=3, guid="ECHO", text="hello back", is_from_me=False),
+            },
+        )
+        assert len(dispatched) == 1, "the agent's own reply started another turn"
+        await imc.close()
 
 
 async def _until(predicate: object, timeout: float = 2.0) -> None:

--- a/test/test_imessage_transport.py
+++ b/test/test_imessage_transport.py
@@ -44,6 +44,12 @@ class FakeClient:
         self.started = False
         self.closed = False
         self.sent: list[tuple[str, str]] = []
+        #: Bodies this fake claims to have sent, consumed on match — the same
+        #: consume-once contract the real ledger has. The real one is tested
+        #: against the real client in test_imessage_client.py; here it is a seam
+        #: so these tests can assert the transport CONSULTS it, and when.
+        self.own_echo_texts: list[str] = []
+        self.echo_checks: list[IMessageInbound] = []
 
     async def start(self) -> None:
         self.started = True
@@ -54,6 +60,13 @@ class FakeClient:
     async def send(self, to: str, text: str) -> str:
         self.sent.append((to, text))
         return "GUID-OUT"
+
+    def is_own_echo(self, inbound: IMessageInbound) -> bool:
+        self.echo_checks.append(inbound)
+        if inbound.text in self.own_echo_texts:
+            self.own_echo_texts.remove(inbound.text)
+            return True
+        return False
 
 
 def _transport(*allowed: str) -> tuple[IMessageTransport, FakeClient, list[IMessageInbound]]:
@@ -206,6 +219,74 @@ class TestReceive:
         recorded.text = ""
         await transport.receive(recorded)
         assert dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_an_own_echo_is_dropped_even_when_the_platform_calls_it_inbound(
+        self,
+    ) -> None:
+        # The self-chat loop of issue #5246: the agent's own reply arrives with
+        # is_from_me FALSE, from a handle that is on the allowlist because it is
+        # the user's own. Nothing about the row says "this is ours" -- only the
+        # client's record of having sent it does.
+        transport, client, dispatched = _transport(OWNER)
+        recorded = _recorded("watch_message_direct")
+        recorded.is_from_me = False
+        client.own_echo_texts.append(recorded.text)
+        with patch("kiro_crew.imessage.transport.sel") as mock_sel:
+            await transport.receive(recorded)
+        assert dispatched == []
+        # Own traffic, not a denial: auditing it would write one entry per
+        # outbound message, exactly as for the is_from_me case above.
+        mock_sel().log_api_access.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_attributed_copy_does_not_consume_the_echo_record(self) -> None:
+        # Ordering guard. If the is_from_me copy were checked against the ledger
+        # it would consume the entry, and the UNattributed echo that follows
+        # would then be dispatched -- restoring the loop while looking fixed.
+        transport, client, dispatched = _transport(OWNER)
+        attributed = _recorded("watch_message_direct")
+        attributed.is_from_me = True
+        client.own_echo_texts.append(attributed.text)
+        await transport.receive(attributed)
+        assert client.echo_checks == []
+
+        echo = _recorded("watch_message_direct")
+        echo.is_from_me = False
+        await transport.receive(echo)
+        assert dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_a_group_row_cannot_spend_the_record_the_real_echo_needs(self) -> None:
+        # The echo check consumes, so it has to run AFTER the gates that drop a
+        # row anyway. A group message carrying the same words would otherwise
+        # spend the record on its way out, and the DM echo that follows would
+        # find nothing and be answered -- the loop, reopened by a side effect.
+        transport, client, dispatched = _transport(OWNER)
+        group = _recorded("watch_message_group")
+        client.own_echo_texts.append(group.text)
+        with patch("kiro_crew.imessage.transport.sel"):
+            await transport.receive(group)
+        assert client.echo_checks == []
+        assert client.own_echo_texts == [group.text], "the group row spent the record"
+
+    @pytest.mark.asyncio
+    async def test_an_unlisted_sender_cannot_spend_the_record_either(self) -> None:
+        transport, client, _dispatched = _transport("+15559876543")
+        recorded = _recorded("watch_message_direct")
+        client.own_echo_texts.append(recorded.text)
+        with patch("kiro_crew.imessage.transport.sel"):
+            await transport.receive(recorded)
+        assert client.echo_checks == []
+        assert client.own_echo_texts == [recorded.text]
+
+    @pytest.mark.asyncio
+    async def test_a_message_that_is_not_an_echo_still_reaches_the_agent(self) -> None:
+        # The guard must not swallow ordinary traffic from the same handle.
+        transport, client, dispatched = _transport(OWNER)
+        client.own_echo_texts.append("something else entirely")
+        await transport.receive(_recorded("watch_message_direct"))
+        assert len(dispatched) == 1
 
     @pytest.mark.asyncio
     async def test_an_unauthorized_sender_gets_no_reply_at_all(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

With the iMessage channel enabled and the user's **own** phone number in
`imessage.allowed_handles`, messaging that number starts a loop: the agent
answers, then answers its own answer, without bound. The Messages transcript
shows every message twice — once sent, once received — with a typing indicator
between each pair.

This is the setup the docs prescribed. `src/kiro_crew/docs/imessage-integration.md`
step 3 of Quick start said "message yourself from another device and say hi", so
the documented first-run flow was the one that looped.

## Why it matters

Every cycle is a real turn against the model provider, so the cost is unbounded
and nothing in the dashboard says anything is wrong — the channel reports healthy
while it burns tokens and rate limit. It fires on the exact configuration a new
user is told to try first.

## What changed (motivation → approach → change)

The only thing separating "the user typed this" from "the agent sent this" was
one flag in `transport.py`: `if inbound.is_from_me: return`. That is sound in a
chat with someone else, where the agent's identity is never an allow-listed
sender. It does not hold in a **self-chat**, where the allow-listed handle IS the
identity the agent sends as, so an echo of its own reply arrives indistinguishable
from user input unless that flag is both present and correct on the row.

The bridge's own contract says it cannot carry that weight alone:
`watch.subscribe` defaults to a 500ms debounce expressly so an **`is_from_me`
correction** can land before a row is emitted, and `sender` is documented as
"Empty for some self-sent messages"
([rpc.md](https://github.com/steipete/imsg/blob/main/docs/rpc.md),
[json.md](https://github.com/steipete/imsg/blob/main/docs/json.md)). Nothing on
the send side compensated: `IMessageClient.send` discarded the guid the bridge
returns, and `_seen_guids` only ever recorded *inbound* guids, so the client kept
no record of what it had itself sent.

So the fix gives the channel a signal it owns rather than a platform flag it does
not: the client keeps a short-lived ledger of what it sent, and the transport
consults it as the last gate before dispatch.

**Three invariants carry it, and each is stated because its absence was a
defect** — this diff went through four review rounds in this one span, and the
last was run as a restructure round rather than a fourth patch:

1. **One record per sent message**, carrying both keys it can be recognised by —
   the body it went out with (NFC-normalized, stripped) and the guid the bridge
   reports. Matching on either consumes the whole record, so neither key can
   outlive the other and swallow the next genuine message carrying it.
2. **The TTL clock starts at the outcome, not at the call.** A record with no
   outcome yet has no expiry and is never pruned *or evicted*, because the echo of
   a slow send arrives before its result does: `_call` waits up to 30s and the
   window is 30s, so a pre-computed expiry let a send that reached its timeout be
   dropped at the exact moment its echo landed. A failure is classified rather
   than assumed — only one that PROVES non-delivery (the bridge's own
   `retry_safe` / `disposition: not_started`, or a rejection before dispatch)
   removes the record; a timeout, cancellation, dead child or `-32001` ("may have
   completed or remains in flight") keeps the guard and starts its clock.
3. **Consumption is the last gate.** After the `is_from_me` drop, so a copy the
   platform already attributes to us cannot spend the record the unattributed echo
   needs; and after the group and allow-list gates, so a row that will be dropped
   anyway cannot spend it on the way out.

`docs/system-specs/modules/messaging.md` is updated in the same commit, because
that spec previously described own-message suppression as `is_from_me` alone. It
now states both signals and, more importantly, states the three ordering
constraints AS constraints -- a contributor refactoring from the spec could
otherwise reorder the gates and reintroduce this loop while believing the spec
permitted it.

Every suppression is also logged -- `WARNING` once per handle, `DEBUG` thereafter,
handle redacted on both paths. The drop is silent to the sender by construction
(replying would be the loop), so the log is the only signal it happened, and
"only the first one per handle" left a later drop indistinguishable from a message
that never arrived.

A match consumes the record, so each sent message is suppressed exactly once and
a genuine later repeat of those words is delivered normally.

**Accepted cost, stated plainly.** In an ordinary chat the echo is dropped by
`is_from_me` before the ledger is consulted, so that record lives its full TTL,
and a user who sends the agent's exact text back inside 30 seconds has that
message silently dropped. The obvious repair — let the attributed copy consume the
record — is the one thing that must not be done, since in a self-chat that copy may
arrive alongside the unattributed echo. A bounded silent drop is the deliberate
trade against an unbounded loop; the TTL is the lever, and it is sized at the
smallest value comfortably above a delivery round trip. The docs say this applies
to every chat, not only to a self-chat.

**What is not verified.** Whether the echo is a second database row (a delivered
copy alongside the sent row) or the same row emitted before its `is_from_me` was
corrected. Telling those apart needs a live Mac with a working `imsg`, and the
machine that reproduced this cannot run one — the bridge is killed on exec by its
EDR stack, including `imsg --help`. Both readings produce the observed transcript
and both share the root cause, which is why the guard keys off what this client
sent rather than off any particular reading of the row. #5255 tracks doing that
live check; #5256 tracks a channel-level backstop for any echo variant the
per-message guard cannot recognise.

## Tests

`test/test_imessage_client.py` — new `TestOwnEchoLedger` (18 cases). The
regression is the whole loop end to end through the real transport: the agent's
reply arriving back on the watch does **not** start another turn. Around it, one
case per invariant and per failure mode:

* a sent body coming back is recognised, across handle formatting differences,
  and across composed vs decomposed text (the body round-trips through the
  Messages database);
* the sent guid is recognised even when the body differs;
* a guid match does not leave the body alias live, and a body match does not
  leave the guid alive — either would silently eat a genuine repeat;
* a match is consumed, so a genuine repeat afterwards gets through, and the body
  key is scoped to the handle it was sent to;
* the body is remembered *before* `send` returns, and a slow send does not
  outlive its own guard — an echo landing mid-call is still recognised;
* the clock starts when the send resolves, not when it began;
* a definitive rejection leaves no record; an ambiguous failure, a timeout and a
  dead bridge all keep the guard; a bridge-proven `not_started` send is forgotten;
* eviction never drops an unresolved record, and resolved records are still
  bounded;
* an entry past the TTL no longer suppresses;
* every suppression is logged, not only the first per handle;
* the accepted false positive is pinned as deliberate, with the reason the obvious
  repair is forbidden.

`test/test_imessage_transport.py` — 5 cases: an own echo is dropped even when the
platform calls it inbound and without an audit event; an attributed copy does not
consume the record; a group row and an unlisted sender cannot spend it; and an
ordinary message from the same handle still reaches the agent.

Every one was mutation-verified — neuter the guard, revert the gate order, make
the consume partial, disable the TTL check, remove the failed-send cleanup, treat
every failure as proven non-delivery, drop the expiry refresh, restore the
pre-computed expiry, or restore state-blind eviction, and the corresponding tests
fail at pytest phase `call`, none at collection.

## Manual verification

N/A — cannot be done on the machine that reproduced the bug: `imsg` is SIGKILLed
on every exec there by the endpoint-security stack, so the channel cannot reach a
connected state locally. The loop itself was observed on the reporter's own Mac
and iPhone, and the guard is exercised end to end through the real client and real
transport against the recorded bridge payloads under
`test/fixtures/channels/imessage/`. #5255 tracks the live check.

## Related Issues

Closes #5246

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend, docs and tests only — no frontend path is touched
and nothing rendered changes.


