### PR TITLE
docs: fix stale set_project comments; add two slot-less test pins

### DIFF
--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -14,8 +14,11 @@ unrepresentable.
 ``slot`` is the dashboard chat slot when the caller has one (chat_runner) and
 ``None`` for a channel turn (TurnDriver). A missing slot NEVER weakens a
 boundary: the dashboard-only directives are refused outright for a slot-less
-caller (they act on a slot, so there is nothing to apply them to), and the
-monitor trio only reads ``slot`` through fail-safe ``getattr``.
+caller (they act on a slot, so there is nothing to apply them to);
+``set_project`` — user-surface-gated rather than dashboard-only, though its
+effect targets the slot — is likewise refused when the turn
+holds no slot; and the monitor trio only reads ``slot`` through fail-safe
+``getattr``.
 
 Every branch returns a human-readable confirmation string and NEVER raises into
 the runner. NOTE: gateway-off (the default), the MODEL already received the
@@ -125,16 +128,16 @@ async def apply_session_directive(
     if kind in _DASHBOARD_ONLY_DIRECTIVES and (
         slot is None or not has_dashboard_surface(session_key)
     ):
-        # These three act on a dashboard chat SLOT (its project/CWD, its
-        # follow-up card, its question card), so the boundary is whether an open
-        # tab exists to receive the effect — not where the conversation started.
-        # A channel-born session displayed in a tab qualifies; a cron, sub-agent
-        # or otherwise tabless caller does not, and must not silently retarget a
-        # slot's project or address a card nothing will render. A slot-less
-        # caller (a channel transport's TurnDriver) is refused for the same
-        # reason even when a tab happens to be open: the effect targets the
-        # SLOT, and this turn does not hold one. The consumer is the only layer
-        # that knows the authoritative session, so the check belongs HERE.
+        # These two act on a dashboard chat SLOT (its follow-up card, its
+        # question card), so the boundary is whether an open tab exists to
+        # receive the effect — not where the conversation started. A
+        # channel-born session displayed in a tab qualifies; a cron, sub-agent
+        # or otherwise tabless caller does not, and must not address a card
+        # nothing will render. A slot-less caller (a channel transport's
+        # TurnDriver) is refused for the same reason even when a tab happens to
+        # be open: the effect targets the SLOT, and this turn does not hold
+        # one. The consumer is the only layer that knows the authoritative
+        # session, so the check belongs HERE.
         _audit(session_key, kind, "denied")
         return (
             f"Error: {kind} only works from a dashboard chat session "
@@ -402,7 +405,7 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
     )
 
 
-# ── dashboard-only effects ───────────────────────────────────────────────────
+# ── slot-targeted effects (the dashboard-only pair + set_project) ────────────
 
 
 async def _set_project(state: Any, slot: Any, args: dict[str, Any]) -> str:

--- a/test/test_driver_session_directives.py
+++ b/test/test_driver_session_directives.py
@@ -536,11 +536,19 @@ class TestChannelApplierBoundary:
         assert "targets this turn's chat slot" in result
 
     @pytest.mark.asyncio
-    async def test_slotless_set_project_refusal_audits_denied(self, monkeypatch, no_dashboard_tabs):
+    @pytest.mark.parametrize(
+        "args", [{"project": "/tmp"}, {"clear": True}], ids=["set-path", "clear"]
+    )
+    async def test_slotless_set_project_refusal_audits_denied(
+        self, args, monkeypatch, no_dashboard_tabs
+    ):
         """SEL truthfulness for the slot-less set_project refusal: it is a
         permission DECISION, so it must audit ``denied`` — never ``error``
         (the crash shape a missing slot-None guard would produce) and never
-        ``success``. Nothing may be mutated on the way out."""
+        ``success``. Nothing may be mutated on the way out. Pinned for BOTH
+        arg shapes: ``_set_project``'s clear path writes slot state before any
+        validation, so the guard is all that keeps a slot-less clear from
+        mutating on the way to the crash."""
         calls: list[dict] = []
 
         class _SelSpy:
@@ -553,7 +561,7 @@ class TestChannelApplierBoundary:
             None,
             "slack:1755000000.123456",
             "set_project",
-            {"project": "/tmp"},
+            dict(args),
         )
         assert result.startswith("Error:")
         assert "targets this turn's chat slot" in result

--- a/test/test_mcp_core_set_project.py
+++ b/test/test_mcp_core_set_project.py
@@ -467,6 +467,13 @@ class TestApplierAuditAndFailSoft:
         )
         assert "Project set to" in result
         assert slot.project == str(tmp_path)
+        # The history-reset flag is load-bearing: it is what cold-starts the
+        # retargeted transcript. With ``linked_session_key`` unset it derives
+        # from the ``_history_key_for(slot.key)`` fallback branch of
+        # ``effective_session_key`` — the slot's own key (already
+        # ``dashboard:``-prefixed, so the helper is identity here). A
+        # channel-LINKED slot derives its linked channel key instead.
+        assert slot._pending_reset_history_key == slot.key
         assert [c["outcome"] for c in sel_spy.calls] == ["success"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What is the problem?

`src/kiro_crew/dashboard/session_directive_apply.py` carries three stale docstrings/comments describing `set_project` as dashboard-only and as gated by the dashboard-only refusal branch: the module docstring enumerates only two slot-shape classes (missing the user-surface directive refused when the turn holds no slot), the dashboard-only refusal comment says "these three act on a dashboard chat SLOT (its project/CWD, ...)" when `_DASHBOARD_ONLY_DIRECTIVES` has two members and project retargeting is gated elsewhere, and the applier section header still reads "dashboard-only effects" over `_set_project`. Two behavior-locking test pins for the slot-less `set_project` refusal gate are also missing: the clear-args shape (`{"clear": true}`) is unpinned, and the channel-session retarget test never asserts the history-reset flag.

## Why this issue matters to the user

The "set_project is dashboard-only" misread these comments invite is exactly how the slot-less crash regressions happened before: a contributor "restores" `set_project` into the dashboard-only set or drops the wrapper guard, and channel users lose project retargeting or hit a crash-shaped error. The unpinned clear path is the riskier half -- `_set_project`'s clear branch writes slot state before any validation, so the wrapper guard is the only thing between a slot-less clear and a mutation-then-crash.

## How our fix solves it

Comment/docstring-only source changes plus two test pins -- zero runtime behavior change (verified: every changed source line is comment or docstring body). The module docstring now enumerates all three slot-shape classes as the code implements them; the refusal comment describes the two card directives it actually guards; the section header names the section's real contents ("slot-targeted effects -- the dashboard-only pair + set_project"). The slot-less refusal test is parametrized over both arg shapes (`ids=["set-path", "clear"]`), and `test_set_project_works_on_channel_sessions` now asserts `slot._pending_reset_history_key == slot.key` -- the flag that cold-starts the retargeted transcript, derived via the `_history_key_for(slot.key)` fallback branch of `effective_session_key` when `linked_session_key` is unset.

## What tests we did

- Touched test files: 70/70 passed.
- Mutation checks: neutralizing the slot-less wrapper guard reddens both parametrized refusal cases; dropping the history-reset flag write reddens all three channel-session cases.
- Full backend suite: 61593 passed; the 171 fails + 11 errors are host-environment classes (sandbox confinement, scratch-path sensitivity, AF_UNIX path length, 120s timeouts) with zero failures in the touched files.
- Gates: black baseline gate, isort, flake8, mypy (1038 files), brand name gate all clean.
- Dual pre-push review (GPT 5.6 Sol + Opus 5 lanes): both NO-BLOCKING-FINDINGS; the Opus lane's advisory findings (a fake-only `!=` assertion, an overstated docstring clause, a hardcoded fixture key) are fixed in this commit.

## Any other suggestions on the work

`docs/system-specs/modules/session.md` still names only the `chat_runner` consumer for session directives and predates the `TurnDriver` consumer and the user-surface/slot-less gate classes -- pre-existing, outside this task's comment+pin scope, worth its own small docs PR.

Closes #5222
