### PR TITLE
feat: persist subagent completion delivery

### DIFF
--- a/docs/request-for-change/rfc-durable-run-coordinator.md
+++ b/docs/request-for-change/rfc-durable-run-coordinator.md
@@ -14,15 +14,16 @@ superseded-by: []
 ---
 # RFC: Durable Run Coordinator — typed lifecycle, idempotent commands, and recoverable delivery
 
-- Status: in-progress — PRs 1–5 are implemented locally; PR 5 lives on
-  `codex/run-coordinator-commands`. Keyed spawn/continue admission and control
-  commands are coordinator-authoritative, exact retries reuse durable responses,
-  and transport uncertainty resolves by command lookup. Legacy run files still
-  mirror lifecycle/terminal state; PRs 6–7 are unimplemented.
+- Status: in-progress — PRs 1–6 are implemented locally; PR 6 lives on
+  `codex/run-coordinator-outbox`. Keyed execution carries a renewable run fence
+  through `starting`, `running`, and atomic terminal/outbox commit; fenced
+  delivery retries reuse one stable event identity. Legacy run files still
+  mirror lifecycle/terminal state; PR 7 is unimplemented.
 - Author: Kyle Seaman, with Codex
 - Created: 2026-08-22
 - Audited against: PR 1 commit `c8eda3c6f`, PR 2 commit `53f365a17`, PR 3 commit
-  `4aa0cba4d`, PR 4 commit `3ed006642`, and the PR 5 working tree
+  `4aa0cba4d`, PR 4 commit `3ed006642`, PR 5 commit `f9b73887a`, and the PR 6
+  working tree
 - Related: `docs/system-specs/modules/subagent.md`,
   `docs/system-specs/modules/session.md`, and
   `docs/request-for-change/rfc-orchestrator-chat-sessions.md`
@@ -344,7 +345,13 @@ class RunCoordinator(Protocol):
         self, completion: RunCompletion, fence: RunFence, expected_version: int
     ) -> CoordinatorResult[OutboxEvent]: ...
     async def renew(self, run_id: str, fence: RunFence, until: float) -> bool: ...
-    async def claim_outbox(self, owner: OwnerLease, limit: int) -> list[OutboxEvent]: ...
+    async def claim_outbox(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        event_id: str = "",
+        acknowledgement: bool = False,
+    ) -> list[OutboxEvent]: ...
     async def release_outbox(
         self, fence: DeliveryFence, available_at: float
     ) -> CoordinatorResult[OutboxEvent]: ...
@@ -602,6 +609,14 @@ Branch: `run-coordinator-outbox`
 lost terminal event; redelivery never repeats execution; existing completion
 envelope consumers ignore or use the additive `event_id`; delivery retry and
 fallback remain bounded.
+
+**Local status:** implemented. Exact execution claims acquire a renewable run
+lease while controls retain independent command-only fences. The manager commits
+`starting` before child startup, `running` before prompting, and terminal state
+plus one outbox row before callbacks. Direct acceptance is fenced and
+acknowledged; dashboard-queued and digest-held events stay pending until their
+existing consumption hooks settle the same event. Payloads contain bounded
+summary/routing data and the full-result path.
 
 ### PR 7 — coordinator-first restart recovery and legacy import
 

--- a/docs/superpowers/plans/2026-08-22-durable-run-coordinator.md
+++ b/docs/superpowers/plans/2026-08-22-durable-run-coordinator.md
@@ -382,36 +382,36 @@ exceptions.
 - Produces: `OutboxDeliveryAdapter.drain_once()` and additive `event_id` in the
   subagent completion envelope.
 
-- [ ] **Step 1: Write the completion crash-window tests.**
+- [x] **Step 1: Write the completion crash-window tests.**
 
   Inject failures before transaction, after transaction, after destination
   acceptance, and after acknowledgement. Assert every committed terminal has
   one pending/delivered event, repeated drains reuse `event_id`, and no path
   submits a second execution command.
 
-- [ ] **Step 2: Verify RED, then implement the delivery adapter.**
+- [x] **Step 2: Verify RED, then implement the delivery adapter.**
 
   Claim bounded batches, call an injected async destination callback, mark only
   accepted events delivered, release failed claims through their delivery fence
   with persisted retry timing, and never include full `result.txt` in the outbox
   payload.
 
-- [ ] **Step 3: Commit terminal outcome and outbox before callbacks.**
+- [x] **Step 3: Commit terminal outcome and outbox before callbacks.**
 
   Route the existing final report claim through `coordinator.complete()` before
   gateway delivery. Keep terminal file mirrors and teardown gates; remove only
   in-memory ordering that the durable transaction replaces.
 
-- [ ] **Step 4: Add stable event IDs to injected envelopes.**
+- [x] **Step 4: Add stable event IDs to injected envelopes.**
 
   Consumers must ignore unknown fields. Queue/digest settlement acknowledges the
   outbox event only when current code would write a delivered tombstone.
 
-- [ ] **Step 5: Verify delivery, batch, TTL, and restart tests.**
+- [x] **Step 5: Verify delivery, batch, TTL, and restart tests.**
 
   Run all named test files with `-n0`, then the broader subagent slice.
 
-- [ ] **Step 6: Update message/subagent specs and commit PR 6.**
+- [x] **Step 6: Update message/subagent specs and commit PR 6.**
 
   Commit: `feat: persist subagent completion delivery`.
 

--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -52,6 +52,7 @@ single completion path that serves every terminal outcome:
 
 ```
 [Subagent completion event]
+Event: `<stable delivery event id>`
 Agent `<id>` (<agent name>) <status> <emoji>
 Task: <first 100 chars of the task>
 
@@ -59,6 +60,13 @@ Task: <first 100 chars of the task>
 ```
 
 - Prefix `SUBAGENT_COMPLETION_PREFIX = '[Subagent completion event]'`.
+- Coordinator-backed completions include an additive `Event:` line and the same
+  identifier in `meta.subagentCompletion.eventId`. A wave digest includes one
+  line per member and every identifier in the additive
+  `meta.subagentCompletion.eventIds` list; `eventId` retains the flushing
+  member's identifier for compatibility. A delivery retry may repeat stable
+  IDs, but it never repeats execution. Legacy envelopes omit the lines and
+  remain valid.
 - `<status> <emoji>` is one of `completed ✅`, `failed ❌`, or `stopped by user ⏹`.
   The agent-name parenthetical is present only when the sub-agent ran under a named
   agent.

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1335,6 +1335,13 @@ answer is not permission: a raised evaluation and a `Decision` without
 
 ## Invariants
 
+- **Sub-agent completion acceptance is coordinator-backed**: keyed sub-agent
+  runs commit terminal state and one stable outbox event before the gateway
+  invokes dashboard/channel routing. Direct acceptance is acknowledged through
+  a delivery fence. A completion parked in a busy dashboard slot remains
+  pending until its turn consumes it; batch-held sibling events remain pending
+  until their digest is accepted. Retries reuse `event_id` and never resubmit
+  execution.
 - **One-way dependency**: `kiro_crew.messaging` never imports `kiro_crew.slack` / `kiro_crew.dashboard`; violations reintroduce the cycle the abstraction removed. This holds at **any nesting depth** — a deferred in-function import is still an edge, so a shared helper that needs something from a surface takes it as a parameter (`parse_dashboard_ttl`'s `parse_duration`). `test_messaging_commands.py::TestLayering` scans the package's ASTs for it. There is exactly ONE recorded exception, and it is recorded as a `(file, module)` pair with a reason rather than as a hole in the scan: `dispatch.py`'s `build_directive_consumer` reaches `dashboard.session_directive_apply`, the SHARED applier the dashboard's own consumer uses, so the dashboard-only denial and the monitor-trio authorization chokepoint live in one place. Injecting that applier as a parameter — the pattern the TTL helper uses — would put a security boundary behind a caller-supplied callable, which is the worse trade. A companion test deletes the entry the moment the edge goes away, so the list cannot rot into a standing pre-authorization.
 - **A hoisted command carries its AUDIT with it.** `cron_command_reply` emits the
   `cron.remove` and `cron.batch_delete` SEL events that used to live in Slack's own

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -95,16 +95,25 @@ The same non-runnable retention applies when queue-drain revalidation rejects a
 run but durable rejection settlement fails; no completion is announced until
 that command outcome commits.
 Immediate keyed batch rejections also suppress the legacy pre-announcement;
-their authority announces the batch member only after the rejected command
-outcome commits. This includes a platform-composition failure raised before the
-manager can register the run: the authority preserves the member's batch metadata
-in its durable rejection and then announces that terminal member. Cancelling a
-keyed queued batch member follows the same
-settle-then-announce ordering, so its terminal event can close a wave and release
-already-held sibling results. If the manager has already returned a known batch
-rejection but its settlement outcome is uncertain, the authority still announces
-that terminal member before surfacing uncertainty; the claimed command remains
-the durable recovery record and cannot replay the manager side effect.
+their manager return retains the admitted run's fence and version, and their
+authority routes the batch member through terminal commit plus the durable outbox
+only after the rejected command outcome commits. This includes a
+platform-composition failure raised before the manager can register the run: the
+authority preserves the member's batch metadata in its durable rejection and then
+normalizes the authority replay into the manager's terminal record shape before
+routing that terminal member through the outbox. Manager-only coordinator fields
+therefore cannot abort wave accounting for a run that never registered. Cancelling
+a keyed queued batch member follows the same settle-then-announce ordering, so its
+terminal event can close a wave and release already-held sibling results. If the
+manager has already returned a known batch rejection but its settlement outcome is
+uncertain, the authority still announces that terminal member before surfacing
+uncertainty; the
+claimed command remains the durable recovery record and cannot replay the manager
+side effect. Cancelling an identity-free queued batch member instead routes a
+synthetic stopped completion through the legacy announcement path, so wave
+accounting closes even though there is no command fence to settle. Both queued
+cancellation paths preserve the spawn's `silent` delivery policy when they
+reconstruct the terminal record.
 At task start the authority durably applies the command before stopping the
 heartbeat and evicting its facade cache. A queued cancellation, approval
 rejection, or orderly shutdown durably rejects the waiting command before
@@ -144,6 +153,15 @@ resolves the stable idempotency key. A lookup distinguishes an unclaimed
 request once only for `PENDING`, while `CLAIMED` remains outcome-uncertain and is
 never recorded as a lost submission.
 
+An exact execution claim also acquires the run lease. The authority passes its
+run fence, command, and optimistic version through the synchronous facade and
+queue payload. `_run` commits `starting` before child startup, `_run_inner`
+commits `running` after session creation and before the prompt, and a 30-second
+heartbeat renews the 90-second lease. A terminal failed, stopped, or interrupted
+run wins lookup reconstruction when its execution command has no stored facade
+result, so pre-start cancellation cannot replay as a successful spawn. Control
+claims still never touch the execution lease.
+
 The port defines typed desired/observed state, terminal outcomes, idempotent
 commands, execution leases with fencing epochs, optimistic lifecycle versions,
 and delivery claims with an independent fencing epoch. The in-memory adapter is
@@ -166,8 +184,12 @@ existing spawn option survives a queue round trip unchanged.
 shielded report tasks, report-to-agent lookup during bounded shutdown, and
 teardown gates that outlive manager registries. It uses a structural protocol
 instead of importing `SubagentInfo`, keeping the manager dependency one-way.
-The effectful delivery coroutine remains on `SubagentManager` until the durable
-outbox migration.
+`SubagentManager` owns the effectful delivery adapter while depending only on
+the coordinator port. The winning terminal reporter commits the outcome and
+outbox row before any WebSocket or parent callback. It keeps its execution
+lease and shielded report alive across transient commit failures, then retries
+the exact outbox event until delivery succeeds or the destination durably
+defers it to its queue/digest.
 
 Private manager views for the old counter, queue, report-task, and teardown-gate
 fields remain as compatibility adapters. They delegate to these boundaries and
@@ -226,8 +248,118 @@ failed operation after its state became durable.
 It always returns the primary result. It calls the shadow
 only after primary completion, swallows shadow failures, compares normalized
 stable field classes without logging payload values, and never repairs the
-primary. Terminal state and delivery move to coordinator authority in the next
-migration phases.
+primary. Keyed execution lifecycle and terminal delivery now use the durable
+coordinator directly; legacy unkeyed runs retain their file-backed report path
+until the restart importer lands.
+
+### Transactional completion outbox
+
+`mark_starting` and `mark_running` accept an exact one-version-ahead replay
+under the same owner and lease epoch when the first SQLite commit succeeded but
+its response was lost. Older versions and different fences still reject, so the
+retry can recover the committed lifecycle version without widening ownership.
+The manager retries each transition once with the same fence and expected
+version, then records the returned version before advancing the lifecycle. If
+both STARTING attempts fail, it leaves the command claimed for recovery and
+does not apply command settlement against an unknown lifecycle state.
+
+For a coordinator-admitted run, `complete()` verifies the execution fence and
+optimistic version, writes the terminal outcome, and inserts one pending outbox
+event in the same SQLite transaction. The payload contains bounded, redacted
+routing metadata, a 4,000-character result summary, and `result_path`; it never
+copies the full transcript. Replaying the completion returns the same
+`event_id`; a conflicting outcome is rejected. Lease expiry makes the run
+eligible for takeover but does not itself invalidate the monotonic fence, so
+the current epoch may still commit its terminal result after host suspend if no
+recovery owner has advanced the epoch first.
+
+Unadmitted batch rejections and lost-submission records have no worker lifecycle,
+so they use `record_terminal()` instead of manufacturing an execution command.
+That boundary atomically creates the terminal run and pending outbox event. A
+gateway exit therefore leaves either no record or a restart-drainable event,
+never a pending command with no consumer. The manager publishes the live
+delivery context before the commit so a concurrent drainer retains batch identity
+and held-sibling settlement debt. Shutdown cancellation cannot abandon this
+pre-commit window: synthetic reporters keep retrying the idempotent terminal
+record until it is durable, then stop before post-commit delivery retries.
+Keyed rejections normally retain the admitted
+run's fence and use the normal terminal commit after command settlement. A
+rejection raised before manager registration has no live record to retain that
+fence, so `record_terminal()` may instead terminalize the existing `ACCEPTED` run
+only when its execution command is already durably `REJECTED`; the run transition
+and pending outbox insert remain one transaction. The stored run identity is
+authoritative when the transient rejection view omits parent or agent metadata.
+
+`OutboxDeliveryAdapter` claims one FIFO event immediately before each delivery,
+increments the delivery claim epoch, and invokes existing gateway routing. Its
+accepted path retains the stable event identity and retries transient
+durable-ack failures without invoking the destination again. If the original
+claim expires, it reclaims that identity for acknowledgement only, so a
+prolonged coordinator outage cannot redeliver an already accepted completion.
+Its 22-minute lease covers the bounded parent-injection and teardown budgets, so a
+valid slow callback cannot be claimed concurrently. It acknowledges only after
+that callback accepts the event. Exceptions and callback-reported routing failures
+release the matching claim with bounded, overflow-safe exponential backoff.
+Intentional dashboard-queue and digest holds retain the lease-length delay. A
+permanently rejected execution fence stops its
+reporter; periodic recovery owns the nonterminal run rather than an impossible
+retry loop or a duplicate legacy delivery. A queued or immediately dispatched
+dashboard turn and a wave-digest hold defer acknowledgement instead: the event
+remains unavailable to background drainers for one lease window, and the
+consumption/digest-settlement hooks retry transient coordinator errors before
+returning and acknowledge every terminal outcome only after the parent consumes
+it. An acknowledgement that waited for the claim lock rechecks the live fence
+before reclaiming, so it cannot miss a claim installed while it waited. A failed
+or rejected release retains the original delivery fence so an
+immediate consumer acknowledgement can still settle the claimed event. If that
+acknowledgement races a successful release of the original claim,
+it reclaims the stable event identity and settles the new fence. Legacy delivered
+tombstones remain limited to successful runs, while teardown gates retain their
+compatibility role.
+
+Delivery retries retain their manager context. Lifecycle events, orchestration
+tracking, and wave accounting run once; every composed wave chunk keeps a
+detached retry snapshot, so a failed non-final or final route cannot recount a
+member, discard the composed chunk, or mutate later live wave progress. A retry
+retains the tracker that owned its first delivery attempt, observes a stop on
+that owner even if the slot has since armed a new plan, and exits before routing;
+the dashboard route rechecks that owner after awaiting a busy slot and before
+handoff. Only the one-shot accounting mutations are skipped on retry. Cron
+injection exceptions explicitly record a routing failure before returning, so
+the outbox claim remains pending. A non-empty drain result ends a synchronous
+reporter only when its attempt is actually `DELIVERED`; released or pending
+attempts stay in the retry loop. The execution heartbeat remains active across
+transient terminal commit failures and stops only after the terminal event is
+durable (or the coordinator permanently rejects the fence).
+
+The durable completion payload retains the `silent` delivery policy and live
+batch labels, child-session key, resolved model, and redacted requested model.
+Restart rehydration restores the session and model metadata used by completed
+cards, plus `silent`, but clears the batch identity: digest progress is volatile,
+so recovered events route independently instead of synthesizing misleading
+one-member wave completions.
+
+After the dashboard or headless API destination registry is initialized,
+startup reconciliation first reaps any matching live process from the legacy
+folder snapshot, then drains every currently eligible bounded batch of
+coordinator completions, and finally reconciles the legacy folders that remain.
+Both legacy-folder snapshots are offloaded so filesystem traversal cannot block
+the gateway event loop during startup.
+The pre-drain reap closes the crash window where outbox delivery could write a
+delivered tombstone and hide a surviving child from the later folder scan. The
+drain still runs when no legacy orphan exists. Starting the reaper earlier could
+misroute and acknowledge a dashboard completion before its slot exists. The
+periodic reaper retries the same sequence so transient startup delivery failures
+remain recoverable without another process restart.
+Manager shutdown cancels and gathers the one-shot reconciliation task before
+tearing down live agents.
+
+Coordinator-backed injected envelopes include `Event: <event_id>` and
+`meta.subagentCompletion.eventId`. Wave digests carry one `Event:` line for each
+member and all of those identifiers in the additive `eventIds` list, while
+retaining `eventId` for compatibility. Consumers may deduplicate with these
+identifiers; consumers that ignore the additive fields retain at-least-once
+behavior.
 
 ## Constants
 
@@ -298,7 +430,21 @@ Spawn flow:
    approval with a 2-minute timeout. Timeout or rejection frees the
    concurrency slot. For coordinator-admitted work, approval rejection and
    cancellation while queued finish the durable command as rejected before
-   dropping its lease, so lookup and exact replay cannot remain pending.
+   terminal delivery, while retaining the run lease until the terminal outbox
+   event commits, so lookup and exact replay cannot remain pending and recovery
+   cannot race the delivery handoff. Rejecting the command does not itself
+   terminalize the run; the fenced `complete()` transition remains the single
+   authority that records the terminal outcome and creates its outbox event.
+   A queue-drain policy exception or returned rejection uses this same handoff:
+   it retains the command claim, records the rejection, installs live batch
+   routing context before the event becomes claimable, and then commits and
+   delivers the terminal event. Any winning drainer attaches the stable event
+   identity to that live context before invoking a callback, so a deferred
+   destination can record and later settle its acknowledgement debt.
+   Policy failures before task ownership also roll back provisional manager
+   registration, capacity, and stagger state before this terminal handoff.
+   A legacy queued entry has no durable fence, so the timer synthesizes and
+   announces its terminal rejection instead of re-raising after dequeue.
 
 ### Tool Approval Cascade
 
@@ -442,7 +588,7 @@ An unmarked `CancelledError` (see intentional-cancel rule) triggers `_schedule_c
   2. **`if not info.done` — the terminal RECORD.** Error synthesis, failure stat, tombstone, cost. First-arrival-wins, so it is never written twice (pinned by `test_subagent.py::TestOnDoneTimeout::test_force_reap_skips_tombstone_when_already_done`).
   3. **`_release_slot(info)` — SLOT accounting.** A one-shot token per `SubagentInfo`; the winner decrements `_running_count` once and drains the queue. Deliberately independent of both flags above: inferring slot ownership from `done` or `reaped` produced a double decrement in one interleaving and none at all in another. A leaked slot permanently starves the spawn queue, which matters far more at the 60-100 concurrent agents the scale work targets. The cancel-recovery respawn **re-arms** this token when it re-admits a slot (`_running_count += 1`), because the respawned run occupies a fresh slot and needs its own release.
   4. **`_claim_finalize(info)` — REPORT ownership** (`subagent_done` + the `_on_done` injection, plus wave-digest settling and the result.txt TTL bookkeeping). Granted to exactly one caller; contains no `await` so the check-and-set is atomic on the loop. It does **not** consult `info.done` — that was the last defect. It returns False while `_recovering` *without consuming itself*, so a pending respawn is not reported done and its respawned run can claim later.
-- **A claimed report is atomic, not merely exclusive.** The claim alone still lost outcomes when the claimer was cancelled mid-report. `_report_terminal` therefore runs on a strongly-referenced task under `asyncio.shield`, spawned by `_run` **before** its teardown awaits so the task is already live wherever a cancellation lands; the caller still receives `CancelledError` while the report completes. `cancel_all()` drains outstanding reports with a bounded timeout and then **cancels and gathers** any straggler, so none is left invoking `_on_done` against tearing-down state or killed by a closing loop. Because the awaiter is shielded, shutdown is bounded by that drain rather than the `_ON_DONE_TIMEOUT` injection cap. Enforced by `test_subagent_reap_race.py`.
+- **A claimed report is atomic, not merely exclusive.** The claim alone still lost outcomes when the claimer was cancelled mid-report. `_report_terminal` therefore runs on a strongly-referenced task under `asyncio.shield`, spawned by `_run` **before** its teardown awaits so the task is already live wherever a cancellation lands; the caller still receives `CancelledError` while the report completes. Synthetic batch terminals are lifecycle-owned at the synchronous scheduling site and always attempt their coordinator commit even after shutdown begins; only post-commit delivery retries stop at shutdown. Keyed rejection reports use the same shielded ownership, so shutdown cannot cancel their coordinator commit before durable state exists. `cancel_all()` drains outstanding reports with a bounded timeout and then **cancels and gathers** any straggler, so none is left invoking `_on_done` against tearing-down state or killed by a closing loop. Because the awaiter is shielded, shutdown is bounded by that drain rather than the `_ON_DONE_TIMEOUT` injection cap. Enforced by `test_subagent_reap_race.py` and the coordinator delivery regressions.
 - **An undelivered report abandoned at shutdown is made RECOVERABLE, not silently dropped.** The terminal record — including the tombstone — is written before delivery is attempted, and a tombstone is exactly what `list_orphans()` uses to EXCLUDE a folder from the next start's reconciliation. So cancelling a still-pending report at the drain deadline would leave an outcome that was never injected *and* invisible to the only path that could still inject it. `cancel_all()` therefore calls `clear_tombstone(id)` for each report it cancels, re-admitting that agent to the next start's orphan reconciliation (which finds `result.txt` and re-delivers). Extending the drain to `_ON_DONE_TIMEOUT` instead was rejected: it would hold gateway shutdown for up to 20 minutes on one wedged injection, which is the exact failure the bounded drain exists to prevent. Only reports cancelled **before** `_on_done` returned are re-admitted — `info._reported_to_parent` is set the moment the injection returns, so a cancellation in the later teardown/tombstone waits cannot cause a duplicate delivery on restart.
 - **Every reporter goes through the claim — including cancel-recovery failure.** There are more terminal paths than the two obvious ones: when a cancel-recovery respawn cannot happen, its `except` arm also finalizes the agent. That site previously fired `subagent_done` and `_on_done` directly, gated only on `done`/`reaped`, so a reaper racing a failed respawn delivered the outcome twice. It now takes `_claim_finalize` like every other reporter and reports through the shielded helper (which matters because `_force_reap` cancels that very task). `_resume_guarded`'s CancelledError arm writes only the RECORD and deliberately never reports — during shutdown the drain owns delivery.
 - **The reaped marker and the recovery cancel precede every `await` in `_force_reap`.** Both used to sit after the session teardown, which yields for up to `_RESET_TIMEOUT` (longer on the SIGKILL path). A recovery task whose bounded handshake expired inside that window observed `reaped == False` and respawned the run being killed — tools executing after a user Stop, strictly worse than a duplicate report.
@@ -622,11 +768,25 @@ session key flows through the `/api/spawn` endpoint as `parent_session`.
 
 Large waves must not flood the WS socket, the parent LLM's context, or the UI. Five mechanisms — WS coalescing/replay-batching and UI caps are inert below their thresholds; digest chunking applies uniformly to every multi-task wave (single-task spawns behave byte-identical to legacy):
 
+Delivery FIFO survives a route failure: a failed non-final chunk owns the
+wave's next delivery position until its retained snapshot is accepted. Same-wave
+callbacks serialize through route acceptance, so later members remain
+unaccounted and retryable instead of composing or delivering the final chunk
+ahead of an in-flight route. A failed one-shot deadline flush restores the live
+wave snapshot and held clocks; a later forced flush or the real wave close then
+owns every result that was not accepted.
+
 - **Batch identity**: `spawn(batch_id=..., batch_total=...)` (threaded from `spawn_run tasks=[...]` — one 12-hex id per multi-task call — via `POST /api/spawn` transport params; survives the stagger queue). `spawn_batch_started {batch_id, count}` fires once per batch on its first started member; the id rides every WS frame (`base["batch_id"]`).
 - **Event coalescing** (`subagent_scale.SubagentEventCoalescer`, wired in the gateway's `_subagent_event`): above 8 active agents, `subagent_tool`/`subagent_stalled`/`subagent_retrying` buffer per-agent (latest state wins, merged) and flush every ~1s as ONE `subagent_batch_update {updates:[...]}` frame to all clients; `subagent_chunk` text buffers append-concatenated (16KB/agent cap) and flushes as `subagent_batch_chunks {chunks:[...]}` to subagent subscribers only. Lifecycle events (`spawn`/`done`/`recovering`/`injection_failed`/`batch_*`) are NEVER coalesced, and a `done`/`spawn` flushes buffered state first so ordering is preserved. Non-int active-count fails open to pass-through.
-- **Chunked wave-digest completion injection** (gateway `_subagent_done`): every batch member is accounted per `batch_id` (this is the single completion consumer for all terminal paths). Every multi-task wave (`batch_total > 1`) delivers results to the parent queue-style: completed members are HELD, and every `SUBAGENT_DIGEST_CHUNK_SIZE` completions (default 10, env `KIROCREW_SUBAGENT_DIGEST_CHUNK_SIZE`, clamped 1..1000) flush ONE `[Subagent batch completion event]` chunk digest — failures first with detail, successes as one-line `result_path` pointers (60KB cap per chunk); the final member flushes the remaining partial chunk. A 60-agent wave = 6 digest turns spread across the wave's runtime — bounded chunk size, incremental signal, and no straggler-gated mega-digest. Chunk buffers (`fail_lines`/`ok_lines`/`guard_msgs`/`held_ok_ids`) reset per flush; cumulative `ok`/`err`/`stopped` counts ride the final chunk's summary. **Spawn discipline**: non-final chunks instruct the parent NOT to spawn new sub-agents while batches are still arriving; the final chunk releases the gate ("finish processing all results before spawning follow-ups") — mirrored by a line in the `spawn_run` tool description. **Chunk order is FIFO**: the injection busy-check (`_injection_slot_busy`) treats a live `slot.task` — the claim assigned synchronously at dispatch — as busy in addition to `slot.running`, so a later chunk waits behind an injection that is dispatched but still inside `bounded_chat_turn`'s off-loop timeout resolution, instead of racing ahead of it or assigning `slot.task` over the earlier chunk's still-pending task. Single-task spawns have no batch identity and keep the plain per-agent injection. A batch member rejected at spawn (empty task, low memory, cwd, governance, bad agent) is counted as submitted AND announced through the done callback with its batch identity (`_announce_rejection`) — so a rejection that closes the wave still reaches the consumer and releases held sibling results (non-batch rejections do not announce; the caller gets the error synchronously). `batch_finished {batch_id, total, ok, err, stopped}` broadcasts for every batch regardless of size. **Wave liveness (lost-submission backstop)**: a member rejected before reaching `spawn()` or lost during transport is counted in every sibling's `batch_total` but never in `submitted` — un-reconciled, the count-driven `batch_members_pending()` wedges the wave forever. Three layers close it: (1) `api_spawn` marks only rejections/capacity reached after manager admission with `counted: true` (preserved through the MCP client's error flattening); coordinator identity conflicts occur before manager admission and remain uncounted; (2) `spawn_run` best-effort POSTs `/api/spawn/lost` for each explicit UNcounted rejection, which calls `record_lost_submission` — counts the member as submitted and announces a synthetic terminal failure through the completion consumer so the wave closes; uncertain transport failures are not immediately reconciled because the gateway may have accepted them; (3) the reaper's `_sweep_stuck_waves` (every sweep) force-reconciles uncertain or lost submissions when `submitted < expected`, all registered members are terminal, nothing is queued, and no submission progress occurred for `_WAVE_STUCK_SECS` (1800s / 30 minutes — deliberately generous, symmetric with the per-agent hard ceiling) — one lost member per sweep, converging across sweeps; this also bounds the `_batch_submitted`/`_batch_progress_ts` leak. Straggler-held partial chunks are bounded by the **hold deadline** (below), not by the member's 30-minute hard ceiling.
+- **Chunked wave-digest completion injection** (gateway `_subagent_done`): every batch member is accounted per `batch_id` (this is the single completion consumer for all terminal paths). Every multi-task wave (`batch_total > 1`) delivers results to the parent queue-style: completed members are HELD, and every `SUBAGENT_DIGEST_CHUNK_SIZE` completions (default 10, env `KIROCREW_SUBAGENT_DIGEST_CHUNK_SIZE`, clamped 1..1000) flush ONE `[Subagent batch completion event]` chunk digest — failures first with detail, successes as one-line `result_path` pointers (60KB cap per chunk); the final member flushes the remaining partial chunk. A 60-agent wave = 6 digest turns spread across the wave's runtime — bounded chunk size, incremental signal, and no straggler-gated mega-digest. Chunk buffers (`fail_lines`/`ok_lines`/`guard_msgs`/`held_delivery_ids`) reset per flush; cumulative `ok`/`err`/`stopped` counts ride the final chunk's summary. **Spawn discipline**: non-final chunks instruct the parent NOT to spawn new sub-agents while batches are still arriving; the final chunk releases the gate ("finish processing all results before spawning follow-ups") — mirrored by a line in the `spawn_run` tool description. **Chunk order is FIFO**: the injection busy-check (`_injection_slot_busy`) treats a live `slot.task` — the claim assigned synchronously at dispatch — as busy in addition to `slot.running`, so a later chunk waits behind an injection that is dispatched but still inside `bounded_chat_turn`'s off-loop timeout resolution, instead of racing ahead of it or assigning `slot.task` over the earlier chunk's still-pending task. A failed non-final chunk owns the next FIFO position only when it carries a stable coordinator outbox event that can replay it exactly. Batch rejections and lost-submission records have no worker lifecycle to create that event, so `_safe_announce` first persists each as a synthetic coordinator terminal and routes its outbox event; a failed final chunk can then be reclaimed exactly instead of losing already-held siblings when the live wave closes. Any remaining callback without a stable event restores its composed buffers to the live wave rather than becoming an unreplayable retry owner. Single-task spawns have no batch identity and keep the plain per-agent injection. A batch member rejected at spawn (empty task, low memory, cwd, governance, bad agent) is counted as submitted AND announced through the done callback with its batch identity (`_announce_rejection`) — so a rejection that closes the wave still reaches the consumer and releases held sibling results (non-batch rejections do not announce; the caller gets the error synchronously). `batch_finished {batch_id, total, ok, err, stopped}` broadcasts for every batch regardless of size. **Wave liveness (lost-submission backstop)**: a member rejected before reaching `spawn()` or lost during transport is counted in every sibling's `batch_total` but never in `submitted` — un-reconciled, the count-driven `batch_members_pending()` wedges the wave forever. Three layers close it: (1) `api_spawn` marks only rejections/capacity reached after manager admission with `counted: true` (preserved through the MCP client's error flattening); coordinator identity conflicts occur before manager admission and remain uncounted; (2) `spawn_run` best-effort POSTs `/api/spawn/lost` for each explicit UNcounted rejection, which calls `record_lost_submission` — counts the member as submitted and announces a synthetic terminal failure through the completion consumer so the wave closes; uncertain transport failures are not immediately reconciled because the gateway may have accepted them; (3) the reaper's `_sweep_stuck_waves` (every sweep) force-reconciles uncertain or lost submissions when `submitted < expected`, all registered members are terminal, nothing is queued, and no submission progress occurred for `_WAVE_STUCK_SECS` (1800s / 30 minutes — deliberately generous, symmetric with the per-agent hard ceiling) — one lost member per sweep, converging across sweeps; this also bounds the `_batch_submitted`/`_batch_progress_ts` leak. Straggler-held partial chunks are bounded by the **hold deadline** (below), not by the member's 30-minute hard ceiling.
 
 - **Digest hold deadline (straggler escape hatch)**: both chunk triggers are event-driven — a COUNT trigger (`SUBAGENT_DIGEST_CHUNK_SIZE` pending completions) and wave close — so neither can fire while a straggler is simply *not finishing*. With the default count (10) above any wave size the concurrency cap realistically produces (2–5), the count trigger is unreachable and wave close becomes the ONLY flush: every sibling's finished result is withheld for the slowest member's entire remaining runtime, and a member that HANGS rather than fails withholds them for the full `_TIMEOUT_SECS` reap — up to 30 minutes of total silence, indistinguishable from a dead session (issue #2215). The reaper's `_sweep_digest_holds` supplies the LATENCY trigger the count lacks: when the OLDEST outstanding hold in a live wave ages past `DIGEST_HOLD_SECS` (default 120s, env `KIROCREW_SUBAGENT_DIGEST_HOLD_SECS`, clamped to `_TIMEOUT_SECS`; `0` opts back out to count-trigger-only), `force_digest_flush` announces a synthetic **flush-only** record through the single completion consumer — the same re-entry mechanism `record_lost_submission` uses, so digest composition, routing, and the held-tombstone settle contract stay in one place. The record carries the wave's `batch_id` but is NOT a member: `_digest_flush_only` makes the gateway skip every per-member side effect (terminal WS event, orchestration tracker accounting, `done`/`ok`/`err` counters, digest lines) and only force the pending chunk out. **One knob, two jobs, now split**: the count keeps bounding digest SIZE for large waves; the deadline caps worst-case delivery LATENCY at every wave size. A wave whose members all finish within the deadline of each other still delivers ONE consolidated digest, so the deliberate small-wave behavior is unchanged. The forced chunk is labelled honestly as a PARTIAL release (`k/k+1`, "N of M delivered, R still running") and tells the parent to synthesize what it has rather than keep waiting. Hold bookkeeping: the gateway stamps `_digest_held_at` when it holds a member and clears it when that member's chunk fires — deliberately separate from `_digest_held`, which is the restart-safety flag the run loop reads and which the sweep must never mutate. The sweep is skipped entirely when `batch_members_pending()` is False, so it can never race the real wave-close digest into a duplicate delivery.
+Wave closure is based on accounted terminal callbacks, never live manager
+membership. A completed callback can already be absent from the manager registry
+while it waits behind the per-wave routing lock. Rejections and lost submissions
+reach the same consumer through synthetic terminal events, with stuck-wave
+recovery as the delayed backstop.
+
 - **Reconnect replay batching** (`ws.py`): more than `SUBAGENT_REPLAY_BATCH_THRESHOLD` (8) replay frames collapse into ONE `subagent_snapshot_batch {items:[{type, data}]}` frame; the client fans items into the per-frame reducers.
 - **Stall two-sweep confirmation** (`_maybe_flag_stall`): the first reaper sweep past `_stall_idle_secs` only marks `_stall_suspect_at`; the second consecutive idle sweep flags `stalled` (event + slow-command record). Any stream activity that BELONGS to the session (`_touch_activity`) resets the suspicion; a `runtime_global` frame fanned out to co-tenants does not. Adds ≤1 sweep interval (~60s) latency; prevents alarm fatigue from healthy-slow agents ambering at scale.
 
@@ -768,6 +928,10 @@ On startup, `SubagentManager` scans `~/.kiro/crew/subagents/` and reconciles:
 3. **PID dead + no result** → write tombstone with "orphaned" error
 
 **Orphan delivery is wired** (not a stub): the gateway registers `on_orphan_notify` (session injection — rides the parent slot's batched pending-failures drain) and `on_orphan_dm` (fallback). The DM fallback collects every undelivered orphan across the reconciliation scan and sends ONE digest message (`"N subagent(s)…"`) — never N pings; a lone orphan keeps the plain per-agent message.
+
+Legacy folder orphan scans and their identity-checked process reaping run off
+the event loop; process-tree termination may invoke bounded platform tools on
+Windows and must not stall gateway traffic.
 
 ### Tombstone Lifecycle
 

--- a/src/kiro_crew/run_coordinator/__init__.py
+++ b/src/kiro_crew/run_coordinator/__init__.py
@@ -1,5 +1,6 @@
 """Typed run coordination boundary for subagent lifecycle state."""
 
+from .delivery import DeliveryAttempt, OutboxDeliveryAdapter
 from .memory import MemoryRunCoordinator
 from .models import (
     CommandClaim,
@@ -25,6 +26,8 @@ from .models import (
     SubmitControl,
     SubmitReceipt,
     SubmitRun,
+    TerminalReceipt,
+    TerminalRun,
 )
 from .shadow import ShadowRunCoordinator
 from .sqlite import SQLiteRunCoordinator
@@ -38,11 +41,13 @@ __all__ = [
     "CoordinatorDecision",
     "CoordinatorReason",
     "CoordinatorResult",
+    "DeliveryAttempt",
     "DeliveryFence",
     "DeliveryState",
     "DesiredState",
     "MemoryRunCoordinator",
     "ObservedState",
+    "OutboxDeliveryAdapter",
     "OutboxEvent",
     "OwnerLease",
     "RunCommand",
@@ -54,6 +59,8 @@ __all__ = [
     "SubmitReceipt",
     "SubmitControl",
     "SubmitRun",
+    "TerminalReceipt",
+    "TerminalRun",
     "SQLiteRunCoordinator",
     "ShadowRunCoordinator",
 ]

--- a/src/kiro_crew/run_coordinator/delivery.py
+++ b/src/kiro_crew/run_coordinator/delivery.py
@@ -1,0 +1,225 @@
+"""Fenced delivery of committed run-coordinator outbox events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from .models import (
+    CoordinatorDecision,
+    CoordinatorResult,
+    DeliveryFence,
+    DeliveryState,
+    OutboxEvent,
+    OwnerLease,
+    RunCoordinator,
+)
+
+logger = logging.getLogger(__name__)
+
+# The destination includes the manager's 20-minute parent-injection cap plus
+# up to 60 seconds of teardown. A claim must remain fenced for that entire
+# valid attempt or another drainer can deliver the same completion concurrently.
+_DELIVERY_LEASE_SECONDS = 22 * 60.0
+_RETRY_BASE_SECONDS = 1.0
+_RETRY_MAX_SECONDS = 300.0
+_MAX_RETRY_EXPONENT = 63
+
+
+@dataclass(frozen=True)
+class DeliveryAttempt:
+    """Observable result of one claimed delivery event."""
+
+    event_id: str
+    status: DeliveryState
+
+
+class OutboxDeliveryAdapter:
+    """Claim, deliver, and acknowledge events through one fenced boundary.
+
+    The destination returns ``True`` only after it has durably accepted the
+    event. ``False`` means delivery was intentionally deferred (for example, a
+    dashboard turn queue owns it); the event becomes pending after one lease
+    window while the eventual consumer may acknowledge the same stable identity.
+    """
+
+    def __init__(
+        self,
+        coordinator: RunCoordinator,
+        destination: Callable[[OutboxEvent], Awaitable[bool]],
+        *,
+        owner_id: str | None = None,
+        clock: Callable[[], float] = time.time,
+        lease_seconds: float = _DELIVERY_LEASE_SECONDS,
+        retry_base_seconds: float = _RETRY_BASE_SECONDS,
+        retry_max_seconds: float = _RETRY_MAX_SECONDS,
+    ) -> None:
+        self._coordinator = coordinator
+        self._destination = destination
+        self._owner_id = owner_id or f"delivery:{uuid.uuid4().hex}"
+        self._clock = clock
+        self._lease_seconds = max(1.0, lease_seconds)
+        self._retry_base_seconds = max(0.0, retry_base_seconds)
+        self._retry_max_seconds = max(self._retry_base_seconds, retry_max_seconds)
+        self._lock = asyncio.Lock()
+        self._inflight: dict[str, DeliveryFence] = {}
+        self._accepted: set[str] = set()
+
+    def _owner_lease(self) -> OwnerLease:
+        return OwnerLease(self._owner_id, self._clock() + self._lease_seconds)
+
+    @staticmethod
+    def _fence(event: OutboxEvent) -> DeliveryFence:
+        return DeliveryFence(event.event_id, event.claim_owner, event.claim_epoch)
+
+    def _retry_at(self, attempts: int) -> float:
+        exponent = min(max(0, attempts - 1), _MAX_RETRY_EXPONENT)
+        delay = min(
+            self._retry_max_seconds,
+            self._retry_base_seconds * (2**exponent),
+        )
+        return self._clock() + delay
+
+    async def _acknowledge_accepted(self, fence: DeliveryFence) -> CoordinatorResult[OutboxEvent]:
+        """Retain an accepted event's fence until its durable ack settles."""
+
+        failures = 0
+        while True:
+            try:
+                result = await self._coordinator.mark_delivered(fence)
+                if result.decision is not CoordinatorDecision.REJECTED:
+                    self._accepted.discard(fence.event_id)
+                    if self._inflight.get(fence.event_id) == fence:
+                        self._inflight.pop(fence.event_id, None)
+                    return result
+                async with self._lock:
+                    claimed = await self._coordinator.claim_outbox(
+                        self._owner_lease(),
+                        1,
+                        event_id=fence.event_id,
+                        acknowledgement=True,
+                    )
+                    if not claimed:
+                        return result
+                    fence = self._fence(claimed[0])
+                    self._inflight[fence.event_id] = fence
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                failures += 1
+                logger.warning(
+                    "Outbox acknowledgement failed for accepted event %s",
+                    fence.event_id,
+                    exc_info=True,
+                )
+                exponent = min(failures - 1, _MAX_RETRY_EXPONENT)
+                delay = min(
+                    self._retry_max_seconds,
+                    self._retry_base_seconds * (2**exponent),
+                )
+                await asyncio.sleep(delay)
+
+    async def drain_once(self, limit: int = 16, event_id: str = "") -> list[DeliveryAttempt]:
+        """Deliver one bounded claim batch, optionally for one exact event."""
+
+        if limit <= 0:
+            return []
+        attempts: list[DeliveryAttempt] = []
+        for _ in range(limit):
+            # Claim only when the destination is about to run. A batch claim
+            # would spend later events' lease while an earlier callback waits.
+            async with self._lock:
+                claimed = await self._coordinator.claim_outbox(
+                    self._owner_lease(),
+                    1,
+                    event_id=event_id,
+                )
+                if not claimed:
+                    break
+                event = claimed[0]
+                self._inflight[event.event_id] = self._fence(event)
+            fence = self._fence(event)
+            settled = False
+            try:
+                if event.event_id in self._accepted:
+                    result = await self._acknowledge_accepted(fence)
+                else:
+                    try:
+                        accepted = await self._destination(event)
+                    except asyncio.CancelledError:
+                        released = await self._coordinator.release_outbox(
+                            fence,
+                            self._retry_at(event.attempts),
+                        )
+                        settled = released.decision is not CoordinatorDecision.REJECTED
+                        raise
+                    except Exception:
+                        logger.warning(
+                            "Outbox delivery failed for event %s",
+                            event.event_id,
+                            exc_info=True,
+                        )
+                        released = await self._coordinator.release_outbox(
+                            fence,
+                            self._retry_at(event.attempts),
+                        )
+                        settled = released.decision is not CoordinatorDecision.REJECTED
+                        if released.value is not None:
+                            attempts.append(DeliveryAttempt(event.event_id, released.value.status))
+                        continue
+
+                    if accepted:
+                        self._accepted.add(event.event_id)
+                        result = await self._acknowledge_accepted(fence)
+                    else:
+                        result = await self._coordinator.release_outbox(
+                            fence,
+                            self._clock() + self._lease_seconds,
+                        )
+                settled = result.decision is not CoordinatorDecision.REJECTED
+                if result.value is not None:
+                    attempts.append(DeliveryAttempt(event.event_id, result.value.status))
+            finally:
+                if settled and self._inflight.get(event.event_id) == fence:
+                    self._inflight.pop(event.event_id, None)
+            if event_id:
+                break
+        return attempts
+
+    async def acknowledge(self, event_id: str) -> OutboxEvent | None:
+        """Acknowledge an event already accepted by a deferred destination."""
+
+        fence = self._inflight.get(event_id)
+        if fence is not None:
+            result = await self._coordinator.mark_delivered(fence)
+            if result.decision is not CoordinatorDecision.REJECTED:
+                if self._inflight.get(event_id) == fence:
+                    self._inflight.pop(event_id, None)
+                return result.value
+            # A deferred destination can settle just after drain_once releases
+            # its claim. Re-claim the stable event identity instead of dropping
+            # that acknowledgement because the captured fence became stale.
+        async with self._lock:
+            fence = self._inflight.get(event_id)
+            if fence is not None:
+                result = await self._coordinator.mark_delivered(fence)
+                if result.decision is not CoordinatorDecision.REJECTED:
+                    if self._inflight.get(event_id) == fence:
+                        self._inflight.pop(event_id, None)
+                    return result.value
+            claimed = await self._coordinator.claim_outbox(
+                self._owner_lease(),
+                1,
+                event_id=event_id,
+                acknowledgement=True,
+            )
+            if not claimed:
+                return None
+            result = await self._coordinator.mark_delivered(self._fence(claimed[0]))
+            if result.decision is CoordinatorDecision.REJECTED:
+                return None
+            return result.value

--- a/src/kiro_crew/run_coordinator/memory.py
+++ b/src/kiro_crew/run_coordinator/memory.py
@@ -32,6 +32,8 @@ from .models import (
     SubmitControl,
     SubmitReceipt,
     SubmitRun,
+    TerminalReceipt,
+    TerminalRun,
 )
 
 _EXECUTION_COMMANDS = frozenset({CommandOperation.SPAWN, CommandOperation.CONTINUE})
@@ -219,6 +221,143 @@ class MemoryRunCoordinator:
                 )
             return self._result(CoordinatorDecision.APPLIED, CoordinatorReason.CREATED, receipt)
 
+    async def record_terminal(self, request: TerminalRun) -> CoordinatorResult[TerminalReceipt]:
+        """Atomically create a terminal-only run and its pending delivery event."""
+
+        async with self._lock:
+            key = (request.run_id, request.event_type)
+            existing = self._runs.get(request.run_id)
+            if existing is not None:
+                event_id = self._outbox_by_run_type.get(key)
+                event = self._outbox.get(event_id) if event_id is not None else None
+                rejected_execution = any(
+                    command.run_id == request.run_id
+                    and command.operation in _EXECUTION_COMMANDS
+                    and command.status is CommandStatus.REJECTED
+                    for command in self._commands.values()
+                )
+                identity_matches = (
+                    request.task == existing.task
+                    and (
+                        not request.parent_session
+                        or request.parent_session == existing.parent_session
+                    )
+                    and (not request.agent or request.agent == existing.agent)
+                    and (
+                        not request.conversation_key
+                        or request.conversation_key == existing.conversation_key
+                    )
+                )
+                destination = request.destination or existing.parent_session
+                if (
+                    identity_matches
+                    and existing.observed_state is ObservedState.TERMINAL
+                    and existing.outcome is request.outcome
+                    and existing.result_path == request.result_path
+                    and existing.error == request.error
+                    and (rejected_execution or existing.created_at == request.created_at)
+                    and existing.terminal_at == request.terminal_at
+                    and event is not None
+                    and event.destination == destination
+                    and event.payload_json == request.payload_json
+                ):
+                    return self._result(
+                        CoordinatorDecision.UNCHANGED,
+                        CoordinatorReason.COMPLETION_REPLAY,
+                        TerminalReceipt(existing, event, created=False),
+                    )
+                if (
+                    rejected_execution
+                    and identity_matches
+                    and existing.observed_state is ObservedState.ACCEPTED
+                    and event is None
+                ):
+                    now = self._clock()
+                    run = replace(
+                        existing,
+                        observed_state=ObservedState.TERMINAL,
+                        outcome=request.outcome,
+                        result_path=request.result_path,
+                        error=request.error,
+                        version=existing.version + 1,
+                        updated_at=now,
+                        terminal_at=request.terminal_at,
+                    )
+                    event = OutboxEvent(
+                        event_id=self._id_factory(),
+                        run_id=run.run_id,
+                        run_version=run.version,
+                        destination=destination,
+                        event_type=request.event_type,
+                        payload_json=request.payload_json,
+                        status=DeliveryState.PENDING,
+                        attempts=0,
+                        available_at=now,
+                        claim_owner="",
+                        claim_expires_at=0.0,
+                        claim_epoch=0,
+                        created_at=now,
+                        delivered_at=None,
+                    )
+                    self._runs[run.run_id] = run
+                    self._outbox[event.event_id] = event
+                    self._outbox_by_run_type[key] = event.event_id
+                    return self._result(
+                        CoordinatorDecision.APPLIED,
+                        CoordinatorReason.COMPLETED,
+                        TerminalReceipt(run, event, created=True),
+                    )
+                return self._result(
+                    CoordinatorDecision.REJECTED,
+                    CoordinatorReason.OUTCOME_CONFLICT,
+                )
+
+            now = self._clock()
+            run = RunRecord(
+                run_id=request.run_id,
+                parent_session=request.parent_session,
+                agent=request.agent,
+                task=request.task,
+                conversation_key=request.conversation_key,
+                desired_state=DesiredState.RUN,
+                observed_state=ObservedState.TERMINAL,
+                outcome=request.outcome,
+                result_path=request.result_path,
+                error=request.error,
+                attempt=1,
+                version=1,
+                owner_id="",
+                lease_expires_at=0.0,
+                lease_epoch=0,
+                created_at=request.created_at,
+                updated_at=now,
+                terminal_at=request.terminal_at,
+            )
+            event = OutboxEvent(
+                event_id=self._id_factory(),
+                run_id=run.run_id,
+                run_version=run.version,
+                destination=request.destination,
+                event_type=request.event_type,
+                payload_json=request.payload_json,
+                status=DeliveryState.PENDING,
+                attempts=0,
+                available_at=now,
+                claim_owner="",
+                claim_expires_at=0.0,
+                claim_epoch=0,
+                created_at=now,
+                delivered_at=None,
+            )
+            self._runs[run.run_id] = run
+            self._outbox[event.event_id] = event
+            self._outbox_by_run_type[key] = event.event_id
+            return self._result(
+                CoordinatorDecision.APPLIED,
+                CoordinatorReason.COMPLETED,
+                TerminalReceipt(run, event, created=True),
+            )
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None:
         async with self._lock:
             command_id = self._command_by_key.get(idempotency_key)
@@ -400,19 +539,6 @@ class MemoryRunCoordinator:
                 updated_at=self._clock(),
             )
             self._commands[command.command_id] = command
-            if status is CommandStatus.REJECTED and command.operation in _EXECUTION_COMMANDS:
-                run = self._runs.get(command.run_id)
-                if run is not None and run.observed_state in _STARTABLE_STATES:
-                    now = self._clock()
-                    self._runs[run.run_id] = replace(
-                        run,
-                        observed_state=ObservedState.TERMINAL,
-                        outcome=RunOutcome.FAILED,
-                        error=rejection_reason,
-                        version=run.version + 1,
-                        updated_at=now,
-                        terminal_at=now,
-                    )
             return self._result(
                 CoordinatorDecision.APPLIED,
                 CoordinatorReason.TRANSITIONED,
@@ -420,7 +546,13 @@ class MemoryRunCoordinator:
             )
 
     def _validate_transition(
-        self, run_id: str, fence: RunFence, expected_version: int, *, now: float
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+        *,
+        now: float,
+        allow_expired: bool = False,
     ) -> CoordinatorResult[RunRecord] | RunRecord:
         run = self._runs.get(run_id)
         if run is None:
@@ -429,7 +561,7 @@ class MemoryRunCoordinator:
             fence.run_id != run_id
             or run.owner_id != fence.owner_id
             or run.lease_epoch != fence.lease_epoch
-            or run.lease_expires_at <= now
+            or (not allow_expired and run.lease_expires_at <= now)
         ):
             return self._result(CoordinatorDecision.REJECTED, CoordinatorReason.STALE_FENCE)
         if run.version != expected_version:
@@ -443,7 +575,15 @@ class MemoryRunCoordinator:
             now = self._clock()
             validated = self._validate_transition(command.run_id, fence, expected_version, now=now)
             if isinstance(validated, CoordinatorResult):
-                return validated
+                current = self._runs.get(command.run_id)
+                if not (
+                    validated.reason is CoordinatorReason.VERSION_CONFLICT
+                    and current is not None
+                    and current.version == expected_version + 1
+                    and current.observed_state is ObservedState.STARTING
+                ):
+                    return validated
+                validated = current
             stored = self._commands.get(command.command_id)
             if (
                 stored is None
@@ -469,11 +609,6 @@ class MemoryRunCoordinator:
                 updated_at=now,
             )
             self._runs[updated.run_id] = updated
-            self._commands[stored.command_id] = replace(
-                stored,
-                status=CommandStatus.APPLIED,
-                updated_at=self._clock(),
-            )
             return self._result(
                 CoordinatorDecision.APPLIED, CoordinatorReason.TRANSITIONED, updated
             )
@@ -485,7 +620,15 @@ class MemoryRunCoordinator:
             now = self._clock()
             validated = self._validate_transition(run_id, fence, expected_version, now=now)
             if isinstance(validated, CoordinatorResult):
-                return validated
+                current = self._runs.get(run_id)
+                if not (
+                    validated.reason is CoordinatorReason.VERSION_CONFLICT
+                    and current is not None
+                    and current.version == expected_version + 1
+                    and current.observed_state is ObservedState.RUNNING
+                ):
+                    return validated
+                validated = current
             if validated.observed_state is ObservedState.RUNNING:
                 return self._result(
                     CoordinatorDecision.UNCHANGED, CoordinatorReason.TRANSITIONED, validated
@@ -541,8 +684,15 @@ class MemoryRunCoordinator:
                     CoordinatorDecision.REJECTED, CoordinatorReason.OUTCOME_CONFLICT
                 )
             now = self._clock()
+            # Expiry makes a run eligible for takeover; the monotonic epoch is
+            # the fence. Let the current epoch commit its terminal result when
+            # no recovery owner won that race, including after host suspend.
             validated = self._validate_transition(
-                completion.run_id, fence, expected_version, now=now
+                completion.run_id,
+                fence,
+                expected_version,
+                now=now,
+                allow_expired=True,
             )
             if isinstance(validated, CoordinatorResult):
                 return self._result(validated.decision, validated.reason)
@@ -626,7 +776,13 @@ class MemoryRunCoordinator:
                     )
             return True
 
-    async def claim_outbox(self, owner: OwnerLease, limit: int) -> list[OutboxEvent]:
+    async def claim_outbox(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        event_id: str = "",
+        acknowledgement: bool = False,
+    ) -> list[OutboxEvent]:
         if limit <= 0:
             return []
         async with self._lock:
@@ -639,7 +795,11 @@ class MemoryRunCoordinator:
             ):
                 if len(claimed) >= limit:
                     break
-                pending = current.status is DeliveryState.PENDING and current.available_at <= now
+                if event_id and current.event_id != event_id:
+                    continue
+                pending = current.status is DeliveryState.PENDING and (
+                    (acknowledgement and bool(event_id)) or current.available_at <= now
+                )
                 expired = (
                     current.status is DeliveryState.CLAIMED and current.claim_expires_at <= now
                 )

--- a/src/kiro_crew/run_coordinator/models.py
+++ b/src/kiro_crew/run_coordinator/models.py
@@ -225,6 +225,30 @@ class CommandReceipt:
     created: bool
 
 
+@dataclass(frozen=True)
+class TerminalRun:
+    run_id: str
+    parent_session: str
+    agent: str
+    task: str
+    conversation_key: str
+    outcome: RunOutcome
+    result_path: str
+    error: str
+    created_at: float
+    terminal_at: float
+    event_type: str
+    destination: str
+    payload_json: str
+
+
+@dataclass(frozen=True)
+class TerminalReceipt:
+    run: RunRecord
+    event: OutboxEvent
+    created: bool
+
+
 T = TypeVar("T")
 
 
@@ -239,6 +263,8 @@ class RunCoordinator(Protocol):
     async def submit(self, request: SubmitRun) -> CoordinatorResult[SubmitReceipt]: ...
 
     async def submit_control(self, request: SubmitControl) -> CoordinatorResult[CommandReceipt]: ...
+
+    async def record_terminal(self, request: TerminalRun) -> CoordinatorResult[TerminalReceipt]: ...
 
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None: ...
 
@@ -280,7 +306,13 @@ class RunCoordinator(Protocol):
 
     async def renew(self, run_id: str, fence: RunFence, until: float) -> bool: ...
 
-    async def claim_outbox(self, owner: OwnerLease, limit: int) -> list[OutboxEvent]: ...
+    async def claim_outbox(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        event_id: str = "",
+        acknowledgement: bool = False,
+    ) -> list[OutboxEvent]: ...
 
     async def release_outbox(
         self, fence: DeliveryFence, available_at: float

--- a/src/kiro_crew/run_coordinator/shadow.py
+++ b/src/kiro_crew/run_coordinator/shadow.py
@@ -26,6 +26,8 @@ from .models import (
     SubmitControl,
     SubmitReceipt,
     SubmitRun,
+    TerminalReceipt,
+    TerminalRun,
 )
 
 logger = logging.getLogger(__name__)
@@ -145,6 +147,12 @@ class ShadowRunCoordinator:
             await self._mirror("submit_control", request),
         )
 
+    async def record_terminal(self, request: TerminalRun) -> CoordinatorResult[TerminalReceipt]:
+        return cast(
+            CoordinatorResult[TerminalReceipt],
+            await self._mirror("record_terminal", request),
+        )
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None:
         return cast(
             CommandReceipt | None,
@@ -231,8 +239,17 @@ class ShadowRunCoordinator:
     async def renew(self, run_id: str, fence: RunFence, until: float) -> bool:
         return cast(bool, await self._mirror("renew", run_id, fence, until))
 
-    async def claim_outbox(self, owner: OwnerLease, limit: int) -> list[OutboxEvent]:
-        return cast(list[OutboxEvent], await self._mirror("claim_outbox", owner, limit))
+    async def claim_outbox(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        event_id: str = "",
+        acknowledgement: bool = False,
+    ) -> list[OutboxEvent]:
+        return cast(
+            list[OutboxEvent],
+            await self._mirror("claim_outbox", owner, limit, event_id, acknowledgement),
+        )
 
     async def release_outbox(
         self, fence: DeliveryFence, available_at: float

--- a/src/kiro_crew/run_coordinator/sqlite.py
+++ b/src/kiro_crew/run_coordinator/sqlite.py
@@ -43,6 +43,8 @@ from .models import (
     SubmitControl,
     SubmitReceipt,
     SubmitRun,
+    TerminalReceipt,
+    TerminalRun,
 )
 
 _SCHEMA_VERSION = 3
@@ -529,6 +531,9 @@ class SQLiteRunCoordinator:
     async def submit_control(self, request: SubmitControl) -> CoordinatorResult[CommandReceipt]:
         return await self._offload("submit_control", request)
 
+    async def record_terminal(self, request: TerminalRun) -> CoordinatorResult[TerminalReceipt]:
+        return await self._offload("record_terminal", request)
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None:
         return await self._offload("get_command_by_key", idempotency_key, persist=False)
 
@@ -591,8 +596,14 @@ class SQLiteRunCoordinator:
     async def renew(self, run_id: str, fence: RunFence, until: float) -> bool:
         return await self._offload("renew", run_id, fence, until)
 
-    async def claim_outbox(self, owner: OwnerLease, limit: int) -> list[OutboxEvent]:
-        return await self._offload("claim_outbox", owner, limit)
+    async def claim_outbox(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        event_id: str = "",
+        acknowledgement: bool = False,
+    ) -> list[OutboxEvent]:
+        return await self._offload("claim_outbox", owner, limit, event_id, acknowledgement)
 
     async def release_outbox(
         self, fence: DeliveryFence, available_at: float

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -6013,14 +6013,14 @@ class GatewayOrchestrator:
     def _defer_queued_delivery(
         slot: Any, announce: str, info: SubagentInfo, *, flush_only: bool
     ) -> None:
-        """Owe a queued completion's delivery tombstones to the queue drain.
+        """Owe dashboard delivery state to the turn that consumes the event.
 
         The retention window for ``result.txt`` (``agent.subagent_result_ttl_secs``)
         exists so the parent can read the full transcript AFTER the completion
         event reaches it. Writing the ``delivered`` tombstone when the announce is
-        merely QUEUED starts that clock while the event is still waiting for a
-        turn, so a long-running turn ahead of it lets the reaper prune every file
-        the queued announce points at (issue #4839).
+        merely queued or scheduled starts that clock before the model consumes
+        the prompt. A long-running turn ahead of it can then let the reaper prune
+        every file the announce points at (issue #4839).
 
         So the ids are handed to the slot keyed on the announce ITSELF,
         ``_delivery_queued`` tells the run loop to skip its own ``mark_delivered``,
@@ -6037,13 +6037,14 @@ class GatewayOrchestrator:
         immediate-tombstone behaviour stands — better a short window than a
         folder no one ever tombstones.
         """
-        # A flush-only record is synthetic (no run, no folder of its own). Only a
-        # COMPLETED member owes a delivered mark: ``info.outcome`` is the codebase's
-        # canonical three-way classification precisely because the ``error``-
-        # nullability idiom reports a user-stopped agent as completed, and a
-        # stopped or failed run already carries its own tombstone whose 7-day
-        # post-mortem window a "delivered" write would shorten to the result TTL.
-        owed: list[str] = [] if (flush_only or info.outcome != "completed") else [info.id]
+        # A flush-only record is synthetic (no run or event of its own). Every
+        # durable event owes an outbox acknowledgement, while only a COMPLETED
+        # member also owes the legacy delivered tombstone; failed/stopped runs
+        # keep their longer post-mortem retention window.
+        durable_event = bool(info._delivery_event_id)
+        owed: list[str] = (
+            [] if flush_only or (info.outcome != "completed" and not durable_event) else [info.id]
+        )
         held = getattr(info, "_digest_settle_ids", None)
         if isinstance(held, list):
             owed.extend(str(h) for h in held)
@@ -6453,7 +6454,11 @@ class GatewayOrchestrator:
             _task.add_done_callback(self._background_tasks.discard)
             _task.add_done_callback(_done)
 
-        async def _subagent_done(info: SubagentInfo) -> None:
+        _batch_delivery_retry_owner: dict[str, str] = {}
+        _batch_delivery_locks: dict[str, asyncio.Lock] = {}
+        _batch_delivery_lock_refs: dict[str, int] = {}
+
+        async def _subagent_done_impl(info: SubagentInfo) -> None:
             async def _inject_with_retry(
                 client,
                 msg: str,
@@ -6541,7 +6546,8 @@ class GatewayOrchestrator:
             # bump would invent an agent that never ran.
             _flush_only = getattr(info, "_digest_flush_only", False) is True
 
-            if not _flush_only:
+            _delivery_retry = getattr(info, "_delivery_retry", False) is True
+            if not _flush_only and not _delivery_retry:
                 await _broadcast_subagent_status(info, "done")
             # Three-way outcome: a user stop is neutral — neither a success nor
             # a failure. The record contract keeps ``error`` unset for stops, so
@@ -6554,6 +6560,11 @@ class GatewayOrchestrator:
             else:
                 status, emoji, single_outcome = "completed", "✅", OUTCOME_OK
             title = f"Subagent `{info.id}` {emoji}"
+            raw_delivery_event_id = getattr(info, "_delivery_event_id", "")
+            delivery_event_id = (
+                raw_delivery_event_id if isinstance(raw_delivery_event_id, str) else ""
+            )
+            event_line = f"Event: `{delivery_event_id}`\n" if delivery_event_id else ""
 
             # ── Orchestration guard: track failures (only in orchestrator mode) ──
             parent_key = info.parent_session_key
@@ -6569,7 +6580,14 @@ class GatewayOrchestrator:
                     _is_orchestrator = (
                         _slot is not None and getattr(_slot, "mode", "") == "orchestrator"
                     )
-                if _slot is not None and _is_orchestrator:
+                # Only a durable retry may already own an orchestration
+                # tracker. A fresh completion snapshots the active slot below.
+                tracker = info._delivery_orchestration_tracker if _delivery_retry else None
+                if tracker is None and _slot is not None and _is_orchestrator:
+                    tracker = getattr(_slot, "_orch_tracker", None)
+                    if tracker is not None:
+                        info._delivery_orchestration_tracker = tracker
+                if _slot is not None and _is_orchestrator and not _delivery_retry:
                     from kiro_crew.context_management import (
                         MAX_STAGE_ESCALATIONS,
                         MAX_STAGE_ROUNDS,
@@ -6581,17 +6599,19 @@ class GatewayOrchestrator:
                     # planning turn (it clears only when the new plan is
                     # armed), so a latch-based drop here would silently
                     # discard subagent completions belonging to that new
-                    # turn — data loss. tracker.stopped scopes the drop to
-                    # a live-but-stopped orchestration; a stale completion
-                    # landing on a cancelled slot whose tracker is absent
-                    # is bounded accounting noise (the stage loop itself
-                    # stays latched and cannot advance).
-                    if not getattr(_slot, "_orch_tracker", None):
+                    # turn — data loss. The retained tracker scopes the drop
+                    # to the orchestration that owned this delivery even when
+                    # the slot arms a new plan between durable attempts.
+                    if tracker is None:
                         _slot._orch_tracker = OrchestrationTracker()
                     tracker = _slot._orch_tracker
-                    if tracker.stopped:
-                        logger.info("Orchestration stopped, ignoring subagent result %s", info.id)
-                        return
+                    assert tracker is not None
+                    info._delivery_orchestration_tracker = tracker
+                if tracker is not None and getattr(tracker, "stopped", False) is True:
+                    logger.info("Orchestration stopped, ignoring subagent result %s", info.id)
+                    return
+                if _slot is not None and _is_orchestrator and not _delivery_retry:
+                    assert tracker is not None
                     task_key = info.task[:80]
                     if _flush_only:
                         # No task ran — nothing to record. Recording it as a
@@ -6669,6 +6689,7 @@ class GatewayOrchestrator:
 
             announce = (
                 f"{SUBAGENT_COMPLETION_PREFIX}\n"
+                f"{event_line}"
                 f"Agent `{info.id}`"
                 f"{f' ({info.agent})' if info.agent else ''}"
                 f" {status} {emoji}\n"
@@ -6689,6 +6710,8 @@ class GatewayOrchestrator:
                 requested_model=info.requested_model or info.model or "",
                 resolved_model=info.resolved_model or "",
             )
+            if delivery_event_id:
+                sub_meta["eventId"] = delivery_event_id
 
             parent_key = info.parent_session_key
 
@@ -6714,6 +6737,7 @@ class GatewayOrchestrator:
                 _batch_id = ""
             if not isinstance(_batch_total, int):
                 _batch_total = 0
+            _batch_retry = False
             if _flush_only and not _batch_id:
                 # A flush-only record without wave identity has nothing to
                 # release and MUST NOT fall through to the per-agent routing
@@ -6734,30 +6758,39 @@ class GatewayOrchestrator:
                     _last = False
                     _oc = ""
                 else:
-                    bp = self._batch_progress.setdefault(
-                        _batch_id,
-                        {
-                            "total": _batch_total,
-                            "done": 0,
-                            "ok": 0,
-                            "err": 0,
-                            "stopped": 0,
-                            "fail_lines": [],
-                            "ok_lines": [],
-                            "guard_msgs": [],
-                            "held_ok_ids": [],
-                            # Members whose delivery is currently held, so the
-                            # hold-deadline sweep's timestamps can be cleared
-                            # when their chunk finally fires.
-                            "held_infos": [],
-                            # Chunked delivery bookkeeping: "flushed" = members whose
-                            # results have already been delivered in a prior chunk;
-                            # "chunks" = digest chunks emitted so far.
-                            "flushed": 0,
-                            "chunks": 0,
-                        },
-                    )
-            if _batch_id and not _flush_only:
+                    _retry_progress = getattr(info, "_delivery_batch_progress", None)
+                    if isinstance(_retry_progress, dict):
+                        _batch_retry = True
+                        # Routing below clears per-chunk buffers after composing
+                        # a non-final digest. Work from a fresh mapping so a
+                        # second failed attempt cannot erase the retained
+                        # snapshot needed by later retries.
+                        bp = dict(_retry_progress)
+                    else:
+                        bp = self._batch_progress.setdefault(
+                            _batch_id,
+                            {
+                                "total": _batch_total,
+                                "done": 0,
+                                "ok": 0,
+                                "err": 0,
+                                "stopped": 0,
+                                "fail_lines": [],
+                                "ok_lines": [],
+                                "guard_msgs": [],
+                                "held_delivery_ids": [],
+                                "delivery_event_ids": [],
+                                # Members whose delivery is held, so the
+                                # deadline sweep can clear their timestamps
+                                # when the chunk finally fires.
+                                "held_infos": [],
+                                # "flushed" = members delivered in an earlier
+                                # chunk; "chunks" = chunks emitted so far.
+                                "flushed": 0,
+                                "chunks": 0,
+                            },
+                        )
+            if _batch_id and not _flush_only and not _batch_retry:
                 bp["done"] += 1
                 # Fold EVERY member's orchestration escalation into the wave
                 # digest — held members return before the announce is sent, so
@@ -6808,22 +6841,13 @@ class GatewayOrchestrator:
                         f"— `{info.id}` {status} {emoji} · {task_text[:80]}{_model_tag}\n"
                         f"  {detail[:400]}{'…' if len(detail) > 400 else ''}"
                     )
+                if delivery_event_id:
+                    bp["delivery_event_ids"].append(delivery_event_id)
+                # Every submitted or reconciled member reaches this consumer.
+                # Live-manager membership can become empty before completed
+                # callbacks waiting on the wave lock are accounted, so it cannot
+                # prove that this callback is the final digest member.
                 _last = bp["total"] > 0 and bp["done"] >= bp["total"]
-                if not _last:
-                    # Robustness: a wave member that failed AT SPAWN never
-                    # reaches this consumer, so done can never hit total.
-                    # Completion is decided by THIS batch's outstanding
-                    # members only (running OR still queued behind the
-                    # stagger gate) — an unrelated agent under the same
-                    # parent must neither hold the digest hostage nor
-                    # release it early.
-                    try:
-                        _last = bool(
-                            self.subagent_mgr
-                            and not self.subagent_mgr.batch_members_pending(_batch_id)
-                        )
-                    except Exception:
-                        _last = False
                 if _last:
                     self._batch_progress.pop(_batch_id, None)
                     # Prune per-wave bookkeeping for ALL wave sizes (bounds
@@ -6848,6 +6872,12 @@ class GatewayOrchestrator:
                             )
                     except Exception:
                         logger.debug("batch_finished broadcast failed", exc_info=True)
+            elif _batch_id and not _flush_only:
+                # The first attempt already composed and accounted this chunk
+                # before routing failed. Reuse its detached snapshot so a retry
+                # cannot mutate the live wave or broadcast completion twice.
+                _last = info._delivery_batch_final
+                _oc = info.outcome
             if _batch_id:
                 if _flush_only and bp["total"] <= 1:
                     # Single-member wave: nothing is ever held, and falling
@@ -6870,7 +6900,12 @@ class GatewayOrchestrator:
                     # lacks — the reaper's hold-deadline sweep forces the
                     # pending chunk out once results have been held too long.
                     _pending = bp["done"] - bp["flushed"]
-                    _flush = _last or _flush_only or _pending >= SUBAGENT_DIGEST_CHUNK_SIZE
+                    _flush = (
+                        _batch_retry
+                        or _last
+                        or _flush_only
+                        or _pending >= SUBAGENT_DIGEST_CHUNK_SIZE
+                    )
                     if not _flush:
                         # Held for the next chunk — the terminal WS event,
                         # tracker accounting, and stats above already ran;
@@ -6890,8 +6925,8 @@ class GatewayOrchestrator:
                         # contract; cleared when this member's chunk fires.
                         info._digest_held_at = time.time()
                         bp.setdefault("held_infos", []).append(info)
-                        if _oc == "completed":
-                            bp["held_ok_ids"].append(info.id)
+                        if _oc == "completed" or info._delivery_event_id:
+                            bp["held_delivery_ids"].append(info.id)
                         logger.info(
                             "Subagent %s: completion held for digest chunk (%d/%d done)",
                             info.id,
@@ -6906,7 +6941,13 @@ class GatewayOrchestrator:
                     # Stash the ids on the flushing member: the run loop
                     # settles them only after _on_done (which includes the
                     # routing below) returns without raising.
-                    info._digest_settle_ids = list(bp.get("held_ok_ids", []))
+                    info._digest_settle_ids = list(bp.get("held_delivery_ids", []))
+                    # A callback without a stable outbox event has no exact
+                    # replay source. Retain the live pre-composition state so
+                    # a failed route can put its chunk back into the wave for
+                    # the next durable member or deadline flush. Only durable
+                    # events may detach a chunk and own its retry position.
+                    _flush_rollback = dict(bp) if _flush_only or not delivery_event_id else None
                     # These members are no longer held: stop the hold clock so
                     # the reaper's deadline sweep does not force a second flush
                     # for results this chunk already carries.
@@ -6921,8 +6962,33 @@ class GatewayOrchestrator:
                     # Deduped union of this chunk's members' escalation
                     # guards — not just the flushing member's.
                     _guards = "".join(dict.fromkeys(bp.get("guard_msgs", [])))
-                    bp["chunks"] += 1
-                    bp["flushed"] = bp["done"]
+                    _chunk_event_ids = list(dict.fromkeys(bp.get("delivery_event_ids", [])))
+                    _chunk_event_lines = "".join(
+                        f"Event: `{event_id}`\n" for event_id in _chunk_event_ids
+                    )
+                    if not _batch_retry:
+                        bp["chunks"] += 1
+                        bp["flushed"] = bp["done"]
+                        # Preserve the exact composed chunk before the live
+                        # per-chunk buffers are replaced below. A failed
+                        # non-final route must retry this chunk without
+                        # recounting its flushing member or disturbing later
+                        # completions already accumulating in the wave.
+                        _delivery_progress = dict(bp)
+                        for _key in (
+                            "held_infos",
+                            "fail_lines",
+                            "ok_lines",
+                            "guard_msgs",
+                            "delivery_event_ids",
+                        ):
+                            _value = _delivery_progress.get(_key)
+                            if isinstance(_value, list):
+                                _delivery_progress[_key] = list(_value)
+                        if _flush_rollback is not None:
+                            _delivery_progress["_flush_rollback"] = _flush_rollback
+                        info._delivery_batch_progress = _delivery_progress
+                        info._delivery_batch_final = _last
                     _chunk_k = bp["chunks"]
                     # Total chunks: full chunks + one final partial. Completion
                     # order fills chunks to exactly CHUNK_SIZE, so this is
@@ -6945,6 +7011,7 @@ class GatewayOrchestrator:
                         # Final chunk: release the spawn-discipline gate.
                         announce = (
                             f"{SUBAGENT_BATCH_COMPLETION_PREFIX}\n"
+                            f"{_chunk_event_lines}"
                             f"Batch results {_chunk_k}/{_chunk_j} — wave finished: "
                             f"{bp['ok']} ✅ · {bp['err']} ❌ · "
                             f"{bp['stopped']} ⏹ of {bp['total']} agents. "
@@ -6989,6 +7056,7 @@ class GatewayOrchestrator:
                         )
                         announce = (
                             f"{SUBAGENT_BATCH_COMPLETION_PREFIX}\n"
+                            f"{_chunk_event_lines}"
                             f"Batch results {_chunk_k}/{_chunk_j} — "
                             f"{bp['done']} of {bp['total']} delivered, "
                             f"{_remaining} still running.\n"
@@ -7014,7 +7082,13 @@ class GatewayOrchestrator:
                         bp["fail_lines"] = []
                         bp["ok_lines"] = []
                         bp["guard_msgs"] = []
-                        bp["held_ok_ids"] = []
+                        bp["held_delivery_ids"] = []
+                        bp["delivery_event_ids"] = []
+
+                    if delivery_event_id:
+                        sub_meta["eventId"] = delivery_event_id
+                    if _chunk_event_ids:
+                        sub_meta["eventIds"] = _chunk_event_ids
 
             # ── Route completion back to the originating session ──
             # Tab open        → that tab (a channel-born tab mirrors on to its channel)
@@ -7141,6 +7215,18 @@ class GatewayOrchestrator:
                                 except Exception:
                                     pass  # Task failed — slot is now idle
 
+                            delivery_tracker = info._delivery_orchestration_tracker
+                            if (
+                                delivery_tracker is not None
+                                and getattr(delivery_tracker, "stopped", False) is True
+                            ):
+                                logger.info(
+                                    "Orchestration stopped while awaiting delivery, "
+                                    "ignoring subagent result %s",
+                                    info.id,
+                                )
+                                return
+
                             # Re-check: another injection may have claimed the slot
                             # during the await above.
                             if _injection_slot_busy(_injection_slot):
@@ -7234,11 +7320,12 @@ class GatewayOrchestrator:
                         # is neither.
                         #
                         # Computed BEFORE the transfer (which detaches the held
-                        # ids); stays False when there is nothing to owe — a
-                        # failed or stopped solo member settles through its own
-                        # failure tombstone, not this ledger.
+                        # ids). A failed or stopped durable member still owes
+                        # the outbox acknowledgement; a non-durable solo member
+                        # settles through its failure tombstone instead.
                         _owes_delivery = bool(info._digest_settle_ids) or (
-                            not _flush_only and info.outcome == "completed"
+                            not _flush_only
+                            and (info.outcome == "completed" or bool(info._delivery_event_id))
                         )
                         self._defer_queued_delivery(
                             _injection_slot, announce, info, flush_only=_flush_only
@@ -7268,6 +7355,13 @@ class GatewayOrchestrator:
                         _injection_slot.task = _task
                         self.dashboard_state._background_tasks.add(_task)
                         _task.add_done_callback(self.dashboard_state._background_tasks.discard)
+                        _arm_queued_delivery_settlement(
+                            self.dashboard_state,
+                            _injection_slot,
+                            _task,
+                            [announce],
+                            _consumed,
+                        )
 
                         def _on_inject_done(t: asyncio.Task) -> None:  # type: ignore[type-arg]
                             if _injection_slot.task is t:
@@ -7613,6 +7707,11 @@ class GatewayOrchestrator:
                         )
                 except Exception:
                     logger.exception("Subagent %s cron injection failed", info.id)
+                    if self.subagent_mgr:
+                        self.subagent_mgr.notify_injection_failed(
+                            info,
+                            reason="cron injection failed",
+                        )
                 finally:
                     if acquired:
                         try:
@@ -7704,6 +7803,73 @@ class GatewayOrchestrator:
                 )
             if not parent_key.startswith("cron:"):
                 logger.info("Subagent %s → notification only (parent=%s)", info.id, parent_key)
+
+        async def _subagent_done(info: SubagentInfo) -> None:
+            """Keep later wave chunks behind a failed non-final chunk."""
+
+            batch_id = info.batch_id if isinstance(info.batch_id, str) else ""
+            if not batch_id:
+                await _subagent_done_impl(info)
+                return
+
+            lock = _batch_delivery_locks.setdefault(batch_id, asyncio.Lock())
+            _batch_delivery_lock_refs[batch_id] = _batch_delivery_lock_refs.get(batch_id, 0) + 1
+
+            def _retain_failed_position() -> None:
+                retry_progress = getattr(info, "_delivery_batch_progress", None)
+                if isinstance(retry_progress, dict):
+                    rollback = retry_progress.get("_flush_rollback")
+                    live_progress = self._batch_progress.get(batch_id)
+                    if isinstance(rollback, dict) and live_progress is not None:
+                        live_progress.clear()
+                        live_progress.update(rollback)
+                        held_at = time.time()
+                        for held in live_progress.get("held_infos", []):
+                            held._digest_held_at = held_at
+                        info._digest_settle_ids = []
+                        info._delivery_batch_progress = None
+                        info._delivery_batch_final = False
+                        return
+                if batch_id and isinstance(retry_progress, dict) and not info._delivery_batch_final:
+                    _batch_delivery_retry_owner[batch_id] = info.id
+
+            try:
+                async with lock:
+                    retry_owner = _batch_delivery_retry_owner.get(batch_id)
+                    if retry_owner and retry_owner != info.id:
+                        # The prior chunk is already composed and owns the
+                        # wave's next delivery position. Leave this member
+                        # unaccounted so its durable event can retry after that
+                        # chunk is accepted.
+                        info._delivery_failed = True
+                        logger.info(
+                            "Subagent %s: delivery waits for batch %s chunk owned by %s",
+                            info.id,
+                            batch_id,
+                            retry_owner,
+                        )
+                        return
+                    try:
+                        await _subagent_done_impl(info)
+                    except asyncio.CancelledError:
+                        _retain_failed_position()
+                        raise
+                    except Exception:
+                        _retain_failed_position()
+                        raise
+                    else:
+                        if info._delivery_failed:
+                            _retain_failed_position()
+                        elif retry_owner == info.id:
+                            _batch_delivery_retry_owner.pop(batch_id, None)
+            finally:
+                remaining = _batch_delivery_lock_refs[batch_id] - 1
+                if remaining:
+                    _batch_delivery_lock_refs[batch_id] = remaining
+                else:
+                    _batch_delivery_lock_refs.pop(batch_id, None)
+                    if batch_id not in _batch_delivery_retry_owner:
+                        _batch_delivery_locks.pop(batch_id, None)
 
         assert self.sessions is not None
         assert self.ctx_builder is not None
@@ -7905,7 +8071,6 @@ class GatewayOrchestrator:
             completion_keep=self._cfg.agent.completion_keep,
             completion_keep_chars=self._cfg.agent.completion_keep_chars,
         )
-        self.subagent_mgr.start_reaper()
 
     def _init_crew(self) -> None:
         """Attach the Crew Mode control plane (engineered pipeline;
@@ -10275,6 +10440,12 @@ class GatewayOrchestrator:
             self._init_crew()
         else:
             await self._init_api_server()
+        # Startup reconciliation can immediately claim and deliver durable
+        # completion events.  Arm it only after the destination registry is
+        # initialized, otherwise a dashboard parent can fall through to the
+        # generic session route and be acknowledged without reaching its slot.
+        if self.subagent_mgr:
+            self.subagent_mgr.start_reaper()
         # Record this gateway's own kirocrew launcher, keyed by the port it
         # serves, so a remote token-mint execs THIS install's venv instead of
         # a stale ~/.local/bin/kirocrew that may point at an uninstalled

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -57,6 +57,7 @@ from kiro_crew.context_management import (
     cap_result_file,
     evict_completed_agents,
 )
+from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.effort import effort_settings_key, model_supports_effort
 from kiro_crew.executors import maintenance_executor, subprocess_executor
 from kiro_crew.hooks import (
@@ -94,10 +95,18 @@ from kiro_crew.resource_status import cached_admission_check
 from kiro_crew.run_coordinator import (
     CommandOperation,
     CoordinatorDecision,
+    DeliveryState,
+    OutboxEvent,
+    RunCommand,
+    RunCompletion,
     RunCoordinator,
+    RunFence,
+    RunOutcome,
     SQLiteRunCoordinator,
     SubmitRun,
+    TerminalRun,
 )
+from kiro_crew.run_coordinator.delivery import OutboxDeliveryAdapter
 from kiro_crew.security import (
     redact_and_truncate,
     redact_credentials,
@@ -109,7 +118,12 @@ from kiro_crew.session_surface import has_dashboard_surface
 from kiro_crew.session_workspace import result_path as _ws_result_path
 from kiro_crew.slack.format import extract_options
 from kiro_crew.stats import Stats
-from kiro_crew.subagent_command_authority import AdmittedExecution, SubagentCommandAuthority
+from kiro_crew.subagent_command_authority import (
+    EXECUTION_LEASE_SECONDS,
+    AdmittedExecution,
+    AuthorityOutcomeUncertain,
+    SubagentCommandAuthority,
+)
 from kiro_crew.subagent_completion_meta import (
     OUTCOME_FAILED,
     OUTCOME_INTERRUPTED,
@@ -443,6 +457,7 @@ def _describe_exception(exc: BaseException) -> str:
 
 
 _MAX_DONE_RESULT_LEN = 50_000  # cap subagent_done payload to avoid bloating WS frames
+_OUTBOX_RESULT_SUMMARY_LEN = 4_000
 
 
 def _done_result(text: str) -> str:
@@ -484,6 +499,8 @@ _RECOVERY_SLOT_WAIT_SECS = 60.0
 _REPORT_DRAIN_TIMEOUT = (
     30.0  # max seconds cancel_all() waits for shielded terminal reports to drain
 )
+_TERMINAL_RETRY_SECONDS = 1.0
+_OUTBOX_DRAIN_BATCH_SIZE = 16
 # Max seconds a cancelled run holds cancellation open for an in-flight off-loop
 # state.json write worker (#6306 review; widened to every off-loop writer by
 # #6308): long enough for any healthy fsync, short enough that a wedged FS
@@ -1300,10 +1317,24 @@ class SubagentInfo:
     # compatibility executor, so run start must settle that durable command.
     _coordinator_admitted: bool = False
     # True while a keyed run is queued or awaiting approval.
+    _coordinator_command: RunCommand | None = None
+    _coordinator_fence: RunFence | None = None
+    _coordinator_version: int = 0
     _coordinator_waiting: bool = False
     # Durable start settlement is unknown, so terminal delivery must wait for
     # cancellation retry or fenced recovery.
     _coordinator_claim_uncertain: bool = False
+    _coordinator_started: bool = False
+    _coordinator_running: bool = False
+    _delivery_event_id: str = ""
+    _delivery_failed: bool = False
+    _delivery_retry: bool = False
+    # Stable owner for in-process durable retries. The dashboard slot may arm a
+    # new plan between attempts and replace its tracker; retaining the original
+    # tracker preserves a cancellation that belongs to this completion.
+    _delivery_orchestration_tracker: Any = None
+    _delivery_batch_progress: dict[str, Any] | None = None
+    _delivery_batch_final: bool = False
     # True when the gateway QUEUED this completion's injection because the
     # parent's slot was busy. Delivery is not consumption: the announce sits in
     # the slot queue until a turn drains it, and that wait is bounded only by the
@@ -1472,6 +1503,26 @@ class SubagentInfo:
         return "completed"
 
 
+@dataclass
+class _OutboxDeliveryContext:
+    info: SubagentInfo
+    source: str
+    injection_timeout_reason: str
+    mark_delivered_on_success: bool
+    settle_digest: bool
+    teardown_done: asyncio.Event | None
+    effects_fired: bool = False
+    callback_started: bool = False
+
+
+class _TerminalCommitRejected(Exception):
+    """The coordinator permanently rejected this executor's terminal fence."""
+
+
+class _OutboxDeliveryRetry(Exception):
+    """The destination did not accept an outbox event and should retry soon."""
+
+
 # Callback: (subagent_info) -> None
 AnnounceCallback = Callable[[SubagentInfo], Awaitable[None]]
 
@@ -1632,6 +1683,13 @@ class SubagentManager:
         # at async run entry during migration.
         self._coordinator = coordinator or SQLiteRunCoordinator()
         self.command_authority = SubagentCommandAuthority(self._coordinator, self)
+        self._outbox_contexts: dict[str, _OutboxDeliveryContext] = {}
+        self._outbox_live_contexts: dict[str, _OutboxDeliveryContext] = {}
+        self._lease_tasks: dict[str, asyncio.Task[None]] = {}
+        self._outbox_delivery = OutboxDeliveryAdapter(
+            self._coordinator,
+            self._deliver_outbox_event,
+        )
         self._lifecycle: SubagentLifecycle[SubagentInfo] = SubagentLifecycle()
         # follow_up watchers (spawn_steer mode="follow_up"), keyed by run id.
         # Manager-OWNED on purpose: these tasks can spawn a brand-new run
@@ -1687,6 +1745,7 @@ class SubagentManager:
         # finalize_batch alongside _batch_submitted.
         self._batch_progress_ts: dict[str, float] = {}
         self._reaper_task: asyncio.Task | None = None  # type: ignore[type-arg]
+        self._reconcile_task: asyncio.Task | None = None  # type: ignore[type-arg]
         # Cache global approval_mode at init to avoid disk I/O on every
         # parentless spawn (cron, webhooks).
         try:
@@ -1881,6 +1940,12 @@ class SubagentManager:
     async def _reconcile_orphans(self) -> None:
         return await self._monitor._reconcile_orphans_impl()
 
+    def _reap_orphan_process(self, state: dict[str, Any]) -> bool:
+        return self._monitor._reap_orphan_process_impl(state)
+
+    async def _drain_pending_outbox(self) -> None:
+        return await self._monitor._drain_pending_outbox_impl()
+
     @staticmethod
     def _is_pid_alive(pid: int) -> bool:
         """Check if a PID is still running."""
@@ -2028,6 +2093,33 @@ class SubagentManager:
     def _claim_finalize(self, info: SubagentInfo, *, supersede_recovery: bool = False) -> bool:
         return self._terminal._claim_finalize_impl(info, supersede_recovery=supersede_recovery)
 
+    async def _coordinator_mark_starting(self, info: SubagentInfo) -> None:
+        return await self._terminal._coordinator_mark_starting_impl(info)
+
+    async def _coordinator_mark_running(self, info: SubagentInfo) -> None:
+        return await self._terminal._coordinator_mark_running_impl(info)
+
+    def _start_coordinator_heartbeat(self, info: SubagentInfo) -> None:
+        return self._terminal._start_coordinator_heartbeat_impl(info)
+
+    async def _stop_coordinator_heartbeat(self, run_id: str) -> None:
+        return await self._terminal._stop_coordinator_heartbeat_impl(run_id)
+
+    def _coordinator_outcome(self, info: SubagentInfo) -> RunOutcome:
+        return self._terminal._coordinator_outcome_impl(info)
+
+    def _completion_payload(self, info: SubagentInfo) -> str:
+        return self._terminal._completion_payload_impl(info)
+
+    async def _commit_terminal_event(self, info: SubagentInfo) -> OutboxEvent | None:
+        return await self._terminal._commit_terminal_event_impl(info)
+
+    def _info_from_outbox(self, event: OutboxEvent) -> SubagentInfo:
+        return self._terminal._info_from_outbox_impl(event)
+
+    async def _deliver_outbox_event(self, event: OutboxEvent) -> bool:
+        return await self._terminal._deliver_outbox_event_impl(event)
+
     async def _report_terminal(
         self,
         info: SubagentInfo,
@@ -2065,6 +2157,9 @@ class SubagentManager:
             settle_digest=settle_digest,
             teardown_done=teardown_done,
         )
+
+    async def _reject_waiting_before_terminal(self, info: SubagentInfo, error: str) -> None:
+        return await self._terminal._reject_waiting_before_terminal_impl(info, error)
 
     def _spawn_terminal_report(
         self,
@@ -2152,6 +2247,9 @@ class SubagentManager:
         _from_queue: bool = False,
         _preassigned_id: str = "",
         _coordinator_admitted: bool = False,
+        _coordinator_command: RunCommand | None = None,
+        _coordinator_fence: RunFence | None = None,
+        _coordinator_version: int = 0,
     ) -> SubagentInfo | None:
         return self._admission.spawn_impl(
             task,
@@ -2177,46 +2275,55 @@ class SubagentManager:
             _from_queue,
             _preassigned_id,
             _coordinator_admitted,
+            _coordinator_command,
+            _coordinator_fence,
+            _coordinator_version,
         )
 
     async def _safe_announce(self, info: SubagentInfo) -> None:
         return await self._admission._safe_announce_impl(info)
 
     def _announce_rejection(
-        self, info: SubagentInfo, *, coordinator_admitted: bool = False
+        self,
+        info: SubagentInfo,
+        *,
+        coordinator_admitted: bool = False,
+        coordinator_command: RunCommand | None = None,
+        coordinator_fence: RunFence | None = None,
+        coordinator_version: int = 0,
     ) -> SubagentInfo:
         return self._admission._announce_rejection_impl(
-            info, coordinator_admitted=coordinator_admitted
+            info,
+            coordinator_admitted=coordinator_admitted,
+            coordinator_command=coordinator_command,
+            coordinator_fence=coordinator_fence,
+            coordinator_version=coordinator_version,
         )
 
     async def announce_durable_rejection(self, info: SubagentInfo | AdmittedExecution) -> None:
-        """Announce a keyed batch rejection, including after uncertain settlement."""
-        if isinstance(info, AdmittedExecution):
-            try:
-                run = await self._coordinator.get_run(info.id)
-            except Exception:
-                logger.warning(
-                    "Failed to hydrate rejected run %s before terminal delivery",
-                    info.id,
-                    exc_info=True,
-                )
-                run = None
-            info = SubagentInfo(
-                id=info.id,
-                task=info.task,
-                started=run.created_at if run is not None else time.time(),
-                done=info.done,
-                queued=info.queued,
-                error=info.error,
-                parent_session_key=run.parent_session if run is not None else "",
-                agent=run.agent if run is not None else "",
-                silent=info.silent,
-                batch_id=info.batch_id,
-                batch_total=info.batch_total,
-                conversation_key=run.conversation_key if run is not None else "",
-            )
-        if info.batch_id and self._on_done:
-            await self._safe_announce(info)
+        return await self._admission.announce_durable_rejection_impl(info)
+
+    def _rollback_unstarted_registration(
+        self,
+        info: SubagentInfo,
+        prior_start: float,
+        occupied_at: float,
+    ) -> None:
+        return self._admission._rollback_unstarted_registration_impl(info, prior_start, occupied_at)
+
+    def _spawn_announcement(self, info: SubagentInfo) -> "asyncio.Task":  # type: ignore[type-arg]
+        return self._admission._spawn_announcement_impl(info)
+
+    async def _report_synthetic_batch_terminal(self, info: SubagentInfo) -> None:
+        return await self._admission._report_synthetic_batch_terminal_impl(info)
+
+    def _spawn_synthetic_batch_terminal_report(
+        self, info: SubagentInfo
+    ) -> "asyncio.Task":  # type: ignore[type-arg]
+        return self._admission._spawn_synthetic_batch_terminal_report_impl(info)
+
+    async def _finalize_queued_rejection(self, info: SubagentInfo) -> None:
+        return await self._admission._finalize_queued_rejection_impl(info)
 
     def _should_stagger_queue(self, now: float) -> tuple[bool, bool]:
         return self._admission._should_stagger_queue_impl(now)
@@ -2251,6 +2358,9 @@ class SubagentManager:
         cwd: str = "",
         _preassigned_id: str = "",
         _coordinator_admitted: bool = False,
+        _coordinator_command: RunCommand | None = None,
+        _coordinator_fence: RunFence | None = None,
+        _coordinator_version: int = 0,
     ) -> SubagentInfo | None:
         return self._continuation.continue_conversation_impl(
             conv_id,
@@ -2262,6 +2372,9 @@ class SubagentManager:
             cwd,
             _preassigned_id,
             _coordinator_admitted,
+            _coordinator_command,
+            _coordinator_fence,
+            _coordinator_version,
         )
 
     def recorded_cwd(self, conv_id: str) -> str:
@@ -2379,8 +2492,17 @@ class SubagentManager:
     async def settle_queued_delivery(self, agent_ids: list[str]) -> None:
         return await self._waves.settle_queued_delivery_impl(agent_ids)
 
-    def _settle_digest_holds(self, info: SubagentInfo) -> None:
-        return self._waves._settle_digest_holds_impl(info)
+    def _delivery_event_for_run(self, run_id: str) -> str:
+        return self._waves._delivery_event_for_run_impl(run_id)
+
+    def _delivery_context_for_run(self, run_id: str) -> _OutboxDeliveryContext | None:
+        return self._waves._delivery_context_for_run_impl(run_id)
+
+    async def _ack_delivery_for_run(self, run_id: str) -> None:
+        return await self._waves._ack_delivery_for_run_impl(run_id)
+
+    async def _settle_digest_holds(self, info: SubagentInfo) -> None:
+        return await self._waves._settle_digest_holds_impl(info)
 
     def get(self, agent_id: str) -> SubagentInfo | None:
         return self._run_events.get_impl(agent_id)
@@ -2668,6 +2790,8 @@ _COMPONENT_GLOBAL_BINDINGS = (
     CONTEXT_GROUP_LESSONS,
     CONTEXT_GROUP_MEMORY,
     CONTEXT_GROUP_PROJECT,
+    CoordinatorDecision,
+    DeliveryState,
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
     EVENT_TEXT_CHUNK,
@@ -2682,24 +2806,38 @@ _COMPONENT_GLOBAL_BINDINGS = (
     LivenessOracle,
     OUTCOME_FAILED,
     OUTCOME_INTERRUPTED,
+    OutboxEvent,
     PROVIDER_LABEL_DEFAULT,
     Path,
+    RunCommand,
+    RunCompletion,
+    RunFence,
+    RunOutcome,
     SUBAGENT_COMPLETION_PREFIX,
     Stats,
     TOOL_AUTO_APPROVE,
     TOOL_DENY,
     TRANSIENT_RETRIES,
+    TerminalRun,
     VERDICT_DEAD,
     VERDICT_STUCK_INPUT,
     VERDICT_UNKNOWN,
     VERDICT_WORKING,
     _AGENT_NAME_RE,
+    _OUTBOX_DRAIN_BATCH_SIZE,
+    _OUTBOX_RESULT_SUMMARY_LEN,
+    _TERMINAL_RETRY_SECONDS,
+    _OutboxDeliveryContext,
+    _OutboxDeliveryRetry,
+    _TerminalCommitRejected,
     _agent_dir,
     _cleanup_session_files_sync,
     _load_child_process_helpers,
     _redact,
     _subagents_dir,
     _ws_result_path,
+    AuthorityOutcomeUncertain,
+    EXECUTION_LEASE_SECONDS,
     acp_error_is_transient,
     advance_fallback_candidate,
     agent_dir_for_display,
@@ -2715,6 +2853,7 @@ _COMPONENT_GLOBAL_BINDINGS = (
     configured_fallback_chain,
     consult_offloaded,
     create_agent_folder,
+    dashboard_slot_key,
     evict_completed_agents,
     extract_options,
     fire_tool_hooks,

--- a/src/kiro_crew/subagent_command_authority.py
+++ b/src/kiro_crew/subagent_command_authority.py
@@ -22,17 +22,19 @@ from .run_coordinator.models import (
     CommandOperation,
     CommandStatus,
     CoordinatorDecision,
+    ObservedState,
     OwnerLease,
     RunCoordinator,
+    RunOutcome,
     SubmitControl,
     SubmitRun,
 )
 from .security import redact_credentials, redact_exfiltration_urls
 
 _CONTROL_LEASE_SECS = 30.0
-_EXECUTION_LEASE_SECS = 90.0
 _SHUTDOWN_SETTLEMENT_RETRY_SECS = 1.0
 logger = logging.getLogger(__name__)
+EXECUTION_LEASE_SECONDS = 90.0
 
 
 @dataclass(frozen=True)
@@ -232,6 +234,21 @@ class SubagentCommandAuthority:
         stored: AdmittedExecution | None = None
         if command.result_json:
             stored = cls._decode_execution_result(command.result_json, run_id, task)
+        run = receipt.run
+        if (
+            not command.result_json
+            and run is not None
+            and run.observed_state is ObservedState.TERMINAL
+            and run.outcome is not None
+            and run.outcome is not RunOutcome.COMPLETED
+        ):
+            return {
+                "found": True,
+                "id": run_id,
+                "error": run.error or f"run ended {run.outcome.value}",
+                "code": f"run_{run.outcome.value}",
+                "counted": True,
+            }
         if command.status is CommandStatus.REJECTED:
             error = (
                 stored.error
@@ -498,6 +515,8 @@ class SubagentCommandAuthority:
             )
             if claim is None:
                 raise AuthorityUnavailable("command outcome is still pending")
+            if claim.fence is None or claim.run is None:
+                raise AuthorityUnavailable("execution claim omitted its run fence")
             queued_legacy_collision = any(
                 str(entry.get("_preassigned_id") or "") == receipt.run.run_id
                 for entry in getattr(self._manager, "_queue", ())
@@ -531,6 +550,9 @@ class SubagentCommandAuthority:
                 **kwargs,
                 "_preassigned_id": receipt.run.run_id,
                 "_coordinator_admitted": True,
+                "_coordinator_command": claim.command,
+                "_coordinator_fence": claim.fence,
+                "_coordinator_version": claim.run.version,
             }
             try:
                 if operation is CommandOperation.CONTINUE:
@@ -795,14 +817,14 @@ class SubagentCommandAuthority:
             return
 
         async def renew() -> None:
-            cadence = _EXECUTION_LEASE_SECS / 3
+            cadence = EXECUTION_LEASE_SECONDS / 3
             while True:
                 await self._sleep(cadence)
                 try:
                     renewed = await self._coordinator.renew(
                         run_id,
                         fence,
-                        self._clock() + _EXECUTION_LEASE_SECS,
+                        self._clock() + EXECUTION_LEASE_SECONDS,
                     )
                 except Exception:
                     continue
@@ -921,11 +943,17 @@ class SubagentCommandAuthority:
             and command.result_json == result_json
         )
 
-    async def reject_waiting_execution(self, run_id: str, error: str) -> None:
-        """Finish a queued or approval-waiting command before dropping its lease."""
+    async def reject_waiting_execution(
+        self,
+        run_id: str,
+        error: str,
+        *,
+        stop_heartbeat: bool = True,
+    ) -> None:
+        """Reject waiting work, optionally retaining its lease through terminal commit."""
 
         waiting = self._waiting_executions.get(run_id)
-        finish_error = ""
+        finish_error = "waiting execution claim not found" if waiting is None else ""
         if waiting is not None:
             command_fence, _result_json = waiting
             safe_error = _redact(error)
@@ -949,7 +977,8 @@ class SubagentCommandAuthority:
             raise AuthorityOutcomeUncertain(
                 f"waiting execution rejection was not durably finished: {finish_error}"
             )
-        await self.stop_execution_heartbeat(run_id)
+        if stop_heartbeat:
+            await self.stop_execution_heartbeat(run_id)
 
     async def execution_started(self, run_id: str) -> None:
         """Commit a waiting command only when its manager task actually starts."""
@@ -981,7 +1010,7 @@ class SubagentCommandAuthority:
         return OwnerLease(
             owner_id=self._owner_id,
             lease_expires_at=self._clock()
-            + (_EXECUTION_LEASE_SECS if execution else _CONTROL_LEASE_SECS),
+            + (EXECUTION_LEASE_SECONDS if execution else _CONTROL_LEASE_SECS),
         )
 
     @staticmethod

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -8,10 +8,17 @@ from ._component import ManagerComponent
 
 if TYPE_CHECKING:
     from ..subagent import (
+        _TERMINAL_RETRY_SECONDS,
+        CoordinatorDecision,
+        DeliveryState,
         KiroCrewConfig,
+        RunCommand,
+        RunFence,
         Stats,
         SubagentInfo,
+        TerminalRun,
         _context_groups_field,
+        _OutboxDeliveryContext,
         _redact,
         _validate_agent,
         _vet_spawn_governance,
@@ -27,12 +34,225 @@ if TYPE_CHECKING:
         uuid,
         validate_cwd,
     )
+    from ..subagent_command_authority import AdmittedExecution
 
 
 class SpawnAdmissionCoordinator(ManagerComponent):
     """Own admission transitions while state remains facade-owned."""
 
     __slots__ = ()
+
+    async def announce_durable_rejection_impl(self, info: SubagentInfo | AdmittedExecution) -> None:
+        """Announce a keyed batch rejection, including after uncertain settlement."""
+
+        if isinstance(info, AdmittedExecution):
+            try:
+                run = await self._manager._coordinator.get_run(info.id)
+            except Exception:
+                logger.warning(
+                    "Failed to hydrate rejected run %s before terminal delivery",
+                    info.id,
+                    exc_info=True,
+                )
+                run = None
+            info = SubagentInfo(
+                id=info.id,
+                task=info.task,
+                started=run.created_at if run is not None else time.time(),
+                done=info.done,
+                queued=info.queued,
+                error=info.error,
+                parent_session_key=run.parent_session if run is not None else "",
+                agent=run.agent if run is not None else "",
+                silent=info.silent,
+                batch_id=info.batch_id,
+                batch_total=info.batch_total,
+                conversation_key=run.conversation_key if run is not None else "",
+            )
+        if info.batch_id and self._manager._on_done:
+            if info._coordinator_fence is not None:
+                await self._manager._run_terminal_report(
+                    info,
+                    source="Subagent keyed batch rejection",
+                    injection_timeout_reason="keyed batch rejection delivery timed out",
+                    mark_delivered_on_success=False,
+                    settle_digest=True,
+                )
+                return
+            await self._manager._safe_announce(info)
+
+    def _rollback_unstarted_registration_impl(
+        self,
+        info: SubagentInfo,
+        prior_start: float,
+        occupied_at: float,
+    ) -> None:
+        """Release provisional manager state when policy fails before task ownership."""
+
+        if info.id in self._manager._tasks:
+            return
+        self._manager._agents.pop(info.id, None)
+        released = self._manager._scheduler.release(info)
+        if self._manager._scheduler.last_start == occupied_at:
+            self._manager._scheduler.last_start = prior_start
+        if info.batch_id and not any(
+            agent.batch_id == info.batch_id for agent in self._manager._agents.values()
+        ):
+            self._manager._seen_batches.discard(info.batch_id)
+        if released:
+            try:
+                self._manager._drain_queue()
+            except Exception:
+                logger.warning("Failed to drain queue after spawn rollback", exc_info=True)
+
+    def _spawn_announcement_impl(self, info: SubagentInfo) -> "asyncio.Task":  # type: ignore[type-arg]
+        """Schedule an announce with durable batch ownership from creation."""
+
+        if info.batch_id and not info._coordinator_admitted:
+            return self._manager._spawn_synthetic_batch_terminal_report(info)
+        return asyncio.create_task(self._manager._safe_announce(info))
+
+    async def _report_synthetic_batch_terminal_impl(self, info: SubagentInfo) -> None:
+        """Give a one-shot batch failure a durable completion event."""
+
+        payload_json = self._manager._completion_payload(info)
+        terminal_at = time.time()
+        request = TerminalRun(
+            run_id=info.id,
+            parent_session=info.parent_session_key,
+            agent=info.agent,
+            task=info.task,
+            conversation_key=info.conversation_key,
+            outcome=self._manager._coordinator_outcome(info),
+            result_path=info.result_path,
+            error=_redact(info.error),
+            created_at=info.started,
+            terminal_at=terminal_at,
+            event_type="subagent_completion",
+            destination=info.parent_session_key,
+            payload_json=payload_json,
+        )
+        context = _OutboxDeliveryContext(
+            info=info,
+            source="Subagent synthetic batch",
+            injection_timeout_reason="synthetic batch delivery timed out",
+            mark_delivered_on_success=False,
+            settle_digest=True,
+            teardown_done=None,
+        )
+        # A periodic drainer may observe the new event before record_terminal()
+        # returns. Publish the live routing context first so that drainer keeps
+        # the batch identity and held-sibling settlement debt.
+        self._manager._outbox_live_contexts[info.id] = context
+
+        async def wait_for_retry() -> None:
+            try:
+                await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+            except asyncio.CancelledError:
+                if not self._manager._shutting_down:
+                    raise
+                logger.warning(
+                    "Synthetic batch terminal retry delay cancelled for %s during shutdown; "
+                    "retrying",
+                    info.id,
+                )
+
+        while True:
+            try:
+                recorded = await self._manager._coordinator.record_terminal(request)
+                if recorded.decision is CoordinatorDecision.REJECTED:
+                    logger.error(
+                        "Synthetic batch terminal commit rejected for %s: %s",
+                        info.id,
+                        recorded.reason.value,
+                    )
+                    break
+            except asyncio.CancelledError:
+                if not self._manager._shutting_down:
+                    raise
+                logger.warning(
+                    "Synthetic batch terminal commit cancelled for %s during shutdown; retrying",
+                    info.id,
+                )
+                continue
+            except Exception:
+                logger.warning(
+                    "Synthetic batch terminal commit failed for %s; retrying",
+                    info.id,
+                    exc_info=True,
+                )
+                await wait_for_retry()
+                continue
+            if recorded.value is None:
+                logger.warning(
+                    "Synthetic batch terminal commit returned no value for %s; retrying",
+                    info.id,
+                )
+                await wait_for_retry()
+                continue
+            info._coordinator_admitted = True
+            info._coordinator_version = recorded.value.run.version
+            event = recorded.value.event
+            info._delivery_event_id = event.event_id
+            if self._manager._outbox_live_contexts.get(info.id) is context:
+                self._manager._outbox_live_contexts.pop(info.id, None)
+            if not info._reported_to_parent:
+                self._manager._outbox_contexts.setdefault(event.event_id, context)
+            while not self._manager._shutting_down:
+                try:
+                    attempts = await self._manager._outbox_delivery.drain_once(
+                        event_id=event.event_id
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning(
+                        "Synthetic batch terminal delivery failed for %s",
+                        info.id,
+                        exc_info=True,
+                    )
+                else:
+                    if any(attempt.status is DeliveryState.DELIVERED for attempt in attempts):
+                        return
+                    if info._reported_to_parent or info._digest_held or info._delivery_queued:
+                        return
+                    # A destination callback that fails leaves the event pending
+                    # behind the adapter's durable retry schedule.  Let that
+                    # owner retry it instead of spinning this lifecycle task.
+                    if context.callback_started:
+                        return
+                await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+            return
+        if self._manager._outbox_live_contexts.get(info.id) is context:
+            self._manager._outbox_live_contexts.pop(info.id, None)
+
+        assert self._manager._on_done is not None
+        try:
+            await self._manager._on_done(info)
+        except Exception:
+            logger.exception("Subagent announce failed for %s", info.id)
+
+    def _spawn_synthetic_batch_terminal_report_impl(
+        self, info: SubagentInfo
+    ) -> "asyncio.Task":  # type: ignore[type-arg]
+        """Launch a synthetic terminal commit under lifecycle ownership."""
+
+        return self._manager._lifecycle.spawn_report(
+            info,
+            lambda: self._manager._report_synthetic_batch_terminal(info),
+        )
+
+    async def _finalize_queued_rejection_impl(self, info: SubagentInfo) -> None:
+        """Reject and deliver a queue entry that cannot start under its durable claim."""
+
+        await self._manager._reject_waiting_before_terminal(info, info.error)
+        await self._manager._run_terminal_report(
+            info,
+            source="Subagent queue",
+            injection_timeout_reason="queued rejection delivery timed out",
+            mark_delivered_on_success=True,
+            settle_digest=True,
+        )
 
     def spawn_impl(
         self,
@@ -59,6 +279,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         _from_queue: bool = False,
         _preassigned_id: str = "",
         _coordinator_admitted: bool = False,
+        _coordinator_command: RunCommand | None = None,
+        _coordinator_fence: RunFence | None = None,
+        _coordinator_version: int = 0,
     ) -> SubagentInfo | None:
         """Spawn a subagent for *task*.
 
@@ -114,6 +337,16 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         # concurrency gate keeps its identity across the round-trip instead of
         # being announced under one id and starting under another.
         agent_id: str = _preassigned_id or uuid.uuid4().hex[:8]
+
+        def announce_rejection(info: SubagentInfo) -> SubagentInfo:
+            return self._manager._announce_rejection(
+                info,
+                coordinator_admitted=_coordinator_admitted,
+                coordinator_command=_coordinator_command,
+                coordinator_fence=_coordinator_fence,
+                coordinator_version=_coordinator_version,
+            )
+
         # Submission accounting: count this member as
         # submitted BEFORE any rejection or queue/registration branching. A
         # member refused below (empty task, low memory, bad cwd, governance)
@@ -131,7 +364,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 while agent_id in self._manager._coordinator_run_id_reservations:
                     agent_id = uuid.uuid4().hex[:8]
             else:
-                return self._manager._announce_rejection(
+                return announce_rejection(
                     SubagentInfo(
                         id=agent_id,
                         task=_redact(str(task or "")),
@@ -141,8 +374,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                         error="run_id_conflict: a keyed admission already owns this id",
                         batch_id=batch_id,
                         batch_total=max(0, int(batch_total)),
-                    ),
-                    coordinator_admitted=False,
+                    )
                 )
         # --- Task guard: refuse empty/whitespace-only tasks (defense in depth).
         # The HTTP handler (api_spawn) and MCP tool schemas validate too, but
@@ -164,7 +396,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 )
             except Exception:
                 logger.debug("SEL audit failed for empty-task rejection", exc_info=True)
-            return self._manager._announce_rejection(
+            return announce_rejection(
                 SubagentInfo(
                     id=agent_id,
                     task="",
@@ -174,8 +406,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     error="spawn refused: task must be a non-empty string",
                     batch_id=batch_id,
                     batch_total=max(0, int(batch_total)),
-                ),
-                coordinator_admitted=_coordinator_admitted,
+                )
             )
 
         # --- Redact task once for all SubagentInfo storage (raw task kept for kiro-cli prompt) ---
@@ -214,9 +445,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 batch_id=batch_id,
                 batch_total=max(0, int(batch_total)),
             )
-            return self._manager._announce_rejection(
-                info, coordinator_admitted=_coordinator_admitted
-            )
+            return announce_rejection(info)
 
         # --- Admission gate: refuse NEW spawns while host memory posture is
         # critical. Complements the absolute spawn_min_memory_gb floor above
@@ -251,9 +480,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 batch_id=batch_id,
                 batch_total=max(0, int(batch_total)),
             )
-            return self._manager._announce_rejection(
-                info, coordinator_admitted=_coordinator_admitted
-            )
+            return announce_rejection(info)
 
         # --- CWD validation: reject bad paths before consuming a slot ---
         resolved_cwd = ""
@@ -286,9 +513,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     batch_id=batch_id,
                     batch_total=max(0, int(batch_total)),
                 )
-                return self._manager._announce_rejection(
-                    info, coordinator_admitted=_coordinator_admitted
-                )
+                return announce_rejection(info)
 
         # --- Governance: spawn capability gate (blast-radius containment) ---
         # A policy/profile may disable sub-agent spawning entirely, or bound it
@@ -306,7 +531,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 error=gov_spawn_err,
                 metadata={"agent": agent, "task": _redacted_task[:120]},
             )
-            return self._manager._announce_rejection(
+            return announce_rejection(
                 SubagentInfo(
                     id=agent_id,
                     task=_redacted_task,
@@ -316,8 +541,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     error=f"spawn refused by governance: {gov_spawn_err}",
                     batch_id=batch_id,
                     batch_total=max(0, int(batch_total)),
-                ),
-                coordinator_admitted=_coordinator_admitted,
+                )
             )
 
         now = time.monotonic()
@@ -339,7 +563,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     agent,
                     app,
                 )
-                return self._manager._announce_rejection(
+                return announce_rejection(
                     SubagentInfo(
                         id=agent_id,
                         task=_redacted_task,
@@ -353,8 +577,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                         ),
                         batch_id=batch_id,
                         batch_total=max(0, int(batch_total)),
-                    ),
-                    coordinator_admitted=_coordinator_admitted,
+                    )
                 )
             # Carry this spawn's id (assigned at the top) in the queue entry so
             # the drained spawn runs under it. The identity must survive the
@@ -391,6 +614,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     "_agent_prevalidated": _agent_prevalidated,
                     "_preassigned_id": agent_id,
                     "_coordinator_admitted": _coordinator_admitted,
+                    "_coordinator_command": _coordinator_command,
+                    "_coordinator_fence": _coordinator_fence,
+                    "_coordinator_version": _coordinator_version,
                 }
             )
             logger.info(
@@ -426,6 +652,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 _coordinator_admitted=_coordinator_admitted,
                 _coordinator_waiting=_coordinator_admitted,
             )
+            info._coordinator_command = _coordinator_command
+            info._coordinator_fence = _coordinator_fence
+            info._coordinator_version = _coordinator_version
             return info
 
         # `_agent_prevalidated` skips the on-loop agent-directory scan: a caller
@@ -456,9 +685,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     batch_id=batch_id,
                     batch_total=max(0, int(batch_total)),
                 )
-                return self._manager._announce_rejection(
-                    info, coordinator_admitted=_coordinator_admitted
-                )
+                return announce_rejection(info)
 
         info = SubagentInfo(
             id=agent_id,
@@ -485,8 +712,13 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         info._raw_task = task  # unredacted prompt for kiro-cli execution
         info._coordinator_admitted = _coordinator_admitted
         info._coordinator_waiting = bool(_from_queue and _coordinator_admitted)
+        info._coordinator_command = _coordinator_command
+        info._coordinator_fence = _coordinator_fence
+        info._coordinator_version = _coordinator_version
         self._manager._agents[agent_id] = info
-        self._manager._scheduler.occupy(info, time.monotonic())
+        prior_start = self._manager._scheduler.last_start
+        occupied_at = time.monotonic()
+        self._manager._scheduler.occupy(info, occupied_at)
         # Batch lifecycle: announce the wave ONCE, on its first member to
         # actually start (queued members haven't started yet — the event marks
         # execution begin, and the UI uses it to key batch progress).
@@ -504,13 +736,17 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             except RuntimeError:
                 pass  # no running loop (sync/test context)
 
-        # Check parent session trust (approval_policy="auto") set by dashboard trust toggle.
-        parent_trusted = (
-            parent_session_key
-            and self._manager._sessions.get_approval_policy(parent_session_key) == "auto"
-        )
+        try:
+            parent_trusted = (
+                parent_session_key
+                and self._manager._sessions.get_approval_policy(parent_session_key) == "auto"
+            )
+            yolo_enabled = bool(self._manager._is_yolo and self._manager._is_yolo())
+        except BaseException:
+            self._manager._rollback_unstarted_registration(info, prior_start, occupied_at)
+            raise
 
-        if self._manager._is_yolo and self._manager._is_yolo():
+        if yolo_enabled:
             self._manager._tasks[agent_id] = asyncio.create_task(self._manager._run(info))
             self._manager._log_spawned(info)
         elif approval_mode == "auto":
@@ -570,9 +806,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 # counts it as complete — without an announce, a wave whose
                 # final member lands here closes with no event and every held
                 # sibling digest strands forever.
-                return self._manager._announce_rejection(
-                    info, coordinator_admitted=_coordinator_admitted
-                )
+                return announce_rejection(info)
         elif self._manager._on_spawn_approval:
             info._coordinator_waiting = info._coordinator_admitted
             self._manager._tasks[agent_id] = asyncio.create_task(
@@ -595,9 +829,7 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             )
             logger.warning("Subagent %s rejected: no approval callback", agent_id)
             if self._manager._on_done:
-                self._manager._tasks[agent_id] = asyncio.ensure_future(
-                    self._manager._safe_announce(info)
-                )
+                self._manager._tasks[agent_id] = self._manager._spawn_announcement(info)
 
         return info
 
@@ -608,13 +840,24 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             info (SubagentInfo): The subagent metadata.
         """
         assert self._manager._on_done is not None
+        if info.batch_id and not info._coordinator_admitted:
+            await self._manager._await_report(
+                self._manager._spawn_synthetic_batch_terminal_report(info)
+            )
+            return
         try:
             await self._manager._on_done(info)
         except Exception:
             logger.exception("Subagent announce failed for %s", info.id)
 
     def _announce_rejection_impl(
-        self, info: SubagentInfo, *, coordinator_admitted: bool = False
+        self,
+        info: SubagentInfo,
+        *,
+        coordinator_admitted: bool = False,
+        coordinator_command: RunCommand | None = None,
+        coordinator_fence: RunFence | None = None,
+        coordinator_version: int = 0,
     ) -> SubagentInfo:
         """Route a terminal spawn rejection through the done callback.
 
@@ -634,11 +877,16 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         those itself off the returned info, so announcing here as well would
         inject the completion twice.
         """
+        info._coordinator_admitted = coordinator_admitted
+        info._coordinator_command = coordinator_command
+        info._coordinator_fence = coordinator_fence
+        info._coordinator_version = coordinator_version
+        # A keyed command must finish its durable rejection before its batch
+        # consumer can count it. Its authority or queue-drain settlement owns
+        # that later announcement.
         if info.batch_id and self._manager._on_done and not coordinator_admitted:
             try:
-                self._manager._tasks[f"reject-{info.id}"] = asyncio.ensure_future(
-                    self._manager._safe_announce(info)
-                )
+                self._manager._tasks[f"reject-{info.id}"] = self._manager._spawn_announcement(info)
             except RuntimeError:
                 pass  # no running loop (sync/test context)
         return info
@@ -678,8 +926,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             return
         params = decision.entry
         if bool(params.get("_coordinator_cancel_pending")):
-            # A failed durable cancellation must not become a later local
-            # start. Retain it behind runnable work for an explicit retry.
+            # A failed durable cancellation must not turn into a later local
+            # start. Move the retained entry behind runnable work; only an
+            # explicit cancellation retry may remove it.
             self._manager._scheduler.enqueue(params)
             if any(
                 not bool(entry.get("_coordinator_cancel_pending")) for entry in self._manager._queue
@@ -719,20 +968,62 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         # the queue round-trip — including `_preassigned_id`, which makes the agent
         # start under the id its caller was already told (and, if the gate re-queues
         # it, keeps that id across the second round-trip too).
-        drained = self._manager.spawn(**params, _from_queue=True)
+        spawn_raised = False
+        try:
+            drained = self._manager.spawn(**params, _from_queue=True)
+        except BaseException as exc:
+            spawn_raised = True
+            drained = SubagentInfo(
+                id=queued_id,
+                task=_redact(str(params.get("task") or "")),
+                parent_session_key=str(params.get("parent_session_key") or ""),
+                agent=str(params.get("agent") or ""),
+                conversation_key=str(params.get("conversation_key") or ""),
+                done=True,
+                error=_redact(str(exc) or type(exc).__name__),
+                silent=bool(params.get("silent")),
+                batch_id=str(params.get("batch_id") or ""),
+                batch_total=int(params.get("batch_total") or 0),
+            )
         coordinator_rejection = bool(
             drained is not None
             and drained.done
             and drained.error
-            and bool(params.get("_coordinator_admitted"))
+            and params.get("_coordinator_fence") is not None
         )
         if coordinator_rejection and drained is not None:
-            rejected = drained
+            report_task = self._manager._tasks.pop(f"reject-{drained.id}", None)
+            if report_task is not None:
+                report_task.cancel()
+            drained._coordinator_admitted = True
+            drained._coordinator_command = params.get("_coordinator_command")
+            drained._coordinator_fence = params.get("_coordinator_fence")
+            drained._coordinator_version = int(params.get("_coordinator_version") or 0)
+            try:
+                self._manager._tasks[f"reject-{drained.id}"] = asyncio.ensure_future(
+                    self._manager._finalize_queued_rejection(drained)
+                )
+            except RuntimeError:
+                pass
+        legacy_coordinator_rejection = bool(
+            drained is not None
+            and drained.done
+            and drained.error
+            and bool(params.get("_coordinator_admitted"))
+            and not coordinator_rejection
+        )
+        if legacy_coordinator_rejection and drained is not None:
+            legacy_drained = drained
 
-            async def _finish_rejected_command() -> None:
+            # The original HTTP caller returned when this entry was queued.
+            # If revalidation now rejects it, no authority call remains on the
+            # stack to finish the durable command, so lookup would report an
+            # outcome-uncertain claim forever.
+            async def _finish_legacy_command_rejection() -> None:
                 try:
                     await self._manager.command_authority.reject_waiting_execution(
-                        rejected.id, rejected.error
+                        legacy_drained.id,
+                        legacy_drained.error,
                     )
                 except Exception:
                     params["_coordinator_cancel_pending"] = True
@@ -743,23 +1034,23 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                     )
                     logger.warning(
                         "Queued subagent %s rejection was not durably recorded",
-                        rejected.id,
+                        legacy_drained.id,
                         exc_info=True,
                     )
                     raise
                 if self._manager._on_done:
-                    await self._manager._safe_announce(rejected)
+                    await self._manager._safe_announce(legacy_drained)
 
             try:
-                task = asyncio.ensure_future(_finish_rejected_command())
-                self._manager._tasks[f"command-reject-{rejected.id}"] = task
+                task = asyncio.ensure_future(_finish_legacy_command_rejection())
+                self._manager._tasks[f"command-reject-{legacy_drained.id}"] = task
 
-                def _forget_rejection(done: asyncio.Task[None]) -> None:
-                    self._manager._tasks.pop(f"command-reject-{rejected.id}", None)
+                def _forget_legacy_rejection(done: asyncio.Task[None]) -> None:
+                    self._manager._tasks.pop(f"command-reject-{legacy_drained.id}", None)
                     if not done.cancelled():
                         done.exception()
 
-                task.add_done_callback(_forget_rejection)
+                task.add_done_callback(_forget_legacy_rejection)
             except RuntimeError:
                 pass
         # A drained spawn has NO synchronous reader: this call site is a timer
@@ -777,13 +1068,14 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             drained is not None
             and drained.done
             and drained.error
-            and not drained.batch_id
-            and not coordinator_rejection
             and self._manager._on_done
+            and not coordinator_rejection
+            and not legacy_coordinator_rejection
+            and (spawn_raised or not drained.batch_id)
         ):
             try:
-                self._manager._tasks[f"reject-{drained.id}"] = asyncio.ensure_future(
-                    self._manager._safe_announce(drained)
+                self._manager._tasks[f"reject-{drained.id}"] = self._manager._spawn_announcement(
+                    drained
                 )
             except RuntimeError:
                 pass  # no running loop (sync/test context)
@@ -847,23 +1139,29 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             logger.exception("Spawn approval failed for %s", info.id)
             approved = False
 
+        # Dashboard approval translates task cancellation into a denial result.
+        # A user-stop marker means cancel() already owns durable settlement;
+        # returning here prevents the approval task from racing it with a
+        # conflicting generic rejection.
+        if info.user_stopped:
+            return
+
         if not approved:
-            # A user stop already owns durable settlement and intentionally
-            # cancelled this approval task.
-            if info.user_stopped:
-                return
             rejection_error = "spawn rejected"
-            try:
-                await self._manager.command_authority.reject_waiting_execution(
-                    info.id, rejection_error
-                )
-            except Exception:
-                logger.warning(
-                    "Subagent %s approval rejection was not durably recorded",
-                    info.id,
-                    exc_info=True,
-                )
-                return
+            if info._coordinator_fence is not None:
+                try:
+                    await self._manager.command_authority.reject_waiting_execution(
+                        info.id,
+                        rejection_error,
+                        stop_heartbeat=False,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Subagent %s approval rejection was not durably recorded",
+                        info.id,
+                        exc_info=True,
+                    )
+                    return
             info.done = True
             info.error = rejection_error
             # Slot accounting through the one-shot token, NOT a bare decrement.
@@ -888,8 +1186,17 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             logger.info("Subagent %s spawn rejected", info.id)
             # Report ownership through the same claim every other terminal path
             # uses, so a concurrent reap/stop cannot also announce.
-            if self._manager._on_done and self._manager._claim_finalize(info):
-                await self._manager._safe_announce(info)
+            if self._manager._claim_finalize(info):
+                if info._coordinator_fence is not None:
+                    await self._manager._run_terminal_report(
+                        info,
+                        source="Subagent approval",
+                        injection_timeout_reason="approval rejection delivery timed out",
+                        mark_delivered_on_success=True,
+                        settle_digest=True,
+                    )
+                elif self._manager._on_done:
+                    await self._manager._safe_announce(info)
             return
 
         self._manager._log_spawned(info)

--- a/src/kiro_crew/subagent_manager/cancellation.py
+++ b/src/kiro_crew/subagent_manager/cancellation.py
@@ -221,23 +221,38 @@ class CancellationCoordinator(ManagerComponent):
         return dropped
 
     async def _finalize_queued_cancel_impl(self, params: dict[str, Any]) -> None:
-        """Durably reject one coordinator-backed queue entry."""
-        rejection_error = "spawn cancelled before start"
-        await self._manager.command_authority.reject_waiting_execution(
-            str(params.get("_preassigned_id") or ""), rejection_error
+        """Deliver a neutral stop for a queued batch or coordinator command."""
+
+        fence = params.get("_coordinator_fence")
+        raw_task = str(params.get("task") or "")
+        info = SubagentInfo(
+            id=str(params.get("_preassigned_id") or ""),
+            task=_redact(raw_task),
+            parent_session_key=str(params.get("parent_session_key") or ""),
+            agent=str(params.get("agent") or ""),
+            conversation_key=str(params.get("conversation_key") or ""),
+            done=True,
+            user_stopped=True,
+            silent=bool(params.get("silent")),
+            batch_id=str(params.get("batch_id") or ""),
+            batch_total=int(params.get("batch_total") or 0),
         )
-        await self._manager.announce_durable_rejection(
-            SubagentInfo(
-                id=str(params.get("_preassigned_id") or ""),
-                task=_redact(str(params.get("task") or "")),
-                parent_session_key=str(params.get("parent_session_key") or ""),
-                agent=str(params.get("agent") or ""),
-                silent=bool(params.get("silent")),
-                done=True,
-                error=rejection_error,
-                batch_id=str(params.get("batch_id") or ""),
-                batch_total=int(params.get("batch_total") or 0),
-            )
+        info._raw_task = raw_task
+        if fence is None:
+            if info.batch_id and self._manager._on_done:
+                await self._manager._safe_announce(info)
+            return
+        info._coordinator_admitted = True
+        info._coordinator_command = params.get("_coordinator_command")
+        info._coordinator_fence = fence
+        info._coordinator_version = int(params.get("_coordinator_version") or 0)
+        await self._manager._reject_waiting_before_terminal(info, "run stopped before execution")
+        await self._manager._run_terminal_report(
+            info,
+            source="Subagent queue",
+            injection_timeout_reason="queued cancellation delivery timed out",
+            mark_delivered_on_success=True,
+            settle_digest=True,
         )
 
     async def cancel_impl(self, agent_id: str) -> bool:
@@ -321,8 +336,13 @@ class CancellationCoordinator(ManagerComponent):
         if self._manager._reaper_task and not self._manager._reaper_task.done():
             self._manager._reaper_task.cancel()
             self._manager._reaper_task = None
-        # Follow-up watchers are cancelled and gathered before announcing.
-        # The announce awaits — _on_done injection can be slow — and
+        reconcile_task = self._manager._reconcile_task
+        self._manager._reconcile_task = None
+        if reconcile_task is not None and not reconcile_task.done():
+            reconcile_task.cancel()
+            await asyncio.gather(reconcile_task, return_exceptions=True)
+        # follow_up watchers: CANCEL AND GATHER FIRST, announce after (GPT
+        # review). The announce awaits — _on_done injection can be slow — and
         # a busy-retry watcher waking during that await could dispatch a
         # continuation into the shutting-down gateway, so every watcher task
         # must be DEAD before anything here yields. Announcing afterwards is
@@ -363,6 +383,8 @@ class CancellationCoordinator(ManagerComponent):
         tasks_to_await: list[asyncio.Task] = []  # type: ignore[type-arg]
         for agent_id, task in list(self._manager._tasks.items()):
             if not task.done():
+                if task in self._manager._lifecycle.report_tasks:
+                    continue
                 # _shutting_down (set above) is the terminal marker for this
                 # site; the chokepoint enforces the contract mechanically.
                 self._manager._cancel_task_intentionally(
@@ -440,4 +462,10 @@ class CancellationCoordinator(ManagerComponent):
                             owner.id,
                             exc_info=True,
                         )
+        lease_tasks = list(self._manager._lease_tasks.values())
+        self._manager._lease_tasks.clear()
+        for lease_task in lease_tasks:
+            lease_task.cancel()
+        if lease_tasks:
+            await asyncio.gather(*lease_tasks, return_exceptions=True)
         await self._manager.command_authority.close()

--- a/src/kiro_crew/subagent_manager/continuation.py
+++ b/src/kiro_crew/subagent_manager/continuation.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
         CONTEXT_GROUP_PROJECT,
         PROVIDER_LABEL_DEFAULT,
         Any,
+        RunCommand,
+        RunFence,
         SubagentInfo,
         _cleanup_session_files_sync,
         _redact,
@@ -221,6 +223,9 @@ class ContinuationCoordinator(ManagerComponent):
         cwd: str = "",
         _preassigned_id: str = "",
         _coordinator_admitted: bool = False,
+        _coordinator_command: RunCommand | None = None,
+        _coordinator_fence: RunFence | None = None,
+        _coordinator_version: int = 0,
     ) -> SubagentInfo | None:
         """Dispatch a follow-up *task* into conversation *conv_id*.
 
@@ -330,6 +335,9 @@ class ContinuationCoordinator(ManagerComponent):
             task,
             _preassigned_id=_preassigned_id,
             _coordinator_admitted=_coordinator_admitted,
+            _coordinator_command=_coordinator_command,
+            _coordinator_fence=_coordinator_fence,
+            _coordinator_version=_coordinator_version,
             parent_session_key=parent_session_key,
             agent=agent,
             model=model,

--- a/src/kiro_crew/subagent_manager/monitoring.py
+++ b/src/kiro_crew/subagent_manager/monitoring.py
@@ -9,6 +9,7 @@ from ._component import ManagerComponent
 if TYPE_CHECKING:
     from ..subagent import (
         _CLK_TCK,
+        _OUTBOX_DRAIN_BATCH_SIZE,
         _REAPER_INTERVAL,
         _SUPPRESS_CEILING,
         OUTCOME_FAILED,
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
         VERDICT_STUCK_INPUT,
         VERDICT_UNKNOWN,
         VERDICT_WORKING,
+        Any,
         LivenessOracle,
         SubagentInfo,
         _agent_dir,
@@ -48,6 +50,44 @@ class OrphanStallMonitor(ManagerComponent):
 
     __slots__ = ()
 
+    def _reap_orphan_process_impl(self, state: dict[str, Any]) -> bool:
+        """Kill a surviving child only when its recorded process identity still matches."""
+
+        agent_id = state.get("id", "")
+        pid = state.get("pid")
+        if not agent_id or not pid or not self._manager._is_pid_alive(pid):
+            return False
+        # ``pid_recorded_at`` names the process write, while ``started`` names
+        # folder creation and can be too old to distinguish PID reuse under load.
+        pid_recorded_at = state.get("pid_recorded_at", state.get("started", 0))
+        if not self._manager._is_orphan_process(pid, pid_recorded_at):
+            return False
+        self._manager._kill_orphan_pid(pid)
+        try:
+            sel().log_tool_invocation(
+                session_key=f"subagent:{agent_id}",
+                source="subagent",
+                tool_name="orphan_reconcile_kill",
+                outcome="killed",
+                metadata={"subagent_id": agent_id, "pid": pid},
+            )
+        except Exception:
+            logger.debug("SEL audit failed for orphan %s", agent_id)
+        return True
+
+    async def _drain_pending_outbox_impl(self) -> None:
+        """Retry durable completions without coupling them to legacy folders."""
+
+        try:
+            while True:
+                attempts = await self._manager._outbox_delivery.drain_once(
+                    limit=_OUTBOX_DRAIN_BATCH_SIZE
+                )
+                if len(attempts) < _OUTBOX_DRAIN_BATCH_SIZE:
+                    return
+        except Exception:
+            logger.warning("Coordinator outbox delivery failed", exc_info=True)
+
     def start_reaper_impl(self) -> None:
         """Start the periodic reaper loop.  Call once after the event loop is running."""
         if self._manager._reaper_task is None:
@@ -64,9 +104,27 @@ class OrphanStallMonitor(ManagerComponent):
         - PID dead + result → tombstone (gateway_restart, delivered)
         - PID dead + no result → tombstone (gateway_restart, notification_pending)
         """
+        # A terminal coordinator event may still have a live child when the
+        # gateway crashed between the durable commit and process teardown.
+        # Reap from the legacy folder snapshot before outbox delivery can
+        # write a tombstone that removes that folder from ``list_orphans``.
+        reaped_orphan_ids: set[str] = set()
         try:
+            orphan_snapshot = await asyncio.to_thread(list_orphans)
+            for state in orphan_snapshot:
+                agent_id = state.get("id", "")
+                if (
+                    agent_id
+                    and agent_id not in self._manager._agents
+                    and await asyncio.to_thread(self._manager._reap_orphan_process, state)
+                ):
+                    reaped_orphan_ids.add(agent_id)
+        except Exception:
+            logger.warning("Pre-delivery orphan process reconciliation failed", exc_info=True)
 
-            orphans = list_orphans()
+        await self._manager._drain_pending_outbox()
+        try:
+            orphans = await asyncio.to_thread(list_orphans)
             if not orphans:
                 return
             logger.info("Reconciling %d orphaned subagent(s)", len(orphans))
@@ -79,7 +137,15 @@ class OrphanStallMonitor(ManagerComponent):
             dm_pending: list[str] = []
             for state in orphans:
                 agent_id = state.get("id", "")
-                if not agent_id or agent_id in self._manager._agents:
+                durable_delivery_run_ids = {
+                    context.info.id for context in self._manager._outbox_contexts.values()
+                }
+                durable_delivery_run_ids.update(self._manager._outbox_live_contexts)
+                if (
+                    not agent_id
+                    or agent_id in self._manager._agents
+                    or agent_id in durable_delivery_run_ids
+                ):
                     continue  # tracked in current run, skip
                 try:
                     pid = state.get("pid")
@@ -93,21 +159,8 @@ class OrphanStallMonitor(ManagerComponent):
 
                     recovery = "undeliverable"
                     if pid and self._manager._is_pid_alive(pid):
-                        # Use pid_recorded_at (when PID was actually written) instead of
-                        # started (folder creation time) to avoid false negatives under load
-                        pid_recorded_at = state.get("pid_recorded_at", state.get("started", 0))
-                        if self._manager._is_orphan_process(pid, pid_recorded_at):
-                            self._manager._kill_orphan_pid(pid)
-                            try:
-                                sel().log_tool_invocation(
-                                    session_key=f"subagent:{agent_id}",
-                                    source="subagent",
-                                    tool_name="orphan_reconcile_kill",
-                                    outcome="killed",
-                                    metadata={"subagent_id": agent_id, "pid": pid},
-                                )
-                            except Exception:
-                                logger.debug("SEL audit failed for orphan %s", agent_id)
+                        if agent_id not in reaped_orphan_ids:
+                            await asyncio.to_thread(self._manager._reap_orphan_process, state)
                         recovery = "result_available" if has_result else "notification_pending"
                     elif has_result:
                         recovery = "result_available"
@@ -399,7 +452,7 @@ class OrphanStallMonitor(ManagerComponent):
             logger.debug("Reaper: startup cost-log compaction failed", exc_info=True)
         while True:
             await asyncio.sleep(_REAPER_INTERVAL)
-            now = time.time()
+            await self._manager._drain_pending_outbox()
             if not self._manager._conv_registry_rebuilt:
                 # First pass after (re)start: re-seed the conversation TTL
                 # registry from state.json so promoted conversations survive
@@ -423,6 +476,7 @@ class OrphanStallMonitor(ManagerComponent):
                 )
             except Exception:
                 logger.debug("Reaper: live-cost sample failed", exc_info=True)
+            now = time.time()
             # Wave liveness backstop: reconcile waves wedged by submissions
             # lost before the process boundary (see _sweep_stuck_waves).
             try:

--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -316,13 +316,34 @@ class RunEventCoordinator(ManagerComponent):
         """Execute a subagent task in its own session."""
         session_key = info.conversation_key or f"subagent:{info.id}"
         try:
-            if info._coordinator_admitted:
+            if not info._coordinator_admitted:
+                await self._manager._shadow_submit_accepted_run(info)
+            else:
+                try:
+                    await self._manager._coordinator_mark_starting(info)
+                except Exception:
+                    # A lost lifecycle response is retried inside the transition.
+                    # If both attempts fail, command settlement must not run: it
+                    # would apply a command whose STARTING state is still unknown.
+                    info._coordinator_claim_uncertain = True
+                    logger.warning(
+                        "Subagent %s starting transition is uncertain",
+                        info.id,
+                        exc_info=True,
+                    )
+                    return
                 try:
                     await self._manager.command_authority.execution_started(info.id)
                 except Exception:
                     try:
+                        # The command fence makes the same result idempotent.
+                        # Reconcile a commit whose response was lost before
+                        # deciding that recovery must own the accepted run.
                         await self._manager.command_authority.execution_started(info.id)
                     except Exception:
+                        # The claimed command remains the only safe retry path.
+                        # Keep the live record cancellable and suppress terminal
+                        # delivery until cancellation or recovery settles it.
                         info._coordinator_claim_uncertain = True
                         await self._manager.command_authority.stop_execution_heartbeat(info.id)
                         logger.warning(
@@ -332,8 +353,7 @@ class RunEventCoordinator(ManagerComponent):
                         )
                         return
                 info._coordinator_waiting = False
-            else:
-                await self._manager._shadow_submit_accepted_run(info)
+                self._manager._start_coordinator_heartbeat(info)
             await asyncio.wait_for(
                 self._manager._run_inner(info, session_key), timeout=self._manager._default_timeout
             )
@@ -487,7 +507,7 @@ class RunEventCoordinator(ManagerComponent):
         # re-raise, so by the time we reach this await the cancellation has been
         # consumed and `shield` would simply wait out the full _ON_DONE_TIMEOUT
         # injection cap — holding `cancel_all()`'s gather for up to 20 minutes.
-        # The report is registered in `self._report_tasks`, so `cancel_all()`'s
+        # The report is registered in `self._manager._report_tasks`, so `cancel_all()`'s
         # bounded drain owns it from here.
         if report_task is not None and not self._manager._shutting_down:
             await self._manager._await_report(report_task)
@@ -760,6 +780,7 @@ class RunEventCoordinator(ManagerComponent):
                 )
             # Detect CC provider to skip permission event loop
             is_cc = self._manager._is_cc_provider(client)
+        await self._manager._coordinator_mark_running(info)
         # Intentionally check info.agent (not resolved `agent`) so only
         # explicitly requested agents skip _SYSTEM_PREFIX (defense-in-depth).
         named_agent = bool(info.agent and _AGENT_NAME_RE.fullmatch(info.agent))

--- a/src/kiro_crew/subagent_manager/terminal.py
+++ b/src/kiro_crew/subagent_manager/terminal.py
@@ -9,23 +9,41 @@ from ._component import ManagerComponent
 if TYPE_CHECKING:
     from ..subagent import (
         _ON_DONE_TIMEOUT,
+        _OUTBOX_RESULT_SUMMARY_LEN,
         _RESET_TIMEOUT,
+        _TERMINAL_RETRY_SECONDS,
+        EXECUTION_LEASE_SECONDS,
         SUBAGENT_COMPLETION_PREFIX,
+        AuthorityOutcomeUncertain,
+        CoordinatorDecision,
+        DeliveryState,
+        OutboxEvent,
+        RunCompletion,
+        RunOutcome,
         Stats,
         SubagentInfo,
         _done_result,
         _injection_notice_outcome,
         _load_child_process_helpers,
+        _OutboxDeliveryContext,
+        _OutboxDeliveryRetry,
         _redact,
+        _TerminalCommitRejected,
         _timeout_context,
         _ws_result_path,
         asyncio,
+        clear_tombstone,
+        dashboard_slot_key,
+        json,
         logger,
         mark_delivered,
         os,
         platform_compat,
+        redact_credentials,
+        redact_exfiltration_urls,
         sel,
         subprocess_executor,
+        time,
     )
 
 
@@ -33,6 +51,326 @@ class TerminalCoordinator(ManagerComponent):
     """Own terminal transitions while state remains facade-owned."""
 
     __slots__ = ()
+
+    async def _coordinator_mark_starting_impl(self, info: SubagentInfo) -> None:
+        """Acquire the first durable lifecycle transition before child startup."""
+
+        if info._coordinator_started or info._coordinator_fence is None:
+            return
+        command = info._coordinator_command
+        if command is None:
+            raise RuntimeError("coordinator execution command is missing")
+        try:
+            result = await self._manager._coordinator.mark_starting(
+                command,
+                info._coordinator_fence,
+                info._coordinator_version,
+            )
+        except Exception:
+            result = await self._manager._coordinator.mark_starting(
+                command,
+                info._coordinator_fence,
+                info._coordinator_version,
+            )
+        if result.value is None or result.decision is CoordinatorDecision.REJECTED:
+            raise RuntimeError(f"coordinator start refused: {result.reason.value}")
+        info._coordinator_version = result.value.version
+        info._coordinator_started = True
+
+    async def _coordinator_mark_running_impl(self, info: SubagentInfo) -> None:
+        """Commit that a child session exists before prompting it."""
+
+        if info._coordinator_running or info._coordinator_fence is None:
+            return
+        try:
+            result = await self._manager._coordinator.mark_running(
+                info.id,
+                info._coordinator_fence,
+                info._coordinator_version,
+            )
+        except Exception:
+            result = await self._manager._coordinator.mark_running(
+                info.id,
+                info._coordinator_fence,
+                info._coordinator_version,
+            )
+        if result.value is None or result.decision is CoordinatorDecision.REJECTED:
+            raise RuntimeError(f"coordinator running transition refused: {result.reason.value}")
+        info._coordinator_version = result.value.version
+        info._coordinator_running = True
+
+    def _start_coordinator_heartbeat_impl(self, info: SubagentInfo) -> None:
+        fence = info._coordinator_fence
+        if fence is None or info.id in self._manager._lease_tasks:
+            return
+        renew_fence = fence
+
+        async def _renew() -> None:
+            cadence = EXECUTION_LEASE_SECONDS / 3
+            while True:
+                await asyncio.sleep(cadence)
+                try:
+                    renewed = await self._manager._coordinator.renew(
+                        info.id,
+                        renew_fence,
+                        time.time() + EXECUTION_LEASE_SECONDS,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Subagent %s coordinator lease renewal failed",
+                        info.id,
+                        exc_info=True,
+                    )
+                    continue
+                if not renewed:
+                    logger.error("Subagent %s lost its coordinator execution lease", info.id)
+                    return
+
+        task = asyncio.create_task(_renew())
+        self._manager._lease_tasks[info.id] = task
+
+        def _forget(done: asyncio.Task[None]) -> None:
+            if self._manager._lease_tasks.get(info.id) is done:
+                self._manager._lease_tasks.pop(info.id, None)
+
+        task.add_done_callback(_forget)
+
+    async def _stop_coordinator_heartbeat_impl(self, run_id: str) -> None:
+        lease_task = self._manager._lease_tasks.pop(run_id, None)
+        if lease_task is None:
+            return
+        lease_task.cancel()
+        await asyncio.gather(lease_task, return_exceptions=True)
+
+    def _coordinator_outcome_impl(self, info: SubagentInfo) -> RunOutcome:
+        if info.user_stopped:
+            return RunOutcome.STOPPED
+        if info.error:
+            return RunOutcome.FAILED
+        return RunOutcome.COMPLETED
+
+    def _completion_payload_impl(self, info: SubagentInfo) -> str:
+        task, _ = redact_exfiltration_urls(info.task)
+        task, _ = redact_credentials(task)
+        error, _ = redact_exfiltration_urls(info.error)
+        error, _ = redact_credentials(error)
+        summary, _ = redact_exfiltration_urls(_done_result(info.result))
+        summary, _ = redact_credentials(summary)
+        summary = summary[:_OUTBOX_RESULT_SUMMARY_LEN]
+        return json.dumps(
+            {
+                "id": info.id,
+                "parent_session_key": info.parent_session_key,
+                "agent": info.agent,
+                "task": task[:1000],
+                "outcome": info.outcome,
+                "error": error[:2000],
+                "result_path": info.result_path,
+                "result_summary": summary,
+                "result_truncated": bool(
+                    info.result_truncated or len(info.result) > _OUTBOX_RESULT_SUMMARY_LEN
+                ),
+                "user_stopped": info.user_stopped,
+                "silent": info.silent,
+                "batch_id": info.batch_id,
+                "batch_total": info.batch_total,
+                "elapsed": info.elapsed,
+                "conversation_key": info.conversation_key,
+                "resolved_model": info.resolved_model,
+                "requested_model": _redact(info.requested_model),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    async def _commit_terminal_event_impl(self, info: SubagentInfo) -> OutboxEvent | None:
+        fence = info._coordinator_fence
+        if fence is None:
+            return None
+        try:
+            result = await self._manager._coordinator.complete(
+                RunCompletion(
+                    run_id=info.id,
+                    outcome=self._manager._coordinator_outcome(info),
+                    result_path=info.result_path,
+                    error=_redact(info.error),
+                    event_type="subagent_completion",
+                    destination=info.parent_session_key,
+                    payload_json=self._manager._completion_payload(info),
+                    terminal_at=time.time(),
+                ),
+                fence,
+                info._coordinator_version,
+            )
+        except Exception:
+            logger.exception("Subagent %s terminal coordinator commit failed", info.id)
+            return None
+        if result.decision is CoordinatorDecision.REJECTED:
+            logger.error(
+                "Subagent %s terminal coordinator commit refused: %s",
+                info.id,
+                result.reason.value,
+            )
+            raise _TerminalCommitRejected(result.reason.value)
+        if result.value is None:
+            return None
+        info._coordinator_version = result.value.run_version
+        info._delivery_event_id = result.value.event_id
+        return result.value
+
+    def _info_from_outbox_impl(self, event: OutboxEvent) -> SubagentInfo:
+        payload = json.loads(event.payload_json)
+        if not isinstance(payload, dict):
+            raise ValueError("subagent completion payload must be an object")
+        info = SubagentInfo(
+            id=str(payload.get("id") or event.run_id),
+            task=str(payload.get("task") or ""),
+            parent_session_key=str(payload.get("parent_session_key") or event.destination),
+            agent=str(payload.get("agent") or ""),
+            done=True,
+            result=str(payload.get("result_summary") or ""),
+            result_path=str(payload.get("result_path") or ""),
+            result_truncated=bool(payload.get("result_truncated")),
+            error=str(payload.get("error") or ""),
+            user_stopped=bool(payload.get("user_stopped")),
+            silent=bool(payload.get("silent")),
+            elapsed=float(payload.get("elapsed") or 0.0),
+            conversation_key=str(payload.get("conversation_key") or ""),
+            resolved_model=str(payload.get("resolved_model") or ""),
+            requested_model=str(payload.get("requested_model") or ""),
+        )
+        # Batch progress lives in the gateway's volatile digest state. After a
+        # restart, replay each stable event independently instead of inventing
+        # a fresh one-member wave from persisted batch labels.
+        info._delivery_event_id = event.event_id
+        return info
+
+    async def _deliver_outbox_event_impl(self, event: OutboxEvent) -> bool:
+        """Hand one claimed event to existing routing, returning acceptance."""
+
+        context = self._manager._outbox_contexts.get(event.event_id)
+        if context is None:
+            context = self._manager._outbox_live_contexts.pop(event.run_id, None)
+            if context is None:
+                info = self._manager._info_from_outbox(event)
+                context = _OutboxDeliveryContext(
+                    info=info,
+                    source="Subagent outbox",
+                    injection_timeout_reason="durable completion delivery timed out",
+                    mark_delivered_on_success=True,
+                    settle_digest=True,
+                    teardown_done=None,
+                )
+            self._manager._outbox_contexts[event.event_id] = context
+        info = context.info
+        info._delivery_event_id = event.event_id
+        # A deferred destination already accepted this stable event into its
+        # own queue or digest. Background retries keep its durable identity
+        # pending for acknowledgement without repeating routing or accounting.
+        if info._digest_held or info._delivery_queued:
+            return False
+        info._delivery_failed = False
+        if not context.effects_fired:
+            await self._manager._fire_event(
+                "subagent_done",
+                info,
+                {
+                    "elapsed": info.elapsed,
+                    "error": _redact(info.error) if info.error else None,
+                    "stopped": info.user_stopped,
+                    "outcome": info.outcome,
+                    "task": _redact(info.task),
+                    "agent": _redact(info.agent),
+                    "child_session": info.conversation_key or f"subagent:{info.id}",
+                    "model": info.resolved_model,
+                    "requested_model": _redact(info.requested_model),
+                    "result": _done_result(info.result),
+                    "event_id": event.event_id,
+                },
+            )
+            context.effects_fired = True
+        if self._manager._on_done:
+            info._delivery_retry = context.callback_started
+            context.callback_started = True
+            try:
+                await asyncio.wait_for(self._manager._on_done(info), timeout=_ON_DONE_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "%s: completion injection timed out for %s after %.0fs",
+                    context.source,
+                    info.id,
+                    _ON_DONE_TIMEOUT,
+                )
+                try:
+                    await self._manager._sessions.reset(info.parent_session_key)
+                except Exception:
+                    logger.debug(
+                        "Failed to reset parent session %s after injection timeout",
+                        info.parent_session_key,
+                        exc_info=True,
+                    )
+                self._manager.notify_injection_failed(
+                    info,
+                    reason=context.injection_timeout_reason,
+                )
+                raise _OutboxDeliveryRetry(context.injection_timeout_reason)
+            except Exception:
+                logger.exception("%s: announce failed for %s", context.source, info.id)
+                raise
+        if info._delivery_failed:
+            raise _OutboxDeliveryRetry("completion destination reported a routing failure")
+        info._delivery_retry = False
+        info._delivery_batch_progress = None
+        info._delivery_batch_final = False
+        info._reported_to_parent = True
+        if info._digest_held or info._delivery_queued:
+            return False
+        if context.settle_digest:
+            await self._manager._settle_digest_holds(info)
+        if context.mark_delivered_on_success and info.outcome == "completed":
+            teardown_done = context.teardown_done
+            if teardown_done is not None and not teardown_done.is_set():
+                try:
+                    await asyncio.wait_for(teardown_done.wait(), timeout=_RESET_TIMEOUT + 30)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Subagent %s: teardown did not complete before the "
+                        "delivered tombstone; writing it anyway",
+                        info.id,
+                    )
+            try:
+                await asyncio.to_thread(mark_delivered, info.id)
+            except Exception:
+                logger.debug("Failed to mark subagent %s delivered", info.id, exc_info=True)
+            try:
+                slot_key = dashboard_slot_key(info.parent_session_key)
+                if slot_key:
+                    _ws_result_path(slot_key, info.id).unlink(missing_ok=True)
+            except Exception:
+                logger.debug("Failed to clean workspace result for %s", info.id, exc_info=True)
+        self._manager._outbox_contexts.pop(event.event_id, None)
+        return True
+
+    async def _reject_waiting_before_terminal_impl(self, info: SubagentInfo, error: str) -> None:
+        """Persist a pre-start rejection while its run lease protects terminal delivery."""
+
+        while True:
+            try:
+                await self._manager.command_authority.reject_waiting_execution(
+                    info.id,
+                    error,
+                    stop_heartbeat=False,
+                )
+                return
+            except asyncio.CancelledError:
+                raise
+            except AuthorityOutcomeUncertain:
+                logger.warning(
+                    "Subagent %s waiting rejection commit failed; retrying",
+                    info.id,
+                    exc_info=True,
+                )
+                await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
 
     def _claim_finalize_impl(self, info: SubagentInfo, *, supersede_recovery: bool = False) -> bool:
         """Claim the exclusive right to report ``info``'s terminal outcome.
@@ -105,6 +443,66 @@ class TerminalCoordinator(ManagerComponent):
         arguments rather than unified away. The WS payload is identical (both
         set ``info.elapsed`` before calling), so it is built from ``info`` here.
         """
+        if info._coordinator_fence is not None:
+            context = _OutboxDeliveryContext(
+                info=info,
+                source=source,
+                injection_timeout_reason=injection_timeout_reason,
+                mark_delivered_on_success=mark_delivered_on_success,
+                settle_digest=settle_digest,
+                teardown_done=teardown_done,
+            )
+            self._manager._outbox_live_contexts[info.id] = context
+            event = None
+            while event is None:
+                try:
+                    event = await self._manager._commit_terminal_event(info)
+                except _TerminalCommitRejected:
+                    if self._manager._outbox_live_contexts.get(info.id) is context:
+                        self._manager._outbox_live_contexts.pop(info.id, None)
+                    await self._manager._stop_coordinator_heartbeat(info.id)
+                    await self._manager.command_authority.stop_execution_heartbeat(info.id)
+                    try:
+                        await asyncio.to_thread(clear_tombstone, info.id)
+                    except Exception:
+                        logger.debug(
+                            "Failed to re-admit stale-fence result %s to recovery",
+                            info.id,
+                            exc_info=True,
+                        )
+                    return
+                if event is None:
+                    await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+            if self._manager._outbox_live_contexts.get(info.id) is context:
+                self._manager._outbox_live_contexts.pop(info.id, None)
+            if not info._reported_to_parent:
+                self._manager._outbox_contexts.setdefault(event.event_id, context)
+            try:
+                await self._manager._stop_coordinator_heartbeat(info.id)
+            finally:
+                await self._manager.command_authority.stop_execution_heartbeat(info.id)
+            if info._reported_to_parent:
+                return
+            while True:
+                try:
+                    attempts = await self._manager._outbox_delivery.drain_once(
+                        event_id=event.event_id
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning(
+                        "Subagent %s durable completion routing failed",
+                        info.id,
+                        exc_info=True,
+                    )
+                else:
+                    if any(attempt.status is DeliveryState.DELIVERED for attempt in attempts):
+                        return
+                    if info._reported_to_parent or info._digest_held or info._delivery_queued:
+                        return
+                await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+
         await self._manager._fire_event(
             "subagent_done",
             info,
@@ -145,7 +543,7 @@ class TerminalCoordinator(ManagerComponent):
                 # _on_done returned without raising, so the wave digest (if this
                 # was the final member) has been handed off. Only NOW settle the
                 # held members' delivery tombstones.
-                self._manager._settle_digest_holds(info)
+                await self._manager._settle_digest_holds(info)
             # Digest-held wave members are NOT marked delivered here: their
             # result has not reached the parent yet (the gateway marks them when
             # the digest fires), so a restart mid-wave leaves them visible to
@@ -187,7 +585,7 @@ class TerminalCoordinator(ManagerComponent):
                 # "delivered" tombstone excludes it from orphan reconciliation;
                 # the reaper prunes it after agent.subagent_result_ttl_secs.
                 try:
-                    mark_delivered(info.id)
+                    await asyncio.to_thread(mark_delivered, info.id)
                 except Exception:
                     logger.debug("Failed to mark subagent %s delivered", info.id, exc_info=True)
                 # Clean up workspace result file (agent-{id}.md in parent dir).
@@ -593,6 +991,7 @@ class TerminalCoordinator(ManagerComponent):
         report could not be injected, including runs cancelled or rejected
         before they ever executed.
         """
+        info._delivery_failed = True
         try:
             # Lazy: the dashboard layer must not be imported by a core module at
             # import time.

--- a/src/kiro_crew/subagent_manager/waves.py
+++ b/src/kiro_crew/subagent_manager/waves.py
@@ -9,9 +9,11 @@ from ._component import ManagerComponent
 if TYPE_CHECKING:
     from ..subagent import (
         _RESET_TIMEOUT,
+        _TERMINAL_RETRY_SECONDS,
         _WAVE_STUCK_SECS,
         DIGEST_HOLD_SECS,
         SubagentInfo,
+        _OutboxDeliveryContext,
         asyncio,
         logger,
         mark_delivered,
@@ -25,6 +27,40 @@ class WaveDigestCoordinator(ManagerComponent):
     """Own waves transitions while state remains facade-owned."""
 
     __slots__ = ()
+
+    def _delivery_event_for_run_impl(self, run_id: str) -> str:
+        for event_id, context in self._manager._outbox_contexts.items():
+            if context.info.id == run_id:
+                return event_id
+        return ""
+
+    def _delivery_context_for_run_impl(self, run_id: str) -> _OutboxDeliveryContext | None:
+        for context in self._manager._outbox_contexts.values():
+            if context.info.id == run_id:
+                return context
+        return None
+
+    async def _ack_delivery_for_run_impl(self, run_id: str) -> None:
+        event_id = self._manager._delivery_event_for_run(run_id)
+        if not event_id:
+            return
+        while True:
+            try:
+                delivered = await self._manager._outbox_delivery.acknowledge(event_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Subagent %s: durable delivery acknowledgement failed; retrying",
+                    run_id,
+                    exc_info=True,
+                )
+                await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+                continue
+            if delivered is not None:
+                self._manager._outbox_contexts.pop(event_id, None)
+                return
+            await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
 
     def batch_members_pending_impl(self, batch_id: str) -> bool:
         """True while ANY member of *batch_id* is still outstanding — running
@@ -105,9 +141,7 @@ class WaveDigestCoordinator(ManagerComponent):
         )
         if self._manager._on_done:
             try:
-                self._manager._tasks[f"lost-{info.id}"] = asyncio.ensure_future(
-                    self._manager._safe_announce(info)
-                )
+                self._manager._tasks[f"lost-{info.id}"] = self._manager._spawn_announcement(info)
             except RuntimeError:
                 pass  # no running loop (sync/test context)
 
@@ -273,7 +307,10 @@ class WaveDigestCoordinator(ManagerComponent):
                 "Digest hold flush announce failed for wave %s", info.batch_id, exc_info=True
             )
             return
-        self._manager._settle_digest_holds(info)
+        if info._delivery_failed:
+            logger.warning("Digest hold flush delivery deferred for wave %s", info.batch_id)
+            return
+        await self._manager._settle_digest_holds(info)
 
     async def settle_queued_delivery_impl(self, agent_ids: list[str]) -> None:
         """Write the ``delivered`` tombstones for completions consumed from a queue.
@@ -310,14 +347,19 @@ class WaveDigestCoordinator(ManagerComponent):
                         "delivered tombstone; writing it anyway",
                         agent_id,
                     )
-            try:
-                await asyncio.to_thread(mark_delivered, agent_id)
-            except Exception:
-                logger.debug(
-                    "Failed to mark drained subagent %s delivered", agent_id, exc_info=True
-                )
+            context = self._manager._delivery_context_for_run(agent_id)
+            if context is None or context.info.outcome == "completed":
+                try:
+                    await asyncio.to_thread(mark_delivered, agent_id)
+                except Exception:
+                    logger.debug(
+                        "Failed to mark drained subagent %s delivered",
+                        agent_id,
+                        exc_info=True,
+                    )
+            await self._manager._ack_delivery_for_run(agent_id)
 
-    def _settle_digest_holds_impl(self, info: SubagentInfo) -> None:
+    async def _settle_digest_holds_impl(self, info: SubagentInfo) -> None:
         """Settle delivery tombstones for wave members whose injection was
         held for this member's digest. Called ONLY after ``_on_done`` returned
         without raising — and it is a real settle only for the routes where
@@ -338,7 +380,10 @@ class WaveDigestCoordinator(ManagerComponent):
         """
         ids, info._digest_settle_ids = info._digest_settle_ids, []
         for _hid in ids:
-            try:
-                mark_delivered(_hid)
-            except Exception:
-                logger.debug("Failed to settle held subagent %s", _hid, exc_info=True)
+            context = self._manager._delivery_context_for_run(_hid)
+            if context is None or context.info.outcome == "completed":
+                try:
+                    await asyncio.to_thread(mark_delivered, _hid)
+                except Exception:
+                    logger.debug("Failed to settle held subagent %s", _hid, exc_info=True)
+            await self._manager._ack_delivery_for_run(_hid)

--- a/test/test_run_coordinator_contract.py
+++ b/test/test_run_coordinator_contract.py
@@ -30,6 +30,7 @@ from kiro_crew.run_coordinator import (
     SQLiteRunCoordinator,
     SubmitControl,
     SubmitRun,
+    TerminalRun,
 )
 
 
@@ -688,7 +689,7 @@ async def test_exact_execution_command_claim_and_finish_are_idempotent(
 
 
 @pytest.mark.asyncio
-async def test_execution_rejection_atomically_terminals_created_run(
+async def test_execution_rejection_retains_fence_for_terminal_outbox_commit(
     coordinator: RunCoordinator,
     clock: FakeClock,
 ) -> None:
@@ -708,9 +709,9 @@ async def test_execution_rejection_atomically_terminals_created_run(
     assert rejected.value is not None
     assert rejected.value.status is CommandStatus.REJECTED
     assert run is not None
-    assert run.observed_state is ObservedState.TERMINAL
-    assert run.outcome is RunOutcome.FAILED
-    assert run.error == "approval denied"
+    assert run.observed_state is ObservedState.ACCEPTED
+    assert run.outcome is None
+    assert run.error == ""
     assert await coordinator.claim_commands(OwnerLease("executor", clock.value + 10), limit=1) == []
 
 
@@ -740,6 +741,9 @@ async def test_command_claim_returns_fence_and_advances_legal_transitions(
     assert starting.decision is CoordinatorDecision.APPLIED
     assert starting.value is not None
     assert starting.value.observed_state is ObservedState.STARTING
+    receipt = await coordinator.get_command_by_key("key-1")
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.CLAIMED
 
     running = await coordinator.mark_running(
         "run-1", claim.fence, expected_version=starting.value.version
@@ -758,7 +762,7 @@ async def test_version_and_execution_fences_reject_without_mutation(
     before = await coordinator.get_run("run-1")
 
     version_conflict = await coordinator.mark_running(
-        "run-1", claim.fence, expected_version=running.version - 1
+        "run-1", claim.fence, expected_version=running.version - 2
     )
     stale = await coordinator.mark_running(
         "run-1",
@@ -771,6 +775,49 @@ async def test_version_and_execution_fences_reject_without_mutation(
     assert stale.decision is CoordinatorDecision.REJECTED
     assert stale.reason is CoordinatorReason.STALE_FENCE
     assert await coordinator.get_run("run-1") == before
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_transition_replays_after_commit_response_loss(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    receipt = await coordinator.submit(_request())
+    assert receipt.value is not None
+    claims = await coordinator.claim_commands(
+        OwnerLease(owner_id="gateway-1", lease_expires_at=clock.value + 30),
+        limit=1,
+    )
+    assert len(claims) == 1
+    claim = claims[0]
+
+    starting = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        expected_version=claim.run.version,
+    )
+    replay_starting = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        expected_version=claim.run.version,
+    )
+    assert starting.value is not None
+    assert replay_starting.decision is CoordinatorDecision.UNCHANGED
+    assert replay_starting.value == starting.value
+
+    running = await coordinator.mark_running(
+        claim.run.run_id,
+        claim.fence,
+        expected_version=starting.value.version,
+    )
+    replay_running = await coordinator.mark_running(
+        claim.run.run_id,
+        claim.fence,
+        expected_version=starting.value.version,
+    )
+    assert running.value is not None
+    assert replay_running.decision is CoordinatorDecision.UNCHANGED
+    assert replay_running.value == running.value
 
 
 @pytest.mark.asyncio
@@ -1233,3 +1280,209 @@ async def test_claim_commands_skips_orphaned_command_without_partial_failure(
     claims = await memory.claim_commands(OwnerLease("gateway-1", clock.value + 10), limit=1)
 
     assert claims == []
+
+
+@pytest.mark.asyncio
+async def test_expired_execution_fence_can_complete_before_takeover(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    await coordinator.submit(_request())
+    claim = (
+        await coordinator.claim_commands(
+            OwnerLease(owner_id="gateway-1", lease_expires_at=clock.value + 5), limit=1
+        )
+    )[0]
+    assert claim.fence is not None
+    assert claim.run is not None
+    starting = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        claim.run.version,
+    )
+    assert starting.value is not None
+    running = await coordinator.mark_running(
+        claim.run.run_id,
+        claim.fence,
+        starting.value.version,
+    )
+    assert running.value is not None
+    clock.value += 6
+
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id=claim.run.run_id,
+            outcome=RunOutcome.COMPLETED,
+            result_path="/result.txt",
+            error="",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json="{}",
+            terminal_at=clock.value,
+        ),
+        claim.fence,
+        running.value.version,
+    )
+
+    assert completed.decision is CoordinatorDecision.APPLIED
+    assert completed.value is not None
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_atomically_creates_replayable_outbox_without_command(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    request = TerminalRun(
+        run_id="synthetic-terminal",
+        parent_session="dashboard:parent",
+        agent="kirocrew",
+        task="record a rejected batch member",
+        conversation_key="",
+        outcome=RunOutcome.FAILED,
+        result_path="",
+        error="spawn submission lost",
+        created_at=clock.value,
+        terminal_at=clock.value,
+        event_type="subagent_completion",
+        destination="dashboard:parent",
+        payload_json='{"id":"synthetic-terminal"}',
+    )
+
+    created = await coordinator.record_terminal(request)
+    replay = await coordinator.record_terminal(request)
+
+    assert created.decision is CoordinatorDecision.APPLIED
+    assert created.value is not None
+    assert created.value.run.observed_state is ObservedState.TERMINAL
+    assert created.value.run.outcome is RunOutcome.FAILED
+    assert created.value.event.status is DeliveryState.PENDING
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+    assert replay.value is not None
+    assert replay.value.event.event_id == created.value.event.event_id
+    assert (
+        await coordinator.claim_commands(
+            OwnerLease("executor", clock.value + 10),
+            limit=1,
+        )
+        == []
+    )
+    claimed = await coordinator.claim_outbox(
+        OwnerLease("delivery", clock.value + 10),
+        limit=1,
+        event_id=created.value.event.event_id,
+    )
+    assert [event.event_id for event in claimed] == [created.value.event.event_id]
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_closes_rejected_execution_and_creates_outbox(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    submitted = await coordinator.submit(_request(run_id="rejected-before-registration"))
+    assert submitted.value is not None
+    claim = (
+        await coordinator.claim_commands(
+            OwnerLease("executor", clock.value + 10),
+            limit=1,
+        )
+    )[0]
+    rejected = await coordinator.finish_command(
+        claim.command_fence,
+        CommandStatus.REJECTED,
+        rejection_reason="PlatformCompositionError",
+        result_json='{"error":"platform policy unavailable"}',
+    )
+    assert rejected.decision is CoordinatorDecision.APPLIED
+
+    request = TerminalRun(
+        run_id="rejected-before-registration",
+        parent_session="",
+        agent="",
+        task="compare the candidates",
+        conversation_key="",
+        outcome=RunOutcome.FAILED,
+        result_path="",
+        error="platform policy unavailable",
+        created_at=clock.value + 1,
+        terminal_at=clock.value + 2,
+        event_type="subagent_completion",
+        destination="",
+        payload_json='{"id":"rejected-before-registration"}',
+    )
+    recorded = await coordinator.record_terminal(request)
+    replay = await coordinator.record_terminal(request)
+
+    assert recorded.decision is CoordinatorDecision.APPLIED
+    assert recorded.value is not None
+    assert recorded.value.run.observed_state is ObservedState.TERMINAL
+    assert recorded.value.run.outcome is RunOutcome.FAILED
+    assert recorded.value.run.parent_session == "dashboard:parent"
+    assert recorded.value.run.agent == "researcher"
+    assert recorded.value.run.created_at == submitted.value.run.created_at
+    assert recorded.value.event.destination == "dashboard:parent"
+    assert recorded.value.event.status is DeliveryState.PENDING
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+    assert replay.value is not None
+    assert replay.value.event.event_id == recorded.value.event.event_id
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_cannot_close_pending_execution(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    await coordinator.submit(_request(run_id="pending-execution"))
+
+    recorded = await coordinator.record_terminal(
+        TerminalRun(
+            run_id="pending-execution",
+            parent_session="dashboard:parent",
+            agent="researcher",
+            task="compare the candidates",
+            conversation_key="",
+            outcome=RunOutcome.FAILED,
+            result_path="",
+            error="not actually settled",
+            created_at=clock.value,
+            terminal_at=clock.value,
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"id":"pending-execution"}',
+        )
+    )
+
+    assert recorded.decision is CoordinatorDecision.REJECTED
+    assert recorded.reason is CoordinatorReason.OUTCOME_CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_rejects_conflicting_replay(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    request = TerminalRun(
+        run_id="synthetic-terminal-conflict",
+        parent_session="dashboard:parent",
+        agent="kirocrew",
+        task="record a rejected batch member",
+        conversation_key="",
+        outcome=RunOutcome.FAILED,
+        result_path="",
+        error="spawn submission lost",
+        created_at=clock.value,
+        terminal_at=clock.value,
+        event_type="subagent_completion",
+        destination="dashboard:parent",
+        payload_json='{"id":"synthetic-terminal-conflict"}',
+    )
+    created = await coordinator.record_terminal(request)
+
+    conflict = await coordinator.record_terminal(
+        replace(request, payload_json='{"id":"different"}')
+    )
+
+    assert created.decision is CoordinatorDecision.APPLIED
+    assert conflict.decision is CoordinatorDecision.REJECTED
+    assert conflict.reason is CoordinatorReason.OUTCOME_CONFLICT

--- a/test/test_run_coordinator_delivery.py
+++ b/test/test_run_coordinator_delivery.py
@@ -1,0 +1,1982 @@
+"""Transactional outbox delivery and retry behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from dataclasses import replace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.run_coordinator import (
+    CommandOperation,
+    CommandStatus,
+    CoordinatorDecision,
+    CoordinatorReason,
+    CoordinatorResult,
+    DeliveryState,
+    MemoryRunCoordinator,
+    OwnerLease,
+    RunCompletion,
+    RunFence,
+    RunOutcome,
+    SubmitRun,
+)
+from kiro_crew.run_coordinator.delivery import DeliveryAttempt, OutboxDeliveryAdapter
+from kiro_crew.subagent import SubagentInfo, SubagentManager, _OutboxDeliveryRetry
+from kiro_crew.subagent_command_authority import AdmittedExecution
+
+
+class _Clock:
+    def __init__(self, value: float = 100.0) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+@pytest.fixture
+def terminal_retry_manager(monkeypatch):
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    info = SubagentInfo(id="run-retry", task="inspect", done=True)
+    info._coordinator_fence = MagicMock()
+    event = MagicMock(event_id="event-retry")
+    return manager, info, event
+
+
+@pytest.mark.asyncio
+async def test_terminal_report_retries_transient_coordinator_commit(terminal_retry_manager) -> None:
+    manager, info, event = terminal_retry_manager
+    authority_stop = AsyncMock()
+    manager.command_authority.stop_execution_heartbeat = authority_stop
+
+    async def commit_then_succeed(_info: SubagentInfo):
+        assert not authority_stop.await_count
+        return None if manager._commit_terminal_event.await_count == 1 else event
+
+    manager._commit_terminal_event = AsyncMock(side_effect=commit_then_succeed)
+    manager._outbox_delivery.drain_once = AsyncMock(
+        return_value=[DeliveryAttempt(event.event_id, DeliveryState.DELIVERED)]
+    )
+
+    await manager._report_terminal(
+        info,
+        source="test",
+        injection_timeout_reason="timeout",
+        mark_delivered_on_success=True,
+    )
+
+    assert manager._commit_terminal_event.await_count == 2
+    authority_stop.assert_awaited_once_with(info.id)
+    manager._outbox_delivery.drain_once.assert_awaited_once_with(event_id=event.event_id)
+
+
+@pytest.mark.asyncio
+async def test_terminal_report_stops_after_permanent_fence_rejection(
+    terminal_retry_manager,
+    monkeypatch,
+) -> None:
+    manager, info, _event = terminal_retry_manager
+    cleared: list[str] = []
+    monkeypatch.setattr("kiro_crew.subagent.clear_tombstone", cleared.append)
+    manager._coordinator.complete = AsyncMock(
+        return_value=CoordinatorResult(
+            CoordinatorDecision.REJECTED,
+            CoordinatorReason.STALE_FENCE,
+            None,
+        )
+    )
+    manager._outbox_delivery.drain_once = AsyncMock()
+
+    await asyncio.wait_for(
+        manager._report_terminal(
+            info,
+            source="test",
+            injection_timeout_reason="timeout",
+            mark_delivered_on_success=True,
+        ),
+        timeout=0.2,
+    )
+
+    manager._coordinator.complete.assert_awaited_once()
+    manager._outbox_delivery.drain_once.assert_not_awaited()
+    assert cleared == [info.id]
+
+
+@pytest.mark.asyncio
+async def test_terminal_report_retries_transient_outbox_routing(terminal_retry_manager) -> None:
+    manager, info, event = terminal_retry_manager
+    manager._commit_terminal_event = AsyncMock(return_value=event)
+    manager._outbox_delivery.drain_once = AsyncMock(
+        side_effect=[
+            RuntimeError("routing unavailable"),
+            [DeliveryAttempt(event.event_id, DeliveryState.DELIVERED)],
+        ]
+    )
+
+    await manager._report_terminal(
+        info,
+        source="test",
+        injection_timeout_reason="timeout",
+        mark_delivered_on_success=True,
+    )
+
+    assert manager._outbox_delivery.drain_once.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_synthetic_batch_terminal_replays_atomic_commit_after_lost_response(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-synthetic")
+    original_record = coordinator.record_terminal
+    calls = 0
+
+    async def commit_then_lose_response(request):
+        nonlocal calls
+        calls += 1
+        result = await original_record(request)
+        if calls == 1:
+            raise RuntimeError("coordinator response lost")
+        return result
+
+    coordinator.record_terminal = commit_then_lose_response  # type: ignore[method-assign]
+    delivered: list[SubagentInfo] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        delivered.append(info)
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="synthetic-run",
+        task="record a rejected batch member",
+        parent_session_key="dashboard:parent",
+        agent="kirocrew",
+        done=True,
+        error="spawn submission lost",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+
+    await manager._report_synthetic_batch_terminal(info)
+
+    run = await coordinator.get_run(info.id)
+    assert calls == 2
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert run.outcome is RunOutcome.FAILED
+    assert coordinator._commands == {}
+    assert list(coordinator._outbox) == ["event-synthetic"]
+    assert info._delivery_event_id == "event-synthetic"
+    assert delivered == [info]
+
+
+@pytest.mark.asyncio
+async def test_pre_registration_rejection_persists_terminal_outbox() -> None:
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-rejected")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="rejected-run",
+            command_id="rejected-command",
+            idempotency_key="rejected-key",
+            payload_hash="rejected-hash",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="reject before registration",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = (
+        await coordinator.claim_commands(
+            OwnerLease("executor", submitted.value.run.created_at + 30),
+            limit=1,
+        )
+    )[0]
+    rejected = await coordinator.finish_command(
+        claim.command_fence,
+        CommandStatus.REJECTED,
+        rejection_reason="PlatformCompositionError",
+    )
+    assert rejected.decision is CoordinatorDecision.APPLIED
+    delivered: list[SubagentInfo] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        delivered.append(info)
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+
+    await manager.announce_durable_rejection(
+        AdmittedExecution(
+            id="rejected-run",
+            task="reject before registration",
+            done=True,
+            error="platform policy unavailable",
+            batch_id="batch-1",
+            batch_total=2,
+        )
+    )
+
+    run = await coordinator.get_run("rejected-run")
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert run.outcome is RunOutcome.FAILED
+    assert list(coordinator._outbox) == ["event-rejected"]
+    assert coordinator._outbox["event-rejected"].destination == "dashboard:parent"
+    assert [info.id for info in delivered] == ["rejected-run"]
+    assert delivered[0].parent_session_key == "dashboard:parent"
+    assert delivered[0].agent == "reviewer"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_retries_cancelled_synthetic_terminal_commit(monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.subagent._REPORT_DRAIN_TIMEOUT", 0.0)
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-shutdown")
+    original_record = coordinator.record_terminal
+    commit_started = asyncio.Event()
+    calls = 0
+
+    async def delayed_record(request):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            commit_started.set()
+            await asyncio.Event().wait()
+        return await original_record(request)
+
+    coordinator.record_terminal = delayed_record  # type: ignore[method-assign]
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="synthetic-shutdown",
+        task="record a rejected batch member",
+        parent_session_key="dashboard:parent",
+        done=True,
+        error="spawn rejected",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+
+    manager._announce_rejection(info)
+    await commit_started.wait()
+    await manager.cancel_all()
+
+    run = await coordinator.get_run(info.id)
+    assert calls == 2
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert list(coordinator._outbox) == ["event-shutdown"]
+
+
+@pytest.mark.parametrize("first_attempt", ["error", "missing-value"])
+@pytest.mark.asyncio
+async def test_shutdown_retries_synthetic_terminal_after_retry_sleep_cancellation(
+    monkeypatch,
+    first_attempt: str,
+) -> None:
+    monkeypatch.setattr("kiro_crew.subagent._REPORT_DRAIN_TIMEOUT", 0.0)
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-retry-cancel")
+    original_record = coordinator.record_terminal
+    retry_started = asyncio.Event()
+    calls = 0
+
+    async def fail_then_record(request):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            if first_attempt == "error":
+                raise RuntimeError("coordinator unavailable")
+            return CoordinatorResult(
+                CoordinatorDecision.APPLIED,
+                CoordinatorReason.COMPLETED,
+                None,
+            )
+        return await original_record(request)
+
+    async def wait_for_retry(_delay: float) -> None:
+        retry_started.set()
+        await asyncio.Event().wait()
+
+    coordinator.record_terminal = fail_then_record  # type: ignore[method-assign]
+    monkeypatch.setattr("kiro_crew.subagent.asyncio.sleep", wait_for_retry)
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="synthetic-retry-cancel",
+        task="record a rejected batch member",
+        parent_session_key="dashboard:parent",
+        done=True,
+        error="spawn rejected",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+
+    manager._announce_rejection(info)
+    await retry_started.wait()
+    await manager.cancel_all()
+
+    run = await coordinator.get_run(info.id)
+    assert calls == 2
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert list(coordinator._outbox) == ["event-retry-cancel"]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_terminal_retries_non_delivered_attempt(monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-retry")
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="synthetic-retry",
+        task="record a rejected batch member",
+        parent_session_key="dashboard:parent",
+        done=True,
+        error="spawn rejected",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+    manager._outbox_delivery.drain_once = AsyncMock(
+        side_effect=[
+            [DeliveryAttempt("event-retry", DeliveryState.PENDING)],
+            [DeliveryAttempt("event-retry", DeliveryState.DELIVERED)],
+        ]
+    )
+
+    await manager._report_synthetic_batch_terminal(info)
+
+    assert manager._outbox_delivery.drain_once.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_scheduled_synthetic_announcement_is_immediately_lifecycle_owned() -> None:
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    info = SubagentInfo(
+        id="synthetic-scheduled",
+        task="record a rejected batch member",
+        done=True,
+        error="spawn rejected",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+
+    task = manager._spawn_announcement(info)
+    try:
+        assert task in manager._lifecycle.report_tasks
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+def test_admitted_batch_rejection_preserves_terminal_fence() -> None:
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    fence = RunFence("rejected-run", "executor", 3)
+    info = SubagentInfo(
+        id="rejected-run",
+        task="reject this batch member",
+        done=True,
+        error="spawn refused by governance",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+
+    result = manager._announce_rejection(
+        info,
+        coordinator_admitted=True,
+        coordinator_fence=fence,
+        coordinator_version=7,
+    )
+
+    assert result is info
+    assert info._coordinator_admitted is True
+    assert info._coordinator_fence == fence
+    assert info._coordinator_version == 7
+
+
+@pytest.mark.asyncio
+async def test_admitted_batch_rejection_routes_through_durable_terminal_report() -> None:
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=MemoryRunCoordinator(),
+    )
+    info = SubagentInfo(
+        id="rejected-run",
+        task="reject this batch member",
+        done=True,
+        error="spawn refused by governance",
+        batch_id="batch-1",
+        batch_total=2,
+        _coordinator_admitted=True,
+        _coordinator_fence=RunFence("rejected-run", "executor", 3),
+        _coordinator_version=7,
+    )
+    manager._run_terminal_report = AsyncMock()  # type: ignore[method-assign]
+
+    await manager.announce_durable_rejection(info)
+
+    manager._run_terminal_report.assert_awaited_once_with(
+        info,
+        source="Subagent keyed batch rejection",
+        injection_timeout_reason="keyed batch rejection delivery timed out",
+        mark_delivered_on_success=False,
+        settle_digest=True,
+    )
+    on_done.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replayed_batch_rejection_is_normalized_before_announcement() -> None:
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=MemoryRunCoordinator(),
+    )
+    replay = AdmittedExecution(
+        id="rejected-run",
+        task="reject this batch member",
+        done=True,
+        error="platform composition failed",
+        batch_id="batch-1",
+        batch_total=2,
+        silent=True,
+    )
+
+    await manager.announce_durable_rejection(replay)
+
+    on_done.assert_awaited_once()
+    announced = on_done.await_args.args[0]
+    assert isinstance(announced, SubagentInfo)
+    assert announced.id == replay.id
+    assert announced.task == replay.task
+    assert announced.done is True
+    assert announced.error == replay.error
+    assert announced.batch_id == replay.batch_id
+    assert announced.batch_total == replay.batch_total
+    assert announced.silent is True
+
+
+async def _completed_event(coordinator: MemoryRunCoordinator, clock: _Clock, run_id: str):
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id=run_id,
+            command_id=f"command-{run_id}",
+            idempotency_key=f"key-{run_id}",
+            payload_hash=f"hash-{run_id}",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        submitted.value.command.command_id,
+        OwnerLease("executor", clock.value + 30),
+    )
+    assert claim is not None and claim.fence is not None and claim.run is not None
+    starting = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        claim.run.version,
+    )
+    assert starting.value is not None
+    running = await coordinator.mark_running(
+        run_id,
+        claim.fence,
+        starting.value.version,
+    )
+    assert running.value is not None
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id=run_id,
+            outcome=RunOutcome.COMPLETED,
+            result_path=f"/results/{run_id}.txt",
+            error="",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json=json.dumps({"id": run_id, "result_summary": "done"}),
+            terminal_at=clock.value,
+        ),
+        claim.fence,
+        running.value.version,
+    )
+    assert completed.value is not None
+    return completed.value
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciliation_drains_completion_committed_before_restart(
+    monkeypatch,
+) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    delivered = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=delivered,
+        coordinator=coordinator,
+    )
+    monkeypatch.setattr("kiro_crew.subagent.list_orphans", lambda: [])
+
+    await manager._reconcile_orphans()
+
+    delivered.assert_awaited_once()
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_startup_orphan_scans_leave_the_event_loop_thread(monkeypatch) -> None:
+    event_loop_thread = threading.get_ident()
+    scan_threads: list[int] = []
+
+    def scan_orphans() -> list[dict[str, object]]:
+        scan_threads.append(threading.get_ident())
+        return []
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    monkeypatch.setattr("kiro_crew.subagent.list_orphans", scan_orphans)
+
+    await manager._reconcile_orphans()
+
+    assert len(scan_threads) == 2
+    assert all(thread_id != event_loop_thread for thread_id in scan_threads)
+
+
+@pytest.mark.asyncio
+async def test_startup_orphan_reaping_leaves_the_event_loop_thread(monkeypatch) -> None:
+    event_loop_thread = threading.get_ident()
+    reap_threads: list[int] = []
+    orphan = {"id": "run-1", "pid": 4242}
+
+    def reap_orphan(_state: dict[str, object]) -> bool:
+        reap_threads.append(threading.get_ident())
+        return False
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    monkeypatch.setattr("kiro_crew.subagent.list_orphans", lambda: [orphan])
+    monkeypatch.setattr(manager, "_is_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(manager, "_reap_orphan_process", reap_orphan)
+    monkeypatch.setattr(manager, "_notify_orphan", AsyncMock(return_value=False))
+
+    await manager._reconcile_orphans()
+
+    assert len(reap_threads) == 2
+    assert all(thread_id != event_loop_thread for thread_id in reap_threads)
+
+
+@pytest.mark.asyncio
+async def test_startup_kills_surviving_child_before_delivering_its_completion(
+    monkeypatch,
+) -> None:
+    """A delivered tombstone must not hide the child from restart cleanup."""
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    order: list[str] = []
+    alive = True
+
+    async def delivered(_info: SubagentInfo) -> None:
+        order.append("deliver")
+
+    def visible_orphans() -> list[dict[str, object]]:
+        if coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED:
+            return []
+        return [
+            {
+                "id": event.run_id,
+                "pid": 4242,
+                "pid_recorded_at": clock.value,
+                "started": clock.value,
+            }
+        ]
+
+    def kill(_pid: int) -> None:
+        nonlocal alive
+        alive = False
+        order.append("kill")
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=delivered,
+        coordinator=coordinator,
+    )
+    monkeypatch.setattr("kiro_crew.subagent.list_orphans", visible_orphans)
+    monkeypatch.setattr(manager, "_is_pid_alive", lambda _pid: alive)
+    monkeypatch.setattr(manager, "_is_orphan_process", lambda _pid, _started: True)
+    monkeypatch.setattr(manager, "_kill_orphan_pid", kill)
+
+    await manager._reconcile_orphans()
+
+    assert order == ["kill", "deliver"]
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciliation_does_not_reprocess_deferred_outbox_as_orphan(
+    monkeypatch,
+) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+
+    async def defer(info: SubagentInfo) -> None:
+        info._delivery_queued = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=defer,
+        coordinator=coordinator,
+    )
+    tombstone = MagicMock()
+    notify = AsyncMock()
+    monkeypatch.setattr("kiro_crew.subagent.list_orphans", lambda: [{"id": event.run_id}])
+    monkeypatch.setattr("kiro_crew.subagent.write_tombstone", tombstone)
+    monkeypatch.setattr(manager, "_notify_orphan", notify)
+
+    await manager._reconcile_orphans()
+
+    assert coordinator._outbox[event.event_id].status is DeliveryState.PENDING
+    tombstone.assert_not_called()
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciliation_drains_every_eligible_outbox_batch(
+    monkeypatch,
+) -> None:
+    clock = _Clock()
+    event_ids = iter(f"event-{index}" for index in range(17))
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: next(event_ids))
+    events = [await _completed_event(coordinator, clock, f"run-{index}") for index in range(17)]
+    remaining = {event.run_id for event in events}
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        coordinator=coordinator,
+    )
+    tombstone = MagicMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(
+        "kiro_crew.subagent.list_orphans",
+        lambda: [{"id": run_id} for run_id in sorted(remaining)],
+    )
+    monkeypatch.setattr(
+        "kiro_crew.subagent.mark_delivered",
+        lambda run_id: remaining.discard(run_id),
+    )
+    monkeypatch.setattr("kiro_crew.subagent.write_tombstone", tombstone)
+    monkeypatch.setattr(manager, "_notify_orphan", notify)
+
+    await manager._reconcile_orphans()
+
+    assert remaining == set()
+    tombstone.assert_not_called()
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deferred_outbox_context_is_not_routed_twice() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    delivered = AsyncMock()
+
+    async def defer(info: SubagentInfo) -> None:
+        info._delivery_queued = True
+        await delivered(info)
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=defer,
+        coordinator=coordinator,
+    )
+    manager._fire_event = AsyncMock()
+
+    assert await manager._deliver_outbox_event(event) is False
+    assert await manager._deliver_outbox_event(event) is False
+
+    delivered.assert_awaited_once()
+    manager._fire_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_replayed_outbox_completion_retains_session_and_model_metadata() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    original = SubagentInfo(
+        id="run-1",
+        task="inspect",
+        parent_session_key="dashboard:parent",
+        agent="reviewer",
+        conversation_key="subagent:conversation-1",
+        resolved_model="served-model",
+        requested_model="requested-model",
+        done=True,
+        result="done",
+    )
+    event = replace(event, payload_json=manager._completion_payload(original))
+    manager._fire_event = AsyncMock()
+
+    assert await manager._deliver_outbox_event(event) is True
+
+    replay = manager._fire_event.await_args.args[1]
+    payload = manager._fire_event.await_args.args[2]
+    assert replay.conversation_key == "subagent:conversation-1"
+    assert replay.resolved_model == "served-model"
+    assert replay.requested_model == "requested-model"
+    assert payload["child_session"] == "subagent:conversation-1"
+    assert payload["model"] == "served-model"
+    assert payload["requested_model"] == "requested-model"
+
+
+@pytest.mark.asyncio
+async def test_failed_parent_injection_keeps_outbox_pending() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+
+    async def fail_delivery(info: SubagentInfo) -> None:
+        info._delivery_failed = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=fail_delivery,
+        coordinator=coordinator,
+    )
+
+    with pytest.raises(_OutboxDeliveryRetry):
+        await manager._deliver_outbox_event(event)
+
+    assert event.event_id in manager._outbox_contexts
+
+
+@pytest.mark.asyncio
+async def test_failed_parent_injection_uses_short_outbox_retry_backoff() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    callbacks = 0
+
+    async def fail_once(info: SubagentInfo) -> None:
+        nonlocal callbacks
+        callbacks += 1
+        if callbacks == 1:
+            info._delivery_failed = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=fail_once,
+        coordinator=coordinator,
+    )
+    manager._fire_event = AsyncMock()
+    manager._outbox_delivery = OutboxDeliveryAdapter(
+        coordinator,
+        manager._deliver_outbox_event,
+        owner_id="gateway",
+        clock=clock,
+        retry_base_seconds=5.0,
+    )
+
+    failed = await manager._outbox_delivery.drain_once(event_id=event.event_id)
+    assert failed[0].status is DeliveryState.PENDING
+    assert await manager._outbox_delivery.drain_once(event_id=event.event_id) == []
+
+    clock.value += 5
+    delivered = await manager._outbox_delivery.drain_once(event_id=event.event_id)
+
+    assert delivered[0].status is DeliveryState.DELIVERED
+    assert callbacks == 2
+    manager._fire_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_parent_retry_reuses_context_without_repeating_lifecycle_event() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    callbacks = 0
+
+    async def fail_once(info: SubagentInfo) -> None:
+        nonlocal callbacks
+        callbacks += 1
+        if callbacks == 1:
+            info._delivery_failed = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=fail_once,
+        coordinator=coordinator,
+    )
+    manager._fire_event = AsyncMock()
+
+    with pytest.raises(_OutboxDeliveryRetry):
+        await manager._deliver_outbox_event(event)
+    assert await manager._deliver_outbox_event(event) is True
+    assert callbacks == 2
+    manager._fire_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reaper_retries_pending_completion_delivery(monkeypatch) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        coordinator=coordinator,
+    )
+    manager._conv_registry_rebuilt = True
+    monkeypatch.setattr("kiro_crew.subagent.compact_cost_log", MagicMock())
+    monkeypatch.setattr(manager, "_sweep_stuck_waves", MagicMock())
+    monkeypatch.setattr(manager, "_sweep_digest_holds", MagicMock())
+    monkeypatch.setattr(manager, "_sweep_conversations", MagicMock())
+    monkeypatch.setattr(
+        asyncio,
+        "sleep",
+        AsyncMock(side_effect=[None, asyncio.CancelledError]),
+    )
+    monkeypatch.setattr(
+        asyncio.get_running_loop(),
+        "run_in_executor",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._reaper_loop()
+
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_stops_startup_outbox_reconciliation(monkeypatch) -> None:
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    started = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def wait_for_delivery() -> None:
+        started.set()
+        await blocked.wait()
+
+    reconcile_method = (
+        "_reconcile_startup" if hasattr(manager, "_reconcile_startup") else "_reconcile_orphans"
+    )
+    monkeypatch.setattr(manager, reconcile_method, wait_for_delivery)
+    manager.start_reaper()
+    await started.wait()
+    reconcile = manager._reconcile_task
+
+    try:
+        await manager.cancel_all()
+        assert reconcile.done()
+    finally:
+        if not reconcile.done():
+            reconcile.cancel()
+            await asyncio.gather(reconcile, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_adapter_acknowledges_only_after_destination_accepts() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    seen: list[str] = []
+
+    async def deliver(claimed) -> bool:
+        seen.append(claimed.event_id)
+        assert claimed.status is DeliveryState.CLAIMED
+        return True
+
+    adapter = OutboxDeliveryAdapter(coordinator, deliver, owner_id="gateway", clock=clock)
+    attempts = await adapter.drain_once(event_id=event.event_id)
+
+    assert seen == [event.event_id]
+    assert [attempt.status for attempt in attempts] == [DeliveryState.DELIVERED]
+    assert (
+        await coordinator.claim_outbox(
+            OwnerLease("other", clock.value + 30), 1, event_id=event.event_id
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_releases_failed_delivery_with_stable_event_id() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    calls = 0
+
+    async def deliver(claimed) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("destination unavailable")
+        return True
+
+    adapter = OutboxDeliveryAdapter(
+        coordinator,
+        deliver,
+        owner_id="gateway",
+        clock=clock,
+        retry_base_seconds=5.0,
+    )
+    failed = await adapter.drain_once(event_id=event.event_id)
+    assert failed[0].status is DeliveryState.PENDING
+    assert failed[0].event_id == event.event_id
+
+    assert await adapter.drain_once(event_id=event.event_id) == []
+    clock.value += 5
+    delivered = await adapter.drain_once(event_id=event.event_id)
+
+    assert delivered[0].status is DeliveryState.DELIVERED
+    assert delivered[0].event_id == event.event_id
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_accepted_delivery_retries_transient_ack_without_redelivery() -> None:
+    class FailOnceAckCoordinator(MemoryRunCoordinator):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.ack_calls = 0
+
+        async def mark_delivered(self, fence):
+            self.ack_calls += 1
+            if self.ack_calls == 1:
+                raise OSError("transient coordinator failure")
+            return await super().mark_delivered(fence)
+
+    clock = _Clock()
+    coordinator = FailOnceAckCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    destination = AsyncMock(return_value=True)
+    adapter = OutboxDeliveryAdapter(
+        coordinator,
+        destination,
+        owner_id="gateway",
+        clock=clock,
+        retry_base_seconds=0.0,
+    )
+
+    attempts = await adapter.drain_once(event_id=event.event_id)
+
+    assert attempts == [DeliveryAttempt(event.event_id, DeliveryState.DELIVERED)]
+    destination.assert_awaited_once()
+    assert destination.await_args.args[0].event_id == event.event_id
+    assert coordinator.ack_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_accepted_delivery_reclaims_expired_ack_without_redelivery() -> None:
+    class AckOutageCoordinator(MemoryRunCoordinator):
+        def __init__(self, *, clock: _Clock) -> None:
+            super().__init__(clock=clock, id_factory=lambda: "event-1")
+            self.clock = clock
+            self.ack_calls = 0
+
+        async def mark_delivered(self, fence):
+            self.ack_calls += 1
+            if self.ack_calls == 1:
+                self.clock.value += 2_000
+                raise OSError("coordinator unavailable past claim expiry")
+            return await super().mark_delivered(fence)
+
+    clock = _Clock()
+    coordinator = AckOutageCoordinator(clock=clock)
+    event = await _completed_event(coordinator, clock, "run-1")
+    destination = AsyncMock(return_value=True)
+    adapter = OutboxDeliveryAdapter(
+        coordinator,
+        destination,
+        owner_id="gateway",
+        clock=clock,
+        retry_base_seconds=0.0,
+    )
+
+    attempts = await adapter.drain_once(event_id=event.event_id)
+    if not attempts:
+        attempts = await adapter.drain_once(event_id=event.event_id)
+
+    assert attempts == [DeliveryAttempt(event.event_id, DeliveryState.DELIVERED)]
+    destination.assert_awaited_once()
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+def test_retry_backoff_caps_before_large_exponent_overflows() -> None:
+    clock = _Clock()
+    adapter = OutboxDeliveryAdapter(
+        MemoryRunCoordinator(clock=clock),
+        AsyncMock(return_value=True),
+        owner_id="gateway",
+        clock=clock,
+    )
+
+    assert adapter._retry_at(1025) == clock.value + 300.0
+
+
+@pytest.mark.asyncio
+async def test_deferred_delivery_can_be_acknowledged_without_redelivery() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    calls = 0
+
+    async def defer(_claimed) -> bool:
+        nonlocal calls
+        calls += 1
+        return False
+
+    adapter = OutboxDeliveryAdapter(coordinator, defer, owner_id="gateway", clock=clock)
+    deferred = await adapter.drain_once(event_id=event.event_id)
+    redelivered = await adapter.drain_once()
+    acknowledged = await adapter.acknowledge(event.event_id)
+
+    assert deferred[0].status is DeliveryState.PENDING
+    assert redelivered == []
+    assert acknowledged is not None
+    assert acknowledged.status is DeliveryState.DELIVERED
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_deferred_release_failure_retains_fence_for_acknowledgement() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+
+    async def defer(_claimed) -> bool:
+        return False
+
+    async def fail_release(*_args, **_kwargs):
+        raise OSError("coordinator release failed")
+
+    coordinator.release_outbox = fail_release  # type: ignore[method-assign]
+    adapter = OutboxDeliveryAdapter(coordinator, defer, owner_id="gateway", clock=clock)
+
+    with pytest.raises(OSError, match="coordinator release failed"):
+        await adapter.drain_once(event_id=event.event_id)
+    acknowledged = await adapter.acknowledge(event.event_id)
+
+    assert acknowledged is not None
+    assert acknowledged.status is DeliveryState.DELIVERED
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_destination_can_acknowledge_without_deadlocking_adapter() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    adapter: OutboxDeliveryAdapter
+
+    async def defer_and_ack(claimed) -> bool:
+        acknowledged = await adapter.acknowledge(claimed.event_id)
+        assert acknowledged is not None
+        return False
+
+    adapter = OutboxDeliveryAdapter(
+        coordinator,
+        defer_and_ack,
+        owner_id="gateway",
+        clock=clock,
+    )
+
+    attempts = await asyncio.wait_for(adapter.drain_once(event_id=event.event_id), timeout=1)
+
+    assert [attempt.status for attempt in attempts] == [DeliveryState.DELIVERED]
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_deferred_acknowledgement_reclaims_after_release_race() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    destination_started = asyncio.Event()
+    release_destination = asyncio.Event()
+    acknowledgement_started = asyncio.Event()
+    continue_acknowledgement = asyncio.Event()
+    original_mark_delivered = coordinator.mark_delivered
+
+    async def defer(_claimed) -> bool:
+        destination_started.set()
+        await release_destination.wait()
+        return False
+
+    async def blocked_mark_delivered(fence):
+        acknowledgement_started.set()
+        await continue_acknowledgement.wait()
+        return await original_mark_delivered(fence)
+
+    coordinator.mark_delivered = blocked_mark_delivered  # type: ignore[method-assign]
+    adapter = OutboxDeliveryAdapter(coordinator, defer, owner_id="gateway", clock=clock)
+    drain_task = asyncio.create_task(adapter.drain_once(event_id=event.event_id))
+    await destination_started.wait()
+    acknowledgement_task = asyncio.create_task(adapter.acknowledge(event.event_id))
+    await acknowledgement_started.wait()
+
+    release_destination.set()
+    await drain_task
+    assert coordinator._outbox[event.event_id].status is DeliveryState.PENDING
+
+    continue_acknowledgement.set()
+    acknowledged = await acknowledgement_task
+
+    assert acknowledged is not None
+    assert acknowledged.status is DeliveryState.DELIVERED
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_deferred_acknowledgement_uses_fence_installed_while_waiting() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    claim_started = asyncio.Event()
+    continue_claim = asyncio.Event()
+    destination_started = asyncio.Event()
+    release_destination = asyncio.Event()
+    original_claim_outbox = coordinator.claim_outbox
+
+    async def blocked_claim_outbox(*args, **kwargs):
+        if not kwargs.get("acknowledgement", False):
+            claim_started.set()
+            await continue_claim.wait()
+        return await original_claim_outbox(*args, **kwargs)
+
+    async def defer(_claimed) -> bool:
+        destination_started.set()
+        await release_destination.wait()
+        return False
+
+    coordinator.claim_outbox = blocked_claim_outbox  # type: ignore[method-assign]
+    adapter = OutboxDeliveryAdapter(coordinator, defer, owner_id="gateway", clock=clock)
+    drain_task = asyncio.create_task(adapter.drain_once(event_id=event.event_id))
+    await claim_started.wait()
+    acknowledgement_task = asyncio.create_task(adapter.acknowledge(event.event_id))
+
+    continue_claim.set()
+    await destination_started.wait()
+    acknowledged = await acknowledgement_task
+    release_destination.set()
+    await drain_task
+
+    assert acknowledged is not None
+    assert acknowledged.status is DeliveryState.DELIVERED
+    assert event.event_id not in adapter._inflight
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_default_delivery_lease_covers_the_destination_timeout_budget() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    seen_expiry = 0.0
+
+    async def deliver(claimed) -> bool:
+        nonlocal seen_expiry
+        seen_expiry = claimed.claim_expires_at
+        return True
+
+    adapter = OutboxDeliveryAdapter(coordinator, deliver, owner_id="gateway", clock=clock)
+    await adapter.drain_once(event_id=event.event_id)
+
+    assert seen_expiry - clock.value >= 1260
+
+
+@pytest.mark.asyncio
+async def test_each_event_gets_a_fresh_delivery_lease_when_draining_a_batch() -> None:
+    clock = _Clock()
+    ids = iter(("event-1", "event-2"))
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: next(ids))
+    await _completed_event(coordinator, clock, "run-1")
+    await _completed_event(coordinator, clock, "run-2")
+    remaining: list[float] = []
+
+    async def deliver(claimed) -> bool:
+        remaining.append(claimed.claim_expires_at - clock.value)
+        if len(remaining) == 1:
+            clock.value += 1300
+        return True
+
+    adapter = OutboxDeliveryAdapter(coordinator, deliver, owner_id="gateway", clock=clock)
+    await adapter.drain_once(limit=2)
+
+    assert remaining == [1320.0, 1320.0]
+
+
+@pytest.mark.asyncio
+async def test_deferred_failed_event_acks_without_legacy_delivered_tombstone(
+    monkeypatch,
+) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    marked: list[str] = []
+    monkeypatch.setattr("kiro_crew.subagent.mark_delivered", marked.append)
+
+    async def defer(info: SubagentInfo) -> None:
+        info.error = "failed"
+        info._delivery_queued = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=defer,
+        coordinator=coordinator,
+    )
+
+    pending = await manager._outbox_delivery.drain_once(event_id=event.event_id)
+    assert pending[0].status is DeliveryState.PENDING
+    assert manager._delivery_event_for_run(event.run_id) == event.event_id
+
+    await manager.settle_queued_delivery([event.run_id])
+
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+    assert marked == []
+
+
+@pytest.mark.asyncio
+async def test_consumed_event_retries_transient_acknowledgement_failure(monkeypatch) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+
+    async def defer(info: SubagentInfo) -> None:
+        info._delivery_queued = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=defer,
+        coordinator=coordinator,
+    )
+    await manager._outbox_delivery.drain_once(event_id=event.event_id)
+    acknowledge = manager._outbox_delivery.acknowledge
+    attempts = 0
+
+    async def fail_once(event_id: str):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("coordinator unavailable")
+        return await acknowledge(event_id)
+
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    monkeypatch.setattr(manager._outbox_delivery, "acknowledge", fail_once)
+
+    await manager.settle_queued_delivery([event.run_id])
+
+    assert attempts == 2
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_consumed_event_retries_when_acknowledgement_loses_its_claim(monkeypatch) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+
+    async def defer(info: SubagentInfo) -> None:
+        info._delivery_queued = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=defer,
+        coordinator=coordinator,
+    )
+    await manager._outbox_delivery.drain_once(event_id=event.event_id)
+    acknowledge = manager._outbox_delivery.acknowledge
+    attempts = 0
+
+    async def lose_claim_once(event_id: str):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return None
+        return await acknowledge(event_id)
+
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    monkeypatch.setattr(manager._outbox_delivery, "acknowledge", lose_claim_once)
+
+    await manager.settle_queued_delivery([event.run_id])
+
+    assert attempts == 2
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
+async def test_digest_held_failed_event_acks_without_legacy_delivered_tombstone(
+    monkeypatch,
+) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    marked: list[str] = []
+    monkeypatch.setattr("kiro_crew.subagent.mark_delivered", marked.append)
+
+    async def hold(info: SubagentInfo) -> None:
+        info.error = "failed"
+        info._digest_held = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=hold,
+        coordinator=coordinator,
+    )
+    pending = await manager._outbox_delivery.drain_once(event_id=event.event_id)
+    assert pending[0].status is DeliveryState.PENDING
+
+    flusher = SubagentInfo(id="flush", task="flush", done=True)
+    flusher._digest_settle_ids = [event.run_id]
+    await manager._settle_digest_holds(flusher)
+
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+    assert marked == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_coordinator_queue_entry_commits_stopped_outcome() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", clock.value + 90),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+    manager._queue = [
+        {
+            "task": "inspect",
+            "agent": "reviewer",
+            "parent_session_key": "dashboard:parent",
+            "batch_id": "batch-1",
+            "batch_total": 2,
+            "_preassigned_id": "run-1",
+            "_coordinator_admitted": True,
+            "_coordinator_command": claim.command,
+            "_coordinator_fence": claim.fence,
+            "_coordinator_version": claim.run.version,
+        }
+    ]
+    manager.command_authority._waiting_executions["run-1"] = (
+        claim.command_fence,
+        "",
+    )
+    manager._settle_digest_holds = AsyncMock()  # type: ignore[method-assign]
+
+    assert await manager.cancel("run-1") is True
+
+    run = await coordinator.get_run("run-1")
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert run.outcome is RunOutcome.STOPPED
+    receipt = await coordinator.get_command_by_key("key-1")
+    assert receipt is not None
+    assert receipt.command.status.value == "rejected"
+    on_done.assert_awaited_once()
+    manager._settle_digest_holds.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raises", [False, True])
+async def test_queue_drain_failure_rejects_command_and_delivers_live_batch(raises: bool) -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", clock.value + 90),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+    delivered: list[SubagentInfo] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        delivered.append(info)
+
+    def policy_failure() -> bool:
+        raise RuntimeError("policy unavailable")
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        max_concurrent=1,
+        is_yolo=policy_failure if raises else None,
+        coordinator=coordinator,
+    )
+    manager._spawn_stagger_secs = 0
+    params = {
+        "task": "inspect",
+        "agent": "",
+        "parent_session_key": "dashboard:parent",
+        "conversation_key": "subagent:continued-run",
+        "batch_id": "batch-1",
+        "batch_total": 2,
+        "_preassigned_id": "run-1",
+        "_coordinator_admitted": True,
+        "_coordinator_command": claim.command,
+        "_coordinator_fence": claim.fence,
+        "_coordinator_version": claim.run.version,
+    }
+    manager._queue = [params]
+    manager.command_authority._waiting_executions["run-1"] = (
+        claim.command_fence,
+        "",
+    )
+    if not raises:
+        manager.spawn = MagicMock(
+            return_value=SubagentInfo(
+                id="run-1",
+                task="inspect",
+                parent_session_key="dashboard:parent",
+                agent="reviewer",
+                conversation_key="subagent:continued-run",
+                done=True,
+                error="agent unavailable",
+                batch_id="batch-1",
+                batch_total=2,
+            )
+        )
+
+    manager._drain_queue()
+    await manager._tasks["reject-run-1"]
+
+    receipt = await coordinator.get_command_by_key("key-1")
+    run = await coordinator.get_run("run-1")
+    assert receipt is not None
+    assert receipt.command.status.value == "rejected"
+    assert receipt.command.result_json
+    assert run is not None
+    assert run.outcome is RunOutcome.FAILED
+    assert manager.running_count == 0
+    assert manager.get("run-1") is None
+    assert len(delivered) == 1
+    assert delivered[0].batch_id == "batch-1"
+    assert delivered[0].batch_total == 2
+    assert delivered[0].conversation_key == "subagent:continued-run"
+
+
+@pytest.mark.asyncio
+async def test_terminal_context_precedes_overlapping_outbox_drain() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", clock.value + 90),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+    delivered: list[SubagentInfo] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        delivered.append(info)
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="run-1",
+        task="inspect",
+        parent_session_key="dashboard:parent",
+        agent="reviewer",
+        done=True,
+        error="agent unavailable",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+
+    async def overlapping_drain(_run_id: str) -> None:
+        assert "event-1" in manager._outbox_contexts
+        await manager._outbox_delivery.drain_once(event_id="event-1")
+
+    manager._stop_coordinator_heartbeat = AsyncMock(  # type: ignore[method-assign]
+        side_effect=overlapping_drain
+    )
+    manager.command_authority.stop_execution_heartbeat = AsyncMock()
+
+    await manager._report_terminal(
+        info,
+        source="test",
+        injection_timeout_reason="timeout",
+        mark_delivered_on_success=True,
+        settle_digest=True,
+    )
+
+    assert len(delivered) == 1
+    assert delivered[0].batch_id == "batch-1"
+    assert delivered[0].batch_total == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_context_precedes_commit_return_outbox_drain() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", clock.value + 90),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+    delivered: list[SubagentInfo] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        assert info._delivery_event_id == "event-1"
+        info._delivery_queued = True
+        delivered.append(info)
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="run-1",
+        task="inspect",
+        parent_session_key="dashboard:parent",
+        agent="reviewer",
+        done=True,
+        error="agent unavailable",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+    original_complete = coordinator.complete
+    overlapping_drain_done = asyncio.Event()
+
+    async def complete_with_overlapping_drain(completion, fence, expected_version):
+        result = await original_complete(completion, fence, expected_version)
+        assert result.value is not None
+        await manager._outbox_delivery.drain_once(event_id=result.value.event_id)
+        overlapping_drain_done.set()
+        return result
+
+    coordinator.complete = complete_with_overlapping_drain  # type: ignore[method-assign]
+    report = asyncio.create_task(
+        manager._report_terminal(
+            info,
+            source="test",
+            injection_timeout_reason="timeout",
+            mark_delivered_on_success=True,
+            settle_digest=True,
+        )
+    )
+    try:
+        await overlapping_drain_done.wait()
+        await asyncio.sleep(0)
+        assert report.done()
+        await report
+    finally:
+        if not report.done():
+            report.cancel()
+            await asyncio.gather(report, return_exceptions=True)
+
+    assert len(delivered) == 1
+    assert delivered[0].batch_id == "batch-1"
+    assert delivered[0].batch_total == 2
+    assert "event-1" in manager._outbox_contexts
+    await manager._ack_delivery_for_run("run-1")
+    assert manager._outbox_contexts == {}
+
+
+@pytest.mark.asyncio
+async def test_legacy_queue_policy_failure_announces_live_batch() -> None:
+    delivered: list[SubagentInfo] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        delivered.append(info)
+
+    def policy_failure() -> bool:
+        raise RuntimeError("policy unavailable")
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        max_concurrent=1,
+        is_yolo=policy_failure,
+        coordinator=MemoryRunCoordinator(),
+    )
+    manager._spawn_stagger_secs = 0
+    manager._queue = [
+        {
+            "task": "inspect",
+            "agent": "",
+            "parent_session_key": "dashboard:parent",
+            "batch_id": "batch-1",
+            "batch_total": 2,
+            "_preassigned_id": "legacy-run-1",
+        }
+    ]
+
+    manager._drain_queue()
+    await manager._tasks["reject-legacy-run-1"]
+
+    assert manager.running_count == 0
+    assert manager.get("legacy-run-1") is None
+    assert len(delivered) == 1
+    assert delivered[0].error == "policy unavailable"
+    assert delivered[0].batch_id == "batch-1"
+    assert delivered[0].batch_total == 2
+
+
+@pytest.mark.asyncio
+async def test_approval_rejection_requests_digest_settlement() -> None:
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=AsyncMock(),
+        on_spawn_approval=AsyncMock(return_value=False),
+        coordinator=MemoryRunCoordinator(),
+    )
+    info = SubagentInfo(
+        id="run-1",
+        task="inspect",
+        parent_session_key="dashboard:parent",
+        batch_id="batch-1",
+        batch_total=2,
+    )
+    info._coordinator_fence = RunFence("run-1", "executor", 1)
+    authority_stop = AsyncMock()
+    authority_reject = AsyncMock()
+    manager.command_authority.stop_execution_heartbeat = authority_stop
+    manager.command_authority.reject_waiting_execution = authority_reject
+
+    async def report_while_lease_is_live(*_args, **_kwargs) -> None:
+        authority_stop.assert_not_awaited()
+
+    manager._run_terminal_report = AsyncMock(  # type: ignore[method-assign]
+        side_effect=report_while_lease_is_live
+    )
+
+    await manager._spawn_with_approval(info)
+
+    authority_reject.assert_awaited_once_with(
+        info.id,
+        "spawn rejected",
+        stop_heartbeat=False,
+    )
+    assert manager._run_terminal_report.await_args.kwargs["settle_digest"] is True
+
+
+@pytest.mark.asyncio
+async def test_exact_outbox_claim_does_not_consume_older_event() -> None:
+    clock = _Clock()
+    ids = iter(("event-1", "event-2"))
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: next(ids))
+    first = await _completed_event(coordinator, clock, "run-1")
+    clock.value += 1
+    second = await _completed_event(coordinator, clock, "run-2")
+
+    claimed = await coordinator.claim_outbox(
+        OwnerLease("gateway", clock.value + 30),
+        1,
+        event_id=second.event_id,
+    )
+    remaining = await coordinator.claim_outbox(
+        OwnerLease("other", clock.value + 30),
+        1,
+        event_id=first.event_id,
+    )
+
+    assert [item.event_id for item in claimed] == [second.event_id]
+    assert [item.event_id for item in remaining] == [first.event_id]
+
+
+@pytest.mark.asyncio
+async def test_manager_commits_terminal_before_callbacks_and_bounds_payload() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", clock.value + 90),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+
+    callback_states: list[str] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        run = await coordinator.get_run(info.id)
+        assert run is not None
+        callback_states.append(run.observed_state.value)
+        assert info._delivery_event_id == "event-1"
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="run-1",
+        task="inspect",
+        parent_session_key="dashboard:parent",
+        agent="reviewer",
+        done=True,
+        result="x" * 3995 + "AKIAIOSFODNN7EXAMPLE" + "y" * 16_000,
+        result_path="/results/run-1.txt",
+        silent=True,
+        batch_id="batch-1",
+        batch_total=2,
+    )
+    info._coordinator_admitted = True
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+    await manager._coordinator_mark_starting(info)
+    await manager._coordinator_mark_running(info)
+
+    await manager._report_terminal(
+        info,
+        source="test",
+        injection_timeout_reason="timeout",
+        mark_delivered_on_success=False,
+    )
+
+    assert callback_states == ["terminal"]
+    event = coordinator._outbox["event-1"]
+    payload = json.loads(event.payload_json)
+    assert event.status is DeliveryState.DELIVERED
+    assert payload["result_path"] == "/results/run-1.txt"
+    assert len(payload["result_summary"]) == 4000
+    assert "AKIA" not in payload["result_summary"]
+    assert payload["result_truncated"] is True
+    assert payload["silent"] is True
+    assert payload["batch_id"] == "batch-1"
+    assert payload["batch_total"] == 2
+    recovered = manager._info_from_outbox(event)
+    assert recovered.silent is True
+    assert recovered.batch_id == ""
+    assert recovered.batch_total == 0
+
+
+@pytest.mark.asyncio
+async def test_run_advances_fenced_lifecycle_and_stops_heartbeat() -> None:
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", 10**12),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+
+    delivered: list[str] = []
+
+    async def on_done(info: SubagentInfo) -> None:
+        delivered.append(info.id)
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(
+        id="run-1",
+        task="inspect",
+        parent_session_key="dashboard:parent",
+    )
+    info._coordinator_admitted = True
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+
+    async def run_inner(target: SubagentInfo, _session_key: str) -> None:
+        await manager._coordinator_mark_running(target)
+        target.result = "done"
+        target.done = True
+
+    manager._run_inner = run_inner  # type: ignore[method-assign]
+    manager._teardown_run_session = AsyncMock()  # type: ignore[method-assign]
+    manager._record_cost = MagicMock()  # type: ignore[method-assign]
+    manager._scheduler.occupy(info, 0.0)
+
+    await manager._run(info)
+
+    run = await coordinator.get_run("run-1")
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert run.outcome is RunOutcome.COMPLETED
+    assert delivered == ["run-1"]
+    assert manager._lease_tasks == {}

--- a/test/test_run_coordinator_shadow.py
+++ b/test/test_run_coordinator_shadow.py
@@ -22,6 +22,7 @@ from kiro_crew.run_coordinator import (
     ShadowRunCoordinator,
     SubmitControl,
     SubmitRun,
+    TerminalRun,
 )
 
 
@@ -218,6 +219,34 @@ async def test_generated_event_id_does_not_create_shadow_parity_mismatch() -> No
     assert completed.value is not None
     assert completed.value.status is DeliveryState.PENDING
     assert mismatches == []
+
+
+@pytest.mark.asyncio
+async def test_shadow_mirrors_atomic_terminal_record() -> None:
+    primary = MemoryRunCoordinator(clock=lambda: 10.0, id_factory=lambda: "primary-event")
+    shadow = MemoryRunCoordinator(clock=lambda: 10.0, id_factory=lambda: "shadow-event")
+    coordinator = ShadowRunCoordinator(primary, shadow)
+    request = TerminalRun(
+        run_id="synthetic-run",
+        parent_session="dashboard:parent",
+        agent="kirocrew",
+        task="record a rejected batch member",
+        conversation_key="",
+        outcome=RunOutcome.FAILED,
+        result_path="",
+        error="spawn submission lost",
+        created_at=10.0,
+        terminal_at=10.0,
+        event_type="subagent_completion",
+        destination="dashboard:parent",
+        payload_json='{"id":"synthetic-run"}',
+    )
+
+    recorded = await coordinator.record_terminal(request)
+
+    assert recorded.decision is CoordinatorDecision.APPLIED
+    assert await primary.get_run(request.run_id) is not None
+    assert await shadow.get_run(request.run_id) is not None
 
 
 @pytest.mark.asyncio

--- a/test/test_run_coordinator_wiring.py
+++ b/test/test_run_coordinator_wiring.py
@@ -11,6 +11,7 @@ import pytest
 
 from kiro_crew.run_coordinator import (
     CommandOperation,
+    CoordinatorDecision,
     MemoryRunCoordinator,
     OwnerLease,
     SQLiteRunCoordinator,
@@ -184,6 +185,53 @@ async def test_shadow_request_construction_failure_is_contained() -> None:
 
 
 @pytest.mark.asyncio
+async def test_starting_transition_retries_a_lost_commit_response() -> None:
+    coordinator = AsyncMock()
+    committed = MagicMock()
+    committed.decision = CoordinatorDecision.UNCHANGED
+    committed.value.version = 4
+    coordinator.mark_starting.side_effect = [OSError("response lost"), committed]
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="starting-response-lost", task="task")
+    info._coordinator_command = MagicMock()
+    info._coordinator_fence = MagicMock()
+    info._coordinator_version = 3
+
+    await manager._coordinator_mark_starting(info)
+
+    assert coordinator.mark_starting.await_count == 2
+    assert info._coordinator_version == 4
+    assert info._coordinator_started is True
+
+
+@pytest.mark.asyncio
+async def test_running_transition_retries_a_lost_commit_response() -> None:
+    coordinator = AsyncMock()
+    committed = MagicMock()
+    committed.decision = CoordinatorDecision.UNCHANGED
+    committed.value.version = 5
+    coordinator.mark_running.side_effect = [OSError("response lost"), committed]
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="running-response-lost", task="task")
+    info._coordinator_fence = MagicMock()
+    info._coordinator_version = 4
+
+    await manager._coordinator_mark_running(info)
+
+    assert coordinator.mark_running.await_count == 2
+    assert info._coordinator_version == 5
+    assert info._coordinator_running is True
+
+
+@pytest.mark.asyncio
 async def test_run_records_shadow_submission_before_execution() -> None:
     order: list[str] = []
     coordinator = AsyncMock()
@@ -289,6 +337,33 @@ async def test_failed_start_settlement_keeps_waiting_run_retryable() -> None:
 
 
 @pytest.mark.asyncio
+async def test_failed_lifecycle_start_transition_never_applies_command() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._claim_finalize = MagicMock(return_value=True)
+    manager._coordinator_mark_starting = AsyncMock(side_effect=OSError("write failed"))
+    manager._start_coordinator_heartbeat = MagicMock()
+    manager.command_authority.execution_started = AsyncMock()
+    info = SubagentInfo(
+        id="uncommitted-start",
+        task="task",
+        _coordinator_admitted=True,
+        _coordinator_waiting=True,
+    )
+    info._coordinator_fence = MagicMock()
+
+    await manager._run(info)
+
+    assert info._coordinator_waiting is True
+    assert info._coordinator_claim_uncertain is True
+    assert info.done is False
+    manager.command_authority.execution_started.assert_not_awaited()
+    manager._run_inner.assert_not_awaited()
+    manager._claim_finalize.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_lost_start_settlement_response_reconciles_before_execution() -> None:
     manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
     manager._run_inner = AsyncMock()
@@ -313,14 +388,39 @@ async def test_lost_start_settlement_response_reconciles_before_execution() -> N
 
 
 @pytest.mark.asyncio
-async def test_queued_cancel_stops_the_authority_lease() -> None:
+async def test_queued_cancel_keeps_authority_lease_until_terminal_commit() -> None:
     manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
-    manager._unqueue = MagicMock(return_value=[{"_preassigned_id": "queued-run"}])
+    queued = {"_preassigned_id": "queued-run"}
+    manager._unqueue = MagicMock(return_value=[queued])
+    manager._finalize_queued_cancel = AsyncMock()
     manager.command_authority.stop_execution_heartbeat = AsyncMock()
 
     assert await manager.cancel("queued-run") is True
 
-    manager.command_authority.stop_execution_heartbeat.assert_awaited_once_with("queued-run")
+    manager.command_authority.stop_execution_heartbeat.assert_not_awaited()
+    manager._finalize_queued_cancel.assert_awaited_once_with(queued)
+
+
+@pytest.mark.asyncio
+async def test_queued_cancel_preserves_silent_delivery_setting() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock(), on_done=AsyncMock())
+    manager._safe_announce = AsyncMock()
+
+    await manager._finalize_queued_cancel(
+        {
+            "_preassigned_id": "silent-queued-run",
+            "task": "task",
+            "conversation_key": "subagent:continued-run",
+            "batch_id": "silent-wave",
+            "batch_total": 1,
+            "silent": True,
+        }
+    )
+
+    manager._safe_announce.assert_awaited_once()
+    announced = manager._safe_announce.await_args.args[0]
+    assert announced.silent is True
+    assert announced.conversation_key == "subagent:continued-run"
 
 
 @pytest.mark.asyncio

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -1711,6 +1711,7 @@ class TestInitSubagents:
                 mock_sm.return_value = mock_sm_inst
                 orch._init_subagents()
         assert orch.subagent_mgr is not None
+        mock_sm_inst.start_reaper.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_init_subagents_respects_max_concurrent(self):
@@ -6463,6 +6464,7 @@ class TestSlackSubagentCompletionPersistence:
         info.silent = False
         info.elapsed = 5.0
         info.started = time.time() - 5.0
+        info._delivery_event_id = "event-persist"
         return info
 
     @pytest.mark.asyncio
@@ -6491,6 +6493,7 @@ class TestSlackSubagentCompletionPersistence:
         assert user_call[0][0] == info.parent_session_key
         assert user_call[0][1] == "user"
         assert "[Subagent completion event]" in user_call[0][2]
+        assert "Event: `event-persist`" in user_call[0][2]
         # Second call: assistant role (the LLM response)
         assert assistant_call[0][0] == info.parent_session_key
         assert assistant_call[0][1] == "assistant"

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -13,8 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew.run_coordinator import MemoryRunCoordinator
-from kiro_crew.subagent import _TURN_LIMIT, SubagentManager
+from kiro_crew.run_coordinator import CommandStatus, MemoryRunCoordinator
+from kiro_crew.subagent import _TURN_LIMIT, SubagentInfo, SubagentManager
 from kiro_crew.subagent_command_authority import (
     AuthorityOutcomeUncertain,
     CommandIdentity,
@@ -465,7 +465,10 @@ class TestSpawnWithApprovalCallback:
 
         with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
             info = await manager.command_authority.spawn(identity, "rejected task")
-            await manager._tasks[info.id]
+            for _ in range(20):
+                if info.done and info.id not in manager._tasks:
+                    break
+                await asyncio.sleep(0)
 
         assert await manager.command_authority.lookup_response(identity.idempotency_key) == {
             "found": True,
@@ -474,6 +477,11 @@ class TestSpawnWithApprovalCallback:
             "code": "spawn_rejected",
             "counted": True,
         }
+        receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+        assert receipt is not None
+        assert receipt.command.status is CommandStatus.REJECTED
+        assert receipt.command.rejection_reason == "spawn rejected"
+        assert receipt.command.result_json
 
     @pytest.mark.asyncio
     async def test_approval_denial_keeps_retry_state_when_settlement_fails(self) -> None:
@@ -492,6 +500,7 @@ class TestSpawnWithApprovalCallback:
         )
         info = SubagentInfo(id="approval-retry", task="rejected task")
         info._coordinator_waiting = True
+        info._coordinator_fence = MagicMock()
         manager._agents[info.id] = info
         manager.command_authority.reject_waiting_execution = AsyncMock(side_effect=reject)
         manager._scheduler.release = MagicMock(return_value=False)
@@ -538,21 +547,27 @@ class TestSpawnWithApprovalCallback:
 
         with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
             first = await manager.command_authority.spawn(first_identity, "hold the slot")
+            first_task = manager._tasks[first.id]
             queued = await manager.command_authority.spawn(queued_identity, "cancel me")
             assert queued.queued is True
             assert await manager.cancel(queued.id) is True
             approval_gate.set()
-            await manager._tasks[first.id]
+            await first_task
 
         assert await manager.command_authority.lookup_response(
             queued_identity.idempotency_key
         ) == {
             "found": True,
             "id": queued_identity.run_id,
-            "error": "spawn cancelled before start",
+            "error": "run stopped before execution",
             "code": "spawn_rejected",
             "counted": True,
         }
+        receipt = await coordinator.get_command_by_key(queued_identity.idempotency_key)
+        assert receipt is not None
+        assert receipt.command.status is CommandStatus.REJECTED
+        assert receipt.command.rejection_reason == "run stopped before execution"
+        assert receipt.command.result_json
 
     @pytest.mark.asyncio
     async def test_queued_cancel_failure_retains_non_runnable_entry_for_retry(self) -> None:
@@ -593,12 +608,14 @@ class TestSpawnWithApprovalCallback:
             on_done=on_done,
         )
         manager.command_authority.reject_waiting_execution = AsyncMock()
+        manager._run_terminal_report = AsyncMock()
         manager._scheduler.enqueue(
             {
                 "task": "cancel safely",
                 "parent_session_key": "parent-session",
                 "_preassigned_id": "queued-batch-cancel",
                 "_coordinator_admitted": True,
+                "_coordinator_fence": MagicMock(),
                 "batch_id": "wave-cancel",
                 "batch_total": 2,
             }
@@ -608,15 +625,51 @@ class TestSpawnWithApprovalCallback:
 
         manager.command_authority.reject_waiting_execution.assert_awaited_once_with(
             "queued-batch-cancel",
-            "spawn cancelled before start",
+            "run stopped before execution",
+            stop_heartbeat=False,
         )
-        on_done.assert_awaited_once()
-        announced = on_done.await_args.args[0]
+        on_done.assert_not_awaited()
+        manager._run_terminal_report.assert_awaited_once()
+        announced = manager._run_terminal_report.await_args.args[0]
         assert announced.id == "queued-batch-cancel"
         assert announced.batch_id == "wave-cancel"
         assert announced.batch_total == 2
         assert announced.done is True
-        assert announced.error == "spawn cancelled before start"
+        assert announced.user_stopped is True
+        assert announced.error == ""
+
+    @pytest.mark.asyncio
+    async def test_legacy_queued_batch_cancel_announces_completion(self) -> None:
+        announced: list[SubagentInfo] = []
+
+        async def on_done(info: SubagentInfo) -> None:
+            announced.append(info)
+
+        manager = SubagentManager(
+            sessions=_mock_sessions(),
+            ctx_builder=_mock_ctx_builder(),
+            on_done=on_done,
+        )
+        manager._scheduler.enqueue(
+            {
+                "task": "cancel safely",
+                "parent_session_key": "parent-session",
+                "_preassigned_id": "legacy-queued-batch-cancel",
+                "batch_id": "legacy-wave-cancel",
+                "batch_total": 2,
+            }
+        )
+
+        assert await manager.cancel("legacy-queued-batch-cancel") is True
+
+        assert len(announced) == 1
+        info = announced[0]
+        assert info.id == "legacy-queued-batch-cancel"
+        assert info.batch_id == "legacy-wave-cancel"
+        assert info.batch_total == 2
+        assert info.done is True
+        assert info.user_stopped is True
+        assert info.error == ""
 
     @pytest.mark.asyncio
     async def test_rejected_spawn_decrements_running_count(self) -> None:

--- a/test/test_subagent_command_authority.py
+++ b/test/test_subagent_command_authority.py
@@ -342,17 +342,16 @@ async def test_keyed_spawn_replay_invokes_sync_manager_once() -> None:
     )
 
     assert replay is first
-    assert manager.spawn_calls == [
-        (
-            "inspect the tree",
-            {
-                "parent_session_key": "dashboard:one",
-                "agent": "reviewer",
-                "_preassigned_id": "run-spawn",
-                "_coordinator_admitted": True,
-            },
-        )
-    ]
+    assert len(manager.spawn_calls) == 1
+    called_task, called_kwargs = manager.spawn_calls[0]
+    assert called_task == "inspect the tree"
+    assert called_kwargs["parent_session_key"] == "dashboard:one"
+    assert called_kwargs["agent"] == "reviewer"
+    assert called_kwargs["_preassigned_id"] == "run-spawn"
+    assert called_kwargs["_coordinator_admitted"] is True
+    assert called_kwargs["_coordinator_command"].command_id == "command-spawn"
+    assert called_kwargs["_coordinator_fence"].run_id == "run-spawn"
+    assert called_kwargs["_coordinator_version"] == 1
 
 
 @pytest.mark.asyncio
@@ -872,6 +871,28 @@ async def test_failed_waiting_rejection_retains_fence_and_heartbeat() -> None:
 
 
 @pytest.mark.asyncio
+async def test_waiting_rejection_can_retain_lease_until_terminal_commit() -> None:
+    manager = _Manager(register_spawn=False)
+    coordinator = MemoryRunCoordinator()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("waiting-rejected-with-lease")
+
+    await authority.spawn(identity, "wait for approval")
+    await authority.reject_waiting_execution(
+        identity.run_id,
+        "spawn rejected",
+        stop_heartbeat=False,
+    )
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.REJECTED
+    assert identity.run_id in authority._waiting_executions
+    assert identity.run_id in authority._lease_tasks
+    await authority.stop_execution_heartbeat(identity.run_id)
+
+
+@pytest.mark.asyncio
 async def test_close_rejects_waiting_execution_before_dropping_lease() -> None:
     coordinator = MemoryRunCoordinator()
     authority = SubagentCommandAuthority(coordinator, _Manager(register_spawn=False))
@@ -1137,17 +1158,16 @@ async def test_keyed_continuation_replay_preserves_conversation_and_run_identity
     )
 
     assert replay is first
-    assert manager.continue_calls == [
-        (
-            "conversation-one",
-            "follow up",
-            {
-                "parent_session_key": "dashboard:one",
-                "_preassigned_id": "run-continue",
-                "_coordinator_admitted": True,
-            },
-        )
-    ]
+    assert len(manager.continue_calls) == 1
+    conversation, called_task, called_kwargs = manager.continue_calls[0]
+    assert conversation == "conversation-one"
+    assert called_task == "follow up"
+    assert called_kwargs["parent_session_key"] == "dashboard:one"
+    assert called_kwargs["_preassigned_id"] == "run-continue"
+    assert called_kwargs["_coordinator_admitted"] is True
+    assert called_kwargs["_coordinator_command"].command_id == "command-continue"
+    assert called_kwargs["_coordinator_fence"].run_id == "run-continue"
+    assert called_kwargs["_coordinator_version"] == 1
 
 
 @pytest.mark.asyncio

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -880,6 +880,7 @@ class TestReaperOffloadsTheSweep:
             patch.object(asyncio.get_running_loop(), "run_in_executor", side_effect=_capture),
             patch.object(mgr, "_sample_live_costs") as sample,
             patch.object(mgr, "_rebuild_conversation_registry", new=AsyncMock()),
+            patch.object(mgr, "_drain_pending_outbox", new=AsyncMock()),
         ):
             task = asyncio.ensure_future(mgr._reaper_loop())
             await asyncio.sleep(0.05)
@@ -1818,12 +1819,13 @@ class TestAnnounceDigestFlush:
         mark.assert_not_called()
         assert info._digest_settle_ids == ["m1"]
 
-    def test_settle_swallows_tombstone_failure(self) -> None:
+    @pytest.mark.asyncio
+    async def test_settle_swallows_tombstone_failure(self) -> None:
         mgr = _manager()
         info = _info()
         info._digest_settle_ids = ["m1"]
         with patch.object(sa, "mark_delivered", side_effect=OSError):
-            mgr._settle_digest_holds(info)
+            await mgr._settle_digest_holds(info)
         assert info._digest_settle_ids == []
 
 

--- a/test/test_subagent_delivery_ttl_anchor.py
+++ b/test/test_subagent_delivery_ttl_anchor.py
@@ -180,16 +180,17 @@ class TestDeferQueuedDelivery:
         # Transferred, not copied: _settle_digest_holds must not double-write.
         assert info._digest_settle_ids == []
 
-    def test_failed_member_owes_nothing(self):
+    def test_failed_durable_member_owes_acknowledgement_without_a_tombstone(self):
         slot = _ChatSlot("s1")
         info = _member(error="boom")
+        info._delivery_event_id = "event-1"
 
         _defer(slot, info)
 
-        assert slot._subagent_delivery_pending == {}
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
         assert info._delivery_queued is True
 
-    def test_stopped_member_owes_nothing(self):
+    def test_stopped_durable_member_owes_acknowledgement_without_a_tombstone(self):
         """A user stop leaves ``error`` EMPTY (it is a neutral outcome), so the
         error-nullability idiom reads it as completed. It already carries a reap
         tombstone with the 7-day post-mortem window, and a "delivered" write would
@@ -197,11 +198,12 @@ class TestDeferQueuedDelivery:
         slot = _ChatSlot("s1")
         info = _member()
         info.user_stopped = True
+        info._delivery_event_id = "event-1"
         assert info.outcome == "stopped" and not info.error
 
         _defer(slot, info)
 
-        assert slot._subagent_delivery_pending == {}
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
 
     def test_flush_only_record_owes_only_the_members_it_releases(self):
         """The synthetic flush record has no run of its own; only the held ids
@@ -892,6 +894,51 @@ class TestReaperDoesNotPruneAQueuedPromise:
         assert slot._subagent_delivery_pending == {_key(slot._queue[0]["content"]): [info.id]}
         assert info._delivery_queued is True
         assert not (agent_root / info.id / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_gateway_idle_route_settles_only_after_turn_consumption(self):
+        """Dispatching an idle dashboard turn is not durable delivery; the
+        outbox debt clears only after the model consumes the completion."""
+        from test_subagent_scale import _mock_dashboard_state, _mock_sessions
+
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = _ChatSlot("main")
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+
+        with patch("kiro_crew.slack.gateway.SubagentManager") as mock_sm:
+            mock_sm_inst = MagicMock()
+            mock_sm_inst.start_reaper = MagicMock()
+            mock_sm_inst.running_agents_for = MagicMock(return_value=[])
+            mock_sm_inst.settle_queued_delivery = AsyncMock()
+            mock_sm.return_value = mock_sm_inst
+            with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+                orch._init_subagents()
+            orch.subagent_mgr = mock_sm_inst
+            orch.dashboard_state.subagents = mock_sm_inst
+            on_done = mock_sm.call_args.kwargs["on_done"]
+
+        consumed = asyncio.Event()
+
+        async def consume_turn(_state, _slot, _announce, **kwargs):
+            callback = kwargs.get("_on_consumed")
+            assert callback is not None
+            callback()
+            consumed.set()
+
+        info = _member()
+        info._delivery_event_id = "event-1"
+        with patch("kiro_crew.slack.gateway._run_chat", side_effect=consume_turn):
+            await on_done(info)
+            assert info._delivery_queued is True
+            assert slot._subagent_delivery_pending
+            await asyncio.wait_for(consumed.wait(), timeout=1)
+            await _settled(lambda: mock_sm_inst.settle_queued_delivery.await_count == 1)
+
+        mock_sm_inst.settle_queued_delivery.assert_awaited_once_with([info.id])
 
 
 def _make_orchestrator():

--- a/test/test_subagent_scale.py
+++ b/test/test_subagent_scale.py
@@ -22,6 +22,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.constants import SUBAGENT_COMPLETION_META_KEY
+from kiro_crew.run_coordinator import MemoryRunCoordinator
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 from kiro_crew.subagent_scale import SubagentEventCoalescer
 
@@ -376,7 +378,7 @@ class TestBatchIdentity:
         with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
             rejected = mgr.spawn("   ", batch_id="wv9", batch_total=2)
             plain = mgr.spawn("   ")  # non-batch rejection: no announce
-        await asyncio.sleep(0)  # let the scheduled announce run
+        await asyncio.gather(*mgr._tasks.values())
         assert rejected is not None and rejected.error
         assert plain is not None and plain.error
         assert len(announced) == 1
@@ -384,6 +386,7 @@ class TestBatchIdentity:
         assert got.batch_id == "wv9" and got.batch_total == 2
         assert got.done and got.error
         assert got.outcome == "failed"
+        assert got._delivery_event_id
 
     @pytest.mark.asyncio
     async def test_no_approval_rejection_announces_batch_member(self):
@@ -410,13 +413,14 @@ class TestBatchIdentity:
         mgr._spawn_stagger_secs = 0.0
         with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
             rejected = mgr.spawn("do work", batch_id="wvA", batch_total=2)
-        await asyncio.sleep(0)
+        await asyncio.gather(*mgr._tasks.values())
         assert rejected is not None and rejected.done
         assert "no approval mechanism" in (rejected.error or "")
         assert len(announced) == 1
         got = announced[0]
         assert got.batch_id == "wvA" and got.batch_total == 2
         assert got.outcome == "failed"
+        assert got._delivery_event_id
 
     @pytest.mark.asyncio
     async def test_record_lost_submission_reconciles_and_announces(self):
@@ -442,7 +446,7 @@ class TestBatchIdentity:
             mgr.record_lost_submission(
                 "wvL", 3, "connection refused", parent_session_key="dashboard:main"
             )
-        await asyncio.sleep(0)
+        await asyncio.gather(*mgr._tasks.values())
         assert mgr._batch_submitted["wvL"] == [3, 3]
         assert mgr.batch_members_pending("wvL") is False  # wave can close
         assert len(announced) == 1
@@ -450,6 +454,7 @@ class TestBatchIdentity:
         assert got.batch_id == "wvL" and got.done and got.error
         assert "submission lost" in got.error
         assert got.outcome == "failed"
+        assert got._delivery_event_id
 
     @pytest.mark.asyncio
     async def test_reaper_stuck_wave_sweep_reconciles(self):
@@ -703,8 +708,11 @@ class TestWaveDigest:
         total = 12  # chunk size 10 -> chunks of 10 + 2
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
 
         with patch("kiro_crew.slack.gateway._run_chat", side_effect=_fake_run_chat), \
@@ -895,8 +903,11 @@ class TestWaveDigest:
         total = 12  # chunk size 10 -> chunk 1/2 at member 10, final 2/2 on close
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
 
         hop_calls: list[int] = []
@@ -948,13 +959,21 @@ class TestWaveDigest:
         orch.dashboard_state.get_slot = MagicMock(return_value=slot)
         mgr, on_done = self._capture_on_done(orch)
         total = 12
-        with patch("kiro_crew.slack.gateway._run_chat", new_callable=AsyncMock):
+
+        async def _fake_run_chat(
+            _state, _slot, _text, *, _directive_user_origin, _on_consumed
+        ):
+            assert _directive_user_origin is False
+            _on_consumed()
+
+        with patch("kiro_crew.slack.gateway._run_chat", _fake_run_chat):
             for i in range(total):
                 mgr.batch_members_pending = MagicMock(
                     return_value=i != total - 1
                 )
                 await on_done(self._member(i, total, error="boom" if i < 2 else ""))
                 await asyncio.sleep(0)
+            await _settle(lambda: slot.task is None)
         finished = [
             c for c in orch.dashboard_state.broadcast_ws.call_args_list
             if c.args and c.args[0] == "batch_finished"
@@ -1060,7 +1079,7 @@ class TestWaveDigest:
         info = SubagentInfo(id="last", task="t")
         info._digest_settle_ids = ["h1", "h2"]
         with patch("kiro_crew.subagent.mark_delivered", side_effect=marked.append):
-            mgr._settle_digest_holds(info)
+            await mgr._settle_digest_holds(info)
         assert marked == ["h1", "h2"]
         assert info._digest_settle_ids == []  # idempotent re-entry safe
         # Structural guarantee: the settle call sits AFTER the awaited
@@ -1426,8 +1445,11 @@ class TestWaveDigest:
         total = 12
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
 
         with patch("kiro_crew.slack.gateway._run_chat", side_effect=_fake_run_chat), \
@@ -1447,6 +1469,148 @@ class TestWaveDigest:
         # …exactly once across the whole wave (deduped within the chunk, and
         # chunk buffers reset between flushes — no bleed into later chunks).
         assert combined.count("You MUST ask the user for guidance") == 1
+
+    @pytest.mark.asyncio
+    async def test_delivery_retry_does_not_resume_stopped_orchestration(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        tracker = MagicMock()
+        tracker.stopped = True
+        slot = MagicMock()
+        slot.mode = "orchestrator"
+        slot.running = False
+        slot.task = None
+        slot._orch_tracker = tracker
+        slot._subagent_deliveries_inflight = 0
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        _mgr, on_done = self._capture_on_done(orch)
+        info = SubagentInfo(
+            id="retry-after-stop",
+            task="late durable delivery",
+            parent_session_key="dashboard:main",
+            done=True,
+            result="done",
+        )
+        info._delivery_retry = True
+        run_chat = AsyncMock()
+
+        with patch("kiro_crew.slack.gateway._run_chat", run_chat):
+            await on_done(info)
+            await asyncio.sleep(0)
+
+        scheduled_task = slot.task
+        if isinstance(scheduled_task, asyncio.Task):
+            scheduled_task.cancel()
+            await asyncio.gather(scheduled_task, return_exceptions=True)
+
+        assert scheduled_task is None
+        run_chat.assert_not_awaited()
+        tracker.record_success.assert_not_called()
+        tracker.record_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delivery_retry_keeps_original_stopped_orchestration_owner(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        stopped_tracker = MagicMock()
+        stopped_tracker.stopped = True
+        current_tracker = MagicMock()
+        current_tracker.stopped = False
+        slot = MagicMock()
+        slot.mode = "orchestrator"
+        slot.running = False
+        slot.task = None
+        slot._orch_tracker = current_tracker
+        slot._subagent_deliveries_inflight = 0
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        _mgr, on_done = self._capture_on_done(orch)
+        info = SubagentInfo(
+            id="retry-after-new-plan",
+            task="late durable delivery",
+            parent_session_key="dashboard:main",
+            done=True,
+            result="done",
+        )
+        info._delivery_retry = True
+        info._delivery_orchestration_tracker = stopped_tracker
+        run_chat = AsyncMock()
+
+        with patch("kiro_crew.slack.gateway._run_chat", run_chat):
+            await on_done(info)
+            await asyncio.sleep(0)
+
+        scheduled_task = slot.task
+        if isinstance(scheduled_task, asyncio.Task):
+            scheduled_task.cancel()
+            await asyncio.gather(scheduled_task, return_exceptions=True)
+
+        assert scheduled_task is None
+        run_chat.assert_not_awaited()
+        current_tracker.record_success.assert_not_called()
+        current_tracker.record_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delivery_retry_rechecks_stop_after_busy_slot_wait(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        tracker = MagicMock()
+        tracker.stopped = False
+        slot = MagicMock()
+        slot.mode = "orchestrator"
+        slot.running = False
+        slot._orch_tracker = tracker
+        slot._subagent_deliveries_inflight = 0
+        busy_started = asyncio.Event()
+        release_busy = asyncio.Event()
+
+        async def _busy_turn():
+            busy_started.set()
+            await release_busy.wait()
+
+        current_task = asyncio.create_task(_busy_turn())
+        slot.task = current_task
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        _mgr, on_done = self._capture_on_done(orch)
+        info = SubagentInfo(
+            id="retry-cancelled-during-wait",
+            task="late durable delivery",
+            parent_session_key="dashboard:main",
+            done=True,
+            result="done",
+        )
+        info._delivery_retry = True
+        info._delivery_orchestration_tracker = tracker
+        run_chat_release = asyncio.Event()
+
+        async def _run_chat(*_args, **_kwargs):
+            await run_chat_release.wait()
+
+        with patch("kiro_crew.slack.gateway._run_chat", side_effect=_run_chat):
+            delivery_task = asyncio.create_task(on_done(info))
+            await busy_started.wait()
+            await asyncio.sleep(0)
+            tracker.stopped = True
+            release_busy.set()
+            await delivery_task
+            await asyncio.sleep(0)
+
+        scheduled_task = slot.task
+        if scheduled_task is not current_task and isinstance(scheduled_task, asyncio.Task):
+            scheduled_task.cancel()
+            await asyncio.gather(scheduled_task, return_exceptions=True)
+
+        assert scheduled_task is current_task
+        tracker.record_success.assert_not_called()
+        tracker.record_failure.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_small_wave_delivers_single_chunk_digest(self):
@@ -1472,8 +1636,11 @@ class TestWaveDigest:
         total = 3
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
 
         with patch("kiro_crew.slack.gateway._run_chat", side_effect=_fake_run_chat), \
@@ -1491,6 +1658,423 @@ class TestWaveDigest:
         assert "Batch results 1/1" in digest
         assert "3 ✅" in digest and "of 3 agents" in digest
         assert "before spawning any follow-up" in digest
+
+    @pytest.mark.asyncio
+    async def test_digest_envelope_and_metadata_include_every_event_id(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = MagicMock()
+        slot.mode = "chat"
+        slot.running = True
+        slot.task = MagicMock()
+        slot._orch_tracker = None
+        slot._subagent_deliveries_inflight = 0
+        slot._subagents_inline_collected = set()
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        mgr, on_done = self._capture_on_done(orch)
+        members = [self._member(index, 3) for index in range(3)]
+        for index, member in enumerate(members):
+            member._delivery_event_id = f"event-{index}"
+            mgr.batch_members_pending = MagicMock(return_value=index != 2)
+            await on_done(member)
+
+        queued = slot.queue_append.call_args
+        announce = queued.args[0]
+        meta = queued.kwargs["meta"][SUBAGENT_COMPLETION_META_KEY]
+
+        # A failed parent route retries the same final member. Composition and
+        # batch accounting are one-shot even though routing is at-least-once.
+        final_member = members[-1]
+        final_member._delivery_queued = False
+        final_member._delivery_retry = True
+        await on_done(final_member)
+        replayed = slot.queue_append.call_args
+
+        for index in range(3):
+            assert f"Event: `event-{index}`" in announce
+        assert meta["eventIds"] == ["event-0", "event-1", "event-2"]
+        assert replayed.args[0] == announce
+        batch_finished = [
+            call for call in orch.dashboard_state.broadcast_ws.call_args_list
+            if call.args and call.args[0] == "batch_finished"
+        ]
+        assert len(batch_finished) == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_nonfinal_chunk_retry_does_not_recount_member(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        mgr, on_done = self._capture_on_done(orch)
+        members = [self._member(index, 12) for index in range(12)]
+        for index, member in enumerate(members):
+            member._delivery_event_id = f"event-{index}"
+
+        for member in members[:9]:
+            mgr.batch_members_pending = MagicMock(return_value=True)
+            await on_done(member)
+
+        orch.dashboard_state.notify = MagicMock(
+            side_effect=RuntimeError("route unavailable")
+        )
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        with pytest.raises(RuntimeError, match="route unavailable"):
+            await on_done(members[9])
+
+        assert members[9]._delivery_batch_progress is not None
+        assert orch._batch_progress["bigwave"]["done"] == 10
+
+        members[9]._delivery_retry = True
+        with pytest.raises(RuntimeError, match="route unavailable"):
+            await on_done(members[9])
+
+        retry_progress = members[9]._delivery_batch_progress
+        assert retry_progress is not None
+        assert len(retry_progress["ok_lines"]) == 10
+
+        orch.dashboard_state.notify = MagicMock()
+        await on_done(members[9])
+
+        orch.dashboard_state.notify.assert_called_once()
+        assert members[9]._digest_held is False
+        assert orch._batch_progress["bigwave"]["done"] == 10
+        assert orch._batch_progress["bigwave"]["flushed"] == 10
+
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        await on_done(members[10])
+        assert orch._batch_progress["bigwave"]["done"] == 11
+        assert not any(
+            call.args and call.args[0] == "batch_finished"
+            for call in orch.dashboard_state.broadcast_ws.call_args_list
+        )
+
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        await on_done(members[11])
+        finished = [
+            call
+            for call in orch.dashboard_state.broadcast_ws.call_args_list
+            if call.args and call.args[0] == "batch_finished"
+        ]
+        assert len(finished) == 1
+        assert finished[0].args[1]["ok"] == 12
+
+    @pytest.mark.asyncio
+    async def test_failed_nonfinal_chunk_blocks_later_chunks_until_retry(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        mgr, on_done = self._capture_on_done(orch)
+        members = [self._member(index, 12) for index in range(12)]
+        for index, member in enumerate(members):
+            member._delivery_event_id = f"event-{index}"
+
+        for member in members[:9]:
+            mgr.batch_members_pending = MagicMock(return_value=True)
+            await on_done(member)
+
+        orch.dashboard_state.notify = MagicMock(
+            side_effect=RuntimeError("route unavailable")
+        )
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        with pytest.raises(RuntimeError, match="route unavailable"):
+            await on_done(members[9])
+
+        orch.dashboard_state.notify = MagicMock()
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        await on_done(members[10])
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        await on_done(members[11])
+
+        assert orch.dashboard_state.notify.call_count == 0
+        assert orch._batch_progress["bigwave"]["done"] == 10
+        assert members[10]._delivery_failed is True
+        assert members[11]._delivery_failed is True
+
+        members[9]._delivery_retry = True
+        await on_done(members[9])
+        members[10]._delivery_failed = False
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        await on_done(members[10])
+        members[11]._delivery_failed = False
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        await on_done(members[11])
+
+        notifications = orch.dashboard_state.notify.call_args_list
+        assert len(notifications) == 2
+        assert members[9]._delivery_batch_final is False
+        assert members[11]._delivery_batch_final is True
+
+    @pytest.mark.asyncio
+    async def test_failed_transient_chunk_returns_to_wave_for_durable_member(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        mgr, on_done = self._capture_on_done(orch)
+        lost = self._member(0, 2, error="spawn submission lost")
+        lost._delivery_event_id = ""
+        sibling = self._member(1, 2)
+
+        orch.dashboard_state.notify = MagicMock(
+            side_effect=RuntimeError("route unavailable")
+        )
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        with patch("kiro_crew.slack.gateway.SUBAGENT_DIGEST_CHUNK_SIZE", 1):
+            with pytest.raises(RuntimeError, match="route unavailable"):
+                await on_done(lost)
+
+            orch.dashboard_state.notify = MagicMock()
+            mgr.batch_members_pending = MagicMock(return_value=False)
+            await on_done(sibling)
+
+        orch.dashboard_state.notify.assert_called_once()
+        progress = sibling._delivery_batch_progress
+        assert progress is not None
+        assert progress["done"] == 2
+        assert progress["err"] == 1
+        assert progress["ok"] == 1
+        assert any("spawn submission lost" in line for line in progress["fail_lines"])
+
+    @pytest.mark.asyncio
+    async def test_final_lost_submission_retries_its_durable_digest(self):
+        now = [1_000.0]
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        _mock_mgr, gateway_on_done = self._capture_on_done(orch)
+        announced: list[SubagentInfo] = []
+
+        async def _on_done(info: SubagentInfo) -> None:
+            announced.append(info)
+            await gateway_on_done(info)
+
+        mgr = SubagentManager(
+            sessions=_mock_sessions(),
+            ctx_builder=_mock_ctx(),
+            on_done=_on_done,
+            coordinator=MemoryRunCoordinator(clock=lambda: now[0]),
+        )
+        mgr._outbox_delivery._clock = lambda: now[0]
+        orch.subagent_mgr = mgr
+        sibling = self._member(0, 2)
+        sibling._delivery_event_id = "event-sibling"
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        await gateway_on_done(sibling)
+        assert sibling._digest_held is True
+
+        orch.dashboard_state.notify = MagicMock(
+            side_effect=RuntimeError("route unavailable")
+        )
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        mgr._outbox_delivery._lease_seconds = 1.0
+        mgr._outbox_delivery._retry_base_seconds = 0.0
+        mgr._outbox_delivery._retry_max_seconds = 0.0
+        with patch("kiro_crew.subagent_persistence.mark_delivered"):
+            mgr.record_lost_submission(
+                "bigwave",
+                2,
+                "connection refused",
+                parent_session_key="dashboard:main",
+            )
+            await asyncio.gather(*list(mgr._tasks.values()))
+
+            lost = announced[-1]
+            assert lost._delivery_event_id
+            assert lost._delivery_batch_final is True
+            assert lost._delivery_batch_progress is not None
+
+            orch.dashboard_state.notify = MagicMock()
+            now[0] += 2.0
+            attempts = await mgr._outbox_delivery.drain_once(
+                event_id=lost._delivery_event_id
+            )
+
+        assert attempts
+        orch.dashboard_state.notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_inflight_nonfinal_route_blocks_concurrent_later_chunks(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.sessions.cancel_current = AsyncMock()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        mgr, on_done = self._capture_on_done(orch)
+        mgr.running = []
+        mgr.queued_count_for = MagicMock(return_value=0)
+        members = [self._member(index, 12) for index in range(12)]
+        for index, member in enumerate(members):
+            member.parent_session_key = "cron:job-1"
+            member._delivery_event_id = f"event-{index}"
+
+        for member in members[:9]:
+            mgr.batch_members_pending = MagicMock(return_value=True)
+            await on_done(member)
+
+        route_started = asyncio.Event()
+        release_route = asyncio.Event()
+        get_calls = 0
+
+        async def _get_or_create(_key):
+            nonlocal get_calls
+            get_calls += 1
+            if get_calls == 1:
+                route_started.set()
+                await release_route.wait()
+                raise RuntimeError("route unavailable")
+            return MagicMock(), False, False
+
+        def _mark_failed(info, reason=""):
+            info._delivery_failed = True
+
+        orch.sessions.get_or_create = AsyncMock(side_effect=_get_or_create)
+        mgr.notify_injection_failed = MagicMock(side_effect=_mark_failed)
+        mgr.batch_members_pending = MagicMock(return_value=True)
+        first_chunk = asyncio.create_task(on_done(members[9]))
+        await route_started.wait()
+
+        later_member = asyncio.create_task(on_done(members[10]))
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        final_member = asyncio.create_task(on_done(members[11]))
+        await asyncio.sleep(0)
+
+        assert get_calls == 1
+        release_route.set()
+        await asyncio.gather(first_chunk, later_member, final_member)
+        assert members[10]._delivery_failed is True
+        assert members[11]._delivery_failed is True
+        assert orch._batch_progress["bigwave"]["done"] == 10
+
+    @pytest.mark.asyncio
+    async def test_completed_callback_waiting_on_wave_lock_prevents_early_final_digest(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        mgr, on_done = self._capture_on_done(orch)
+        mgr.running = []
+        mgr.queued_count_for = MagicMock(return_value=0)
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        members = [self._member(index, 2) for index in range(2)]
+        for index, member in enumerate(members):
+            member.parent_session_key = "cron:job-1"
+            member._delivery_event_id = f"event-{index}"
+
+        route_started = asyncio.Event()
+        release_route = asyncio.Event()
+        get_calls = 0
+
+        async def _get_or_create(_key):
+            nonlocal get_calls
+            get_calls += 1
+            route_started.set()
+            if get_calls == 1:
+                await release_route.wait()
+            return MagicMock(), False, False
+
+        orch.sessions.get_or_create = AsyncMock(side_effect=_get_or_create)
+        first = asyncio.create_task(on_done(members[0]))
+        await asyncio.sleep(0)
+        second = asyncio.create_task(on_done(members[1]))
+        await asyncio.sleep(0)
+        await route_started.wait()
+
+        try:
+            assert members[0]._delivery_batch_progress is None
+            assert members[1]._delivery_batch_progress is not None
+            assert members[1]._delivery_batch_progress["done"] == 2
+        finally:
+            release_route.set()
+            await asyncio.gather(first, second)
+        assert get_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_flush_only_chunk_rolls_back_for_wave_close(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_slot = MagicMock(return_value=None)
+        mgr, on_done = self._capture_on_done(orch)
+        members = [self._member(index, 3) for index in range(3)]
+
+        for member in members[:2]:
+            mgr.batch_members_pending = MagicMock(return_value=True)
+            await on_done(member)
+
+        flush = SubagentInfo(
+            id="flush",
+            task="held wave results",
+            parent_session_key="dashboard:main",
+            batch_id="bigwave",
+            batch_total=3,
+            done=True,
+        )
+        flush._digest_flush_only = True
+        orch.dashboard_state.notify = MagicMock(
+            side_effect=RuntimeError("route unavailable")
+        )
+        with pytest.raises(RuntimeError, match="route unavailable"):
+            await on_done(flush)
+
+        orch.dashboard_state.notify = MagicMock()
+        mgr.batch_members_pending = MagicMock(return_value=False)
+        await on_done(members[2])
+
+        orch.dashboard_state.notify.assert_called_once()
+        final_progress = members[2]._delivery_batch_progress
+        assert final_progress is not None
+        assert len(final_progress["ok_lines"]) == 3
+        assert set(members[2]._digest_settle_ids) == {"w0", "w1"}
+
+    @pytest.mark.asyncio
+    async def test_generic_cron_injection_failure_marks_delivery_failed(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.sessions.get_or_create = AsyncMock(
+            side_effect=RuntimeError("provider unavailable")
+        )
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        mgr, on_done = self._capture_on_done(orch)
+        mgr.running = []
+        mgr.queued_count_for = MagicMock(return_value=0)
+        member = self._member(0, 1)
+        member.batch_id = ""
+        member.batch_total = 0
+        member.parent_session_key = "cron:job-1"
+
+        def mark_failed(info, reason=""):
+            info._delivery_failed = True
+
+        mgr.notify_injection_failed = MagicMock(side_effect=mark_failed)
+        await on_done(member)
+
+        mgr.notify_injection_failed.assert_called_once_with(
+            member,
+            reason="cron injection failed",
+        )
+        assert member._delivery_failed is True
 
     @pytest.mark.asyncio
     async def test_single_spawn_keeps_per_agent_injection(self):
@@ -1512,8 +2096,11 @@ class TestWaveDigest:
         mgr.running_agents_for = MagicMock(return_value=[])
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
 
         solo = SubagentInfo(
@@ -1528,6 +2115,53 @@ class TestWaveDigest:
         assert len(injected) == 1
         assert injected[0].startswith("[Subagent completion event]")
         assert "Batch results" not in injected[0]
+
+    @pytest.mark.asyncio
+    async def test_failed_durable_single_spawn_acks_after_idle_turn_consumes(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = MagicMock()
+        slot.mode = "chat"
+        slot.running = False
+        slot.task = None
+        slot._orch_tracker = None
+        slot._subagent_deliveries_inflight = 0
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        mgr, on_done = self._capture_on_done(orch)
+        mgr.running_agents_for = MagicMock(return_value=[])
+        ledger, settled = _wire_hold_settlement(orch, slot, mgr)
+
+        async def _consuming_run_chat(
+            _state,
+            _slot,
+            _text,
+            *,
+            _directive_user_origin,
+            _on_consumed,
+        ):
+            assert _directive_user_origin is False
+            _on_consumed()
+
+        failed = SubagentInfo(
+            id="failed-durable-solo",
+            task="one-off task",
+            parent_session_key="dashboard:main",
+        )
+        failed.done = True
+        failed.error = "boom"
+        failed._delivery_event_id = "event-failed-durable-solo"
+
+        with patch("kiro_crew.slack.gateway._run_chat", _consuming_run_chat):
+            await on_done(failed)
+            await _settle(lambda: slot.task is None)
+            await _settle(lambda: bool(settled))
+
+        assert ledger == {}
+        assert settled == [[failed.id]]
+        assert failed._delivery_queued is True
 
 
 # ── 4b. Hold deadline (straggler escape hatch, issue #2215) ──────────
@@ -1675,6 +2309,16 @@ class TestDigestHoldDeadline:
         assert marked == []  # failure → nothing tombstoned
         assert info._digest_settle_ids == ["h0", "h1"]
 
+        async def _defer_delivery(record):
+            record._delivery_failed = True
+
+        mgr._on_done = AsyncMock(side_effect=_defer_delivery)
+        with patch("kiro_crew.subagent.mark_delivered", side_effect=marked.append):
+            await mgr._announce_digest_flush(info)
+        assert marked == []  # deferred routing → nothing tombstoned
+        assert info._digest_settle_ids == ["h0", "h1"]
+
+        info._delivery_failed = False
         mgr._on_done = AsyncMock()
         with patch("kiro_crew.subagent.mark_delivered", side_effect=marked.append):
             await mgr._announce_digest_flush(info)
@@ -1707,8 +2351,11 @@ class TestDigestHoldDeadline:
         gw_mgr.batch_members_pending = MagicMock(return_value=True)  # straggler alive
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
 
         # Real manager for the sweep, wired to the gateway's own consumer.
@@ -1778,13 +2425,12 @@ class TestDigestHoldDeadline:
         ledger, settled = _wire_hold_settlement(orch, slot, mgr)
         injected: list[str] = []
 
-        async def _fake_run_chat(_state, _slot, text, *, _directive_user_origin, _on_consumed=None, **_kw):
+        async def _fake_run_chat(
+            _state, _slot, text, *, _directive_user_origin, _on_consumed
+        ):
             assert _directive_user_origin is False
+            _on_consumed()
             injected.append(text)
-            # The model consumed the flushed digest — the condition that
-            # settles the held siblings on this route (#2233).
-            if _on_consumed is not None:
-                _on_consumed()
 
         members = [
             SubagentInfo(

--- a/test/test_subagent_turn_resilience.py
+++ b/test/test_subagent_turn_resilience.py
@@ -996,12 +996,16 @@ def test_no_raw_cancel_outside_chokepoint():
     allowed_substrings = (
         "task.cancel()",  # chokepoint body — verified below to be unique
         "self._reaper_task.cancel()",
+        "reconcile_task.cancel()",
         # A reap supersedes a pending respawn; the recovery task schedules the
         # respawn and is NOT a managed run, so no terminal marker applies.
         "recovery_task.cancel()",
         # Shielded terminal-report tasks drained at shutdown — also not managed
         # runs; cancelling them cannot trigger a respawn.
         "report_task.cancel()",
+        # Coordinator lease-heartbeat tasks are observers, not managed runs.
+        # Cancelling them cannot trigger run recovery.
+        "lease_task.cancel()",
         # follow_up watchers (spawn_steer mode="follow_up") — observers, not
         # managed runs: no terminal marker applies, and cancelling one cannot
         # trigger a respawn (it only ever DISPATCHES via continue_conversation,
@@ -1021,8 +1025,10 @@ def test_no_raw_cancel_outside_chokepoint():
         for rel, n, line in raw_sites
         if "task.cancel()" in line
         and "_reaper_task" not in line
+        and "reconcile_task" not in line
         and "recovery_task" not in line
         and "report_task" not in line
+        and "lease_task" not in line
     ]
     assert len(generic) == 1, (
         f"expected exactly one raw task.cancel() (the chokepoint body), " f"found: {generic}"


### PR DESCRIPTION
> Stacked change: **PR 5 of 7**
>
> Stack: #5277 → #5278 → #5279 → #5280 → #5281 → #5282 → #5283
> Base: #5280
> Next: #5282

## Problem / Motivation

Recording a terminal subagent result and delivering its completion to the parent are separate operations, so a crash or retry between them can lose or duplicate the completion event.

## Why it matters

Parent synthesis and batch accounting depend on completion events remaining durable until the parent actually consumes them, including failed and stopped runs that must retain their longer post-mortem window.

## What changed (motivation → approach → change)

- Adds a fenced outbox delivery adapter with claim epochs, retry/defer behavior, and idempotent acknowledgement.
- Creates the stable completion event atomically with the first terminal outcome and keeps pre-start rejection separate from terminal run state.
- Routes gateway completion delivery through the durable outbox while preserving existing injected-message envelopes and batch identity.
- Reaps matching surviving child processes from the legacy folder snapshot before outbox delivery can write a tombstone that hides them from restart cleanup.
- Offloads identity-checked orphan process reaping so bounded Windows process-tree termination cannot stall the gateway event loop.
- Retains the original orchestration owner across durable delivery attempts and rechecks it after a busy-slot wait, so cancellation cannot route a stale result into a newly armed plan.
- Snapshots the active completion tracker for fresh deliveries while reserving retained trackers for durable retries, so test doubles and stale orchestration state cannot suppress a newly completed result.
- Retains immutable retry snapshots and serializes same-wave callbacks so later or final chunks cannot overtake a failed non-final route.
- Closes waves from accounted terminal callbacks rather than live manager membership, preventing a callback waiting on the wave lock from causing an early partial final digest.
- Rolls unreplayable synthetic chunks back into live wave state; only durable events can own an exact retry position.
- Defers acknowledgement for queued and digest-held completions until consumption, including failed and stopped direct dashboard deliveries, without replacing their error/stop tombstone with a short-lived `delivered` tombstone.
- Retries transient coordinator acknowledgement failures under the retained delivery fence without re-invoking the destination.
- Hands callback-reported delivery failures back to the adapter's bounded durable retry schedule while retrying unattempted synthetic delivery before shutdown.
- Preserves admitted keyed-rejection fences and routes their terminal state through the transactional outbox after command settlement, so a gateway crash cannot lose the completion.
- Routes identity-free queued batch stops through the synthetic legacy completion path, ensuring cancellation still closes wave accounting without a command fence.
- Immediately lifecycle-owns scheduled synthetic reports and shields keyed and direct terminal commits so shutdown drains them before cancelling background work.
- Keeps coordinator commit retries alive through shutdown while stopping only post-commit delivery retries.
- Rechecks the live in-flight fence after waiting for the adapter lock, so queue and digest acknowledgements settle a concurrent claim instead of returning without an acknowledgement.
- Preserves conversation identity, resolved model, and redacted requested-model metadata across durable terminal replay.

## Tests

- `test/test_run_coordinator_delivery.py` covers fenced claims, retry/defer behavior, acknowledgement races, failed/stopped delivery consumption, durable keyed-rejection routing, startup process-reap ordering, shutdown settlement, replay metadata, and callback retry ownership: 49 passed.
- `test/test_subagent.py` covers keyed and identity-free queued batch cancellation, including the synthetic stopped completion that closes a legacy wave.
- The current stack-tip focused coordinator suite passes: 507 passed, 1 valid platform skip.
- Black, subprocess encoding, isort, flake8, Linux-parity mypy, docs, harness-parity, brand, and public-tree scrub gates pass at the stack tip.

## Manual verification

N/A — retry, queue, digest, crash-recovery, cancellation, callback-ordering, and keyed-rejection behavior is deterministically covered by automated tests.

## Related Issues

No linked issue: this stack implements the locally reviewed durable run coordinator RFC.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff