### PR TITLE
fix(config): report stored values that hold a superseded default

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -194,6 +194,40 @@ The parent directory is created on first call if it doesn't exist.
 
 The CLI (`cli.py:main()`) auto-detects and sets the env var at startup.
 
+## Superseded Defaults (reported, never rewritten)
+
+`config.json` is a full materialization of the schema -- every field is written to
+disk, including fields the operator never set -- and each field is resolved as
+`data.get(key, DEFAULT)`. A stored value therefore always beats the dataclass
+default, so **changing a shipped default reaches only installs created after the
+change**; a pre-existing install keeps whatever value was materialized last.
+
+`config/superseded_defaults.py` holds an append-only registry
+(`SUPERSEDED_DEFAULTS`) of default changes existing installs should be told about,
+each entry naming the dotted key, the old default, the new default, and the
+release that changed it. `superseded_default_drift(base_data)` returns the entries
+whose stored value equals the old default, comparing type as well as value so a
+stored `0` is not read as `False`.
+
+Two surfaces render it, and neither writes:
+
+- The load path warns once per key per process, evaluated on the **stored base
+  document before the `config.local.json` merge** -- an overlay value is the
+  operator's live choice and says nothing about what the base materialized, so a
+  base drift is still reported when an overlay masks it, and an overlay-only value
+  is not reported at all.
+- `kirocrew doctor` prints a `Stored Defaults` section reading `config.json`
+  directly. Drift is informational and does NOT become an issue; an unreadable or
+  malformed config does.
+
+**Why nothing is corrected automatically.** At least one registered key also has a
+documented escape hatch (`mcp_gateway.forward_declared_env`, whose stored `false`
+is pinned as honoured by `test_a_real_false_still_turns_it_off`). On disk that
+escape hatch and a stale materialized default are the same bytes, so a rewrite
+cannot correct one without overriding the other. Telling them apart needs per-key
+provenance -- a record of which keys the operator actually set -- which this layer
+does not have.
+
 ## Config Overlay (config.local.json)
 
 User overrides can be placed in `~/.kiro/crew/config.local.json`. This file is

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -44,6 +44,7 @@ from kiro_crew.config.paths import (
     kiro_agents_dir,
     project_agents_dir,
 )
+from kiro_crew.config.superseded_defaults import render_doctor_section
 from kiro_crew.constants import MIN_NODE_MAJOR
 from kiro_crew.dashboard.crash_dump_store import (
     dump_age_seconds,
@@ -2022,6 +2023,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # agent.model, and the whole point here is that the global is not
     # necessarily what a new session gets.
     _doctor_effective_model(cfg, proj, issues)
+
+    # ── Stored defaults a release has since changed (#5244) ──
+    render_doctor_section(issues)
 
     # ── Data Home (+ leftover legacy home) ──
     _doctor_data_home()

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -77,6 +77,10 @@ from kiro_crew.config.paths import (  # noqa: F401, kiro_agents_dir
     kiro_agents_dir,
 )
 
+# Superseded-default reporting (#5244). Leaf module: stdlib only, so importing it
+# here creates no cycle.
+from kiro_crew.config.superseded_defaults import drift_summary, superseded_default_drift
+
 # Schema validation + the validated-data cache live in ``config.validation``.
 # Re-exported here for backward compatibility — callers and tests still
 # reference these as ``kiro_crew.config.loader.X`` (e.g. the cache tests patch
@@ -970,6 +974,36 @@ def update_config_locked(
             return result
     finally:
         os.close(fd)
+
+
+# Keys already warned about in this process. The gateway loads config repeatedly
+# and a superseded default is per-install information, not per-load, so it is
+# said once; ``doctor`` is the surface that renders it again on demand.
+_REPORTED_SUPERSEDED_KEYS: set[str] = set()
+
+
+def _report_superseded_defaults(base_data: dict) -> None:
+    """Warn once per key when a stored base value still holds a superseded default.
+
+    *base_data* is the ``config.json`` document as read, BEFORE the
+    ``config.local.json`` overlay is merged over it. Reporting on the base is the
+    point: the overlay is a separate user-owned file whose value is the operator's
+    live choice, so it neither proves nor disproves what the base has materialized.
+
+    Reads only. This deliberately does NOT correct the value -- for a key that also
+    has a documented escape hatch, a stored old default and a deliberate opt-out
+    are the same bytes on disk, so a rewrite cannot correct one without overriding
+    the other. Telling the operator is the part that can be done without guessing.
+
+    Warned at most once per key per process. The gateway loads config repeatedly,
+    and a line the operator has already read is noise that trains them to ignore
+    the next one; the durable, re-readable rendering lives in ``doctor``.
+    """
+    for entry in superseded_default_drift(base_data):
+        if entry.dotted_key in _REPORTED_SUPERSEDED_KEYS:
+            continue
+        _REPORTED_SUPERSEDED_KEYS.add(entry.dotted_key)
+        logger.warning("Superseded default in stored config: %s", drift_summary(entry))
 
 
 def stamp_config_meta(data: dict) -> dict:
@@ -6177,6 +6211,16 @@ class KiroCrewConfig:
                         logger.warning("Config is not a JSON object, using defaults")
                 except (json.JSONDecodeError, OSError) as e:
                     logger.warning("Failed to load config from %s: %s", path, e)
+
+            # Report -- never correct -- a stored BASE value that still holds a
+            # superseded default (issue #5244), before the overlay merge below:
+            # the overlay is the operator's live choice and says nothing about
+            # what the base materialized. Read-only by design; a key with a
+            # documented escape hatch cannot be corrected automatically, because
+            # a stale default and a deliberate opt-out are the same bytes.
+            # Skipped when no base file loaded -- nothing is stored to report on.
+            if loaded_base:
+                _report_superseded_defaults(data)
 
             # Deep-merge config.local.json overlay (user-owned, never touched by setup)
             local_data: dict = {}

--- a/src/kiro_crew/config/superseded_defaults.py
+++ b/src/kiro_crew/config/superseded_defaults.py
@@ -1,0 +1,186 @@
+"""Detect stored config values that still hold a superseded dataclass default.
+
+Why this module exists
+----------------------
+``config.json`` is written as a FULL materialization of the schema: every field
+lands on disk, including ones the operator never set. The loader then resolves
+each field as ``data.get(key, DEFAULT)``, so a stored value always beats the
+dataclass default. The consequence (issue #5244) is that changing a shipped
+default only reaches installs created after the change -- every pre-existing
+install keeps whatever value was materialized the last time it wrote config, and
+nothing tells anyone.
+
+Why this REPORTS and never rewrites
+-----------------------------------
+An earlier revision corrected the stored value. That cannot be done safely for a
+key that also has a documented escape hatch, and at least one does:
+``test_a_real_false_still_turns_it_off`` in the gateway env suite pins that an
+explicitly stored ``forward_declared_env: false`` is honoured, and calls it "the
+escape hatch for a server that must not share a backend". On disk that escape
+hatch and a stale materialized default are the SAME BYTES, so no rewrite can tell
+them apart -- correcting one necessarily overrides the other.
+
+Distinguishing them needs per-key provenance (which keys the operator actually
+set), which is a materially larger change to the config layer and its own piece
+of work. Until that exists, the honest scope is to make the drift VISIBLE and
+leave the change to the operator: a warning on the gateway's own log and a
+``doctor`` section naming the key, the stored value, the current default, and the
+release that changed it.
+
+Scope discipline
+-----------------
+Nothing here writes to configuration: detection is pure, and the doctor renderer
+below only reads. Reading `config.json` lives HERE rather than in the CLI so the
+config package stays the one place that knows what the stored document means; the
+caller's job is to decide when to show it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SupersededDefault:
+    """One shipped default change that already-materialized installs never saw.
+
+    ``dotted_key`` addresses a scalar field as ``<section>.<field>`` (the only
+    shape the current entries need). ``old_default`` and ``new_default`` are the
+    literal values before and after the change; an install is reported as drifted
+    only when its stored value equals ``old_default``. ``changed_in`` names the
+    PR the change shipped in, so the report can say when the divergence started.
+    """
+
+    dotted_key: str
+    old_default: object
+    new_default: object
+    changed_in: str
+
+
+# The explicit, versioned registry of superseded defaults. APPEND-ONLY: a future
+# default change that existing installs should be told about adds an entry here.
+#
+# A forgotten entry means that one field's drift goes unreported, which is the
+# known cost of an explicit list. It is accepted because the alternative -- deriving
+# "was this value chosen or merely materialized" automatically -- is exactly the
+# provenance the config layer does not have.
+SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
+    # #4566 changed mcp_gateway.forward_declared_env from False to True because
+    # the False default was costing env-declaring servers their pooling. It
+    # shipped with no migration, so an install materialized while the default was
+    # still False keeps resolving False and never received the fix (issue #5244).
+    SupersededDefault(
+        dotted_key="mcp_gateway.forward_declared_env",
+        old_default=False,
+        new_default=True,
+        changed_in="#4566",
+    ),
+)
+
+
+def _split_dotted(dotted_key: str) -> tuple[str, str]:
+    """Split ``"<section>.<field>"`` into its two parts.
+
+    Only the two-level shape is supported, which is all the current entries need;
+    a malformed key raises so a bad registry entry fails loudly in tests rather
+    than silently reporting nothing in production.
+    """
+    section, _, field = dotted_key.partition(".")
+    if not section or not field or "." in field:
+        raise ValueError("superseded-default key must be '<section>.<field>': " + repr(dotted_key))
+    return section, field
+
+
+def superseded_default_drift(base_data: dict) -> list[SupersededDefault]:
+    """Return the registered entries whose STORED value is the superseded default.
+
+    *base_data* must be the stored base document (``config.json`` alone), never the
+    view produced by merging ``config.local.json`` over it. The overlay is a
+    separate user-owned file applied at read time; a value it supplies is the
+    operator's live choice and says nothing about what the base has materialized,
+    so reporting on the merged view would both miss real drift in the base and
+    describe a value the base does not hold.
+
+    An entry is reported only when the stored value equals ``old_default`` with the
+    same type -- ``bool`` is an ``int`` subclass, so requiring the type as well
+    keeps a stored ``0`` from being read as ``False``. An absent section, an absent
+    key, or any other value is not drift: those already resolve to the current
+    dataclass default at parse time, which is the desired outcome.
+
+    Pure: reads *base_data* and returns a list. Nothing is mutated or written.
+    """
+    drifted: list[SupersededDefault] = []
+    for entry in SUPERSEDED_DEFAULTS:
+        section, field = _split_dotted(entry.dotted_key)
+        section_data = base_data.get(section)
+        if not isinstance(section_data, dict) or field not in section_data:
+            continue
+        stored = section_data[field]
+        if type(stored) is type(entry.old_default) and stored == entry.old_default:
+            drifted.append(entry)
+    return drifted
+
+
+def drift_summary(entry: SupersededDefault) -> str:
+    """One line describing *entry*'s drift, shared by the log and ``doctor``.
+
+    Kept in one place so the two surfaces cannot drift into describing the same
+    condition differently, and worded as a statement of fact plus the operator's
+    options -- this mechanism does not know whether the stored value was chosen
+    deliberately, and must not imply the value is wrong.
+    """
+    return (
+        f"{entry.dotted_key} is stored as {entry.old_default!r}, which was the default "
+        f"before {entry.changed_in} changed it to {entry.new_default!r}. An install that "
+        f"predates that change keeps the old value because a stored value beats the "
+        f"default. If {entry.old_default!r} was not a deliberate choice, removing the key "
+        f"or setting it to {entry.new_default!r} adopts the current default."
+    )
+
+
+def render_doctor_section(issues: list[str]) -> None:
+    """Print the ``Stored Defaults`` section of ``kirocrew doctor``.
+
+    Reads ``config.json`` DIRECTLY rather than the resolved config, and does not
+    merge ``config.local.json``: the question is what the base file has
+    materialized, and the resolved view cannot answer it -- a stored value and the
+    same value arriving from the current default are indistinguishable once parsed.
+
+    Drift is informational and does NOT become an issue. This cannot tell a stale
+    materialized default from a deliberate opt-out (on disk they are identical), so
+    presenting it as something to fix would be telling operators to undo their own
+    choices. It prints what is stored, what the current default is, and which
+    release changed it, and leaves the decision with them. An unreadable or
+    non-object config IS an issue: that is unambiguously wrong.
+
+    ``config_path`` is imported lazily because ``config.loader`` imports this
+    module for the load-path warning, so a module-level import would be a cycle.
+    """
+    from kiro_crew.config.loader import config_path
+
+    print("\nStored Defaults")
+    path = config_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print("  drift:       ✅ no config file yet (current defaults apply)")
+        return
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"  drift:       ⚠️  could not read {path}: {e}")
+        issues.append("stored defaults unreadable")
+        return
+    if not isinstance(raw, dict):
+        print(f"  drift:       ⚠️  {path} is not a JSON object")
+        issues.append("stored defaults unreadable")
+        return
+
+    drifted = superseded_default_drift(raw)
+    if not drifted:
+        print("  drift:       ✅ no stored value holds a superseded default")
+        return
+    for entry in drifted:
+        print(f"  drift:       ℹ️  {drift_summary(entry)}")

--- a/test/test_config_superseded_defaults.py
+++ b/test/test_config_superseded_defaults.py
@@ -1,0 +1,249 @@
+"""Reporting of stored config values that still hold a superseded default.
+
+``config.json`` is a full materialization of the schema and the loader resolves
+each field as ``data.get(key, DEFAULT)``, so a stored value always beats a
+changed dataclass default. #4566 changed ``mcp_gateway.forward_declared_env``
+False->True with no migration, so every pre-existing install stayed False and
+nothing said so.
+
+These tests pin that the drift is DETECTED and REPORTED and that the stored value
+is never touched. The read-only posture is the load-bearing part: the same key has
+a documented escape hatch (``test_a_real_false_still_turns_it_off`` in the gateway
+env suite pins that a stored ``false`` is honoured), and on disk that escape hatch
+and a stale materialized default are identical, so a rewrite cannot correct one
+without overriding the other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from kiro_crew.config import loader as L
+from kiro_crew.config import superseded_defaults as SD
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.superseded_defaults import (
+    SupersededDefault,
+    drift_summary,
+    superseded_default_drift,
+)
+
+# The one shipped entry, resolved by key so the tests describe the real change
+# rather than hard-coding a duplicate of the registry.
+FDE_ENTRY = next(
+    e for e in SD.SUPERSEDED_DEFAULTS if e.dotted_key == "mcp_gateway.forward_declared_env"
+)
+
+
+@pytest.fixture(autouse=True)
+def _forget_process_warnings():
+    """The warned-keys set is process-global; each test starts from empty."""
+    L._REPORTED_SUPERSEDED_KEYS.clear()
+    yield
+    L._REPORTED_SUPERSEDED_KEYS.clear()
+
+
+def _point_home(tmp_path, monkeypatch) -> None:
+    """Redirect every config path at *tmp_path* so nothing touches the real home.
+
+    ``render_doctor_section`` resolves ``config_path`` lazily out of the loader
+    module, so patching it there covers the doctor surface too.
+    """
+    cfgp = tmp_path / "config.json"
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+
+
+def _write_config(tmp_path, data: dict) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(data), encoding="utf-8")
+    # Same-second edits can share an mtime with the cached fingerprint, so drop
+    # the process cache explicitly to force a real re-read every load().
+    L._invalidate_config_cache()
+
+
+def _write_local(tmp_path, data: dict) -> None:
+    (tmp_path / "config.local.json").write_text(json.dumps(data), encoding="utf-8")
+    L._invalidate_config_cache()
+
+
+def _on_disk(tmp_path) -> dict:
+    return json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------
+# Detection: pure, and precise about what counts as drift.
+# --------------------------------------------------------------------------
+
+
+def test_stored_old_default_is_reported_as_drift():
+    base = {"mcp_gateway": {"forward_declared_env": False}}
+    assert superseded_default_drift(base) == [FDE_ENTRY]
+    # Detection is pure: the document is not touched.
+    assert base == {"mcp_gateway": {"forward_declared_env": False}}
+
+
+def test_stored_current_default_is_not_drift():
+    assert superseded_default_drift({"mcp_gateway": {"forward_declared_env": True}}) == []
+
+
+def test_absent_key_and_absent_section_are_not_drift():
+    """An absent key already resolves to the current default, so there is nothing to say."""
+    assert superseded_default_drift({"mcp_gateway": {}}) == []
+    assert superseded_default_drift({}) == []
+    assert KiroCrewConfig().mcp_gateway.forward_declared_env is True
+
+
+def test_zero_is_not_read_as_false():
+    """bool is an int subclass; a stored 0 must not be reported as the False default."""
+    assert superseded_default_drift({"mcp_gateway": {"forward_declared_env": 0}}) == []
+
+
+def test_malformed_registry_key_raises_loudly():
+    bad = SupersededDefault(
+        dotted_key="no_dot", old_default=False, new_default=True, changed_in="#0"
+    )
+    with pytest.raises(ValueError):
+        SD._split_dotted(bad.dotted_key)
+
+
+def test_drift_summary_names_value_default_and_release():
+    text = drift_summary(FDE_ENTRY)
+    assert "mcp_gateway.forward_declared_env" in text
+    assert "#4566" in text
+    # Both sides of the change are stated, so the reader can judge it themselves.
+    assert "False" in text and "True" in text
+
+
+# --------------------------------------------------------------------------
+# The load path: reports, and never writes.
+# --------------------------------------------------------------------------
+
+
+def test_load_reports_drift_and_leaves_the_value_alone(tmp_path, monkeypatch, caplog):
+    """The escape hatch is honoured: a stored false still resolves false.
+
+    This is the same contract the gateway env suite pins, and the reason this
+    mechanism reports instead of correcting.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {"forward_declared_env": False}})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        cfg = KiroCrewConfig.load()
+
+    assert cfg.mcp_gateway.forward_declared_env is False
+    assert _on_disk(tmp_path)["mcp_gateway"]["forward_declared_env"] is False
+    assert any("forward_declared_env" in r.getMessage() for r in caplog.records)
+
+
+def test_load_warns_once_per_process_not_once_per_load(tmp_path, monkeypatch, caplog):
+    """A line the operator already read is noise; doctor is the re-readable surface."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {"forward_declared_env": False}})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        KiroCrewConfig.load()
+        first = len([r for r in caplog.records if "forward_declared_env" in r.getMessage()])
+        L._invalidate_config_cache()
+        KiroCrewConfig.load()
+        second = len([r for r in caplog.records if "forward_declared_env" in r.getMessage()])
+
+    assert first == 1
+    assert second == 1
+
+
+def test_load_says_nothing_when_the_stored_value_is_current(tmp_path, monkeypatch, caplog):
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {"forward_declared_env": True}})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        cfg = KiroCrewConfig.load()
+
+    assert cfg.mcp_gateway.forward_declared_env is True
+    assert not [r for r in caplog.records if "forward_declared_env" in r.getMessage()]
+
+
+def test_base_drift_is_reported_even_when_an_overlay_masks_it(tmp_path, monkeypatch, caplog):
+    """The base is what was materialized; an overlay hides it from the resolved view.
+
+    Reporting on the merged document would miss exactly the case worth reporting:
+    the operator removes the overlay one day and silently inherits the old value.
+    """
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {"forward_declared_env": False}})
+    _write_local(tmp_path, {"mcp_gateway": {"forward_declared_env": True}})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        cfg = KiroCrewConfig.load()
+
+    # The overlay is the operator's live choice and still wins for this load.
+    assert cfg.mcp_gateway.forward_declared_env is True
+    # The base drift underneath it is still reported.
+    assert any("forward_declared_env" in r.getMessage() for r in caplog.records)
+
+
+def test_an_overlay_only_value_is_not_reported_as_base_drift(tmp_path, monkeypatch, caplog):
+    """The base has no opinion, so there is no materialized value to report on."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {}})
+    _write_local(tmp_path, {"mcp_gateway": {"forward_declared_env": False}})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        cfg = KiroCrewConfig.load()
+
+    assert cfg.mcp_gateway.forward_declared_env is False
+    assert not [r for r in caplog.records if "forward_declared_env" in r.getMessage()]
+
+
+# --------------------------------------------------------------------------
+# doctor: the durable, re-readable rendering.
+# --------------------------------------------------------------------------
+
+
+def test_doctor_reports_drift_without_calling_it_an_issue(tmp_path, monkeypatch, capsys):
+    """Informational: this cannot tell a stale default from a deliberate opt-out."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {"forward_declared_env": False}})
+
+    issues: list[str] = []
+    SD.render_doctor_section(issues)
+    out = capsys.readouterr().out
+
+    assert "Stored Defaults" in out
+    assert "forward_declared_env" in out
+    assert "#4566" in out
+    assert issues == []
+
+
+def test_doctor_says_clean_when_nothing_drifted(tmp_path, monkeypatch, capsys):
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"mcp_gateway": {"forward_declared_env": True}})
+
+    issues: list[str] = []
+    SD.render_doctor_section(issues)
+    out = capsys.readouterr().out
+
+    assert "no stored value holds a superseded default" in out
+    assert issues == []
+
+
+def test_doctor_handles_a_missing_config_file(tmp_path, monkeypatch, capsys):
+    _point_home(tmp_path, monkeypatch)
+    issues: list[str] = []
+    SD.render_doctor_section(issues)
+    assert "no config file yet" in capsys.readouterr().out
+    assert issues == []
+
+
+def test_doctor_flags_an_unreadable_config(tmp_path, monkeypatch, capsys):
+    """A malformed file IS an issue -- unlike drift, it is unambiguously wrong."""
+    _point_home(tmp_path, monkeypatch)
+    (tmp_path / "config.json").write_text("{not json", encoding="utf-8")
+
+    issues: list[str] = []
+    SD.render_doctor_section(issues)
+    assert "could not read" in capsys.readouterr().out
+    assert issues == ["stored defaults unreadable"]


### PR DESCRIPTION
## 1. What is the problem?

`config.json` is written as a FULL materialization of the schema -- every field lands on disk, including ones the operator never set -- and the loader resolves each field as `data.get(key, DEFAULT)`. A stored value therefore always beats the dataclass default.

Consequence: **changing a shipped default only reaches installs created after the change.** Every pre-existing install keeps whatever value was materialized the last time it wrote config, no migration corrects it, and nothing tells anybody.

## 2. Why this issue matters to the user

It has already silently voided a merged fix.

#4566 changed `mcp_gateway.forward_declared_env` from `False` to `True` precisely because the `False` default was costing servers their pooling -- its own commit message says "One ordinary key such as LOG_LEVEL cost the whole server its pooling."

On an install whose `config.json` was materialized while the default was still `False`, that fix is a no-op. The rewriter keeps deciding:

```
rewriter: opted-in server '<name>' (agent '<agent>') declares env (1 keys) of which some
would be withheld from a shared backend (mcp_gateway.forward_declared_env is off --
enable it to pool); leaving it unwrapped
```

so every env-declaring server runs unwrapped, one process per session. Measured on an upgraded install: 29 (server, agent) pairs left unwrapped in one gateway generation, **29 of 29** attributable to the flag rather than to secret keys -- including servers declaring a single non-secret key that every co-tenant spells identically, which is an ideal pooling candidate.

The operator has no way to notice. The stored value is valid JSON, the code default reads `True`, and the change log says the bug is fixed. That invisibility is what this PR closes.

## 3. How our fix solves it -- chain from symptom to root cause

Symptom: a shipped default change has no effect after upgrade.
-> The loader prefers a stored value over the default (`data.get(key, DEFAULT)`).
-> The stored value is ALWAYS present, because the writer materializes the whole schema.
-> Nothing ever compares a materialized value against a superseded default, or says so.

So the root cause is in the config layer, not in the MCP gateway. `forward_declared_env` is the first casualty, not the bug.

`config/superseded_defaults.py` adds an append-only registry (`SUPERSEDED_DEFAULTS`) naming, per entry, the dotted key, the old default, the new default, and the release that changed it, plus a pure detector `superseded_default_drift(base_data)`. Two surfaces render it:

- The load path warns **once per key per process**. The gateway loads config repeatedly, and a line the operator has already read is noise that trains them to ignore the next one.
- `kirocrew doctor` gains a `Stored Defaults` section. Drift is informational and deliberately does NOT become a doctor issue; an unreadable or non-object config does.

Three details are load-bearing:

- Detection reads the **stored base document, before the `config.local.json` merge**. An overlay value is the operator's live choice and says nothing about what the base materialized. So a base drift is still reported when an overlay masks it -- which is exactly the case worth reporting, because the operator removes the overlay one day and silently inherits the old value -- and an overlay-only value is not reported at all.
- Comparison requires the same **type** as well as the same value. `bool` is an `int` subclass, so a stored `0` is not read as the `False` default.
- Reading `config.json` for the doctor section lives in the **config package**, not in the CLI. The package stays the one place that knows what the stored document means; the CLI decides only when to show it, which is why `cli_doctor.py` gains four lines and nothing else. `config_path` is imported lazily there because the loader imports this module for the load-path warning.

### Why nothing is rewritten

An earlier revision of this PR corrected the stored value. That is not safe for a key that also has a documented escape hatch, and at least one registered key does: `test_a_real_false_still_turns_it_off` in the gateway env suite pins that a stored `forward_declared_env: false` is honoured, and its docstring calls it *"The escape hatch for a server that must not share a backend."* On disk that escape hatch and a stale materialized default are the **same bytes**, so a rewrite cannot correct one without overriding the other -- and the rewrite revision did in fact break that test.

Telling them apart requires per-key provenance: a record of which keys the operator actually set. The config layer does not have it, and adding it is a materially larger change that wants its own review. Until then, reporting is the part that can be done without guessing at intent.

## 4. What tests we did

`test/test_config_superseded_defaults.py`, 15 cases:

- detection is pure and precise: a stored old default is drift; the current default, an absent key, an absent section, and a stored `0` are not; a malformed registry key raises rather than silently reporting nothing
- the load path reports the drift and **leaves the stored value alone** -- the resolved config and the file on disk both still hold `false`
- the warning fires once per process, not once per load
- a base drift is reported even when an overlay masks it; an overlay-only value is not reported as base drift
- the doctor section renders drift without recording an issue, says so plainly when clean, tolerates a missing config, and DOES flag an unreadable one

Mutation-verified, four ways, each turning exactly one test red and green again when restored: reporting on the merged view instead of the base, dropping the once-per-process dedupe, silently correcting the value instead of only reporting it, and dropping the exact-type guard.

Also green: `test_a_real_false_still_turns_it_off` and its whole class (26), the fail-open-config-writer ratchet (15), the doctor suite (227), `test_config_baseline.py` (10, no default changed so the committed baseline is untouched), and the config-related suite (368 passed / 14 skipped). `flake8`, `isort --check`, `mypy` clean on the changed files.

`cli_doctor.py` is 4 insertions with 0 deletions; `test_cli.py` is unchanged.

## 5. Any other suggestions on the work

The timeline is worth recording, because two commits interact rather than either being wrong alone:

- #3511 introduced the pre-classification that leaves an env-declaring entry unwrapped instead of spawning a pooled backend without a declared key. With `forward_declared_env` still defaulting `False`, that de-pooled every env-declaring server at once.
- #4566, four days later, diagnosed the default and changed it.
- Any install that materialized `config.json` in that window is pinned to `False`. This PR makes that visible; it does not undo it.

Deliberately not attempted here:

- **#5309** -- while adding the doctor section, an unrelated reachable crash came to light: `doctor`'s MCP Tools section raises `AttributeError` when the agent spec is valid JSON but not an object. The fix was written and verified in this branch, then removed: it is a separate concern and a First Principles review was right that it rode along undeclared. Filed with the reproduction so it lands on its own.
- **Per-key provenance** is the only shape that could correct a materialized default automatically while preserving a documented escape hatch, because it is the only one that can tell them apart. It belongs in the config layer with its own review.
- **A ratchet** asserting that any future default change is accompanied by either a registry entry here or an explicit opt-out. Without it, the known cost of an explicit list stands: a forgotten entry means that one field's drift goes unreported.

The registry is currently rendered only in a log line and in `doctor`. Surfacing it on the System page is a reasonable third surface and a separate, frontend-scoped change.

Closes #5244
