### PR TITLE
fix: lock credential temp files to owner before content in messaging and weixin writers

### DIFF
--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 
 from aiohttp import web
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.browser.command_bus import (
     DEFAULT_COMMAND_TIMEOUT_MS,
     DEFAULT_DRAIN_WAIT_MS,
@@ -2396,15 +2397,18 @@ def _clean_id_list(raw: object, is_valid: Callable[[str], bool], label: str) -> 
 def _write_env_updates(updates: dict[str, str | None]) -> None:
     """Update select keys in config_dir/.env, preserving comments and order.
 
-    A value of ``None`` deletes the key; new keys are appended. The write is
-    atomic (0600 temp file in the same dir, then rename) so a crash can never
-    truncate .env and lose other credentials, and there is no world-readable
-    window between create and chmod.
+    A value of ``None`` deletes the key; new keys are appended. The write goes
+    through :func:`kiro_crew.atomic_write.atomic_write` with
+    ``restrict_to_owner=True``, which locks the unique temp file down to its
+    owner BEFORE any content byte is written: POSIX mode bits protect nothing
+    on Windows (``fchmod_safe`` is a documented no-op there), so a lockdown
+    applied after the write would leave the tokens readable under the
+    directory-inherited DACL for the whole write — and indefinitely if the
+    lockdown fails. ``restrict_on_error="warn"`` keeps this writer's contract:
+    a host where the lockdown cannot be applied must not abort a token save
+    that already succeeded.
     """
-    import tempfile  # noqa: F811
-
     from kiro_crew.config.loader import env_path  # noqa: F811
-    from kiro_crew.platform_compat import fchmod_safe, restrict_to_owner
 
     ep = env_path()
     lines = ep.read_text(encoding="utf-8").splitlines() if ep.exists() else []
@@ -2425,30 +2429,8 @@ def _write_env_updates(updates: dict[str, str | None]) -> None:
     for k, new_val in updates.items():
         if k not in seen and new_val:
             out.append(f"{k}={new_val}")
-    ep.parent.mkdir(parents=True, exist_ok=True)
     content = "\n".join(out) + ("\n" if out else "")
-    # mkstemp creates the file with mode 0600 and O_EXCL; rename is atomic on
-    # the same filesystem. fchmod is belt-and-suspenders in case of odd umask.
-    fd, tmp_name = tempfile.mkstemp(dir=str(ep.parent), prefix=".env.", suffix=".tmp")
-    try:
-        # Portable perms: os.fchmod is POSIX-only (absent on Windows, where a
-        # raw call would raise AttributeError and 500 every token save).
-        # fchmod_safe applies 0600 on POSIX and no-ops on Windows;
-        # restrict_to_owner then locks the completed file down on both.
-        fchmod_safe(fd, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-        os.replace(tmp_name, ep)
-        try:
-            restrict_to_owner(ep)
-        except OSError:
-            logger.warning("could not restrict .env permissions", exc_info=True)
-    except BaseException:
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
+    atomic_write(ep, content, restrict_to_owner=True, restrict_on_error="warn")
 
 
 async def api_slack_manifest(request: web.Request) -> web.Response:
@@ -2694,7 +2676,9 @@ async def _slack_config_save_locked(request: web.Request) -> web.Response:
 
     # ── Phase 2: commit. All validation passed, so writes are safe. ──
     if env_updates:
-        _write_env_updates(env_updates)
+        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
+        # which must not block the event loop.
+        await asyncio.to_thread(_write_env_updates, env_updates)
         # Keep the live process environment in sync with the new .env state.
         # load_credentials() lets os.environ win over .env, so without this a
         # replaced/cleared token would keep being reported as installed by GET
@@ -3016,7 +3000,9 @@ async def _discord_config_save_locked(request: web.Request) -> web.Response:
 
     # ── Phase 2: commit. All validation passed, so writes are safe. ──
     if env_updates:
-        _write_env_updates(env_updates)
+        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
+        # which must not block the event loop.
+        await asyncio.to_thread(_write_env_updates, env_updates)
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
         # save handler for the full rationale).
@@ -3857,7 +3843,9 @@ async def api_webex_config_save(request: web.Request) -> web.Response:
                     relabel="session_folder" in changes,
                 )
         if env_updates:
-            _write_env_updates(env_updates)
+            # Off-loop: on Windows the owner-only lockdown shells out to icacls,
+            # which must not block the event loop.
+            await asyncio.to_thread(_write_env_updates, env_updates)
             # Keep the live process environment in sync (see the Slack save path).
             for key, new_val in env_updates.items():
                 if new_val is None:

--- a/src/kiro_crew/dashboard/handlers/weixin_qr.py
+++ b/src/kiro_crew/dashboard/handlers/weixin_qr.py
@@ -44,7 +44,6 @@ from kiro_crew.dashboard.channel_folders import (
 )
 from kiro_crew.dashboard.handlers.agents import _get_config_lock
 from kiro_crew.dashboard.handlers.messaging import is_direct_local_request
-from kiro_crew.platform_compat import restrict_to_owner
 from kiro_crew.weixin.client import ILINK_BASE_URL, WeixinClient
 
 logger = logging.getLogger(__name__)
@@ -95,21 +94,22 @@ def _atomic_write(path: Path, text: str, *, secret: bool = False) -> None:
     with ``mkstemp`` so concurrent writers to the same target cannot collide on a
     deterministic ``.tmp`` name (an ENOENT race).
 
-    Permissions are never weakened. ``secret=True`` forces 0600 and then applies
-    :func:`restrict_to_owner`, which locks the file down on Windows too (POSIX
-    mode bits are meaningless against NTFS ACLs). For a non-secret file the
-    EXISTING mode is carried over, because the replacement would otherwise adopt
-    the umask default and silently downgrade an already-restricted file —
-    ``config.json`` can hold inline fallback credentials, so a 0600 → 0644
-    transition there would expose them to other local users.
+    Permissions are never weakened. ``secret=True`` passes
+    ``restrict_to_owner=True`` to the shared helper, which locks the unique
+    temp file down to its owner BEFORE any content byte is written — POSIX mode
+    bits are meaningless against NTFS ACLs, so a lockdown applied to the final
+    path after the write would leave the credential readable under the
+    directory-inherited DACL for the whole write. ``restrict_on_error="warn"``
+    keeps this writer's contract: a host where the lockdown cannot be applied
+    must not abort a credential save that already succeeded. For a non-secret
+    file the EXISTING mode is carried over, because the replacement would
+    otherwise adopt the umask default and silently downgrade an
+    already-restricted file — ``config.json`` can hold inline fallback
+    credentials, so a 0600 → 0644 transition there would expose them to other
+    local users.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
     if secret:
-        atomic_write(path, text, mode=0o600)
-        try:
-            restrict_to_owner(path)
-        except OSError:
-            logger.warning("weixin: could not restrict credential permissions", exc_info=True)
+        atomic_write(path, text, restrict_to_owner=True, restrict_on_error="warn")
         return
     preserved: Optional[int] = None
     try:

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -1387,6 +1387,41 @@ class TestWriteEnvUpdates:
         mod._write_env_updates({"A": "1"})
         assert env.read_text(encoding="utf-8") == "A=1\n"
 
+    def test_the_owner_lockdown_precedes_any_content_byte(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The ordering IS the security property: fchmod_safe is a no-op on
+        Windows, so a lockdown applied after the write leaves the tokens
+        readable under the directory-inherited DACL for the whole write. The
+        shared helper restricts the empty temp file first; assert the sequence
+        through the same os.write seam the helper's own ordering test uses."""
+        import os as _os
+
+        from kiro_crew import platform_compat
+
+        env = tmp_path / ".env"
+        monkeypatch.setattr(loader, "env_path", lambda: env)
+
+        events: list[str] = []
+        real_restrict = platform_compat.restrict_to_owner
+        real_os_write = _os.write
+
+        def _spy(path: Any) -> None:
+            events.append("restrict")
+            return real_restrict(path)
+
+        def _tracking_write(fd: int, data: Any) -> int:
+            events.append("write")
+            return real_os_write(fd, data)
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _spy)
+        monkeypatch.setattr(_os, "write", _tracking_write)
+
+        mod._write_env_updates({"SLACK_BOT_TOKEN": "xoxb-secret"})
+
+        assert events == ["restrict", "write"], events
+        assert env.read_text(encoding="utf-8") == "SLACK_BOT_TOKEN=xoxb-secret\n"
+
 
 class _FakeResponse:
     """Minimal aiohttp response double: ``status`` plus an awaitable ``json()``."""

--- a/test/test_weixin_qr.py
+++ b/test/test_weixin_qr.py
@@ -42,6 +42,53 @@ def test_atomic_write_secret_leaves_no_temp_file_behind(tmp_path):
     assert [p.name for p in tmp_path.iterdir()] == [".env"]
 
 
+def test_atomic_write_secret_locks_down_before_any_content_byte(tmp_path, monkeypatch):
+    """The ordering IS the security property: POSIX mode bits protect nothing
+    against NTFS ACLs, so a lockdown applied to the final path after the write
+    leaves the credential readable under the directory-inherited DACL for the
+    whole write. The shared helper restricts the empty temp file first; assert
+    the sequence through the same os.write seam the helper's own ordering test
+    uses."""
+    from kiro_crew import platform_compat
+
+    events = []
+    real_restrict = platform_compat.restrict_to_owner
+    real_os_write = os.write
+
+    def _spy(path):
+        events.append("restrict")
+        return real_restrict(path)
+
+    def _tracking_write(fd, data):
+        events.append("write")
+        return real_os_write(fd, data)
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _spy)
+    monkeypatch.setattr(os, "write", _tracking_write)
+
+    target = tmp_path / ".env"
+    qr._atomic_write(target, "WEIXIN=abc\n", secret=True)
+
+    assert events == ["restrict", "write"], events
+    assert target.read_text() == "WEIXIN=abc\n"
+
+
+def test_atomic_write_secret_survives_a_lockdown_refusal(tmp_path, monkeypatch):
+    """A host where the owner lockdown fails (e.g. SID resolution refused) must
+    warn and keep the credential save, not abort a sign-in that already
+    succeeded: the writer's contract is enforce-and-warn."""
+    from kiro_crew import platform_compat
+
+    def _boom(path):
+        raise OSError("icacls failed")
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _boom)
+    target = tmp_path / ".env"
+    qr._atomic_write(target, "WEIXIN=abc\n", secret=True)  # must not raise
+    assert target.read_text() == "WEIXIN=abc\n"
+    assert [p.name for p in tmp_path.iterdir()] == [".env"]  # no temp residue
+
+
 def test_env_value_round_trips_and_delete_preserves_other_keys(tmp_path, monkeypatch):
     ep = tmp_path / ".env"
     ep.write_text("OTHER=keepme\nWEIXIN_TOKEN=old\n", encoding="utf-8")


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A -- ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Two dashboard credential writers apply the Windows owner lockdown only AFTER the secret is already on disk -- the same exposure-window class PR #5228 closed in `cli_setup.py`:

- `dashboard/handlers/messaging.py` `_write_env_updates` (Slack / Discord / Telegram / Webex / WeCom / Teams tokens in `.env`): hand-rolled `mkstemp` + `fchmod_safe` + write + `os.replace`, then `restrict_to_owner(ep)` on the FINAL path.
- `dashboard/handlers/weixin_qr.py` `_atomic_write(secret=True)` (Weixin credential): `atomic_write(mode=0o600)` then `restrict_to_owner(path)` after the rename.

`fchmod_safe` is a documented no-op on Windows, so between the write and the lockdown the tokens sit readable under the directory-inherited DACL -- and indefinitely when the lockdown raises, since both sites deliberately only warn.

## Why it matters

On a multi-user Windows host, every dashboard credential save (any messaging channel token) has a window where the secret is readable by other local users, and a failed `icacls` lockdown leaves it exposed permanently while the save still reports success. These are exactly the files that hold live bot tokens.

## What changed (motivation -> approach -> change)

Symptom -> root cause: both writers get the lockdown ORDER wrong -- restriction is applied to the final path after content landed, instead of to the empty temp file before any content byte exists.

The shared helper `kiro_crew.atomic_write.atomic_write` already implements the correct order: `restrict_to_owner=True` locks the unique temp file down BEFORE any content is written, and `restrict_on_error="warn"` reproduces each call site's existing warn-only failure contract (a host where the lockdown fails must not abort a token save that already succeeded). Both sites now delegate to it, deleting the duplicated hand-rolled get-the-order-wrong logic (~30 lines): `_write_env_updates` drops its `mkstemp`/`fchmod_safe`/`os.replace`/post-hoc `restrict_to_owner` block, and `weixin_qr._atomic_write(secret=True)` drops its post-write lockdown. The helper also brings the #4381 symlinked-parent refusal and the Windows rename-retry to both sites for free.

Local pre-push review then surfaced that three of `_write_env_updates`'s six callers (the Slack, Discord and Webex config-save handlers) invoked it synchronously ON the event loop -- a pre-existing violation of `no-blocking-call-on-event-loop` (the lockdown shells out to `whoami`/`icacls` on Windows), which the other three call sites already avoid via `asyncio.to_thread`. Rather than ship the migration on top of that, all three are now offloaded the same way, so every caller of the writer runs it off-loop.

Out of scope (per the issue): the broader shared-helper DACL residual for legacy `write_config_atomically` call sites -- that is a separate design decision.

## Tests

- `test_handlers_messaging_coverage.py::TestWriteEnvUpdates::test_the_owner_lockdown_precedes_any_content_byte` -- asserts the `restrict` -> `write` sequence through the same `platform_compat.restrict_to_owner` / `os.write` seams the helper's own ordering test uses; mutation-verified (dropping `restrict_to_owner=True` turns it red).
- `test_weixin_qr.py::test_atomic_write_secret_locks_down_before_any_content_byte` -- same ordering lock-in for the Weixin writer.
- `test_weixin_qr.py::test_atomic_write_secret_survives_a_lockdown_refusal` -- the warn-only contract: an `OSError` from the lockdown must not abort the save and must leave no temp residue; mutation-verified (dropping `restrict_on_error="warn"` turns it red).
- Existing suites re-run green: messaging coverage, weixin_qr, slack/telegram/webex/discord config handlers, atomic_write capabilities (332 tests), plus isort / flake8 / mypy (1038 files) / brand gate.

## Manual verification

N/A -- unit coverage sufficient: the ordering property and the warn contract are asserted at the exact syscall seams, and the Windows-specific behavior lives in the already-tested shared helper.

## Related Issues

Closes #5240

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, behavior contract unchanged at the API level; docstrings updated in place
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to credential file writers; no rendered UI delta.
