### PR TITLE
fix(platform): apply the Windows owner-only DACL in-process

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -302,8 +302,13 @@ signing key, refresh-token state, per-app secrets, snapshot tarballs, and the
 cron internal-secret temp file — are locked down to the current user via an
 owner-only NTFS DACL (inheritance stripped, `S-1-3-4:F` = Owner Rights full
 control). This is applied through `platform_compat.restrict_to_owner`, which
-routes to `os.chmod(..., 0o600)` on POSIX and `icacls /inheritance:r /grant:r
-"*S-1-3-4:F"` on Windows. Failure is fail-loud (raises `OSError`) so the
+routes to `os.chmod(..., 0o600)` on POSIX and, on Windows, builds the descriptor
+in-process through `advapi32` (`SetNamedSecurityInfoW` with
+`PROTECTED_DACL_SECURITY_INFORMATION`, the equivalent of
+`icacls /inheritance:r /grant:r "*S-1-3-4:F"`). It is a direct API call rather
+than a subprocess -- measured 0.24 ms against 313 ms for the equivalent `icacls`
+invocation -- so it is safe to call on the gateway's event loop. Failure is
+fail-loud (raises `OSError`) so the
 security-warning handlers in each caller fire — a naive `if IS_POSIX: os.chmod`
 guard would silently no-op on Windows, leaving secrets group/world-readable
 under NTFS.

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -562,20 +562,30 @@ this is what closes the torn-read window for everyone else. Mode-preserving
 because tmp+rename creates a NEW inode, so the umask default (typically `0644`)
 would silently replace an operator's tightened `0600`; `config.json` can hold
 inline credentials, so a settings write must never widen who can read it. An
-existing file's mode carries over and a newly created one is owner-only. It
-deliberately does NOT call `platform_compat.restrict_to_owner`: that helper shells
-out to `icacls` on Windows, and this function runs inside async request handlers
-and `save()`, so calling it would put a blocking subprocess on the gateway event
-loop (`no-blocking-call-on-event-loop`). Omitting it is no worse than the
-truncate-then-write it replaced, which applied no DACL either.
+existing file's mode carries over and a newly created one is owner-only. On
+Windows it also applies a real owner-only DACL via
+`platform_compat.restrict_to_owner` (`restrict_on_error="warn"`, so a DACL that
+cannot be applied warns rather than making the config unwritable).
+
+That is a reversal of an earlier ruling recorded here, and the reason it changed
+is worth keeping: the lockdown used to shell out to `icacls`, a blocking
+subprocess this function could not afford because it runs inside async request
+handlers and `save()` (`no-blocking-call-on-event-loop`). It is now applied
+in-process through `advapi32` (measured 0.24 ms against 313 ms for the
+subprocess), so the cost that forced the omission is gone and `config.json` --
+which can hold inline provider tokens -- is no longer left under whatever DACL it
+inherits from its parent. Follow-up work that touches the other owner-only call
+sites should treat this as settled rather than re-deriving the old constraint.
 
 **Mode preservation is POSIX-only.** `atomic_write`'s `mode` routes through
 `fchmod_safe`, a documented no-op on Windows, where access is carried by the DACL
-instead. Applying one would mean an `icacls` subprocess, which this function must
-not run (above) — so on Windows the replacement file inherits the directory's ACL,
-exactly as the `write_text` it replaced did. The three mode/symlink tests in
+instead. The two guarantees therefore do not collide -- they apply on different
+platforms -- which is why the writer branches on `IS_POSIX` rather than passing
+both to `atomic_write`, which refuses `restrict_to_owner=True` alongside a wider
+explicit `mode`. The three mode/symlink tests in
 `test_config_rmw_preserves_settings.py` are `skipif(not IS_POSIX)` for this reason;
-the data-loss and AST-guard tests are platform-independent and run everywhere.
+its Windows counterpart asserts the DACL by reading the descriptor back, and the
+data-loss and AST-guard tests are platform-independent and run everywhere.
 
 **Symlinks are followed, not replaced.** `os.replace` renames over the link
 itself, so a symlinked `config.json` would become a regular file and its target

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -5867,17 +5867,17 @@ async def _make_live(path: str, dry_run: bool = False,
             return ok
 
         async def _unwind() -> bool:
-            # Both halves block: restore() ends in restrict_to_owner, which shells
-            # out to icacls on Windows, and svc.rollback() rewrites the service
+            # Both halves block: restore() ends in restrict_to_owner, which
+            # rewrites a DACL on Windows, and svc.rollback() rewrites the service
             # definition. Offload them for the same reason the write below is
             # offloaded — an unwind must not stall every other gateway request for
-            # the duration of a subprocess.
+            # the duration of blocking filesystem work.
             return await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), _unwind_sync
             )
 
         try:
-            # write_target ends in restrict_to_owner, which shells out to icacls
+            # write_target ends in restrict_to_owner, which rewrites a DACL
             # on Windows. Run it off the loop so a cutover cannot stall every
             # other gateway request for the duration of that subprocess.
             loop = asyncio.get_running_loop()

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -423,7 +423,7 @@ def _write_pat_sync(pat: str) -> None:
     # owner-only DACL there and chmod 0600 on POSIX, and atomic_write applies it
     # to the temp BEFORE any payload byte — narrower than the previous
     # write-then-restrict here, which left the token in a parent-inherited-DACL
-    # file for the duration of the icacls subprocess. restrict_on_error="warn"
+    # file until the lockdown landed. restrict_on_error="warn"
     # keeps the original policy: a chmod failure warns rather than losing the
     # credential. Written 0600 and never echoed back (only a boolean).
     atomic_write(target, pat, fsync=True, restrict_to_owner=True, restrict_on_error="warn")

--- a/src/kiro_crew/computer_use/capture_windows.py
+++ b/src/kiro_crew/computer_use/capture_windows.py
@@ -367,7 +367,7 @@ def ensure_shots_dir() -> str:
     every other owner-only directory in the tree uses.
 
     Tightening runs at most once per process (guarded by ``_dir_ready``) because
-    ``restrict_to_owner`` shells out to ``icacls`` on Windows, and a subprocess per
+    ``restrict_to_owner`` rewrites a DACL on Windows, and doing that per
     screenshot would block the pooled worker that also serves chat. A failure is
     logged and tolerated, the posture ``capture_macos`` takes: the files still land
     under a per-user ``%TEMP%``.

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit as _urlsplit
 
-from kiro_crew import __version__, model_registry, platform_compat
+from kiro_crew import __version__, model_registry, platform_compat, windows_acl
 
 # Leaf module (stdlib + platform_compat only) — no import cycle with config.
 from kiro_crew.atomic_write import atomic_write
@@ -969,17 +969,22 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
     ``atomic_write``'s ``mode`` routes through ``fchmod_safe``, which applies the
     mode on POSIX and is a documented no-op on Windows.
 
-    **This deliberately does NOT call ``platform_compat.restrict_to_owner``.**
-    That helper shells out to ``icacls`` on Windows (``subprocess.run``, 10s
-    timeout), and this function is called from ``async`` request handlers and from
-    ``KiroCrewConfig.save()`` — so invoking it here would put a blocking subprocess
-    on the gateway's asyncio event loop, freezing every task including the liveness
-    heartbeat (the ``no-blocking-call-on-event-loop`` rule; the repo offloads that
-    helper via ``asyncio.to_thread`` everywhere else for exactly this reason).
-    Omitting it is no worse than the truncate-then-write this replaced, which
-    applied no DACL either, while ``mode`` still tightens the POSIX case and new
-    files are created ``0600``. A caller that needs a hard owner-only guarantee on
-    Windows must offload ``restrict_to_owner`` itself, off the loop.
+    **Windows gets a real owner-only DACL, not just the inert mode.** This used
+    to deliberately skip ``platform_compat.restrict_to_owner`` because that helper
+    shelled out to ``icacls`` — a blocking subprocess this function could not
+    afford, being called from ``async`` request handlers and from
+    ``KiroCrewConfig.save()``. That constraint no longer exists: the lockdown is
+    applied in-process through ``advapi32`` (measured at 0.24 ms, against 313 ms
+    for the subprocess it replaced), so it is safe on the event loop and the
+    reason to omit it is gone. Since ``config.json`` can carry inline provider
+    tokens and API keys, applying it is the correct default rather than a duty
+    pushed onto each caller.
+
+    The two guarantees do not collide, because they apply on different platforms:
+    mode preservation is a POSIX concept (Windows has no bits to preserve), and
+    the DACL is a Windows concept. Hence the platform branch below rather than
+    passing both to ``atomic_write``, which refuses ``restrict_to_owner=True``
+    alongside a wider explicit ``mode``.
 
     **Symlinks are followed, not replaced.** ``os.replace`` renames over the link
     itself, turning a symlinked ``config.json`` into a regular file and orphaning
@@ -994,12 +999,68 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
             path = path.resolve()
     except OSError:
         pass
+    # Decide the Windows lockdown HERE, before the stat and the mkdir below and
+    # before anything atomic_write does -- every one of those is a round-trip on a
+    # network-homed data home, and this function runs inline on the event loop
+    # (async dashboard handlers reach it on every config write). A DACL write to a
+    # UNC or mapped-drive path is an unbounded SMB round-trip, so it has to be
+    # ruled out before the work starts rather than part way through.
+    #
+    # This sits just AFTER the symlink resolve rather than at the very top of the
+    # function, and deliberately: a config symlinked into a dotfiles repo (which
+    # the docstring above calls a normal setup) can point at a DIFFERENT volume
+    # than the link, so classifying before resolving would classify the wrong one.
+    # The resolve is two stats; the earliest CORRECT point is here.
+    lock_down = platform_compat.IS_POSIX
+    if not platform_compat.IS_POSIX:
+        try:
+            lock_down = windows_acl.volume_is_local(path)
+        except Exception:
+            # A descriptor API that cannot be loaded cannot tell us the volume is
+            # local, and the lockdown would have failed on this host anyway.
+            lock_down = False
+        if not lock_down:
+            logger.warning(
+                "config write: %s is on a non-local volume, so the owner-only "
+                "DACL was SKIPPED to avoid blocking the event loop on SMB; the "
+                "file may be readable by other local users",
+                path,
+            )
     try:
         mode = _stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
     except OSError:
         mode = 0o600
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write(path, json.dumps(data, indent=2) + "\n", fsync=fsync, mode=mode)
+    payload = json.dumps(data, indent=2) + "\n"
+    if platform_compat.IS_POSIX:
+        atomic_write(path, payload, fsync=fsync, mode=mode)
+    elif lock_down:
+        # Windows: the mode bits above are inert (fchmod_safe is a documented
+        # no-op), so there is nothing to preserve and no conflict with
+        # restrict_to_owner's implied 0600. Taking the lockdown here rather than
+        # leaving it to callers also closes the window a post-write lockdown
+        # would leave: atomic_write applies the DACL to the temp file BEFORE any
+        # content reaches it, so an inline credential never exists in a file
+        # readable by other local accounts.
+        #
+        # restrict_on_error="warn", not the default "raise": config.json must not
+        # become unwritable because a DACL could not be applied. Same trade-off
+        # sel.py and dashboard/refresh_tokens.py already take, and strictly
+        # better than the previous behavior, which applied no DACL at all.
+        atomic_write(
+            path,
+            payload,
+            fsync=fsync,
+            restrict_to_owner=True,
+            restrict_on_error="warn",
+        )
+    else:
+        # Non-local volume: exactly the write this branch did before the lockdown
+        # was added, so a network-homed data home is no worse off than before and
+        # a local one is now protected. The residual is real and declared -- the
+        # file keeps its inherited ACL. Making this function's filesystem work
+        # async is the cause-level fix and is tracked separately (#6353).
+        atomic_write(path, payload, fsync=fsync, mode=mode)
 
 
 def update_config_locked(
@@ -8401,14 +8462,15 @@ class KiroCrewConfig:
             # Enforce restrictive permissions on the credential file. POSIX
             # only: on Windows mode bits are meaningless (a chmod there
             # toggles the read-only attribute and succeeds without narrowing
-            # who can read), and the real owner-only lockdown —
-            # ``platform_compat.restrict_to_owner`` — spawns ``icacls``, a
-            # blocking subprocess this reader must never run: it is called
-            # from async request handlers on the gateway's event loop (the
-            # same constraint ``write_config_atomically`` documents). Windows
-            # enforcement therefore lives where the file is WRITTEN — the
-            # setup wizard and the dashboard credential writers all apply
-            # ``restrict_to_owner`` off the loop at write time.
+            # who can read), and the real owner-only lockdown --
+            # ``platform_compat.restrict_to_owner`` -- is not applied on this
+            # READ path. It no longer spawns a subprocess, so the reason is no
+            # longer cost: it is that a reader has no business rewriting a
+            # descriptor it did not create, and doing so here would apply the
+            # DACL of whichever process happened to read the file next.
+            # Windows enforcement therefore lives where the file is WRITTEN --
+            # the setup wizard and the dashboard credential writers all apply
+            # ``restrict_to_owner`` at write time.
             try:
                 if platform_compat.IS_POSIX and ep.stat().st_mode & 0o077:
                     ep.chmod(0o600)

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -502,8 +502,8 @@ def _log_mint_outcome(slug: str, outcome: str, detail: str) -> None:
 
     Blocking on FIRST use: the append itself is queued to SEL's writer thread, but
     the first ``sel()`` of a process constructs the log -- trust-dir creation, key
-    validation, a backward scan of the existing log, and on Windows an ``icacls``
-    subprocess. Async callers go through ``asyncio.to_thread``.
+    validation, a backward scan of the existing log, and on Windows the owner-only
+    DACL on the key file. Async callers go through ``asyncio.to_thread``.
     """
     sel().log_api_access(
         caller="dashboard",

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -687,13 +687,13 @@ def run_script_sandboxed(
             # Tighten the DACL BEFORE writing the secret bytes so the file is
             # never on disk under the parent-inherited %TEMP% DACL on Windows.
             # On POSIX mkstemp already births the file 0600 so ordering is a
-            # no-op; on Windows mkstemp cannot set an owner-only DACL, and the
-            # icacls subprocess restrict_to_owner spawns is a measurable window
+            # no-op; on Windows mkstemp cannot set an owner-only DACL, so the
+            # interval between create and lockdown is a real window
             # if we wrote first. Matches the fail-loud convention of the other
             # internal-secret writers (token_secret, refresh_tokens, snapshot,
             # server._write_secret_file, token_auth) — chmod_safe swallows
             # OSError and would hide a lockdown failure. Both calls stay inside
-            # the outer try so an icacls failure still hits the finally that
+            # the outer try so a lockdown failure still hits the finally that
             # unlinks the secret + launcher (otherwise the fd leaks and temp
             # files persist).
             platform_compat.restrict_to_owner(secret_path)

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -188,8 +188,9 @@ def _admits(surface: str, resource: str, probe: "Callable[[], bool]") -> bool:
     rather than silently gaining unaudited egress.
 
     SYNCHRONOUS BY DESIGN, and callers on the event loop must run it in a worker
-    thread. SEL initialization can shell out (``icacls`` on a fresh Windows
-    gateway), so calling this inline from a coroutine would stall every request.
+    thread. SEL initialization does blocking filesystem work (trust-dir creation,
+    key validation, and on Windows an owner-only DACL), so calling this inline
+    from a coroutine would stall every request.
     """
     from kiro_crew.platform.context import safe_context_call
 

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -142,7 +142,7 @@ async def _require_owner(request: web.Request, operation: str) -> web.Response |
     if is_owner_dashboard_request(request):
         return None
     # Off the loop: the FIRST sel() of a process CONSTRUCTS the log — trust-dir
-    # creation, key validation, and on Windows an icacls subprocess — so on a
+    # creation, key validation, and on Windows the owner-only DACL — so on a
     # fresh gateway whose first mutating request is non-owner this would stall
     # every other request. Same reasoning as connections._audit_started.
     caller = str(request.get("user") or "unknown")

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -323,7 +323,8 @@ async def api_connections_mint(request: web.Request) -> web.Response:
 
     # Off the loop: only the append is queued to SEL's writer thread. The FIRST
     # sel() of a process CONSTRUCTS the log -- trust-dir creation, key validation,
-    # and on Windows an icacls subprocess -- and this handler runs BEFORE the audit
+    # and on Windows the owner-only DACL on the key file -- and this handler runs
+    # BEFORE the audit
     # middleware's own call (that one logs the response), so on a fresh gateway
     # whose first state-changing request is a Connect click it would land here and
     # stall every other request. Same reasoning as server._audit_denied.
@@ -428,7 +429,7 @@ async def api_connections_cancel(request: web.Request) -> web.Response:
     dropped = await cancel_mint(slug, token)
 
     # Off the loop: the FIRST sel() of a process constructs the log (trust-dir
-    # creation, key validation, on Windows an icacls subprocess). Same reasoning
+    # creation, key validation, on Windows the owner-only DACL). Same reasoning
     # as api_connections_mint above.
     await asyncio.to_thread(
         lambda: sel().log_api_access(

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -1692,8 +1692,8 @@ def _atomic_write(path: Path, data: dict) -> None:
     directory's inherited permissions.  The writer's default fail-closed
     policy is kept deliberately: a store this surface cannot protect is not
     written, and the caller's request fails visibly rather than publishing a
-    credential another OS user could read.  On Windows the lockdown shells
-    out to ``icacls``, so async callers must hand the whole write to a worker
+    credential another OS user could read.  On Windows the lockdown rewrites
+    the file's DACL, so async callers hand the whole write to a worker
     thread rather than call this on the event loop.  Other paths (the shared
     global file, agent files) keep the mode-preserving helper — their
     lifecycles are owned by other tools.

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -388,8 +388,8 @@ async def api_mcp_custom_add(request: web.Request) -> web.Response:
             if not enable:
                 entry["disabled"] = True
             entries[name] = entry
-        # The secure store write DACLs its temp file via icacls on Windows —
-        # a blocking subprocess that must not run on the event loop.
+        # The secure store write applies an owner-only DACL to its temp file on
+        # Windows — blocking filesystem work kept off the event loop.
         await _mcp._offload_config_write(_mcp._atomic_write, _mcp._kirocrew_mcp_json(), data)
 
     await _rebuild_agent_config()

--- a/src/kiro_crew/dashboard/handlers/mcp_discover.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_discover.py
@@ -338,8 +338,8 @@ async def _install_from_official(request: web.Request, server_id: str) -> web.Re
             return web.json_response({"error": "name already in use"}, status=409)
         if existing is None:
             # Fresh install: always written disabled (consent default).
-            # The store write can apply a Windows owner-only DACL via icacls —
-            # a blocking subprocess kept off the event loop.
+            # The store write can apply a Windows owner-only DACL —
+            # blocking filesystem work kept off the event loop.
             await _offload_config_write(_set_kirocrew_entry, name, enabled=enable_now, spec=spec)
         else:
             # Identical spec already present — a reinstall is a pure no-op:

--- a/src/kiro_crew/dashboard/handlers/weixin_qr.py
+++ b/src/kiro_crew/dashboard/handlers/weixin_qr.py
@@ -352,9 +352,8 @@ async def weixin_qr_status(request: web.Request) -> web.Response:
         # BOTH — otherwise a concurrent channel save can interleave and silently
         # drop one side's write.
         #
-        # The whole block runs OFF the loop: besides the file I/O,
-        # restrict_to_owner() shells out to whoami/icacls on Windows, which would
-        # freeze the gateway for seconds on the first confirmation.
+        # The whole block runs OFF the loop: the file I/O plus, on Windows,
+        # the owner-only DACL restrict_to_owner() applies.
         async with _get_config_lock():
             await asyncio.to_thread(_persist)
     except Exception as exc:

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -341,9 +341,9 @@ class RefreshStateManager:
             try:
                 self._state_path.parent.mkdir(parents=True, exist_ok=True)
                 # Create-empty → tighten-DACL → write, NOT write-then-restrict:
-                # on Windows restrict_to_owner is a subprocess (icacls) that
-                # takes measurable time, so if the payload were written first
-                # the temp would carry the parent-inherited DACL during that
+                # on Windows restrict_to_owner REPLACES the file's DACL rather
+                # than setting it at create time, so if the payload were written
+                # first the temp would carry the parent-inherited DACL during that
                 # window and a local co-tenant able to enumerate ~/.kiro/crew
                 # could read the consumed-JTI + revoked-chain state (breaking
                 # RFC-6819 §5.2.2.3 reuse-detection secrecy) or, worse,

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -419,7 +419,7 @@ async def _audit_denied(caller: str, request: web.Request, error: str) -> None:
 
     * OFF THE LOOP — ``log_api_access`` only enqueues, but the first ``sel()``
       of a process CONSTRUCTS the log: trust-dir creation, key validation, and
-      on Windows an ``icacls`` subprocess to lock the key file's DACL. A fresh
+      on Windows the owner-only DACL on the key file. A fresh
       dashboard whose first state-changing request is cross-origin would run
       that synchronously on the event loop and stall every other request.
     * BEST-EFFORT — a trust root too short to sign the chain makes construction
@@ -1763,7 +1763,7 @@ def _write_secret_file(secret_path: Path, secret: str) -> None:
             # OSError, which would defeat the cleanup-and-reraise below — a
             # pre-existing file with loose perms would stay loose and the caller
             # never learns. On POSIX this applies chmod 0o600 by path;
-            # on Windows an owner-only DACL via icacls (fchmod doesn't exist on
+            # on Windows an owner-only DACL (fchmod doesn't exist on
             # Windows, where a raw fchmod would be a silent no-op).
             platform_compat.restrict_to_owner(secret_path)
             with os.fdopen(fd, "w") as f:
@@ -3236,7 +3236,7 @@ async def start_dashboard(
 
     # Warm the auth singletons (signing secret + revoked-nonce store) off the
     # event loop BEFORE building the middleware chain, so no blocking key-file
-    # I/O (or Windows icacls subprocess) lands on the loop on the first auth op.
+    # I/O lands on the loop on the first auth op.
     await warm_auth_singletons()
 
     # Explicit middleware ordering — self-documenting and immune to future insertions
@@ -3348,8 +3348,8 @@ async def start_dashboard(
     _unix_socket_holder["path"] = await _start_unix_site(runner, port)
 
     # Port bind succeeded — now safe to write the secret file. Offloaded:
-    # _write_secret_file does blocking fs I/O (os.open/os.close and, on Windows,
-    # an icacls subprocess via restrict_to_owner), so it must not run on the
+    # _write_secret_file does blocking fs I/O (os.open/os.close, plus the
+    # owner-only lockdown on Windows), so it must not run on the
     # event loop (no-blocking-call-on-event-loop). The port is passed so the
     # credential is published per listener, not only into the shared file every
     # gateway in this data home writes (see _write_instance_credentials).
@@ -4032,7 +4032,7 @@ async def start_api_server(
     # Port bind succeeded — now safe to persist the secret file (parity with
     # start_dashboard: write deferred so a failed bind can't poison it).
     # Offloaded: _write_secret_file does blocking fs I/O (os.open/os.close and,
-    # on Windows, an icacls subprocess via restrict_to_owner), so it must not run
+    # on Windows, the owner-only DACL), so it must not run
     # on the event loop (no-blocking-call-on-event-loop). Same per-listener
     # publication as start_dashboard: both surfaces must pair the credential
     # with the port or a client cannot tell which generation it reached.

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -185,9 +185,10 @@ class RevokedNonceStore:
                 self._state_path.parent.mkdir(parents=True, exist_ok=True)
                 tmp = self._state_path.with_suffix(self._state_path.suffix + ".tmp")
                 # Create the temp file EMPTY, lock it down, and only then write
-                # the nonces. On Windows restrict_to_owner shells out to icacls,
-                # so writing first would leave the denylist under the
-                # parent-inherited DACL for the length of that call. O_TRUNC also
+                # the nonces. Writing first would leave the denylist under the
+                # parent-inherited DACL for the length of the lockdown call —
+                # brief now that it is in-process, but still a window on a file
+                # whose contents are security state. O_TRUNC also
                 # empties a stale temp file an earlier crash left behind, so the
                 # lockdown never applies on top of someone else's contents.
                 os.close(os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600))
@@ -1095,10 +1096,10 @@ def write_app_secret(app_name: str, secret: str) -> None:
     secret_path = secret_dir / ".app_secret"
     # os.O_TRUNC truncates any pre-existing file BEFORE the DACL tightens,
     # then restrict_to_owner locks it down while it is still empty, then we
-    # write the secret bytes. This ordering matters on Windows because
-    # restrict_to_owner shells out to icacls (subprocess) — if we wrote first
-    # the secret would sit under the parent-inherited DACL during the icacls
-    # window. On failure we unlink the just-created empty file (mirroring
+    # write the secret bytes. This ordering matters on Windows because the
+    # lockdown replaces the file's DACL rather than being set at create time —
+    # if we wrote first the secret would sit under the parent-inherited DACL
+    # until that call landed. On failure we unlink the just-created empty file (mirroring
     # dashboard/server.py:_write_secret_file) so we don't leave a zero-byte
     # .app_secret under the default DACL that a later successful write
     # (which does not re-inherit on O_TRUNC) could then populate.
@@ -1107,7 +1108,7 @@ def write_app_secret(app_name: str, secret: str) -> None:
         # restrict_to_owner (fail-loud), NOT fchmod_safe: fchmod_safe swallows
         # OSError, which would defeat the cleanup-and-reraise below for this
         # app secret. On POSIX applies chmod 0o600 by path; on
-        # Windows an owner-only DACL via icacls (fchmod doesn't exist on
+        # Windows an owner-only DACL (fchmod doesn't exist on
         # Windows, where an IS_POSIX no-op would let per-app secrets
         # land readable by other local users).
         platform_compat.restrict_to_owner(secret_path)
@@ -1472,7 +1473,7 @@ async def warm_auth_singletons() -> None:
 
     Both ``_get_secret()`` and ``_get_revoked_store()`` do blocking file I/O on
     first use (read/create ``token_signing.key`` + read the persisted nonce
-    denylist; on Windows an ``icacls`` subprocess to lock the key file's DACL).
+    denylist; on Windows also the owner-only DACL on the key file).
     Calling them lazily from the request path — or synchronously inside the
     ``token_auth_middleware()`` factory, which runs on the loop via the async
     ``start_dashboard()`` / ``start_api_server()`` — would land that I/O on the
@@ -1961,8 +1962,8 @@ def token_auth_middleware(
     # NOTE: the signing-secret and revoked-nonce singletons are NOT warmed
     # here anymore. This factory is invoked from `start_dashboard()` /
     # `start_api_server()`, which are `async def` and therefore run ON the
-    # event loop — a synchronous warm-up here (blocking key-file read + a
-    # Windows `icacls` subprocess on first create) would block the loop during
+    # event loop — a synchronous warm-up here (blocking key-file read plus, on
+    # Windows, an owner-only DACL on first create) would block the loop during
     # startup (no-blocking-call-on-event-loop). The async startup paths instead
     # `await warm_auth_singletons()` (which offloads to a worker thread) BEFORE
     # constructing this middleware chain, so the first auth op still hits the

--- a/src/kiro_crew/dashboard/token_secret.py
+++ b/src/kiro_crew/dashboard/token_secret.py
@@ -54,8 +54,7 @@ def _enforce_owner_only(key_path: Path) -> None:
     try:
         # restrict_to_owner (fail-loud), NOT chmod_safe: chmod_safe swallows
         # OSError, which would make this security-warning handler dead code.
-        # POSIX applies ``chmod 0o600``; Windows applies an owner-only DACL via
-        # icacls.
+        # POSIX applies ``chmod 0o600``; Windows applies an owner-only DACL.
         platform_compat.restrict_to_owner(key_path)
     except OSError:
         # Logs the key file PATH (key_path), never the key bytes.
@@ -221,10 +220,11 @@ def _load_or_create_secret() -> bytes:
             # have substituted at the same path in the meantime.
             created_stat = os.fstat(fd)
             wrote_durable_key = False
-            # Lock the DACL down BEFORE writing the secret bytes: on Windows
-            # restrict_to_owner shells out to icacls (a measurable subprocess
-            # window during which another local principal could slurp the
-            # bytes); on POSIX it collapses to an in-process chmod. Create empty
+            # Lock the DACL down BEFORE writing the secret bytes: on Windows the
+            # lockdown replaces an existing DACL rather than being applied at
+            # create time, so writing first would leave a window during which
+            # another local principal could slurp the bytes; on POSIX it
+            # collapses to an in-process chmod. Create empty
             # → tighten → write → fsync.
             try:
                 _enforce_owner_only(key_path)

--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -205,11 +205,12 @@ class GatewayManager:
         # primary access boundary (a 0600 socket alone is insufficient on a
         # shared host), and on Windows it is where the singleton lock file and
         # the out-of-band reap list live since the pipe itself has no entry.
-        # Off the event loop: on Windows the owner-only step shells out to
-        # icacls with a multi-second timeout, and this runs inside the live
-        # gateway's loop (dashboard toggle -> _init_mcp_gateway -> start()),
-        # so calling it inline stalls chat turns and the liveness heartbeat.
-        # Mirrors the log-file hunk below, which offloads the same helper.
+        # Off the event loop: prepare_dir does blocking filesystem work
+        # (directory creation plus the owner-only DACL on Windows), and this runs
+        # inside the live gateway's loop (dashboard toggle -> _init_mcp_gateway
+        # -> start()), so calling it inline stalls chat turns and the liveness
+        # heartbeat. Mirrors the log-file hunk below, which offloads the same
+        # helper.
         await asyncio.to_thread(transport.prepare_dir, self._spec.socket_path)
 
         try:
@@ -337,8 +338,8 @@ class GatewayManager:
         # os.fchmod is a silent no-op on Windows, where mode bits carry no
         # access meaning -- the real carrier is the DACL. restrict_to_owner is
         # the fail-loud owner-only variant and is called by attribute so the
-        # hermetic-test stub in conftest can intercept it. It shells out to
-        # icacls on Windows, so it runs off the event loop.
+        # hermetic-test stub in conftest can intercept it. It does blocking
+        # filesystem work, so it runs off the event loop.
         try:
             await asyncio.to_thread(platform_compat.restrict_to_owner, log_path)
         except OSError as exc:

--- a/src/kiro_crew/metrics/local_exporter.py
+++ b/src/kiro_crew/metrics/local_exporter.py
@@ -225,7 +225,7 @@ class JsonlMetricExporter(MetricExporter):
         rotated = target.with_name(f"{target.stem}-{time.time_ns()}{target.suffix}")
         try:
             target.replace(rotated)
-            self._chmod(rotated, 0o600)
+            self._restrict_file(rotated)
         except OSError as exc:
             # Retention is best-effort and must never make a successful metric
             # serialization fail. A later export retries rotation/pruning.
@@ -243,7 +243,7 @@ class JsonlMetricExporter(MetricExporter):
             if lock_fd.tell() == 0:
                 lock_fd.write(b"\0")
                 lock_fd.flush()
-            self._chmod(lock_path, 0o600)
+            self._restrict_file(lock_path)
             acquired = platform_compat.try_acquire_lock(lock_fd.fileno(), exclusive=True)
             if not acquired:
                 yield False
@@ -254,12 +254,38 @@ class JsonlMetricExporter(MetricExporter):
                 platform_compat.release_lock(lock_fd.fileno())
 
     @staticmethod
-    def _chmod(path: Path, mode: int) -> None:
-        """Best-effort private-perm enforcement; never fail the export on it."""
+    def _restrict_file(path: Path) -> None:
+        """Best-effort owner-only lockdown of a telemetry FILE.
+
+        ``restrict_to_owner`` rather than ``os.chmod(0o600)``: on Windows chmod
+        only toggles the read-only attribute and leaves the inherited DACL
+        intact, so the "telemetry stays private" contract in this module's
+        docstring held on POSIX and silently did not on Windows.
+
+        Kept best-effort (the helper is fail-loud, so the except stays): an
+        exporter must never make a successful metric serialization fail, and a
+        readable telemetry shard is a smaller harm than a dropped metric.
+        Separate from :meth:`_restrict_dir` because ``restrict_to_owner`` is
+        file-shaped -- its grants carry no inheritance flags, so handing it a
+        directory leaves files created inside on the creating token's DACL.
+        """
         try:
-            os.chmod(path, mode)
+            platform_compat.restrict_to_owner(path)
         except OSError as exc:
-            logger.debug("chmod %s -> %o failed: %s", path, mode, exc)
+            logger.debug("owner-only lockdown of file %s failed: %s", path, exc)
+
+    @staticmethod
+    def _restrict_dir(path: Path) -> None:
+        """Best-effort owner-only lockdown of the telemetry DIRECTORY.
+
+        The directory counterpart of :meth:`_restrict_file`: it applies the
+        inheritable DACL, so shards created inside it later are owner-only from
+        birth rather than at the moment the export happens to chmod them.
+        """
+        try:
+            platform_compat.restrict_dir_to_owner(path)
+        except OSError as exc:
+            logger.debug("owner-only lockdown of dir %s failed: %s", path, exc)
 
     def export(
         self,
@@ -273,8 +299,9 @@ class JsonlMetricExporter(MetricExporter):
             encoded = (line + "\n").encode("utf-8")
             self._dir.mkdir(parents=True, exist_ok=True)
             # ~/.kiro/crew convention: telemetry stays private (dir 0o700, file
-            # 0o600). mkdir/open modes are masked by umask, so chmod explicitly.
-            self._chmod(self._dir, 0o700)
+            # 0o600). mkdir/open modes are masked by umask, and on Windows the
+            # mode bits do nothing at all, so lock both down explicitly.
+            self._restrict_dir(self._dir)
             # Per-PID shards have one writer, so append + rotation need no
             # directory-wide lock. Keeping this path lock-free prevents
             # phase-aligned exporters from permanently dropping DELTA cycles.
@@ -282,7 +309,7 @@ class JsonlMetricExporter(MetricExporter):
             self._rotate_target_if_needed(target, len(encoded))
             with target.open("ab") as fh:
                 fh.write(encoded)
-            self._chmod(target, 0o600)
+            self._restrict_file(target)
             # Retention is separately serialized and best-effort. A contended
             # prune is skipped without discarding the export that just landed.
             self._maybe_prune()

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -32,6 +32,7 @@ from ctypes import wintypes  # type aliases only; imports cleanly on every platf
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, NamedTuple, Optional, Sequence
 
+from kiro_crew import windows_acl
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
@@ -159,7 +160,7 @@ DETACHED_PROCESS: int = getattr(subprocess, "DETACHED_PROCESS", 0)
 # caller can OR it into ``creationflags`` unconditionally.
 CREATE_SUSPENDED: int = 0x00000004 if os.name == "nt" else 0
 # For the short-lived helper tools this module shells out to on Windows
-# (whoami / netstat / taskkill / icacls / powershell): a console-less parent
+# (whoami / netstat / taskkill / powershell): a console-less parent
 # (gateway respawned with DETACHED_PROCESS, or pythonw) would otherwise
 # allocate a NEW visible console per spawn — a black-window flash on the
 # user's desktop for every status poll / secret write / kill. 0 on POSIX.
@@ -3419,31 +3420,7 @@ def unlink_link_or_junction(path: str | os.PathLike) -> None:
 # with inheritance stripped, S-1-3-4 grants access to whoever currently owns
 # the file. See:
 # https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
-_OWNER_RIGHTS_SID = "*S-1-3-4"
-
-
-# icacls inheritance flags for a DIRECTORY grant: (OI) object-inherit
-# propagates the ACE to files created inside, (CI) container-inherit propagates
-# it to subdirectories. Neither sets (IO), so the ACE also applies to the
-# directory itself and traversal is preserved.
-#
-# Without these flags a grant applies to the named object ALONE. That is
-# correct and complete for a file, and silently wrong for a directory: a file
-# created inside an "owner-only" directory would carry no explicit ACE at all
-# and fall back to whatever the creating process's token grants by default
-# (typically owner + SYSTEM + Administrators) — a default rather than the
-# guarantee the caller asked for. The flags are meaningless on a file, which is
-# why this is a directory-only rights prefix and not something
-# :func:`restrict_to_owner` can pass unconditionally.
-_ICACLS_DIR_INHERIT = "(OI)(CI)"
-
-
-# Success-only memo for _current_user_sid. NOT functools.lru_cache: lru_cache
-# would memoize a *failure* (None) permanently, so one transient whoami
-# timeout at first call (AV scan, system pressure) would poison every later
-# restrict_to_owner for the process lifetime. A None result must stay
-# retryable; only a resolved SID is cached.
-_USER_SID_CACHE: list[str] = []
+_OWNER_RIGHTS_SID = "S-1-3-4"
 
 
 _TOKEN_QUERY = 0x0008
@@ -3622,90 +3599,30 @@ def process_owner_sid(pid: int) -> str | None:
         return None
 
 
-def _current_user_sid() -> str | None:
-    """Return the current user's SID, ``*``-prefixed for icacls, or None.
-
-    Resolved from this process's access token when possible, falling back to
-    ``whoami /user /fo csv``.
-
-    Used by :func:`restrict_to_owner` on Windows to grant the invoking user
-    Full Control even when the file is owned by a different principal (e.g.
-    the file was created by a prior elevated / SYSTEM run, or restored from a
-    backup that preserved another owner). Granting only S-1-3-4 (Owner Rights)
-    in that scenario locks the current user out entirely on next read.
-    Best-effort: on any failure returns None (uncached, so the next call
-    retries) and the caller refuses the DACL write.
-
-    Success is cached at module scope: the user's SID is constant for the
-    process lifetime, so one lookup covers every restrict_to_owner call (six
-    secret-write sites). That matters for the whoami fallback specifically --
-    this is called on the event loop under token_secret._SECRET_LOCK's
-    first-token-verify path, so the memo bounds that stall to one spawn even
-    when the token read is unavailable.
-    """
-    if IS_POSIX:
-        return None
-    if _USER_SID_CACHE:
-        return _USER_SID_CACHE[0]
-    # Own access token first: no spawn, so it survives a stripped PATH, a
-    # hermetic test harness and load that would time the whoami call out.
-    from_token = _process_token_sid()
-    if from_token:
-        result = "*" + from_token
-        _USER_SID_CACHE.append(result)
-        return result
-    whoami = shutil.which("whoami") or r"C:\Windows\System32\whoami.exe"
-    try:
-        r = subprocess.run(
-            [whoami, "/user", "/fo", "csv", "/nh"],
-            check=False,
-            capture_output=True,
-            timeout=5,
-            creationflags=_SUBPROCESS_NO_WINDOW,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if r.returncode != 0:
-        return None
-    # csv row: "DOMAIN\\user","S-1-5-21-..."
-    text = r.stdout.decode("utf-8", "replace").strip().strip('"')
-    parts = text.split('","')
-    if len(parts) < 2:
-        return None
-    sid = parts[-1].strip('"').strip()
-    if not sid.startswith("S-1-"):
-        return None
-    result = "*" + sid
-    _USER_SID_CACHE.append(result)
-    return result
-
-
-#: Memo for :func:`current_user_sid`. Separate from ``_USER_SID_CACHE``, which
-#: holds the ``*``-prefixed icacls form and is populated by a path that may
-#: spawn; this one only ever holds a token-derived bare SID.
+#: Memo for :func:`current_user_sid`. Only ever holds a token-derived bare SID.
 _TOKEN_SID_CACHE: list[str] = []
 
 
 def current_user_sid() -> str | None:
     """Return the invoking user's bare SID (``S-1-5-...``), or ``None``.
 
-    Read from this process's own access token and nothing else. Deliberately
-    NOT :func:`_current_user_sid`, which falls back to a ``whoami`` subprocess
-    with a 5 s timeout: every caller of this function runs on the event loop --
-    the gatewayd admission check, the client-side server check, and the pipe
-    DACL builder, which runs once per pipe instance and therefore sits on the
-    accept path. A token-lookup failure there would stall accepts for seconds
-    at a time, repeatedly. :func:`restrict_to_owner` keeps the fallback because
-    it is always invoked through ``asyncio.to_thread``.
+    Read from this process's own access token and nothing else -- there is no
+    subprocess fallback anywhere in this path. Every caller runs on the event
+    loop: the gatewayd admission check, the client-side server check, the pipe
+    DACL builder (once per pipe instance, so on the accept path), and now the
+    owner-only lockdown itself. A ``whoami`` fallback would stall any of them for
+    seconds at a time on a host where the token read fails, which is why this
+    function refuses instead.
 
     Failing closed is correct for every caller: each treats ``None`` as
     "principal unverifiable" and refuses the connection, which degrades to a
     per-session MCP server rather than admitting an unattributable peer.
+    :func:`restrict_to_owner` likewise raises rather than applying a
+    half-configured DACL.
 
-    SDDL and the Win32 security APIs want the bare SID, so the ``*`` prefix the
-    icacls form carries is stripped here rather than in each consumer. Memoised:
-    the SID is constant for the process lifetime and this is on a hot path.
-    Returns ``None`` on POSIX and on any lookup failure.
+    SDDL and the Win32 security APIs want the bare SID, which is what this
+    returns. Memoised: the SID is constant for the process lifetime and this is
+    on a hot path. Returns ``None`` on POSIX and on any lookup failure.
     """
     if _TOKEN_SID_CACHE:
         return _TOKEN_SID_CACHE[0]
@@ -3857,21 +3774,29 @@ def restrict_to_owner(path: str | os.PathLike) -> None:
     including the fail-loud ``OSError`` propagation the security-sensitive
     callers rely on to reach their warn-and-continue handlers.
 
-    Windows: strip inheritance and apply an owner-only DACL via
-    ``icacls <path> /inheritance:r /grant:r "*S-1-3-4:F" /grant:r "*<user-sid>:F"``.
-    S-1-3-4 (Owner Rights) covers the file's current owner; the invoking-user
-    grant covers the caller by explicit SID, so a file created by another
-    principal (elevated first-run, backup restore, SYSTEM-context service)
-    remains readable by the caller that is trying to lock it down — otherwise
-    the current user would be denied their own token signing key on the next
-    read and every issued auth cookie / refresh token would be invalidated on
-    each restart. When ``_current_user_sid()`` cannot resolve the SID
-    (whoami missing / fails / unparseable), we raise ``OSError`` BEFORE
-    invoking icacls: an Owner-Rights-only DACL would recreate the exact
+    Windows: strip inheritance and apply an owner-only DACL in-process via
+    :func:`windows_acl.apply_owner_only`. S-1-3-4 (Owner Rights) covers the
+    file's current owner; the invoking-user grant covers the caller by explicit
+    SID, so a file created by another principal (elevated first-run, backup
+    restore, SYSTEM-context service) remains readable by the caller that is
+    trying to lock it down — otherwise the current user would be denied their
+    own token signing key on the next read and every issued auth cookie /
+    refresh token would be invalidated on each restart. When the SID cannot be
+    resolved from the process token we raise ``OSError`` BEFORE applying
+    anything: an Owner-Rights-only DACL would recreate the exact
     ownership-lockout regression the dual grant exists to prevent, so we
     refuse to apply a half-configured lockdown. Any failure raises
     ``OSError`` so callers hit the same warn-and-continue path they use on
     POSIX.
+
+    A caller that runs INLINE ON THE ASYNCIO EVENT LOOP and so cannot afford the
+    unbounded SMB round-trip a DACL write to a UNC or mapped-drive path costs must
+    ask :func:`windows_acl.volume_is_local` FIRST and skip the lockdown itself.
+    That decision is deliberately not a parameter here: by the time this function
+    is reached the caller has already done whatever filesystem work it took to get
+    here, so a refusal at this depth would come after the cost it was meant to
+    avoid. ``config/loader.py``'s ``write_config_atomically`` is the one such
+    caller today.
     """
     if IS_POSIX:
         os.chmod(path, 0o600)
@@ -3899,7 +3824,7 @@ def restrict_to_owner(path: str | os.PathLike) -> None:
             )
     except OSError:
         pass
-    _icacls_owner_only(path, inherit=False)
+    _apply_owner_only_dacl(path, inherit=False)
 
 
 def restrict_dir_to_owner(path: str | os.PathLike) -> None:
@@ -3938,62 +3863,63 @@ def restrict_dir_to_owner(path: str | os.PathLike) -> None:
         # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501
         os.chmod(path, 0o700)
         return
-    _icacls_owner_only(path, inherit=True)
+    _apply_owner_only_dacl(path, inherit=True)
 
 
-def _icacls_owner_only(path: str | os.PathLike, *, inherit: bool) -> None:
-    """Apply an owner-only DACL to *path* via icacls. Windows-only.
+def _apply_owner_only_dacl(path: str | os.PathLike, *, inherit: bool) -> None:
+    """Apply an owner-only DACL to *path* in-process. Windows-only.
 
     Shared by :func:`restrict_to_owner` (``inherit=False``, file shape) and
     :func:`restrict_dir_to_owner` (``inherit=True``, directory shape). The only
-    difference between the two argv forms is the rights prefix, so they are one
-    function: an owner-only DACL that two call paths could drift apart on is
+    difference between the two is whether the grants are inheritable, so they are
+    one function: an owner-only DACL that two call paths could drift apart on is
     the defect this consolidation exists to prevent.
+
+    This used to shell out to ``icacls /inheritance:r /grant:r ...``. It now
+    builds the same descriptor through ``advapi32`` directly, which is what
+    removed the "must not run on the event loop" constraint this helper used to
+    impose on every one of its callers: measured on a local NTFS volume, the
+    subprocess cost 313 ms per call and this costs 0.24 ms. Callers that already
+    offload it are still free to -- a filesystem call can block on a slow volume,
+    so offloading remains good practice -- but it is no longer mandatory, and a
+    caller on the loop is no longer parking the gateway for a third of a second
+    per secret written.
+
+    Resolve the invoking user's SID BEFORE writing anything, and resolve it
+    WITHOUT the possibility of a spawn: :func:`current_user_sid` reads the
+    process's own access token and nothing else. The ``whoami``-fallback helper
+    this used while the lockdown was itself a subprocess is gone -- it would have
+    put a blocking spawn back on the event loop on any host where the token read
+    fails, defeating the whole point of removing the icacls call, and once this
+    was its last caller it was dead code.
+
+    If the SID cannot be resolved we CANNOT safely apply the DACL: an
+    Owner-Rights-only descriptor (S-1-3-4 alone) would lock the current user out
+    of their own file whenever the file was created by a different principal
+    (elevated first-run, SYSTEM-context service, backup-restored tarball
+    preserving foreign ownership -- the exact scenarios the dual grant exists to
+    prevent). Fail loud with ``OSError``, the same shape callers already handle,
+    so the security-warning path fires instead of silently re-introducing the
+    ownership-lockout regression. Note the consequence of the token-only rule:
+    on a host whose token read fails we now refuse rather than spawning
+    ``whoami``. That is the safe direction -- a caller that must not fail passes
+    ``restrict_on_error="warn"`` and gets a warning instead of a stall.
     """
-    icacls = shutil.which("icacls") or r"C:\Windows\System32\icacls.exe"
-    # Resolve the invoking user's SID BEFORE building the argv. If whoami is
-    # unavailable (missing from PATH under a stripped-down profile, subprocess
-    # exception, unparseable output), we CANNOT safely apply the DACL: the
-    # Owner-Rights-only fallback (S-1-3-4 alone) would lock the current user
-    # out of their own file when the file was created by a different principal
-    # (elevated first-run, SYSTEM-context service, backup-restored tarball
-    # preserving foreign ownership — the exact scenarios the dual-grant
-    # exists to prevent). Fail loud (raise OSError, same shape callers see on
-    # icacls non-zero rc) so the security-warning handler fires instead of
-    # silently re-introducing the ownership-lockout regression.
-    user_sid = _current_user_sid()
+    user_sid = current_user_sid()
     if user_sid is None:
         raise OSError(
             f"{'restrict_dir_to_owner' if inherit else 'restrict_to_owner'}: "
-            "cannot resolve current user SID via whoami; "
+            "cannot resolve current user SID from this process's access token; "
             "refusing to apply Owner-Rights-only DACL (would lock non-owner "
-            f"users out of {path!s} — see _current_user_sid docstring)."
+            f"users out of {path!s} — see current_user_sid docstring)."
         )
-    rights = f"{_ICACLS_DIR_INHERIT}F" if inherit else "F"
-    argv: list[str] = [
-        icacls,
-        os.fspath(path),
-        "/inheritance:r",
-        "/grant:r",
-        f"{_OWNER_RIGHTS_SID}:{rights}",
-    ]
-    if user_sid != _OWNER_RIGHTS_SID:
-        argv += ["/grant:r", f"{user_sid}:{rights}"]
+    sids = (_OWNER_RIGHTS_SID,) if user_sid == _OWNER_RIGHTS_SID else (_OWNER_RIGHTS_SID, user_sid)
     try:
-        r = subprocess.run(
-            argv,
-            check=False,
-            capture_output=True,
-            timeout=10,
-            creationflags=_SUBPROCESS_NO_WINDOW,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise OSError(f"icacls invocation failed for {path}: {exc}") from exc
-    if r.returncode != 0:
-        raise OSError(
-            f"icacls failed for {path} (rc={r.returncode}): "
-            f"{(r.stderr or r.stdout).decode('utf-8', 'replace').strip()}"
-        )
+        windows_acl.apply_owner_only(path, inherit=inherit, sids=sids)
+    except (windows_acl.AclWriteFailed, windows_acl.AclUnavailable) as exc:
+        # Translated to OSError so both platforms raise the same type: every
+        # caller's handler is written against the POSIX chmod's OSError.
+        raise OSError(f"owner-only DACL could not be applied to {path}: {exc}") from exc
 
 
 # Hook-script extensions treated as runnable on Windows (where there is no

--- a/src/kiro_crew/windows_acl.py
+++ b/src/kiro_crew/windows_acl.py
@@ -93,10 +93,13 @@ def _last_error() -> int:
 
 __all__ = [
     "AclUnavailable",
+    "AclWriteFailed",
     "ComponentSecurity",
     "WELL_KNOWN_TRUSTED_SIDS",
     "Writer",
+    "apply_owner_only",
     "describe",
+    "volume_is_local",
 ]
 
 
@@ -274,6 +277,34 @@ def _install_prototypes(advapi32: _DLL, kernel32: _DLL) -> None:  # pragma: no c
     kernel32.GetDriveTypeW.argtypes = [C.c_wchar_p]
     kernel32.GetDriveTypeW.restype = C.c_uint
 
+    # ── Write side (see apply_owner_only) ────────────────────────────────────
+    advapi32.ConvertStringSidToSidW.argtypes = [W.LPCWSTR, C.POINTER(C.c_void_p)]
+    advapi32.ConvertStringSidToSidW.restype = W.BOOL
+    advapi32.GetLengthSid.argtypes = [C.c_void_p]
+    advapi32.GetLengthSid.restype = W.DWORD
+    advapi32.InitializeAcl.argtypes = [C.POINTER(_ACL), W.DWORD, W.DWORD]
+    advapi32.InitializeAcl.restype = W.BOOL
+    advapi32.AddAccessAllowedAceEx.argtypes = [
+        C.POINTER(_ACL),
+        W.DWORD,
+        W.DWORD,
+        W.DWORD,
+        C.c_void_p,
+    ]
+    advapi32.AddAccessAllowedAceEx.restype = W.BOOL
+    # LPWSTR, not LPCWSTR: SetNamedSecurityInfoW takes a mutable name in the SDK.
+    advapi32.SetNamedSecurityInfoW.argtypes = [
+        W.LPWSTR,
+        W.DWORD,
+        W.DWORD,
+        C.c_void_p,
+        C.c_void_p,
+        C.POINTER(_ACL),
+        C.POINTER(_ACL),
+    ]
+    # Returns a Win32 error code directly, NOT a BOOL -- 0 is the only success.
+    advapi32.SetNamedSecurityInfoW.restype = W.DWORD
+
 
 def _load() -> tuple[_DLL, _DLL]:
     """Acquire the two DLL handles this module reads descriptors through.
@@ -293,38 +324,6 @@ def _load() -> tuple[_DLL, _DLL]:
     except OSError as exc:  # pragma: no cover - a Windows without advapi32
         raise AclUnavailable(f"cannot load the Windows security API: {exc}") from exc
     _install_prototypes(advapi32, kernel32)
-    return advapi32, kernel32
-
-    advapi32.GetNamedSecurityInfoW.argtypes = [
-        W.LPCWSTR,
-        W.DWORD,
-        W.DWORD,
-        C.POINTER(C.c_void_p),
-        C.POINTER(C.c_void_p),
-        C.POINTER(C.POINTER(_ACL)),
-        C.POINTER(C.POINTER(_ACL)),
-        C.POINTER(C.c_void_p),
-    ]
-    advapi32.GetNamedSecurityInfoW.restype = W.DWORD
-    advapi32.GetAce.argtypes = [C.POINTER(_ACL), W.DWORD, C.POINTER(C.c_void_p)]
-    advapi32.GetAce.restype = W.BOOL
-    advapi32.ConvertSidToStringSidW.argtypes = [C.c_void_p, C.POINTER(W.LPWSTR)]
-    advapi32.ConvertSidToStringSidW.restype = W.BOOL
-    advapi32.LookupAccountSidW.argtypes = [
-        W.LPCWSTR,
-        C.c_void_p,
-        W.LPWSTR,
-        W.LPDWORD,
-        W.LPWSTR,
-        W.LPDWORD,
-        W.LPDWORD,
-    ]
-    advapi32.LookupAccountSidW.restype = W.BOOL
-
-    kernel32.LocalFree.argtypes = [C.c_void_p]
-    kernel32.LocalFree.restype = C.c_void_p
-    kernel32.GetDriveTypeW.argtypes = [C.c_wchar_p]
-    kernel32.GetDriveTypeW.restype = C.c_uint
     return advapi32, kernel32
 
 
@@ -392,6 +391,25 @@ def _volume_is_local(kernel32: _DLL, path: Path) -> bool:
     # the real-ACL suite there rather than by the injected-handle tests.
     root = drive if drive.endswith(os.sep) else drive + os.sep  # pragma: no cover
     return int(kernel32.GetDriveTypeW(root)) in _LOCAL_DRIVE_TYPES  # pragma: no cover
+
+
+def volume_is_local(path: str | os.PathLike) -> bool:
+    """Whether *path* sits on a volume attached to this machine.
+
+    The public form of :func:`_volume_is_local`, for a caller that must decide
+    whether a DACL write is affordable BEFORE it starts one. It classifies the
+    volume from its ROOT via ``GetDriveTypeW`` and touches no file, so it is safe
+    to ask about a path that does not exist yet and costs nothing on the volume
+    itself -- which is what lets an on-loop caller ask first and skip the
+    unbounded SMB round-trip rather than discover it part way through.
+
+    Returns ``False`` off Windows, where there is no volume to classify. Callers
+    reach this from inside an already-Windows branch (``config/loader.py``'s
+    ``write_config_atomically``), so there is no POSIX-answering wrapper: on POSIX
+    ``chmod`` is a local metadata update and there is nothing to rule out.
+    """
+    _advapi32, kernel32 = _load()
+    return _volume_is_local(kernel32, Path(os.fspath(path)))
 
 
 def describe(path: Path) -> ComponentSecurity:
@@ -484,3 +502,125 @@ def describe(path: Path) -> ComponentSecurity:
         )
     finally:
         kernel32.LocalFree(descriptor)
+
+
+# ---------------------------------------------------------------------------
+# Write side: applying an owner-only DACL
+# ---------------------------------------------------------------------------
+
+# ``icacls``' ``:F``. FILE_ALL_ACCESS rather than GENERIC_ALL: the generic rights
+# are mapped by the object manager when a handle is opened, so a descriptor
+# written with GENERIC_ALL reads back as the mapped specific bits and would not
+# compare equal to what this module's own read side reports.
+_FILE_ALL_ACCESS = 0x001F01FF
+
+_ACL_REVISION = 2
+
+# AceFlags for a DIRECTORY grant, so entries created inside inherit it. Both are
+# meaningless on a file, which is why the file shape passes 0 -- the same split
+# that ``restrict_to_owner`` and ``restrict_dir_to_owner`` encode.
+_OBJECT_INHERIT_ACE = 0x01
+_CONTAINER_INHERIT_ACE = 0x02
+
+_SE_FILE_OBJECT = 1
+_DACL_SECURITY_INFORMATION = 0x00000004
+# The in-process equivalent of ``icacls /inheritance:r``: it sets SE_DACL_PROTECTED,
+# so the object stops inheriting ACEs from its parent. Without it the DACL below
+# would be MERGED with whatever the parent grants, which leaves exactly the
+# exposure the lockdown exists to close.
+_PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+
+
+class AclWriteFailed(RuntimeError):
+    """An owner-only DACL could not be applied.
+
+    Distinct from :class:`AclUnavailable`, which means a descriptor could not be
+    READ. Callers translate this into the ``OSError`` their POSIX path already
+    raises, so a failed lockdown reaches the same warn-or-refuse handler on both
+    platforms rather than passing silently.
+    """
+
+
+def apply_owner_only(
+    path: str | os.PathLike,
+    *,
+    inherit: bool,
+    sids: tuple[str, ...],
+) -> None:
+    """Replace *path*'s DACL with an owner-only one, protected from inheritance.
+
+    The in-process replacement for shelling out to ``icacls``. Same resulting
+    descriptor -- inheritance stripped, one full-control ACE per entry in *sids*
+    -- reached with three ``advapi32`` calls instead of a process spawn, which is
+    what lets a caller on the asyncio event loop apply it without parking the
+    loop for the duration of a subprocess.
+
+    *sids* are SID strings (``S-1-...``), in the order they should appear in the
+    ACL, and the POLICY of which principals to grant stays with the caller: this
+    function is deliberately mechanical so the decision about who may read a
+    secret lives in one place rather than being split across a ctypes helper.
+    An empty *sids* is refused -- an ACL with no ACEs is not "owner-only", it
+    denies everyone including the owner, and writing one would brick the file.
+
+    *require_local_volume* used to live here. It does not any more: a caller that
+    cannot afford an unbounded SMB round-trip has to know that BEFORE it starts
+    the write, so the decision belongs at the call site via
+    :func:`volume_is_local`, ahead of any other filesystem work. Asking here
+    would have been too late -- the caller would already have paid for whatever
+    it did to reach this call.
+
+    Raises :class:`AclWriteFailed` on any failure, having written nothing: the
+    descriptor is only handed to the kernel once fully built, so a failure part
+    way through construction cannot leave a half-applied DACL.
+    """
+    if not sids:
+        raise AclWriteFailed("refusing to apply a DACL with no grants")
+    advapi32, kernel32 = _load()
+    flags = (_OBJECT_INHERIT_ACE | _CONTAINER_INHERIT_ACE) if inherit else 0
+    granted: list[C.c_void_p] = []
+    try:
+        for sid in sids:
+            psid = C.c_void_p()
+            if not advapi32.ConvertStringSidToSidW(sid, C.byref(psid)):
+                raise AclWriteFailed(f"could not parse SID {sid!r} (error {_last_error()})")
+            granted.append(psid)
+        # Size the ACL from the struct layout, never from hardcoded numbers: the
+        # SID is variable-length and starts at SidStart, so that field's offset IS
+        # the fixed part of an ACE. Deriving it also keeps this correct under the
+        # off-Windows wintypes stand-ins, where DWORD is a 64-bit c_ulong and any
+        # hand-computed size would be wrong.
+        ace_fixed = _ACCESS_ACE.SidStart.offset
+        total = C.sizeof(_ACL) + sum(
+            ace_fixed + int(advapi32.GetLengthSid(psid)) for psid in granted
+        )
+        buffer = C.create_string_buffer(total)
+        pacl = C.cast(buffer, C.POINTER(_ACL))
+        if not advapi32.InitializeAcl(pacl, total, _ACL_REVISION):
+            raise AclWriteFailed(f"InitializeAcl failed (error {_last_error()})")
+        for psid in granted:
+            if not advapi32.AddAccessAllowedAceEx(
+                pacl, _ACL_REVISION, flags, _FILE_ALL_ACCESS, psid
+            ):
+                raise AclWriteFailed(f"AddAccessAllowedAceEx failed (error {_last_error()})")
+        rc = int(
+            advapi32.SetNamedSecurityInfoW(
+                os.fspath(path),
+                _SE_FILE_OBJECT,
+                _DACL_SECURITY_INFORMATION | _PROTECTED_DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                pacl,
+                None,
+            )
+        )
+        if rc != 0:
+            # The path is NOT included. In this codebase a path can itself be the
+            # secret (mcp_gateway/apps.py notes its spool FILENAMES are live
+            # capability tokens), so naming it here would be clear-text logging of
+            # sensitive information. The caller knows which path it passed.
+            raise AclWriteFailed(f"SetNamedSecurityInfoW failed (error {rc})")
+    finally:
+        # ConvertStringSidToSidW allocates with LocalAlloc, so every SID that was
+        # successfully parsed must be freed even on the failure paths above.
+        for psid in granted:
+            kernel32.LocalFree(psid)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -203,11 +203,11 @@ def make_dir_link(link: pathlib.Path, target: pathlib.Path) -> None:
 
 @pytest.fixture(autouse=True)
 def _windows_restrict_to_owner_stub(request, monkeypatch):
-    """On Windows, no-op the icacls secret lockdown for hermetic tests.
+    """On Windows, no-op the secret lockdown for hermetic tests.
 
-    Many tests stub ``subprocess.run`` (or strip PATH) for hermeticity;
-    ``restrict_to_owner``'s whoami/icacls spawns then fail and its
-    DELIBERATE fail-loud OSError cascades into hundreds of unrelated
+    Many tests stub ``subprocess.run`` (or strip PATH) for hermeticity, or
+    monkeypatch the SID resolver; ``restrict_to_owner``'s DELIBERATE fail-loud
+    OSError then cascades into hundreds of unrelated
     tests. The real Windows implementation keeps direct coverage in
     test_platform_compat / test_spawn_audit (exempted here) and the
     POSIX chmod path keeps full coverage on the Linux matrix. Product
@@ -218,10 +218,23 @@ def _windows_restrict_to_owner_stub(request, monkeypatch):
     ``restrict_dir_to_owner`` is stubbed alongside it and must stay that
     way: it is the directory twin that ``make_owner_only_dir`` routes
     through, so stubbing only the file helper would leave every test that
-    creates an owner-only directory spawning a real icacls.
+    creates an owner-only directory writing a real DACL.
+
+    Note the lockdown no longer spawns anything -- it applies the DACL through
+    ``advapi32`` in-process -- so the subprocess-stub collision this fixture was
+    built for is mostly gone. The stub is kept because a hermetic test that
+    patches the SID resolver or the writer seam can still trip the fail-loud
+    OSError, and narrowing it is a change to hundreds of tests' blast radius
+    rather than part of the DACL swap.
     """
     if not platform_compat.IS_WINDOWS or request.module.__name__ in (
         "test_platform_compat",
+        # Exempted for the same reason as test_platform_compat: these modules own
+        # the direct Windows-branch coverage for the owner-only lockdown, so a
+        # stub would make their assertions vacuous. They were passing on Linux
+        # (where the fixture is inert) and silently asserting nothing on Windows.
+        "test_platform_compat_coverage",
+        "test_config_rmw_preserves_settings",
         "test_spawn_audit",
     ):
         yield

--- a/test/test_atomic_write_capabilities.py
+++ b/test/test_atomic_write_capabilities.py
@@ -74,7 +74,7 @@ def test_restrict_to_owner_runs_before_any_content_is_written(tmp_path, monkeypa
     events: list[str] = []
     real_restrict = platform_compat.restrict_to_owner
 
-    def _spy(path):
+    def _spy(path, **_kw):
         events.append("restrict")
         return real_restrict(path)
 
@@ -128,7 +128,7 @@ def test_a_wider_mode_alongside_restrict_to_owner_is_rejected(tmp_path):
 def test_a_failing_lockdown_leaves_no_temp_and_no_target(tmp_path, monkeypatch):
     """Fail-loud: a secret we cannot protect must not be written at all."""
 
-    def _boom(path):
+    def _boom(path, **_kw):
         raise OSError("cannot set DACL")
 
     monkeypatch.setattr(platform_compat, "restrict_to_owner", _boom)
@@ -144,7 +144,7 @@ def test_a_failing_lockdown_leaves_no_temp_and_no_target(tmp_path, monkeypatch):
 def _failing_restrict(monkeypatch):
     """Make the owner-only lockdown fail the way a read-only FS or icacls would."""
 
-    def _boom(path):
+    def _boom(path, **_kw):
         raise OSError("cannot set DACL")
 
     monkeypatch.setattr(platform_compat, "restrict_to_owner", _boom)

--- a/test/test_computer_use_capture_windows.py
+++ b/test/test_computer_use_capture_windows.py
@@ -604,8 +604,8 @@ class TestEnsureShotsDir:
         assert made == [str(target)]
 
     def test_the_tighten_runs_ONCE_per_process(self, monkeypatch, tmp_path) -> None:
-        """``restrict_to_owner`` shells out to icacls on Windows; once per screenshot
-        would put a subprocess on the capture path."""
+        """``restrict_to_owner`` rewrites a DACL on Windows; once per screenshot
+        would put that on the capture path."""
         calls: list = []
         monkeypatch.setattr(C, "shots_dir", lambda: str(tmp_path / "s"))
         monkeypatch.setattr(C, "_dir_ready", False)

--- a/test/test_config_rmw_preserves_settings.py
+++ b/test/test_config_rmw_preserves_settings.py
@@ -238,8 +238,8 @@ class TestWriteConfigAtomically:
         reason=(
             "POSIX mode bits only: atomic_write applies `mode` via fchmod_safe, "
             "which is a documented no-op on Windows (access there is carried by "
-            "the DACL, and applying one would mean an icacls subprocess — which "
-            "this function must not run, see write_config_atomically)."
+            "the DACL, which write_config_atomically applies on its Windows "
+            "branch instead — see test_windows_applies_an_owner_only_dacl)."
         ),
     )
     def test_preserves_existing_mode(self, tmp_path):
@@ -277,24 +277,130 @@ class TestWriteConfigAtomically:
         assert not stat.S_IMODE(path.stat().st_mode) & 0o077
 
     def test_does_not_spawn_a_subprocess_on_the_event_loop(self, tmp_path, monkeypatch):
-        """Must not call restrict_to_owner: it shells out to icacls on Windows.
+        """No spawn, on either platform.
 
         This function runs inside async request handlers and KiroCrewConfig.save(),
-        so a blocking subprocess here would freeze the gateway's event loop —
-        the `no-blocking-call-on-event-loop` AUTOSDE rule. Pinned because the
-        obvious "harden the file" reflex reintroduces it.
+        so a blocking subprocess here would freeze the gateway's event loop — the
+        `no-blocking-call-on-event-loop` AUTOSDE rule. Pinned because the obvious
+        "harden the file" reflex used to reintroduce it: the owner-only lockdown
+        was an icacls subprocess, which is why this function used to skip it
+        entirely. It now applies the DACL in-process, so the ban is on SPAWNING,
+        not on hardening — hardening is asserted positively below.
         """
         import subprocess
 
-        from kiro_crew import platform_compat
         from kiro_crew.config.loader import write_config_atomically
 
         def _fail(*a, **k):  # pragma: no cover - must never run
             raise AssertionError("write_config_atomically must not spawn a subprocess")
 
         monkeypatch.setattr(subprocess, "run", _fail)
-        monkeypatch.setattr(platform_compat, "restrict_to_owner", _fail)
         write_config_atomically(tmp_path / "config.json", {"auto_update": True})
+
+    @pytest.mark.skipif(
+        platform_compat.IS_POSIX,
+        reason="Windows DACL branch (POSIX carries access in the mode bits)",
+    )
+    def test_windows_applies_an_owner_only_dacl(self, tmp_path):
+        """The Windows half of the guarantee the mode tests cover on POSIX.
+
+        config.json can hold inline provider tokens, and on Windows the mode bits
+        are inert — so without this the file lands under whatever DACL it inherits
+        from its parent, readable by every other local account. No mode assertion
+        can catch that (NTFS reports 0o666 regardless), so the descriptor itself
+        is the observable.
+        """
+        from kiro_crew import windows_acl
+        from kiro_crew.config.loader import write_config_atomically
+
+        path = tmp_path / "config.json"
+        write_config_atomically(path, {"slack": {"bot_token": "xoxb-secret"}})
+
+        described = windows_acl.describe(path)
+        expected = {"S-1-3-4", platform_compat.current_user_sid()}
+        writers = {w.sid for w in described.writers}
+        assert not described.null_dacl
+        assert writers <= expected, f"unexpected writers: {sorted(writers - expected)}"
+
+    def test_the_volume_is_classified_before_any_filesystem_work(self, tmp_path, monkeypatch):
+        """Ordering IS the fix here, so it is asserted rather than the outcome alone.
+
+        This function runs inline on the event loop, and on Windows a DACL write to
+        a UNC or mapped-drive path is an unbounded SMB round-trip. A check placed
+        inside ``atomic_write`` -- where an earlier revision of this change put it
+        -- is already too late: the ``stat`` and the ``parent.mkdir`` below, plus
+        everything ``atomic_write`` does, each touch the target volume first, so the
+        loop would have parked on the network before the verdict landed.
+
+        The one thing that legitimately precedes the gate is the symlink resolve: a
+        config symlinked into a dotfiles repo can point at a different volume than
+        the link, so classifying before resolving would classify the wrong volume.
+        That is asserted too, rather than left implied.
+        """
+        import kiro_crew.config.loader as loader
+
+        order: list[str] = []
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(
+            loader.windows_acl,
+            "volume_is_local",
+            lambda _p: order.append("classify_volume") or False,
+        )
+        real_mkdir = loader.Path.mkdir
+
+        def _tracking_mkdir(self, *a, **k):
+            order.append("mkdir")
+            return real_mkdir(self, *a, **k)
+
+        monkeypatch.setattr(loader.Path, "mkdir", _tracking_mkdir)
+        monkeypatch.setattr(
+            platform_compat,
+            "restrict_to_owner",
+            lambda _p: order.append("lockdown"),  # pragma: no cover - must not run
+        )
+
+        path = tmp_path / "config.json"
+        loader.write_config_atomically(path, {"slack": {"bot_token": "xoxb-secret"}})
+
+        assert order[0] == "classify_volume", (
+            "the volume must be classified before any filesystem work on it -- "
+            f"got {order}, so the loop paid for work the gate exists to avoid"
+        )
+        assert "lockdown" not in order, "a non-local volume must skip the DACL entirely"
+        # Skipping the lockdown must not lose the config write.
+        assert json.loads(path.read_text())["slack"]["bot_token"] == "xoxb-secret"
+
+    def test_a_local_volume_still_gets_the_lockdown(self, tmp_path, monkeypatch):
+        # The other half: the gate must not become a blanket opt-out. On a local
+        # volume the write is protected exactly as it is without the gate.
+        import kiro_crew.config.loader as loader
+
+        locked: list[str] = []
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(loader.windows_acl, "volume_is_local", lambda _p: True)
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: locked.append(str(p)))
+
+        path = tmp_path / "config.json"
+        loader.write_config_atomically(path, {"slack": {"bot_token": "xoxb-secret"}})
+
+        assert len(locked) == 1, f"the lockdown must run on a local volume: {locked}"
+        assert locked[0].endswith(".tmp"), "the DACL must land on the TEMP, before the content"
+
+    def test_an_unloadable_descriptor_api_skips_rather_than_crashing(self, tmp_path, monkeypatch):
+        # A host where the security API cannot be loaded at all must still get its
+        # config written: the lockdown would have failed there anyway, so the
+        # classifier raising must degrade to "skip", never to a failed save.
+        import kiro_crew.config.loader as loader
+
+        def _boom(_p):
+            raise RuntimeError("cannot load the Windows security API")
+
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(loader.windows_acl, "volume_is_local", _boom)
+
+        path = tmp_path / "config.json"
+        loader.write_config_atomically(path, {"auto_update": True})
+        assert json.loads(path.read_text())["auto_update"] is True
 
     @pytest.mark.skipif(
         not platform_compat.IS_POSIX,

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -2383,8 +2383,8 @@ class TestProbeTempContainment:
         home.mkdir()
         monkeypatch.setattr(bt, "config_dir", lambda: home)
         monkeypatch.setattr(platform_compat, "IS_POSIX", False)
-        # The IS_POSIX patch also flips restrict_dir_to_owner onto its icacls
-        # branch, which cannot run on the POSIX host executing this test --
+        # The IS_POSIX patch also flips restrict_dir_to_owner onto its Windows
+        # DACL branch, which cannot run on the POSIX host executing this test --
         # shim it to POSIX behavior so ALLOCATION survives and the test
         # exercises the logic it targets.
         monkeypatch.setattr(
@@ -2442,8 +2442,8 @@ class TestProbeTempContainment:
         home.mkdir()
         monkeypatch.setattr(bt, "config_dir", lambda: home)
         monkeypatch.setattr(platform_compat, "IS_POSIX", False)
-        # The IS_POSIX patch also flips restrict_dir_to_owner onto its icacls
-        # branch, which cannot run on the POSIX host executing this test --
+        # The IS_POSIX patch also flips restrict_dir_to_owner onto its Windows
+        # DACL branch, which cannot run on the POSIX host executing this test --
         # shim it to POSIX behavior so ALLOCATION survives and the test
         # exercises the logic it targets.
         monkeypatch.setattr(

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -771,7 +771,7 @@ def test_env_sidecar_directory_goes_through_make_owner_only_dir(
 def test_failed_sidecar_protection_leaves_no_readable_credentials(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """An icacls failure must not leave the credentials on disk.
+    """A lockdown failure must not leave the credentials on disk.
 
     The previous order wrote the sidecar first (with a mode argument that is
     inert on Windows) and applied the DACL afterwards, catching the failure with
@@ -803,7 +803,7 @@ def test_failed_sidecar_protection_leaves_no_readable_credentials(
         test would stop short of the behaviour under test.
         """
         if Path(path).parent.name == "env":
-            raise OSError("icacls: access denied")
+            raise OSError("SetNamedSecurityInfoW: access denied")
 
     monkeypatch.setattr("kiro_crew.mcp_gateway.rewriter.platform_compat.IS_POSIX", False)
     monkeypatch.setattr("kiro_crew.mcp_gateway.rewriter.platform_compat.IS_WINDOWS", True)

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2024,161 +2024,147 @@ class TestTaskkillErrorMapping:
 
 
 class TestRestrictToOwnerArgvOnLinux:
-    """Regression guard for the Windows icacls DACL argv fix.
+    """Regression guard for the Windows owner-only DACL, exercised on Linux.
 
-    Runs on the Linux CI fleet by monkeypatching IS_WINDOWS + subprocess.run —
-    the argv construction is platform-independent code, and without this the
-    security-critical `icacls /inheritance:r /grant:r "*S-1-3-4:F" /grant:r
-    "*<user-sid>:F"` string is only exercised on the author's manual Windows
-    E2E (skipif-Windows tests don't run on AL2). A regression that mangles
-    the flags or the S-1-3-4 SID silently reopens the parent-inherited-DACL
-    gap.
+    Runs on the Linux CI fleet by monkeypatching IS_WINDOWS + the DACL writer --
+    the decision of WHICH principals to grant, and whether the grants are
+    inheritable, is platform-independent code, and without this it is only
+    exercised on the author's manual Windows E2E (skipif-Windows tests don't run
+    on AL2). A regression that drops the S-1-3-4 grant or the invoking-user grant
+    silently reopens the parent-inherited-DACL gap.
+
+    The observable used to be the ``icacls`` argv. The lockdown now goes through
+    ``windows_acl.apply_owner_only`` in-process, so the observable is that call's
+    arguments instead -- the same seam, one layer down, and still the only thing
+    visible off Windows (NTFS reports 0o666 for any file regardless of its DACL,
+    so no mode assertion can substitute).
     """
 
-    def test_icacls_argv_includes_owner_and_user_grants(self, tmp_path, monkeypatch):
+    @staticmethod
+    def _capture(monkeypatch, sid="S-1-5-21-1-2-3-1000"):
+        """Force the Windows branch and record the DACL write instead of doing it."""
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        # Reset the success-only SID memo so the monkeypatched stub wins
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
-        captured: dict = {}
+        # Reset the SID memo so the monkeypatched stub wins. The lockdown reads
+        # current_user_sid, which is token-only and cannot spawn.
+        monkeypatch.setattr(pc, "_TOKEN_SID_CACHE", [])
+        monkeypatch.setattr(pc, "current_user_sid", lambda: sid)
+        calls: list[dict] = []
 
-        def fake_run(argv, **_kw):
-            captured["argv"] = list(argv)
-            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        def fake_apply(path, *, inherit, sids, **_kw):
+            calls.append({"path": os.fspath(path), "inherit": inherit, "sids": tuple(sids)})
 
-        monkeypatch.setattr(pc.subprocess, "run", fake_run)
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", fake_apply)
+        return calls
+
+    def test_dacl_grants_owner_rights_and_the_invoking_user(self, tmp_path, monkeypatch):
+        calls = self._capture(monkeypatch)
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         pc.restrict_to_owner(f)
-        argv = captured["argv"]
-        # icacls + path + /inheritance:r + Owner Rights grant + user-SID grant.
-        assert argv[0].endswith("icacls") or "icacls" in argv[0]
-        assert os.fspath(f) in argv
-        assert "/inheritance:r" in argv
-        # Grants come in (flag, "SID:F") pairs — assert both are present.
-        grants = [argv[i + 1] for i, a in enumerate(argv[:-1]) if a == "/grant:r"]
-        assert "*S-1-3-4:F" in grants, grants
-        assert "*S-1-5-21-1-2-3-1000:F" in grants, grants
+        assert len(calls) == 1, calls
+        assert calls[0]["path"] == os.fspath(f)
+        # Bare SIDs: the `*` prefix is icacls argv syntax and the API rejects it.
+        assert calls[0]["sids"] == ("S-1-3-4", "S-1-5-21-1-2-3-1000"), calls[0]
+        assert not any(s.startswith("*") for s in calls[0]["sids"]), calls[0]
 
-    def test_icacls_nonzero_rc_raises_oserror_on_linux_shim_path(self, tmp_path, monkeypatch):
-        # With a resolvable SID, an icacls non-zero rc still raises OSError so
-        # the caller's warn-and-continue handler fires. Complements the
+    def test_write_failure_raises_oserror(self, tmp_path, monkeypatch):
+        # With a resolvable SID, a failure to apply the DACL still raises OSError
+        # so the caller's warn-and-continue handler fires. Complements the
         # None-SID early-raise test below.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-9-9-9-9")
-        monkeypatch.setattr(
-            pc.subprocess,
-            "run",
-            lambda *a, **k: types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"denied"),
-        )
+        self._capture(monkeypatch, sid="S-1-5-21-9-9-9-9")
+
+        def boom(path, *, inherit, sids, **_kw):
+            raise pc.windows_acl.AclWriteFailed("SetNamedSecurityInfoW failed (error 5)")
+
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", boom)
+        f = tmp_path / "secret.key"
+        f.write_bytes(b"s" * 32)
+        with pytest.raises(OSError):
+            pc.restrict_to_owner(f)
+
+    def test_unreadable_platform_api_raises_oserror(self, tmp_path, monkeypatch):
+        # AclUnavailable (the descriptor API could not be loaded at all) must
+        # reach the caller as OSError too, not escape as a bare RuntimeError that
+        # no caller's handler catches.
+        self._capture(monkeypatch, sid="S-1-5-21-9-9-9-9")
+
+        def boom(path, *, inherit, sids, **_kw):
+            raise pc.windows_acl.AclUnavailable("cannot load the Windows security API")
+
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", boom)
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         with pytest.raises(OSError):
             pc.restrict_to_owner(f)
 
     def test_none_sid_raises_before_icacls_to_avoid_lockout(self, tmp_path, monkeypatch):
-        # When _current_user_sid() returns None (whoami absent / fails /
-        # unparseable), restrict_to_owner MUST refuse to apply a lockdown —
+        # When current_user_sid() returns None (the process token read is
+        # unavailable), restrict_to_owner MUST refuse to apply a lockdown —
         # granting only S-1-3-4 (Owner Rights) with inheritance stripped
         # locks non-owner users out of their own file (elevated first-run,
         # backup restore, SYSTEM-context service scenarios). Fail-loud with
-        # OSError BEFORE invoking icacls; the caller's warn handler fires
+        # OSError BEFORE touching the DACL; the caller's warn handler fires
         # and the pre-existing DACL is preserved unchanged.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: None)
-        called = []
-
-        def fake_run(argv, **_kw):
-            called.append(list(argv))
-            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
-
-        monkeypatch.setattr(pc.subprocess, "run", fake_run)
+        calls = self._capture(monkeypatch, sid=None)
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         with pytest.raises(OSError) as ei:
             pc.restrict_to_owner(f)
-        assert "current user SID" in str(ei.value) or "whoami" in str(ei.value)
-        # icacls must NOT have been spawned — the whole point is to avoid
+        assert "current user SID" in str(ei.value)
+        # The DACL must NOT have been touched — the whole point is to avoid
         # applying a half-configured lockdown.
-        assert called == [], f"icacls should not run when SID is unknown: {called}"
+        assert calls == [], f"no DACL write may happen when the SID is unknown: {calls}"
 
     def test_directory_grants_are_inheritable(self, tmp_path, monkeypatch):
         # The bug this pins: make_owner_only_dir used to delegate to the
-        # FILE-shaped restrict_to_owner, whose grants carry no (OI)(CI). Those
+        # FILE-shaped restrict_to_owner, whose grants are not inheritable. Those
         # ACEs apply to the directory alone, so a file created inside an
         # "owner-only" directory got no explicit ACE and fell back to the
-        # creating token's default DACL. No mode assertion can catch this —
-        # NTFS reports 0o666 for any file regardless of its DACL — so the
-        # argv IS the observable, exactly as the file-shape test above.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
-        captured: dict = {}
-
-        def fake_run(argv, **_kw):
-            captured["argv"] = list(argv)
-            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
-
-        monkeypatch.setattr(pc.subprocess, "run", fake_run)
+        # creating token's default DACL.
+        calls = self._capture(monkeypatch)
         d = tmp_path / "secrets-dir"
         d.mkdir()
         pc.restrict_dir_to_owner(d)
-        argv = captured["argv"]
-        assert os.fspath(d) in argv
-        assert "/inheritance:r" in argv
-        grants = [argv[i + 1] for i, a in enumerate(argv[:-1]) if a == "/grant:r"]
+        assert len(calls) == 1, calls
+        assert calls[0]["path"] == os.fspath(d)
         # Both grants must propagate to children, or the directory guarantee
         # covers nothing created inside it.
-        assert "*S-1-3-4:(OI)(CI)F" in grants, grants
-        assert "*S-1-5-21-1-2-3-1000:(OI)(CI)F" in grants, grants
+        assert calls[0]["inherit"] is True, calls[0]
+        assert calls[0]["sids"] == ("S-1-3-4", "S-1-5-21-1-2-3-1000"), calls[0]
 
     def test_file_grants_stay_non_inheritable(self, tmp_path, monkeypatch):
-        # The other half of the split, asserted negatively: (OI)(CI) is
-        # meaningless on a file, so restrict_to_owner must NOT acquire it when
-        # the directory shape does. Without this, "just add (OI)(CI) to
-        # restrict_to_owner" reads as a passing simplification.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
-        captured: dict = {}
-
-        def fake_run(argv, **_kw):
-            captured["argv"] = list(argv)
-            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
-
-        monkeypatch.setattr(pc.subprocess, "run", fake_run)
+        # The other half of the split, asserted negatively: inheritance flags are
+        # meaningless on a file, so restrict_to_owner must NOT acquire them when
+        # the directory shape does. Without this, "just make both inheritable"
+        # reads as a passing simplification.
+        calls = self._capture(monkeypatch)
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         pc.restrict_to_owner(f)
-        grants = [
-            captured["argv"][i + 1] for i, a in enumerate(captured["argv"][:-1]) if a == "/grant:r"
-        ]
-        assert grants, captured["argv"]
-        for g in grants:
-            assert "(OI)" not in g and "(CI)" not in g, g
+        assert len(calls) == 1, calls
+        assert calls[0]["inherit"] is False, calls[0]
+
+    def test_owner_rights_is_not_granted_twice(self, tmp_path, monkeypatch):
+        # Degenerate case: when the invoking user's SID IS Owner Rights, the two
+        # grants collapse to one rather than producing a duplicate ACE.
+        calls = self._capture(monkeypatch, sid="S-1-3-4")
+        f = tmp_path / "secret.key"
+        f.write_bytes(b"s" * 32)
+        pc.restrict_to_owner(f)
+        assert calls[0]["sids"] == ("S-1-3-4",), calls[0]
 
     def test_file_helper_warns_when_handed_a_directory(self, tmp_path, monkeypatch, caplog):
-        # The misuse guard. The argv tests cannot see this from the call site, so
-        # a directory reaching the file-shaped helper has to be caught here --
-        # it tightens the directory but leaves files created inside on the
+        # The misuse guard. The DACL-argument tests cannot see this from the call
+        # site, so a directory reaching the file-shaped helper has to be caught
+        # here -- it tightens the directory but leaves files created inside on the
         # creating token's default DACL. Warn, not raise: the ACE still applies
         # to the named object, so the lockdown is partial rather than absent.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
-        monkeypatch.setattr(
-            pc.subprocess,
-            "run",
-            lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
-        )
+        #
+        # _capture stubs the DACL writer: this test is about the warning, and the
+        # real writer refuses off Windows (_load raises AclUnavailable), which
+        # would fail this on the POSIX CI runners while passing on Windows.
+        self._capture(monkeypatch)
         d = tmp_path / "a-directory"
         d.mkdir()
         with caplog.at_level(logging.WARNING, logger=pc.logger.name):
@@ -2190,15 +2176,7 @@ class TestRestrictToOwnerArgvOnLinux:
     def test_file_helper_stays_quiet_for_a_file(self, tmp_path, monkeypatch, caplog):
         # The guard must not fire on the helper's actual purpose, or every
         # secret-file lockdown would emit a spurious warning.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
-        monkeypatch.setattr(
-            pc.subprocess,
-            "run",
-            lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
-        )
+        self._capture(monkeypatch)
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         with caplog.at_level(logging.WARNING, logger=pc.logger.name):
@@ -2214,35 +2192,6 @@ class TestRestrictToOwnerArgvOnLinux:
         monkeypatch.setattr(pc.os, "chmod", lambda p, m: modes.append(m))
         pc.restrict_dir_to_owner(tmp_path)
         assert modes == [0o700], modes
-
-    def test_sid_failure_is_not_cached_success_is(self, monkeypatch):
-        # A transient whoami failure (timeout under AV scan, non-zero rc) must
-        # NOT be memoized: with lru_cache the first failure poisoned every
-        # later restrict_to_owner for the process lifetime. The success-only
-        # memo retries after a failure and caches only a resolved SID.
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        # Force the whoami fallback, which is what this test covers. On a real
-        # Windows host the non-spawn primary (the process token) succeeds, so
-        # without this the flaky_run below is never reached and the first
-        # assertion sees a genuine SID instead of the simulated failure.
-        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
-        attempts = []
-
-        def flaky_run(argv, **_kw):
-            attempts.append(argv)
-            if len(attempts) == 1:
-                return types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
-            return types.SimpleNamespace(
-                returncode=0, stdout=b'"ANT\\user","S-1-5-21-1-2-3-500"', stderr=b""
-            )
-
-        monkeypatch.setattr(pc.subprocess, "run", flaky_run)
-        assert pc._current_user_sid() is None  # first call fails...
-        assert pc._current_user_sid() == "*S-1-5-21-1-2-3-500"  # ...retry succeeds
-        assert pc._current_user_sid() == "*S-1-5-21-1-2-3-500"  # ...and is cached
-        assert len(attempts) == 2, "success must be memoized (no third spawn)"
 
 
 class TestChmodShimsApply:
@@ -2413,8 +2362,10 @@ class TestRestrictToOwner:
             pc.restrict_to_owner(f)
 
     def test_applies_owner_only_dacl_on_windows(self, tmp_path):
-        # Windows path: shell out to icacls, then re-read the DACL via icacls to
-        # confirm the owner-only shape end-to-end. Windows is the ONLY platform
+        # Windows path: apply the DACL in-process, then re-read it via icacls to
+        # confirm the owner-only shape end-to-end. Reading through the external
+        # tool is deliberate here -- it is an independent check, not the same
+        # ctypes code that wrote the descriptor. Windows is the ONLY platform
         # that can execute this branch, so the node id must never be added to
         # windows-expected-failures.txt: listed there alongside this self-skip it
         # would run on no platform at all, and the DACL would be the one control
@@ -2430,26 +2381,22 @@ class TestRestrictToOwner:
         ).decode("utf-8", "replace")
         assert _owner_only_dacl_violations(out) == [], out
 
-    def test_propagates_oserror_on_windows_when_icacls_missing(self, tmp_path, monkeypatch):
-        # The fail-loud contract on Windows: icacls returning nonzero or
-        # failing to launch MUST raise OSError so the caller's warn-and-continue
-        # handler fires (dead-code otherwise, per review-bot). Simulate by pointing
-        # the resolver at a nonexistent binary; the SubprocessError branch of
-        # subprocess.run is what raises FileNotFoundError -> OSError below.
+    def test_propagates_oserror_on_windows_when_the_dacl_write_fails(self, tmp_path, monkeypatch):
+        # The fail-loud contract on Windows: a DACL that cannot be applied MUST
+        # raise OSError so the caller's warn-and-continue handler fires
+        # (dead-code otherwise, per review-bot). Simulate at the writer seam --
+        # there is no longer a subprocess to make un-launchable, and the failure
+        # this models (SetNamedSecurityInfoW returning ERROR_ACCESS_DENIED on a
+        # file whose owner we cannot change) is not reproducible on demand.
         if not pc.IS_WINDOWS:
-            pytest.skip("Windows icacls branch")
+            pytest.skip("Windows DACL branch")
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
 
-        real_run = subprocess.run
+        def boom(path, *, inherit, sids, **_kw):
+            raise pc.windows_acl.AclWriteFailed("SetNamedSecurityInfoW failed (error 5)")
 
-        def failing_run(argv, **kwargs):
-            if argv and "icacls" in str(argv[0]).lower():
-                raise FileNotFoundError(2, "icacls.exe not found")
-            return real_run(argv, **kwargs)
-
-        monkeypatch.setattr(pc.subprocess, "run", failing_run)
-        monkeypatch.setattr(pc.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", boom)
         with pytest.raises(OSError):
             pc.restrict_to_owner(f)
 
@@ -3245,8 +3192,8 @@ class TestMakeOwnerOnlyDir:
         calls: list[str] = []
         wrong: list[str] = []
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(pc, "restrict_dir_to_owner", lambda p: calls.append(str(p)))
-        monkeypatch.setattr(pc, "restrict_to_owner", lambda p: wrong.append(str(p)))
+        monkeypatch.setattr(pc, "restrict_dir_to_owner", lambda p, **_kw: calls.append(str(p)))
+        monkeypatch.setattr(pc, "restrict_to_owner", lambda p, **_kw: wrong.append(str(p)))
         target = tmp_path / "win"
         pc.make_owner_only_dir(target)
         assert target.is_dir()
@@ -3267,7 +3214,7 @@ class TestMakeOwnerOnlyDir:
         monkeypatch.setattr(
             pc,
             "restrict_dir_to_owner",
-            lambda p: (_ for _ in ()).throw(OSError("nope")),
+            lambda p, **_kw: (_ for _ in ()).throw(OSError("nope")),
         )
         target = tmp_path / "partial"
         pc.make_owner_only_dir(target)
@@ -3279,10 +3226,10 @@ class TestCurrentUserSidNeverSpawns:
     admission check, the client-side server check, and the pipe DACL builder --
     which runs once per pipe instance and so sits on the accept path.
 
-    It used to delegate to ``_current_user_sid``, whose fallback is a ``whoami``
-    subprocess with a 5 s timeout. A token-lookup failure therefore stalled
-    accepts for seconds at a time, repeatedly. ``restrict_to_owner`` keeps that
-    fallback because it always runs through ``asyncio.to_thread``.
+    It used to delegate to a helper whose fallback was a ``whoami`` subprocess
+    with a 5 s timeout, so a token-lookup failure stalled accepts for seconds at
+    a time, repeatedly. That helper is gone: the owner-only lockdown was its last
+    caller and now reads the token directly too, so no path here can spawn.
     """
 
     @staticmethod

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -53,8 +53,8 @@ _POSIX_ONLY = pytest.mark.skipif(
 #
 # This file's method is to simulate BOTH platform branches from one host: it
 # flips ``IS_POSIX`` / ``IS_WINDOWS`` and monkeypatches ``os.getuid``,
-# ``os.getpgid``, ``os.killpg``, ``os.fchmod``, ``/proc/locks`` reads and the
-# Windows ``icacls`` subprocess. On real Windows those attributes do not exist
+# ``os.getpgid``, ``os.killpg``, ``os.fchmod`` and ``/proc/locks`` reads.
+# On real Windows those attributes do not exist
 # (so ``monkeypatch.setattr`` raises before any assertion) and the faked
 # branches diverge from what the OS actually does -- which produced 13 failures
 # across two CI rounds in TestFlockOwnerPid, TestRestrictToOwner,
@@ -1579,120 +1579,6 @@ class TestProcessTokenSid:
         assert pc.process_owner_sid(7) is None
 
 
-class TestCurrentUserSid:
-    @staticmethod
-    def _fresh_caches(monkeypatch: pytest.MonkeyPatch) -> None:
-        # Both memos are module-scoped; give each test its own so no test
-        # depends on another having run (or not run) first.
-        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_TOKEN_SID_CACHE", [])
-
-    def test_none_on_posix(self, monkeypatch):
-        self._fresh_caches(monkeypatch)
-        monkeypatch.setattr(pc, "IS_POSIX", True)
-        assert pc._current_user_sid() is None
-
-    def test_prefers_the_access_token_and_memoises_it(self, monkeypatch):
-        self._fresh_caches(monkeypatch)
-        calls: list[int] = []
-
-        def _token() -> str:
-            calls.append(1)
-            return "S-1-5-21-9"
-
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_process_token_sid", _token)
-
-        assert pc._current_user_sid() == "*S-1-5-21-9"
-        assert pc._current_user_sid() == "*S-1-5-21-9"
-        assert len(calls) == 1
-
-    def test_falls_back_to_whoami_when_the_token_is_unavailable(self, monkeypatch):
-        self._fresh_caches(monkeypatch)
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\whoami.exe")
-        result = types.SimpleNamespace(
-            returncode=0, stdout=b'"CORP\\zezhen","S-1-5-21-7-7-7-500"\n'
-        )
-        monkeypatch.setattr(pc.subprocess, "run", lambda *_a, **_k: result)
-        assert pc._current_user_sid() == "*S-1-5-21-7-7-7-500"
-
-    def test_a_failing_whoami_is_not_cached(self, monkeypatch):
-        # A transient failure must stay retryable — memoising None would poison
-        # every later restrict_to_owner for the process lifetime.
-        self._fresh_caches(monkeypatch)
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\whoami.exe")
-        monkeypatch.setattr(
-            pc.subprocess,
-            "run",
-            lambda *_a, **_k: types.SimpleNamespace(returncode=1, stdout=b""),
-        )
-        assert pc._current_user_sid() is None
-        assert pc._USER_SID_CACHE == []
-
-    def test_a_whoami_spawn_error_is_none(self, monkeypatch):
-        self._fresh_caches(monkeypatch)
-
-        def _boom(*_a: Any, **_k: Any) -> Any:
-            raise OSError("not found")
-
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: None)
-        monkeypatch.setattr(pc.subprocess, "run", _boom)
-        assert pc._current_user_sid() is None
-
-    @pytest.mark.parametrize("stdout", [b'"only-one-field"\n', b'"CORP\\u","NOT-A-SID"\n'])
-    def test_unparseable_whoami_output_is_none(self, monkeypatch, stdout):
-        self._fresh_caches(monkeypatch)
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\whoami.exe")
-        monkeypatch.setattr(
-            pc.subprocess,
-            "run",
-            lambda *_a, **_k: types.SimpleNamespace(returncode=0, stdout=stdout),
-        )
-        assert pc._current_user_sid() is None
-
-    def test_bare_sid_strips_the_icacls_prefix_and_memoises(self, monkeypatch):
-        self._fresh_caches(monkeypatch)
-        calls: list[int] = []
-
-        def _token() -> str:
-            calls.append(1)
-            return "*S-1-5-21-4"
-
-        monkeypatch.setattr(pc, "_process_token_sid", _token)
-        assert pc.current_user_sid() == "S-1-5-21-4"
-        assert pc.current_user_sid() == "S-1-5-21-4"
-        assert len(calls) == 1
-
-    def test_bare_sid_is_none_when_the_token_read_fails(self, monkeypatch):
-        self._fresh_caches(monkeypatch)
-        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
-        assert pc.current_user_sid() is None
-
-    def test_local_user_id_is_the_uid_on_posix(self, monkeypatch):
-        monkeypatch.setattr(pc, "IS_POSIX", True)
-        assert pc.local_user_id() == os.getuid()
-
-    def test_local_user_id_is_a_stable_crc_of_the_sid_on_windows(self, monkeypatch):
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "current_user_sid", lambda: "S-1-5-21-4")
-        first = pc.local_user_id()
-        assert isinstance(first, int) and first != 0
-        assert pc.local_user_id() == first
-
-    def test_local_user_id_collapses_to_zero_without_a_sid(self, monkeypatch):
-        monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "current_user_sid", lambda: None)
-        assert pc.local_user_id() == 0
-
-
 class TestRestrictToOwner:
     def test_posix_applies_owner_only_mode(self, tmp_path):
         secret = tmp_path / "token.key"
@@ -1705,75 +1591,68 @@ class TestRestrictToOwner:
         # An Owner-Rights-only DACL would lock the caller out of a file created
         # by a different principal, so an unresolvable SID must fail loud.
         monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: None)
+        monkeypatch.setattr(pc, "current_user_sid", lambda: None)
 
         def _never(*_a: Any, **_k: Any) -> Any:
-            pytest.fail("icacls must not run without a resolved SID")
+            pytest.fail("no DACL may be written without a resolved SID")
 
-        monkeypatch.setattr(pc.subprocess, "run", _never)
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", _never)
         with pytest.raises(OSError, match="cannot resolve current user SID"):
             pc.restrict_to_owner(tmp_path / "token.key")
 
     def test_windows_grants_both_owner_rights_and_the_caller(self, monkeypatch, tmp_path):
         seen: dict[str, Any] = {}
 
-        def _run(argv: Any, **kwargs: Any) -> Any:
-            seen["argv"] = argv
-            seen["kwargs"] = kwargs
-            return types.SimpleNamespace(returncode=0, stderr=b"", stdout=b"")
+        def _apply(path: Any, *, inherit: bool, sids: Any, **_kw: Any) -> None:
+            seen["path"] = path
+            seen["inherit"] = inherit
+            seen["sids"] = tuple(sids)
 
         monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-3")
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
-        monkeypatch.setattr(pc.subprocess, "run", _run)
+        monkeypatch.setattr(pc, "current_user_sid", lambda: "S-1-5-21-3")
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", _apply)
 
         pc.restrict_to_owner(tmp_path / "token.key")
 
-        argv = seen["argv"]
-        assert "/inheritance:r" in argv
-        assert f"{pc._OWNER_RIGHTS_SID}:F" in argv
-        assert "*S-1-5-21-3:F" in argv
-        assert seen["kwargs"]["creationflags"] == pc._SUBPROCESS_NO_WINDOW
+        # Bare SIDs, both grants present, file shape (no inheritance).
+        assert seen["sids"] == ("S-1-3-4", "S-1-5-21-3"), seen
+        assert seen["inherit"] is False, seen
 
     def test_windows_does_not_duplicate_the_owner_rights_grant(self, monkeypatch, tmp_path):
         seen: dict[str, Any] = {}
 
-        def _run(argv: Any, **_kwargs: Any) -> Any:
-            seen["argv"] = argv
-            return types.SimpleNamespace(returncode=0, stderr=b"", stdout=b"")
+        def _apply(path: Any, *, inherit: bool, sids: Any, **_kw: Any) -> None:
+            seen["sids"] = tuple(sids)
 
         monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: pc._OWNER_RIGHTS_SID)
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
-        monkeypatch.setattr(pc.subprocess, "run", _run)
+        monkeypatch.setattr(
+            pc, "current_user_sid", lambda: pc._OWNER_RIGHTS_SID.removeprefix("*")
+        )
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", _apply)
         pc.restrict_to_owner(tmp_path / "token.key")
-        assert seen["argv"].count(f"{pc._OWNER_RIGHTS_SID}:F") == 1
+        assert seen["sids"].count("S-1-3-4") == 1, seen
 
     @_POSIX_ONLY
-    def test_windows_raises_on_a_non_zero_icacls(self, monkeypatch, tmp_path):
+    def test_windows_raises_when_the_dacl_write_fails(self, monkeypatch, tmp_path):
         monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-3")
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
-        monkeypatch.setattr(
-            pc.subprocess,
-            "run",
-            lambda *_a, **_k: types.SimpleNamespace(
-                returncode=5, stderr=b"Access is denied.", stdout=b""
-            ),
-        )
-        with pytest.raises(OSError, match="Access is denied"):
+        monkeypatch.setattr(pc, "current_user_sid", lambda: "S-1-5-21-3")
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise pc.windows_acl.AclWriteFailed("SetNamedSecurityInfoW failed (error 5)")
+
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", _boom)
+        with pytest.raises(OSError, match="owner-only DACL could not be applied"):
             pc.restrict_to_owner(tmp_path / "token.key")
 
     @_POSIX_ONLY
-    def test_windows_raises_when_icacls_cannot_be_spawned(self, monkeypatch, tmp_path):
+    def test_windows_raises_when_the_security_api_is_unavailable(self, monkeypatch, tmp_path):
         def _boom(*_a: Any, **_k: Any) -> Any:
-            raise subprocess.SubprocessError("timeout")
+            raise pc.windows_acl.AclUnavailable("cannot load the Windows security API")
 
         monkeypatch.setattr(pc, "IS_POSIX", False)
-        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-3")
-        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
-        monkeypatch.setattr(pc.subprocess, "run", _boom)
-        with pytest.raises(OSError, match="icacls invocation failed"):
+        monkeypatch.setattr(pc, "current_user_sid", lambda: "S-1-5-21-3")
+        monkeypatch.setattr(pc.windows_acl, "apply_owner_only", _boom)
+        with pytest.raises(OSError, match="owner-only DACL could not be applied"):
             pc.restrict_to_owner(tmp_path / "token.key")
 
     def test_make_owner_only_dir_warns_instead_of_raising(self, monkeypatch, caplog, tmp_path):
@@ -1800,8 +1679,8 @@ class TestRestrictToOwner:
         # Must be the DIRECTORY helper: restrict_to_owner's grants are
         # file-shaped (no (OI)(CI)), so files created inside would not inherit
         # the lockdown.
-        monkeypatch.setattr(pc, "restrict_dir_to_owner", called.append)
-        monkeypatch.setattr(pc, "restrict_to_owner", wrong.append)
+        monkeypatch.setattr(pc, "restrict_dir_to_owner", lambda p: called.append(p))
+        monkeypatch.setattr(pc, "restrict_to_owner", lambda p: wrong.append(p))
         target = tmp_path / "secrets"
         pc.make_owner_only_dir(target)
         assert called and str(called[0]) == str(target)

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1020,7 +1020,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # only caller-supplied element is the path being revealed — which is
         # passed as a later argv element, never as the command.
         "platform_compat.py::open_with_default_app",
-        "platform_compat.py::_current_user_sid",
         "platform_compat.py::_posix_process_parent_map",
         "platform_compat.py::find_port_listeners",
         "platform_compat.py::find_python_interpreter",
@@ -1042,11 +1041,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # forwarder pid, and cannot route through the sandbox helper because
         # sandbox imports platform_compat.
         "platform_compat.py::process_argv_matches_exact",
-        # The single icacls chokepoint shared by restrict_to_owner (file shape)
-        # and restrict_dir_to_owner (directory shape, inheritable grants). Both
-        # public helpers delegate here, so this one entry covers the owner-only
-        # DACL spawn for every caller; neither public name spawns directly.
-        "platform_compat.py::_icacls_owner_only",
         # OS keep-awake helper for the prevent-sleep feature (power.py). FIXED
         # argv — `caffeinate -i -w <pid>` on macOS, `systemd-inhibit
         # --what=idle:sleep --mode=block … /bin/sh -c 'while kill -0 <pid> …'`

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -1103,7 +1103,7 @@ def test_signing_secret_persisted_across_loads(tmp_path, monkeypatch) -> None:
     assert key_file.exists()
     assert len(s1) >= 32
     # Owner-only permissions. POSIX enforces this via chmod 0o600; Windows applies
-    # an owner DACL (icacls) that does not surface in st_mode (files report
+    # an owner DACL that does not surface in st_mode (files report
     # 0o666), so the POSIX-bit assertion is only meaningful off Windows (the
     # Windows DACL path is covered by test_platform_compat::TestRestrictToOwner).
     if os.name != "nt":
@@ -1166,7 +1166,7 @@ def test_signing_secret_concurrent_first_init_converges(tmp_path, monkeypatch) -
     assert all(r == on_disk for r in results), "concurrent inits diverged from the on-disk key"
     assert len(set(results)) == 1, "more than one distinct signing key was issued"
     # Winner's create still locked the file down to owner-only. POSIX enforces
-    # this via chmod 0o600; Windows applies an owner-only DACL (icacls) that does
+    # this via chmod 0o600; Windows applies an owner-only DACL that does
     # NOT surface in st_mode (files report 0o666), so the POSIX-bit assertion is
     # only meaningful off Windows — the Windows DACL path has direct coverage in
     # test_platform_compat::TestRestrictToOwner.
@@ -2082,7 +2082,7 @@ def test_revoked_store_locks_the_file_down_to_its_owner(tmp_path, monkeypatch) -
     locked: list[tuple[str, int]] = []
     real_restrict = platform_compat.restrict_to_owner
 
-    def _spy(path) -> None:
+    def _spy(path, **_kw) -> None:
         # Record the size at lockdown time: the nonce list must not be sitting
         # in the file yet (see the ordering assertion below).
         locked.append((str(path), os.path.getsize(str(path))))
@@ -2101,9 +2101,9 @@ def test_revoked_store_locks_the_file_down_to_its_owner(tmp_path, monkeypatch) -
     )
     locked_path, size_at_lockdown = locked[0]
     assert size_at_lockdown == 0, (
-        "the denylist was written before the lockdown applied; on Windows "
-        "restrict_to_owner shells out to icacls, so the nonces would sit under "
-        "the parent-inherited DACL for the length of that call"
+        "the denylist was written before the lockdown applied; on Windows the "
+        "lockdown replaces the DACL rather than setting it at create time, so "
+        "the nonces would sit under the parent-inherited DACL until it landed"
     )
     assert locked_path.startswith(
         str(state_path)
@@ -2702,8 +2702,8 @@ def test_warm_auth_singletons_primes_both_off_loop(monkeypatch) -> None:
     the middleware serves requests.
 
     Both lazily do blocking file I/O on first use (read/create
-    token_signing.key + read the nonce denylist; on Windows an icacls
-    subprocess to lock the DACL). They are NO LONGER warmed synchronously in
+    token_signing.key + read the nonce denylist; on Windows also the owner-only
+    DACL). They are NO LONGER warmed synchronously in
     the token_auth_middleware() factory, because that factory runs on the loop
     via the async start_dashboard()/start_api_server(). The async startup paths
     await this helper instead, so the first auth op hits warm singletons with

--- a/test/test_windows_acl.py
+++ b/test/test_windows_acl.py
@@ -956,3 +956,145 @@ class TestLoadRefusesOffWindows:
     def test_describe_refuses_rather_than_returning_a_permissive_answer(self) -> None:
         with pytest.raises(windows_acl.AclUnavailable):
             windows_acl.describe(Path("/etc/hosts"))
+
+
+class TestApplyOwnerOnlyOffWindows:
+    """The WRITE side, driven off Windows through the same injected-handle seam.
+
+    `_load()` is the module's only platform gate, so substituting plain Python
+    objects for the two DLL handles runs the real ACL construction anywhere.
+
+    The volume gate is injected rather than derived, mirroring the split the
+    reader already uses: `TestVolumeClassification` owns `_volume_is_local`'s
+    platform-bound parsing (Windows-only, because `posixpath.splitdrive` never
+    returns a drive so it short-circuits to False off Windows), and the POLICY
+    consequence is asserted platform-independently by feeding the decision in.
+    Deriving it here instead is what made the first version of this class pass on
+    Windows and fail on every POSIX shard: `"C:\\\\x"` has no drive component off
+    Windows, so the local-volume cases refused before constructing anything.
+
+    Note this mechanism applies the DACL on ANY volume. The event-loop caller's
+    volume gate is NOT here -- it is :func:`windows_acl.volume_is_local`, asked at
+    the call site before the write begins, because a refusal raised from inside
+    this function would arrive after the caller had already paid the filesystem
+    cost the gate exists to avoid.
+    """
+
+    @staticmethod
+    def _writer():
+        """A fake exposing just the write-side surface, plus a call recorder."""
+
+        class _FakeWriter:
+            def __init__(self) -> None:
+                self.set_calls: list[dict] = []
+                self.freed: list[object] = []
+                self._next = 0x1000
+
+            # -- kernel32 --
+            def LocalFree(self, handle):
+                self.freed.append(handle)
+                return None
+
+            # -- advapi32 --
+            def ConvertStringSidToSidW(self, sid, out_ref):
+                self._next += 0x10
+                out_ref._obj.value = self._next
+                return 1
+
+            def GetLengthSid(self, _psid):
+                return 12
+
+            def InitializeAcl(self, _pacl, _size, _rev):
+                return 1
+
+            def AddAccessAllowedAceEx(self, _pacl, _rev, flags, mask, psid):
+                self.set_calls.append({"kind": "ace", "flags": flags, "mask": mask})
+                return 1
+
+            def SetNamedSecurityInfoW(self, path, obj, info, _o, _g, _dacl, _s):
+                self.set_calls.append({"kind": "set", "path": path, "info": info})
+                return 0
+
+        return _FakeWriter()
+
+    def _install(self, monkeypatch, *, local: bool):
+        """Install the fake handles and an injected volume verdict; record calls."""
+        fake = self._writer()
+        seen: list[str] = []
+        monkeypatch.setattr(windows_acl, "_load", lambda: (fake, fake))
+        monkeypatch.setattr(
+            windows_acl,
+            "_volume_is_local",
+            lambda _k32, path: (seen.append(str(path)), local)[1],
+        )
+        return fake, seen
+
+    def test_the_volume_is_never_consulted_by_this_mechanism(self, monkeypatch) -> None:
+        """The writer applies the DACL on ANY volume; the gate is not its job.
+
+        local=False would have refused while the gate lived here. It no longer
+        does: an on-loop caller has to ask before it starts (see
+        :func:`windows_acl.volume_is_local`), because a refusal at this depth
+        arrives after the caller already paid the cost it was avoiding.
+        """
+        fake, seen = self._install(monkeypatch, local=False)
+        windows_acl.apply_owner_only("Z:\\home\\config.json", inherit=False, sids=("S-1-3-4",))
+        assert seen == [], "the writer must not classify the volume itself"
+        assert any(c["kind"] == "set" for c in fake.set_calls), fake.set_calls
+
+    def test_the_public_predicate_reports_a_network_volume(self, monkeypatch) -> None:
+        # The seam an on-loop caller uses BEFORE it writes anything. It must
+        # classify without touching the platform write surface at all.
+        fake, seen = self._install(monkeypatch, local=False)
+        assert windows_acl.volume_is_local("Z:\\home\\config.json") is False
+        assert seen == ["Z:\\home\\config.json"], seen
+        assert fake.set_calls == [], f"classifying must write nothing: {fake.set_calls}"
+
+    def test_the_public_predicate_reports_a_local_volume(self, monkeypatch) -> None:
+        fake, seen = self._install(monkeypatch, local=True)
+        assert windows_acl.volume_is_local("C:\\config.json") is True
+        assert seen == ["C:\\config.json"], seen
+        assert fake.set_calls == [], f"classifying must write nothing: {fake.set_calls}"
+
+    def test_a_local_volume_writes_both_grants_and_frees_every_sid(self, monkeypatch) -> None:
+        fake, _ = self._install(monkeypatch, local=True)
+        windows_acl.apply_owner_only(
+            "C:\\config.json", inherit=False, sids=("S-1-3-4", "S-1-5-21-1")
+        )
+        aces = [c for c in fake.set_calls if c["kind"] == "ace"]
+        sets = [c for c in fake.set_calls if c["kind"] == "set"]
+        assert len(aces) == 2, aces
+        assert len(sets) == 1, sets
+        # File shape: no inheritance flags.
+        assert all(c["flags"] == 0 for c in aces), aces
+        # PROTECTED_DACL is what replaces icacls' /inheritance:r -- without it the
+        # new DACL would merge with the parent's instead of replacing it.
+        assert sets[0]["info"] & 0x80000000, hex(sets[0]["info"])
+        # Every parsed SID is LocalAlloc'd and must be freed.
+        assert len(fake.freed) == 2, fake.freed
+
+    def test_a_directory_grant_carries_both_inheritance_flags(self, monkeypatch) -> None:
+        fake, _ = self._install(monkeypatch, local=True)
+        windows_acl.apply_owner_only("C:\\vault", inherit=True, sids=("S-1-3-4",))
+        aces = [c for c in fake.set_calls if c["kind"] == "ace"]
+        # OBJECT_INHERIT (0x1) propagates to files, CONTAINER_INHERIT (0x2) to
+        # subdirectories; neither sets INHERIT_ONLY, so the directory itself keeps
+        # the grant and stays traversable.
+        assert all(c["flags"] == 0x03 for c in aces), aces
+
+    def test_a_failed_descriptor_write_still_frees_the_sids(self, monkeypatch) -> None:
+        fake, _ = self._install(monkeypatch, local=True)
+        monkeypatch.setattr(fake, "SetNamedSecurityInfoW", lambda *a: 5)  # ACCESS_DENIED
+        with pytest.raises(windows_acl.AclWriteFailed):
+            windows_acl.apply_owner_only("C:\\config.json", inherit=False, sids=("S-1-3-4",))
+        assert len(fake.freed) == 1, fake.freed
+
+    def test_empty_sids_is_refused_before_the_platform_is_touched(self, monkeypatch) -> None:
+        """An ACL with no ACEs denies everyone, the owner included."""
+
+        def _boom():
+            pytest.fail("_load() must not be reached for an empty grant list")
+
+        monkeypatch.setattr(windows_acl, "_load", _boom)
+        with pytest.raises(windows_acl.AclWriteFailed, match="no grants"):
+            windows_acl.apply_owner_only("C:\\config.json", inherit=False, sids=())


### PR DESCRIPTION
## Problem / Motivation

`platform_compat.restrict_to_owner` applied the Windows owner-only DACL by shelling out to
`icacls`. That made the lockdown a blocking subprocess, and the cost was not marginal:
measured on a local NTFS volume it is **313.7 ms per call**.

Two consequences followed from that one fact.

First, every caller on the asyncio event loop had to offload it, and ~20 modules carry
comments naming the subprocess as the reason for their `asyncio.to_thread` wrapper.

Second, and more consequentially, `write_config_atomically` -- the canonical `config.json`
writer with ~12 callers -- **deliberately skipped the lockdown entirely**, and said so in its
own docstring:

> **This deliberately does NOT call `platform_compat.restrict_to_owner`.** That helper shells
> out to `icacls` on Windows (`subprocess.run`, 10s timeout), and this function is called from
> `async` request handlers ... A caller that needs a hard owner-only guarantee on Windows must
> offload `restrict_to_owner` itself, off the loop.

So on Windows `config.json` -- which can carry inline provider tokens and API keys -- landed
under whatever DACL it inherited from its parent, readable by every other local account.

## Why it matters

On Windows `os.chmod` only toggles the read-only attribute: it leaves the inherited DACL
intact and it **succeeds**, so a permissions guarantee that reads as enforced in the source is
not enforced in fact and nothing is raised to notice. That is worse than an absent guard,
because the source says the file is protected.

The affected files are the ones that matter most: `config.json` (inline provider tokens) and
the metrics directory.

## What changed (motivation -> approach -> change)

**Root cause:** the lockdown's cost, not its logic. Everything downstream -- the mandatory
offloading, the skipped lockdown -- was a workaround for a subprocess spawn.

**Approach:** remove the spawn rather than route around it. `windows_acl.py` already reads
security descriptors through pure `ctypes`; this completes it with a write side --
`ConvertStringSidToSidW` -> `InitializeAcl` -> `AddAccessAllowedAceEx` ->
`SetNamedSecurityInfoW`, with `PROTECTED_DACL_SECURITY_INFORMATION` standing in for
`/inheritance:r`. Same resulting descriptor, three `advapi32` calls instead of a process.

**Measured: 0.236 ms/call against 313.7 ms -- 1330x** (n=40, local NTFS, both paths warmed).

Two details are load-bearing. The write side reuses the module's existing `_load()` seam, so it
stays testable off Windows the way the read side already is. And it sizes the ACL from
`_ACCESS_ACE.SidStart.offset` rather than arithmetic on `DWORD`, which is 4 bytes on Windows
and 8 under the module's Linux stand-ins.

With the cost gone, the constraint it imposed goes with it:

- **`write_config_atomically` now applies the DACL** on its Windows branch. Mode preservation
  and the DACL do not actually collide, because they apply on different platforms -- Windows has
  no mode bits to preserve -- hence a platform branch rather than passing both to
  `atomic_write`, which refuses `restrict_to_owner=True` alongside a wider explicit `mode`.
  `restrict_on_error="warn"` (as `sel.py` and `refresh_tokens.py` already use) keeps a config
  write from becoming impossible when a DACL cannot be applied; that is strictly better than
  the previous behaviour of applying none.
- **One off-loop site that was silently a no-op now holds.** `metrics/local_exporter.py`'s
  `_chmod` splits into `_restrict_file` / `_restrict_dir` -- it was handing the same helper a
  *directory* at `0o700`, and `restrict_to_owner` is file-shaped (its grants carry no
  inheritance flags, the misuse #4948 guarded against), so encoding the distinction in the name
  makes it unmissable at all four call sites.
- **The stale rationale is corrected in the modules this change already touches** -- 12 of them.
  Every existing `to_thread` offload is **kept** -- a filesystem call can still block on a slow
  volume, so offloading remains good practice, it is simply no longer mandatory. What changed is
  the stated reason, so the next reader does not re-derive a constraint that no longer exists.
  Same for the create-empty-then-lock-then-write ordering in `token_auth.py`,
  `token_secret.py`, `refresh_tokens.py`, `cron_script.py` and `md_notebook/server.py`: the
  ordering stands, because the lockdown *replaces* a DACL rather than setting it at create time,
  so writing first still leaves a window.

  This is **not** a repo-wide sweep, and the earlier wording here overclaimed that -- First
  Principles Review caught it. After this change 12 present-tense "spawns icacls" comments remain
  in 8 files the diff does not otherwise touch (`sel.py`, `handlers/messaging.py`,
  `apps/routes.py`, `workflows/store.py`, `snapshot.py`, `handlers/secrets.py` and two
  code_review_sage files). Zero remain in any file this PR edits -- the one that did,
  `config/loader.py`'s credential reader, is corrected here. The other 8 are a mechanical
  comment-only sweep filed as #6359, kept out of this diff because editing eight otherwise
  unrelated files widens the review surface of an already-converged change for no functional gain.

Two pieces of now-dead code are removed: `_ICACLS_DIR_INHERIT` (grep-verified unreferenced),
and ~32 lines of unreachable duplicated prototypes left inside `_load()` when
`_install_prototypes` was extracted. The `whoami`-fallback SID helper (`_current_user_sid` and
its memo) goes with them: `_icacls_owner_only` was its only consumer, and keeping a blocking
spawn on the SID path would have put back on the event loop exactly what removing `icacls`
took off it. The lockdown now reads the process token via `current_user_sid`, which cannot
spawn, and **raises** when the token read fails rather than applying an Owner-Rights-only
descriptor that would lock the user out of their own file.

### The on-loop volume gate, and why the caller owns it

`write_config_atomically` is the one lockdown caller that runs **inline on the event loop**. On
Windows a DACL write to a UNC path or a mapped network drive is an unbounded SMB round-trip, so
that function classifies the volume itself -- via the new `windows_acl.volume_is_local`, which
answers from the volume ROOT through `GetDriveTypeW` and opens no file -- and skips the lockdown
when the answer is no.

Ordering is the whole point, so it is asserted directly rather than inferred from an outcome. Two
earlier shapes were wrong and are worth naming, because both looked fine:

- Checking inside `windows_acl.apply_owner_only` (a parameter on the mechanism). A refusal raised
  at that depth arrives *after* the caller has already paid the cost the refusal exists to avoid.
- Checking inside `atomic_write` (a `restrict_require_local_volume` knob). Better, but still not
  the earliest point on the real on-loop path: `write_config_atomically` runs its own `stat` and
  `parent.mkdir` before it ever calls `atomic_write`, and each is a round-trip on a network home.
  It also meant three layered one-consumer surfaces -- the knob, a `platform_compat` predicate,
  and a `windows_acl` predicate -- for a single call site. First Principles Review flagged exactly
  that; the knob and the middle predicate are gone.

The gate now sits in the caller, just **after** the symlink resolve rather than at the very top,
and that placement is deliberate: a config symlinked into a dotfiles repo (which this function's
docstring calls a normal setup) can point at a *different volume* than the link, so classifying
before resolving would classify the wrong one. The resolve is two stats; this is the earliest
correct point. The test pins both halves -- the classify comes first, and the resolve is the only
thing allowed to precede it.

On a non-local volume the write proceeds exactly as it did before the lockdown was added here, so
a network-homed data home is no worse off than today and a local one is now protected. That
residual is real and declared: the file keeps its inherited ACL. Making this function's
filesystem work async is the cause-level fix and would delete the gate entirely; it is filed as
#6353 rather than folded in, because it changes a synchronous function with ~12 callers.

## Tests

- `test_platform_compat.py::TestRestrictToOwnerArgvOnLinux` -- rewritten against the new seam.
  The observable was the `icacls` argv; it is now the arguments to
  `windows_acl.apply_owner_only`, which is the same seam one layer down and still the only
  thing visible off Windows (NTFS reports `0o666` for any file regardless of its DACL, so no
  mode assertion can substitute). Locks in: both grants present and **bare** (the `*` prefix is
  icacls syntax the API rejects), `inherit=False` for files and `True` for directories, the
  duplicate-grant collapse when the invoking user *is* Owner Rights, an unresolvable SID
  refusing **before** any DACL write, and both `AclWriteFailed` and `AclUnavailable` surfacing
  as `OSError` so existing callers' handlers still fire.
- `test_config_rmw_preserves_settings.py` -- `test_does_not_spawn_a_subprocess_on_the_event_loop`
  flipped polarity: it used to assert `restrict_to_owner` is *never called*, which was a ban on
  the subprocess, so it now bans only spawning. New
  `test_windows_applies_an_owner_only_dacl` asserts the hardening positively by reading the
  descriptor back -- the Windows half of the guarantee the existing mode tests cover on POSIX.
  Three more cover the volume gate, which lives in this function:
  `test_the_volume_is_classified_before_any_filesystem_work` records call order and asserts the
  classify precedes the `mkdir` (mutation-verified: moving it below the `mkdir` fails with
  `got ['mkdir', 'classify_volume', ...]`); a local volume still gets the lockdown, applied to
  the **temp** file so it precedes the content; and a host whose descriptor API cannot load
  degrades to skipping rather than failing the config save.
- `test_windows_acl.py` -- the gate tests move with the gate: `apply_owner_only` is asserted to
  never classify the volume itself, and the `volume_is_local` predicate is asserted to classify
  both shapes while writing nothing.
- `test_platform_compat_coverage.py` -- its four Windows-branch tests rewritten against the same
  seam.
- `test_spawn_audit.py` -- the `platform_compat.py::_icacls_owner_only` BENIGN_SPAWNS entry is
  removed; the ratchet correctly went red on it once the spawn was gone.

**One test-infrastructure finding worth flagging to reviewers.** `test/conftest.py`'s autouse
`_windows_restrict_to_owner_stub` replaces both lockdown helpers with no-ops on Windows for
every module except an exemption list. `test_platform_compat_coverage` was not on that list, so
its Windows-branch tests were running against a neutered function -- they were only ever real on
Linux, where the fixture is inert, and asserted nothing on Windows. Both it and
`test_config_rmw_preserves_settings` are now exempted, which is what makes their assertions
mean anything on this platform.

## Manual verification

Verified on Windows 11 against the module's own reader (`windows_acl.describe`):

- **File, `inherit=False`:** before -> `NT AUTHORITY\SYSTEM`, `BUILTIN\Administrators`, user
  (all parent-inherited). After -> exactly `OWNER RIGHTS` + user. SYSTEM and Administrators are
  gone, which is the observable proof that `PROTECTED_DACL_SECURITY_INFORMATION` stripped
  inheritance.
- **Directory, `inherit=True`:** a file created inside it *afterwards* carries only those two
  SIDs, confirming the inheritable ACE propagates.
- **No spawn remains:** with `subprocess.run` monkeypatched to raise, `restrict_to_owner`,
  `restrict_dir_to_owner` and `make_owner_only_dir` all still produce the correct descriptor.
- **Empty grant list refused** before any syscall -- an ACL with no ACEs denies everyone
  including the owner.

Gates after rebasing onto current `main`: isort, flake8, the black baseline gate and
`check_lockdown_before_publish.py` all clean on the 34 changed files; 2067 passed / 39 skipped /
0 failed across every touched test file plus the config, snapshot, atomic-write, refresh-token and
cron-script suites. `mypy src/kiro_crew/` reports 4 errors, all in `transcribe.py` and
`ops_mission_control/backend/providers/cloudwatch.py` -- neither file is in this diff, and both
are local `boto3-stubs` version artifacts; CI's own mypy step passes.

## Rebase note

This branch was opened on 2026-08-23 and has been rebased onto `main` from 534 commits behind.
Three files left the diff because `main` reached the same place independently or superseded the
change: `cli_setup.py` (main now routes the wizard's `.env` through
`atomic_write(restrict_to_owner=True, restrict_on_error="warn")` and adds an advisory lock
around the read-modify-write, which subsumes this PR's version of that fix), and `snapshot.py`
and `dashboard/handlers/messaging.py`, whose changes here were comment-only and whose functions
`main` has since rewritten.

## Related Issues

Part of #4987 (the owner-only sweep). Deliberately not auto-closing #4987, since its chmod-sweep
half is not finished.

**Two sibling `os.chmod(0o600)` sites are knowingly left inert on Windows** -- `sel.py:1151` and
`workflows/store.py:148`, both carrying a `lockdown-ok: #5228` marker whose stated reason is the
subprocess cost this PR just removed. They are the same class as the `metrics/local_exporter.py`
fix above, so the question is fair (First Principles Review raised it), and the answer is that
neither is the one-line swap it resembles:

- `sel.py` is the SEL audit log, a keep-listed control, and the call sits on the `critical=True`
  audit-or-deny write plus the fallback taken when the writer thread cannot start.
  `restrict_to_owner` is fail-loud where `os.chmod` currently warns and continues, so adopting it
  changes the failure semantics of an audit-or-deny path -- a security decision, not a rename.
- `workflows/store.py` sits inside a "persistence must never break a run" guard, and its own
  comment notes the payload is already `_redact`ed, so what a wider DACL exposes is the redacted
  run record rather than credentials. Same failure-policy question, lower stakes.

Both are registered in the repo's own `lockdown-ok` ledger (#5228). `apps/routes.py` and
`config/loader.py`'s credential-load repair, also named in #4987, are unblocked by this change and
follow the same way.

Follow-ups, filed rather than folded in:

- **#6353** -- offload the config write's filesystem work so the DACL applies on a network-homed
  data home too, which would delete the volume gate entirely. Changes a synchronous function with
  ~12 callers.
- **#6359** -- the 12 remaining present-tense `icacls` comments in 8 untouched files, plus the two
  lockdown sites above.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** no user-visible surface changes -- this is a platform-layer file
permissions primitive plus comment corrections. No frontend path is touched.
