### PR TITLE
fix: cancel a pending deferred tray hide when a show is requested

### DIFF
--- a/website/electron/global-hotkey.js
+++ b/website/electron/global-hotkey.js
@@ -23,6 +23,10 @@
  */
 
 const { globalShortcut } = require("electron");
+// Pure helper (no Electron dependency): disarms a tray hide that hideToTray()
+// deferred to the fullscreen exit, so a summon landing in that gap is not
+// silently undone when the exit completes.
+const { cancelPendingTrayHide } = require("./hide-to-tray");
 
 /**
  * Platform-appropriate default, mirroring the modifier rationale documented in
@@ -92,6 +96,10 @@ function createSummonHandler({ getWindow, createWindow, focusApp }) {
   return () => {
     const win = typeof getWindow === "function" ? getWindow() : null;
     if (win && !(typeof win.isDestroyed === "function" && win.isDestroyed())) {
+      // A summon during hideToTray()'s deferred fullscreen-exit hide must win
+      // over the pending hide, or the window shown below is hidden again the
+      // moment the exit animation completes.
+      cancelPendingTrayHide(win);
       if (typeof win.isMinimized === "function" && win.isMinimized() && win.restore) {
         win.restore();
       }

--- a/website/electron/hide-to-tray.js
+++ b/website/electron/hide-to-tray.js
@@ -36,10 +36,24 @@
 // visible regression, since the window would come back windowed and the geometry
 // listener would persist it as windowed for the next launch too. Off darwin this
 // stays exactly the plain hide it has always been.
+//
+// CANCELLATION: while the hide is deferred (up to the 2s backstop) the window is
+// still visible, so a show request landing in that gap — Dock activate, the tray
+// "Show" item, the summon hotkey — would either be skipped (`isVisible()` is
+// still true) or be silently undone moments later when the deferred hide fires.
+// `cancelPendingTrayHide(win)` disarms the pending hide (clears the backstop and
+// removes the listener) so the show wins; every show path that expresses user
+// intent to see the window calls it first.
 
 // How long to wait for `leave-full-screen` before hiding anyway. Generous
 // relative to the ~0.5s macOS Space animation.
 const DEFAULT_LEAVE_TIMEOUT_MS = 2000;
+
+// The one pending deferred hide per window, keyed on the window itself so a
+// show path can disarm it without threading a handle through main.js. WeakMap:
+// a window destroyed (or dropped) mid-deferral must not be kept alive by its
+// own cancel closure.
+const pendingHides = new WeakMap();
 
 const isDead = (win) => {
   try {
@@ -114,9 +128,14 @@ function hideToTray(win, opts = {}) {
 
   let settled = false;
   let timer = null;
-  const finish = () => {
+  // Exactly-once settlement, shared by all three exits: the event, the
+  // backstop, and a cancellation. `hide` distinguishes the first two (tear the
+  // machinery down, then hide) from a cancel (tear it down and leave the window
+  // visible — the user just asked for it back).
+  const settle = (hide) => {
     if (settled) return;
     settled = true;
+    pendingHides.delete(win);
     if (timer !== null) {
       try {
         clearTimer(timer);
@@ -140,13 +159,23 @@ function hideToTray(win, opts = {}) {
     } catch {
       /* best effort */
     }
-    hideNow();
+    if (hide) hideNow();
   };
+  function finish() {
+    settle(true);
+  }
+
+  // Registered before the listener is armed so no window exists in which the
+  // hide is pending but not cancellable. A stale entry is impossible: every
+  // settle path deletes it, and cancelling an already-settled hide is a no-op
+  // behind the `settled` guard.
+  pendingHides.set(win, () => settle(false));
 
   try {
     win.once("leave-full-screen", finish);
   } catch {
     // Cannot observe the transition, so a deferred hide would never land.
+    pendingHides.delete(win);
     result.hidden = hideNow();
     return result;
   }
@@ -179,4 +208,26 @@ function hideToTray(win, opts = {}) {
   return result;
 }
 
-module.exports = { hideToTray, DEFAULT_LEAVE_TIMEOUT_MS };
+/**
+ * Disarm a hide that hideToTray() deferred to the fullscreen exit, so a show
+ * request that lands inside that window (Dock activate, tray "Show", the summon
+ * hotkey) is not silently undone when the exit completes. Clears the backstop
+ * timer and removes the `leave-full-screen` listener; the fullscreen exit
+ * itself is NOT reversed — the window simply stays visible, windowed, which is
+ * what a user asking for the window back expects.
+ *
+ * Call it before performing any user-initiated show. Safe to call always: a
+ * window with no pending hide is a no-op.
+ *
+ * @param {object} win  The window that was passed to hideToTray().
+ * @returns {boolean}   true when a pending deferred hide was disarmed.
+ */
+function cancelPendingTrayHide(win) {
+  if (!win) return false;
+  const cancel = pendingHides.get(win);
+  if (!cancel) return false;
+  cancel();
+  return true;
+}
+
+module.exports = { hideToTray, cancelPendingTrayHide, DEFAULT_LEAVE_TIMEOUT_MS };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -20,7 +20,7 @@ const { createTokenRetryHandler } = require("./token-retry");
 const { createRendererRecovery } = require("./renderer-recovery");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { exitImmersiveModes } = require("./blocking-prompt");
-const { hideToTray } = require("./hide-to-tray");
+const { hideToTray, cancelPendingTrayHide } = require("./hide-to-tray");
 const { shouldRetryLocalTokenMint, tokenMintRetryDelayMs, TOKEN_MINT_MAX_RETRIES } = require("./token-acquire");
 const { createDisplayMediaHandler } = require("./display-media");
 const { applyFocusModeChrome } = require("./focus-chrome");
@@ -281,6 +281,9 @@ if (!app.requestSingleInstanceLock()) {
 } else {
   app.on("second-instance", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
+      // Relaunching the app is a request for the window back; it must win over
+      // a hide still deferred to the fullscreen exit (see hide-to-tray.js).
+      cancelPendingTrayHide(mainWindow);
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.show();
       mainWindow.focus();
@@ -2277,6 +2280,13 @@ function createWindow() {
 }
 
 function createTray() {
+  // A tray gesture asking for the window back must first disarm any hide that
+  // hideToTray() deferred to the fullscreen exit, or the show is undone moments
+  // later when the exit completes (see hide-to-tray.js CANCELLATION).
+  const showFromTray = () => {
+    cancelPendingTrayHide(mainWindow);
+    mainWindow?.show();
+  };
   // Nightly ships its own icon (night-sky variant) so the menu-bar presence
   // matches the Dock identity; app.name was set channel-aware at boot.
   const nightly = identityFamily(app.getVersion()) === "nightly";
@@ -2314,7 +2324,7 @@ function createTray() {
   // tabs were removed with the single-surface shell redesign).
   tray.setContextMenu(
     Menu.buildFromTemplate([
-      { label: `Show ${app.name}`, click: () => mainWindow?.show() },
+      { label: `Show ${app.name}`, click: showFromTray },
       { type: "separator" },
       { label: "New Connection Window…", click: () => openNewConnectionWindow() },
       { type: "separator" },
@@ -2323,7 +2333,7 @@ function createTray() {
       { label: "Quit", click: () => { isQuitting = true; app.quit(); } },
     ])
   );
-  tray.on("click", () => mainWindow?.show());
+  tray.on("click", showFromTray);
 }
 
 // ── Remote host settings ──
@@ -3145,6 +3155,9 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
 
 async function openNewConnectionWindow() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
+  // Reachable from the tray menu during the deferred fullscreen-exit hide; the
+  // pending hide would otherwise take the parent away from under the modal.
+  cancelPendingTrayHide(mainWindow);
   mainWindow.show();
 
   const css = await getModalCSS();
@@ -3444,6 +3457,9 @@ app.whenReady().then(async () => {
   const openSettingsPage = (tab) => {
     const win = focusedDashboardWindow();
     if (!win) return;
+    // The window may be mid deferred-hide (still visible, still focusable);
+    // opening settings on it is a request to keep it, not lose it 2s later.
+    cancelPendingTrayHide(win);
     if (win.isMinimized()) win.restore();
     win.show();
     win.focus();
@@ -3930,6 +3946,7 @@ app.whenReady().then(async () => {
         });
         n.on("click", () => {
           if (mainWindow && !mainWindow.isDestroyed()) {
+            cancelPendingTrayHide(mainWindow);
             if (mainWindow.isMinimized()) mainWindow.restore();
             mainWindow.show();
             mainWindow.focus();
@@ -4023,6 +4040,12 @@ app.whenReady().then(async () => {
   }
 
   app.on("activate", () => {
+    // An activate landing while hideToTray() is still waiting out the
+    // fullscreen-exit animation must win over the pending hide: the window is
+    // still visible at this point, so the isVisible() guard below would skip
+    // the show and the deferred hide would then take the window away — the
+    // user clicked the Dock icon and watched the window vanish.
+    cancelPendingTrayHide(mainWindow);
     if (!mainWindow?.isVisible()) mainWindow?.show();
   });
 });

--- a/website/electron/test/global-hotkey.test.js
+++ b/website/electron/test/global-hotkey.test.js
@@ -205,6 +205,45 @@ test("the handler creates a window when none exists or it is destroyed", () => {
   assert.deepStrictEqual(gone.calls, []);
 });
 
+// A summon landing while hideToTray() is still waiting out the macOS
+// fullscreen-exit animation must disarm the pending hide — otherwise the show
+// below is silently undone the moment the exit completes and the user watches
+// the window they just summoned vanish. Drive the REAL hide-to-tray module (it
+// is pure, no Electron dependency) so this pins the integration, not a stub.
+test("the handler disarms a deferred tray hide before showing", () => {
+  const { mod } = loadModule();
+  const { hideToTray } = require(path.join(__dirname, "..", "hide-to-tray"));
+  const win = fakeWindow();
+  const listeners = new Map();
+  win.isFullScreen = () => true;
+  win.setFullScreen = () => win.calls.push("setFullScreen");
+  // Record hide() so the final "no hide after summon" assertion is not
+  // vacuously true on a window with no hide member.
+  win.hide = () => win.calls.push("hide");
+  win.once = (event, fn) => listeners.set(event, fn);
+  win.off = (event, fn) => {
+    if (listeners.get(event) === fn) listeners.delete(event);
+  };
+  let backstop = null;
+  hideToTray(win, {
+    isMac: true,
+    setTimeoutFn: (fn) => { backstop = fn; return { unref() { return this; } }; },
+    clearTimeoutFn: () => { backstop = null; },
+  });
+  assert.deepStrictEqual(win.calls, ["setFullScreen"], "hide must be deferred, not immediate");
+
+  const handler = mod.createSummonHandler({ getWindow: () => win, createWindow: () => {} });
+  handler();
+  assert.deepStrictEqual(win.calls, ["setFullScreen", "show", "focus"]);
+
+  // The exit animation still completes and the backstop may already be in
+  // flight — neither may hide the window the user just summoned.
+  const leave = listeners.get("leave-full-screen");
+  if (leave) leave();
+  if (backstop) backstop();
+  assert.deepStrictEqual(win.calls, ["setFullScreen", "show", "focus"], "no hide after summon");
+});
+
 test("a throwing summon handler is caught, not propagated to the dispatcher", () => {
   const { mod, state } = loadModule();
   const logs = [];

--- a/website/electron/test/hide-to-tray.test.js
+++ b/website/electron/test/hide-to-tray.test.js
@@ -2,7 +2,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
-const { hideToTray, DEFAULT_LEAVE_TIMEOUT_MS } = require("../hide-to-tray");
+const { hideToTray, cancelPendingTrayHide, DEFAULT_LEAVE_TIMEOUT_MS } = require("../hide-to-tray");
 
 // Fake BrowserWindow/BaseWindow recording the calls hideToTray makes. Only the
 // members the helper touches are implemented. `once` captures listeners so a
@@ -235,6 +235,90 @@ describe("hideToTray", () => {
   });
 });
 
+// A show request (Dock activate, tray "Show", the summon hotkey) landing while
+// the hide is deferred to the fullscreen exit must win over the pending hide.
+// Without a cancel, the show either gets skipped (the window is still visible,
+// so `isVisible()` guards it away) or is silently undone moments later when
+// `leave-full-screen` (or the backstop) fires — the user asks for the window
+// back and watches it vanish.
+describe("cancelPendingTrayHide", () => {
+  it("disarms a deferred hide so the fullscreen exit no longer hides", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+
+    assert.equal(cancelPendingTrayHide(win), true, "a pending hide must report disarmed");
+    assert.equal(timers.scheduled[0].cleared, true, "the backstop must be cleared");
+    assert.equal(win.listeners.size, 0, "the leave-full-screen listener must be removed");
+
+    // The transition still completes (the exit itself is not reversed) and the
+    // backstop may already be in flight — neither may hide now.
+    timers.fire();
+    assert.deepEqual(win.calls, [["setFullScreen", false]], "no hide after cancel");
+  });
+
+  it("returns false when nothing is pending", () => {
+    assert.equal(cancelPendingTrayHide(makeWin()), false);
+    assert.equal(cancelPendingTrayHide(null), false);
+    assert.equal(cancelPendingTrayHide(undefined), false);
+  });
+
+  // An immediate (non-deferred) hide leaves nothing to cancel: the window is
+  // already hidden, and the later show() re-shows it normally.
+  it("has nothing to cancel after a non-fullscreen hide", () => {
+    const win = makeWin({ fullScreen: false });
+    hideToTray(win, mac());
+    assert.equal(cancelPendingTrayHide(win), false);
+  });
+
+  // Exactly-once settlement is shared with the hide paths: once the event or
+  // the backstop has hidden the window, there is no pending hide left, and a
+  // late cancel must not report having disarmed anything.
+  it("is a no-op after the deferred hide already landed", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+    win.emitLeaveFullScreen();
+    assert.deepEqual(win.calls, [["setFullScreen", false], ["hide"]]);
+    assert.equal(cancelPendingTrayHide(win), false);
+  });
+
+  it("is idempotent — a second cancel reports nothing pending", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+    assert.equal(cancelPendingTrayHide(win), true);
+    assert.equal(cancelPendingTrayHide(win), false);
+  });
+
+  // The user closes again after summoning the window back: the next close must
+  // defer-and-hide exactly as the first one did, unaffected by the cancel.
+  it("does not break a subsequent hideToTray on the same window", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true });
+    hideToTray(win, mac(timers));
+    cancelPendingTrayHide(win);
+
+    hideToTray(win, mac(timers));
+    assert.deepEqual(win.calls, [["setFullScreen", false], ["setFullScreen", false]]);
+    win.emitLeaveFullScreen();
+    assert.deepEqual(win.calls, [
+      ["setFullScreen", false],
+      ["setFullScreen", false],
+      ["hide"],
+    ]);
+  });
+
+  // The setFullScreen-throw path settles synchronously inside hideToTray, so it
+  // must not leave a cancellable entry behind.
+  it("has nothing to cancel when the exit could not be started", () => {
+    const timers = makeTimers();
+    const win = makeWin({ fullScreen: true, throwOnSetFullScreen: true });
+    hideToTray(win, mac(timers));
+    assert.equal(cancelPendingTrayHide(win), false);
+  });
+});
+
 // The helper above is only a fix if main.js actually routes the tray close
 // through it. A correct helper with the old `mainWindow.hide()` still at the
 // call site passes every test above while the bug is fully intact, so pin the
@@ -261,5 +345,52 @@ describe("main.js tray-close wiring", () => {
       /mainWindow\.hide\(\)/,
       "a direct hide() orphans the macOS fullscreen Space — go through hideToTray",
     );
+  });
+
+  // A correct cancel helper with the show paths still calling a bare show()
+  // passes every unit test above while the bug is fully intact: an activate or
+  // tray gesture during the deferred hide would still lose to it. Pin each
+  // user-initiated show path to the cancel.
+  it("cancels the pending hide before the activate show", () => {
+    const branch = MAIN_JS.match(/app\.on\("activate", \(\) => \{([\s\S]*?)\}\);/);
+    assert.ok(branch, "could not locate the activate handler");
+    const body = branch[1];
+    assert.match(body, /cancelPendingTrayHide\(mainWindow\)/);
+    assert.ok(
+      body.indexOf("cancelPendingTrayHide") < body.indexOf(".show()"),
+      "the cancel must run before the show",
+    );
+  });
+
+  it("routes both tray show gestures through the cancelling helper", () => {
+    // The menu item and the icon click are the same user intent; both must
+    // disarm the pending hide, so both go through the one helper that does.
+    const helper = MAIN_JS.match(/const showFromTray = \(\) => \{([\s\S]*?)\};/);
+    assert.ok(helper, "could not locate showFromTray");
+    assert.match(helper[1], /cancelPendingTrayHide\(mainWindow\)/);
+    assert.match(MAIN_JS, /\{ label: `Show \$\{app\.name\}`, click: showFromTray \}/);
+    assert.match(MAIN_JS, /tray\.on\("click", showFromTray\)/);
+  });
+
+  // The remaining user-intent shows of a possibly-deferred window: relaunching
+  // the app (second-instance), the tray "New Connection Window…" item, opening
+  // settings, and clicking the update notification. Each must disarm before it
+  // shows, or the window it surfaces vanishes when the deferral settles.
+  it("cancels the pending hide on every other user-intent show path", () => {
+    const sites = [
+      ["second-instance", /app\.on\("second-instance", \(\) => \{([\s\S]*?)\}\);/],
+      ["openNewConnectionWindow", /async function openNewConnectionWindow\(\) \{([\s\S]*?)const css/],
+      ["openSettingsPage", /const openSettingsPage = \(tab\) => \{([\s\S]*?)\};/],
+      ["update-notification click", /n\.on\("click", \(\) => \{([\s\S]*?)\}\);/],
+    ];
+    for (const [name, re] of sites) {
+      const m = MAIN_JS.match(re);
+      assert.ok(m, `could not locate the ${name} show path`);
+      assert.match(m[1], /cancelPendingTrayHide\(/, `${name} must disarm the pending hide`);
+      assert.ok(
+        m[1].indexOf("cancelPendingTrayHide") < m[1].indexOf(".show()"),
+        `${name}: the cancel must run before the show`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## What is the problem?

`hideToTray()` defers the tray hide on macOS until the fullscreen Space is torn down: it arms a `leave-full-screen` listener plus a 2s backstop timer and hides when either fires. Nothing disarmed that pending hide, so any show request landing inside the gap silently lost to it. The Dock activate handler saw `isVisible() === true` (the window has not hidden yet), skipped its `show()`, and the deferred hide then took the window away; the tray Show item, the tray icon click, and the summon hotkey showed the window only for the deferred hide to undo it moments later.

## Why this issue matters to the user

The user closes a fullscreen window to the tray, immediately wants it back, and asks for it the normal way -- clicking the Dock icon, the tray icon, or pressing the summon hotkey. The window appears (or stays) for a fraction of a second and then vanishes. There is no error and no second cue; it reads as the app eating the click, and the user has to ask a second time.

## How our fix solves it

The symptom chain is: show request during the deferral -> either skipped by the `isVisible()` guard or performed and then reverted -> because the deferred `finish()` was closure-local to `hideToTray()` with no way to disarm it. The fix makes the pending hide cancellable and cancels it at every user-intent show:

- `hide-to-tray.js` tracks the one pending hide per window in a module `WeakMap` and refactors the exactly-once `finish()` into `settle(hide)` -- the event and the backstop settle with a hide, a cancellation settles without one (backstop cleared, listener removed, window left visible). New export `cancelPendingTrayHide(win)`; a window with nothing pending is a no-op, and a later close re-arms a fresh deferral.
- Every user-initiated show path disarms first: the `activate` handler, both tray gestures (menu Show and icon click, routed through one `showFromTray` helper), the global-hotkey summon handler, the `second-instance` handler, the tray New Connection Window item, settings opens, and the update-notification click. The gateway-reconnect `show()`s are liveness-driven, not a user asking for the window back, and are deliberately unchanged.
- The fullscreen exit itself is not reversed: the window stays visible, windowed -- which matches what the geometry listener has already persisted and avoids fighting AppKit mid-animation.

## What tests we did

- 7 new unit tests for `cancelPendingTrayHide` in `test/hide-to-tray.test.js`: disarm clears the backstop and removes the listener, the later event/backstop no longer hide, nothing pending returns false (non-fullscreen hide, settled hide, second cancel, failed `setFullScreen`), and a subsequent `hideToTray` on the same window re-arms cleanly.
- Wiring pins on `main.js` text (same idiom as the existing tray-close wiring tests): the activate handler, both tray gestures, and each of the four other user-intent show paths must call the cancel before their `show()`.
- An integration test in `test/global-hotkey.test.js` driving the real `hide-to-tray` module through the summon handler: hide deferred, summon, then the leave event and backstop fire -- no hide.
- Mutation checks: removing the WeakMap registration, removing the summon-handler cancel, reverting the activate handler, making cancel settle *with* a hide, and removing the second-instance cancel each turn at least one test red.
- Full local gates: electron suite (owned files 44/44; the full-suite `gateway-stop`/`petOverlays` reds reproduce identically on pristine main under parallel load and pass in isolation on both trees, so they are host/base-owned), `npx tsc -b` clean, jscpd clean, brand gate clean.
- This is Electron main-process wiring with no rendered surface, so verification is the unit/integration suite above plus code reasoning; no screenshot applies.

## Any other suggestions on the work

Both pre-push review lanes ran on this diff: the adversarial lane returned clean; the other lane's four findings (second-instance, notification click, New Connection Window, settings -- all the same missed-call-site class) are fixed and pinned in this PR. A possible follow-up is folding the per-site calls into a single `showMainWindow()` helper, but that refactor touches shows with differing restore/focus semantics and is out of scope for a targeted fix.

Fixes #4937
