### PR TITLE
fix(win): stage kiro-cli's identity store from either AppData root

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -175,9 +175,19 @@ _CLI_SQLITE_DBS = (
 # account, but NOT kiro-cli's own credential — so a token from here can only be
 # used when a matching profile ARN proves the account independently. It can never
 # satisfy the source-anchored path.
+#
+# The Windows entries mirror the kiro-cli tuple above rather than stopping at the
+# POSIX layouts: the fence (``_SENSITIVE_HOME_DIRS``) and sign-in staging both
+# already name ``AppData/{Local,Roaming}/amazon-q``, so omitting them here made
+# an amazon-q token unreadable for usage on exactly the platform where it is
+# fenced -- a store every writer treats as a secret and this reader treats as
+# absent. Untrusted either way (``from_cli_store=False``), so this widens what
+# can be READ for credit reporting, never what is believed.
 _OTHER_SQLITE_DBS = (
     Path.home() / ".local" / "share" / "amazon-q" / "data.sqlite3",
     Path.home() / "Library" / "Application Support" / "amazon-q" / "data.sqlite3",
+    Path.home() / "AppData" / "Local" / "amazon-q" / "data.sqlite3",
+    Path.home() / "AppData" / "Roaming" / "amazon-q" / "data.sqlite3",
 )
 _SQLITE_TOKEN_KEYS = ("kirocli:odic:token", "codewhisperer:odic:token", "kirocli:social:token", "kirocli:external-idp:token")
 

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -448,6 +448,17 @@ class _AuthStoreMapping:
     source: Path
     staged_relative: Path
     filenames: tuple[str, ...]
+    # Mappings sharing a group are ALTERNATE locations of ONE store, only one of
+    # which a given host uses. Staging must abort when a matched store cannot be
+    # read, because a staged home with no identity looks signed-out -- but that
+    # rule is right per LOCATION and wrong across alternates, where a stale
+    # leftover in the root this host abandoned would abort staging from the root
+    # it actually uses. Within a group the abort is therefore deferred: it fires
+    # only when NO alternate yielded an identity. ``None`` means "not an
+    # alternate of anything" and keeps the strict per-location rule -- the AWS
+    # SSO cache is a single location holding several token files, and losing any
+    # one of those must still abort.
+    group: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1104,15 +1115,36 @@ def _auth_store_mappings(
                 )
             )
     elif platform_name == "win32":
+        # Both AppData roots, because the installed CLI is observed using either
+        # one and every OTHER reader of this store already covers both: the fence
+        # (``_SENSITIVE_HOME_DIRS``), the trusted live-store list
+        # (``_CLI_SQLITE_DBS``), the logout fingerprint
+        # (``_win32_identity_store_path``) and ``kiro_cli_state_dbs``. Staging
+        # was the last reader still naming Local alone, so on a host whose CLI
+        # keeps its store under Roaming it staged NOTHING and the staged home
+        # looked signed-out. ``LOCALAPPDATA``/``APPDATA`` are honoured for the
+        # source side (that is where this host's real store lives), while the
+        # staged side is the fixed default layout the staged env re-points those
+        # variables at.
         local_app_data = Path(environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
+        roaming_app_data = Path(environ.get("APPDATA") or home / "AppData" / "Roaming")
         for app_name in app_names:
-            mappings.append(
-                _AuthStoreMapping(
-                    source=local_app_data / app_name,
-                    staged_relative=Path("AppData") / "Local" / app_name,
-                    filenames=_AUTH_SQLITE_FILES,
+            for source_root, staged_root in (
+                (local_app_data, "Local"),
+                (roaming_app_data, "Roaming"),
+            ):
+                mappings.append(
+                    _AuthStoreMapping(
+                        source=source_root / app_name,
+                        staged_relative=Path("AppData") / staged_root / app_name,
+                        filenames=_AUTH_SQLITE_FILES,
+                        # The two roots of one product are alternates, so a stale
+                        # store in the unused root cannot abort staging from the
+                        # used one. Distinct ``staged_relative`` values keep them
+                        # from overwriting each other when a host has both.
+                        group=f"win32:{app_name}",
+                    )
                 )
-            )
     else:
         data_home = Path(environ.get("XDG_DATA_HOME") or home / ".local" / "share")
         for app_name in app_names:
@@ -1176,7 +1208,13 @@ def _prepare_auth_workspace(
             platform_compat.chmod_safe(str(root), 0o700)
         else:
             platform_compat.restrict_dir_to_owner(str(root))
+        # Deferred aborts, keyed by group: a group records its failure and is
+        # judged only after every alternate has been attempted.
+        group_staged: dict[str, bool] = {}
+        group_failed: dict[str, str] = {}
         for mapping in _auth_store_mappings(platform_name, home, environ):
+            if mapping.group is not None:
+                group_staged.setdefault(mapping.group, False)
             for pattern in mapping.filenames:
                 for source in mapping.source.glob(pattern):
                     staged_path = root / mapping.staged_relative / source.name
@@ -1184,14 +1222,34 @@ def _prepare_auth_workspace(
                     # every other identity file is a small JSON token copied
                     # under the bounded byte rules. Both abort staging on
                     # failure — never omit a matched store as though absent.
+                    # For a mapping in a GROUP the abort is deferred to the
+                    # group verdict below, because the alternates of one store
+                    # are not each independently required.
                     if source.name == _AUTH_SQLITE_DB:
                         if not _project_identity_database(source, staged_path):
-                            raise OSError(_AUTH_STORE_READ_ERROR)
+                            if mapping.group is None:
+                                raise OSError(_AUTH_STORE_READ_ERROR)
+                            group_failed[mapping.group] = _AUTH_STORE_READ_ERROR
+                            continue
+                        if mapping.group is not None:
+                            group_staged[mapping.group] = True
                         continue
                     content = _read_bounded_regular_file(source)
                     if content is None:
-                        raise OSError(_AUTH_STORE_READ_ERROR)
+                        if mapping.group is None:
+                            raise OSError(_AUTH_STORE_READ_ERROR)
+                        group_failed[mapping.group] = _AUTH_STORE_READ_ERROR
+                        continue
                     _atomic_write_secret_bytes(staged_path, content)
+                    if mapping.group is not None:
+                        group_staged[mapping.group] = True
+
+        # A group that had a readable store in ANY of its alternates is staged.
+        # A group whose every matched store failed is the signed-out-looking
+        # case the strict rule exists for, so it still aborts.
+        for group, message in group_failed.items():
+            if not group_staged.get(group, False):
+                raise OSError(message)
 
         env = dict(base_env)
         env.update(

--- a/test/test_windows_identity_store_paths.py
+++ b/test/test_windows_identity_store_paths.py
@@ -1,0 +1,251 @@
+"""Every reader of kiro-cli's Windows identity store must name the same places.
+
+Several places in the tree resolve that store, each with its own hardcoded
+per-platform list and no shared helper, so they drift apart one reader at a time.
+The fence (``_SENSITIVE_HOME_DIRS``), the trusted live-store list
+(``_CLI_SQLITE_DBS``), the logout fingerprint (``_win32_identity_store_path``)
+and ``kiro_cli_state_dbs`` all cover both AppData roots; sign-in staging was the
+last one still naming ``AppData/Local`` alone, so on a host whose CLI keeps its
+store under Roaming it staged nothing and the staged home looked signed-out.
+
+These tests pin the agreement, and in particular the ordering constraint that
+makes it safe: a path may be TRUSTED only if it is also FENCED. A trusted path
+outside the fence is one an agent file tool could author, which would let it
+forge the identity rows these readers believe.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from kiro_crew import kiro_prerequisite as kp
+from kiro_crew.dashboard.handlers import kiro_usage_api as usage_api
+from kiro_crew.security import _SENSITIVE_HOME_DIRS
+
+# The two roots the installed CLI is observed using, for each product whose store
+# holds a live SSO bearer token.
+_EXPECTED_WINDOWS_STORE_DIRS = frozenset(
+    {
+        "AppData/Local/kiro-cli",
+        "AppData/Local/amazon-q",
+        "AppData/Roaming/kiro-cli",
+        "AppData/Roaming/amazon-q",
+    }
+)
+
+
+def _home_relative(path: Path) -> str:
+    """Return ``path`` relative to the real home, as a forward-slash string.
+
+    The store tuples are built from ``Path.home()`` at import time, so on a POSIX
+    CI host the Windows entries are POSIX-shaped strings under that home. Only
+    the home-relative remainder is comparable to ``_SENSITIVE_HOME_DIRS``, which
+    is itself expressed home-relative with forward slashes.
+    """
+
+    return path.relative_to(Path.home()).as_posix()
+
+
+def _windows_entries(paths: tuple[Path, ...]) -> set[str]:
+    """Home-relative DIRECTORIES of the Windows entries in a store tuple."""
+
+    relatives = (_home_relative(path) for path in paths)
+    return {
+        str(PurePosixPath(relative).parent)
+        for relative in relatives
+        if relative.startswith("AppData/")
+    }
+
+
+def _is_fenced(relative_dir: str) -> bool:
+    """Whether a home-relative directory is inside a fenced store directory."""
+
+    candidate = PurePosixPath(relative_dir)
+    return any(
+        candidate == PurePosixPath(fenced) or PurePosixPath(fenced) in candidate.parents
+        for fenced in _SENSITIVE_HOME_DIRS
+    )
+
+
+class TestWindowsIdentityStorePathsAgree:
+    def test_fence_covers_every_expected_store(self) -> None:
+        """The fence is the floor: it must name every location anyone trusts."""
+
+        assert _EXPECTED_WINDOWS_STORE_DIRS <= set(_SENSITIVE_HOME_DIRS)
+
+    def test_every_trusted_windows_store_is_fenced(self) -> None:
+        """The ordering constraint, stated as an assertion.
+
+        Membership in the trusted tuple sets ``from_cli_store=True``, a claim that
+        rests entirely on agent file tools being unable to write the path. Adding
+        a location to a store tuple without fencing it first creates a forgeable
+        trusted path, so this fails on that mistake rather than letting it ship.
+
+        Derived from the tuples themselves rather than from a hardcoded list, so a
+        future entry is covered without anyone remembering to extend this test --
+        which is the failure mode that let staging drift in the first place.
+        """
+
+        trusted = _windows_entries(usage_api._CLI_SQLITE_DBS) | _windows_entries(
+            usage_api._OTHER_SQLITE_DBS
+        )
+        assert trusted, "no Windows entries found -- the tuples changed shape"
+        unfenced = sorted(entry for entry in trusted if not _is_fenced(entry))
+        assert not unfenced, f"trusted but NOT fenced: {unfenced}"
+
+    def test_read_lists_cover_both_roots_for_both_products(self) -> None:
+        """A store fenced on Windows but absent from the read list is unreadable."""
+
+        assert _windows_entries(usage_api._CLI_SQLITE_DBS) == {
+            "AppData/Local/kiro-cli",
+            "AppData/Roaming/kiro-cli",
+        }
+        assert _windows_entries(usage_api._OTHER_SQLITE_DBS) == {
+            "AppData/Local/amazon-q",
+            "AppData/Roaming/amazon-q",
+        }
+
+
+class TestSigninStagingCoversBothAppDataRoots:
+    """Staging was the last reader naming one root, so a Roaming host staged nothing."""
+
+    def test_staging_covers_both_roots(self, tmp_path: Path) -> None:
+        mappings = kp._auth_store_mappings("win32", tmp_path, {})
+        staged = {
+            mapping.source.relative_to(tmp_path).as_posix()
+            for mapping in mappings
+            if mapping.source.is_relative_to(tmp_path / "AppData")
+        }
+        assert staged == set(_EXPECTED_WINDOWS_STORE_DIRS)
+
+    def test_the_two_roots_of_one_product_are_alternates(self, tmp_path: Path) -> None:
+        """They share a group, which is what defers the abort across them."""
+
+        mappings = kp._auth_store_mappings("win32", tmp_path, {})
+        for app_name in ("kiro-cli", "amazon-q"):
+            roots = [m for m in mappings if m.group == f"win32:{app_name}"]
+            assert len(roots) == 2
+            assert len({m.staged_relative for m in roots}) == 2
+
+    def test_each_root_stages_under_its_own_relative_path(self, tmp_path: Path) -> None:
+        """Distinct staged paths, so one root cannot overwrite the other's store."""
+
+        mappings = kp._auth_store_mappings("win32", tmp_path, {})
+        staged_relatives = [m.staged_relative for m in mappings]
+        assert len(staged_relatives) == len(set(staged_relatives))
+
+    def test_the_aws_sso_cache_is_not_an_alternate_of_anything(self, tmp_path: Path) -> None:
+        """One location holding several token files: losing any one must still abort."""
+
+        mappings = kp._auth_store_mappings("win32", tmp_path, {})
+        sso = [m for m in mappings if m.source == tmp_path / ".aws" / "sso" / "cache"]
+        assert len(sso) == 1
+        assert sso[0].group is None
+
+    def test_env_vars_are_honoured_for_the_source_side(self, tmp_path: Path) -> None:
+        """The real store lives where the variables point; the staged side is fixed."""
+
+        mappings = kp._auth_store_mappings(
+            "win32",
+            tmp_path,
+            {"APPDATA": str(tmp_path / "roam"), "LOCALAPPDATA": str(tmp_path / "loc")},
+        )
+        kiro = {m.source: m.staged_relative for m in mappings if m.source.name == "kiro-cli"}
+        assert kiro == {
+            tmp_path / "loc" / "kiro-cli": Path("AppData") / "Local" / "kiro-cli",
+            tmp_path / "roam" / "kiro-cli": Path("AppData") / "Roaming" / "kiro-cli",
+        }
+
+
+def _write_identity_store(path: Path) -> None:
+    """Write a store holding every identity table, so projection succeeds."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path))
+    with contextlib.closing(connection):
+        for table in kp._AUTH_IDENTITY_TABLES:
+            connection.execute(f'CREATE TABLE "{table}" (key TEXT PRIMARY KEY, value TEXT)')
+        connection.commit()
+
+
+def _write_unusable_store(path: Path) -> None:
+    """Write a store with NO identity table, the shape that fails projection."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path))
+    with contextlib.closing(connection):
+        connection.execute("CREATE TABLE unrelated (k TEXT)")
+        connection.commit()
+
+
+class TestStagingToleratesTheUnusedAppDataRoot:
+    """Widening staging to both roots must not turn a stale store into a failure.
+
+    Staging aborts rather than omit a matched store, because a staged home with no
+    identity looks signed-out. That rule is right per LOCATION and wrong across
+    alternates: once both roots are staged, a leftover database in the root a host
+    does not use would abort staging from the root it does, breaking sign-in on
+    exactly the hosts this change is meant to fix.
+    """
+
+    def _stage(self, home: Path, monkeypatch, staging: Path) -> None:
+        monkeypatch.setattr(kp, "_ensure_auth_staging_parent", lambda h: staging)
+        kp._prepare_auth_workspace("win32", home, {}, {})
+
+    def test_a_usable_root_survives_a_dead_store_in_the_other(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        staging = tmp_path / "stage"
+        staging.mkdir()
+        _write_identity_store(tmp_path / "AppData" / "Local" / "kiro-cli" / kp._AUTH_SQLITE_DB)
+        _write_unusable_store(tmp_path / "AppData" / "Roaming" / "kiro-cli" / kp._AUTH_SQLITE_DB)
+
+        self._stage(tmp_path, monkeypatch, staging)
+
+    def test_the_reverse_shape_also_survives(self, tmp_path: Path, monkeypatch) -> None:
+        """A downgraded host: live store in Roaming, stale leftover in Local."""
+
+        staging = tmp_path / "stage"
+        staging.mkdir()
+        _write_unusable_store(tmp_path / "AppData" / "Local" / "kiro-cli" / kp._AUTH_SQLITE_DB)
+        _write_identity_store(tmp_path / "AppData" / "Roaming" / "kiro-cli" / kp._AUTH_SQLITE_DB)
+
+        self._stage(tmp_path, monkeypatch, staging)
+
+    def test_no_usable_store_in_any_root_still_aborts(self, tmp_path: Path, monkeypatch) -> None:
+        """The signed-out-looking case must stay loud."""
+
+        staging = tmp_path / "stage"
+        staging.mkdir()
+        _write_unusable_store(tmp_path / "AppData" / "Local" / "kiro-cli" / kp._AUTH_SQLITE_DB)
+
+        with pytest.raises(OSError):
+            self._stage(tmp_path, monkeypatch, staging)
+
+    def test_a_dead_store_in_both_roots_aborts(self, tmp_path: Path, monkeypatch) -> None:
+        staging = tmp_path / "stage"
+        staging.mkdir()
+        for root in ("Local", "Roaming"):
+            _write_unusable_store(tmp_path / "AppData" / root / "kiro-cli" / kp._AUTH_SQLITE_DB)
+
+        with pytest.raises(OSError):
+            self._stage(tmp_path, monkeypatch, staging)
+
+    def test_a_roaming_only_host_actually_stages_its_store(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The bug this change fixes: Roaming-only staged nothing at all."""
+
+        staging = tmp_path / "stage"
+        staging.mkdir()
+        _write_identity_store(tmp_path / "AppData" / "Roaming" / "kiro-cli" / kp._AUTH_SQLITE_DB)
+
+        monkeypatch.setattr(kp, "_ensure_auth_staging_parent", lambda h: staging)
+        workspace = kp._prepare_auth_workspace("win32", tmp_path, {}, {})
+
+        staged_db = Path(workspace.root) / "AppData" / "Roaming" / "kiro-cli" / kp._AUTH_SQLITE_DB
+        assert staged_db.exists()


### PR DESCRIPTION
## Problem / Motivation

Several places resolve kiro-cli's Windows identity store, each with its own
hardcoded per-platform list and no shared helper, so they drift apart one reader
at a time. Four of them now cover both AppData roots: the sensitive-path fence
(`_SENSITIVE_HOME_DIRS`), the trusted live-store list (`_CLI_SQLITE_DBS`), the
logout fingerprint (`_win32_identity_store_path`) and `kiro_cli_state_dbs`.

Sign-in staging was the last reader still naming `AppData/Local` alone. On a host
whose CLI keeps its store under `AppData/Roaming` it staged **nothing** -- and
because `_prepare_auth_workspace` re-points both `APPDATA` and `LOCALAPPDATA`
into the staged root, the staged CLI then looked at an empty home.

A second, smaller gap: `_OTHER_SQLITE_DBS` stopped at the POSIX layouts, so an
amazon-q token was fenced and staged on Windows but never read for usage -- a
store every writer treats as a secret and that one reader treats as absent.

## Why it matters

A Roaming-layout Windows host is signed in to kiro-cli, and the trusted auth call
still behaves as though it is signed out, because the identity it needs was never
copied into the staged home. The user sees a sign-in that will not stick. On the
same host the credit pill silently omits an amazon-q token it is allowed to read.

## What changed (motivation -> approach -> change)

**Symptom:** a Roaming-layout host stages no identity, so the staged CLI looks
signed-out.
**Cause:** `_auth_store_mappings` built only `LOCALAPPDATA/<app>` for win32.
**Change:** build both roots, honouring `LOCALAPPDATA`/`APPDATA` for the source
side (that is where this host's real store lives) while keeping the staged side
at the fixed default layout the staged env re-points those variables at.

Widening staging alone would have introduced a second bug, so the change is two
parts rather than one. Staging aborts rather than omit a matched store, because a
staged home with no identity looks signed-out. That rule is right per LOCATION
and wrong across alternates: once both roots are staged, a stale leftover in the
root a host abandoned would abort staging from the root it actually uses --
breaking sign-in on exactly the hosts this fix targets. So `_AuthStoreMapping`
gains a `group` marking mappings that are ALTERNATE locations of one store, and
the abort is deferred within a group: it fires only when NO alternate yielded an
identity. `group=None` preserves the strict per-location rule, which is what the
AWS SSO cache needs -- one location holding several token files, where losing any
one of them must still abort.

`_OTHER_SQLITE_DBS` gains the two Windows amazon-q entries. Those stores remain
untrusted (`from_cli_store=False`), so this widens what can be READ for credit
reporting, never what is believed.

## Tests

`test/test_windows_identity_store_paths.py` (new, 13 tests).

**Verified not vacuous.** With the source changes reverted and the tests
unchanged, 7 fail -- including the two that pin the actual defects: a
Roaming-only host staging nothing, and the reverse shape (live Roaming next to a
stale Local) aborting staging. The 6 that pass on base are ratchets on agreement
main already has, and are there to keep it.

The ordering constraint is asserted rather than described: a path may be TRUSTED
only if it is also FENCED, derived from the tuples themselves rather than from a
hardcoded list, so a future entry is covered without anyone remembering to extend
the test. That is precisely the failure mode that let staging drift here.

Gates: 364 passed across `test_windows_identity_store_paths`,
`test_kiro_usage_api`, `test_kiro_prerequisite`, `test_external_logout_detection`.
flake8, isort and mypy clean on all three changed files; the new test file is
black-clean (both touched src files are in `.github/black-baseline.txt`).

## Manual verification

N/A -- no user-visible surface; the behaviour is Windows-only path resolution and
is covered by the unit tests above, which exercise both AppData layouts and both
stale-leftover shapes through the real staging function.

## Scope note: what this branch dropped, and why

This branch previously carried a rework of the `%APPDATA%` / `%LOCALAPPDATA%`
shell-fence regex, and was blocked by GPT 5.6 and Opus 4.8 on that construct.
**That work is dropped**, because main has since landed equivalent coverage
independently (`dd81b97d4`, `5a4bc9646`) and main's version is measurably
stronger.

Measured by loading both revisions' `security.py` in one process and running a
spelling matrix through `is_sensitive_bash_command`:

| spelling | main | old branch |
|---|---|---|
| `%LOCALAPPDATA%\kiro-cli\...` | blocked | blocked |
| `!LOCALAPPDATA!\kiro-cli\...` (cmd `/V:ON`) | **blocked** | **permitted** |
| `%LOCALAPPDATA%\x\..\kiro-cli\...` | **blocked** | **permitted** |
| `%APPDATA%\x\..\kiro-cli\...` | **blocked** | **permitted** |

Keeping the old construct would have regressed the fence on three spellings, so
Opus's blocking finding was correct and the right remedy was removal, not a
patch. Both blocking findings are moot against this head: the construct they
addressed is gone.

Two items deliberately **not** folded in:

1. `%LOCALAPPDATA%\\kiro-cli\data.sqlite3` (duplicated separator) is permitted by
   the fence on main today; Windows collapses repeated separators, so it reaches
   the live token store. Pre-existing on main, so it belongs to its own issue
   rather than to this diff.
2. Trailing-dot and 8.3 short-name spellings are also permitted on main -- the
   class already tracked in #5265.

`_win32_identity_store_path`'s both-roots-present rule is left exactly as main has
it (most recently written wins). An earlier version of this branch made ambiguity
refuse to trust either store; main's docstring rejects that on the record, because
reporting both-present as absent would disable identity tracking on every upgraded
host. Reversing a documented maintainer decision is not this PR's business.
