### PR TITLE
fix(deps): bump happy-dom past the MutationObserver WeakRef GC bug (#5178)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -86,7 +86,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "7.0.1",
         "fast-check": "4.6.0",
-        "happy-dom": "^20.11.1",
+        "happy-dom": "^20.11.6",
         "jscpd": "3.5.10",
         "jsdom": "26.1.0",
         "msw": "2.12.14",
@@ -7489,9 +7489,9 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "20.11.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
-      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "7.0.1",
     "fast-check": "4.6.0",
-    "happy-dom": "^20.11.1",
+    "happy-dom": "^20.11.6",
     "jscpd": "3.5.10",
     "jsdom": "26.1.0",
     "msw": "2.12.14",


### PR DESCRIPTION
## What is the problem?

`Frontend Tests (4)` fails intermittently on the two "CliPanel theme and font sync" repaint tests (#5178): the terminal cursor stays on the boot palette (`#89b4fa`) instead of picking up the injected custom-theme accent (`#ff8800`), and `waitFor` times out. It reproduces only on loaded CI runners -- the same tests pass 41/41 in isolation and the CI-exact shard command passes locally.

## Why this issue matters to the user

This is currently the top red on the fleet: it failed 3 consecutive times (initial run + 2 targeted reruns) on PR #5179 and intermittently elsewhere, blocking green CI for changes that never touch CliPanel. Every contributor pays for it in reruns and misread signal.

## How our fix solves it

Symptom to root cause: the repaint never happens -> CliPanel's repaint is driven by a module-level `MutationObserver` watching `<head>` -> in happy-dom <= 20.11.1, `MutationObserverListener` registers the per-node mutation callback as `new WeakRef((record) => this.report(record))` with NO strong reference to that closure anywhere, and the dispatch path (`Node.js` `reportMutation`) silently drops the record when `deref()` returns undefined -> under GC pressure (coverage-instrumented CI workers) V8 collects the closure and the observer goes permanently deaf -> the theme signal never reaches the terminal and the assertion times out. GC pressure is why it bites loaded runners and never an idle machine.

Deterministic reproduction (node `--expose-gc`, happy-dom 20.11.1):

```
observe(document.head, { childList: true })
appendChild(style)   // callback fires: before = 1
globalThis.gc()
appendChild(style2)  // callback NEVER fires: after = 0
```

Upstream fixed the orphaned WeakRef in capricorn86/happy-dom#2272 (issue capricorn86/happy-dom#2264), released in 20.11.2. This PR bumps the devDependency to the current patch release, 20.11.6. The same repro on 20.11.6 keeps firing after `gc()` (`after = 1`).

Test-only blast radius: happy-dom is the vitest DOM environment (devDependency), not a product dependency; no shipped code changes.

## What tests we did

- Deterministic GC repro on 20.11.1 (drops the mutation) vs 20.11.6 (delivers it) -- the mechanism-level proof above.
- Full website vitest suite on the bump: 1474 files / 22938 tests passed, 2 expected-fail, 3 skipped, zero regressions.
- `npx tsc -b` clean; `npm run jscpd` clean.

## Any other suggestions on the work

- The CliPanel scheduler itself already survives dead rAF handles (cancel-and-reschedule); the tests were correctly written with `waitFor` anchors. No test or component change is needed once the environment stops eating mutations -- which is why this fix is a dependency floor bump and nothing else.
- After this merges, PR #5179 (currently blocked only by this flake) gets rebased and should go fully green.

Closes #5178
