### PR TITLE
feat: recover subagents from the run coordinator

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -369,7 +369,6 @@ src/kiro_crew/slack/events.py
 src/kiro_crew/slack/handler.py
 src/kiro_crew/slack/interactions.py
 src/kiro_crew/slack/sessions_view.py
-src/kiro_crew/subagent_persistence.py
 src/kiro_crew/subagent_scale.py
 src/kiro_crew/suggestions.py
 src/kiro_crew/testing/channel_fixtures.py
@@ -380,7 +379,6 @@ src/kiro_crew/webhooks.py
 src/kiro_crew/weixin/client.py
 src/kiro_crew/workflows/agent_exec.py
 src/kiro_crew/workflows/context.py
-test/conftest.py
 test/fake_mcp_app_server.py
 test/metrics/test_context_occupancy.py
 test/metrics/test_cost_breakdown.py
@@ -1070,7 +1068,6 @@ test/test_skill_versioning.py
 test/test_skills.py
 test/test_slack_agent_passthrough.py
 test/test_slack_dashboard_live_sync.py
-test/test_slack_gateway.py
 test/test_slack_gateway_coverage.py
 test/test_slack_handler_coverage_branches.py
 test/test_slack_home_tab.py
@@ -1114,8 +1111,6 @@ test/test_subagent.py
 test/test_subagent_context_groups.py
 test/test_subagent_continuable.py
 test/test_subagent_cost.py
-test/test_subagent_persistence.py
-test/test_subagent_reap_race.py
 test/test_subagent_scale.py
 test/test_subagent_sizing.py
 test/test_subagent_stall.py

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -411,6 +411,12 @@ process EXISTS and must never be conflated with `ProcessLookupError` — and on
 Windows they ask `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` instead of
 signalling anything.
 
+Persisted termination authority uses `platform_compat.process_identity_token`,
+which versions the Windows creation FILETIME and has reboot-unique,
+locale-independent counterparts on Linux and macOS. A platform without such a
+token records the PID as non-owned, so restart recovery can observe it but can
+never use it to authorize a signal.
+
 `test/test_windows_kill_probe_audit.py` enforces this as a tripwire rather than a
 convention: it walks the AST of every module under `src/kiro_crew` and fails on a
 raw signal-0 probe until the author either routes it through the shim or records

--- a/docs/request-for-change/rfc-durable-run-coordinator.md
+++ b/docs/request-for-change/rfc-durable-run-coordinator.md
@@ -5,7 +5,7 @@ revision: v1
 author: Kyle Seaman, with Codex
 created: 2026-08-22
 last-audited: 2026-08-22
-audited-at: c8eda3c6f
+audited-at: 09b58e9b4
 doc-pr:
 implementation-prs: []
 tracking-issues: []
@@ -14,16 +14,16 @@ superseded-by: []
 ---
 # RFC: Durable Run Coordinator — typed lifecycle, idempotent commands, and recoverable delivery
 
-- Status: in-progress — PRs 1–6 are implemented locally; PR 6 lives on
-  `codex/run-coordinator-outbox`. Keyed execution carries a renewable run fence
-  through `starting`, `running`, and atomic terminal/outbox commit; fenced
-  delivery retries reuse one stable event identity. Legacy run files still
-  mirror lifecycle/terminal state; PR 7 is unimplemented.
+- Status: implemented locally — PRs 1–7 are prepared as a stack. Keyed
+  execution carries a renewable run fence through `starting`, `running`, and
+  atomic terminal/outbox commit; fenced delivery retries reuse one stable event
+  identity. Restart recovery imports legacy folders read-only, takes over only
+  expired leases, reports uncertain work as interrupted, and never replays it.
 - Author: Kyle Seaman, with Codex
 - Created: 2026-08-22
-- Audited against: PR 1 commit `c8eda3c6f`, PR 2 commit `53f365a17`, PR 3 commit
-  `4aa0cba4d`, PR 4 commit `3ed006642`, PR 5 commit `f9b73887a`, and the PR 6
-  working tree
+- Audited against: PR 1 commit `09b58e9b4`, PR 2 commit `ffe2b0f76`, PR 3 commit
+  `6db805ec2`, PR 4 commit `458472368`, PR 5 commit `ee198e741`, PR 6 commit
+  `391ccd202`, and local branch `run-coordinator-recovery` for PR 7
 - Related: `docs/system-specs/modules/subagent.md`,
   `docs/system-specs/modules/session.md`, and
   `docs/request-for-change/rfc-orchestrator-chat-sessions.md`
@@ -633,6 +633,22 @@ terminal commit, destination acceptance, and delivery acknowledgement converges
 to a documented state; a stale owner cannot commit after takeover; uncertain
 execution is reported once without automatic replay; legacy-only installs
 upgrade without losing retained results.
+
+**Local status:** implemented. Schema v4 records the source version on imported
+runs, and schema v5 records process identity and ownership inside the protected
+coordinator store. The importer reads known legacy fields without modifying
+source files and is idempotent against native coordinator rows; agent-writable
+legacy process fields never authorize termination, non-finite timestamps are
+skipped per folder, and legacy destinations never manufacture pending outbox
+work. A dedicated child does not receive a prompt until its fenced process
+identity is durably stored; failure aborts execution while the legacy state
+mirror remains best-effort. Recovery claims expired
+nonterminal leases with a fresh epoch, signals only a coordinator-owned PID with
+an exact fenced start identity, retains partial output, commits `interrupted`,
+emits a SEL termination audit, and drains terminal outbox work separately. The
+periodic reaper retries leases that had not expired at startup while excluding
+locally active run IDs. A hermetic sleeper-process test exercises the real
+takeover/termination path.
 
 ### Deferred cleanup after the compatibility window
 

--- a/docs/superpowers/plans/2026-08-22-durable-run-coordinator.md
+++ b/docs/superpowers/plans/2026-08-22-durable-run-coordinator.md
@@ -103,16 +103,16 @@ exceptions.
 - Consumes: the approved RFC at revision v1.
 - Produces: exact branch, file, test, and verification boundaries for PRs 2–7.
 
-- [ ] **Step 1: Add this plan and link it from the RFC.**
+- [x] **Step 1: Add this plan and link it from the RFC.**
 
   Add a `Detailed implementation plan` link next to the RFC's related docs.
 
-- [ ] **Step 2: Verify documentation.**
+- [x] **Step 2: Verify documentation.**
 
   Run `bash scripts/docs-lint.sh` and `git diff --check`.
   Expected: both exit zero.
 
-- [ ] **Step 3: Amend PR 1's local commit.**
+- [x] **Step 3: Amend PR 1's local commit.**
 
   Run `git commit --amend --no-edit` so PR 1 remains one logical commit.
 
@@ -135,7 +135,7 @@ exceptions.
 - Produces: `RunCoordinator`, all typed records/enums, `MemoryRunCoordinator`,
   and optional `coordinator=` injection on `SubagentManager`.
 
-- [ ] **Step 1: Write failing model and submission tests.**
+- [x] **Step 1: Write failing model and submission tests.**
 
   Parameterize a coordinator factory initially with `MemoryRunCoordinator` and
   assert: first submit returns `created=True`; same key/hash returns the same run
@@ -143,18 +143,18 @@ exceptions.
   conflict without mutation; a
   rejected request creates a queryable terminal failed run and rejected command.
 
-- [ ] **Step 2: Run the contract test and verify RED.**
+- [x] **Step 2: Run the contract test and verify RED.**
 
   Run `python -m pytest test/test_run_coordinator_contract.py -n0 -q`.
   Expected: collection fails because `kiro_crew.run_coordinator` does not exist.
 
-- [ ] **Step 3: Implement typed models and in-memory submission.**
+- [x] **Step 3: Implement typed models and in-memory submission.**
 
   Use `str, Enum` values from the RFC and frozen dataclasses. Store records in
   private dictionaries protected by one `asyncio.Lock`; copy records with
   `dataclasses.replace` instead of mutating returned objects.
 
-- [ ] **Step 4: Write failing claim, fence, completion, and outbox tests.**
+- [x] **Step 4: Write failing claim, fence, completion, and outbox tests.**
 
   Assert command claim assigns owner and epoch; matching fences advance
   `starting -> running -> terminal`; stale fences raise; completion returns one
@@ -163,23 +163,23 @@ exceptions.
   `claim_epoch`, its prior delivery fence is rejected, and delivered events no
   longer claim.
 
-- [ ] **Step 5: Run the new tests and verify RED.**
+- [x] **Step 5: Run the new tests and verify RED.**
 
   Expected: failures name unimplemented transition methods, not fixture errors.
 
-- [ ] **Step 6: Implement the minimal in-memory state machine.**
+- [x] **Step 6: Implement the minimal in-memory state machine.**
 
   Centralize legal transitions in one map and validate terminal/outcome
   coherence before replacing a record. Use a caller-injected clock and ID
   factory so tests assert exact values without sleeping.
 
-- [ ] **Step 7: Add facade injection without changing authority.**
+- [x] **Step 7: Add facade injection without changing authority.**
 
   Add `coordinator: RunCoordinator | None = None` to `SubagentManager.__init__`
   and store `self._coordinator = coordinator or MemoryRunCoordinator()`. Do not
   route production transitions through it yet.
 
-- [ ] **Step 8: Verify and commit PR 2.**
+- [x] **Step 8: Verify and commit PR 2.**
 
   Run focused tests, format only new/touched files, run flake8/mypy on those
   files, update RFC audit metadata, and commit:
@@ -208,41 +208,41 @@ exceptions.
 - Produces: `RunFinalizer.claim_report()`, `claim_slot()`, `rearm_slot()` and
   `SubagentScheduler` capacity/queue operations.
 
-- [ ] **Step 1: Write failing finalizer tests.**
+- [x] **Step 1: Write failing finalizer tests.**
 
   Move the pure claim cases out of the manager fixture: exactly one report
   claim, recovery withholding without consumption, superseding recovery,
   exactly one slot claim, and rearming only for an admitted recovery attempt.
 
-- [ ] **Step 2: Verify RED, then implement `RunFinalizer`.**
+- [x] **Step 2: Verify RED, then implement `RunFinalizer`.**
 
   Run `python -m pytest test/test_subagent_lifecycle.py -n0 -q`; verify missing
   module failure; implement the three synchronous no-await methods; rerun green.
 
-- [ ] **Step 3: Write failing scheduler tests.**
+- [x] **Step 3: Write failing scheduler tests.**
 
   Assert FIFO queue order, maximum-capacity admission, one-time release, parent
   depth, batch presence, removal by preassigned ID, and queue payload identity.
 
-- [ ] **Step 4: Verify RED, then implement `SubagentScheduler`.**
+- [x] **Step 4: Verify RED, then implement `SubagentScheduler`.**
 
   Keep stagger timing and actual `spawn()` calls in the facade; the scheduler
   owns only queue and capacity policy. Expose read-only `running_count` and
   `queued` views plus explicit `admit`, `release`, `enqueue`, `pop_next`,
   `remove`, `count_parent`, and `has_batch` operations.
 
-- [ ] **Step 5: Delegate manager behavior through the boundaries.**
+- [x] **Step 5: Delegate manager behavior through the boundaries.**
 
   Keep `_claim_finalize`, `_release_slot`, `_running_count`, and `_queue` as
   compatibility shims for existing callers/tests, but make each forward to the
   extracted object. Replace production mutations with scheduler operations.
 
-- [ ] **Step 6: Run race and scale regressions.**
+- [x] **Step 6: Run race and scale regressions.**
 
   Run the new tests plus `test/test_subagent_reap_race.py` and the queue/lost-
   submission classes in `test/test_subagent_scale.py`, all with `-n0`.
 
-- [ ] **Step 7: Update the subagent spec and commit PR 3.**
+- [x] **Step 7: Update the subagent spec and commit PR 3.**
 
   Document the new ownership boundary without changing behavior. Commit:
   `refactor: extract subagent lifecycle boundaries`.
@@ -269,39 +269,39 @@ exceptions.
 - Produces: `SQLiteRunCoordinator`, `ShadowRunCoordinator`, schema version 1,
   and owner-only/sensitive coordinator storage.
 
-- [ ] **Step 1: Add SQLite to the contract factory and verify RED.**
+- [x] **Step 1: Add SQLite to the contract factory and verify RED.**
 
   Construct `SQLiteRunCoordinator(tmp_path / "coordinator" / "runs.sqlite3",
   clock=fake_clock, id_factory=fake_ids)`. Expected: import failure.
 
-- [ ] **Step 2: Write failing schema and security tests.**
+- [x] **Step 2: Write failing schema and security tests.**
 
   Assert four tables and schema version, WAL and busy timeout, transactional
   re-open, newer-schema refusal, corrupt-file refusal, owner-only directory/file
   helpers, and sensitive matching for the coordinator directory plus sidecars
   under current and legacy data-home prefixes.
 
-- [ ] **Step 3: Implement schema and synchronous transaction core.**
+- [x] **Step 3: Implement schema and synchronous transaction core.**
 
   Use one stdlib `sqlite3` connection per worker call, bound SQL parameters,
   explicit `BEGIN IMMEDIATE`, foreign keys, Python enum validation, and
   transactional migration metadata. Never keep a connection on the event-loop
   object and never use `executescript()` inside a migration transaction.
 
-- [ ] **Step 4: Add async wrappers and verify off-loop behavior.**
+- [x] **Step 4: Add async wrappers and verify off-loop behavior.**
 
   Every protocol method calls its synchronous counterpart through
   `asyncio.to_thread`. A test monkeypatches the sync worker to record thread ID
   and asserts it differs from the event-loop thread; it does not use durations.
 
-- [ ] **Step 5: Implement and test shadow parity.**
+- [x] **Step 5: Implement and test shadow parity.**
 
   `ShadowRunCoordinator` calls the legacy-authoritative coordinator first,
   mirrors successful transitions to SQLite, compares normalized records at
   stable boundaries, and reports a bounded `ParityMismatch` callback without
   repairing or failing legacy behavior.
 
-- [ ] **Step 6: Update security/subagent specs and commit PR 4.**
+- [x] **Step 6: Update security/subagent specs and commit PR 4.**
 
   Run coordinator/security tests, docs lint, formatting, flake8, and mypy.
   Commit: `feat: add sqlite run coordinator shadow store`.
@@ -435,43 +435,43 @@ exceptions.
   readers.
 - Produces: `RunRecovery.reconcile()` and idempotent `LegacyRunImporter`.
 
-- [ ] **Step 1: Write importer and lease-takeover tests.**
+- [x] **Step 1: Write importer and lease-takeover tests.**
 
   Cover running, completed, delivered, tombstoned, continuable, corrupt, and
   missing-result folders; repeated import; expired lease takeover; stale owner
   mutation rejection; and legacy files left byte-identical.
 
-- [ ] **Step 2: Verify RED, then implement the importer.**
+- [x] **Step 2: Verify RED, then implement the importer.**
 
   Validate IDs with the existing containment rule, parse known fields only,
   record source version, and create coordinator records idempotently. Corruption
   emits a diagnostic and leaves the folder untouched.
 
-- [ ] **Step 3: Write and implement the recovery decision matrix.**
+- [x] **Step 3: Write and implement the recovery decision matrix.**
 
   Coordinator terminal + pending event drains delivery. Running + verified live
   child follows current kill-and-report policy. Starting/running + no verified
   child becomes `interrupted` with partial result retained. No state permits
   automatic replay except the existing zero-tool cancel-recovery rule.
 
-- [ ] **Step 4: Add deterministic crash-window tests.**
+- [x] **Step 4: Add deterministic crash-window tests.**
 
   Assert convergence after every boundary listed in RFC section 7.3 using
   injected failure points and clocks, never sleeps.
 
-- [ ] **Step 5: Add one hermetic subprocess restart test.**
+- [x] **Step 5: Add one hermetic subprocess restart test.**
 
   Spawn only a Python sleeper with `cwd` under `tmp_path`; capture and terminate
   it through `platform_compat`; guarantee cleanup in `finally`; verify takeover
   fences the old owner and preserves partial output.
 
-- [ ] **Step 6: Make startup coordinator-first with legacy fallback.**
+- [x] **Step 6: Make startup coordinator-first with legacy fallback.**
 
   Import legacy-only folders once, acquire expired leases, reconcile runs, then
   drain pending delivery. Keep old orphan recovery available when coordinator
   mode is disabled.
 
-- [ ] **Step 7: Verify, document, and commit PR 7.**
+- [x] **Step 7: Verify, document, and commit PR 7.**
 
   Run recovery/persistence/subagent tests, docs lint, formatting, flake8, mypy,
   and the full repository gate if the environment supports it. Commit:
@@ -481,13 +481,27 @@ exceptions.
 
 ## Final stacked verification
 
-- [ ] Confirm every branch contains exactly one commit relative to its parent.
-- [ ] Confirm every worktree is clean and no branch was pushed.
-- [ ] Run `python3 scripts/check_black_formatting.py`.
-- [ ] Run `isort --check-only` on all changed Python files.
-- [ ] Run `flake8` and `mypy` on all changed Python files.
-- [ ] Run all coordinator and subagent-focused tests with `-n0`.
-- [ ] Run `bash scripts/docs-lint.sh`.
-- [ ] Run `git diff --check` for every adjacent branch pair.
-- [ ] Record any unavailable full-suite gate explicitly; never describe an
+- [x] Confirm every branch contains exactly one commit relative to its parent.
+- [x] Confirm every worktree is clean and no branch was pushed.
+- [x] Run `python3 scripts/check_black_formatting.py`.
+- [x] Run `isort --check-only` on all changed Python files.
+- [x] Run `flake8` and `mypy` on all changed Python files.
+- [x] Run all coordinator and subagent-focused tests with `-n0`.
+- [x] Run `bash scripts/docs-lint.sh`.
+- [x] Run `git diff --check` for every adjacent branch pair.
+- [x] Record any unavailable full-suite gate explicitly; never describe an
   unrun gate as passing.
+
+### Local verification record
+
+- The coordinator/subagent slice passed 647 tests serially. The handler, MCP,
+  command-authority, and API-contract slice passed another 423 tests serially.
+- Formatting, import order, changed-file flake8 and mypy, documentation lint,
+  and adjacent-branch whitespace checks passed from the repository virtual
+  environment.
+- The full repository run was attempted on macOS with Python 3.14: 60,964
+  passed, 385 skipped, 6 xfailed, 2 errored, and 95 failed. The failures mixed
+  platform/test-harness issues (including BSD `date`, Unix-socket path length,
+  and unrelated adversarial parser/timeouts) with stack contract failures. The
+  stack-related failures were isolated, corrected, and covered by the two green
+  serial slices above; the full-repository attempt is not reported as passing.

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1874,6 +1874,12 @@ without that disclosure. Likewise, the `suspicious_patterns` row states it is
 not enforced at the PreToolUse gate — the gate uses the narrower
 `audit_bash_exfiltration` plus the denied-command rules.
 
+Coordinator restart recovery is an output boundary too: both legacy imports and
+native lease takeovers redact task, agent, and error fields before constructing a
+durable completion event. The security-posture registry names those two modules
+separately so a recovery-only delivery path cannot disappear from the coverage
+inventory.
+
 **`/api/security/stats` is retained but no longer used by the dashboard**, which
 reads `/api/security/posture` (same counts plus the items). It re-sources via
 `posture_counts_async`, which resolves every `items_fn` — so the count is still

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -73,9 +73,18 @@ executor's run lease.
 Rejected legacy admission is durably reflected as a rejected command and failed
 terminal run. A claimed execution with an uncertain crash is not automatically
 replayed. Accepted keyed runs carry `_coordinator_admitted`, preventing `_run`
-from creating a second shadow command. Legacy synchronous spawns still submit at
-async `_run` entry and await the coordinator's own bounded operation instead of
-imposing a shorter caller deadline. Failures remain contained during migration.
+from creating a second shadow command. Legacy synchronous spawns submit and
+claim their stable shadow command at async `_run` entry. Submission diagnostics
+remain failure-contained, and the async pre-execution submit and claim await the
+coordinator's own bounded SQLite operation instead of imposing a shorter caller
+deadline. Execution fails closed before entering the child session when no run
+fence was acquired. If a coordinator reports an uncertain claim timeout, the
+manager resolves the stable command key once. An owned, unexpired committed
+claim continues with its reconstructed run fence; an ambiguous result emits no
+local terminal callback, keeps the live record nonterminal and cancellable, and
+is left to fenced durable recovery. This prevents a late commit from producing
+both an immediate unfenced failure and a later recovered interruption while
+still allowing an operator Stop to settle the retained claim as STOPPED.
 Queued and approval-waiting keyed runs retain a bounded pre-execution lease.
 Their commands remain `CLAIMED` until the manager task actually starts, so a
 gateway restart cannot turn volatile queued work into a durable applied result.
@@ -189,7 +198,7 @@ the coordinator port. The winning terminal reporter commits the outcome and
 outbox row before any WebSocket or parent callback. It keeps its execution
 lease and shielded report alive across transient commit failures, then retries
 the exact outbox event until delivery succeeds or the destination durably
-defers it to its queue/digest.
+defers it to its queue/digest or releases it for the periodic outbox drainer.
 
 Private manager views for the old counter, queue, report-task, and teardown-gate
 fields remain as compatibility adapters. They delegate to these boundaries and
@@ -199,17 +208,20 @@ must not regain independent state.
 
 `SQLiteRunCoordinator` implements the shared contract with fresh short-lived
 connections and offloads every filesystem/database operation from the event
-loop onto a dedicated two-worker coordinator pool. Every accepted-run shadow
-submission has a one-second total manager deadline; timeout is diagnostic and
-legacy execution begins while an already-running SQLite worker may finish in
-the coordinator pool. Lock waits therefore queue among coordinator calls and
-cannot starve asyncio's shared executor after the deadline. Mutations run under
-`BEGIN IMMEDIATE`; schema v3 uses `runs`, `commands`,
-`outbox`, and `metadata`, with WAL, `synchronous=FULL`, foreign keys, a bounded
+loop onto a dedicated two-worker coordinator pool. The coordinator-first
+recovery layer strongly retains and awaits every accepted-run submission until
+it reaches a definite durable or failed outcome; task cancellation cannot
+cancel a queued executor future. Lock waits therefore queue among coordinator
+calls and cannot starve asyncio's shared executor. Mutations run under
+`BEGIN IMMEDIATE`; schema v4 uses
+`runs`, `commands`, `outbox`, and `metadata`, with WAL, `synchronous=FULL`,
+foreign keys, a bounded
 busy timeout, and a quick integrity check. Ordered, contiguous migrations are
 applied in that transaction; v2 adds the durable command payload to the v1 base
 schema and v3 adds independent command claims/results while permitting
-pre-cutover control targets. Failed upgrades roll back cleanly for idempotent
+pre-cutover control targets. Schema v4 records the source version for imported
+legacy runs. Schema v5 records fenced child-process identity and ownership in
+the protected coordinator store. Failed upgrades roll back cleanly for idempotent
 retry. The physical shipped columns recover a missing schema-version metadata
 row instead of replaying already-applied `ALTER TABLE` statements. The implementation
 hydrates the typed in-memory state machine from those rows and rewrites the
@@ -248,9 +260,31 @@ failed operation after its state became durable.
 It always returns the primary result. It calls the shadow
 only after primary completion, swallows shadow failures, compares normalized
 stable field classes without logging payload values, and never repairs the
-primary. Keyed execution lifecycle and terminal delivery now use the durable
-coordinator directly; legacy unkeyed runs retain their file-backed report path
-until the restart importer lands.
+primary. Keyed execution lifecycle, terminal delivery, and restart recovery use
+the durable coordinator directly. Legacy unkeyed folders are imported read-only
+and keep their file-backed result path as a compatibility mirror. Recovery
+excludes runs with a live manager task and preassigned runs still in the local
+spawn queue; retained terminal manager records remain eligible to repair a
+failed terminal commit or delivery. A pending keyed authority submission stays
+reserved for safe command replay, while an unkeyed manager shadow row carries
+an explicit legacy-shadow source marker and becomes eligible for recovery after
+a one-sweep grace period. The grace prevents a recovery snapshot from claiming
+a shadow row created concurrently by a newly started manager task while still
+converging stale pre-restart rows. The live gateway owner claims new unkeyed
+shadow rows and transitions them through the same starting/running fence as
+keyed runs, so protected process identity is available before any prompt. For a
+platform that cannot produce a process-start identity, the PID is recorded for
+attribution as explicitly non-owned; execution continues, but recovery can
+never use that row to authorize a signal.
+For a
+process write that committed after its await was cancelled, the same execution
+fence may resynchronize exactly one stale lifecycle version only when the
+stored and requested process identities are identical. A replacement must
+first observe the committed version; other version conflicts remain rejected.
+For a coordinator-persisted
+child process, recovery verifies the recorded durable identity
+and uses the pinned process-tree kill; a lost identity or failed termination
+leaves the run non-terminal for a later safe retry.
 
 ### Transactional completion outbox
 
@@ -340,19 +374,106 @@ so recovered events route independently instead of synthesizing misleading
 one-member wave completions.
 
 After the dashboard or headless API destination registry is initialized,
-startup reconciliation first reaps any matching live process from the legacy
-folder snapshot, then drains every currently eligible bounded batch of
-coordinator completions, and finally reconciles the legacy folders that remain.
-Both legacy-folder snapshots are offloaded so filesystem traversal cannot block
-the gateway event loop during startup.
-The pre-drain reap closes the crash window where outbox delivery could write a
-delivered tombstone and hide a surviving child from the later folder scan. The
-drain still runs when no legacy orphan exists. Starting the reaper earlier could
-misroute and acknowledge a dashboard completion before its slot exists. The
-periodic reaper retries the same sequence so transient startup delivery failures
-remain recoverable without another process restart.
-Manager shutdown cancels and gathers the one-shot reconciliation task before
-tearing down live agents.
+startup coordinator reconciliation imports legacy folders, recovers expired
+runs, terminates every verified surviving child before completing its recovered
+terminal record, and drains every currently eligible bounded batch of pending
+completions, even when no legacy orphan exists. If the protected coordinator
+store cannot be
+opened or migrated, startup recovery logs the failure and fails closed; it does
+not signal a process selected from mutable legacy folder metadata. Malformed,
+non-finite, oversized, or excessively nested legacy JSON is quarantined per
+folder so one agent-written record cannot prevent healthy siblings from import.
+The legacy root and every child are opened component-by-component with
+descriptor-relative no-follow operations, and all enumeration, metadata, and
+file reads stay relative to those pinned descriptors. Reads have a 1 MiB
+ceiling; links, reparse points, devices, hardlinks, and swapped ancestors fail
+closed. A platform without descriptor-relative no-follow traversal skips the
+compatibility import rather than weakening it; native coordinator recovery
+still proceeds.
+Legacy compatibility reconciliation offloads its pre- and post-delivery folder
+snapshots so filesystem traversal cannot block the gateway event loop during
+startup.
+Within one live gateway, a run whose coordinator submission, command claim,
+starting transition, or start settlement becomes uncertain delegates terminal
+ownership to durable recovery because the bounded await can expire after SQLite
+has accepted the work. An uncertain batch member remains outstanding for wave
+accounting until recovery supplies its terminal event. The recovered event
+inherits the live batch identity before it replaces that member, so a sibling
+cannot close a partial digest and strand the recovered result outside the wave.
+The timed submit stays shielded and strongly referenced until its
+bounded-executor operation settles, ensuring a queued write can still create
+the durable recovery record instead of being cancelled with no owner. If that
+settlement proves the write failed or produced no durable run, the uncertainty
+guard is cleared and the existing one-shot legacy terminal reporter resumes;
+its tombstone write runs off the event loop. Orderly shutdown drains both the
+retained submit and any fallback reporter it schedules before snapshotting
+outstanding terminal reports. If the gateway's outer shutdown bound cancels
+any shutdown phase before that chain settles, it removes and verifies the
+legacy cancellation tombstone off the event loop for every retained submit,
+fallback, and unreported terminal task so the next start can reconcile the
+accepted run.
+The fallback clears and verifies the absence of the old cancellation tombstone
+off the event loop before reporting. On platforms with descriptor-relative
+filesystem operations, it pins the no-follow run directory once and performs
+both unlink and verification through that descriptor, so a concurrent directory
+swap cannot redirect the operation to a different tombstone. A failed or
+unverifiable clearance keeps the retained settlement and its terminal claim
+retryable until the blocker is absent; shutdown cancellation retains its owner
+for the synchronous recovery handoff. Because tombstone clearance yields, the
+fallback then revalidates that
+no durable fence or newer cancel-recovery attempt appeared. Each retained
+submission carries a monotonic attempt generation: a respawn clears only its
+predecessor's uncertainty, while callbacks from the predecessor cannot mutate or
+terminalize it. A pending cancel recovery rechecks the user-stop marker after
+the original task exits and while waiting for capacity, so Stop cannot race a
+new admission generation into existence behind its retained-submit drain. If
+the predecessor committed an execution claim before its
+response stalled, the current generation adopts the stable, unexpired same-owner
+fence rather than competing with durable recovery. The fallback checks that
+ownership before every destructive
+tombstone attempt and again after the worker returns; if a user Stop wins during
+the unlink, its abnormal marker is restored before the stale fallback exits. A
+current fallback atomically supersedes a still-pending cancel recovery through
+the terminal report claim before marking the run done. It writes its error tombstone
+only after the parent accepts the completion. A queued or digest-held fallback carries explicit legacy tombstone
+debt through the existing consumption ledger instead, including its error kind,
+so acceptance without consumption cannot suppress restart recovery and later
+consumption restores the seven-day failure retention rather than a short
+`delivered` retention window. If the synchronous route exhausts its retries,
+the fallback remains unreported and tombstone-free for restart reconciliation;
+an evicted live record still writes the fixed submission-failure detail when
+later consumption settles its error debt. Coordinator import remains idempotent
+if the durable submission committed at the cancellation boundary.
+Durable recovery remains the sole terminal owner only after a committed write.
+Once a durable submit receipt exists, every later command-claim exception is
+treated as an uncertain claim rather than a failed submission. A stable
+same-owner fence may be adopted; otherwise recovery remains the only terminal
+owner, so an operational claim failure cannot produce both a local failure and
+a later recovered interruption.
+A user Stop waits for that retained admission chain to settle before reap
+claims terminal reporting. Once admission has acquired a fence, the neutral
+STOPPED result is committed through that fence; a definite admission failure
+keeps the legacy reporter authoritative. The run body rechecks the stop marker
+after admission, so it cannot begin execution while Stop is waiting. This
+ordering leaves exactly one terminal owner and prevents lease-expiry recovery
+from emitting a second interruption for the same accepted run. If admission
+settles with an uncertain command claim, Stop retries or adopts the stable
+same-owner claim until it has a fence; it never falls through to unfenced local
+reporting while the durable row can still be recovered. If stable lookup shows
+that recovery already terminalized the run or a live newer owner took its lease,
+Stop yields local reporting to that durable owner instead of retrying forever.
+It keeps the live record's uncertainty marker until the durable outbox replaces
+that record, so running and batch-pending views converge with recovered delivery.
+The retained submit records its current-generation boolean outcome before its
+done callback replaces or removes the task, so a failed submission clears the
+earlier cancellation uncertainty and uses the legacy reporter instead of
+retrying a command that was never written. The drain yields through completion
+callbacks between retained links, so an already-finished submit cannot starve
+the callback that installs or removes its fallback reporter.
+Starting the reaper earlier could misroute and acknowledge a dashboard
+completion before its slot exists. The periodic reaper repeats the full fenced
+legacy import, recovery, and delivery sweep, while manager shutdown cancels and
+gathers the one-shot reconciliation task before tearing down live agents.
 
 Coordinator-backed injected envelopes include `Event: <event_id>` and
 `meta.subagentCompletion.eventId`. Wave digests carry one `Event:` line for each
@@ -367,7 +488,6 @@ behavior.
 |----------|-------|---------|
 | `_MAX_CONCURRENT` | 3 | Legacy fallback / auto-size floor. `agent.max_subagents` now defaults to `0` = auto-size the cap at startup (floor 3, ceiling `agent.subagent_auto_max`, default 32); a positive value pins a fixed cap. Session-shared subagents are cost-sampled as the runtime's measured RSS/CPU divided by the live shared-session count on that PID (`_live_shared_count`), so the memory term no longer binds and the cap rises to the provider-concurrency ceiling. |
 | `_TIMEOUT_SECS` | 1800 | Hard timeout per subagent (30 minutes) |
-| `_SHADOW_SUBMIT_TIMEOUT_SECS` | 1 | Total manager deadline for best-effort accepted-run shadow submission |
 | `_ON_DONE_TIMEOUT` | 1200 | Outer cap: max total seconds for semaphore wait + injection (20 minutes) |
 | `INJECTION_TIMEOUT` | 900 | Inner cap: max seconds for a single `stream_and_collect` call (15 minutes); default `_DEFAULT_INJECTION_TIMEOUT = 900.0`, tunable via `KIROCREW_INJECTION_TIMEOUT` (float seconds, clamped to `_ON_DONE_TIMEOUT`) |
 | `_RESET_TIMEOUT` | 30 | Max seconds for session reset in finally block |
@@ -589,7 +709,7 @@ An unmarked `CancelledError` (see intentional-cancel rule) triggers `_schedule_c
   3. **`_release_slot(info)` — SLOT accounting.** A one-shot token per `SubagentInfo`; the winner decrements `_running_count` once and drains the queue. Deliberately independent of both flags above: inferring slot ownership from `done` or `reaped` produced a double decrement in one interleaving and none at all in another. A leaked slot permanently starves the spawn queue, which matters far more at the 60-100 concurrent agents the scale work targets. The cancel-recovery respawn **re-arms** this token when it re-admits a slot (`_running_count += 1`), because the respawned run occupies a fresh slot and needs its own release.
   4. **`_claim_finalize(info)` — REPORT ownership** (`subagent_done` + the `_on_done` injection, plus wave-digest settling and the result.txt TTL bookkeeping). Granted to exactly one caller; contains no `await` so the check-and-set is atomic on the loop. It does **not** consult `info.done` — that was the last defect. It returns False while `_recovering` *without consuming itself*, so a pending respawn is not reported done and its respawned run can claim later.
 - **A claimed report is atomic, not merely exclusive.** The claim alone still lost outcomes when the claimer was cancelled mid-report. `_report_terminal` therefore runs on a strongly-referenced task under `asyncio.shield`, spawned by `_run` **before** its teardown awaits so the task is already live wherever a cancellation lands; the caller still receives `CancelledError` while the report completes. Synthetic batch terminals are lifecycle-owned at the synchronous scheduling site and always attempt their coordinator commit even after shutdown begins; only post-commit delivery retries stop at shutdown. Keyed rejection reports use the same shielded ownership, so shutdown cannot cancel their coordinator commit before durable state exists. `cancel_all()` drains outstanding reports with a bounded timeout and then **cancels and gathers** any straggler, so none is left invoking `_on_done` against tearing-down state or killed by a closing loop. Because the awaiter is shielded, shutdown is bounded by that drain rather than the `_ON_DONE_TIMEOUT` injection cap. Enforced by `test_subagent_reap_race.py` and the coordinator delivery regressions.
-- **An undelivered report abandoned at shutdown is made RECOVERABLE, not silently dropped.** The terminal record — including the tombstone — is written before delivery is attempted, and a tombstone is exactly what `list_orphans()` uses to EXCLUDE a folder from the next start's reconciliation. So cancelling a still-pending report at the drain deadline would leave an outcome that was never injected *and* invisible to the only path that could still inject it. `cancel_all()` therefore calls `clear_tombstone(id)` for each report it cancels, re-admitting that agent to the next start's orphan reconciliation (which finds `result.txt` and re-delivers). Extending the drain to `_ON_DONE_TIMEOUT` instead was rejected: it would hold gateway shutdown for up to 20 minutes on one wedged injection, which is the exact failure the bounded drain exists to prevent. Only reports cancelled **before** `_on_done` returned are re-admitted — `info._reported_to_parent` is set the moment the injection returns, so a cancellation in the later teardown/tombstone waits cannot cause a duplicate delivery on restart.
+- **An undelivered report abandoned at shutdown is made RECOVERABLE, not silently dropped.** The terminal record — including the tombstone — is written before delivery is attempted, and a tombstone is exactly what `list_orphans()` uses to EXCLUDE a folder from the next start's reconciliation. So cancelling a still-pending report at the drain deadline would leave an outcome that was never injected *and* invisible to the only path that could still inject it. `cancel_all()` therefore clears each cancelled report's tombstone and verifies the marker is absent before claiming the agent was re-admitted to the next start's orphan reconciliation (which finds `result.txt` and re-delivers). A failed or unverifiable deletion remains a loud recovery error, never a successful handoff. Extending the drain to `_ON_DONE_TIMEOUT` instead was rejected: it would hold gateway shutdown for up to 20 minutes on one wedged injection, which is the exact failure the bounded drain exists to prevent. Only reports cancelled **before** `_on_done` returned are re-admitted — `info._reported_to_parent` is set the moment the injection returns, so a cancellation in the later teardown/tombstone waits cannot cause a duplicate delivery on restart.
 - **Every reporter goes through the claim — including cancel-recovery failure.** There are more terminal paths than the two obvious ones: when a cancel-recovery respawn cannot happen, its `except` arm also finalizes the agent. That site previously fired `subagent_done` and `_on_done` directly, gated only on `done`/`reaped`, so a reaper racing a failed respawn delivered the outcome twice. It now takes `_claim_finalize` like every other reporter and reports through the shielded helper (which matters because `_force_reap` cancels that very task). `_resume_guarded`'s CancelledError arm writes only the RECORD and deliberately never reports — during shutdown the drain owns delivery.
 - **The reaped marker and the recovery cancel precede every `await` in `_force_reap`.** Both used to sit after the session teardown, which yields for up to `_RESET_TIMEOUT` (longer on the SIGKILL path). A recovery task whose bounded handshake expired inside that window observed `reaped == False` and respawned the run being killed — tools executing after a user Stop, strictly worse than a duplicate report.
 - **Delivery bookkeeping trails teardown.** Spawning the report ahead of teardown opens a window the older ordering did not have: writing the "delivered" tombstone before the session is torn down would hide a surviving child from orphan reconciliation if the process died in between. The report therefore waits on a `teardown_done` event (set in `_run`'s `finally`, so it fires even under cancellation, and bounded so the report can never wedge) before marking delivery. A reaped or recovery-failed member still settles its **siblings'** digest holds, since those siblings' results did reach the parent even though this member's did not. On the dashboard routes the report's own settle and `mark_delivered` are no-ops by design: `_subagent_done` defers the delivery bookkeeping — the completed member's own tombstone AND any held wave siblings — to the parent's CONSUMPTION of the announce via `_defer_queued_delivery` (the #4839 content-keyed slot ledger + `_delivery_queued`), on the queue branch settled by the drain and on the direct-injection branch by `_arm_queued_delivery_settlement` armed on the injection task (#2233). A bare `_on_done` return is a local routing success, not evidence the parent received anything; an unconfirmed hand-off leaves the debt parked and orphan-recoverable rather than tombstoned.
@@ -766,7 +886,7 @@ session key flows through the `/api/spawn` endpoint as `parent_session`.
 
 ## Scale Plumbing (60-100 concurrent agents)
 
-Large waves must not flood the WS socket, the parent LLM's context, or the UI. Five mechanisms — WS coalescing/replay-batching and UI caps are inert below their thresholds; digest chunking applies uniformly to every multi-task wave (single-task spawns behave byte-identical to legacy):
+Large waves must not flood the WS socket, the parent LLM's context, or the UI. Six mechanisms — WS coalescing/replay-batching and UI caps are inert below their thresholds; digest chunking applies uniformly to every multi-task wave (single-task spawns behave byte-identical to legacy):
 
 Delivery FIFO survives a route failure: a failed non-final chunk owns the
 wave's next delivery position until its retained snapshot is accepted. Same-wave
@@ -776,6 +896,7 @@ ahead of an in-flight route. A failed one-shot deadline flush restores the live
 wave snapshot and held clocks; a later forced flush or the real wave close then
 owns every result that was not accepted.
 
+- **Recovered interruption accounting**: an `interrupted` member advances wave completion and appears in the digest detail. Its per-member outcome remains neutral, but the three-bucket wave aggregate counts it in `err` so `ok + err + stopped == total` at wave close.
 - **Batch identity**: `spawn(batch_id=..., batch_total=...)` (threaded from `spawn_run tasks=[...]` — one 12-hex id per multi-task call — via `POST /api/spawn` transport params; survives the stagger queue). `spawn_batch_started {batch_id, count}` fires once per batch on its first started member; the id rides every WS frame (`base["batch_id"]`).
 - **Event coalescing** (`subagent_scale.SubagentEventCoalescer`, wired in the gateway's `_subagent_event`): above 8 active agents, `subagent_tool`/`subagent_stalled`/`subagent_retrying` buffer per-agent (latest state wins, merged) and flush every ~1s as ONE `subagent_batch_update {updates:[...]}` frame to all clients; `subagent_chunk` text buffers append-concatenated (16KB/agent cap) and flushes as `subagent_batch_chunks {chunks:[...]}` to subagent subscribers only. Lifecycle events (`spawn`/`done`/`recovering`/`injection_failed`/`batch_*`) are NEVER coalesced, and a `done`/`spawn` flushes buffered state first so ordering is preserved. Non-int active-count fails open to pass-through.
 - **Chunked wave-digest completion injection** (gateway `_subagent_done`): every batch member is accounted per `batch_id` (this is the single completion consumer for all terminal paths). Every multi-task wave (`batch_total > 1`) delivers results to the parent queue-style: completed members are HELD, and every `SUBAGENT_DIGEST_CHUNK_SIZE` completions (default 10, env `KIROCREW_SUBAGENT_DIGEST_CHUNK_SIZE`, clamped 1..1000) flush ONE `[Subagent batch completion event]` chunk digest — failures first with detail, successes as one-line `result_path` pointers (60KB cap per chunk); the final member flushes the remaining partial chunk. A 60-agent wave = 6 digest turns spread across the wave's runtime — bounded chunk size, incremental signal, and no straggler-gated mega-digest. Chunk buffers (`fail_lines`/`ok_lines`/`guard_msgs`/`held_delivery_ids`) reset per flush; cumulative `ok`/`err`/`stopped` counts ride the final chunk's summary. **Spawn discipline**: non-final chunks instruct the parent NOT to spawn new sub-agents while batches are still arriving; the final chunk releases the gate ("finish processing all results before spawning follow-ups") — mirrored by a line in the `spawn_run` tool description. **Chunk order is FIFO**: the injection busy-check (`_injection_slot_busy`) treats a live `slot.task` — the claim assigned synchronously at dispatch — as busy in addition to `slot.running`, so a later chunk waits behind an injection that is dispatched but still inside `bounded_chat_turn`'s off-loop timeout resolution, instead of racing ahead of it or assigning `slot.task` over the earlier chunk's still-pending task. A failed non-final chunk owns the next FIFO position only when it carries a stable coordinator outbox event that can replay it exactly. Batch rejections and lost-submission records have no worker lifecycle to create that event, so `_safe_announce` first persists each as a synthetic coordinator terminal and routes its outbox event; a failed final chunk can then be reclaimed exactly instead of losing already-held siblings when the live wave closes. Any remaining callback without a stable event restores its composed buffers to the live wave rather than becoming an unreplayable retry owner. Single-task spawns have no batch identity and keep the plain per-agent injection. A batch member rejected at spawn (empty task, low memory, cwd, governance, bad agent) is counted as submitted AND announced through the done callback with its batch identity (`_announce_rejection`) — so a rejection that closes the wave still reaches the consumer and releases held sibling results (non-batch rejections do not announce; the caller gets the error synchronously). `batch_finished {batch_id, total, ok, err, stopped}` broadcasts for every batch regardless of size. **Wave liveness (lost-submission backstop)**: a member rejected before reaching `spawn()` or lost during transport is counted in every sibling's `batch_total` but never in `submitted` — un-reconciled, the count-driven `batch_members_pending()` wedges the wave forever. Three layers close it: (1) `api_spawn` marks only rejections/capacity reached after manager admission with `counted: true` (preserved through the MCP client's error flattening); coordinator identity conflicts occur before manager admission and remain uncounted; (2) `spawn_run` best-effort POSTs `/api/spawn/lost` for each explicit UNcounted rejection, which calls `record_lost_submission` — counts the member as submitted and announces a synthetic terminal failure through the completion consumer so the wave closes; uncertain transport failures are not immediately reconciled because the gateway may have accepted them; (3) the reaper's `_sweep_stuck_waves` (every sweep) force-reconciles uncertain or lost submissions when `submitted < expected`, all registered members are terminal, nothing is queued, and no submission progress occurred for `_WAVE_STUCK_SECS` (1800s / 30 minutes — deliberately generous, symmetric with the per-agent hard ceiling) — one lost member per sweep, converging across sweeps; this also bounds the `_batch_submitted`/`_batch_progress_ts` leak. Straggler-held partial chunks are bounded by the **hold deadline** (below), not by the member's 30-minute hard ceiling.
@@ -921,13 +1042,102 @@ Folder-per-agent persistence at `~/.kiro/crew/subagents/{id}/`:
 
 ### Gateway Restart Reconciliation
 
-On startup, `SubagentManager` scans `~/.kiro/crew/subagents/` and reconciles:
+Startup converges both compatibility and coordinator state:
 
-1. **PID alive** → kill process group, deliver result if available, tombstone if not
-2. **PID dead + result.txt exists** → deliver result to parent session
-3. **PID dead + no result** → write tombstone with "orphaned" error
+1. The identity-checked legacy orphan scan runs first so a surviving child can
+   be reaped before any completion delivery writes a tombstone that removes the
+   folder from the compatibility scan. Its routing metadata never authorizes
+   delivery. `LegacyRunImporter` then reads known fields from legacy folders and creates only
+   missing coordinator rows. For an existing nonterminal row it may retain a
+   previously empty `result.txt` path, but agent-writable state and tombstone
+   files never overwrite an existing coordinator row's lifecycle state,
+   outcome, error, ownership, or version; fenced recovery is the only terminal
+   authority for native rows. Legacy `pid`, `pid_start_id`, and
+   `process_owned` fields are never imported and never authorize a signal. The
+   importer never rewrites or deletes `state.json`, `result.txt`, or
+   `tombstone.json`. Each scan submits its parsed records as one coordinator
+   batch, so the SQLite adapter loads and persists one snapshot rather than one
+   full snapshot per folder. Corrupt/mismatched folders and records with non-finite or
+   out-of-range timestamps are diagnosed and skipped without blocking sibling
+   imports. A legacy run ID that changes under credential or exfiltration-URL
+   redaction is also rejected and redacted from import diagnostics, preventing
+   sensitive folder names from reaching recovery payload IDs, result paths, or
+   gateway logs.
+   Legacy parent/destination fields are also agent-writable, so tombstones
+   import as terminal history without creating outbox work; only
+   coordinator-authenticated destinations can authorize a pending injection.
+   New imported rows record `source_version="legacy-state-v1"`.
+2. `RunRecovery` claims nonterminal runs whose execution lease is absent or
+   expired and whose execution command is no longer pending, except for a stale
+   legacy-shadow row after its grace period. It also claims an expired terminal
+   row while that row retains an owned child identity, covering a crash after
+   the terminal commit but before session teardown. A durable keyed submission
+   that has not yet been claimed remains eligible for normal execution after
+   restart. A recovery claim increments the run epoch, so a pre-restart owner
+   cannot commit after takeover. Runs with a live manager task and locally queued
+   run IDs are excluded from periodic reconciliation; a retained completed
+   record without a live task is not.
+3. A recorded child is killed only when the active fenced executor persisted
+   its identity in the owner-only coordinator database, the child is live, and
+   its `process_start_id` exactly matches
+   `platform_compat.process_identity_token(process_id)`. The token includes the
+   Linux boot ID, uses locale-independent microsecond start time on macOS, and
+   uses the process creation FILETIME on Windows. Dedicated executions
+   persist this opaque identity beside the PID before the child receives a
+   prompt; a protected coordinator write failure aborts execution, while the
+   legacy `state.json` mirror remains best-effort. Shared
+   sessions persist the runtime PID for attribution but mark it non-owned and
+   never persist a kill-authorizing start identity, because that process also
+   hosts the parent and other sessions. On Windows the compatibility layer
+   keeps the verified process handle pinned across tree termination so PID
+   reuse cannot retarget the signal. The default recovery path uses
+   `kill_process_tree_pinned` on every platform, which revalidates the recorded
+   process identity at the termination boundary. A live PID with a different
+   versioned durable identity is a reused PID: recovery never signals the
+   replacement and treats the original child as exited so its retained output
+   converges to `interrupted`. A mismatched legacy Linux or macOS/other POSIX
+   identity remains unverified because the old token can alias across a boot or
+   change with locale or timezone formatting. An unverified, unreadable, or missing identity is never signalled and leaves
+   the coordinator run and protected process identity intact for a later fenced
+   recovery attempt. A termination error does the same.
+   Recovery writes an `orphan_reconcile_kill` SEL authorization synchronously
+   and off the event loop before signalling the process; the critical write
+   must be durable before termination, and an audit failure leaves the child
+   and run untouched
+   for a later retry.
+4. A claimed nonterminal run becomes `interrupted`; any partial `result.txt`
+   path is retained. Outbox rehydration preserves that explicit fourth outcome
+   even though the explanatory error is non-empty, and the parent announcement
+   points at the retained partial result instead of rendering an ordinary
+   failure. Recovery never claims or replays its execution command. A terminal
+   cleanup claim never replaces the committed outcome or outbox payload; after
+   the child is absent or verified termination succeeds, it only clears the
+   protected process identity under the recovery fence.
+5. Coordinator-authenticated terminal pending outbox events drain through the
+   same fenced delivery adapter after protected terminal-child cleanup. If a
+   terminal child identity is unreadable, unverified, or cannot be terminated,
+   recovery leaves the identity intact. The coordinator atomically excludes that
+   run's event from every outbox claim while the terminal row retains its owned
+   process identity, including during a still-valid recovery lease, so a later
+   reaper pass or another delivery caller cannot publish completion prematurely.
+   That exclusion is per run: an unreapable terminal child does not prevent the
+   same drain pass from delivering unrelated eligible completion events.
+   Normal execution follows the same boundary: its terminal reporter waits for
+   dedicated-session teardown, clears the protected process identity with the
+   current execution fence only after reset succeeds, and then claims the event.
+   A failed teardown or rejected clear leaves the event pending for fenced
+   recovery instead of blocking the run task or delivering early.
+   Legacy tombstones create no outbox event and therefore cannot route a
+   completion from their untrusted metadata.
 
-**Orphan delivery is wired** (not a stub): the gateway registers `on_orphan_notify` (session injection — rides the parent slot's batched pending-failures drain) and `on_orphan_dm` (fallback). The DM fallback collects every undelivered orphan across the reconciliation scan and sends ONE digest message (`"N subagent(s)…"`) — never N pings; a lone orphan keeps the plain per-agent message.
+The periodic reaper repeats idempotent legacy import, expired-lease
+reconciliation, and delivery drain, so a transient import failure or a lease that
+is still valid at process startup converges without another restart. Each pass
+excludes locally active and queued run IDs from both legacy-folder import and
+recovery claims, so an accepted local run cannot lose its coordinator identity to
+an older folder with the same ID. A
+coordinator-open or migration failure is fail-closed: folder-based PID metadata
+does not authorize orphan termination or completion delivery.
 
 Legacy folder orphan scans and their identity-checked process reaping run off
 the event loop; process-tree termination may invoke bounded platform tools on
@@ -943,7 +1153,13 @@ Windows and must not stall gateway traffic.
   (default 1h); all other tombstones after 7 days. `prune_stale_tombstones` takes
   a per-cause cutoff for this.
 - `spawn_status` falls back to persistence layer for completed/tombstoned agents,
-  reading the retained `result.txt` (and honoring offset/limit/grep).
+  reading the retained `result.txt` from the trusted subagents root through a
+  bounded component-by-component descriptor-pinned no-link walk (and honoring
+  offset/limit/grep). A linked,
+  hardlinked, special, oversized, or escaped transcript falls back to the
+  already bounded in-memory result. A platform without descriptor-relative
+  no-follow traversal also uses that fail-closed fallback; a disk-only orphan
+  remains visible but has no readable transcript on that platform.
 
 ### MCP Tool: `spawn_status`
 
@@ -1074,7 +1290,9 @@ Decision + lifecycle:
   `_get_parent_runtime()` (falling back to `SessionManager.get_subagent_runtime()`
   — a companion runtime), calls `runtime.create_session()`, and wraps the handle
   in `AcpSessionProvider`. `SubagentInfo._session_sharing` / `_shared_provider`
-  record the shared path.
+  record the shared path. Its PID may be persisted for attribution, but it is
+  explicitly non-owned and carries no process-start identity, so restart
+  recovery can never signal the parent runtime on behalf of a subagent run.
 - On any failure the code falls back transparently to the legacy
   per-process path (`get_or_create`).
 - Cleanup (`_run` finally + `_force_reap`) calls `_shared_provider.shutdown()` to

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import stat
 import time
 from pathlib import Path
 from typing import Any, Callable, cast
@@ -64,6 +65,7 @@ from kiro_crew.dashboard.state import (
     DashboardState,
 )
 from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot
+from kiro_crew.hooks import MAX_FILE_BYTES
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES, SLACK_NAMESPACE, ChannelLink
 from kiro_crew.messaging.renderer import (
@@ -77,6 +79,7 @@ from kiro_crew.notifications.bus import (
     NotificationPayload,
     NotificationValidationError,
 )
+from kiro_crew.pinned_fs import PinnedPathRefusal, open_dir_chain_nofollow
 from kiro_crew.platform.governance_profiles import HOST_SESSION_KEY
 from kiro_crew.platform_compat import IS_MACOS
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
@@ -90,7 +93,7 @@ from kiro_crew.subagent_command_authority import (
     AuthorityUnavailable,
     CommandIdentity,
 )
-from kiro_crew.subagent_persistence import _agent_dir, read_state
+from kiro_crew.subagent_persistence import _agent_dir, agent_dir_for_display, read_state
 from kiro_crew.validation import (
     _EMOJI_NAME_RE,
     CHANNEL_ID_RE,
@@ -759,6 +762,51 @@ def _redact(text: str) -> str:
 
 _SPAWN_STATUS_MAX_LINES = 2000  # cap lines returned per spawn_status page
 _SPAWN_STATUS_MAX_GREP_LEN = 500
+_SPAWN_RESULT_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NONBLOCK", 0)
+)
+
+
+def _read_spawn_result(agent_id: str, path: Path) -> str | None:
+    """Read the canonical transcript through a strictly pinned directory chain."""
+    declared_dir = agent_dir_for_display(agent_id)
+    declared_expected = Path(os.path.abspath(declared_dir / "result.txt"))
+    candidate = Path(os.path.abspath(path))
+    if os.path.normcase(str(candidate)) != os.path.normcase(str(declared_expected)):
+        return None
+    trusted_root = declared_dir.parent.resolve()
+    expected = Path(os.path.abspath(trusted_root / declared_dir.name / "result.txt"))
+    try:
+        root_fd = open_dir_chain_nofollow(expected.parent, what="subagent result root")
+    except (OSError, PinnedPathRefusal):
+        return None
+    try:
+        try:
+            fd = os.open(expected.name, _SPAWN_RESULT_OPEN_FLAGS, dir_fd=root_fd)
+        except OSError:
+            return None
+        try:
+            opened = os.fstat(fd)
+            if (
+                opened.st_nlink > 1
+                or not stat.S_ISREG(opened.st_mode)
+                or getattr(opened, "st_reparse_tag", False)
+            ):
+                return None
+            with os.fdopen(fd, "rb") as stream:
+                raw = stream.read(MAX_FILE_BYTES + 1)
+            fd = -1
+        finally:
+            if fd >= 0:
+                os.close(fd)
+    finally:
+        os.close(root_fd)
+    if len(raw) > MAX_FILE_BYTES:
+        return None
+    return raw.decode("utf-8", errors="replace")
 
 
 def _spawn_result_view(text: str, offset: int, limit: int, grep: str) -> tuple[str, dict]:
@@ -831,15 +879,11 @@ async def api_spawn_status(request: web.Request) -> web.Response:
                     "done": True,
                     "started": disk_state.get("started"),
                 }
-                result_path = _agent_dir(agent_id) / "result.txt"
+                result_path = agent_dir_for_display(agent_id) / "result.txt"
                 result = ""
-                if result_path.exists() and not is_sensitive_path(str(result_path)):
-                    try:
-                        result = await asyncio.to_thread(
-                            result_path.read_text, encoding="utf-8", errors="replace"
-                        )
-                    except OSError:
-                        pass
+                loaded = await asyncio.to_thread(_read_spawn_result, agent_id, result_path)
+                if loaded is not None:
+                    result = loaded
                 # _redact() defined at line 82 of this file; calls both
                 # redact_exfiltration_urls() and redact_credentials() per security guidelines.
                 view, view_meta = await _apply_result_view(request, result)
@@ -866,15 +910,14 @@ async def api_spawn_status(request: web.Request) -> web.Response:
     if info.done:
         # Read full result from disk (info.result is truncated to 3000 chars)
         result = info.result
-        if info.result_path and not is_sensitive_path(info.result_path):
-            try:
-                result = await asyncio.to_thread(
-                    Path(info.result_path).read_text,
-                    encoding="utf-8",
-                    errors="replace",
-                )
-            except OSError:
-                pass
+        if info.result_path:
+            loaded = await asyncio.to_thread(
+                _read_spawn_result,
+                agent_id,
+                Path(info.result_path),
+            )
+            if loaded is not None:
+                result = loaded
         view, view_meta = await _apply_result_view(request, result)
         data["result"] = _redact(view)
         if view_meta:

--- a/src/kiro_crew/dashboard/slot_queue_repository.py
+++ b/src/kiro_crew/dashboard/slot_queue_repository.py
@@ -33,6 +33,7 @@ class SlotQueueRepository:
         timestamp_provider: Callable[[], str] | None = None,
         delivery_key: Callable[[str], str] = _delivery_key,
         max_pending_deliveries: Callable[[], int] | None = None,
+        delivery_claim_factory: Callable[[list[str], set[str]], list[str]] | None = None,
     ) -> None:
         self._id_provider = id_provider or (lambda: uuid.uuid4().hex[:12])
         self._timestamp_provider = timestamp_provider or (
@@ -41,6 +42,9 @@ class SlotQueueRepository:
         self._delivery_key = delivery_key
         self._max_pending_deliveries = max_pending_deliveries or (
             lambda: MAX_PENDING_SUBAGENT_DELIVERIES
+        )
+        self._delivery_claim_factory = delivery_claim_factory or (
+            lambda agent_ids, _errors: agent_ids
         )
 
     def queue_append(
@@ -118,6 +122,8 @@ class SlotQueueRepository:
         owner: Any,
         content: str,
         agent_ids: list[str],
+        *,
+        error_tombstone_ids: set[str] | None = None,
     ) -> None:
         """Remember which agents a queued completion still owes delivery."""
         if not content or not agent_ids:
@@ -125,11 +131,16 @@ class SlotQueueRepository:
         key = self._delivery_key(content)
         owed = owner._subagent_delivery_pending.setdefault(key, [])
         owed.extend(agent_id for agent_id in agent_ids if agent_id not in owed)
+        error_ids = set(error_tombstone_ids or ()).intersection(agent_ids)
+        if error_ids:
+            owner._subagent_error_tombstone_pending.setdefault(key, set()).update(error_ids)
         # Only the consuming row may settle an entry.  A turn tail can dequeue
         # its successor before the current settlement callback runs, so sweeping
         # merely because content left the queue would lose the successor's debt.
         while len(owner._subagent_delivery_pending) > self._max_pending_deliveries():
-            owner._subagent_delivery_pending.pop(next(iter(owner._subagent_delivery_pending)))
+            evicted = next(iter(owner._subagent_delivery_pending))
+            owner._subagent_delivery_pending.pop(evicted)
+            owner._subagent_error_tombstone_pending.pop(evicted, None)
 
     def owes_subagent_delivery(self, owner: Any, contents: list[str]) -> bool:
         """Return whether any named completion has unsettled delivery debt."""
@@ -140,9 +151,12 @@ class SlotQueueRepository:
     def take_pending_subagent_deliveries(self, owner: Any, contents: list[str]) -> list[str]:
         """Claim delivery marks in consumed-row order and forget only those rows."""
         claimed: list[str] = []
+        error_ids: set[str] = set()
         for content in contents:
-            claimed.extend(owner._subagent_delivery_pending.pop(self._delivery_key(content), []))
-        return claimed
+            key = self._delivery_key(content)
+            claimed.extend(owner._subagent_delivery_pending.pop(key, []))
+            error_ids.update(owner._subagent_error_tombstone_pending.pop(key, set()))
+        return self._delivery_claim_factory(claimed, error_ids.intersection(claimed))
 
     def queue_remove_by_id(self, owner: Any, queue_id: str) -> str | None:
         """Remove the matching entry and return its content."""

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -358,6 +358,16 @@ NATIVE_SUBAGENT_TERMINAL_TTL_SECS = 3600.0
 _MAX_PENDING_SUBAGENT_DELIVERIES = 128
 
 
+class _PendingSubagentDeliveries(list[str]):
+    """Claimed run ids plus the subset that owe an error tombstone."""
+
+    __slots__ = ("error_tombstone_ids",)
+
+    def __init__(self, agent_ids: list[str], error_tombstone_ids: set[str]) -> None:
+        super().__init__(agent_ids)
+        self.error_tombstone_ids = frozenset(error_tombstone_ids)
+
+
 def _delivery_key(content: str) -> str:
     """Identity of a queued completion for delivery bookkeeping.
 
@@ -3060,6 +3070,7 @@ class _ChatSlot:
         "_subagent_deliveries_inflight",
         "_subagents_inline_collected",
         "_subagent_delivery_pending",
+        "_subagent_error_tombstone_pending",
         "_recovery_retrigger_count",
         "_prompt_busy_retries",
         "_acp_pipe_death_retries",
@@ -3173,6 +3184,9 @@ class _ChatSlot:
             timestamp_provider=lambda: datetime.now(timezone.utc).isoformat(),
             delivery_key=lambda content: _delivery_key(content),
             max_pending_deliveries=lambda: _MAX_PENDING_SUBAGENT_DELIVERIES,
+            delivery_claim_factory=lambda agent_ids, error_ids: _PendingSubagentDeliveries(
+                agent_ids, error_ids
+            ),
         )
         # (content revision, links) cache for the sidebar PR chips scan.
         self._source_links_revision = 0
@@ -3418,6 +3432,10 @@ class _ChatSlot:
         # retention TTL is measured from consumption rather than from run
         # completion (issue #4839). See ``take_pending_subagent_deliveries``.
         self._subagent_delivery_pending: dict[str, list[str]] = {}
+        # Subset of the delivery ledger whose legacy fallback outcome is an
+        # error. Keeping the kind beside the ids prevents consumption from
+        # shortening a failed run's retention as though it had completed.
+        self._subagent_error_tombstone_pending: dict[str, set[str]] = {}
         self._recovery_retrigger_count: int = 0
         self._prompt_busy_retries: int = 0
         self._acp_pipe_death_retries: int = 0
@@ -4237,8 +4255,19 @@ class _ChatSlot:
     def queue_pop(self, index: int = 0) -> dict[str, Any]:
         return self._queue_repository.queue_pop(self, index)
 
-    def note_pending_subagent_delivery(self, content: str, agent_ids: list[str]) -> None:
-        self._queue_repository.note_pending_subagent_delivery(self, content, agent_ids)
+    def note_pending_subagent_delivery(
+        self,
+        content: str,
+        agent_ids: list[str],
+        *,
+        error_tombstone_ids: set[str] | None = None,
+    ) -> None:
+        self._queue_repository.note_pending_subagent_delivery(
+            self,
+            content,
+            agent_ids,
+            error_tombstone_ids=error_tombstone_ids,
+        )
 
     def owes_subagent_delivery(self, contents: list[str]) -> bool:
         return self._queue_repository.owes_subagent_delivery(self, contents)

--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -70,6 +70,7 @@ __all__ = [
     "is_reparse_point",
     "is_regular_at",
     "stat_at",
+    "open_dir_chain_nofollow",
     "open_dir_pinned",
     "open_in_pinned_parent",
     "open_verified_chain",
@@ -181,6 +182,41 @@ def dir_flags() -> int:
     platform no longer has.
     """
     return os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+
+def open_dir_chain_nofollow(
+    path: str | Path,
+    *,
+    what: str,
+    refusal: type[Exception] = PinnedPathRefusal,
+) -> int:
+    """Open an absolute directory path one lexical component at a time.
+
+    Unlike :func:`open_dir_pinned`, this strict form never resolves a linked
+    ancestor before pinning it. It is for roots that must contain no links at
+    all, including compatibility trees writable by a surviving child process.
+    """
+    if not supports_pinned_walk():
+        raise refusal(
+            f"refusing to use the {what}: this platform cannot pin a no-follow " "directory walk"
+        )
+    parts = Path(os.path.abspath(path)).parts
+    try:
+        fd = os.open(parts[0], dir_flags())
+    except OSError as exc:
+        raise refusal(f"refusing to use the {what}: its root cannot be pinned") from exc
+    try:
+        for component in parts[1:]:
+            next_fd = os.open(component, dir_flags(), dir_fd=fd)
+            previous_fd = fd
+            fd = next_fd
+            os.close(previous_fd)
+    except OSError as exc:
+        os.close(fd)
+        raise refusal(
+            f"refusing to use the {what}: a directory component cannot be pinned"
+        ) from exc
+    return fd
 
 
 def pin_parent(

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -2656,6 +2656,46 @@ def _linux_boot_id() -> str | None:
         return None
 
 
+_DURABLE_PROCESS_IDENTITY_VERSION = "v1"
+
+
+def process_identity_token(pid: int) -> str | None:
+    """Return a reboot-unique, locale-independent identity for *pid*.
+
+    Unlike :func:`process_start_time`, this helper returns no token on a
+    platform whose available identity can alias another process lifetime.
+    Callers may persist a non-empty result across gateway restarts and use an
+    exact match as authorization for identity-pinned process termination.
+    """
+
+    value: str | None
+    platform_name: str
+    if sys.platform == "linux":
+        ticks = process_start_time(pid)
+        boot = _linux_boot_id()
+        if not ticks or not boot:
+            return None
+        value = f"{ticks}:{boot}"
+        platform_name = "linux"
+    elif sys.platform == "darwin":
+        value = _darwin_process_start_microtime(pid)
+        platform_name = "darwin"
+    elif IS_WINDOWS:
+        value = process_start_time(pid)
+        platform_name = "windows"
+    else:
+        return None
+    if not value:
+        return None
+    return f"{_DURABLE_PROCESS_IDENTITY_VERSION}:{platform_name}:{value}"
+
+
+def is_durable_process_identity_token(value: str) -> bool:
+    """Return whether *value* carries the versioned durable identity format."""
+
+    return value.startswith(f"{_DURABLE_PROCESS_IDENTITY_VERSION}:")
+
+
 def _own_identity_token(pid: int) -> str | None:
     """Reboot-unique start-time token for THIS process, or ``None``.
 

--- a/src/kiro_crew/run_coordinator/__init__.py
+++ b/src/kiro_crew/run_coordinator/__init__.py
@@ -1,8 +1,10 @@
 """Typed run coordination boundary for subagent lifecycle state."""
 
 from .delivery import DeliveryAttempt, OutboxDeliveryAdapter
+from .legacy import LegacyImportReport, LegacyRunImporter
 from .memory import MemoryRunCoordinator
 from .models import (
+    LEGACY_SHADOW_SOURCE_VERSION,
     CommandClaim,
     CommandFence,
     CommandOperation,
@@ -14,9 +16,12 @@ from .models import (
     DeliveryFence,
     DeliveryState,
     DesiredState,
+    LegacyImportReceipt,
+    LegacyRunImport,
     ObservedState,
     OutboxEvent,
     OwnerLease,
+    RecoveryClaim,
     RunCommand,
     RunCompletion,
     RunCoordinator,
@@ -29,6 +34,7 @@ from .models import (
     TerminalReceipt,
     TerminalRun,
 )
+from .recovery import RecoveryReport, RunRecovery
 from .shadow import ShadowRunCoordinator
 from .sqlite import SQLiteRunCoordinator
 
@@ -45,17 +51,25 @@ __all__ = [
     "DeliveryFence",
     "DeliveryState",
     "DesiredState",
+    "LegacyImportReceipt",
+    "LegacyImportReport",
+    "LegacyRunImport",
+    "LEGACY_SHADOW_SOURCE_VERSION",
+    "LegacyRunImporter",
     "MemoryRunCoordinator",
     "ObservedState",
     "OutboxDeliveryAdapter",
     "OutboxEvent",
     "OwnerLease",
+    "RecoveryClaim",
+    "RecoveryReport",
     "RunCommand",
     "RunCompletion",
     "RunCoordinator",
     "RunFence",
     "RunOutcome",
     "RunRecord",
+    "RunRecovery",
     "SubmitReceipt",
     "SubmitControl",
     "SubmitRun",

--- a/src/kiro_crew/run_coordinator/legacy.py
+++ b/src/kiro_crew/run_coordinator/legacy.py
@@ -1,0 +1,322 @@
+"""Read-only import of pre-coordinator subagent run folders."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import os
+import stat
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from kiro_crew.config.paths import data_home
+from kiro_crew.hooks import FileTooLargeError
+from kiro_crew.pinned_fs import (
+    PinnedPathRefusal,
+    open_dir_chain_nofollow,
+    supports_pinned_tree_walk,
+)
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+from .models import (
+    CoordinatorDecision,
+    LegacyRunImport,
+    ObservedState,
+    RunCoordinator,
+    RunOutcome,
+)
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_VERSION = "legacy-state-v1"
+_MAX_AGENT_CHARS = 200
+_MAX_CONVERSATION_KEY_CHARS = 500
+_MAX_TASK_CHARS = 1000
+_MAX_ERROR_CHARS = 2000
+_MAX_LEGACY_JSON_BYTES = 1024 * 1024
+_DIR_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+)
+_FILE_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NONBLOCK", 0)
+)
+
+
+@dataclass(frozen=True)
+class LegacyImportReport:
+    imported: int = 0
+    existing: int = 0
+    corrupt: int = 0
+
+
+def _redact(value: str) -> str:
+    value, _ = redact_exfiltration_urls(value)
+    value, _ = redact_credentials(value)
+    return value
+
+
+def _number(value: object, default: float) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            number = float(value)
+        except OverflowError as exc:
+            raise ValueError("legacy timestamp is out of range") from exc
+        if not math.isfinite(number):
+            raise ValueError("legacy timestamp must be finite")
+        return number
+    return default
+
+
+class LegacyRunImporter:
+    """Import known legacy fields while leaving source folders byte-identical."""
+
+    def __init__(
+        self,
+        coordinator: RunCoordinator,
+        *,
+        root: Path | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._coordinator = coordinator
+        self._root = root
+        self._clock = clock
+
+    def _base(self) -> Path:
+        if self._root is not None:
+            return self._root
+        # The configured data home is operator-owned and may intentionally be
+        # a symlink. Resolve that trusted prefix before the no-follow walk so
+        # the untrusted ``subagents`` tree itself remains link-resistant.
+        return data_home().resolve(strict=False) / "subagents"
+
+    def _open_base(self) -> int | None:
+        if not supports_pinned_tree_walk():
+            return None
+        try:
+            return open_dir_chain_nofollow(self._base(), what="legacy subagent root")
+        except (OSError, PinnedPathRefusal):
+            return None
+
+    @staticmethod
+    def _is_directory(base_fd: int, name: str) -> bool:
+        try:
+            entry = os.stat(name, dir_fd=base_fd, follow_symlinks=False)
+        except OSError:
+            return False
+        return stat.S_ISDIR(entry.st_mode) and not getattr(entry, "st_reparse_tag", False)
+
+    @classmethod
+    def _folders(cls, base_fd: int) -> list[str]:
+        folders: list[str] = []
+        try:
+            names = sorted(os.listdir(base_fd))
+        except OSError:
+            return folders
+        for name in names:
+            if cls._is_directory(base_fd, name):
+                folders.append(name)
+        return folders
+
+    @staticmethod
+    def _safe_run_id(run_id: str) -> str:
+        if (
+            not run_id
+            or run_id in (".", "..")
+            or ".." in run_id
+            or "/" in run_id
+            or "\\" in run_id
+            or "\0" in run_id
+        ):
+            raise ValueError("invalid legacy run id")
+        return run_id
+
+    @staticmethod
+    def _valid_id(run_id: object, folder_name: str) -> str:
+        if not isinstance(run_id, str) or run_id != folder_name:
+            raise ValueError("state id does not match its folder")
+        if _redact(run_id) != run_id:
+            raise ValueError("legacy run id contains sensitive data")
+        return run_id
+
+    @staticmethod
+    def _read_object(
+        folder_fd: int, name: str, *, missing_ok: bool = False
+    ) -> dict[str, object] | None:
+        try:
+            fd = os.open(name, _FILE_OPEN_FLAGS, dir_fd=folder_fd)
+        except FileNotFoundError:
+            if missing_ok:
+                return None
+            raise ValueError("legacy record is missing") from None
+        except OSError:
+            raise ValueError("legacy record is not a safe regular file") from None
+        try:
+            opened = os.fstat(fd)
+            if (
+                opened.st_nlink > 1
+                or not stat.S_ISREG(opened.st_mode)
+                or getattr(opened, "st_reparse_tag", False)
+            ):
+                raise ValueError("legacy record is not a safe regular file")
+            opened_fd = fd
+            fd = -1
+            with os.fdopen(opened_fd, "rb") as stream:
+                raw = stream.read(_MAX_LEGACY_JSON_BYTES + 1)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        if len(raw) > _MAX_LEGACY_JSON_BYTES:
+            raise FileTooLargeError("legacy record exceeds its safety cap")
+        value = json.loads(raw.decode("utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("legacy record must be an object")
+        return value
+
+    @staticmethod
+    def _has_result(folder_fd: int) -> bool:
+        try:
+            fd = os.open("result.txt", _FILE_OPEN_FLAGS, dir_fd=folder_fd)
+        except FileNotFoundError:
+            return False
+        except OSError:
+            raise ValueError("legacy result is not a safe regular file") from None
+        try:
+            opened = os.fstat(fd)
+            if (
+                opened.st_nlink > 1
+                or not stat.S_ISREG(opened.st_mode)
+                or getattr(opened, "st_reparse_tag", False)
+            ):
+                raise ValueError("legacy result is not a safe regular file")
+            return True
+        finally:
+            os.close(fd)
+
+    def _request(self, base_fd: int, folder_name: str) -> LegacyRunImport:
+        run_id = self._safe_run_id(folder_name)
+        try:
+            folder_fd = os.open(run_id, _DIR_OPEN_FLAGS, dir_fd=base_fd)
+        except OSError:
+            raise ValueError("legacy run folder is not a safe directory") from None
+        try:
+            state = self._read_object(folder_fd, "state.json")
+            assert state is not None
+            run_id = self._valid_id(state.get("id"), folder_name)
+            tombstone = self._read_object(folder_fd, "tombstone.json", missing_ok=True)
+            result_path = (
+                str(self._base() / run_id / "result.txt") if self._has_result(folder_fd) else ""
+            )
+        finally:
+            os.close(folder_fd)
+        started = _number(state.get("started"), self._clock())
+        updated = _number(state.get("updated_at"), started)
+        task = _redact(str(state.get("task") or ""))[:_MAX_TASK_CHARS]
+        agent = _redact(str(state.get("agent") or ""))[:_MAX_AGENT_CHARS]
+        conversation = _redact(str(state.get("conversation_key") or ""))[
+            :_MAX_CONVERSATION_KEY_CHARS
+        ]
+        if tombstone is None:
+            return LegacyRunImport(
+                run_id=run_id,
+                parent_session="",
+                agent=agent,
+                task=task,
+                conversation_key=conversation,
+                observed_state=ObservedState.RUNNING,
+                outcome=None,
+                result_path=result_path,
+                error="",
+                created_at=started,
+                updated_at=updated,
+                terminal_at=None,
+                source_version=_SOURCE_VERSION,
+            )
+
+        died = _number(tombstone.get("died"), updated)
+        raw_outcome = str(tombstone.get("outcome") or "")
+        try:
+            outcome = RunOutcome(raw_outcome)
+        except ValueError:
+            outcome = (
+                RunOutcome.COMPLETED
+                if tombstone.get("cause") == "delivered"
+                else RunOutcome.INTERRUPTED
+            )
+        error = _redact(
+            str(tombstone.get("detail") or tombstone.get("cause") or "gateway restart")
+        )[:_MAX_ERROR_CHARS]
+        return LegacyRunImport(
+            run_id=run_id,
+            parent_session="",
+            agent=agent,
+            task=task,
+            conversation_key=conversation,
+            observed_state=ObservedState.TERMINAL,
+            outcome=outcome,
+            result_path=result_path,
+            error=error,
+            created_at=started,
+            updated_at=died,
+            terminal_at=died,
+            source_version=_SOURCE_VERSION,
+            # Legacy routing fields are agent-writable evidence, not authority.
+            # Import terminal history without manufacturing a pending delivery
+            # that could inject into an attacker-selected session.
+            event_type="",
+            destination="",
+            payload_json="",
+            delivery_state=None,
+        )
+
+    async def import_all(
+        self,
+        *,
+        exclude_run_ids: frozenset[str] = frozenset(),
+    ) -> LegacyImportReport:
+        imported = 0
+        existing = 0
+        corrupt = 0
+        base_fd = await asyncio.to_thread(self._open_base)
+        if base_fd is None:
+            return LegacyImportReport()
+        try:
+            folders = await asyncio.to_thread(self._folders, base_fd)
+            requests: list[LegacyRunImport] = []
+            for folder_name in folders:
+                if folder_name in exclude_run_ids:
+                    continue
+                try:
+                    request = await asyncio.to_thread(self._request, base_fd, folder_name)
+                    requests.append(request)
+                except (
+                    FileTooLargeError,
+                    OSError,
+                    RecursionError,
+                    TypeError,
+                    UnicodeDecodeError,
+                    ValueError,
+                ):
+                    corrupt += 1
+                    logger.warning("legacy subagent import skipped for %s", _redact(folder_name))
+            results = await self._coordinator.import_legacy_batch(tuple(requests))
+            for request, result in zip(requests, results):
+                if result.decision is CoordinatorDecision.APPLIED:
+                    imported += 1
+                elif result.decision is CoordinatorDecision.UNCHANGED:
+                    existing += 1
+                else:
+                    corrupt += 1
+                    logger.warning("legacy subagent import skipped for %s", _redact(request.run_id))
+        finally:
+            await asyncio.to_thread(os.close, base_fd)
+        return LegacyImportReport(imported=imported, existing=existing, corrupt=corrupt)

--- a/src/kiro_crew/run_coordinator/memory.py
+++ b/src/kiro_crew/run_coordinator/memory.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from dataclasses import replace
 
 from .models import (
+    LEGACY_SHADOW_SOURCE_VERSION,
     CommandClaim,
     CommandFence,
     CommandOperation,
@@ -21,9 +22,12 @@ from .models import (
     DeliveryFence,
     DeliveryState,
     DesiredState,
+    LegacyImportReceipt,
+    LegacyRunImport,
     ObservedState,
     OutboxEvent,
     OwnerLease,
+    RecoveryClaim,
     RunCommand,
     RunCompletion,
     RunFence,
@@ -40,6 +44,7 @@ _EXECUTION_COMMANDS = frozenset({CommandOperation.SPAWN, CommandOperation.CONTIN
 _CONTROL_COMMANDS = frozenset(
     {CommandOperation.STEER, CommandOperation.CANCEL, CommandOperation.RELEASE}
 )
+_LEGACY_SHADOW_RECOVERY_GRACE_SECONDS = 60.0
 _STARTABLE_STATES = frozenset({ObservedState.ACCEPTED, ObservedState.QUEUED})
 _COMPLETABLE_STATES = frozenset(
     {
@@ -130,6 +135,7 @@ class MemoryRunCoordinator:
                 created_at=now,
                 updated_at=now,
                 terminal_at=None if accepted else now,
+                source_version=request.source_version,
             )
             command = RunCommand(
                 command_id=request.command_id,
@@ -358,6 +364,109 @@ class MemoryRunCoordinator:
                 TerminalReceipt(run, event, created=True),
             )
 
+    async def import_legacy(
+        self, request: LegacyRunImport
+    ) -> CoordinatorResult[LegacyImportReceipt]:
+        """Create a legacy-only run without manufacturing an execution command."""
+
+        async with self._lock:
+            existing = self._runs.get(request.run_id)
+            if existing is not None:
+                event_id = self._outbox_by_run_type.get((request.run_id, request.event_type))
+                existing_event = self._outbox.get(event_id) if event_id else None
+                # Legacy files are evidence, not lifecycle authority. A crash
+                # can leave a durable coordinator row before result.txt is
+                # written, so retain that path for the fenced recovery which
+                # follows. Never copy terminal state, outcome, error, owner, or
+                # version from an agent-writable tombstone into an existing row.
+                if (
+                    existing.observed_state is not ObservedState.TERMINAL
+                    and not existing.result_path
+                    and request.result_path
+                ):
+                    existing = replace(existing, result_path=request.result_path)
+                    self._runs[request.run_id] = existing
+                    return self._result(
+                        CoordinatorDecision.APPLIED,
+                        CoordinatorReason.TRANSITIONED,
+                        LegacyImportReceipt(existing, existing_event, created=False),
+                    )
+                return self._result(
+                    CoordinatorDecision.UNCHANGED,
+                    CoordinatorReason.IDEMPOTENT_REPLAY,
+                    LegacyImportReceipt(existing, existing_event, created=False),
+                )
+            terminal = request.observed_state is ObservedState.TERMINAL
+            if terminal != (request.outcome is not None):
+                return self._result(
+                    CoordinatorDecision.REJECTED,
+                    CoordinatorReason.INVALID_TRANSITION,
+                )
+            if bool(request.event_type) != bool(request.delivery_state):
+                return self._result(
+                    CoordinatorDecision.REJECTED,
+                    CoordinatorReason.INVALID_TRANSITION,
+                )
+            run = RunRecord(
+                run_id=request.run_id,
+                parent_session=request.parent_session,
+                agent=request.agent,
+                task=request.task,
+                conversation_key=request.conversation_key,
+                desired_state=DesiredState.RUN,
+                observed_state=request.observed_state,
+                outcome=request.outcome,
+                result_path=request.result_path,
+                error=request.error,
+                attempt=1,
+                version=1,
+                owner_id="",
+                lease_expires_at=0.0,
+                lease_epoch=0,
+                created_at=request.created_at,
+                updated_at=request.updated_at,
+                terminal_at=request.terminal_at,
+                source_version=request.source_version,
+            )
+            self._runs[run.run_id] = run
+            event: OutboxEvent | None = None
+            if request.event_type and request.delivery_state is not None:
+                delivered = request.delivery_state is DeliveryState.DELIVERED
+                event = OutboxEvent(
+                    event_id=self._id_factory(),
+                    run_id=run.run_id,
+                    run_version=run.version,
+                    destination=request.destination,
+                    event_type=request.event_type,
+                    payload_json=request.payload_json,
+                    status=request.delivery_state,
+                    attempts=1 if delivered else 0,
+                    available_at=request.updated_at,
+                    claim_owner="",
+                    claim_expires_at=0.0,
+                    claim_epoch=0,
+                    created_at=request.updated_at,
+                    delivered_at=request.terminal_at if delivered else None,
+                )
+                self._outbox[event.event_id] = event
+                self._outbox_by_run_type[(run.run_id, event.event_type)] = event.event_id
+            return self._result(
+                CoordinatorDecision.APPLIED,
+                CoordinatorReason.CREATED,
+                LegacyImportReceipt(run, event, created=True),
+            )
+
+    async def import_legacy_batch(
+        self, requests: tuple[LegacyRunImport, ...]
+    ) -> list[CoordinatorResult[LegacyImportReceipt]]:
+        """Import a scan as one coordinator operation.
+
+        The SQLite adapter loads and persists the in-memory model once around
+        this call, avoiding a full database snapshot for every legacy folder.
+        """
+
+        return [await self.import_legacy(request) for request in requests]
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None:
         async with self._lock:
             command_id = self._command_by_key.get(idempotency_key)
@@ -399,6 +508,66 @@ class MemoryRunCoordinator:
         )
         return claims[0] if claims else None
 
+    async def claim_recovery(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        exclude_run_ids: frozenset[str] = frozenset(),
+    ) -> list[RecoveryClaim]:
+        """Fence expired executions, including terminal rows needing child cleanup."""
+
+        if limit <= 0:
+            return []
+        async with self._lock:
+            now = self._clock()
+            if owner.lease_expires_at <= now:
+                return []
+            pending_execution_run_ids = {
+                command.run_id
+                for command in self._commands.values()
+                if command.operation in _EXECUTION_COMMANDS
+                and command.status is CommandStatus.PENDING
+                and (
+                    self._runs[command.run_id].source_version != LEGACY_SHADOW_SOURCE_VERSION
+                    or self._runs[command.run_id].created_at
+                    > now - _LEGACY_SHADOW_RECOVERY_GRACE_SECONDS
+                )
+            }
+            claims: list[RecoveryClaim] = []
+            for current in sorted(
+                self._runs.values(), key=lambda item: (item.created_at, item.run_id)
+            ):
+                if len(claims) >= limit:
+                    break
+                terminal_cleanup = (
+                    current.observed_state is ObservedState.TERMINAL
+                    and current.process_owned
+                    and current.process_id > 1
+                    and bool(current.process_start_id)
+                )
+                if (
+                    current.run_id in exclude_run_ids
+                    or current.run_id in pending_execution_run_ids
+                    or (current.observed_state is ObservedState.TERMINAL and not terminal_cleanup)
+                    or current.lease_expires_at > now
+                ):
+                    continue
+                run = replace(
+                    current,
+                    owner_id=owner.owner_id,
+                    lease_expires_at=owner.lease_expires_at,
+                    lease_epoch=current.lease_epoch + 1,
+                    updated_at=now,
+                )
+                self._runs[run.run_id] = run
+                claims.append(
+                    RecoveryClaim(
+                        run=run,
+                        fence=RunFence(run.run_id, owner.owner_id, run.lease_epoch),
+                    )
+                )
+            return claims
+
     async def _claim_commands(
         self,
         owner: OwnerLease,
@@ -436,7 +605,11 @@ class MemoryRunCoordinator:
                 fence: RunFence | None = None
                 legacy_lease_epoch = 0
                 if acquire_run_lease:
-                    if run is None:
+                    if (
+                        run is None
+                        or run.observed_state is ObservedState.TERMINAL
+                        or run.lease_expires_at > now
+                    ):
                         continue
                     legacy_lease_epoch = run.lease_epoch + 1
                     run = replace(
@@ -648,6 +821,125 @@ class MemoryRunCoordinator:
                 CoordinatorDecision.APPLIED, CoordinatorReason.TRANSITIONED, updated
             )
 
+    async def record_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+        process_id: int,
+        process_start_id: str,
+        process_owned: bool,
+    ) -> CoordinatorResult[RunRecord]:
+        async with self._lock:
+            now = self._clock()
+            validated = self._validate_transition(run_id, fence, expected_version, now=now)
+            if isinstance(validated, CoordinatorResult):
+                current = self._runs.get(run_id)
+                if not (
+                    validated.reason is CoordinatorReason.VERSION_CONFLICT
+                    and current is not None
+                    and current.version == expected_version + 1
+                    and current.observed_state is ObservedState.RUNNING
+                    and current.process_id == process_id
+                    and current.process_start_id == process_start_id
+                    and current.process_owned is process_owned
+                ):
+                    return validated
+                # A process record is the only lifecycle write that can advance
+                # a RUNNING row by one version. The SQLite worker may commit that
+                # write after its cancelled await returns no value. Only the
+                # identical process identity may replay that stale request; a
+                # replacement child must first observe the committed version.
+                validated = current
+            if (
+                type(process_id) is not int
+                or process_id <= 1
+                or not isinstance(process_start_id, str)
+                or (process_owned and not process_start_id)
+            ):
+                return self._result(
+                    CoordinatorDecision.REJECTED, CoordinatorReason.INVALID_TRANSITION
+                )
+            if validated.observed_state is not ObservedState.RUNNING:
+                return self._result(
+                    CoordinatorDecision.REJECTED, CoordinatorReason.INVALID_TRANSITION
+                )
+            if (
+                validated.process_id == process_id
+                and validated.process_start_id == process_start_id
+                and validated.process_owned is process_owned
+            ):
+                return self._result(
+                    CoordinatorDecision.UNCHANGED, CoordinatorReason.TRANSITIONED, validated
+                )
+            updated = replace(
+                validated,
+                process_id=process_id,
+                process_start_id=process_start_id,
+                process_owned=process_owned,
+                version=validated.version + 1,
+                updated_at=now,
+            )
+            self._runs[updated.run_id] = updated
+            return self._result(
+                CoordinatorDecision.APPLIED, CoordinatorReason.TRANSITIONED, updated
+            )
+
+    async def clear_recovered_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+    ) -> CoordinatorResult[RunRecord]:
+        """Clear a terminal row's protected child identity after reconciliation."""
+
+        async with self._lock:
+            now = self._clock()
+            validated = self._validate_transition(run_id, fence, expected_version, now=now)
+            if isinstance(validated, CoordinatorResult):
+                current = self._runs.get(run_id)
+                if not (
+                    validated.reason is CoordinatorReason.VERSION_CONFLICT
+                    and current is not None
+                    and current.version == expected_version + 1
+                    and current.observed_state is ObservedState.TERMINAL
+                    and current.process_id == 0
+                    and not current.process_start_id
+                    and not current.process_owned
+                ):
+                    return validated
+                return self._result(
+                    CoordinatorDecision.UNCHANGED,
+                    CoordinatorReason.TRANSITIONED,
+                    current,
+                )
+            if validated.observed_state is not ObservedState.TERMINAL:
+                return self._result(
+                    CoordinatorDecision.REJECTED, CoordinatorReason.INVALID_TRANSITION
+                )
+            if (
+                validated.process_id == 0
+                and not validated.process_start_id
+                and not validated.process_owned
+            ):
+                return self._result(
+                    CoordinatorDecision.UNCHANGED,
+                    CoordinatorReason.TRANSITIONED,
+                    validated,
+                )
+            updated = replace(
+                validated,
+                process_id=0,
+                process_start_id="",
+                process_owned=False,
+                version=validated.version + 1,
+                updated_at=now,
+            )
+            self._runs[updated.run_id] = updated
+            return self._result(
+                CoordinatorDecision.APPLIED, CoordinatorReason.TRANSITIONED, updated
+            )
+
     async def complete(
         self, completion: RunCompletion, fence: RunFence, expected_version: int
     ) -> CoordinatorResult[OutboxEvent]:
@@ -796,6 +1088,18 @@ class MemoryRunCoordinator:
                 if len(claimed) >= limit:
                     break
                 if event_id and current.event_id != event_id:
+                    continue
+                run = self._runs.get(current.run_id)
+                if (
+                    run is not None
+                    and run.observed_state is ObservedState.TERMINAL
+                    and run.process_owned
+                    and run.process_id > 1
+                    and bool(run.process_start_id)
+                ):
+                    # Delivery cannot race a terminal cleanup lease. The process
+                    # identity remains protected until fenced recovery proves the
+                    # child absent or terminates it successfully.
                     continue
                 pending = current.status is DeliveryState.PENDING and (
                     (acknowledgement and bool(event_id)) or current.available_at <= now

--- a/src/kiro_crew/run_coordinator/models.py
+++ b/src/kiro_crew/run_coordinator/models.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generic, Protocol, TypeVar
 
+LEGACY_SHADOW_SOURCE_VERSION = "legacy-shadow-v1"
+
 
 class DesiredState(str, Enum):
     RUN = "run"
@@ -96,6 +98,10 @@ class RunRecord:
     created_at: float
     updated_at: float
     terminal_at: float | None
+    source_version: str = ""
+    process_id: int = 0
+    process_start_id: str = ""
+    process_owned: bool = False
 
 
 @dataclass(frozen=True)
@@ -154,6 +160,12 @@ class CommandClaim:
 
 
 @dataclass(frozen=True)
+class RecoveryClaim:
+    run: RunRecord
+    fence: RunFence
+
+
+@dataclass(frozen=True)
 class RunCompletion:
     run_id: str
     outcome: RunOutcome
@@ -197,6 +209,7 @@ class SubmitRun:
     accepted: bool = True
     rejection_reason: str = ""
     payload_json: str = ""
+    source_version: str = ""
 
 
 @dataclass(frozen=True)
@@ -249,6 +262,34 @@ class TerminalReceipt:
     created: bool
 
 
+@dataclass(frozen=True)
+class LegacyRunImport:
+    run_id: str
+    parent_session: str
+    agent: str
+    task: str
+    conversation_key: str
+    observed_state: ObservedState
+    outcome: RunOutcome | None
+    result_path: str
+    error: str
+    created_at: float
+    updated_at: float
+    terminal_at: float | None
+    source_version: str
+    event_type: str = ""
+    destination: str = ""
+    payload_json: str = ""
+    delivery_state: DeliveryState | None = None
+
+
+@dataclass(frozen=True)
+class LegacyImportReceipt:
+    run: RunRecord
+    event: OutboxEvent | None
+    created: bool
+
+
 T = TypeVar("T")
 
 
@@ -266,6 +307,14 @@ class RunCoordinator(Protocol):
 
     async def record_terminal(self, request: TerminalRun) -> CoordinatorResult[TerminalReceipt]: ...
 
+    async def import_legacy(
+        self, request: LegacyRunImport
+    ) -> CoordinatorResult[LegacyImportReceipt]: ...
+
+    async def import_legacy_batch(
+        self, requests: tuple[LegacyRunImport, ...]
+    ) -> list[CoordinatorResult[LegacyImportReceipt]]: ...
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None: ...
 
     async def claim_commands(self, owner: OwnerLease, limit: int) -> list[CommandClaim]: ...
@@ -275,6 +324,13 @@ class RunCoordinator(Protocol):
     ) -> list[CommandClaim]: ...
 
     async def claim_command(self, command_id: str, owner: OwnerLease) -> CommandClaim | None: ...
+
+    async def claim_recovery(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        exclude_run_ids: frozenset[str] = frozenset(),
+    ) -> list[RecoveryClaim]: ...
 
     async def finish_command(
         self,
@@ -298,6 +354,23 @@ class RunCoordinator(Protocol):
 
     async def mark_running(
         self, run_id: str, fence: RunFence, expected_version: int
+    ) -> CoordinatorResult[RunRecord]: ...
+
+    async def record_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+        process_id: int,
+        process_start_id: str,
+        process_owned: bool,
+    ) -> CoordinatorResult[RunRecord]: ...
+
+    async def clear_recovered_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
     ) -> CoordinatorResult[RunRecord]: ...
 
     async def complete(

--- a/src/kiro_crew/run_coordinator/recovery.py
+++ b/src/kiro_crew/run_coordinator/recovery.py
@@ -1,0 +1,260 @@
+"""Coordinator-first reconciliation after a gateway restart."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from kiro_crew import platform_compat
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import sel
+
+from .delivery import OutboxDeliveryAdapter
+from .legacy import LegacyImportReport, LegacyRunImporter
+from .models import (
+    CoordinatorDecision,
+    DeliveryState,
+    ObservedState,
+    OwnerLease,
+    RunCompletion,
+    RunCoordinator,
+    RunOutcome,
+    RunRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+_RECOVERY_LEASE_SECONDS = 90.0
+_RECOVERY_BATCH_SIZE = 128
+_DELIVERY_BATCH_SIZE = 256
+_EVENT_TYPE = "subagent_completion"
+
+
+def _audit_orphan_termination(run_id: str, pid: int) -> None:
+    """Durably authorize an orphan kill before the process side effect."""
+    sel().log_tool_invocation(
+        session_key=f"subagent:{run_id}",
+        source="subagent",
+        tool_name="orphan_reconcile_kill",
+        outcome="kill_authorized",
+        metadata={"subagent_id": run_id, "pid": pid},
+        critical=True,
+    )
+
+
+@dataclass(frozen=True)
+class RecoveryReport:
+    imported: int = 0
+    existing: int = 0
+    corrupt: int = 0
+    interrupted: int = 0
+    terminated: int = 0
+    delivered: int = 0
+
+
+def _redact(value: str) -> str:
+    value, _ = redact_exfiltration_urls(value)
+    value, _ = redact_credentials(value)
+    return value
+
+
+class RunRecovery:
+    """Converge durable terminal delivery without replaying execution commands."""
+
+    def __init__(
+        self,
+        coordinator: RunCoordinator,
+        delivery: OutboxDeliveryAdapter,
+        *,
+        owner_id: str | None = None,
+        clock: Callable[[], float] = time.time,
+        terminate_process: Callable[[int], object] | None = None,
+        process_identity: Callable[[int], str | None] = platform_compat.process_identity_token,
+        process_alive: Callable[[int], bool] = platform_compat.pid_exists,
+        lease_seconds: float = _RECOVERY_LEASE_SECONDS,
+    ) -> None:
+        self._coordinator = coordinator
+        self._delivery = delivery
+        self._owner_id = owner_id or f"recovery:{uuid.uuid4().hex}"
+        self._clock = clock
+        self._terminate_process = terminate_process
+        self._process_identity = process_identity
+        self._process_alive = process_alive
+        self._lease_seconds = max(1.0, lease_seconds)
+
+    def completion_for(
+        self,
+        run: RunRecord,
+        *,
+        outcome: RunOutcome = RunOutcome.INTERRUPTED,
+    ) -> RunCompletion:
+        error = "interrupted by gateway restart" if outcome is RunOutcome.INTERRUPTED else run.error
+        task = _redact(run.task)[:1000]
+        safe_error = _redact(error)[:2000]
+        payload = json.dumps(
+            {
+                "id": run.run_id,
+                "parent_session_key": run.parent_session,
+                "agent": _redact(run.agent),
+                "task": task,
+                "outcome": outcome.value,
+                "error": safe_error,
+                "result_path": run.result_path,
+                "result_summary": "",
+                "result_truncated": bool(run.result_path),
+                "user_stopped": outcome is RunOutcome.STOPPED,
+                "batch_id": "",
+                "batch_total": 0,
+                "elapsed": max(0.0, self._clock() - run.created_at),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return RunCompletion(
+            run_id=run.run_id,
+            outcome=outcome,
+            result_path=run.result_path,
+            error=safe_error,
+            event_type=_EVENT_TYPE,
+            destination=run.parent_session,
+            payload_json=payload,
+            terminal_at=self._clock(),
+        )
+
+    async def _verified_live_process(self, run: RunRecord) -> tuple[tuple[int, str] | None, bool]:
+        """Return a coordinator-pinned child and whether its identity is unverified."""
+
+        if not run.process_owned or run.process_id <= 1:
+            return None, False
+        if not await asyncio.to_thread(self._process_alive, run.process_id):
+            return None, False
+        if not run.process_start_id:
+            return None, True
+        current = await asyncio.to_thread(self._process_identity, run.process_id)
+        if current is None:
+            return None, True
+        if current != run.process_start_id:
+            durable_pair = platform_compat.is_durable_process_identity_token(
+                run.process_start_id
+            ) and platform_compat.is_durable_process_identity_token(current)
+            if not durable_pair and not platform_compat.IS_WINDOWS:
+                # Older Linux rows lack a boot id, while older BSD rows use a
+                # locale/TZ-formatted value. A mismatch cannot prove replacement.
+                return None, True
+            # The recorded child is gone and this PID now belongs to another process.
+            # Never signal the replacement, but do let the original run converge to
+            # interrupted instead of deferring recovery forever.
+            return None, False
+        return (run.process_id, run.process_start_id), False
+
+    async def reconcile(
+        self,
+        *,
+        importer: LegacyRunImporter | None = None,
+        exclude_run_ids: frozenset[str] = frozenset(),
+    ) -> RecoveryReport:
+        """Import once, fence expired runs, interrupt them, then drain delivery."""
+
+        imported = LegacyImportReport()
+        if importer is not None:
+            imported = await importer.import_all(exclude_run_ids=exclude_run_ids)
+        interrupted = 0
+        terminated = 0
+        while True:
+            now = self._clock()
+            claims = await self._coordinator.claim_recovery(
+                OwnerLease(self._owner_id, now + self._lease_seconds),
+                _RECOVERY_BATCH_SIZE,
+                exclude_run_ids,
+            )
+            if not claims:
+                break
+            for claim in claims:
+                terminal_cleanup = claim.run.observed_state is ObservedState.TERMINAL
+                process, live_unverified = await self._verified_live_process(claim.run)
+                if live_unverified:
+                    logger.warning(
+                        "Live orphan process identity is unverified for run %s; retrying later",
+                        claim.run.run_id,
+                    )
+                    continue
+                if process is not None:
+                    try:
+                        await asyncio.to_thread(
+                            _audit_orphan_termination,
+                            claim.run.run_id,
+                            process[0],
+                        )
+                    except Exception:
+                        logger.warning(
+                            "SEL audit blocked orphan termination for run %s",
+                            claim.run.run_id,
+                            exc_info=True,
+                        )
+                        continue
+                    try:
+                        if self._terminate_process is None:
+                            termination_result: object = await asyncio.to_thread(
+                                platform_compat.kill_process_tree_pinned,
+                                process[0],
+                                process[1],
+                                platform_compat.SIGKILL,
+                            )
+                        else:
+                            termination_result = await asyncio.to_thread(
+                                self._terminate_process,
+                                process[0],
+                            )
+                        if termination_result is False:
+                            logger.warning(
+                                "Verified orphan identity changed before termination for run %s",
+                                claim.run.run_id,
+                            )
+                            continue
+                        terminated += 1
+                    except ProcessLookupError:
+                        pass
+                    except (OSError, ValueError):
+                        logger.warning(
+                            "Failed to terminate verified orphan process for run %s",
+                            claim.run.run_id,
+                        )
+                        continue
+                if terminal_cleanup:
+                    await self._coordinator.clear_recovered_process(
+                        claim.run.run_id,
+                        claim.fence,
+                        claim.run.version,
+                    )
+                    continue
+                result = await self._coordinator.complete(
+                    self.completion_for(claim.run),
+                    claim.fence,
+                    claim.run.version,
+                )
+                if result.decision is not CoordinatorDecision.REJECTED:
+                    interrupted += 1
+                    if claim.run.process_owned and result.value is not None:
+                        await self._coordinator.clear_recovered_process(
+                            claim.run.run_id,
+                            claim.fence,
+                            result.value.run_version,
+                        )
+            if len(claims) < _RECOVERY_BATCH_SIZE:
+                break
+
+        attempts = await self._delivery.drain_once(limit=_DELIVERY_BATCH_SIZE)
+        delivered = sum(1 for attempt in attempts if attempt.status is DeliveryState.DELIVERED)
+        return RecoveryReport(
+            imported=imported.imported,
+            existing=imported.existing,
+            corrupt=imported.corrupt,
+            interrupted=interrupted,
+            terminated=terminated,
+            delivered=delivered,
+        )

--- a/src/kiro_crew/run_coordinator/shadow.py
+++ b/src/kiro_crew/run_coordinator/shadow.py
@@ -16,8 +16,11 @@ from .models import (
     CoordinatorDecision,
     CoordinatorResult,
     DeliveryFence,
+    LegacyImportReceipt,
+    LegacyRunImport,
     OutboxEvent,
     OwnerLease,
+    RecoveryClaim,
     RunCommand,
     RunCompletion,
     RunCoordinator,
@@ -153,6 +156,22 @@ class ShadowRunCoordinator:
             await self._mirror("record_terminal", request),
         )
 
+    async def import_legacy(
+        self, request: LegacyRunImport
+    ) -> CoordinatorResult[LegacyImportReceipt]:
+        return cast(
+            CoordinatorResult[LegacyImportReceipt],
+            await self._mirror("import_legacy", request),
+        )
+
+    async def import_legacy_batch(
+        self, requests: tuple[LegacyRunImport, ...]
+    ) -> list[CoordinatorResult[LegacyImportReceipt]]:
+        return cast(
+            list[CoordinatorResult[LegacyImportReceipt]],
+            await self._mirror("import_legacy_batch", requests),
+        )
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None:
         return cast(
             CommandReceipt | None,
@@ -174,6 +193,17 @@ class ShadowRunCoordinator:
         return cast(
             CommandClaim | None,
             await self._mirror("claim_command", command_id, owner),
+        )
+
+    async def claim_recovery(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        exclude_run_ids: frozenset[str] = frozenset(),
+    ) -> list[RecoveryClaim]:
+        return cast(
+            list[RecoveryClaim],
+            await self._mirror("claim_recovery", owner, limit, exclude_run_ids),
         )
 
     async def finish_command(
@@ -226,6 +256,44 @@ class ShadowRunCoordinator:
         return cast(
             CoordinatorResult[RunRecord],
             await self._mirror("mark_running", run_id, fence, expected_version),
+        )
+
+    async def record_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+        process_id: int,
+        process_start_id: str,
+        process_owned: bool,
+    ) -> CoordinatorResult[RunRecord]:
+        return cast(
+            CoordinatorResult[RunRecord],
+            await self._mirror(
+                "record_process",
+                run_id,
+                fence,
+                expected_version,
+                process_id,
+                process_start_id,
+                process_owned,
+            ),
+        )
+
+    async def clear_recovered_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+    ) -> CoordinatorResult[RunRecord]:
+        return cast(
+            CoordinatorResult[RunRecord],
+            await self._mirror(
+                "clear_recovered_process",
+                run_id,
+                fence,
+                expected_version,
+            ),
         )
 
     async def complete(

--- a/src/kiro_crew/run_coordinator/sqlite.py
+++ b/src/kiro_crew/run_coordinator/sqlite.py
@@ -32,9 +32,12 @@ from .models import (
     DeliveryFence,
     DeliveryState,
     DesiredState,
+    LegacyImportReceipt,
+    LegacyRunImport,
     ObservedState,
     OutboxEvent,
     OwnerLease,
+    RecoveryClaim,
     RunCommand,
     RunCompletion,
     RunFence,
@@ -47,7 +50,7 @@ from .models import (
     TerminalRun,
 )
 
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 5
 _BUSY_TIMEOUT_MS = 5000
 _JOURNAL_MODE_LOCK = threading.Lock()
 _DATABASE_NAME = "coordinator.db"
@@ -162,6 +165,18 @@ _MIGRATIONS: tuple[tuple[int, tuple[str, ...]], ...] = (
             "DROP TABLE commands_v2",
             "CREATE INDEX commands_status_created ON commands(status, created_at)",
             "CREATE INDEX commands_run_created ON commands(run_id, created_at)",
+        ),
+    ),
+    (
+        4,
+        ("ALTER TABLE runs ADD COLUMN source_version TEXT NOT NULL DEFAULT ''",),
+    ),
+    (
+        5,
+        (
+            "ALTER TABLE runs ADD COLUMN process_id INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE runs ADD COLUMN process_start_id TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE runs ADD COLUMN process_owned INTEGER NOT NULL DEFAULT 0",
         ),
     ),
 )
@@ -361,6 +376,10 @@ class SQLiteRunCoordinator:
                 created_at=row["created_at"],
                 updated_at=row["updated_at"],
                 terminal_at=row["terminal_at"],
+                source_version=row["source_version"],
+                process_id=row["process_id"],
+                process_start_id=row["process_start_id"],
+                process_owned=bool(row["process_owned"]),
             )
             memory._runs[record.run_id] = record
         for row in connection.execute("SELECT * FROM commands"):
@@ -412,9 +431,13 @@ class SQLiteRunCoordinator:
         connection.execute("DELETE FROM runs")
         connection.executemany(
             """
-            INSERT INTO runs VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-            )
+            INSERT INTO runs (
+                run_id, parent_session, agent, task, conversation_key,
+                desired_state, observed_state, outcome, result_path, error,
+                attempt, version, owner_id, lease_expires_at, lease_epoch,
+                created_at, updated_at, terminal_at, source_version,
+                process_id, process_start_id, process_owned
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -436,6 +459,10 @@ class SQLiteRunCoordinator:
                     run.created_at,
                     run.updated_at,
                     run.terminal_at,
+                    run.source_version,
+                    run.process_id,
+                    run.process_start_id,
+                    int(run.process_owned),
                 )
                 for run in memory._runs.values()
             ],
@@ -534,6 +561,16 @@ class SQLiteRunCoordinator:
     async def record_terminal(self, request: TerminalRun) -> CoordinatorResult[TerminalReceipt]:
         return await self._offload("record_terminal", request)
 
+    async def import_legacy(
+        self, request: LegacyRunImport
+    ) -> CoordinatorResult[LegacyImportReceipt]:
+        return await self._offload("import_legacy", request)
+
+    async def import_legacy_batch(
+        self, requests: tuple[LegacyRunImport, ...]
+    ) -> list[CoordinatorResult[LegacyImportReceipt]]:
+        return await self._offload("import_legacy_batch", requests)
+
     async def get_command_by_key(self, idempotency_key: str) -> CommandReceipt | None:
         return await self._offload("get_command_by_key", idempotency_key, persist=False)
 
@@ -547,6 +584,14 @@ class SQLiteRunCoordinator:
 
     async def claim_command(self, command_id: str, owner: OwnerLease) -> CommandClaim | None:
         return await self._offload("claim_command", command_id, owner)
+
+    async def claim_recovery(
+        self,
+        owner: OwnerLease,
+        limit: int,
+        exclude_run_ids: frozenset[str] = frozenset(),
+    ) -> list[RecoveryClaim]:
+        return await self._offload("claim_recovery", owner, limit, exclude_run_ids)
 
     async def finish_command(
         self,
@@ -587,6 +632,38 @@ class SQLiteRunCoordinator:
         self, run_id: str, fence: RunFence, expected_version: int
     ) -> CoordinatorResult[RunRecord]:
         return await self._offload("mark_running", run_id, fence, expected_version)
+
+    async def record_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+        process_id: int,
+        process_start_id: str,
+        process_owned: bool,
+    ) -> CoordinatorResult[RunRecord]:
+        return await self._offload(
+            "record_process",
+            run_id,
+            fence,
+            expected_version,
+            process_id,
+            process_start_id,
+            process_owned,
+        )
+
+    async def clear_recovered_process(
+        self,
+        run_id: str,
+        fence: RunFence,
+        expected_version: int,
+    ) -> CoordinatorResult[RunRecord]:
+        return await self._offload(
+            "clear_recovered_process",
+            run_id,
+            fence,
+            expected_version,
+        )
 
     async def complete(
         self, completion: RunCompletion, fence: RunFence, expected_version: int

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -608,6 +608,18 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "through command-status lookup.",
     ),
     (
+        "Legacy subagent recovery",
+        "run_coordinator/legacy.py",
+        "Task, agent, and failure text imported from legacy run folders before a "
+        "durable completion event can be delivered to the parent session.",
+    ),
+    (
+        "Coordinator recovery",
+        "run_coordinator/recovery.py",
+        "Task, agent, and interruption text in restart-recovery completion events "
+        "before durable delivery to the parent session.",
+    ),
+    (
         "Voice reply (TTS)",
         "voice_reply.py",
         "Spoken text is redacted before synthesis so a credential is never read " "aloud.",

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -286,6 +286,7 @@ from kiro_crew.subagent import (
 )
 from kiro_crew.subagent_completion_meta import (
     OUTCOME_FAILED,
+    OUTCOME_INTERRUPTED,
     OUTCOME_OK,
     OUTCOME_STOPPED,
     single_completion_meta,
@@ -6040,16 +6041,29 @@ class GatewayOrchestrator:
         # A flush-only record is synthetic (no run or event of its own). Every
         # durable event owes an outbox acknowledgement, while only a COMPLETED
         # member also owes the legacy delivered tombstone; failed/stopped runs
-        # keep their longer post-mortem retention window.
+        # keep their longer post-mortem retention window. A failed shadow
+        # admission fallback is the exception: it has no durable outbox event,
+        # so its explicitly carried legacy debt settles only after consumption.
         durable_event = bool(info._delivery_event_id)
+        legacy_tombstone = info._legacy_delivery_tombstone
         owed: list[str] = (
-            [] if flush_only or (info.outcome != "completed" and not durable_event) else [info.id]
+            []
+            if flush_only
+            or (info.outcome != "completed" and not durable_event and not legacy_tombstone)
+            else [info.id]
         )
         held = getattr(info, "_digest_settle_ids", None)
+        error_ids = {info.id} if legacy_tombstone and not flush_only else set()
+        held_error_ids = getattr(info, "_digest_error_tombstone_ids", None)
         if isinstance(held, list):
             owed.extend(str(h) for h in held)
+        if isinstance(held_error_ids, list):
+            error_ids.update(str(h) for h in held_error_ids)
         try:
-            slot.note_pending_subagent_delivery(announce, owed)
+            if error_ids:
+                slot.note_pending_subagent_delivery(announce, owed, error_tombstone_ids=error_ids)
+            else:
+                slot.note_pending_subagent_delivery(announce, owed)
         except Exception:
             logger.debug(
                 "Subagent %s: could not defer queued delivery marks", info.id, exc_info=True
@@ -6058,6 +6072,8 @@ class GatewayOrchestrator:
         info._delivery_queued = True
         if isinstance(held, list):
             info._digest_settle_ids = []
+        if isinstance(held_error_ids, list):
+            info._digest_error_tombstone_ids = []
 
     @staticmethod
     def _notif_meta(parent_key: str | None) -> dict[str, str] | None:
@@ -6553,7 +6569,13 @@ class GatewayOrchestrator:
             # a failure. The record contract keeps ``error`` unset for stops, so
             # every consumer below must branch on ``user_stopped`` explicitly
             # rather than inferring success from an empty error.
-            if info.user_stopped:
+            if info.outcome == OUTCOME_INTERRUPTED:
+                status, emoji, single_outcome = (
+                    "interrupted by gateway restart",
+                    "⚠",
+                    OUTCOME_INTERRUPTED,
+                )
+            elif info.user_stopped:
                 status, emoji, single_outcome = "stopped by user", "⏹", OUTCOME_STOPPED
             elif info.error:
                 status, emoji, single_outcome = "failed", "❌", OUTCOME_FAILED
@@ -6624,6 +6646,8 @@ class GatewayOrchestrator:
                         # skew success stats; recording it as failure would
                         # trigger retry-guidance guards for a deliberate act.
                         pass
+                    elif info.outcome == OUTCOME_INTERRUPTED:
+                        pass
                     elif info.error:
                         if tracker.record_failure(task_key):
                             guard_msg = (
@@ -6665,7 +6689,14 @@ class GatewayOrchestrator:
             # transcript on demand (read / grep / spawn_status) instead of re-running
             # the subagent.
             result_path = info.result_path or ""
-            if info.user_stopped:
+            if info.outcome == OUTCOME_INTERRUPTED:
+                detail = info.error or "Interrupted by gateway restart."
+                if result_path:
+                    detail += (
+                        f"\n\nPartial result saved at: `{result_path}`\n"
+                        "Use the read tool to retrieve it."
+                    )
+            elif info.user_stopped:
                 _partial = info.result or ""
                 detail = (
                     "Stopped by the user before completing. Do NOT treat this as "
@@ -6779,6 +6810,7 @@ class GatewayOrchestrator:
                                 "ok_lines": [],
                                 "guard_msgs": [],
                                 "held_delivery_ids": [],
+                                "held_error_tombstone_ids": [],
                                 "delivery_event_ids": [],
                                 # Members whose delivery is held, so the
                                 # deadline sweep can clear their timestamps
@@ -6802,9 +6834,12 @@ class GatewayOrchestrator:
                 _oc = info.outcome
                 if _oc == "stopped":
                     bp["stopped"] += 1
-                elif _oc == "failed":
+                elif _oc in ("failed", OUTCOME_INTERRUPTED):
+                    # The aggregate contract has three buckets. Preserve the
+                    # exact interrupted outcome on the member, but count it as
+                    # a non-success so the final tallies still equal ``done``.
                     bp["err"] += 1
-                else:
+                elif _oc == "completed":
                     bp["ok"] += 1
                 # Per-member model provenance in the PARENT-READ digest text
                 # (issue #5337): the announce body the parent LLM consumes is
@@ -6925,8 +6960,14 @@ class GatewayOrchestrator:
                         # contract; cleared when this member's chunk fires.
                         info._digest_held_at = time.time()
                         bp.setdefault("held_infos", []).append(info)
-                        if _oc == "completed" or info._delivery_event_id:
+                        if (
+                            _oc == "completed"
+                            or info._delivery_event_id
+                            or info._legacy_delivery_tombstone
+                        ):
                             bp["held_delivery_ids"].append(info.id)
+                        if info._legacy_delivery_tombstone:
+                            bp["held_error_tombstone_ids"].append(info.id)
                         logger.info(
                             "Subagent %s: completion held for digest chunk (%d/%d done)",
                             info.id,
@@ -6942,6 +6983,7 @@ class GatewayOrchestrator:
                     # settles them only after _on_done (which includes the
                     # routing below) returns without raising.
                     info._digest_settle_ids = list(bp.get("held_delivery_ids", []))
+                    info._digest_error_tombstone_ids = list(bp.get("held_error_tombstone_ids", []))
                     # A callback without a stable outbox event has no exact
                     # replay source. Retain the live pre-composition state so
                     # a failed route can put its chunk back into the wave for
@@ -7083,6 +7125,7 @@ class GatewayOrchestrator:
                         bp["ok_lines"] = []
                         bp["guard_msgs"] = []
                         bp["held_delivery_ids"] = []
+                        bp["held_error_tombstone_ids"] = []
                         bp["delivery_event_ids"] = []
 
                     if delivery_event_id:
@@ -7325,7 +7368,11 @@ class GatewayOrchestrator:
                         # settles through its failure tombstone instead.
                         _owes_delivery = bool(info._digest_settle_ids) or (
                             not _flush_only
-                            and (info.outcome == "completed" or bool(info._delivery_event_id))
+                            and (
+                                info.outcome == "completed"
+                                or bool(info._delivery_event_id)
+                                or info._legacy_delivery_tombstone
+                            )
                         )
                         self._defer_queued_delivery(
                             _injection_slot, announce, info, flush_only=_flush_only
@@ -7827,6 +7874,7 @@ class GatewayOrchestrator:
                         for held in live_progress.get("held_infos", []):
                             held._digest_held_at = held_at
                         info._digest_settle_ids = []
+                        info._digest_error_tombstone_ids = []
                         info._delivery_batch_progress = None
                         info._delivery_batch_final = False
                         return

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -93,15 +93,20 @@ from kiro_crew.providers.base import (
 )
 from kiro_crew.resource_status import cached_admission_check
 from kiro_crew.run_coordinator import (
+    LEGACY_SHADOW_SOURCE_VERSION,
     CommandOperation,
+    CommandStatus,
     CoordinatorDecision,
     DeliveryState,
+    LegacyRunImporter,
     OutboxEvent,
+    OwnerLease,
     RunCommand,
     RunCompletion,
     RunCoordinator,
     RunFence,
     RunOutcome,
+    RunRecovery,
     SQLiteRunCoordinator,
     SubmitRun,
     TerminalRun,
@@ -151,7 +156,7 @@ from kiro_crew.subagent_persistence import (
     _cleanup_session_files_sync,
     _subagents_dir,
     agent_dir_for_display,
-    clear_tombstone,
+    clear_tombstone_for_recovery,
     create_agent_folder,
     list_orphans,
     mark_delivered,
@@ -494,7 +499,6 @@ _STEER_STARTUP_POLL_SECS = 0.5
 # latency is irrelevant next to permanent wedging.
 _WAVE_STUCK_SECS = 1800
 _RESET_TIMEOUT = 30.0  # max seconds for session reset in finally block
-_SHADOW_SUBMIT_TIMEOUT_SECS = 1.0
 _RECOVERY_SLOT_WAIT_SECS = 60.0
 _REPORT_DRAIN_TIMEOUT = (
     30.0  # max seconds cancel_all() waits for shielded terminal reports to drain
@@ -1178,6 +1182,11 @@ _SYSTEM_PREFIX = (
     "Only output meaningful, actionable results. Never output greetings or filler.\n\n"
 )
 
+# This bounds only reconciliation after the coordinator itself reports an
+# uncertain claim timeout; normal submit and claim calls own their deadlines.
+_COORDINATOR_CLAIM_LOOKUP_TIMEOUT_SECS = 1.0
+_SHADOW_SUBMISSION_FAILURE_DETAIL = "run coordinator submission failed after timeout"
+
 
 @dataclass
 class SubagentInfo:
@@ -1313,6 +1322,7 @@ class SubagentInfo:
     # digest COMPOSITION would re-open the restart-loss window between
     # composing and routing.
     _digest_settle_ids: list[str] = field(default_factory=list)
+    _digest_error_tombstone_ids: list[str] = field(default_factory=list)
     # True when async command authority admitted this run before invoking the
     # compatibility executor, so run start must settle that durable command.
     _coordinator_admitted: bool = False
@@ -1324,8 +1334,13 @@ class SubagentInfo:
     # Durable start settlement is unknown, so terminal delivery must wait for
     # cancellation retry or fenced recovery.
     _coordinator_claim_uncertain: bool = False
+    _coordinator_shadow_generation: int = 0
+    _coordinator_shadow_submission_durable: bool | None = None
     _coordinator_started: bool = False
     _coordinator_running: bool = False
+    # True only after the coordinator has durably recorded a child identity
+    # that outbox claims must protect until teardown proves the child stopped.
+    _coordinator_process_protected: bool = False
     _delivery_event_id: str = ""
     _delivery_failed: bool = False
     _delivery_retry: bool = False
@@ -1335,6 +1350,7 @@ class SubagentInfo:
     _delivery_orchestration_tracker: Any = None
     _delivery_batch_progress: dict[str, Any] | None = None
     _delivery_batch_final: bool = False
+    _recovered_outcome: str = ""
     # True when the gateway QUEUED this completion's injection because the
     # parent's slot was busy. Delivery is not consumption: the announce sits in
     # the slot queue until a turn drains it, and that wait is bounded only by the
@@ -1345,6 +1361,7 @@ class SubagentInfo:
     # settles the tombstone instead — see
     # ``_ChatSlot.take_pending_subagent_deliveries`` (issue #4839).
     _delivery_queued: bool = False
+    _legacy_delivery_tombstone: bool = False
     max_turns: int = 0
     reaped: bool = False
     streaming_text: str = ""
@@ -1487,7 +1504,7 @@ class SubagentInfo:
 
     @property
     def outcome(self) -> str:
-        """Canonical three-way terminal outcome: 'stopped' | 'failed' | 'completed'.
+        """Canonical terminal outcome, including coordinator recovery interruption.
 
         THE single source of truth for terminal-state classification. Consumers
         MUST use this (or the ``outcome`` field carried on every subagent_done
@@ -1496,6 +1513,8 @@ class SubagentInfo:
         user-stopped agent as completed. ``stopped``/``error`` remain on the
         wire for compatibility.
         """
+        if self._recovered_outcome == OUTCOME_INTERRUPTED:
+            return OUTCOME_INTERRUPTED
         if self.user_stopped:
             return "stopped"
         if self.error:
@@ -1682,13 +1701,26 @@ class SubagentManager:
         # compatibility executor. Legacy synchronous callers remain mirrored
         # at async run entry during migration.
         self._coordinator = coordinator or SQLiteRunCoordinator()
-        self.command_authority = SubagentCommandAuthority(self._coordinator, self)
+        self._coordinator_owner_id = f"gateway:{uuid.uuid4().hex}"
+        self.command_authority = SubagentCommandAuthority(
+            self._coordinator,
+            self,
+            owner_id=self._coordinator_owner_id,
+        )
         self._outbox_contexts: dict[str, _OutboxDeliveryContext] = {}
         self._outbox_live_contexts: dict[str, _OutboxDeliveryContext] = {}
+        self._outbox_live_run_batches: dict[str, tuple[str, int]] = {}
+        self._coordinator_shadow_submits: set[asyncio.Task[Any]] = set()
+        self._coordinator_shadow_submit_owners: dict[asyncio.Task[Any], SubagentInfo] = {}
         self._lease_tasks: dict[str, asyncio.Task[None]] = {}
         self._outbox_delivery = OutboxDeliveryAdapter(
             self._coordinator,
             self._deliver_outbox_event,
+        )
+        self._legacy_run_importer = LegacyRunImporter(self._coordinator)
+        self._run_recovery = RunRecovery(
+            self._coordinator,
+            self._outbox_delivery,
         )
         self._lifecycle: SubagentLifecycle[SubagentInfo] = SubagentLifecycle()
         # follow_up watchers (spawn_steer mode="follow_up"), keyed by run id.
@@ -1937,6 +1969,12 @@ class SubagentManager:
     def start_reaper(self) -> None:
         return self._monitor.start_reaper_impl()
 
+    def _coordinator_active_run_ids(self) -> frozenset[str]:
+        return self._monitor._coordinator_active_run_ids_impl()
+
+    async def _reconcile_startup(self) -> None:
+        return await self._monitor._reconcile_startup_impl()
+
     async def _reconcile_orphans(self) -> None:
         return await self._monitor._reconcile_orphans_impl()
 
@@ -2099,6 +2137,20 @@ class SubagentManager:
     async def _coordinator_mark_running(self, info: SubagentInfo) -> None:
         return await self._terminal._coordinator_mark_running_impl(info)
 
+    async def _coordinator_record_process(
+        self,
+        info: SubagentInfo,
+        process_id: int,
+        process_start_id: str,
+        process_owned: bool,
+    ) -> None:
+        return await self._terminal._coordinator_record_process_impl(
+            info, process_id, process_start_id, process_owned
+        )
+
+    async def _record_process_identity(self, info: SubagentInfo, session_key: str) -> None:
+        return await self._terminal._record_process_identity_impl(info, session_key)
+
     def _start_coordinator_heartbeat(self, info: SubagentInfo) -> None:
         return self._terminal._start_coordinator_heartbeat_impl(info)
 
@@ -2113,6 +2165,9 @@ class SubagentManager:
 
     async def _commit_terminal_event(self, info: SubagentInfo) -> OutboxEvent | None:
         return await self._terminal._commit_terminal_event_impl(info)
+
+    async def _clear_terminal_process(self, info: SubagentInfo) -> bool:
+        return await self._terminal._clear_terminal_process_impl(info)
 
     def _info_from_outbox(self, event: OutboxEvent) -> SubagentInfo:
         return self._terminal._info_from_outbox_impl(event)
@@ -2129,6 +2184,8 @@ class SubagentManager:
         mark_delivered_on_success: bool,
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
+        process_stopped: "asyncio.Event | None" = None,
+        tombstone_error_on_success: bool = False,
     ) -> None:
         return await self._terminal._report_terminal_impl(
             info,
@@ -2137,6 +2194,8 @@ class SubagentManager:
             mark_delivered_on_success=mark_delivered_on_success,
             settle_digest=settle_digest,
             teardown_done=teardown_done,
+            process_stopped=process_stopped,
+            tombstone_error_on_success=tombstone_error_on_success,
         )
 
     async def _run_terminal_report(
@@ -2148,6 +2207,8 @@ class SubagentManager:
         mark_delivered_on_success: bool,
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
+        process_stopped: "asyncio.Event | None" = None,
+        tombstone_error_on_success: bool = False,
     ) -> None:
         return await self._terminal._run_terminal_report_impl(
             info,
@@ -2156,6 +2217,8 @@ class SubagentManager:
             mark_delivered_on_success=mark_delivered_on_success,
             settle_digest=settle_digest,
             teardown_done=teardown_done,
+            process_stopped=process_stopped,
+            tombstone_error_on_success=tombstone_error_on_success,
         )
 
     async def _reject_waiting_before_terminal(self, info: SubagentInfo, error: str) -> None:
@@ -2170,6 +2233,8 @@ class SubagentManager:
         mark_delivered_on_success: bool,
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
+        process_stopped: "asyncio.Event | None" = None,
+        tombstone_error_on_success: bool = False,
     ) -> "asyncio.Task":  # type: ignore[type-arg]
         return self._terminal._spawn_terminal_report_impl(
             info,
@@ -2178,6 +2243,8 @@ class SubagentManager:
             mark_delivered_on_success=mark_delivered_on_success,
             settle_digest=settle_digest,
             teardown_done=teardown_done,
+            process_stopped=process_stopped,
+            tombstone_error_on_success=tombstone_error_on_success,
         )
 
     @staticmethod
@@ -2489,8 +2556,18 @@ class SubagentManager:
     async def _announce_digest_flush(self, info: SubagentInfo) -> None:
         return await self._waves._announce_digest_flush_impl(info)
 
-    async def settle_queued_delivery(self, agent_ids: list[str]) -> None:
-        return await self._waves.settle_queued_delivery_impl(agent_ids)
+    async def settle_queued_delivery(
+        self,
+        agent_ids: list[str],
+        *,
+        error_tombstone_ids: set[str] | frozenset[str] | None = None,
+    ) -> None:
+        return await self._waves.settle_queued_delivery_impl(
+            agent_ids, error_tombstone_ids=error_tombstone_ids
+        )
+
+    def _write_error_delivery_tombstone(self, agent_id: str) -> None:
+        return self._waves._write_error_delivery_tombstone_impl(agent_id)
 
     def _delivery_event_for_run(self, run_id: str) -> str:
         return self._waves._delivery_event_for_run_impl(run_id)
@@ -2511,10 +2588,15 @@ class SubagentManager:
     def count(self) -> int:
         return len(self.running)
 
-    async def _teardown_run_session(self, info: SubagentInfo, session_key: str) -> None:
+    async def _teardown_run_session(self, info: SubagentInfo, session_key: str) -> bool:
         return await self._run_events._teardown_run_session_impl(info, session_key)
 
-    async def _shadow_submit_accepted_run(self, info: SubagentInfo) -> None:
+    async def _shadow_submit_accepted_run(
+        self,
+        info: SubagentInfo,
+        *,
+        generation: int | None = None,
+    ) -> bool:
         """Best-effort mirror of a legacy-accepted run into the coordinator.
 
         The legacy manager and run folder remain authoritative in this phase.
@@ -2522,9 +2604,9 @@ class SubagentManager:
         any coordinator failure is diagnostic rather than an execution failure.
         """
         try:
-            await asyncio.wait_for(
-                self._shadow_submit_accepted_run_unchecked(info),
-                timeout=_SHADOW_SUBMIT_TIMEOUT_SECS,
+            return await self._shadow_submit_accepted_run_unchecked(
+                info,
+                generation=generation,
             )
         except Exception:
             # Request construction, injected adapters, and result inspection
@@ -2535,11 +2617,19 @@ class SubagentManager:
                 info.id,
                 exc_info=True,
             )
+            return False
 
-    async def _shadow_submit_accepted_run_unchecked(self, info: SubagentInfo) -> None:
+    async def _shadow_submit_accepted_run_unchecked(
+        self,
+        info: SubagentInfo,
+        *,
+        generation: int | None = None,
+    ) -> bool:
         coordinator = self._coordinator
         if coordinator is None:
-            return
+            return False
+        if info._coordinator_fence is not None:
+            return True
         operation = CommandOperation.CONTINUE if info.conversation_key else CommandOperation.SPAWN
         raw_task = info._raw_task or info.task
         stored_task = _redact(raw_task).encode("utf-8", errors="replace").decode("utf-8")[:1000]
@@ -2584,8 +2674,15 @@ class SubagentManager:
             task=stored_task,
             conversation_key=info.conversation_key,
             operation=operation,
+            source_version=LEGACY_SHADOW_SOURCE_VERSION,
         )
         result = await coordinator.submit(request)
+
+        # Cancellation retains this coroutine after its `_run` has exited. A
+        # replacement can begin meanwhile, so the old attempt may observe the
+        # durable result but must not claim or mutate the replacement's fence.
+        if generation is not None and generation != info._coordinator_shadow_generation:
+            return True
 
         if result is None:
             # Injected adapters are expected to honor the typed port. Keep this
@@ -2594,20 +2691,20 @@ class SubagentManager:
                 "run coordinator shadow returned no result for run=%s boundary=submit",
                 info.id,
             )
-            return
+            return False
         if result.decision is CoordinatorDecision.REJECTED:
             logger.warning(
                 "run coordinator shadow rejected legacy run=%s boundary=submit reason=%s",
                 info.id,
                 result.reason.value,
             )
-            return
+            return False
         if result.value is None:
             logger.warning(
                 "run coordinator shadow omitted receipt for run=%s boundary=submit",
                 info.id,
             )
-            return
+            return False
 
         run = result.value.run
         command = result.value.command
@@ -2633,6 +2730,399 @@ class SubagentManager:
             logger.warning(
                 "run coordinator legacy mismatch at boundary=submit fields=%s",
                 ",".join(sorted(mismatches)),
+            )
+
+        try:
+            claim = await self._coordinator.claim_command(
+                command_id,
+                OwnerLease(
+                    owner_id=self._coordinator_owner_id,
+                    lease_expires_at=time.time() + EXECUTION_LEASE_SECONDS,
+                ),
+            )
+        except Exception:
+            # Any claim failure happens after the durable submit receipt exists.
+            # Treating it as a failed submission would emit one local failure
+            # and let recovery emit a second interruption. Read the stable
+            # command once: an owned, unexpired committed claim is safe to
+            # resume; every other result stays exclusively recoverable.
+            if generation is not None and generation != info._coordinator_shadow_generation:
+                return True
+            if await self._adopt_owned_shadow_claim(
+                info,
+                command_id=command_id,
+                generation=generation,
+            ):
+                return True
+            if generation is None or generation == info._coordinator_shadow_generation:
+                info._coordinator_claim_uncertain = True
+            logger.error(
+                "Subagent %s coordinator claim outcome is uncertain; "
+                "deferring terminal ownership to durable recovery",
+                info.id,
+                exc_info=True,
+            )
+            return True
+        if claim is None or claim.fence is None or claim.run is None:
+            # An older generation can commit the idempotent claim before its
+            # response is cancelled. The replacement then receives no new
+            # claim, but it owns the same durable owner lease and must adopt
+            # that fence instead of reporting a competing local failure.
+            if generation is not None and generation != info._coordinator_shadow_generation:
+                return True
+            if await self._adopt_owned_shadow_claim(
+                info,
+                command_id=command_id,
+                generation=generation,
+            ):
+                return True
+            if generation is None or generation == info._coordinator_shadow_generation:
+                info._coordinator_claim_uncertain = True
+            logger.error(
+                "Subagent %s coordinator claim is unavailable; "
+                "deferring terminal ownership to durable recovery",
+                info.id,
+            )
+            return True
+        if generation is not None and generation != info._coordinator_shadow_generation:
+            return True
+        info._coordinator_command = claim.command
+        info._coordinator_fence = claim.fence
+        info._coordinator_version = claim.run.version
+        return True
+
+    async def _await_retained_shadow_submit(self, info: SubagentInfo) -> None:
+        """Keep an accepted run's durable submission alive across cancellation."""
+
+        info._coordinator_shadow_generation += 1
+        generation = info._coordinator_shadow_generation
+        info._coordinator_shadow_submission_durable = None
+        # A recovery respawn is a new local admission attempt. Uncertainty from
+        # the cancelled attempt remains owned by its generation and cannot make
+        # this replacement discard a fence it acquires itself.
+        info._coordinator_claim_uncertain = False
+        origin_task = asyncio.current_task()
+        submit_task = asyncio.create_task(
+            self._shadow_submit_accepted_run(info, generation=generation)
+        )
+        self._coordinator_shadow_submits.add(submit_task)
+        self._coordinator_shadow_submit_owners[submit_task] = info
+        settlement_scheduled = False
+
+        def _schedule_failed_settlement() -> None:
+            nonlocal settlement_scheduled
+            if (
+                settlement_scheduled
+                or not submit_task.done()
+                or generation != info._coordinator_shadow_generation
+                or not info._coordinator_claim_uncertain
+                or info._coordinator_fence is not None
+            ):
+                return
+            try:
+                submission_durable = submit_task.result()
+            except asyncio.CancelledError:
+                submission_durable = False
+            except Exception:
+                submission_durable = False
+            if submission_durable:
+                return
+            settlement_scheduled = True
+            settlement_task = asyncio.create_task(
+                self._resume_legacy_terminal_after_failed_shadow_submit(
+                    info,
+                    generation=generation,
+                    origin_task=origin_task,
+                )
+            )
+            self._coordinator_shadow_submits.add(settlement_task)
+            self._coordinator_shadow_submit_owners[settlement_task] = info
+
+            def _settlement_done(done: asyncio.Task[None]) -> None:
+                self._coordinator_shadow_submits.discard(done)
+                if not done.cancelled():
+                    self._coordinator_shadow_submit_owners.pop(done, None)
+
+            settlement_task.add_done_callback(_settlement_done)
+
+        def _settled(done: asyncio.Task[bool]) -> None:
+            if generation == info._coordinator_shadow_generation and not done.cancelled():
+                try:
+                    info._coordinator_shadow_submission_durable = done.result()
+                except Exception:
+                    info._coordinator_shadow_submission_durable = False
+            self._coordinator_shadow_submits.discard(done)
+            if not done.cancelled():
+                self._coordinator_shadow_submit_owners.pop(done, None)
+            _schedule_failed_settlement()
+
+        submit_task.add_done_callback(_settled)
+        try:
+            await asyncio.shield(submit_task)
+        except asyncio.CancelledError:
+            # The SQLite worker cannot be cancelled once it starts. Treat its
+            # outcome as uncertain until this strongly-held task proves whether
+            # a durable run and execution fence exist.
+            if generation == info._coordinator_shadow_generation:
+                info._coordinator_claim_uncertain = True
+                self._retain_recovery_batch(info)
+            _schedule_failed_settlement()
+            raise
+
+    async def _drain_retained_shadow_submits(self, info: SubagentInfo) -> bool | None:
+        """Wait for this run's retained admission chain and return its outcome."""
+
+        settled = info._coordinator_shadow_submission_durable
+        durable_seen = settled is True
+        failed_seen = settled is False
+        while True:
+            tasks = [
+                task
+                for task, owner in list(self._coordinator_shadow_submit_owners.items())
+                if owner is info
+            ]
+            if not tasks:
+                if durable_seen:
+                    return True
+                if failed_seen:
+                    return False
+                return None
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if result is True:
+                    durable_seen = True
+                elif result is False:
+                    failed_seen = True
+            # ``gather`` completes synchronously when every task was already
+            # done. Yield once so their completion callbacks can remove the
+            # finished link and install any fallback-settlement successor
+            # before this loop inspects the retained chain again.
+            await asyncio.sleep(0)
+
+    async def _resolve_stopped_shadow_claim(self, info: SubagentInfo) -> bool:
+        """Return whether this manager still owns stopped-run reporting."""
+
+        operation = CommandOperation.CONTINUE if info.conversation_key else CommandOperation.SPAWN
+        command_id = f"{operation.value}:{info.id}"
+        generation = info._coordinator_shadow_generation
+        while info._coordinator_claim_uncertain and info._coordinator_fence is None:
+            claim = None
+            try:
+                claim = await self._coordinator.claim_command(
+                    command_id,
+                    OwnerLease(
+                        owner_id=self._coordinator_owner_id,
+                        lease_expires_at=time.time() + EXECUTION_LEASE_SECONDS,
+                    ),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Subagent %s stopped claim retry failed",
+                    info.id,
+                    exc_info=True,
+                )
+            if claim is not None and claim.fence is not None and claim.run is not None:
+                info._coordinator_command = claim.command
+                info._coordinator_fence = claim.fence
+                info._coordinator_version = claim.run.version
+            elif await self._adopt_owned_shadow_claim(
+                info,
+                command_id=command_id,
+                generation=generation,
+            ):
+                pass
+            if info._coordinator_fence is not None:
+                info._coordinator_claim_uncertain = False
+                return True
+            if await self._shadow_claim_taken_over(
+                info,
+                command_id=command_id,
+                generation=generation,
+            ):
+                return False
+            await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+        return info._coordinator_fence is not None
+
+    async def _shadow_claim_taken_over(
+        self,
+        info: SubagentInfo,
+        *,
+        command_id: str,
+        generation: int,
+    ) -> bool:
+        """Detect terminal or live foreign ownership after an uncertain claim."""
+
+        receipt = None
+        try:
+            receipt = await asyncio.wait_for(
+                self._coordinator.get_command_by_key(command_id),
+                timeout=_COORDINATOR_CLAIM_LOOKUP_TIMEOUT_SECS,
+            )
+        except Exception:
+            logger.warning(
+                "run coordinator stopped-claim lookup failed for run=%s",
+                info.id,
+                exc_info=True,
+            )
+        if generation != info._coordinator_shadow_generation:
+            return True
+        if receipt is None or receipt.run is None:
+            return False
+        run = receipt.run
+        if run.outcome is not None:
+            return True
+        return bool(
+            run.owner_id
+            and run.owner_id != self._coordinator_owner_id
+            and run.lease_expires_at > time.time()
+        )
+
+    async def _adopt_owned_shadow_claim(
+        self,
+        info: SubagentInfo,
+        *,
+        command_id: str,
+        generation: int | None,
+    ) -> bool:
+        """Adopt a stable same-owner claim after an inconclusive claim response."""
+
+        receipt = None
+        try:
+            receipt = await asyncio.wait_for(
+                self._coordinator.get_command_by_key(command_id),
+                timeout=_COORDINATOR_CLAIM_LOOKUP_TIMEOUT_SECS,
+            )
+        except Exception:
+            logger.warning(
+                "run coordinator shadow claim lookup failed for run=%s",
+                info.id,
+                exc_info=True,
+            )
+        # The lookup itself yields control. A replacement generation may have
+        # started while it was pending, so stale attempts cannot mutate its
+        # fence or uncertainty state.
+        if generation is not None and generation != info._coordinator_shadow_generation:
+            return True
+        now = time.time()
+        if (
+            receipt is None
+            or receipt.run is None
+            or receipt.command.status is not CommandStatus.CLAIMED
+            or receipt.command.owner_id != self._coordinator_owner_id
+            or receipt.command.claim_expires_at <= now
+            or receipt.run.owner_id != self._coordinator_owner_id
+            or receipt.run.lease_expires_at <= now
+        ):
+            return False
+        info._coordinator_command = receipt.command
+        info._coordinator_fence = RunFence(
+            run_id=receipt.run.run_id,
+            owner_id=receipt.run.owner_id,
+            lease_epoch=receipt.run.lease_epoch,
+        )
+        info._coordinator_version = receipt.run.version
+        return True
+
+    async def _resume_legacy_terminal_after_failed_shadow_submit(
+        self,
+        info: SubagentInfo,
+        *,
+        generation: int | None = None,
+        origin_task: asyncio.Task[Any] | None = None,
+    ) -> None:
+        """Report locally when an uncertain submission later proves non-durable."""
+
+        settlement_generation = (
+            info._coordinator_shadow_generation if generation is None else generation
+        )
+
+        def owns_settlement() -> bool:
+            return (
+                settlement_generation == info._coordinator_shadow_generation
+                and info._coordinator_claim_uncertain
+                and not info._finalized
+                and not info._reap_started
+                and not info.reaped
+                and not info.user_stopped
+            )
+
+        while True:
+            # Check before EVERY destructive attempt. A user Stop or a newer
+            # shadow generation owns any marker written after this point.
+            if not owns_settlement():
+                return
+            cleared = await asyncio.to_thread(
+                clear_tombstone_for_recovery,
+                info.id,
+            )
+            if not owns_settlement():
+                # A terminal owner can write its marker while the unlink runs
+                # in the worker. Restore the abnormal marker if this attempt
+                # removed it; completed owners intentionally remain visible
+                # until their delivery path writes the delivered marker.
+                if cleared and info._finalized and info.outcome != "completed":
+                    cause = "cancelled" if info.user_stopped else "error"
+                    await asyncio.to_thread(self._write_tombstone, info, cause)
+                return
+            if cleared:
+                break
+            logger.warning(
+                "Subagent %s cannot resume legacy reporting while its recovery "
+                "tombstone remains; retrying",
+                info.id,
+            )
+            await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
+
+        # Tombstone clearance yields, so durable admission or the one-shot
+        # cancel recovery can win while it is retried. A fence transfers
+        # ownership to durable recovery. A different live task is the cancel
+        # recovery's respawn; its own retained submit will either establish a
+        # fence or schedule a settlement tied to that newer task.
+        if info._coordinator_fence is not None:
+            return
+        live_task = self._tasks.get(info.id)
+        if (
+            origin_task is not None
+            and live_task is not None
+            and live_task is not origin_task
+            and not live_task.done()
+        ):
+            return
+
+        # The claim and state transition contain no await, so a pending recovery
+        # sees either the open pre-terminal state or the completed terminal one.
+        # Superseding clears `_recovering`; otherwise both paths can decline and
+        # strand the parent notification.
+        if not self._claim_finalize(info, supersede_recovery=True):
+            return
+        info._coordinator_claim_uncertain = False
+        info.done = True
+        info.error = _SHADOW_SUBMISSION_FAILURE_DETAIL
+        info.elapsed = time.time() - info.started
+        Stats().inc_subagent_failed()
+        info._legacy_delivery_tombstone = True
+        self._record_cost(info)
+        self._spawn_terminal_report(
+            info,
+            source="Subagent",
+            injection_timeout_reason=(
+                f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s "
+                "(late coordinator submission failure)"
+            ),
+            mark_delivered_on_success=False,
+            settle_digest=True,
+            tombstone_error_on_success=True,
+        )
+
+    def _retain_recovery_batch(self, info: SubagentInfo) -> None:
+        """Keep live-only wave routing for a run handed to durable recovery."""
+
+        if info.batch_id:
+            self._outbox_live_run_batches[info.id] = (
+                info.batch_id,
+                info.batch_total,
             )
 
     async def _run(self, info: SubagentInfo) -> None:
@@ -2778,7 +3268,28 @@ class SubagentManager:
     async def cancel(self, agent_id: str) -> bool:
         return await self._cancellation.cancel_impl(agent_id)
 
+    async def _readmit_unsettled_shadow_submissions(
+        self,
+        owners: Iterable[SubagentInfo],
+    ) -> None:
+        return await self._cancellation._readmit_unsettled_shadow_submissions_impl(owners)
+
     async def cancel_all(self) -> None:
+        """Cancel all running subagents and wait for cleanup."""
+
+        self._shutting_down = True
+        try:
+            await self._cancel_all_impl()
+        except asyncio.CancelledError:
+            owners = list(self._coordinator_shadow_submit_owners.values())
+            for report_task in self._lifecycle.pending_reports():
+                owner = self._lifecycle.owner_for(report_task)
+                if owner is not None and not owner._reported_to_parent:
+                    owners.append(owner)
+            await self._readmit_unsettled_shadow_submissions(owners)
+            raise
+
+    async def _cancel_all_impl(self) -> None:
         return await self._cancellation.cancel_all_impl()
 
 
@@ -2848,7 +3359,7 @@ _COMPONENT_GLOBAL_BINDINGS = (
     asyncio,
     cached_admission_check,
     cap_result_file,
-    clear_tombstone,
+    clear_tombstone_for_recovery,
     compact_cost_log,
     configured_fallback_chain,
     consult_offloaded,

--- a/src/kiro_crew/subagent_manager/cancellation.py
+++ b/src/kiro_crew/subagent_manager/cancellation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 from ._component import ManagerComponent
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
         SubagentInfo,
         _redact,
         asyncio,
-        clear_tombstone,
+        clear_tombstone_for_recovery,
         logger,
         time,
     )
@@ -54,13 +54,13 @@ class CancellationCoordinator(ManagerComponent):
         task object to fully complete (its finally does session release/reset,
         slot decrement, and pops the task registry) before respawning. This
         guarantees the old finally can neither pop the new task out of
-        ``self._tasks`` nor emit a duplicate completion, and the respawn never
+        ``self._manager._tasks`` nor emit a duplicate completion, and the respawn never
         starts against a session whose reset is still in flight. The respawn
         then re-acquires a slot by waiting for capacity (the old finally's
         ``_drain_queue`` may have admitted a queued spawn into the freed slot),
         so the concurrency ceiling is never exceeded.
 
-        The pending ``_resume`` task itself is registered in ``self._tasks``
+        The pending ``_resume`` task itself is registered in ``self._manager._tasks``
         (under ``"<id>:recovery"``) so ``cancel_all()`` reaches it during
         shutdown — a recovery can never outlive or escape manager teardown.
         """
@@ -82,7 +82,12 @@ class CancellationCoordinator(ManagerComponent):
                             info.id,
                         )
                         raise RuntimeError("original task teardown timed out")
-                if info.done or info._reap_started or info.reaped:
+                if (
+                    info.done
+                    or info.user_stopped
+                    or info._reap_started
+                    or info.reaped
+                ):
                     info._recovering = False
                     return
                 if self._manager._shutting_down:
@@ -93,7 +98,12 @@ class CancellationCoordinator(ManagerComponent):
                 # never pushes the pool past max_concurrent.
                 deadline = time.time() + _RECOVERY_SLOT_WAIT_SECS
                 while True:
-                    if info.done or info._reap_started or info.reaped:
+                    if (
+                        info.done
+                        or info.user_stopped
+                        or info._reap_started
+                        or info.reaped
+                    ):
                         info._recovering = False
                         return
                     if self._manager._shutting_down:
@@ -279,6 +289,9 @@ class CancellationCoordinator(ManagerComponent):
                         await self._manager._finalize_queued_cancel(remaining[0])
                         remaining.pop(0)
                 except Exception:
+                    # The command still owns a durable claim. Keep its local
+                    # queue record, but mark it non-runnable until a caller
+                    # retries cancellation and commits the rejection.
                     for entry in remaining:
                         entry["_coordinator_cancel_pending"] = True
                         self._manager._scheduler.enqueue(entry)
@@ -296,6 +309,10 @@ class CancellationCoordinator(ManagerComponent):
                 return True
             return False
         if info._coordinator_waiting:
+            # Stop the approval task before settlement yields: approval may
+            # resolve during the coordinator write, and must not enter _run
+            # after the operator has cancelled it. The neutral marker prevents
+            # the intentional task cancellation from triggering recovery.
             info.user_stopped = True
             approval_task = self._manager._tasks.get(agent_id)
             if (
@@ -304,10 +321,16 @@ class CancellationCoordinator(ManagerComponent):
                 and not approval_task.done()
             ):
                 self._manager._cancel_task_intentionally(
-                    approval_task, info, reason="approval_wait_cancel"
+                    approval_task,
+                    info,
+                    reason="approval_wait_cancel",
                 )
+            # Keep the record and its lease retryable when durable rejection
+            # fails; the stopped approval task makes that retained state
+            # explicitly non-runnable.
             await self._manager.command_authority.reject_waiting_execution(
-                agent_id, "spawn cancelled before start"
+                agent_id,
+                "spawn cancelled before start",
             )
             info._coordinator_waiting = False
             info._coordinator_claim_uncertain = False
@@ -321,6 +344,18 @@ class CancellationCoordinator(ManagerComponent):
         # Preserve whatever streamed before the stop as a partial result.
         if not info.result and info.streaming_text:
             info.result = info.streaming_text
+        # Admission is strongly retained across cancellation. Let it resolve
+        # before the reap claims terminal reporting so a committed coordinator
+        # row receives the STOPPED result through its fence instead of recovery
+        # later producing a second terminal outcome.
+        submission_durable = await self._manager._drain_retained_shadow_submits(info)
+        if info._coordinator_fence is not None or submission_durable is False:
+            info._coordinator_claim_uncertain = False
+        if (
+            info._coordinator_claim_uncertain
+            and not await self._manager._resolve_stopped_shadow_claim(info)
+        ):
+            return True
         # _force_reap emits the (single) stopped-aware ``subagent_done`` event
         # and drives _on_done delivery — no second event here.
         await self._manager._force_reap(
@@ -328,11 +363,34 @@ class CancellationCoordinator(ManagerComponent):
         )
         return True
 
+    async def _readmit_unsettled_shadow_submissions_impl(
+        self,
+        owners: Iterable[SubagentInfo],
+    ) -> None:
+        """Expose accepted legacy runs when shutdown abandons durable admission."""
+
+        seen: set[str] = set()
+        for owner in owners:
+            if owner.id in seen or owner._coordinator_fence is not None:
+                continue
+            seen.add(owner.id)
+            try:
+                if await asyncio.to_thread(clear_tombstone_for_recovery, owner.id):
+                    logger.warning(
+                        "cancel_all: %s's coordinator submission did not settle — "
+                        "re-admitted to orphan recovery",
+                        owner.id,
+                    )
+            except Exception:
+                logger.debug(
+                    "cancel_all: failed to re-admit unsettled coordinator submission %s",
+                    owner.id,
+                    exc_info=True,
+                )
+
     async def cancel_all_impl(self) -> None:
-        """Cancel all running subagents and wait for cleanup."""
-        # Shutdown-driven cancellations must never trigger the one-shot
-        # unexpected-cancel auto-continue (the loop is going away).
-        self._manager._shutting_down = True
+        """Run shutdown cleanup under ``cancel_all``'s recovery boundary."""
+
         if self._manager._reaper_task and not self._manager._reaper_task.done():
             self._manager._reaper_task.cancel()
             self._manager._reaper_task = None
@@ -394,6 +452,13 @@ class CancellationCoordinator(ManagerComponent):
         if tasks_to_await:
             await asyncio.gather(*tasks_to_await, return_exceptions=True)
         self._manager._tasks.clear()
+        # A retained submission can settle by scheduling a local terminal
+        # reporter. Drain the full submission/settlement chain before taking
+        # the report snapshot so shutdown cannot miss that newly created task.
+        while self._manager._coordinator_shadow_submits:
+            shadow_submits = list(self._manager._coordinator_shadow_submits)
+            self._manager._coordinator_shadow_submits.clear()
+            await asyncio.gather(*shadow_submits, return_exceptions=True)
         # Shielded terminal reports keep running after their awaiter is
         # cancelled (that is the point). Drain them with a BOUNDED wait so a
         # report is not orphaned by a closing event loop, without letting a
@@ -450,7 +515,7 @@ class CancellationCoordinator(ManagerComponent):
                     if owner._reported_to_parent:
                         continue
                     try:
-                        if clear_tombstone(owner.id):
+                        if await asyncio.to_thread(clear_tombstone_for_recovery, owner.id):
                             logger.warning(
                                 "cancel_all: %s's completion was not delivered — "
                                 "re-admitted to orphan recovery for the next start",

--- a/src/kiro_crew/subagent_manager/monitoring.py
+++ b/src/kiro_crew/subagent_manager/monitoring.py
@@ -50,6 +50,31 @@ class OrphanStallMonitor(ManagerComponent):
 
     __slots__ = ()
 
+    def _coordinator_active_run_ids_impl(self) -> frozenset[str]:
+        """Fence live manager tasks and locally queued runs from recovery."""
+
+        active = frozenset(
+            run_id
+            for run_id, task in self._manager._tasks.items()
+            if run_id in self._manager._agents and not task.done()
+        )
+        return active | self._manager._scheduler.queued_run_ids()
+
+    async def _reconcile_startup_impl(self) -> None:
+        """Import legacy-only state, recover expired runs, and drain delivery."""
+
+        try:
+            await self._manager._reconcile_orphans()
+        except Exception:
+            logger.exception("Legacy subagent recovery failed")
+        try:
+            await self._manager._run_recovery.reconcile(
+                importer=self._manager._legacy_run_importer,
+                exclude_run_ids=self._manager._coordinator_active_run_ids(),
+            )
+        except Exception:
+            logger.exception("Coordinator-first subagent recovery failed")
+
     def _reap_orphan_process_impl(self, state: dict[str, Any]) -> bool:
         """Kill a surviving child only when its recorded process identity still matches."""
 
@@ -92,8 +117,9 @@ class OrphanStallMonitor(ManagerComponent):
         """Start the periodic reaper loop.  Call once after the event loop is running."""
         if self._manager._reaper_task is None:
             self._manager._reaper_task = asyncio.create_task(self._manager._reaper_loop())
-            # One-shot orphan reconciliation on startup
-            self._manager._reconcile_task = asyncio.create_task(self._manager._reconcile_orphans())
+            # Coordinator state is authoritative on restart. Legacy folders are
+            # imported read-only before the same fenced recovery policy runs.
+            self._manager._reconcile_task = asyncio.create_task(self._manager._reconcile_startup())
 
     async def _reconcile_orphans_impl(self) -> None:
         """Scan for orphaned agent folders from a prior gateway run.
@@ -452,6 +478,13 @@ class OrphanStallMonitor(ManagerComponent):
             logger.debug("Reaper: startup cost-log compaction failed", exc_info=True)
         while True:
             await asyncio.sleep(_REAPER_INTERVAL)
+            try:
+                await self._manager._run_recovery.reconcile(
+                    importer=self._manager._legacy_run_importer,
+                    exclude_run_ids=self._manager._coordinator_active_run_ids(),
+                )
+            except Exception:
+                logger.warning("Reaper: coordinator recovery failed", exc_info=True)
             await self._manager._drain_pending_outbox()
             if not self._manager._conv_registry_rebuilt:
                 # First pass after (re)start: re-seed the conversation TTL

--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -256,7 +256,7 @@ class RunEventCoordinator(ManagerComponent):
         """Get agent info by ID."""
         return self._manager._agents.get(agent_id)
 
-    async def _teardown_run_session_impl(self, info: SubagentInfo, session_key: str) -> None:
+    async def _teardown_run_session_impl(self, info: SubagentInfo, session_key: str) -> bool:
         """Release and reset the run's own session (skipped when reaped).
 
         Split out of ``_run``'s ``finally`` so the caller can wrap it in a nested
@@ -309,36 +309,58 @@ class RunEventCoordinator(ManagerComponent):
                     )
                 except Exception:
                     logger.exception("Subagent %s: SEL audit failed", info.id)
+                return False
             except Exception:
                 logger.exception("Subagent %s: reset failed", info.id)
+                return False
+        return True
 
     async def _run_impl(self, info: SubagentInfo) -> None:
         """Execute a subagent task in its own session."""
         session_key = info.conversation_key or f"subagent:{info.id}"
         try:
-            if not info._coordinator_admitted:
-                await self._manager._shadow_submit_accepted_run(info)
-            else:
+            authority_admitted = info._coordinator_admitted
+            if not authority_admitted:
+                await self._manager._await_retained_shadow_submit(info)
+            if info.user_stopped or info._reap_started:
+                return
+            if info._coordinator_claim_uncertain:
+                self._manager._retain_recovery_batch(info)
+                return
+            if info._coordinator_fence is None:
+                # A definite admission failure has no durable owner. Keep the
+                # accepted run tombstone-free until the legacy reporter can
+                # deliver its terminal result or restart reconciliation can
+                # recover it.
+                info._coordinator_claim_uncertain = True
+                self._manager._retain_recovery_batch(info)
+                await self._manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+                return
+            try:
+                await self._manager._coordinator_mark_starting(info)
+            except Exception:
+                if not authority_admitted:
+                    raise
+                # A lost lifecycle response is retried inside the transition.
+                # If both attempts fail, command settlement must not run: it
+                # would apply a command whose STARTING state is still unknown.
+                info._coordinator_claim_uncertain = True
+                await self._manager.command_authority.stop_execution_heartbeat(info.id)
+                self._manager._retain_recovery_batch(info)
+                logger.warning(
+                    "Subagent %s starting transition is uncertain",
+                    info.id,
+                    exc_info=True,
+                )
+                return
+            if authority_admitted:
                 try:
-                    await self._manager._coordinator_mark_starting(info)
-                except Exception:
-                    # A lost lifecycle response is retried inside the transition.
-                    # If both attempts fail, command settlement must not run: it
-                    # would apply a command whose STARTING state is still unknown.
-                    info._coordinator_claim_uncertain = True
-                    logger.warning(
-                        "Subagent %s starting transition is uncertain",
-                        info.id,
-                        exc_info=True,
-                    )
-                    return
-                try:
+                    # The command fence makes the same result idempotent.
+                    # Reconcile a commit whose response was lost before
+                    # deciding that recovery must own the accepted run.
                     await self._manager.command_authority.execution_started(info.id)
                 except Exception:
                     try:
-                        # The command fence makes the same result idempotent.
-                        # Reconcile a commit whose response was lost before
-                        # deciding that recovery must own the accepted run.
                         await self._manager.command_authority.execution_started(info.id)
                     except Exception:
                         # The claimed command remains the only safe retry path.
@@ -346,14 +368,15 @@ class RunEventCoordinator(ManagerComponent):
                         # delivery until cancellation or recovery settles it.
                         info._coordinator_claim_uncertain = True
                         await self._manager.command_authority.stop_execution_heartbeat(info.id)
+                        self._manager._retain_recovery_batch(info)
                         logger.warning(
                             "Subagent %s start settlement is uncertain",
                             info.id,
                             exc_info=True,
                         )
                         return
-                info._coordinator_waiting = False
-                self._manager._start_coordinator_heartbeat(info)
+            info._coordinator_waiting = False
+            self._manager._start_coordinator_heartbeat(info)
             await asyncio.wait_for(
                 self._manager._run_inner(info, session_key), timeout=self._manager._default_timeout
             )
@@ -460,6 +483,7 @@ class RunEventCoordinator(ManagerComponent):
             # already-spawned report holds its "delivered" tombstone until the
             # child is provably gone (see `_report_terminal`).
             teardown_done = self._manager._lifecycle.open_teardown(info.id)
+            process_stopped = asyncio.Event() if info._coordinator_process_protected else None
             # Published where it survives this record being evicted: a settlement
             # that happens OUTSIDE this report (the parent's queue drain, issue
             # #4839) can come due after a dashboard clear/cancel has removed the run
@@ -477,12 +501,17 @@ class RunEventCoordinator(ManagerComponent):
                     mark_delivered_on_success=True,
                     settle_digest=True,
                     teardown_done=teardown_done,
+                    process_stopped=process_stopped,
                 )
             # Nested try/finally: the teardown awaits must never be able to skip
             # the bookkeeping below (see `_teardown_run_session`).
             try:
                 if not info.reaped:
-                    await self._manager._teardown_run_session(info, session_key)
+                    teardown_succeeded = await self._manager._teardown_run_session(
+                        info, session_key
+                    )
+                    if teardown_succeeded and process_stopped is not None:
+                        process_stopped.set()
             finally:
                 # Guard 2 of 3 — SLOT accounting on its own one-shot token, so
                 # the count is released exactly once whichever terminal path
@@ -781,6 +810,8 @@ class RunEventCoordinator(ManagerComponent):
             # Detect CC provider to skip permission event loop
             is_cc = self._manager._is_cc_provider(client)
         await self._manager._coordinator_mark_running(info)
+        if info._session_sharing and info._pid:
+            await self._manager._coordinator_record_process(info, info._pid, "", False)
         # Intentionally check info.agent (not resolved `agent`) so only
         # explicitly requested agents skip _SYSTEM_PREFIX (defense-in-depth).
         named_agent = bool(info.agent and _AGENT_NAME_RE.fullmatch(info.agent))
@@ -900,21 +931,9 @@ class RunEventCoordinator(ManagerComponent):
         )
         # Stream results to disk for orchestrated chat.
 
-        # Record PID for orphan recovery. Off-loop and drained on cancellation
-        # via _write_state_off_loop (#6288, #7302): update_state ends in a
-        # synchronous fsync, and the reaper, every chat turn and the heartbeat
-        # share this loop. Off-loop also means the write TAKES update_state's
-        # per-agent lock, which on-loop callers skip (#7280), so it can no longer
-        # interleave with another pool writer's read-merge-rewrite.
-        try:
-            pid = self._manager._sessions.get_pid(session_key)
-            if pid:
-                info._pid = pid  # make available for _write_tombstone
-                await self._manager._write_state_off_loop(
-                    info, "PID record", pid=pid, pid_recorded_at=time.time()
-                )
-        except Exception:
-            logger.debug("Failed to record PID for %s", info.id, exc_info=True)
+        # Protected identity is the only restart authority for terminating this
+        # process tree. Failure must abort before the child receives a prompt.
+        await self._manager._record_process_identity(info, session_key)
 
         # Record session_id and provider type for session file cleanup
         try:
@@ -1719,12 +1738,13 @@ class RunEventCoordinator(ManagerComponent):
         info._shared_provider = provider
         if runtime.pid:
             info._pid = runtime.pid
-            # Same off-loop, drained write as the non-shared spawn path's PID
-            # record (#6288, #7302). Unguarded here as before: this method has no
-            # best-effort contract, so an _atomic_write failure still propagates
-            # to the caller rather than yielding a session with no recorded pid.
             await self._manager._write_state_off_loop(
-                info, "PID record", pid=runtime.pid, pid_recorded_at=time.time()
+                info,
+                "PID record",
+                pid=runtime.pid,
+                pid_recorded_at=time.time(),
+                pid_start_id="",
+                process_owned=False,
             )
         logger.info(
             "Subagent %s using session sharing on runtime PID %s (session %s, key %s)",

--- a/src/kiro_crew/subagent_manager/terminal.py
+++ b/src/kiro_crew/subagent_manager/terminal.py
@@ -13,10 +13,11 @@ if TYPE_CHECKING:
         _RESET_TIMEOUT,
         _TERMINAL_RETRY_SECONDS,
         EXECUTION_LEASE_SECONDS,
+        OUTCOME_INTERRUPTED,
         SUBAGENT_COMPLETION_PREFIX,
         AuthorityOutcomeUncertain,
         CoordinatorDecision,
-        DeliveryState,
+        OwnerLease,
         OutboxEvent,
         RunCompletion,
         RunOutcome,
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
         _timeout_context,
         _ws_result_path,
         asyncio,
-        clear_tombstone,
+        clear_tombstone_for_recovery,
         dashboard_slot_key,
         json,
         logger,
@@ -51,6 +52,93 @@ class TerminalCoordinator(ManagerComponent):
     """Own terminal transitions while state remains facade-owned."""
 
     __slots__ = ()
+
+    async def _coordinator_record_process_impl(
+        self,
+        info: SubagentInfo,
+        process_id: int,
+        process_start_id: str,
+        process_owned: bool,
+    ) -> None:
+        """Persist fenced process identity before it can authorize recovery cleanup."""
+
+        fence = info._coordinator_fence
+        if fence is None:
+            raise RuntimeError("coordinator execution fence is missing")
+        result = await self._manager._coordinator.record_process(
+            info.id,
+            fence,
+            info._coordinator_version,
+            process_id,
+            process_start_id,
+            process_owned,
+        )
+        if result.value is None or result.decision is CoordinatorDecision.REJECTED:
+            raise RuntimeError(f"coordinator process record refused: {result.reason.value}")
+        info._coordinator_version = result.value.version
+        info._coordinator_process_protected = bool(process_owned and process_start_id)
+
+    async def _clear_terminal_process_impl(self, info: SubagentInfo) -> bool:
+        """Release a terminal row's child guard after local teardown succeeds."""
+
+        fence = info._coordinator_fence
+        if fence is None:
+            return False
+        try:
+            result = await self._manager._coordinator.clear_recovered_process(
+                info.id,
+                fence,
+                info._coordinator_version,
+            )
+        except Exception:
+            logger.warning(
+                "Subagent %s terminal process cleanup could not be recorded",
+                info.id,
+                exc_info=True,
+            )
+            return False
+        if result.value is None or result.decision is CoordinatorDecision.REJECTED:
+            logger.warning(
+                "Subagent %s terminal process cleanup refused: %s",
+                info.id,
+                result.reason.value,
+            )
+            return False
+        info._coordinator_version = result.value.version
+        info._coordinator_process_protected = False
+        return True
+
+    async def _record_process_identity_impl(self, info: SubagentInfo, session_key: str) -> None:
+        """Persist protected process identity before any child prompt can run."""
+
+        pid = self._manager._sessions.get_pid(session_key)
+        if not pid:
+            return
+        info._pid = pid
+        pid_start_id = await asyncio.to_thread(platform_compat.process_identity_token, pid)
+        process_owned = bool(pid_start_id)
+        try:
+            await self._manager._write_state_off_loop(
+                info,
+                "PID record",
+                pid=pid,
+                pid_recorded_at=time.time(),
+                pid_start_id=pid_start_id or "",
+                process_owned=process_owned,
+            )
+        except Exception:
+            logger.debug("Failed to mirror PID for %s", info.id, exc_info=True)
+        # `_run_inner` is also a focused unit seam. Only the admitted `_run`
+        # path owns a coordinator fence; that path rejects a missing fence
+        # before reaching this method.
+        if info._coordinator_fence is None:
+            return
+        await self._manager._coordinator_record_process(
+            info,
+            pid,
+            pid_start_id or "",
+            process_owned,
+        )
 
     async def _coordinator_mark_starting_impl(self, info: SubagentInfo) -> None:
         """Acquire the first durable lifecycle transition before child startup."""
@@ -106,6 +194,7 @@ class TerminalCoordinator(ManagerComponent):
         renew_fence = fence
 
         async def _renew() -> None:
+            nonlocal renew_fence
             cadence = EXECUTION_LEASE_SECONDS / 3
             while True:
                 await asyncio.sleep(cadence)
@@ -123,8 +212,31 @@ class TerminalCoordinator(ManagerComponent):
                     )
                     continue
                 if not renewed:
-                    logger.error("Subagent %s lost its coordinator execution lease", info.id)
-                    return
+                    command = info._coordinator_command
+                    replacement = None
+                    if command is not None:
+                        try:
+                            replacement = await self._manager._coordinator.claim_command(
+                                command.command_id,
+                                OwnerLease(
+                                    renew_fence.owner_id,
+                                    time.time() + EXECUTION_LEASE_SECONDS,
+                                ),
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Subagent %s coordinator lease reacquisition failed",
+                                info.id,
+                                exc_info=True,
+                            )
+                    if replacement is None or replacement.fence is None:
+                        logger.error("Subagent %s lost its coordinator execution lease", info.id)
+                        return
+                    info._coordinator_command = replacement.command
+                    info._coordinator_fence = replacement.fence
+                    if replacement.run is not None:
+                        info._coordinator_version = replacement.run.version
+                    renew_fence = replacement.fence
 
         task = asyncio.create_task(_renew())
         self._manager._lease_tasks[info.id] = task
@@ -239,6 +351,8 @@ class TerminalCoordinator(ManagerComponent):
             resolved_model=str(payload.get("resolved_model") or ""),
             requested_model=str(payload.get("requested_model") or ""),
         )
+        if payload.get("outcome") == RunOutcome.INTERRUPTED.value:
+            info._recovered_outcome = OUTCOME_INTERRUPTED
         # Batch progress lives in the gateway's volatile digest state. After a
         # restart, replay each stable event independently instead of inventing
         # a fresh one-member wave from persisted batch labels.
@@ -253,6 +367,12 @@ class TerminalCoordinator(ManagerComponent):
             context = self._manager._outbox_live_contexts.pop(event.run_id, None)
             if context is None:
                 info = self._manager._info_from_outbox(event)
+                live_batch = self._manager._outbox_live_run_batches.pop(event.run_id, None)
+                if live_batch is not None:
+                    info.batch_id, info.batch_total = live_batch
+                uncertain = self._manager._agents.get(event.run_id)
+                if uncertain is not None and uncertain._coordinator_claim_uncertain:
+                    self._manager._agents[event.run_id] = info
                 context = _OutboxDeliveryContext(
                     info=info,
                     source="Subagent outbox",
@@ -419,6 +539,8 @@ class TerminalCoordinator(ManagerComponent):
         mark_delivered_on_success: bool,
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
+        process_stopped: "asyncio.Event | None" = None,
+        tombstone_error_on_success: bool = False,
     ) -> None:
         """Deliver ``info``'s one-shot terminal report as a single unit.
 
@@ -463,7 +585,7 @@ class TerminalCoordinator(ManagerComponent):
                     await self._manager._stop_coordinator_heartbeat(info.id)
                     await self._manager.command_authority.stop_execution_heartbeat(info.id)
                     try:
-                        await asyncio.to_thread(clear_tombstone, info.id)
+                        await asyncio.to_thread(clear_tombstone_for_recovery, info.id)
                     except Exception:
                         logger.debug(
                             "Failed to re-admit stale-fence result %s to recovery",
@@ -483,6 +605,20 @@ class TerminalCoordinator(ManagerComponent):
                 await self._manager.command_authority.stop_execution_heartbeat(info.id)
             if info._reported_to_parent:
                 return
+            if process_stopped is not None:
+                if teardown_done is not None and not teardown_done.is_set():
+                    try:
+                        await asyncio.wait_for(teardown_done.wait(), timeout=_RESET_TIMEOUT + 30)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "Subagent %s teardown did not settle its protected process",
+                            info.id,
+                        )
+                        return
+                if not process_stopped.is_set():
+                    return
+                if not await self._clear_terminal_process_impl(info):
+                    return
             while True:
                 try:
                     attempts = await self._manager._outbox_delivery.drain_once(
@@ -497,7 +633,11 @@ class TerminalCoordinator(ManagerComponent):
                         exc_info=True,
                     )
                 else:
-                    if any(attempt.status is DeliveryState.DELIVERED for attempt in attempts):
+                    # A returned attempt means the fence was durably settled:
+                    # either delivered or released for the periodic outbox
+                    # drainer. The terminal reporter owns only this immediate
+                    # attempt and must not wait through the released lease.
+                    if attempts:
                         return
                     if info._reported_to_parent or info._digest_held or info._delivery_queued:
                         return
@@ -525,7 +665,8 @@ class TerminalCoordinator(ManagerComponent):
                 # Carry the requested pin on the terminal report too, redacted
                 # like the spawn frame: after a reconnect the completed card is
                 # rebuilt from this event alone, so without it the live-downgrade
-                # amber chip would silently vanish from a downgraded finished run.
+                # amber chip would silently vanish from a downgraded finished run
+                # (Opus/Design/First-Principles review on #5326).
                 "requested_model": _redact(info.requested_model),
                 "result": _done_result(info.result),
             },
@@ -534,11 +675,31 @@ class TerminalCoordinator(ManagerComponent):
             return
         try:
             await asyncio.wait_for(self._manager._on_done(info), timeout=_ON_DONE_TIMEOUT)
+            if tombstone_error_on_success and info._delivery_failed:
+                # A synchronous router can exhaust its own retries and return
+                # normally after flagging failure. The shadow fallback has no
+                # durable outbox event, so a tombstone here would suppress the
+                # only remaining delivery owner: restart reconciliation.
+                return
             # The outcome has REACHED the parent. Recorded before any further
             # await so a shutdown cancellation landing in the teardown wait or
             # the tombstone write below is not mistaken for a lost delivery by
             # `cancel_all()` (which would re-deliver it on the next start).
             info._reported_to_parent = True
+            if (
+                tombstone_error_on_success
+                and info.error
+                and not info._delivery_queued
+                and not info._digest_held
+            ):
+                try:
+                    await asyncio.to_thread(self._manager._write_tombstone, info, "error")
+                except Exception:
+                    logger.debug(
+                        "Failed to tombstone reported shadow fallback %s",
+                        info.id,
+                        exc_info=True,
+                    )
             if settle_digest:
                 # _on_done returned without raising, so the wave digest (if this
                 # was the final member) has been handed off. Only NOW settle the
@@ -633,6 +794,8 @@ class TerminalCoordinator(ManagerComponent):
         mark_delivered_on_success: bool,
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
+        process_stopped: "asyncio.Event | None" = None,
+        tombstone_error_on_success: bool = False,
     ) -> None:
         """Spawn the shielded terminal report and block until it completes.
 
@@ -653,6 +816,8 @@ class TerminalCoordinator(ManagerComponent):
                 mark_delivered_on_success=mark_delivered_on_success,
                 settle_digest=settle_digest,
                 teardown_done=teardown_done,
+                process_stopped=process_stopped,
+                tombstone_error_on_success=tombstone_error_on_success,
             )
         )
 
@@ -665,13 +830,15 @@ class TerminalCoordinator(ManagerComponent):
         mark_delivered_on_success: bool,
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
+        process_stopped: "asyncio.Event | None" = None,
+        tombstone_error_on_success: bool = False,
     ) -> "asyncio.Task":  # type: ignore[type-arg]
         """Launch :meth:`_report_terminal` on a strongly-referenced task.
 
         Returns immediately (no ``await``) so the caller can start the report
         BEFORE its own teardown awaits, guaranteeing the report exists and is
         held alive independently of the caller's fate. The task is retained in
-        ``self._report_tasks`` (so it cannot be garbage-collected while its
+        ``self._manager._report_tasks`` (so it cannot be garbage-collected while its
         awaiter is cancelled, and so ``cancel_all()`` can drain it) and
         self-removes on completion.
         """
@@ -684,6 +851,8 @@ class TerminalCoordinator(ManagerComponent):
                 mark_delivered_on_success=mark_delivered_on_success,
                 settle_digest=settle_digest,
                 teardown_done=teardown_done,
+                process_stopped=process_stopped,
+                tombstone_error_on_success=tombstone_error_on_success,
             ),
         )
 

--- a/src/kiro_crew/subagent_manager/waves.py
+++ b/src/kiro_crew/subagent_manager/waves.py
@@ -9,6 +9,7 @@ from ._component import ManagerComponent
 if TYPE_CHECKING:
     from ..subagent import (
         _RESET_TIMEOUT,
+        _SHADOW_SUBMISSION_FAILURE_DETAIL,
         _TERMINAL_RETRY_SECONDS,
         _WAVE_STUCK_SECS,
         DIGEST_HOLD_SECS,
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
         sel,
         time,
         uuid,
+        write_tombstone,
     )
 
 
@@ -62,6 +64,19 @@ class WaveDigestCoordinator(ManagerComponent):
                 return
             await asyncio.sleep(_TERMINAL_RETRY_SECONDS)
 
+    def _write_error_delivery_tombstone_impl(self, agent_id: str) -> None:
+        info = self._manager._agents.get(agent_id)
+        if info is not None:
+            self._manager._write_tombstone(info, "error")
+            return
+        write_tombstone(
+            agent_id,
+            cause="error",
+            recovery_action="pending",
+            outcome="failed",
+            detail=_SHADOW_SUBMISSION_FAILURE_DETAIL,
+        )
+
     def batch_members_pending_impl(self, batch_id: str) -> bool:
         """True while ANY member of *batch_id* is still outstanding — running
         (registered, not done), queued behind the stagger gate (not yet
@@ -75,7 +90,10 @@ class WaveDigestCoordinator(ManagerComponent):
         _bs = self._manager._batch_submitted.get(batch_id)
         if _bs is not None and _bs[1] > 0 and _bs[0] < _bs[1]:
             return True  # submissions still in flight
-        if any(a.batch_id == batch_id and not a.done for a in self._manager._agents.values()):
+        if any(
+            a.batch_id == batch_id and (not a.done or a._coordinator_claim_uncertain)
+            for a in self._manager._agents.values()
+        ):
             return True
         return self._manager._scheduler.contains_batch(batch_id)
 
@@ -312,7 +330,12 @@ class WaveDigestCoordinator(ManagerComponent):
             return
         await self._manager._settle_digest_holds(info)
 
-    async def settle_queued_delivery_impl(self, agent_ids: list[str]) -> None:
+    async def settle_queued_delivery_impl(
+        self,
+        agent_ids: list[str],
+        *,
+        error_tombstone_ids: set[str] | frozenset[str] | None = None,
+    ) -> None:
         """Write the ``delivered`` tombstones for completions consumed from a queue.
 
         The queued-injection path (issue #4839) deliberately leaves a completion
@@ -336,6 +359,8 @@ class WaveDigestCoordinator(ManagerComponent):
         The tombstone write itself is offloaded: it fsyncs, and this runs on the
         gateway event loop.
         """
+        carried_error_ids: frozenset[str] = getattr(agent_ids, "error_tombstone_ids", frozenset())
+        errors = set(error_tombstone_ids if error_tombstone_ids is not None else carried_error_ids)
         for agent_id in agent_ids:
             gate = self._manager._lifecycle.gate_for(agent_id)
             if gate is not None and not gate.is_set():
@@ -348,14 +373,21 @@ class WaveDigestCoordinator(ManagerComponent):
                         agent_id,
                     )
             context = self._manager._delivery_context_for_run(agent_id)
-            if context is None or context.info.outcome == "completed":
+            if agent_id in errors:
+                try:
+                    await asyncio.to_thread(self._manager._write_error_delivery_tombstone, agent_id)
+                except Exception:
+                    logger.debug(
+                        "Failed to mark drained subagent %s failed",
+                        agent_id,
+                        exc_info=True,
+                    )
+            elif context is None or context.info.outcome == "completed":
                 try:
                     await asyncio.to_thread(mark_delivered, agent_id)
                 except Exception:
                     logger.debug(
-                        "Failed to mark drained subagent %s delivered",
-                        agent_id,
-                        exc_info=True,
+                        "Failed to mark drained subagent %s delivered", agent_id, exc_info=True
                     )
             await self._manager._ack_delivery_for_run(agent_id)
 
@@ -379,9 +411,16 @@ class WaveDigestCoordinator(ManagerComponent):
         unwritable run folder must not strand the rest of the chunk.
         """
         ids, info._digest_settle_ids = info._digest_settle_ids, []
+        error_ids = set(info._digest_error_tombstone_ids)
+        info._digest_error_tombstone_ids = []
         for _hid in ids:
             context = self._manager._delivery_context_for_run(_hid)
-            if context is None or context.info.outcome == "completed":
+            if _hid in error_ids:
+                try:
+                    await asyncio.to_thread(self._manager._write_error_delivery_tombstone, _hid)
+                except Exception:
+                    logger.debug("Failed to settle held failed subagent %s", _hid, exc_info=True)
+            elif context is None or context.info.outcome == "completed":
                 try:
                     await asyncio.to_thread(mark_delivered, _hid)
                 except Exception:

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
 from kiro_crew.jsonl_util import rotate_jsonl_at
+from kiro_crew.pinned_fs import PinnedPathRefusal, open_dir_pinned, stat_at, supports_pinned_walk
 from kiro_crew.providers.cleanup import _is_safe_path
 
 logger = logging.getLogger(__name__)
@@ -33,13 +34,17 @@ logger = logging.getLogger(__name__)
 # dashboard/handlers/usage.py is the reference implementation.
 _SUBAGENTS_DIR: Path | None = None
 
+_TOMBSTONE_DIR_FD_SUPPORTED = (
+    supports_pinned_walk() and os.unlink in os.supports_dir_fd and os.stat in os.supports_dir_fd
+)
+
 
 def _subagents_dir() -> Path:
     """Subagents registry directory, resolved against the live data home."""
     return _SUBAGENTS_DIR if _SUBAGENTS_DIR is not None else data_home() / "subagents"
 
 
-def _agent_dir(agent_id: str) -> Path:
+def _validate_agent_id(agent_id: str) -> None:
     if (
         not agent_id
         or agent_id == "."
@@ -49,6 +54,10 @@ def _agent_dir(agent_id: str) -> Path:
         or "\0" in agent_id
     ):
         raise ValueError(f"Invalid agent_id: {agent_id!r}")
+
+
+def _agent_dir(agent_id: str) -> Path:
+    _validate_agent_id(agent_id)
     base = _subagents_dir()
     resolved = (base / agent_id).resolve()
     parent = base.resolve()
@@ -79,10 +88,11 @@ def agent_dir_for_display(agent_id: str) -> Path:
     human or an agent will read and then act on.
 
     Raises the same ``ValueError`` as :func:`_agent_dir` for a rejected
-    ``agent_id`` -- the validation is not duplicated here, it is delegated, so
-    the two cannot drift apart.
+    ``agent_id``. It deliberately validates only the identifier spelling: an
+    I/O caller can pin and reject the directory itself without resolving an
+    attacker-swappable child first.
     """
-    _agent_dir(agent_id)  # validation only; the return value is deliberately unused
+    _validate_agent_id(agent_id)
     return _subagents_dir() / agent_id
 
 
@@ -393,6 +403,72 @@ def clear_tombstone(agent_id: str) -> bool:
         return False
 
 
+def clear_tombstone_for_recovery(agent_id: str) -> bool:
+    """Clear a tombstone and verify orphan recovery can see the agent.
+
+    ``clear_tombstone`` retains its best-effort compatibility contract, whose
+    false result cannot distinguish an already-absent marker from a failed
+    unlink. Recovery handoffs need the stronger postcondition: the marker must
+    be absent after the attempt. Filesystem inspection fails closed because an
+    unreadable marker is not evidence that restart reconciliation can admit it.
+    """
+
+    agent_dir = _agent_dir(agent_id)
+    if _TOMBSTONE_DIR_FD_SUPPORTED:
+        try:
+            dir_fd = open_dir_pinned(agent_dir, what="subagent recovery directory")
+        except (OSError, PinnedPathRefusal):
+            logger.error(
+                "Cannot pin subagent directory for %s; recovery remains blocked",
+                agent_id,
+                exc_info=True,
+            )
+            return False
+        try:
+            try:
+                os.unlink("tombstone.json", dir_fd=dir_fd)
+            except FileNotFoundError:
+                pass
+            if stat_at(dir_fd, "tombstone.json") is None:
+                return True
+        except OSError:
+            logger.error(
+                "Cannot clear tombstone for %s; recovery remains blocked",
+                agent_id,
+                exc_info=True,
+            )
+            return False
+        finally:
+            os.close(dir_fd)
+        logger.error(
+            "Tombstone remains for %s after clearance; recovery remains blocked",
+            agent_id,
+        )
+        return False
+
+    # Windows has no descriptor-relative unlink. Resolve the agent directory
+    # once so deletion and verification at least share one spelling; the
+    # platform cannot provide the stronger POSIX inode pin.
+    tombstone = agent_dir / "tombstone.json"
+    try:
+        tombstone.unlink(missing_ok=True)
+        tombstone.stat()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        logger.error(
+            "Cannot verify tombstone clearance for %s; recovery remains blocked",
+            agent_id,
+            exc_info=True,
+        )
+        return False
+    logger.error(
+        "Tombstone remains for %s after clearance; recovery remains blocked",
+        agent_id,
+    )
+    return False
+
+
 # ── slow-command record (stalled but STILL RUNNING) ──────────────────
 
 
@@ -505,8 +581,12 @@ def prune_stale_tombstones(max_age_days: int = 7, delivered_ttl_secs: int = 3600
                 # Best-effort session cleanup — must not block folder removal
                 try:
                     state = read_state(d.name)
-                    session_id = ts.get("session_id") or (state.get("session_id", "") if state else "")
-                    provider = ts.get("provider") or (state.get("provider", "acp") if state else "acp")
+                    session_id = ts.get("session_id") or (
+                        state.get("session_id", "") if state else ""
+                    )
+                    provider = ts.get("provider") or (
+                        state.get("provider", "acp") if state else "acp"
+                    )
                     cwd = ts.get("cwd") or (state.get("cwd", "") if state else "")
                     # keep=True conversations retain their session files as
                     # resume material for spawn_continue; the conversation

--- a/src/kiro_crew/subagent_scheduler.py
+++ b/src/kiro_crew/subagent_scheduler.py
@@ -103,6 +103,13 @@ class SubagentScheduler:
     def contains_batch(self, batch_id: str) -> bool:
         return any(entry.get("batch_id") == batch_id for entry in self.queue)
 
+    def queued_run_ids(self) -> frozenset[str]:
+        """Return stable run identities still waiting in the local queue."""
+
+        return frozenset(
+            run_id for entry in self.queue if (run_id := str(entry.get("_preassigned_id") or ""))
+        )
+
     def find_conversation(self, conversation_key: str) -> dict[str, Any] | None:
         for entry in self.queue:
             key = str(entry.get("conversation_key") or "") or (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,7 +52,9 @@ if os.name == "nt":
 # ── Hypothesis profiles ─────────────────────────────────────────────────
 # Default (CI): fast iteration.  Run ``HYPOTHESIS_PROFILE=thorough python -m pytest``
 # for deeper coverage.
-settings.register_profile("default", max_examples=20, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+settings.register_profile(
+    "default", max_examples=20, suppress_health_check=[HealthCheck.too_slow], deadline=None
+)
 settings.register_profile("thorough", max_examples=100)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 
@@ -139,11 +141,7 @@ if platform_compat.IS_WINDOWS:
     # bypasses collect_ignore. One file, two readers, no drift.
     _ignore_listfile = os.path.join(os.path.dirname(__file__), "windows-collect-ignore.txt")
     with open(_ignore_listfile, encoding="utf-8") as _fh:
-        collect_ignore = [
-            name
-            for name in (ln.split("#", 1)[0].strip() for ln in _fh)
-            if name
-        ]
+        collect_ignore = [name for name in (ln.split("#", 1)[0].strip() for ln in _fh) if name]
 
 
 def make_escaping_link(inside: pathlib.Path, outside: pathlib.Path) -> str:
@@ -337,9 +335,7 @@ def pytest_handlecrashitem(crashitem, report, sched) -> None:
     _crash_victims.append(str(crashitem))
 
 
-def _format_abandoned_run_report(
-    crashes: list[tuple[str, str]], victims: list[str]
-) -> str:
+def _format_abandoned_run_report(crashes: list[tuple[str, str]], victims: list[str]) -> str:
     """Build the terminal report for a run abandoned after worker crashes.
 
     Wording is deliberately non-causal: worker replacement is routine here
@@ -485,6 +481,23 @@ def _restore_autonudge_singleton():
                 except Exception:  # noqa: BLE001 - teardown must not mask the test result
                     pass
         _an._INSTANCE = inherited
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_run_coordinator(monkeypatch):
+    """Keep unit tests off the bounded production SQLite worker pool.
+
+    Tests that exercise SQLite instantiate that adapter directly. Legacy
+    ``SubagentManager`` tests otherwise share the process-wide two-worker pool,
+    so parallel shards can turn unrelated manager behavior into coordinator
+    submission timeouts.
+    """
+    from kiro_crew.run_coordinator import MemoryRunCoordinator
+
+    monkeypatch.setattr(
+        "kiro_crew.subagent.SQLiteRunCoordinator",
+        MemoryRunCoordinator,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -853,16 +866,29 @@ class MockSlackClient(SlackClientOps):
         self._fetch_message_result: str | None = None
         self._fetch_thread_replies_result: list[dict] = []
 
-    async def post_message(self, channel, text, thread_ts=None, unfurl_links=None, unfurl_media=None):
+    async def post_message(
+        self, channel, text, thread_ts=None, unfurl_links=None, unfurl_media=None
+    ):
         ts = f"{self._next_ts}.000000"
         self._next_ts += 1
         self.actions.append(
-            ("post", {"channel": channel, "text": text, "thread_ts": thread_ts, "ts": ts,
-                      "unfurl_links": unfurl_links, "unfurl_media": unfurl_media})
+            (
+                "post",
+                {
+                    "channel": channel,
+                    "text": text,
+                    "thread_ts": thread_ts,
+                    "ts": ts,
+                    "unfurl_links": unfurl_links,
+                    "unfurl_media": unfurl_media,
+                },
+            )
         )
         return ts
 
-    async def post_blocks(self, channel, blocks, text, thread_ts=None, unfurl_links=None, unfurl_media=None):
+    async def post_blocks(
+        self, channel, blocks, text, thread_ts=None, unfurl_links=None, unfurl_media=None
+    ):
         ts = f"{self._next_ts}.000000"
         self._next_ts += 1
         self.actions.append(
@@ -898,7 +924,18 @@ class MockSlackClient(SlackClientOps):
         return f"D{user_id}"
 
     async def post_ephemeral(self, channel, user_id, text, blocks=None, thread_ts=None):
-        self.actions.append(("ephemeral", {"channel": channel, "user_id": user_id, "text": text, "blocks": blocks, "thread_ts": thread_ts}))
+        self.actions.append(
+            (
+                "ephemeral",
+                {
+                    "channel": channel,
+                    "user_id": user_id,
+                    "text": text,
+                    "blocks": blocks,
+                    "thread_ts": thread_ts,
+                },
+            )
+        )
 
     async def views_publish(self, user_id, view):
         self.actions.append(("views_publish", {"user_id": user_id, "view": view}))
@@ -924,7 +961,9 @@ class MockSlackClient(SlackClientOps):
         )
 
     async def start_stream(self, channel, thread_ts, initial_text=None, team_id=None, user_id=None):
-        if not getattr(self, "_stream_enabled", False) or getattr(self, "_start_stream_fails", False):
+        if not getattr(self, "_stream_enabled", False) or getattr(
+            self, "_start_stream_fails", False
+        ):
             return None
         ts = f"{self._next_ts}.000000"
         self._next_ts += 1
@@ -979,8 +1018,20 @@ class MockSlackClient(SlackClientOps):
         self.actions.append(("fetch_message", {"channel": channel, "ts": ts}))
         return self._fetch_message_result
 
-    async def fetch_thread_replies(self, channel: str, thread_ts: str, limit: int = 200, warn_on_pagination: bool = True) -> list[dict]:
-        self.actions.append(("fetch_thread_replies", {"channel": channel, "thread_ts": thread_ts, "limit": limit, "warn_on_pagination": warn_on_pagination}))
+    async def fetch_thread_replies(
+        self, channel: str, thread_ts: str, limit: int = 200, warn_on_pagination: bool = True
+    ) -> list[dict]:
+        self.actions.append(
+            (
+                "fetch_thread_replies",
+                {
+                    "channel": channel,
+                    "thread_ts": thread_ts,
+                    "limit": limit,
+                    "warn_on_pagination": warn_on_pagination,
+                },
+            )
+        )
         return self._fetch_thread_replies_result
 
 
@@ -1219,9 +1270,7 @@ def healthy_host_memory(monkeypatch: pytest.MonkeyPatch) -> None:
 
     real_check = subagent.check_memory_available
 
-    def _pinned_check(
-        min_gb: float | None = None, path: str | None = None
-    ) -> tuple[bool, float]:
+    def _pinned_check(min_gb: float | None = None, path: str | None = None) -> tuple[bool, float]:
         if path is None:
             return (True, _HEALTHY_AVAILABLE_GB)
         if min_gb is None:

--- a/test/test_handlers_messaging_coverage.py
+++ b/test/test_handlers_messaging_coverage.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 from pathlib import Path
 from types import SimpleNamespace
@@ -28,6 +29,9 @@ from aiohttp import web
 
 import kiro_crew.config.loader as loader
 import kiro_crew.dashboard.handlers.messaging as mod
+import kiro_crew.subagent_persistence as subagent_persistence
+from conftest import requires_symlinks
+from kiro_crew.pinned_fs import supports_pinned_walk
 from kiro_crew.subagent import AGENT_NOT_FOUND_CODE
 
 
@@ -65,6 +69,15 @@ class _Req:
 
 
 _BAD_JSON = ValueError("not json")
+requires_pinned_walk = pytest.mark.skipif(
+    not supports_pinned_walk(),
+    reason="spawn transcript reads require descriptor-pinned traversal",
+)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NONBLOCK"), reason="O_NONBLOCK unavailable")
+def test_spawn_result_opens_are_nonblocking() -> None:
+    assert mod._SPAWN_RESULT_OPEN_FLAGS & os.O_NONBLOCK
 
 
 def _run(handler: Any, req: _Req) -> web.Response:
@@ -618,6 +631,7 @@ class TestApiSpawnStatus:
         req = _Req(_state(subagents=mgr), None, match_info={"agent_id": "a1"})
         assert _run(mod.api_spawn_status, req).status == 404
 
+    @requires_pinned_walk
     def test_disk_fallback_returns_result_and_tombstone_cause(
         self, monkeypatch, tmp_path: Path
     ) -> None:
@@ -631,6 +645,7 @@ class TestApiSpawnStatus:
         mgr.get.return_value = None
         monkeypatch.setattr(mod, "read_state", lambda aid: {"task": "t", "started": 1.0})
         monkeypatch.setattr(mod, "_agent_dir", lambda aid: agent_dir)
+        monkeypatch.setattr(mod, "agent_dir_for_display", lambda aid: agent_dir)
         req = _Req(_state(subagents=mgr), None, match_info={"agent_id": "a1"})
         data = _payload(_run(mod.api_spawn_status, req))
         assert data["done"] is True
@@ -652,6 +667,7 @@ class TestApiSpawnStatus:
         assert data["error"] == "Orphaned (unknown cause)"
         assert data["result"] == "_No result._"
 
+    @requires_pinned_walk
     def test_disk_fallback_paging_adds_result_meta(self, monkeypatch, tmp_path: Path) -> None:
         agent_dir = tmp_path / "a1"
         agent_dir.mkdir()
@@ -660,6 +676,7 @@ class TestApiSpawnStatus:
         mgr.get.return_value = None
         monkeypatch.setattr(mod, "read_state", lambda aid: {"task": "t"})
         monkeypatch.setattr(mod, "_agent_dir", lambda aid: agent_dir)
+        monkeypatch.setattr(mod, "agent_dir_for_display", lambda aid: agent_dir)
         req = _Req(
             _state(subagents=mgr),
             None,
@@ -680,8 +697,12 @@ class TestApiSpawnStatus:
         assert data["turns"] == 2 and data["last_tool"] == "fs_read"
         assert isinstance(data["elapsed"], int)
 
-    def test_done_agent_prefers_full_result_from_disk(self, tmp_path: Path) -> None:
-        result_file = tmp_path / "result.txt"
+    @requires_pinned_walk
+    def test_done_agent_prefers_full_result_from_disk(self, monkeypatch, tmp_path: Path) -> None:
+        agent_dir = tmp_path / "a1"
+        agent_dir.mkdir()
+        monkeypatch.setattr(mod, "agent_dir_for_display", lambda _agent_id: agent_dir)
+        result_file = agent_dir / "result.txt"
         result_file.write_text("full transcript", encoding="utf-8")
         mgr = _mgr()
         mgr.get.return_value = _info(
@@ -699,6 +720,71 @@ class TestApiSpawnStatus:
         )
         req = _Req(_state(subagents=mgr), None, match_info={"agent_id": "a1"})
         assert _payload(_run(mod.api_spawn_status, req))["result"] == "in-memory"
+
+    def test_done_agent_refuses_hardlinked_result_path(self, monkeypatch, tmp_path: Path) -> None:
+        agent_dir = tmp_path / "a1"
+        agent_dir.mkdir()
+        monkeypatch.setattr(mod, "agent_dir_for_display", lambda _agent_id: agent_dir)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("outside secret", encoding="utf-8")
+        result_file = agent_dir / "result.txt"
+        os.link(outside, result_file)
+        mgr = _mgr()
+        mgr.get.return_value = _info(
+            done=True,
+            result="in-memory",
+            result_path=str(result_file),
+        )
+        req = _Req(_state(subagents=mgr), None, match_info={"agent_id": "a1"})
+
+        assert _payload(_run(mod.api_spawn_status, req))["result"] == "in-memory"
+
+    @requires_symlinks
+    def test_done_agent_refuses_linked_result_directory(self, monkeypatch, tmp_path: Path) -> None:
+        subagents = tmp_path / "subagents"
+        subagents.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "result.txt").write_text("outside secret", encoding="utf-8")
+        (subagents / "a1").symlink_to(outside, target_is_directory=True)
+        result_path = subagents / "a1" / "result.txt"
+        monkeypatch.setattr(subagent_persistence, "_SUBAGENTS_DIR", subagents)
+        mgr = _mgr()
+        mgr.get.return_value = _info(
+            done=True,
+            result="in-memory",
+            result_path=str(result_path),
+        )
+        req = _Req(_state(subagents=mgr), None, match_info={"agent_id": "a1"})
+
+        assert _payload(_run(mod.api_spawn_status, req))["result"] == "in-memory"
+
+    @requires_symlinks
+    @requires_pinned_walk
+    def test_done_agent_reads_result_through_linked_home_spelling(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        real_subagents = tmp_path / "real" / "subagents"
+        agent_dir = real_subagents / "a1"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "result.txt").write_text("full transcript", encoding="utf-8")
+        declared_subagents = tmp_path / "declared-subagents"
+        declared_subagents.symlink_to(real_subagents, target_is_directory=True)
+        declared_agent_dir = declared_subagents / "a1"
+        monkeypatch.setattr(
+            mod,
+            "agent_dir_for_display",
+            lambda _agent_id: declared_agent_dir,
+        )
+        mgr = _mgr()
+        mgr.get.return_value = _info(
+            done=True,
+            result="in-memory",
+            result_path=str(declared_agent_dir / "result.txt"),
+        )
+        req = _Req(_state(subagents=mgr), None, match_info={"agent_id": "a1"})
+
+        assert _payload(_run(mod.api_spawn_status, req))["result"] == "full transcript"
 
 
 # ── api_spawn_list / retry / delete / clear ──

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -1426,6 +1426,27 @@ class TestProcessStartTime:
         assert pc.process_start_time(os.getpid())
 
 
+class TestProcessIdentityToken:
+    def test_linux_token_includes_boot_identity(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "process_start_time", lambda _pid: "12345")
+        monkeypatch.setattr(pc, "_linux_boot_id", lambda: "boot-aaaa")
+
+        assert pc.process_identity_token(4321) == "v1:linux:12345:boot-aaaa"
+
+    def test_darwin_token_uses_locale_independent_microtime(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "_darwin_process_start_microtime", lambda _pid: "1724500000.000042")
+
+        assert pc.process_identity_token(4321) == "v1:darwin:1724500000.000042"
+
+    def test_alias_prone_platform_has_no_durable_token(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "freebsd14")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+
+        assert pc.process_identity_token(4321) is None
+
+
 class TestOwnProcessStartTime:
     """The module-cached self identity the metrics exporter stamps on shards.
 

--- a/test/test_run_coordinator_contract.py
+++ b/test/test_run_coordinator_contract.py
@@ -12,6 +12,7 @@ import kiro_crew.config.paths as paths_mod
 import kiro_crew.run_coordinator.sqlite as sqlite_mod
 import kiro_crew.run_coordinator_anchor as anchor_mod
 from kiro_crew.run_coordinator import (
+    LEGACY_SHADOW_SOURCE_VERSION,
     CommandClaim,
     CommandFence,
     CommandOperation,
@@ -20,6 +21,7 @@ from kiro_crew.run_coordinator import (
     CoordinatorReason,
     DeliveryFence,
     DeliveryState,
+    LegacyRunImport,
     MemoryRunCoordinator,
     ObservedState,
     OwnerLease,
@@ -754,6 +756,110 @@ async def test_command_claim_returns_fence_and_advances_legal_transitions(
 
 
 @pytest.mark.asyncio
+async def test_process_identity_is_fenced_versioned_and_idempotent(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    claim, running = await _claimed_running(coordinator, clock)
+
+    recorded = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        running.version,
+        4321,
+        "start-1",
+        True,
+    )
+    assert recorded.decision is CoordinatorDecision.APPLIED
+    assert recorded.value is not None
+    assert recorded.value.process_id == 4321
+    assert recorded.value.process_start_id == "start-1"
+    assert recorded.value.process_owned is True
+    assert recorded.value.version == running.version + 1
+
+    replay = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        recorded.value.version,
+        4321,
+        "start-1",
+        True,
+    )
+    stale = await coordinator.record_process(
+        "run-1",
+        type(claim.fence)(run_id="run-1", owner_id="other", lease_epoch=1),
+        recorded.value.version,
+        9999,
+        "forged",
+        True,
+    )
+    missing_identity = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        recorded.value.version,
+        9999,
+        "",
+        True,
+    )
+
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+    assert stale.reason is CoordinatorReason.STALE_FENCE
+    assert missing_identity.reason is CoordinatorReason.INVALID_TRANSITION
+    assert await coordinator.get_run("run-1") == recorded.value
+
+
+@pytest.mark.asyncio
+async def test_process_identity_resynchronizes_one_committed_write(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    claim, running = await _claimed_running(coordinator, clock)
+
+    recorded = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        running.version,
+        4321,
+        "start-1",
+        True,
+    )
+    assert recorded.value is not None
+
+    replay = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        running.version,
+        4321,
+        "start-1",
+        True,
+    )
+    replacement = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        running.version,
+        8765,
+        "start-2",
+        True,
+    )
+    too_stale = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        running.version,
+        9999,
+        "start-3",
+        True,
+    )
+
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+    assert replay.value == recorded.value
+    assert replacement.decision is CoordinatorDecision.REJECTED
+    assert replacement.reason is CoordinatorReason.VERSION_CONFLICT
+    assert too_stale.decision is CoordinatorDecision.REJECTED
+    assert too_stale.reason is CoordinatorReason.VERSION_CONFLICT
+    assert await coordinator.get_run("run-1") == recorded.value
+
+
+@pytest.mark.asyncio
 async def test_version_and_execution_fences_reject_without_mutation(
     coordinator: RunCoordinator,
     clock: FakeClock,
@@ -1098,6 +1204,65 @@ async def test_release_outbox_rejects_non_finite_retry_deadline(
 
 
 @pytest.mark.asyncio
+async def test_outbox_claim_waits_for_terminal_process_cleanup(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    claim, running = await _claimed_running(coordinator, clock)
+    recorded = await coordinator.record_process(
+        running.run_id,
+        claim.fence,
+        running.version,
+        process_id=4321,
+        process_start_id="same",
+        process_owned=True,
+    )
+    assert recorded.value is not None
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id=running.run_id,
+            outcome=RunOutcome.COMPLETED,
+            result_path="/tmp/result.txt",
+            error="",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"summary":"done"}',
+            terminal_at=clock.value,
+        ),
+        claim.fence,
+        expected_version=recorded.value.version,
+    )
+    assert completed.value is not None
+
+    blocked = await coordinator.claim_outbox(
+        OwnerLease(owner_id="gateway-1", lease_expires_at=clock.value + 5),
+        limit=1,
+    )
+
+    assert blocked == []
+    clock.value += 31
+    recovery_claims = await coordinator.claim_recovery(
+        OwnerLease(owner_id="recovery", lease_expires_at=clock.value + 30),
+        limit=1,
+    )
+    assert len(recovery_claims) == 1
+    recovery_claim = recovery_claims[0]
+    cleared = await coordinator.clear_recovered_process(
+        recovery_claim.run.run_id,
+        recovery_claim.fence,
+        recovery_claim.run.version,
+    )
+    assert cleared.value is not None
+
+    released = await coordinator.claim_outbox(
+        OwnerLease(owner_id="gateway-1", lease_expires_at=clock.value + 5),
+        limit=1,
+    )
+
+    assert len(released) == 1
+
+
+@pytest.mark.asyncio
 async def test_claim_limits_and_order_are_deterministic(
     coordinator: RunCoordinator,
     clock: FakeClock,
@@ -1269,17 +1434,55 @@ async def test_transition_uses_one_clock_sample_for_fence_and_timestamp() -> Non
 
 @pytest.mark.asyncio
 async def test_claim_commands_skips_orphaned_command_without_partial_failure(
-    coordinator: RunCoordinator,
     clock: FakeClock,
 ) -> None:
-    memory = coordinator
-    assert isinstance(memory, MemoryRunCoordinator)
+    memory = MemoryRunCoordinator(clock=clock)
     await memory.submit(_request())
     memory._runs.pop("run-1")
 
     claims = await memory.claim_commands(OwnerLease("gateway-1", clock.value + 10), limit=1)
 
     assert claims == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal", [False, True])
+async def test_execution_claim_does_not_steal_a_live_or_terminal_run(
+    clock: FakeClock,
+    terminal: bool,
+) -> None:
+    memory = MemoryRunCoordinator(clock=clock)
+    await memory.submit(_request())
+    first = (await memory.claim_commands(OwnerLease("gateway-1", clock.value + 30), limit=1))[0]
+    if terminal:
+        starting = await memory.mark_starting(first.command, first.fence, first.run.version)
+        assert starting.value is not None
+        running = await memory.mark_running("run-1", first.fence, starting.value.version)
+        assert running.value is not None
+        completed = await memory.complete(
+            RunCompletion(
+                run_id="run-1",
+                outcome=RunOutcome.COMPLETED,
+                result_path="",
+                error="",
+                event_type="subagent_completion",
+                destination="dashboard:parent",
+                payload_json="{}",
+                terminal_at=clock.value,
+            ),
+            first.fence,
+            running.value.version,
+        )
+        assert completed.value is not None
+    memory._commands["command-1"] = replace(
+        memory._commands["command-1"], status=CommandStatus.PENDING
+    )
+    before = await memory.get_run("run-1")
+
+    reclaimed = await memory.claim_command("command-1", OwnerLease("gateway-2", clock.value + 30))
+
+    assert reclaimed is None
+    assert await memory.get_run("run-1") == before
 
 
 @pytest.mark.asyncio
@@ -1486,3 +1689,224 @@ async def test_terminal_record_rejects_conflicting_replay(
     assert created.decision is CoordinatorDecision.APPLIED
     assert conflict.decision is CoordinatorDecision.REJECTED
     assert conflict.reason is CoordinatorReason.OUTCOME_CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_legacy_import_and_recovery_claim_are_idempotent_and_fenced(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    request = LegacyRunImport(
+        run_id="legacy-1",
+        parent_session="dashboard:parent",
+        agent="kirocrew",
+        task="old work",
+        conversation_key="",
+        observed_state=ObservedState.RUNNING,
+        outcome=None,
+        result_path="/tmp/result.txt",
+        error="",
+        created_at=10.0,
+        updated_at=20.0,
+        terminal_at=None,
+        source_version="legacy-state-v1",
+    )
+
+    created = await coordinator.import_legacy(request)
+    replay = await coordinator.import_legacy(request)
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery-1", clock.value + 10),
+        1,
+    )
+
+    assert created.decision is CoordinatorDecision.APPLIED
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+    assert len(claims) == 1
+    assert claims[0].run.source_version == "legacy-state-v1"
+    assert claims[0].fence.lease_epoch == 1
+    assert (
+        await coordinator.claim_recovery(
+            OwnerLease("recovery-2", clock.value + 20),
+            1,
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_claims_terminal_run_with_owned_process_until_cleanup(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    claim, running = await _claimed_running(coordinator, clock)
+    recorded = await coordinator.record_process(
+        "run-1",
+        claim.fence,
+        running.version,
+        4321,
+        "start-1",
+        True,
+    )
+    assert recorded.value is not None
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id="run-1",
+            outcome=RunOutcome.COMPLETED,
+            result_path="/tmp/result.txt",
+            error="",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"id":"run-1"}',
+            terminal_at=clock.value,
+        ),
+        claim.fence,
+        recorded.value.version,
+    )
+    assert completed.value is not None
+    terminal_version = completed.value.run_version
+    clock.value += 31
+
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", clock.value + 10),
+        1,
+    )
+
+    assert len(claims) == 1
+    assert claims[0].run.observed_state is ObservedState.TERMINAL
+    assert claims[0].run.outcome is RunOutcome.COMPLETED
+    assert claims[0].run.version == terminal_version
+    assert claims[0].run.process_owned is True
+
+    cleared = await coordinator.clear_recovered_process(
+        "run-1",
+        claims[0].fence,
+        claims[0].run.version,
+    )
+    replay = await coordinator.clear_recovered_process(
+        "run-1",
+        claims[0].fence,
+        claims[0].run.version,
+    )
+
+    assert cleared.decision is CoordinatorDecision.APPLIED
+    assert cleared.value is not None
+    assert cleared.value.observed_state is ObservedState.TERMINAL
+    assert cleared.value.outcome is RunOutcome.COMPLETED
+    assert cleared.value.process_id == 0
+    assert cleared.value.process_start_id == ""
+    assert cleared.value.process_owned is False
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_claim_a_pending_execution_submission(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    submitted = await coordinator.submit(_request())
+    assert submitted.value is not None
+
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery-1", clock.value + 10),
+        1,
+    )
+
+    assert claims == []
+    command = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("gateway-1", clock.value + 10),
+    )
+    assert command is not None
+
+
+@pytest.mark.asyncio
+async def test_recovery_defers_a_fresh_pending_legacy_shadow_submission(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    submitted = await coordinator.submit(
+        replace(_request(), source_version=LEGACY_SHADOW_SOURCE_VERSION)
+    )
+    assert submitted.value is not None
+
+    fresh_claims = await coordinator.claim_recovery(
+        OwnerLease("recovery-1", clock.value + 10),
+        1,
+    )
+    clock.value += 61.0
+    stale_claims = await coordinator.claim_recovery(
+        OwnerLease("recovery-2", clock.value + 10),
+        1,
+    )
+
+    assert fresh_claims == []
+    assert [claim.run.run_id for claim in stale_claims] == ["run-1"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_terminal_import_preserves_delivery_state(
+    coordinator: RunCoordinator,
+) -> None:
+    imported = await coordinator.import_legacy(
+        LegacyRunImport(
+            run_id="legacy-terminal",
+            parent_session="dashboard:parent",
+            agent="kirocrew",
+            task="old work",
+            conversation_key="",
+            observed_state=ObservedState.TERMINAL,
+            outcome=RunOutcome.INTERRUPTED,
+            result_path="/tmp/result.txt",
+            error="gateway restart",
+            created_at=10.0,
+            updated_at=20.0,
+            terminal_at=20.0,
+            source_version="legacy-state-v1",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"id":"legacy-terminal"}',
+            delivery_state=DeliveryState.PENDING,
+        )
+    )
+
+    assert imported.value is not None
+    assert imported.value.event is not None
+    assert imported.value.event.status is DeliveryState.PENDING
+
+
+@pytest.mark.asyncio
+async def test_legacy_import_retains_result_evidence_without_terminalizing_existing_run(
+    coordinator: RunCoordinator,
+) -> None:
+    submitted = await coordinator.submit(_request(run_id="shadow-run"))
+    assert submitted.value is not None
+
+    imported = await coordinator.import_legacy(
+        LegacyRunImport(
+            run_id="shadow-run",
+            parent_session="dashboard:parent",
+            agent="researcher",
+            task="compare the candidates",
+            conversation_key="",
+            observed_state=ObservedState.TERMINAL,
+            outcome=RunOutcome.INTERRUPTED,
+            result_path="/tmp/shadow-run/result.txt",
+            error="agent-written tombstone",
+            created_at=10.0,
+            updated_at=20.0,
+            terminal_at=20.0,
+            source_version="legacy-state-v1",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"id":"shadow-run"}',
+            delivery_state=DeliveryState.PENDING,
+        )
+    )
+
+    assert imported.decision is CoordinatorDecision.APPLIED
+    assert imported.value is not None
+    assert imported.value.run.observed_state is ObservedState.ACCEPTED
+    assert imported.value.run.outcome is None
+    assert imported.value.run.error == ""
+    assert imported.value.run.result_path == "/tmp/shadow-run/result.txt"
+    assert imported.value.event is None

--- a/test/test_run_coordinator_delivery.py
+++ b/test/test_run_coordinator_delivery.py
@@ -17,6 +17,7 @@ from kiro_crew.run_coordinator import (
     CoordinatorReason,
     CoordinatorResult,
     DeliveryState,
+    LegacyImportReport,
     MemoryRunCoordinator,
     OwnerLease,
     RunCompletion,
@@ -27,6 +28,7 @@ from kiro_crew.run_coordinator import (
 from kiro_crew.run_coordinator.delivery import DeliveryAttempt, OutboxDeliveryAdapter
 from kiro_crew.subagent import SubagentInfo, SubagentManager, _OutboxDeliveryRetry
 from kiro_crew.subagent_command_authority import AdmittedExecution
+from kiro_crew.subagent_persistence import create_agent_folder, write_result_chunk
 
 
 class _Clock:
@@ -85,7 +87,10 @@ async def test_terminal_report_stops_after_permanent_fence_rejection(
 ) -> None:
     manager, info, _event = terminal_retry_manager
     cleared: list[str] = []
-    monkeypatch.setattr("kiro_crew.subagent.clear_tombstone", cleared.append)
+    monkeypatch.setattr(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        lambda agent_id: (cleared.append(agent_id), True)[1],
+    )
     manager._coordinator.complete = AsyncMock(
         return_value=CoordinatorResult(
             CoordinatorDecision.REJECTED,
@@ -901,6 +906,9 @@ async def test_reaper_retries_pending_completion_delivery(monkeypatch) -> None:
         coordinator=coordinator,
     )
     manager._conv_registry_rebuilt = True
+    manager._legacy_run_importer.import_all = AsyncMock(  # type: ignore[method-assign]
+        return_value=LegacyImportReport()
+    )
     monkeypatch.setattr("kiro_crew.subagent.compact_cost_log", MagicMock())
     monkeypatch.setattr(manager, "_sweep_stuck_waves", MagicMock())
     monkeypatch.setattr(manager, "_sweep_digest_holds", MagicMock())
@@ -1415,6 +1423,26 @@ async def test_digest_held_failed_event_acks_without_legacy_delivered_tombstone(
 
     assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
     assert marked == []
+
+
+@pytest.mark.asyncio
+async def test_digest_held_shadow_fallback_keeps_error_tombstone(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
+    info = SubagentInfo(id="legacy-fallback", task="task", done=True)
+    info.error = "coordinator submission failed"
+    create_agent_folder(info.id, task=info.task, parent_session="dashboard:parent")
+    write_result_chunk(info.id, "partial result")
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    manager._agents[info.id] = info
+
+    flusher = SubagentInfo(id="flush", task="flush", done=True)
+    flusher._digest_settle_ids = [info.id]
+    flusher._digest_error_tombstone_ids = [info.id]
+    await manager._settle_digest_holds(flusher)
+
+    tombstone = json.loads((tmp_path / info.id / "tombstone.json").read_text(encoding="utf-8"))
+    assert tombstone["cause"] == "error"
+    assert tombstone["outcome"] == "failed"
 
 
 @pytest.mark.asyncio

--- a/test/test_run_coordinator_recovery.py
+++ b/test/test_run_coordinator_recovery.py
@@ -1,0 +1,1335 @@
+"""Coordinator-first restart recovery and legacy import contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from conftest import requires_symlinks
+from kiro_crew import platform_compat
+from kiro_crew.run_coordinator import (
+    CommandOperation,
+    CoordinatorDecision,
+    MemoryRunCoordinator,
+    ObservedState,
+    OwnerLease,
+    RunOutcome,
+    SubmitRun,
+)
+from kiro_crew.run_coordinator import legacy as legacy_module
+from kiro_crew.run_coordinator.delivery import OutboxDeliveryAdapter
+from kiro_crew.run_coordinator.legacy import LegacyRunImporter
+from kiro_crew.run_coordinator.recovery import RunRecovery
+
+requires_pinned_tree_walk = pytest.mark.skipif(
+    not legacy_module.supports_pinned_tree_walk(),
+    reason="legacy import requires descriptor-pinned tree traversal",
+)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NONBLOCK"), reason="O_NONBLOCK unavailable")
+def test_legacy_file_opens_are_nonblocking() -> None:
+    assert legacy_module._FILE_OPEN_FLAGS & os.O_NONBLOCK
+
+
+@pytest.mark.asyncio
+async def test_legacy_import_skips_when_pinned_tree_walk_is_unavailable(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _legacy_state(tmp_path, "unsupported1")
+    coordinator = MemoryRunCoordinator()
+    monkeypatch.setattr(legacy_module, "supports_pinned_tree_walk", lambda: False)
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report == legacy_module.LegacyImportReport()
+    assert await coordinator.get_run("unsupported1") is None
+
+
+def _write_json(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True), encoding="utf-8")
+
+
+def _legacy_state(root: Path, run_id: str, **fields: object) -> Path:
+    folder = root / run_id
+    _write_json(
+        folder / "state.json",
+        {
+            "id": run_id,
+            "task": "recover this work",
+            "agent": "kirocrew",
+            "parent_session": "dashboard:default",
+            "started": 10.0,
+            "updated_at": 20.0,
+            "status": "running",
+            "pid": None,
+            **fields,
+        },
+    )
+    return folder
+
+
+async def _record_protected_process(
+    coordinator: MemoryRunCoordinator,
+    clock: list[float],
+    run_id: str,
+    process_id: int,
+    process_start_id: str,
+    *,
+    process_owned: bool = True,
+) -> None:
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id=run_id,
+            command_id=f"command-{run_id}",
+            idempotency_key=f"key-{run_id}",
+            payload_hash=f"hash-{run_id}",
+            parent_session="dashboard:default",
+            agent="kirocrew",
+            task="recover this work",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        f"command-{run_id}",
+        OwnerLease("executor", clock[0] + 10.0),
+    )
+    assert claim is not None
+    starting = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        claim.run.version,
+    )
+    assert starting.value is not None
+    running = await coordinator.mark_running(run_id, claim.fence, starting.value.version)
+    assert running.value is not None
+    recorded = await coordinator.record_process(
+        run_id,
+        claim.fence,
+        running.value.version,
+        process_id,
+        process_start_id,
+        process_owned,
+    )
+    assert recorded.value is not None
+    clock[0] += 11.0
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_is_idempotent_and_leaves_files_byte_identical(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    _legacy_state(tmp_path, "running1", keep=True)
+    delivered = _legacy_state(tmp_path, "done1")
+    (delivered / "result.txt").write_text("finished", encoding="utf-8")
+    _write_json(
+        delivered / "tombstone.json",
+        {
+            "id": "done1",
+            "cause": "delivered",
+            "recovery_action": "delivered",
+            "died": 30.0,
+            "result_available": True,
+            "result_path": str(delivered / "result.txt"),
+        },
+    )
+    before = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    importer = LegacyRunImporter(coordinator, root=tmp_path, clock=lambda: clock[0])
+    first = await importer.import_all()
+    second = await importer.import_all()
+
+    assert first.imported == 2
+    assert second.imported == 0
+    assert second.existing == 2
+    assert await coordinator.get_run("running1") is not None
+    terminal = await coordinator.get_run("done1")
+    assert terminal is not None
+    assert terminal.observed_state is ObservedState.TERMINAL
+    assert terminal.outcome is RunOutcome.COMPLETED
+    after = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_submits_one_coordinator_batch_per_scan(tmp_path):
+    coordinator = MemoryRunCoordinator()
+    coordinator.import_legacy_batch = AsyncMock(  # type: ignore[method-assign]
+        wraps=coordinator.import_legacy_batch
+    )
+    for index in range(20):
+        _legacy_state(tmp_path, f"run-{index}")
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.imported == 20
+    coordinator.import_legacy_batch.assert_awaited_once()
+    requests = coordinator.import_legacy_batch.await_args.args[0]
+    assert len(requests) == 20
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_skips_locally_active_run_ids(tmp_path):
+    coordinator = MemoryRunCoordinator()
+    _legacy_state(tmp_path, "active")
+    _legacy_state(tmp_path, "orphan")
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all(
+        exclude_run_ids=frozenset({"active"})
+    )
+
+    assert report.imported == 1
+    assert await coordinator.get_run("active") is None
+    assert await coordinator.get_run("orphan") is not None
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_process_metadata_never_authorizes_termination(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    _legacy_state(
+        tmp_path,
+        "failed-live",
+        pid=4321,
+        pid_start_id="same",
+        process_owned=True,
+    )
+    importer = LegacyRunImporter(coordinator, root=tmp_path, clock=lambda: clock[0])
+    imported = await importer.import_all()
+    run = await coordinator.get_run("failed-live")
+
+    assert imported.imported == 1
+    assert run is not None
+    assert run.observed_state is ObservedState.RUNNING
+    assert run.outcome is None
+    assert run.process_id == 0
+    assert run.process_owned is False
+
+    terminated: list[int] = []
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=terminated.append,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    recovered = await coordinator.get_run("failed-live")
+
+    assert report.terminated == 0
+    assert report.interrupted == 1
+    assert terminated == []
+    assert recovered is not None
+    assert recovered.outcome is RunOutcome.INTERRUPTED
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_skips_corrupt_and_traversal_like_folders(tmp_path, caplog):
+    bad = tmp_path / "corrupt"
+    bad.mkdir()
+    (bad / "state.json").write_text("{broken", encoding="utf-8")
+    mismatched = _legacy_state(tmp_path, "folder-id")
+    state = json.loads((mismatched / "state.json").read_text(encoding="utf-8"))
+    state["id"] = "../escape"
+    _write_json(mismatched / "state.json", state)
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.corrupt == 2
+    assert report.imported == 0
+    assert "legacy subagent import skipped" in caplog.text
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_rejects_run_id_that_redaction_would_change(tmp_path, caplog):
+    run_id = "AKIA" + "IOSFODNN7EXAMPLE"
+    _legacy_state(tmp_path, run_id)
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.corrupt == 1
+    assert report.imported == 0
+    assert await coordinator.get_run(run_id) is None
+    assert run_id not in caplog.text
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_redacts_and_bounds_routing_metadata(tmp_path):
+    credential = "AKIAIOSFODNN7EXAMPLE"
+    _legacy_state(
+        tmp_path,
+        "bounded-fields",
+        agent="a" * 300 + credential,
+        conversation_key="c" * 600 + credential,
+    )
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.imported == 1
+    run = await coordinator.get_run("bounded-fields")
+    assert run is not None
+    assert len(run.agent) == 200
+    assert len(run.conversation_key) == 500
+    assert credential not in run.agent
+    assert credential not in run.conversation_key
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_skips_deep_json_without_blocking_siblings(tmp_path):
+    deep = tmp_path / "deep-json"
+    deep.mkdir()
+    depth = 2000
+    (deep / "state.json").write_text(
+        "[" * depth + "0" + "]" * depth,
+        encoding="utf-8",
+    )
+    _legacy_state(tmp_path, "good-json")
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.corrupt == 1
+    assert report.imported == 1
+    assert await coordinator.get_run("good-json") is not None
+
+
+@pytest.mark.asyncio
+@requires_symlinks
+@requires_pinned_tree_walk
+async def test_legacy_import_bounds_and_pins_json_reads(tmp_path):
+    import_root = tmp_path / "legacy"
+    import_root.mkdir()
+    oversized = import_root / "oversized"
+    oversized.mkdir()
+    (oversized / "state.json").write_bytes(b" " * (1024 * 1024 + 1))
+
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside = outside_dir / "state.json"
+    _write_json(outside, {"id": "linked"})
+    linked = import_root / "linked"
+    linked.mkdir()
+    (linked / "state.json").symlink_to(outside)
+
+    _legacy_state(import_root, "good-bounded")
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=import_root).import_all()
+
+    assert report.corrupt == 2
+    assert report.imported == 1
+    assert await coordinator.get_run("good-bounded") is not None
+
+
+@pytest.mark.asyncio
+@requires_symlinks
+@requires_pinned_tree_walk
+async def test_legacy_import_accepts_a_symlinked_trusted_data_home(tmp_path, monkeypatch):
+    target_home = tmp_path / "target-home"
+    legacy_root = target_home / "subagents"
+    legacy_root.mkdir(parents=True)
+    _legacy_state(legacy_root, "linked-home-run")
+    configured_home = tmp_path / "configured-home"
+    configured_home.symlink_to(target_home, target_is_directory=True)
+    monkeypatch.setattr(legacy_module, "data_home", lambda: configured_home)
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator).import_all()
+
+    assert report.imported == 1
+    assert await coordinator.get_run("linked-home-run") is not None
+
+
+@pytest.mark.asyncio
+@requires_symlinks
+@requires_pinned_tree_walk
+async def test_legacy_import_rejects_linked_folder_before_directory_probe(tmp_path, monkeypatch):
+    import_root = tmp_path / "legacy"
+    import_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    linked = _legacy_state(import_root, "linked")
+    parked = import_root / "parked"
+    _legacy_state(import_root, "good-local")
+    coordinator = MemoryRunCoordinator()
+    real_is_directory = LegacyRunImporter._is_directory
+
+    def _swap_after_directory_classification(base_fd, name):
+        result = real_is_directory(base_fd, name)
+        if name == "linked" and result:
+            linked.rename(parked)
+            linked.symlink_to(outside, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(
+        LegacyRunImporter,
+        "_is_directory",
+        staticmethod(_swap_after_directory_classification),
+    )
+
+    report = await LegacyRunImporter(coordinator, root=import_root).import_all()
+
+    assert report.imported == 1
+    assert await coordinator.get_run("good-local") is not None
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_closes_pinned_root_off_loop(tmp_path, monkeypatch):
+    _legacy_state(tmp_path, "good-local")
+    coordinator = MemoryRunCoordinator()
+    real_to_thread = asyncio.to_thread
+    close_off_loop = False
+
+    async def _track_to_thread(function, /, *args, **kwargs):
+        nonlocal close_off_loop
+        if function is os.close:
+            close_off_loop = True
+        return await real_to_thread(function, *args, **kwargs)
+
+    monkeypatch.setattr(legacy_module.asyncio, "to_thread", _track_to_thread)
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.imported == 1
+    assert close_off_loop is True
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_skips_non_finite_timestamp_without_blocking_siblings(tmp_path):
+    _legacy_state(tmp_path, "bad-time", started=float("nan"))
+    _legacy_state(tmp_path, "good-time")
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.corrupt == 1
+    assert report.imported == 1
+    assert await coordinator.get_run("bad-time") is None
+    assert await coordinator.get_run("good-time") is not None
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_import_skips_oversized_timestamp_without_blocking_siblings(tmp_path):
+    bad = _legacy_state(tmp_path, "bad-time", started=10**400)
+    _legacy_state(tmp_path, "good-time")
+    before = (bad / "state.json").read_bytes()
+    coordinator = MemoryRunCoordinator()
+
+    report = await LegacyRunImporter(coordinator, root=tmp_path).import_all()
+
+    assert report.corrupt == 1
+    assert report.imported == 1
+    assert await coordinator.get_run("bad-time") is None
+    assert await coordinator.get_run("good-time") is not None
+    assert (bad / "state.json").read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_recovery_takeover_fences_old_owner_without_replaying_command(tmp_path):
+    clock = [10.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run1",
+            command_id="command1",
+            idempotency_key="key1",
+            payload_hash="hash1",
+            parent_session="dashboard:default",
+            agent="kirocrew",
+            task="work",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    old_claim = await coordinator.claim_command("command1", OwnerLease("old", 20.0))
+    assert old_claim is not None
+    clock[0] = 21.0
+    delivered = AsyncMock(return_value=True)
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            delivered,
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+    )
+
+    report = await recovery.reconcile()
+
+    assert report.interrupted == 1
+    run = await coordinator.get_run("run1")
+    assert run is not None
+    assert run.outcome is RunOutcome.INTERRUPTED
+    assert run.lease_epoch == old_claim.fence.lease_epoch + 1
+    stale = await coordinator.complete(
+        recovery.completion_for(run, outcome=RunOutcome.COMPLETED),
+        old_claim.fence,
+        old_claim.run.version,
+    )
+    assert stale.decision is CoordinatorDecision.REJECTED
+    stale_exact = await coordinator.complete(
+        recovery.completion_for(run),
+        old_claim.fence,
+        old_claim.run.version,
+    )
+    assert stale_exact.decision is CoordinatorDecision.REJECTED
+    assert delivered.await_count == 1
+    receipt = await coordinator.get_command_by_key("key1")
+    assert receipt is not None
+    assert receipt.command.attempt == 1
+
+
+@pytest.mark.asyncio
+async def test_recovery_terminates_only_verified_live_child(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    terminated: list[int] = []
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=terminated.append,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+
+    assert report.terminated == 1
+    assert terminated == [4321]
+
+
+@pytest.mark.asyncio
+async def test_recovery_cleans_terminal_child_without_replacing_outcome(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    claim = await coordinator.claim_recovery(OwnerLease("terminal", clock[0] + 10), 1)
+    assert len(claim) == 1
+    completed = await coordinator.complete(
+        RunRecovery(
+            coordinator,
+            OutboxDeliveryAdapter(coordinator, AsyncMock(return_value=True)),
+            clock=lambda: clock[0],
+        ).completion_for(claim[0].run, outcome=RunOutcome.COMPLETED),
+        claim[0].fence,
+        claim[0].run.version,
+    )
+    assert completed.value is not None
+    clock[0] += 11.0
+    delivered = AsyncMock(return_value=True)
+    terminated: list[int] = []
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            delivered,
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=terminated.append,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 0
+    assert report.terminated == 1
+    assert report.delivered == 1
+    assert terminated == [4321]
+    delivered.assert_awaited_once()
+    assert run is not None
+    assert run.observed_state is ObservedState.TERMINAL
+    assert run.outcome is RunOutcome.COMPLETED
+    assert run.process_id == 0
+    assert run.process_start_id == ""
+    assert run.process_owned is False
+
+
+@pytest.mark.asyncio
+async def test_recovery_defers_terminal_delivery_when_child_cleanup_fails(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    claim = await coordinator.claim_recovery(OwnerLease("terminal", clock[0] + 10), 1)
+    assert len(claim) == 1
+    completed = await coordinator.complete(
+        RunRecovery(
+            coordinator,
+            OutboxDeliveryAdapter(coordinator, AsyncMock(return_value=True)),
+            clock=lambda: clock[0],
+        ).completion_for(claim[0].run, outcome=RunOutcome.COMPLETED),
+        claim[0].fence,
+        claim[0].run.version,
+    )
+    assert completed.value is not None
+    clock[0] += 11.0
+    delivered = AsyncMock(return_value=True)
+
+    def refuse_termination(_pid: int) -> None:
+        raise PermissionError("access denied")
+
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            delivered,
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=refuse_termination,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 0
+    assert report.terminated == 0
+    assert report.delivered == 0
+    delivered.assert_not_awaited()
+    assert run is not None
+    assert run.outcome is RunOutcome.COMPLETED
+    assert run.process_owned is True
+
+    clock[0] += 60.0
+    second_report = await recovery.reconcile()
+
+    assert second_report.delivered == 0
+    delivered.assert_not_awaited()
+    leased_run = await coordinator.get_run("live1")
+    assert leased_run is not None
+    assert leased_run.process_owned is True
+
+
+@pytest.mark.asyncio
+async def test_recovery_drains_unrelated_completion_when_terminal_child_cleanup_fails(tmp_path):
+    clock = [100.0]
+    event_ids = iter(("protected-event", "unrelated-event"))
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=event_ids.__next__)
+    await _record_protected_process(coordinator, clock, "protected1", 4321, "same")
+    protected_claim = await coordinator.claim_recovery(OwnerLease("terminal", clock[0] + 10), 1)
+    assert len(protected_claim) == 1
+    completion_factory = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(coordinator, AsyncMock(return_value=True)),
+        clock=lambda: clock[0],
+    )
+    protected = await coordinator.complete(
+        completion_factory.completion_for(
+            protected_claim[0].run,
+            outcome=RunOutcome.COMPLETED,
+        ),
+        protected_claim[0].fence,
+        protected_claim[0].run.version,
+    )
+    assert protected.value is not None
+    clock[0] += 11.0
+
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="unrelated1",
+            command_id="command-unrelated1",
+            idempotency_key="key-unrelated1",
+            payload_hash="hash-unrelated1",
+            parent_session="dashboard:default",
+            agent="kirocrew",
+            task="finish independently",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    unrelated_claim = await coordinator.claim_command(
+        "command-unrelated1",
+        OwnerLease("executor", clock[0] + 10),
+    )
+    assert unrelated_claim is not None
+    starting = await coordinator.mark_starting(
+        unrelated_claim.command,
+        unrelated_claim.fence,
+        unrelated_claim.run.version,
+    )
+    assert starting.value is not None
+    running = await coordinator.mark_running(
+        "unrelated1",
+        unrelated_claim.fence,
+        starting.value.version,
+    )
+    assert running.value is not None
+    unrelated = await coordinator.complete(
+        completion_factory.completion_for(running.value, outcome=RunOutcome.COMPLETED),
+        unrelated_claim.fence,
+        running.value.version,
+    )
+    assert unrelated.value is not None
+    delivered = AsyncMock(return_value=True)
+
+    def refuse_termination(_pid: int) -> None:
+        raise PermissionError("access denied")
+
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            delivered,
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=refuse_termination,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+
+    assert report.delivered == 1
+    delivered.assert_awaited_once()
+    assert delivered.await_args.args[0].run_id == "unrelated1"
+    protected_run = await coordinator.get_run("protected1")
+    assert protected_run is not None
+    assert protected_run.process_owned is True
+
+
+@pytest.mark.asyncio
+async def test_recovery_refuses_termination_when_sel_audit_fails(tmp_path, monkeypatch):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    terminated: list[int] = []
+    audit = MagicMock()
+    audit.log_tool_invocation.side_effect = OSError("audit unavailable")
+    monkeypatch.setattr("kiro_crew.run_coordinator.recovery.sel", lambda: audit)
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=terminated.append,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.terminated == 0
+    assert terminated == []
+    assert run is not None
+    assert run.outcome is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_default_termination_pins_the_recorded_process_identity(
+    tmp_path,
+    monkeypatch,
+):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    calls: list[tuple[int, str, int]] = []
+
+    def pinned_kill(pid: int, start_id: str, sig: int) -> bool:
+        calls.append((pid, start_id, sig))
+        return True
+
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(platform_compat, "kill_process_tree_pinned", pinned_kill)
+    audit = MagicMock()
+    audit_threads: list[int] = []
+    audit.log_tool_invocation.side_effect = lambda **_kwargs: audit_threads.append(
+        threading.get_ident()
+    )
+    event_loop_thread = threading.get_ident()
+    monkeypatch.setattr("kiro_crew.run_coordinator.recovery.sel", lambda: audit)
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+
+    assert report.terminated == 1
+    assert calls == [(4321, "same", platform_compat.SIGKILL)]
+    assert audit_threads
+    assert audit_threads[0] != event_loop_thread
+    audit.log_tool_invocation.assert_called_once_with(
+        session_key="subagent:live1",
+        source="subagent",
+        tool_name="orphan_reconcile_kill",
+        outcome="kill_authorized",
+        metadata={"subagent_id": "live1", "pid": 4321},
+        critical=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_uses_default_pinned_termination_on_posix(
+    tmp_path,
+    monkeypatch,
+):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    pinned_kill = MagicMock(return_value=True)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(platform_compat, "kill_process_tree_pinned", pinned_kill)
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 1
+    assert report.terminated == 1
+    pinned_kill.assert_called_once_with(4321, "same", platform_compat.SIGKILL)
+    assert run is not None
+    assert run.observed_state is ObservedState.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_recovery_never_terminates_a_shared_runtime(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(
+        coordinator,
+        clock,
+        "shared1",
+        4321,
+        "",
+        process_owned=False,
+    )
+    terminated: list[int] = []
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=terminated.append,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+
+    assert report.terminated == 0
+    assert report.interrupted == 1
+    assert terminated == []
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_terminalize_a_child_that_failed_to_terminate(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+
+    def refuse_termination(_pid: int) -> None:
+        raise PermissionError("access denied")
+
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=refuse_termination,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 0
+    assert report.terminated == 0
+    assert run is not None
+    assert run.observed_state is not ObservedState.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_terminalize_when_pinned_kill_loses_identity(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "same")
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=lambda _pid: False,
+        process_identity=lambda _pid: "same",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 0
+    assert report.terminated == 0
+    assert run is not None
+    assert run.observed_state is not ObservedState.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_recovery_preserves_live_child_with_unreadable_identity(tmp_path):
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "old")
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        process_identity=lambda _pid: None,
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 0
+    assert report.terminated == 0
+    assert run is not None
+    assert run.observed_state is not ObservedState.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_recovery_terminalizes_original_child_after_pid_reuse(tmp_path, monkeypatch):
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "v1:linux:old:boot")
+    terminated: list[int] = []
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        terminate_process=terminated.append,
+        process_identity=lambda _pid: "v1:linux:reused:boot",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 1
+    assert report.terminated == 0
+    assert terminated == []
+    assert run is not None
+    assert run.observed_state is ObservedState.TERMINAL
+    assert run.outcome is RunOutcome.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_recovery_preserves_live_child_when_posix_identity_format_drifts(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(coordinator, clock, "live1", 4321, "old-format")
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        process_identity=lambda _pid: "new-format",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 0
+    assert report.terminated == 0
+    assert run is not None
+    assert run.observed_state is not ObservedState.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_recovery_terminalizes_recycled_pid_with_durable_posix_identity(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0], id_factory=lambda: "event-1")
+    await _record_protected_process(
+        coordinator,
+        clock,
+        "live1",
+        4321,
+        "v1:darwin:1724500000.000042",
+    )
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(
+            coordinator,
+            AsyncMock(return_value=True),
+            owner_id="delivery",
+            clock=lambda: clock[0],
+        ),
+        owner_id="recovery",
+        clock=lambda: clock[0],
+        process_identity=lambda _pid: "v1:darwin:1724500001.000042",
+        process_alive=lambda _pid: True,
+    )
+
+    report = await recovery.reconcile()
+    run = await coordinator.get_run("live1")
+
+    assert report.interrupted == 1
+    assert report.terminated == 0
+    assert run is not None
+    assert run.observed_state is ObservedState.TERMINAL
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_legacy_destination_cannot_create_pending_delivery(tmp_path):
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "legacy-event")
+    folder = _legacy_state(tmp_path, "pending1")
+    (folder / "result.txt").write_text("partial", encoding="utf-8")
+    _write_json(
+        folder / "tombstone.json",
+        {
+            "id": "pending1",
+            "cause": "gateway_restart",
+            "recovery_action": "notification_pending",
+            "died": 40.0,
+            "outcome": "interrupted",
+        },
+    )
+    delivered = AsyncMock(return_value=True)
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(coordinator, delivered, owner_id="delivery"),
+        owner_id="recovery",
+    )
+
+    report = await recovery.reconcile(importer=LegacyRunImporter(coordinator, root=tmp_path))
+
+    assert report.imported == 1
+    assert report.interrupted == 0
+    assert report.delivered == 0
+    delivered.assert_not_awaited()
+    imported = await coordinator.get_run("pending1")
+    assert imported is not None
+    assert imported.parent_session == ""
+
+
+@pytest.mark.asyncio
+async def test_real_sleeper_is_terminated_after_restart_takeover(tmp_path):
+    if not platform_compat.IS_WINDOWS:
+        pytest.skip("default identity-pinned termination is available only on Windows")
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        cwd=tmp_path,
+        start_new_session=platform_compat.IS_POSIX,
+        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+    )
+    try:
+        start_id = platform_compat.process_identity_token(process.pid)
+        if start_id is None:
+            pytest.skip("process identity is unavailable on this host")
+        clock = [100.0]
+        coordinator = MemoryRunCoordinator(clock=lambda: clock[0])
+        await _record_protected_process(
+            coordinator,
+            clock,
+            "sleeper1",
+            process.pid,
+            start_id,
+        )
+        recovery = RunRecovery(
+            coordinator,
+            OutboxDeliveryAdapter(
+                coordinator,
+                AsyncMock(return_value=True),
+                owner_id="delivery",
+            ),
+            owner_id="recovery",
+            clock=lambda: clock[0],
+        )
+
+        report = await recovery.reconcile()
+        process.wait(timeout=5)
+
+        assert report.terminated == 1
+        run = await coordinator.get_run("sleeper1")
+        assert run is not None
+        assert run.outcome is RunOutcome.INTERRUPTED
+    finally:
+        if process.poll() is None:
+            try:
+                platform_compat.kill_process_tree(process.pid, platform_compat.SIGKILL)
+            except (OSError, ProcessLookupError, ValueError):
+                pass
+            process.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+@requires_pinned_tree_walk
+async def test_manager_startup_runs_legacy_reaping_before_coordinator_recovery(
+    tmp_path,
+    monkeypatch,
+):
+    from kiro_crew.subagent import SubagentManager
+
+    _legacy_state(tmp_path, "startup1")
+    (tmp_path / "startup1" / "result.txt").write_text("partial result", encoding="utf-8")
+    monkeypatch.setattr("kiro_crew.subagent_persistence._SUBAGENTS_DIR", tmp_path)
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "startup-event")
+    announced = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=announced,
+        coordinator=coordinator,
+    )
+    importer = LegacyRunImporter(coordinator, root=tmp_path)
+    manager._legacy_run_importer = importer
+    manager._run_recovery = RunRecovery(
+        coordinator,
+        manager._outbox_delivery,
+        owner_id="startup-recovery",
+    )
+    fallback = AsyncMock()
+    monkeypatch.setattr(manager, "_reconcile_orphans", fallback)
+
+    await manager._reconcile_startup()
+
+    fallback.assert_awaited_once()
+    announced.assert_awaited_once()
+    info = announced.await_args.args[0]
+    assert info.id == "startup1"
+    assert info.error == "interrupted by gateway restart"
+    assert info.outcome == "interrupted"
+    assert info.result_path == str(tmp_path / "startup1" / "result.txt")
+    run = await coordinator.get_run("startup1")
+    assert run is not None
+    assert run.outcome is RunOutcome.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_manager_startup_fails_closed_when_coordinator_recovery_errors(
+    monkeypatch,
+) -> None:
+    from kiro_crew.subagent import SubagentManager
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    reconcile = AsyncMock(side_effect=OSError("coordinator unavailable"))
+    monkeypatch.setattr(manager._run_recovery, "reconcile", reconcile)
+    legacy_fallback = AsyncMock()
+    monkeypatch.setattr(manager, "_reconcile_orphans", legacy_fallback)
+
+    await manager._reconcile_startup()
+
+    reconcile.assert_awaited_once()
+    legacy_fallback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_manager_recovery_excludes_only_active_and_queued_runs() -> None:
+    from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    active = asyncio.create_task(asyncio.Event().wait())
+    manager._agents["active"] = SubagentInfo(id="active", task="active")
+    manager._agents["retained"] = SubagentInfo(id="retained", task="done", done=True)
+    manager._tasks["active"] = active
+    manager._scheduler.enqueue({"_preassigned_id": "queued"})
+    manager._run_recovery.reconcile = AsyncMock()  # type: ignore[method-assign]
+    manager._reconcile_orphans = AsyncMock()  # type: ignore[method-assign]
+
+    try:
+        await manager._reconcile_startup()
+    finally:
+        active.cancel()
+        await asyncio.gather(active, return_exceptions=True)
+
+    assert manager._run_recovery.reconcile.await_args.kwargs["exclude_run_ids"] == frozenset(
+        {"active", "queued"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_passes_active_run_exclusions_to_legacy_importer(tmp_path) -> None:
+    coordinator = MemoryRunCoordinator()
+    importer = LegacyRunImporter(coordinator, root=tmp_path)
+    importer.import_all = AsyncMock(  # type: ignore[method-assign]
+        return_value=legacy_module.LegacyImportReport()
+    )
+    recovery = RunRecovery(
+        coordinator,
+        OutboxDeliveryAdapter(coordinator, AsyncMock(return_value=True), owner_id="delivery"),
+    )
+    excluded = frozenset({"active", "queued"})
+
+    await recovery.reconcile(importer=importer, exclude_run_ids=excluded)
+
+    importer.import_all.assert_awaited_once_with(exclude_run_ids=excluded)
+
+
+@pytest.mark.asyncio
+async def test_periodic_recovery_retries_legacy_import(monkeypatch) -> None:
+    from kiro_crew.subagent import SubagentManager
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    manager._conv_registry_rebuilt = True
+    manager._run_recovery.reconcile = AsyncMock()  # type: ignore[method-assign]
+    monkeypatch.setattr("kiro_crew.subagent.compact_cost_log", MagicMock())
+    monkeypatch.setattr(manager, "_sweep_stuck_waves", MagicMock())
+    monkeypatch.setattr(manager, "_sweep_digest_holds", MagicMock())
+    monkeypatch.setattr(manager, "_sweep_conversations", MagicMock())
+    monkeypatch.setattr(
+        asyncio,
+        "sleep",
+        AsyncMock(side_effect=[None, asyncio.CancelledError]),
+    )
+    monkeypatch.setattr(
+        asyncio.get_running_loop(),
+        "run_in_executor",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._reaper_loop()
+
+    manager._run_recovery.reconcile.assert_awaited_once_with(
+        importer=manager._legacy_run_importer,
+        exclude_run_ids=frozenset(),
+    )

--- a/test/test_run_coordinator_sqlite.py
+++ b/test/test_run_coordinator_sqlite.py
@@ -17,7 +17,9 @@ import kiro_crew.run_coordinator.sqlite as sqlite_module
 from kiro_crew.run_coordinator import (
     CommandOperation,
     CoordinatorDecision,
+    LegacyRunImport,
     MemoryRunCoordinator,
+    ObservedState,
     ShadowRunCoordinator,
     SQLiteRunCoordinator,
     SubmitRun,
@@ -44,6 +46,44 @@ def _request(
         accepted=True,
         rejection_reason="",
     )
+
+
+def _legacy_request(run_id: str) -> LegacyRunImport:
+    return LegacyRunImport(
+        run_id=run_id,
+        parent_session="dashboard:parent",
+        agent="kirocrew",
+        task="recover",
+        conversation_key="",
+        observed_state=ObservedState.RUNNING,
+        outcome=None,
+        result_path="",
+        error="",
+        created_at=10.0,
+        updated_at=20.0,
+        terminal_at=None,
+        source_version="legacy-state-v1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sqlite_legacy_batch_persists_one_snapshot(tmp_path: Path, monkeypatch) -> None:
+    coordinator = SQLiteRunCoordinator(tmp_path / "coordinator.db")
+    real_save = coordinator._save_memory
+    saves: list[None] = []
+
+    def track_save(connection, memory) -> None:
+        saves.append(None)
+        real_save(connection, memory)
+
+    monkeypatch.setattr(coordinator, "_save_memory", track_save)
+
+    results = await coordinator.import_legacy_batch(
+        tuple(_legacy_request(f"legacy-{index}") for index in range(20))
+    )
+
+    assert all(result.decision is CoordinatorDecision.APPLIED for result in results)
+    assert saves == [None]
 
 
 @pytest.mark.asyncio
@@ -92,7 +132,7 @@ async def test_sqlite_schema_enables_durability_pragmas(tmp_path: Path) -> None:
         inspect_owned_connection
     )
 
-    assert version == ("3",)
+    assert version == ("5",)
     assert journal_mode == "wal"
     assert synchronous == 2
     assert foreign_keys == 1
@@ -179,7 +219,7 @@ async def test_corrupt_database_is_refused_without_deletion(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_v1_database_migrates_to_v3_once(tmp_path: Path) -> None:
+async def test_v1_database_migrates_to_v4_once(tmp_path: Path) -> None:
     path = tmp_path / "coordinator.db"
     coordinator = SQLiteRunCoordinator(path)
     await coordinator.submit(_request())
@@ -214,9 +254,43 @@ async def test_v1_database_migrates_to_v3_once(tmp_path: Path) -> None:
             """)
         connection.execute("DROP TABLE commands")
         connection.execute("ALTER TABLE commands_v1 RENAME TO commands")
+        connection.execute("""
+            CREATE TABLE runs_v1 (
+                run_id TEXT PRIMARY KEY,
+                parent_session TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                task TEXT NOT NULL,
+                conversation_key TEXT NOT NULL,
+                desired_state TEXT NOT NULL,
+                observed_state TEXT NOT NULL,
+                outcome TEXT,
+                result_path TEXT NOT NULL,
+                error TEXT NOT NULL,
+                attempt INTEGER NOT NULL,
+                version INTEGER NOT NULL,
+                owner_id TEXT NOT NULL,
+                lease_expires_at REAL NOT NULL,
+                lease_epoch INTEGER NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                terminal_at REAL
+            )
+            """)
+        connection.execute("""
+            INSERT INTO runs_v1
+            SELECT run_id, parent_session, agent, task, conversation_key,
+                   desired_state, observed_state, outcome, result_path, error,
+                   attempt, version, owner_id, lease_expires_at, lease_epoch,
+                   created_at, updated_at, terminal_at
+            FROM runs
+            """)
+        connection.execute("DROP TABLE runs")
+        connection.execute("ALTER TABLE runs_v1 RENAME TO runs")
         connection.execute("UPDATE metadata SET value = '1' WHERE key = 'schema_version'")
         connection.execute("DELETE FROM metadata WHERE key = 'migration.2.applied_at'")
         connection.execute("DELETE FROM metadata WHERE key = 'migration.3.applied_at'")
+        connection.execute("DELETE FROM metadata WHERE key = 'migration.4.applied_at'")
+        connection.execute("DELETE FROM metadata WHERE key = 'migration.5.applied_at'")
 
     migrated = await SQLiteRunCoordinator(path).submit(_request())
     reopened = await SQLiteRunCoordinator(path).submit(_request())
@@ -228,15 +302,23 @@ async def test_v1_database_migrates_to_v3_once(tmp_path: Path) -> None:
     with sqlite3.connect(path) as connection:
         assert connection.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
-        ).fetchone() == ("3",)
+        ).fetchone() == ("5",)
         assert connection.execute(
             "SELECT COUNT(*) FROM metadata WHERE key = 'migration.2.applied_at'"
         ).fetchone() == (1,)
         assert connection.execute(
             "SELECT COUNT(*) FROM metadata WHERE key = 'migration.3.applied_at'"
         ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM metadata WHERE key = 'migration.4.applied_at'"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM metadata WHERE key = 'migration.5.applied_at'"
+        ).fetchone() == (1,)
         command_columns = {row[1] for row in connection.execute("PRAGMA table_info(commands)")}
         assert {"claim_expires_at", "claim_epoch", "result_json"} <= command_columns
+        run_columns = {row[1] for row in connection.execute("PRAGMA table_info(runs)")}
+        assert {"source_version", "process_id", "process_start_id", "process_owned"} <= run_columns
         assert connection.execute("PRAGMA foreign_key_list(commands)").fetchall() == []
 
 
@@ -267,14 +349,14 @@ async def test_failed_migration_rolls_back_and_can_retry(
     path = tmp_path / "coordinator.db"
     await SQLiteRunCoordinator(path).get_run("missing")
     migrations = sqlite_module._MIGRATIONS
-    monkeypatch.setattr(sqlite_module, "_SCHEMA_VERSION", 4)
+    monkeypatch.setattr(sqlite_module, "_SCHEMA_VERSION", 6)
     monkeypatch.setattr(
         sqlite_module,
         "_MIGRATIONS",
         migrations
         + (
             (
-                4,
+                6,
                 (
                     "CREATE TABLE migration_probe (value TEXT NOT NULL)",
                     "THIS IS NOT SQL",
@@ -289,7 +371,7 @@ async def test_failed_migration_rolls_back_and_can_retry(
     with sqlite3.connect(path) as connection:
         assert connection.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
-        ).fetchone() == ("3",)
+        ).fetchone() == ("5",)
         assert (
             connection.execute(
                 "SELECT name FROM sqlite_master "  # wokeignore:rule=master
@@ -301,13 +383,13 @@ async def test_failed_migration_rolls_back_and_can_retry(
     monkeypatch.setattr(
         sqlite_module,
         "_MIGRATIONS",
-        migrations + ((4, ("CREATE TABLE migration_probe (value TEXT NOT NULL)",)),),
+        migrations + ((6, ("CREATE TABLE migration_probe (value TEXT NOT NULL)",)),),
     )
     await SQLiteRunCoordinator(path).get_run("missing")
     with sqlite3.connect(path) as connection:
         assert connection.execute(
             "SELECT value FROM metadata WHERE key = 'schema_version'"
-        ).fetchone() == ("4",)
+        ).fetchone() == ("6",)
         assert connection.execute(
             "SELECT name FROM sqlite_master "  # wokeignore:rule=master
             "WHERE name = 'migration_probe'"

--- a/test/test_run_coordinator_wiring.py
+++ b/test/test_run_coordinator_wiring.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
+import threading
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,13 +17,22 @@ from kiro_crew.run_coordinator import (
     CoordinatorDecision,
     MemoryRunCoordinator,
     OwnerLease,
+    RunFence,
+    RunOutcome,
     SQLiteRunCoordinator,
+    SubmitRun,
 )
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 from kiro_crew.subagent_command_authority import AuthorityOutcomeUncertain
 
 
-def test_subagent_manager_defaults_to_durable_sqlite_coordinator() -> None:
+def test_subagent_manager_defaults_to_durable_sqlite_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "kiro_crew.subagent.SQLiteRunCoordinator",
+        SQLiteRunCoordinator,
+    )
     manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
     assert isinstance(manager._coordinator, SQLiteRunCoordinator)
 
@@ -35,6 +47,58 @@ def test_subagent_manager_preserves_injected_coordinator_identity() -> None:
     assert manager._coordinator is coordinator
     assert manager.command_authority._coordinator is coordinator
     assert manager.command_authority._manager is manager
+
+
+@pytest.mark.asyncio
+async def test_execution_heartbeat_reacquires_an_expired_command_lease(monkeypatch) -> None:
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0])
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="run-1",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command("command-1", OwnerLease("executor", 101.0))
+    assert claim is not None and claim.fence is not None and claim.run is not None
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="run-1", task="inspect")
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+    reacquired = asyncio.Event()
+    original_claim = coordinator.claim_command
+
+    async def observed_claim(command_id, owner):
+        result = await original_claim(command_id, owner)
+        if result is not None:
+            reacquired.set()
+        return result
+
+    monkeypatch.setattr(coordinator, "claim_command", observed_claim)
+    monkeypatch.setattr("kiro_crew.subagent.EXECUTION_LEASE_SECONDS", 0.03)
+    clock[0] = 102.0
+
+    manager._start_coordinator_heartbeat(info)
+    try:
+        await asyncio.wait_for(reacquired.wait(), timeout=1)
+    finally:
+        await manager._stop_coordinator_heartbeat("run-1")
+
+    assert info._coordinator_fence is not None
+    assert info._coordinator_fence.lease_epoch == claim.fence.lease_epoch + 1
 
 
 @pytest.mark.asyncio
@@ -73,12 +137,9 @@ async def test_accepted_run_is_submitted_after_legacy_admission() -> None:
     assert run is not None
     assert "AKIAIOSFODNN7EXAMPLE" not in run.task
     assert "\ud800" not in run.task
-    claims = await coordinator.claim_commands(
-        owner=OwnerLease(owner_id="test-owner", lease_expires_at=9_999_999_999.0),
-        limit=1,
-    )
-    assert len(claims) == 1
-    command = claims[0].command
+    assert info._coordinator_fence is not None
+    command = info._coordinator_command
+    assert command is not None
     assert command.operation is CommandOperation.SPAWN
     payload = json.loads(command.payload_json)
     assert payload == {
@@ -112,6 +173,10 @@ async def test_accepted_run_is_submitted_after_legacy_admission() -> None:
 async def test_default_shadow_persists_accepted_run(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(
+        "kiro_crew.subagent.SQLiteRunCoordinator",
+        SQLiteRunCoordinator,
+    )
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
 
@@ -122,6 +187,49 @@ async def test_default_shadow_persists_accepted_run(
     )
     assert stored is not None
     assert stored.task == "task"
+
+
+@pytest.mark.asyncio
+async def test_manager_persists_process_identity_through_its_execution_fence() -> None:
+    coordinator = MemoryRunCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    await coordinator.submit(
+        SubmitRun(
+            run_id="process-run",
+            command_id="process-command",
+            idempotency_key="process-key",
+            payload_hash="process-hash",
+            parent_session="parent-1",
+            agent="researcher",
+            task="task",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    claim = await coordinator.claim_command(
+        "process-command",
+        OwnerLease("executor", 9_999_999_999.0),
+    )
+    assert claim is not None
+    info = SubagentInfo(id="process-run", task="task")
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+
+    await manager._coordinator_mark_starting(info)
+    await manager._coordinator_mark_running(info)
+    await manager._coordinator_record_process(info, 4321, "start-1", True)
+
+    stored = await coordinator.get_run("process-run")
+    assert stored is not None
+    assert stored.process_id == 4321
+    assert stored.process_start_id == "start-1"
+    assert stored.process_owned is True
+    assert info._coordinator_version == stored.version
 
 
 @pytest.mark.asyncio
@@ -143,13 +251,11 @@ async def test_continuation_submission_is_stable_and_idempotent() -> None:
     await manager._shadow_submit_accepted_run(info)
     await manager._shadow_submit_accepted_run(info)
 
-    claims = await coordinator.claim_commands(
-        owner=OwnerLease(owner_id="test-owner", lease_expires_at=9_999_999_999.0),
-        limit=2,
-    )
-    assert len(claims) == 1
-    assert claims[0].command.operation is CommandOperation.CONTINUE
-    assert claims[0].command.command_id == "continue:run-2"
+    receipt = await coordinator.get_command_by_key("continue:run-2")
+    assert receipt is not None
+    assert receipt.command.operation is CommandOperation.CONTINUE
+    assert receipt.command.command_id == "continue:run-2"
+    assert info._coordinator_fence is not None
 
 
 @pytest.mark.asyncio
@@ -232,7 +338,7 @@ async def test_running_transition_retries_a_lost_commit_response() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_records_shadow_submission_before_execution() -> None:
+async def test_unfenced_shadow_submission_aborts_before_execution() -> None:
     order: list[str] = []
     coordinator = AsyncMock()
 
@@ -252,22 +358,724 @@ async def test_run_records_shadow_submission_before_execution() -> None:
 
     manager._run_inner = AsyncMock(side_effect=run_inner)
     manager._teardown_run_session = AsyncMock()
-    manager._claim_finalize = MagicMock(return_value=False)
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
 
-    await manager._run(SubagentInfo(id="run-4", task="task"))
+    info = SubagentInfo(id="run-4", task="task")
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        return_value=True,
+    ):
+        await manager._run(info)
 
-    assert order == ["submit", "execute"]
+    assert order == ["submit"]
+    assert info.done is True
+    assert info.error == "run coordinator submission failed after timeout"
+    assert info._legacy_delivery_tombstone is True
+    manager._run_inner.assert_not_awaited()
+    manager._spawn_terminal_report.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_stalled_shadow_submission_does_not_block_legacy_execution() -> None:
-    coordinator = AsyncMock()
-    never_settles = asyncio.Event()
+async def test_slow_shadow_submit_waits_without_cancelling_accepted_run() -> None:
+    class DelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release_submit = asyncio.Event()
+            self.submit_started = asyncio.Event()
+            self.submit_cancelled = False
 
-    async def submit(_request: object) -> None:
-        await never_settles.wait()
+        async def submit(self, request):
+            self.submit_started.set()
+            try:
+                await self.release_submit.wait()
+            except asyncio.CancelledError:
+                self.submit_cancelled = True
+                raise
+            return await super().submit(request)
 
-    coordinator.submit.side_effect = submit
+    coordinator = DelayedSubmitCoordinator()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._fire_event = AsyncMock()
+    info = SubagentInfo(id="late-submit", task="task")
+    manager._agents[info.id] = info
+
+    run_task = asyncio.create_task(manager._run(info))
+    await coordinator.submit_started.wait()
+    await asyncio.sleep(0)
+
+    assert run_task.done() is False
+    assert coordinator.submit_cancelled is False
+    manager._run_inner.assert_not_awaited()
+    manager._fire_event.assert_not_awaited()
+    on_done.assert_not_awaited()
+
+    coordinator.release_submit.set()
+    await run_task
+
+    assert info._coordinator_claim_uncertain is False
+    assert info._coordinator_fence is not None
+    manager._run_inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slow_shadow_submit_failure_reports_one_terminal_failure() -> None:
+    class FailingDelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release_submit = asyncio.Event()
+            self.submit_started = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            await self.release_submit.wait()
+            raise RuntimeError("sqlite write failed")
+
+    coordinator = FailingDelayedSubmitCoordinator()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._fire_event = AsyncMock()
+    info = SubagentInfo(id="failed-late-submit", task="task")
+    manager._agents[info.id] = info
+
+    run_task = asyncio.create_task(manager._run(info))
+    await coordinator.submit_started.wait()
+    await asyncio.sleep(0)
+
+    assert run_task.done() is False
+    on_done.assert_not_awaited()
+
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        return_value=True,
+    ):
+        coordinator.release_submit.set()
+        await run_task
+        if manager._report_tasks:
+            await asyncio.gather(*manager._report_tasks)
+
+    assert info._coordinator_claim_uncertain is False
+    assert info._finalized is True
+    assert info.error == "run coordinator submission failed after timeout"
+    assert info._legacy_delivery_tombstone is True
+    manager._fire_event.assert_awaited_once()
+    on_done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_admission_awaits_coordinator_submit_and_claim() -> None:
+    coordinator = MemoryRunCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="durable-admission-fence", task="task")
+
+    await manager._shadow_submit_accepted_run(info)
+
+    assert info._coordinator_claim_uncertain is False
+    assert info._coordinator_fence is not None
+    assert info._coordinator_command is not None
+
+
+@pytest.mark.asyncio
+async def test_late_shadow_submit_failure_reopens_recovery_off_loop() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="late-shadow-failure", task="task")
+    info._coordinator_claim_uncertain = True
+    manager._claim_finalize = MagicMock(return_value=True)
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
+    clear_threads: list[int] = []
+
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        side_effect=lambda _agent_id: (
+            clear_threads.append(threading.get_ident()),
+            True,
+        )[1],
+    ):
+        settlement = manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+        if inspect.isawaitable(settlement):
+            await settlement
+
+    assert clear_threads
+    assert clear_threads != [threading.get_ident()]
+    assert info._legacy_delivery_tombstone is True
+    manager._spawn_terminal_report.assert_called_once()
+    report_call = manager._spawn_terminal_report.call_args
+    assert report_call.args == (info,)
+    assert report_call.kwargs["tombstone_error_on_success"] is True
+
+
+@pytest.mark.asyncio
+async def test_late_shadow_submit_failure_retries_before_consuming_terminal_claim() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="blocked-shadow-failure", task="task")
+    info._coordinator_claim_uncertain = True
+    events: list[str] = []
+    clear_attempts = 0
+
+    def clear_for_recovery(_agent_id: str) -> bool:
+        nonlocal clear_attempts
+        clear_attempts += 1
+        events.append("clear")
+        return clear_attempts > 1
+
+    async def retry_sleep(_delay: float) -> None:
+        events.append("retry")
+        assert info._coordinator_claim_uncertain is True
+        manager._claim_finalize.assert_not_called()
+
+    manager._claim_finalize = MagicMock(
+        side_effect=lambda _info, **_kwargs: (events.append("finalize"), True)[1]
+    )
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
+
+    with (
+        patch(
+            "kiro_crew.subagent.clear_tombstone_for_recovery",
+            side_effect=clear_for_recovery,
+        ),
+        patch("kiro_crew.subagent.asyncio.sleep", side_effect=retry_sleep) as sleep,
+    ):
+        await manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+
+    assert events == ["clear", "retry", "clear", "finalize"]
+    sleep.assert_awaited_once()
+    assert info._coordinator_claim_uncertain is False
+    assert info._legacy_delivery_tombstone is True
+    manager._claim_finalize.assert_called_once_with(info, supersede_recovery=True)
+    manager._record_cost.assert_called_once_with(info)
+    manager._spawn_terminal_report.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_late_shadow_retry_stops_before_clearing_new_terminal_marker() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="stopped-shadow-retry", task="task")
+    info._coordinator_claim_uncertain = True
+    clear_attempts = 0
+
+    def blocked_clear(_agent_id: str) -> bool:
+        nonlocal clear_attempts
+        clear_attempts += 1
+        assert clear_attempts == 1, "a newer terminal owner must stop tombstone retries"
+        return False
+
+    async def user_stop_wins(_delay: float) -> None:
+        info.done = True
+        info.user_stopped = True
+        info._finalized = True
+
+    manager._spawn_terminal_report = MagicMock()
+    with (
+        patch(
+            "kiro_crew.subagent.clear_tombstone_for_recovery",
+            side_effect=blocked_clear,
+        ),
+        patch("kiro_crew.subagent.asyncio.sleep", side_effect=user_stop_wins),
+    ):
+        await manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+
+    assert clear_attempts == 1
+    assert info.error == ""
+    manager._spawn_terminal_report.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_late_shadow_clear_restores_terminal_marker_when_stop_wins_in_worker() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="stopped-during-shadow-clear", task="task")
+    info._coordinator_claim_uncertain = True
+    clear_started = threading.Event()
+    clear_release = threading.Event()
+
+    def delayed_clear(_agent_id: str) -> bool:
+        clear_started.set()
+        assert clear_release.wait(timeout=2)
+        return True
+
+    manager._write_tombstone = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        side_effect=delayed_clear,
+    ):
+        settlement = asyncio.create_task(
+            manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+        )
+        assert await asyncio.to_thread(clear_started.wait, 2)
+        info.done = True
+        info.user_stopped = True
+        info._finalized = True
+        clear_release.set()
+        await settlement
+
+    assert info.error == ""
+    manager._write_tombstone.assert_called_once_with(info, "cancelled")
+    manager._spawn_terminal_report.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_late_shadow_submit_failure_supersedes_pending_cancel_recovery() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="recovering-shadow-failure", task="task")
+    info._coordinator_claim_uncertain = True
+    info._recovering = True
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
+
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        return_value=True,
+    ):
+        await manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+
+    assert info._finalized is True
+    assert info._recovering is False
+    assert info.done is True
+    assert info.error
+    manager._spawn_terminal_report.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_shadow_settlement_defers_to_launched_cancel_recovery() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="respawned-shadow-failure", task="task")
+    info._coordinator_claim_uncertain = True
+    info._coordinator_shadow_generation = 2
+    info._cancel_retry_used = True
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
+
+    origin_task = asyncio.create_task(asyncio.sleep(0))
+    await origin_task
+    replacement_release = asyncio.Event()
+    replacement_task = asyncio.create_task(replacement_release.wait())
+    manager._tasks[info.id] = replacement_task
+
+    try:
+        with patch(
+            "kiro_crew.subagent.clear_tombstone_for_recovery",
+            return_value=True,
+        ):
+            await manager._resume_legacy_terminal_after_failed_shadow_submit(
+                info,
+                generation=1,
+                origin_task=origin_task,
+            )
+
+        assert info._coordinator_claim_uncertain is True
+        assert info._finalized is False
+        assert info.done is False
+        manager._spawn_terminal_report.assert_not_called()
+    finally:
+        replacement_release.set()
+        await replacement_task
+
+
+@pytest.mark.asyncio
+async def test_cancel_recovery_shadow_attempt_clears_stale_uncertainty_before_execution() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="respawned-shadow-execution", task="task")
+    info._coordinator_claim_uncertain = True
+    info._coordinator_shadow_generation = 1
+    info._coordinator_fence = MagicMock()
+    info._cancel_retry_used = True
+    info._slot_released = True
+    manager._coordinator_mark_starting = AsyncMock()
+    manager._start_coordinator_heartbeat = MagicMock()
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock(return_value=None)
+
+    await manager._run(info)
+
+    assert info._coordinator_shadow_generation == 2
+    assert info._coordinator_claim_uncertain is False
+    manager._run_inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_late_shadow_settlement_defers_when_durable_fence_appears() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="durable-shadow-settlement", task="task")
+    info._coordinator_claim_uncertain = True
+    manager._record_cost = MagicMock()
+    manager._spawn_terminal_report = MagicMock()
+
+    def clear_after_recovery_wins(_agent_id: str) -> bool:
+        info._coordinator_fence = MagicMock()
+        return True
+
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        side_effect=clear_after_recovery_wins,
+    ):
+        await manager._resume_legacy_terminal_after_failed_shadow_submit(info)
+
+    assert info._coordinator_claim_uncertain is True
+    assert info._finalized is False
+    assert info.done is False
+    manager._spawn_terminal_report.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shadow_fallback_tombstones_only_after_parent_report() -> None:
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+    )
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    info = SubagentInfo(id="reported-shadow-fallback", task="task")
+    info.done = True
+    info.error = "coordinator submission failed"
+
+    await manager._report_terminal(
+        info,
+        source="Subagent",
+        injection_timeout_reason="timed out",
+        mark_delivered_on_success=False,
+        tombstone_error_on_success=True,
+    )
+
+    on_done.assert_awaited_once_with(info)
+    assert info._reported_to_parent is True
+    manager._write_tombstone.assert_called_once_with(info, "error")
+
+
+@pytest.mark.asyncio
+async def test_shadow_fallback_defers_tombstone_when_parent_queues() -> None:
+    async def queue_completion(info: SubagentInfo) -> None:
+        info._delivery_queued = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=queue_completion,
+    )
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    info = SubagentInfo(id="queued-shadow-fallback", task="task")
+    info.done = True
+    info.error = "coordinator submission failed"
+
+    await manager._report_terminal(
+        info,
+        source="Subagent",
+        injection_timeout_reason="timed out",
+        mark_delivered_on_success=False,
+        tombstone_error_on_success=True,
+    )
+
+    assert info._reported_to_parent is True
+    manager._write_tombstone.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shadow_fallback_route_failure_stays_recoverable() -> None:
+    async def fail_delivery(info: SubagentInfo) -> None:
+        info._delivery_failed = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=fail_delivery,
+    )
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    manager._settle_digest_holds = AsyncMock()
+    info = SubagentInfo(id="failed-shadow-fallback", task="task")
+    info.done = True
+    info.error = "coordinator submission failed"
+
+    await manager._report_terminal(
+        info,
+        source="Subagent",
+        injection_timeout_reason="timed out",
+        mark_delivered_on_success=False,
+        settle_digest=True,
+        tombstone_error_on_success=True,
+    )
+
+    assert info._reported_to_parent is False
+    manager._write_tombstone.assert_not_called()
+    manager._settle_digest_holds.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_shadow_claim_defers_terminal_delivery_to_recovery() -> None:
+    class DelayedClaimCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            self.now = time.time()
+            super().__init__(clock=lambda: self.now)
+            self.release_claim = asyncio.Event()
+            self.lookup_started = asyncio.Event()
+            self.claim_task: asyncio.Task | None = None
+
+        async def claim_command(self, command_id, owner):
+            async def commit_claim():
+                await self.release_claim.wait()
+                return await super(DelayedClaimCoordinator, self).claim_command(
+                    command_id,
+                    owner,
+                )
+
+            self.claim_task = asyncio.create_task(commit_claim())
+            raise asyncio.TimeoutError
+
+        async def get_command_by_key(self, idempotency_key):
+            self.lookup_started.set()
+            return await super().get_command_by_key(idempotency_key)
+
+    coordinator = DelayedClaimCoordinator()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._fire_event = AsyncMock()
+    info = SubagentInfo(
+        id="late-claim",
+        task="task",
+        batch_id="batch-late",
+        batch_total=2,
+    )
+    manager._agents[info.id] = info
+
+    run_task = asyncio.create_task(manager._run(info))
+    await asyncio.wait_for(coordinator.lookup_started.wait(), timeout=1)
+    await run_task
+    coordinator.release_claim.set()
+    assert coordinator.claim_task is not None
+    await coordinator.claim_task
+
+    receipt = await coordinator.get_command_by_key("spawn:late-claim")
+    assert receipt is not None
+    assert receipt.command.status.value == "claimed"
+    assert info._coordinator_claim_uncertain is True
+    assert info._finalized is False
+    assert manager.batch_members_pending("batch-late") is True
+    manager._run_inner.assert_not_awaited()
+    manager._fire_event.assert_not_awaited()
+    on_done.assert_not_awaited()
+
+    coordinator.now += 1_000
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", coordinator.now + 100),
+        limit=1,
+    )
+    assert len(claims) == 1
+    completion = manager._run_recovery.completion_for(claims[0].run)
+    completed = await coordinator.complete(
+        completion,
+        claims[0].fence,
+        claims[0].run.version,
+    )
+    assert completed.value is not None
+    await manager._outbox_delivery.drain_once()
+
+    manager._fire_event.assert_awaited_once()
+    on_done.assert_awaited_once()
+    delivered = on_done.await_args.args[0]
+    assert delivered.batch_id == "batch-late"
+    assert delivered.batch_total == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_shadow_claim_defers_terminal_delivery_to_recovery() -> None:
+    class FailedClaimCoordinator(MemoryRunCoordinator):
+        async def claim_command(self, command_id, owner):
+            raise OSError("claim unavailable")
+
+    coordinator = FailedClaimCoordinator()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._fire_event = AsyncMock()
+    info = SubagentInfo(id="failed-claim", task="task")
+
+    await manager._run(info)
+
+    receipt = await coordinator.get_command_by_key("spawn:failed-claim")
+    assert receipt is not None
+    assert receipt.command.status.value == "pending"
+    assert info._coordinator_claim_uncertain is True
+    assert info._finalized is False
+    manager._run_inner.assert_not_awaited()
+    manager._fire_event.assert_not_awaited()
+    on_done.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_shadow_claim_resumes_from_stable_committed_fence() -> None:
+    class ClaimBeforeLookupCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release_claim = asyncio.Event()
+            self.claim_task: asyncio.Task | None = None
+
+        async def claim_command(self, command_id, owner):
+            async def commit_claim():
+                await self.release_claim.wait()
+                return await super(ClaimBeforeLookupCoordinator, self).claim_command(
+                    command_id,
+                    owner,
+                )
+
+            self.claim_task = asyncio.create_task(commit_claim())
+            raise asyncio.TimeoutError
+
+        async def get_command_by_key(self, idempotency_key):
+            self.release_claim.set()
+            assert self.claim_task is not None
+            await self.claim_task
+            return await super().get_command_by_key(idempotency_key)
+
+    coordinator = ClaimBeforeLookupCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._claim_finalize = MagicMock(return_value=False)
+    manager._start_coordinator_heartbeat = MagicMock()
+    info = SubagentInfo(id="resolved-claim", task="task")
+
+    await manager._run(info)
+
+    assert info._coordinator_claim_uncertain is False
+    assert info._coordinator_fence is not None
+    assert info._coordinator_fence.owner_id == manager._coordinator_owner_id
+    manager._run_inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_shadow_claim_lookup_cannot_overwrite_replacement_fence() -> None:
+    class DelayedLookupCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lookup_started = asyncio.Event()
+            self.release_lookup = asyncio.Event()
+
+        async def claim_command(self, command_id, owner):
+            await super().claim_command(command_id, owner)
+            raise asyncio.TimeoutError
+
+        async def get_command_by_key(self, idempotency_key):
+            self.lookup_started.set()
+            await self.release_lookup.wait()
+            return await super().get_command_by_key(idempotency_key)
+
+    coordinator = DelayedLookupCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="stale-claim-lookup", task="task")
+    info._coordinator_shadow_generation = 1
+    old_attempt = asyncio.create_task(manager._shadow_submit_accepted_run(info, generation=1))
+    await coordinator.lookup_started.wait()
+
+    replacement_fence = MagicMock()
+    info._coordinator_shadow_generation = 2
+    info._coordinator_fence = replacement_fence
+    coordinator.release_lookup.set()
+    await old_attempt
+
+    assert info._coordinator_fence is replacement_fence
+    assert info._coordinator_claim_uncertain is False
+
+
+@pytest.mark.asyncio
+async def test_replacement_adopts_claim_committed_by_stale_shadow_attempt() -> None:
+    class DelayedFirstClaimCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first_claim_committed = asyncio.Event()
+            self.release_first_claim = asyncio.Event()
+            self.claim_calls = 0
+
+        async def claim_command(self, command_id, owner):
+            self.claim_calls += 1
+            claim = await super().claim_command(command_id, owner)
+            if self.claim_calls == 1:
+                self.first_claim_committed.set()
+                await self.release_first_claim.wait()
+            return claim
+
+    coordinator = DelayedFirstClaimCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="stale-claim-response", task="task")
+    info._coordinator_shadow_generation = 1
+    first_attempt = asyncio.create_task(manager._shadow_submit_accepted_run(info, generation=1))
+    await coordinator.first_claim_committed.wait()
+
+    info._coordinator_shadow_generation = 2
+    replacement_durable = await manager._shadow_submit_accepted_run(info, generation=2)
+
+    assert replacement_durable is True
+    assert info._coordinator_fence is not None
+    assert info._coordinator_fence.owner_id == manager._coordinator_owner_id
+    assert info._coordinator_claim_uncertain is False
+
+    coordinator.release_first_claim.set()
+    await first_attempt
+
+
+@pytest.mark.asyncio
+async def test_slow_shadow_submission_waits_for_durable_admission_before_execution() -> None:
+    class DelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.submit_started = asyncio.Event()
+            self.release_submit = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            await self.release_submit.wait()
+            return await super().submit(request)
+
+    coordinator = DelayedSubmitCoordinator()
     manager = SubagentManager(
         sessions=MagicMock(),
         ctx_builder=MagicMock(),
@@ -277,11 +1085,399 @@ async def test_stalled_shadow_submission_does_not_block_legacy_execution() -> No
     manager._run_inner = AsyncMock()
     manager._teardown_run_session = AsyncMock()
     manager._claim_finalize = MagicMock(return_value=False)
+    manager._start_coordinator_heartbeat = MagicMock()
 
-    with patch("kiro_crew.subagent._SHADOW_SUBMIT_TIMEOUT_SECS", 0):
-        await manager._run(info)
+    run_task = asyncio.create_task(manager._run(info))
+    await coordinator.submit_started.wait()
+    await asyncio.sleep(0)
 
+    assert run_task.done() is False
+    manager._run_inner.assert_not_awaited()
+    assert manager._coordinator_shadow_submits
+
+    coordinator.release_submit.set()
+    await run_task
+
+    receipt = await coordinator.get_command_by_key("spawn:durable-admission")
+    assert receipt is not None
+    assert receipt.command.status.value == "claimed"
+    assert info._coordinator_claim_uncertain is False
     manager._run_inner.assert_awaited_once_with(info, "subagent:durable-admission")
+
+
+@pytest.mark.asyncio
+async def test_user_stop_waits_for_retained_admission_and_reports_once() -> None:
+    class DelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.submit_started = asyncio.Event()
+            self.release_submit = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            await self.release_submit.wait()
+            return await super().submit(request)
+
+    coordinator = DelayedSubmitCoordinator()
+    sessions = MagicMock()
+    sessions.reset = AsyncMock()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    info = SubagentInfo(id="stopped-admission", task="task")
+    manager._agents[info.id] = info
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._start_coordinator_heartbeat = MagicMock()
+    manager._write_tombstone = MagicMock()
+    manager._fire_event = AsyncMock()
+
+    run_task = asyncio.create_task(manager._run(info))
+    manager._tasks[info.id] = run_task
+    await coordinator.submit_started.wait()
+
+    cancel_task = asyncio.create_task(manager.cancel(info.id))
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert cancel_task.done() is False
+    on_done.assert_not_awaited()
+
+    coordinator.release_submit.set()
+    assert await cancel_task is True
+    await asyncio.gather(run_task, return_exceptions=True)
+
+    receipt = await coordinator.get_command_by_key("spawn:stopped-admission")
+    assert receipt is not None
+    assert receipt.run.outcome is RunOutcome.STOPPED
+    manager._run_inner.assert_not_awaited()
+    on_done.assert_awaited_once()
+
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", time.time() + 100),
+        limit=1,
+    )
+    assert claims == []
+
+
+@pytest.mark.asyncio
+async def test_user_stop_resolves_uncertain_claim_before_reporting() -> None:
+    class UncertainClaimCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.claim_calls = 0
+            self.lookup_started = asyncio.Event()
+            self.release_lookup = asyncio.Event()
+
+        async def claim_command(self, command_id, owner):
+            self.claim_calls += 1
+            if self.claim_calls == 1:
+                raise asyncio.TimeoutError
+            return await super().claim_command(command_id, owner)
+
+        async def get_command_by_key(self, idempotency_key):
+            self.lookup_started.set()
+            await self.release_lookup.wait()
+            return await super().get_command_by_key(idempotency_key)
+
+    coordinator = UncertainClaimCoordinator()
+    sessions = MagicMock()
+    sessions.reset = AsyncMock()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    info = SubagentInfo(id="stopped-uncertain-claim", task="task")
+    manager._agents[info.id] = info
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._start_coordinator_heartbeat = MagicMock()
+    manager._write_tombstone = MagicMock()
+    manager._fire_event = AsyncMock()
+
+    run_task = asyncio.create_task(manager._run(info))
+    manager._tasks[info.id] = run_task
+    await coordinator.lookup_started.wait()
+
+    cancel_task = asyncio.create_task(manager.cancel(info.id))
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert cancel_task.done() is False
+    on_done.assert_not_awaited()
+
+    coordinator.release_lookup.set()
+    assert await cancel_task is True
+    await asyncio.gather(run_task, return_exceptions=True)
+
+    receipt = await coordinator.get_command_by_key("spawn:stopped-uncertain-claim")
+    assert receipt is not None
+    assert receipt.run.outcome is RunOutcome.STOPPED
+    assert coordinator.claim_calls == 2
+    manager._run_inner.assert_not_awaited()
+    on_done.assert_awaited_once()
+
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", time.time() + 100),
+        limit=1,
+    )
+    assert claims == []
+
+
+@pytest.mark.asyncio
+async def test_user_stop_can_settle_admission_that_already_returned_uncertain() -> None:
+    class UncertainAdmissionCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.claim_calls = 0
+
+        async def claim_command(self, command_id, owner):
+            self.claim_calls += 1
+            if self.claim_calls == 1:
+                raise asyncio.TimeoutError
+            return await super().claim_command(command_id, owner)
+
+    coordinator = UncertainAdmissionCoordinator()
+    sessions = MagicMock()
+    sessions.reset = AsyncMock()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    info = SubagentInfo(id="stopped-after-uncertain-admission", task="task")
+    manager._agents[info.id] = info
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._start_coordinator_heartbeat = MagicMock()
+    manager._write_tombstone = MagicMock()
+    manager._fire_event = AsyncMock()
+
+    await manager._run(info)
+
+    assert info._coordinator_claim_uncertain is True
+    assert info.done is False
+    assert info.error == ""
+    manager._run_inner.assert_not_awaited()
+    on_done.assert_not_awaited()
+
+    assert await manager.cancel(info.id) is True
+
+    receipt = await coordinator.get_command_by_key("spawn:stopped-after-uncertain-admission")
+    assert receipt is not None
+    assert receipt.run.outcome is RunOutcome.STOPPED
+    assert coordinator.claim_calls == 2
+    on_done.assert_awaited_once()
+
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", time.time() + 100),
+        limit=1,
+    )
+    assert claims == []
+
+
+@pytest.mark.asyncio
+async def test_user_stop_yields_when_recovery_terminalized_uncertain_claim() -> None:
+    now = time.time()
+    coordinator = MemoryRunCoordinator(clock=lambda: now)
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="stopped-after-recovery", task="task")
+    manager._agents[info.id] = info
+
+    assert await manager._shadow_submit_accepted_run(info) is True
+    info._coordinator_fence = None
+    info._coordinator_claim_uncertain = True
+    now += 1_000
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", now + 100),
+        limit=1,
+    )
+    assert len(claims) == 1
+    claim = claims[0]
+    completion = manager._run_recovery.completion_for(claim.run)
+    await coordinator.complete(completion, claim.fence, claim.run.version)
+    manager._force_reap = AsyncMock()
+    manager._fire_event = AsyncMock()
+
+    assert await asyncio.wait_for(manager.cancel(info.id), timeout=1) is True
+
+    assert info._coordinator_claim_uncertain is True
+    manager._force_reap.assert_not_awaited()
+    attempts = await manager._outbox_delivery.drain_once()
+    assert attempts
+    recovered = manager._agents[info.id]
+    assert recovered is not info
+    assert recovered.done is True
+    assert recovered.outcome == "interrupted"
+
+
+@pytest.mark.asyncio
+async def test_user_stop_yields_to_live_recovery_owner() -> None:
+    now = time.time()
+    coordinator = MemoryRunCoordinator(clock=lambda: now)
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="stopped-during-recovery", task="task")
+    manager._agents[info.id] = info
+
+    assert await manager._shadow_submit_accepted_run(info) is True
+    info._coordinator_fence = None
+    info._coordinator_claim_uncertain = True
+    now += 1_000
+    claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", now + 100),
+        limit=1,
+    )
+    assert len(claims) == 1
+    manager._force_reap = AsyncMock()
+
+    assert await asyncio.wait_for(manager.cancel(info.id), timeout=1) is True
+
+    assert info._coordinator_claim_uncertain is True
+    manager._force_reap.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pending_cancel_recovery_does_not_respawn_after_user_stop() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    manager._run = AsyncMock()
+    info = SubagentInfo(id="stopped-before-respawn", task="task")
+    info._recovering = True
+    armed = asyncio.Event()
+    release_original = asyncio.Event()
+
+    async def original_run() -> None:
+        manager._schedule_cancel_recovery(info)
+        armed.set()
+        await release_original.wait()
+
+    original = asyncio.create_task(original_run())
+    await armed.wait()
+    recovery = manager._tasks[f"{info.id}:recovery"]
+    info.user_stopped = True
+    release_original.set()
+    await original
+    await recovery
+
+    assert info._recovering is False
+    assert info._coordinator_shadow_generation == 0
+    manager._run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_user_stop_uses_legacy_report_after_definite_submit_failure() -> None:
+    sessions = MagicMock()
+    sessions.reset = AsyncMock()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+        on_done=on_done,
+    )
+    info = SubagentInfo(id="stopped-failed-submit", task="task")
+    info._coordinator_claim_uncertain = True
+    manager._agents[info.id] = info
+    manager._write_tombstone = MagicMock()
+    manager._fire_event = AsyncMock()
+    manager._resolve_stopped_shadow_claim = AsyncMock()
+
+    failed_submit = asyncio.create_task(asyncio.sleep(0, result=False))
+    manager._coordinator_shadow_submits.add(failed_submit)
+    manager._coordinator_shadow_submit_owners[failed_submit] = info
+
+    def forget_failed_submit(done: asyncio.Task[bool]) -> None:
+        manager._coordinator_shadow_submits.discard(done)
+        manager._coordinator_shadow_submit_owners.pop(done, None)
+
+    failed_submit.add_done_callback(forget_failed_submit)
+
+    assert await manager.cancel(info.id) is True
+
+    assert info._coordinator_claim_uncertain is False
+    manager._resolve_stopped_shadow_claim.assert_not_awaited()
+    on_done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_submit_outcome_survives_settlement_task_handoff() -> None:
+    class FailedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.submit_started = asyncio.Event()
+            self.release_submit = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            await self.release_submit.wait()
+            raise OSError("submit failed")
+
+    coordinator = FailedSubmitCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="failed-submit-handoff", task="task")
+
+    admission_task = asyncio.create_task(manager._await_retained_shadow_submit(info))
+    await coordinator.submit_started.wait()
+    admission_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await admission_task
+    info.user_stopped = True
+
+    coordinator.release_submit.set()
+    assert await manager._drain_retained_shadow_submits(info) is False
+    assert not manager._coordinator_shadow_submits
+    assert await manager._drain_retained_shadow_submits(info) is False
+
+
+@pytest.mark.asyncio
+async def test_retained_submit_drain_yields_finished_task_callbacks(monkeypatch) -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    info = SubagentInfo(id="finished-submit-callback", task="task")
+    info._coordinator_shadow_submission_durable = False
+
+    finished = asyncio.create_task(asyncio.sleep(0, result=False))
+    await finished
+    manager._coordinator_shadow_submits.add(finished)
+    manager._coordinator_shadow_submit_owners[finished] = info
+
+    def cleanup(done: asyncio.Task[bool]) -> None:
+        manager._coordinator_shadow_submits.discard(done)
+        manager._coordinator_shadow_submit_owners.pop(done, None)
+
+    finished.add_done_callback(cleanup)
+    gather_calls = 0
+
+    async def bounded_gather(*tasks, **kwargs):
+        nonlocal gather_calls
+        gather_calls += 1
+        assert gather_calls == 1, "finished retained task was polled without yielding"
+        assert kwargs == {"return_exceptions": True}
+        return [task.result() for task in tasks]
+
+    monkeypatch.setattr(asyncio, "gather", bounded_gather)
+
+    assert await manager._drain_retained_shadow_submits(info) is False
+    assert not manager._coordinator_shadow_submit_owners
 
 
 @pytest.mark.asyncio
@@ -295,8 +1491,11 @@ async def test_authoritatively_admitted_run_does_not_submit_twice() -> None:
     manager._run_inner = AsyncMock()
     manager._teardown_run_session = AsyncMock()
     manager._claim_finalize = MagicMock(return_value=False)
+    manager._coordinator_mark_starting = AsyncMock()
+    manager._start_coordinator_heartbeat = MagicMock()
     manager.command_authority.execution_started = AsyncMock()
     info = SubagentInfo(id="run-5", task="task", _coordinator_admitted=True)
+    info._coordinator_fence = MagicMock()
 
     await manager._run(info)
 
@@ -320,6 +1519,8 @@ async def test_failed_start_settlement_keeps_waiting_run_retryable() -> None:
     info = SubagentInfo(
         id="waiting-run",
         task="task",
+        batch_id="waiting-wave",
+        batch_total=3,
         _coordinator_admitted=True,
         _coordinator_waiting=True,
     )
@@ -330,6 +1531,7 @@ async def test_failed_start_settlement_keeps_waiting_run_retryable() -> None:
     assert info._coordinator_waiting is True
     assert info._coordinator_claim_uncertain is True
     assert info.done is False
+    assert manager._outbox_live_run_batches[info.id] == ("waiting-wave", 3)
     manager._run_inner.assert_not_awaited()
     manager._claim_finalize.assert_not_called()
     assert manager.command_authority.execution_started.await_count == 2
@@ -348,6 +1550,8 @@ async def test_failed_lifecycle_start_transition_never_applies_command() -> None
     info = SubagentInfo(
         id="uncommitted-start",
         task="task",
+        batch_id="starting-wave",
+        batch_total=4,
         _coordinator_admitted=True,
         _coordinator_waiting=True,
     )
@@ -358,6 +1562,7 @@ async def test_failed_lifecycle_start_transition_never_applies_command() -> None
     assert info._coordinator_waiting is True
     assert info._coordinator_claim_uncertain is True
     assert info.done is False
+    assert manager._outbox_live_run_batches[info.id] == ("starting-wave", 4)
     manager.command_authority.execution_started.assert_not_awaited()
     manager._run_inner.assert_not_awaited()
     manager._claim_finalize.assert_not_called()
@@ -369,6 +1574,8 @@ async def test_lost_start_settlement_response_reconciles_before_execution() -> N
     manager._run_inner = AsyncMock()
     manager._teardown_run_session = AsyncMock()
     manager._claim_finalize = MagicMock(return_value=False)
+    manager._coordinator_mark_starting = AsyncMock()
+    manager._start_coordinator_heartbeat = MagicMock()
     manager.command_authority.execution_started = AsyncMock(
         side_effect=[AuthorityOutcomeUncertain("response lost"), None]
     )
@@ -378,6 +1585,7 @@ async def test_lost_start_settlement_response_reconciles_before_execution() -> N
         _coordinator_admitted=True,
         _coordinator_waiting=True,
     )
+    info._coordinator_fence = MagicMock()
 
     await manager._run(info)
 
@@ -431,3 +1639,373 @@ async def test_manager_shutdown_closes_command_authority() -> None:
     await manager.cancel_all()
 
     manager.command_authority.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_readmits_unreported_terminal_owner() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    manager._cancel_all_impl = AsyncMock(side_effect=asyncio.CancelledError)
+    report_task = asyncio.create_task(asyncio.Event().wait())
+    info = SubagentInfo(id="unreported-shadow-fallback", task="task")
+    manager._lifecycle.pending_reports = MagicMock(return_value={report_task})
+    manager._lifecycle.owner_for = MagicMock(return_value=info)
+    event_loop_thread = threading.get_ident()
+    cleared: list[str] = []
+
+    def _clear_tombstone(agent_id: str) -> bool:
+        assert threading.get_ident() != event_loop_thread
+        cleared.append(agent_id)
+        return True
+
+    try:
+        with patch(
+            "kiro_crew.subagent.clear_tombstone_for_recovery",
+            side_effect=_clear_tombstone,
+        ) as clear:
+            with pytest.raises(asyncio.CancelledError):
+                await manager.cancel_all()
+        clear.assert_called_once_with(info.id)
+        assert cleared == [info.id]
+    finally:
+        report_task.cancel()
+        await asyncio.gather(report_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_manager_shutdown_retains_active_shadow_submission_for_recovery() -> None:
+    class DelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release_submit = asyncio.Event()
+            self.submit_started = asyncio.Event()
+            self.submit_cancelled = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            try:
+                await self.release_submit.wait()
+            except asyncio.CancelledError:
+                self.submit_cancelled.set()
+                raise
+            return await super().submit(request)
+
+    coordinator = DelayedSubmitCoordinator()
+    on_done = AsyncMock()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=on_done,
+    )
+    manager.command_authority.close = AsyncMock()
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    info = SubagentInfo(id="shutdown-shadow-submit", task="task")
+    manager._agents[info.id] = info
+    run_task = asyncio.create_task(manager._run(info))
+    manager._tasks[info.id] = run_task
+    await coordinator.submit_started.wait()
+
+    shutdown_task = asyncio.create_task(manager.cancel_all())
+    try:
+        await run_task
+
+        assert coordinator.submit_cancelled.is_set() is False
+        assert shutdown_task.done() is False
+    finally:
+        coordinator.release_submit.set()
+        await shutdown_task
+
+    assert info._coordinator_fence is not None
+    assert info._coordinator_claim_uncertain is True
+    assert manager._coordinator_shadow_submits == set()
+    on_done.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_readmits_unsettled_shadow_submission() -> None:
+    class DelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.submit_started = asyncio.Event()
+            self.submit_cancelled = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.submit_cancelled.set()
+                raise
+
+    coordinator = DelayedSubmitCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=AsyncMock(),
+    )
+    manager.command_authority.close = AsyncMock()
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock()
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    info = SubagentInfo(id="cancelled-shutdown-submit", task="task")
+    manager._agents[info.id] = info
+    run_task = asyncio.create_task(manager._run(info))
+    manager._tasks[info.id] = run_task
+    await coordinator.submit_started.wait()
+
+    shutdown_task = asyncio.create_task(manager.cancel_all())
+    await run_task
+    for _ in range(100):
+        if not manager._coordinator_shadow_submits:
+            break
+        await asyncio.sleep(0)
+    assert manager._coordinator_shadow_submits == set()
+    assert shutdown_task.done() is False
+
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        return_value=True,
+    ) as clear:
+        shutdown_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await shutdown_task
+
+    assert coordinator.submit_cancelled.is_set()
+    clear.assert_any_call(info.id)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_readmits_submit_before_drain_starts() -> None:
+    class DelayedSubmitCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release_submit = asyncio.Event()
+            self.submit_started = asyncio.Event()
+
+        async def submit(self, request):
+            self.submit_started.set()
+            await self.release_submit.wait()
+            return await super().submit(request)
+
+    coordinator = DelayedSubmitCoordinator()
+    teardown_started = asyncio.Event()
+
+    async def delayed_teardown(*_args) -> None:
+        teardown_started.set()
+        await asyncio.Event().wait()
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=AsyncMock(),
+    )
+    manager.command_authority.close = AsyncMock()
+    manager._run_inner = AsyncMock()
+    manager._teardown_run_session = AsyncMock(side_effect=delayed_teardown)
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    info = SubagentInfo(id="pre-drain-shutdown-submit", task="task")
+    manager._agents[info.id] = info
+    run_task = asyncio.create_task(manager._run(info))
+    manager._tasks[info.id] = run_task
+    await coordinator.submit_started.wait()
+
+    shutdown_task = asyncio.create_task(manager.cancel_all())
+    await teardown_started.wait()
+
+    with patch(
+        "kiro_crew.subagent.clear_tombstone_for_recovery",
+        return_value=True,
+    ) as clear:
+        shutdown_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await shutdown_task
+
+    clear.assert_called_once_with(info.id)
+    assert run_task.done()
+
+    coordinator.release_submit.set()
+    retained = list(manager._coordinator_shadow_submits)
+    if retained:
+        await asyncio.gather(*retained, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_manager_shutdown_drains_retained_shadow_submission() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    manager.command_authority.close = AsyncMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    settled = asyncio.Event()
+
+    async def retained_submit() -> None:
+        started.set()
+        await release.wait()
+        settled.set()
+
+    submit_task = asyncio.create_task(retained_submit())
+    manager._coordinator_shadow_submits.add(submit_task)
+    await started.wait()
+
+    shutdown_task = asyncio.create_task(manager.cancel_all())
+    await asyncio.sleep(0)
+
+    assert submit_task.cancelled() is False
+    assert shutdown_task.done() is False
+
+    release.set()
+    await shutdown_task
+
+    assert settled.is_set()
+    assert manager._coordinator_shadow_submits == set()
+    manager.command_authority.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_manager_shutdown_drains_report_created_by_late_shadow_settlement() -> None:
+    manager = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+    manager.command_authority.close = AsyncMock()
+    submit_release = asyncio.Event()
+    report_started = asyncio.Event()
+    report_release = asyncio.Event()
+    info = SubagentInfo(id="late-shadow-report", task="task")
+
+    async def retained_submit() -> None:
+        await submit_release.wait()
+
+    async def late_report() -> None:
+        report_started.set()
+        await report_release.wait()
+
+    submit_task = asyncio.create_task(retained_submit())
+    manager._coordinator_shadow_submits.add(submit_task)
+
+    def schedule_report(_done: asyncio.Task[None]) -> None:
+        manager._lifecycle.spawn_report(info, late_report)
+
+    submit_task.add_done_callback(schedule_report)
+    shutdown_task = asyncio.create_task(manager.cancel_all())
+    await asyncio.sleep(0)
+    submit_release.set()
+    await report_started.wait()
+
+    assert shutdown_task.done() is False
+
+    report_release.set()
+    await shutdown_task
+
+
+@pytest.mark.asyncio
+async def test_process_identity_persistence_failure_aborts_before_execution(monkeypatch) -> None:
+    sessions = MagicMock()
+    sessions.get_pid.return_value = 4321
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    info = SubagentInfo(id="run-process", task="inspect")
+    info._coordinator_fence = RunFence(info.id, "executor", 1)
+    manager._coordinator_record_process = AsyncMock(side_effect=OSError("write failed"))
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.process_identity_token",
+        lambda _pid: "s1",
+    )
+    monkeypatch.setattr("kiro_crew.subagent.update_state", MagicMock())
+
+    with pytest.raises(OSError, match="write failed"):
+        await manager._record_process_identity(info, "subagent:run-process")
+
+    assert info._pid == 4321
+
+
+@pytest.mark.asyncio
+async def test_process_identity_mirrors_legacy_state_off_loop(monkeypatch) -> None:
+    sessions = MagicMock()
+    sessions.get_pid.return_value = 4321
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    manager._coordinator_record_process = AsyncMock()
+    info = SubagentInfo(id="run-process-off-loop", task="inspect")
+    info._coordinator_fence = RunFence(info.id, "executor", 1)
+    event_loop_thread = threading.get_ident()
+    update_threads: list[int] = []
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.process_identity_token",
+        lambda _pid: "s1",
+    )
+    monkeypatch.setattr(
+        "kiro_crew.subagent.update_state",
+        lambda *_args, **_kwargs: update_threads.append(threading.get_ident()),
+    )
+
+    await manager._record_process_identity(info, "subagent:run-process-off-loop")
+
+    assert update_threads
+    assert update_threads != [event_loop_thread]
+    manager._coordinator_record_process.assert_awaited_once_with(
+        info,
+        4321,
+        "s1",
+        True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_process_start_identity_records_unowned_process(monkeypatch) -> None:
+    sessions = MagicMock()
+    sessions.get_pid.return_value = 4321
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+    manager._coordinator_record_process = AsyncMock()
+    manager._write_state_off_loop = AsyncMock()
+    info = SubagentInfo(id="run-process-unidentified", task="inspect")
+    info._coordinator_fence = RunFence(info.id, "executor", 1)
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.process_identity_token",
+        lambda _pid: None,
+    )
+
+    await manager._record_process_identity(info, "subagent:run-process-unidentified")
+
+    manager._write_state_off_loop.assert_awaited_once()
+    state_args = manager._write_state_off_loop.await_args
+    assert state_args.args == (info, "PID record")
+    assert state_args.kwargs["pid"] == 4321
+    assert state_args.kwargs["pid_start_id"] == ""
+    assert state_args.kwargs["process_owned"] is False
+    manager._coordinator_record_process.assert_awaited_once_with(
+        info,
+        4321,
+        "",
+        False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_identity_requires_an_execution_fence() -> None:
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=MemoryRunCoordinator(),
+    )
+
+    with pytest.raises(RuntimeError, match="execution fence is missing"):
+        await manager._coordinator_record_process(
+            SubagentInfo(id="unfenced-run", task="inspect"),
+            4321,
+            "start-1",
+            True,
+        )

--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -8,6 +8,7 @@ fresh processes — and that fallback to legacy path works correctly.
 from __future__ import annotations
 
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from kiro_crew.acp.runtime import AcpRuntimeDead
 from kiro_crew.acp.session_provider import AcpSessionProvider
 from kiro_crew.acp.types import AcpEvent
 from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK
+from kiro_crew.run_coordinator import MemoryRunCoordinator
 from kiro_crew.subagent import SubagentManager
 
 # ``SubagentManager.spawn`` refuses -- registering no task -- while the host
@@ -285,6 +287,43 @@ class TestSessionSharingSpawn:
         assert isinstance(info._shared_provider, AcpSessionProvider)
 
     @pytest.mark.asyncio
+    async def test_shared_session_never_persists_kill_authority(self):
+        """Recovery must not treat the parent runtime as this run's child."""
+        from kiro_crew.subagent import SubagentInfo
+
+        sessions = _mock_sessions(sharing_eligible=True)
+        manager = SubagentManager(
+            sessions=sessions,
+            ctx_builder=_mock_ctx_builder_auto(),
+            is_yolo=lambda: True,
+        )
+        info = SubagentInfo(
+            id="shared1",
+            task="hello",
+            parent_session_key="dashboard:slot1",
+        )
+
+        event_loop_thread = threading.get_ident()
+        update_threads: list[int] = []
+        with (
+            patch(
+                "kiro_crew.subagent.update_state",
+                side_effect=lambda *_args, **_kwargs: update_threads.append(threading.get_ident()),
+            ) as update,
+            patch("kiro_crew.subagent.platform_compat.process_start_time") as process_start_time,
+        ):
+            provider = await manager._create_shared_session(info, "subagent:shared1", "kirocrew")
+
+        process_start_time.assert_not_called()
+        update.assert_called_once()
+        assert update.call_args.args == ("shared1",)
+        assert update.call_args.kwargs["pid"] == 12345
+        assert update.call_args.kwargs["pid_start_id"] == ""
+        assert update.call_args.kwargs["process_owned"] is False
+        assert update_threads != [event_loop_thread]
+        await provider.shutdown()
+
+    @pytest.mark.asyncio
     async def test_shared_session_cleanup_destroys_handle(self):
         """On completion, shared session calls provider.shutdown() not reset()."""
         sessions = _mock_sessions(sharing_eligible=True)
@@ -475,6 +514,7 @@ class TestSessionSharingMultiAgent:
             ctx_builder=_mock_ctx_builder_auto(),
             is_yolo=lambda: True,
             max_concurrent=4,
+            coordinator=MemoryRunCoordinator(),
         )
         # Disable stagger so both spawns start immediately
         manager._spawn_stagger_secs = 0.0
@@ -486,7 +526,8 @@ class TestSessionSharingMultiAgent:
         ):
             info1 = manager.spawn("task A", parent_session_key="dashboard:slot1")
             info2 = manager.spawn("task B", parent_session_key="dashboard:slot1")
-            await asyncio.gather(_wait_until_done(info1), _wait_until_done(info2))
+            tasks = [manager._tasks[info1.id], manager._tasks[info2.id]]
+            await asyncio.gather(*tasks)
 
         # Both should use session sharing
         assert info1._session_sharing is True
@@ -506,6 +547,7 @@ class TestSessionSharingMultiAgent:
             ctx_builder=_mock_ctx_builder_auto(),
             is_yolo=lambda: True,
             max_concurrent=4,
+            coordinator=MemoryRunCoordinator(),
         )
         manager._spawn_stagger_secs = 0.0
 
@@ -516,7 +558,8 @@ class TestSessionSharingMultiAgent:
         ):
             info1 = manager.spawn("task A", parent_session_key="dashboard:slot1")
             info2 = manager.spawn("task B", parent_session_key="dashboard:slot2")
-            await asyncio.gather(_wait_until_done(info1), _wait_until_done(info2))
+            tasks = [manager._tasks[info1.id], manager._tasks[info2.id]]
+            await asyncio.gather(*tasks)
 
         assert info1._session_sharing is True
         assert info2._session_sharing is True

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -178,11 +178,13 @@ class TestGatewayOrchestratorInit:
         cfg = KiroCrewConfig()
         cfg.slack.allowed_users = [{"slack_id": "U_STALE"}]
         with patch.object(
-            cfg, "load_credentials", return_value={
+            cfg,
+            "load_credentials",
+            return_value={
                 "SLACK_APP_TOKEN": "xapp-t",
                 "SLACK_BOT_TOKEN": "xoxb-t",
                 "KIROCREW_OWNER_ID": "U_OWNER",
-            }
+            },
         ):
             orch = GatewayOrchestrator(cfg)
         assert "U_STALE" not in orch._allowed_users
@@ -250,9 +252,7 @@ class TestOpenDmWithRetry:
         These tests assert the retry COUNT and the final result, never the delay, so
         the 5s this class spent asleep bought no coverage. The retry loop still runs.
         """
-        monkeypatch.setattr(
-            "kiro_crew.slack.retry.asyncio.sleep", AsyncMock(return_value=None)
-        )
+        monkeypatch.setattr("kiro_crew.slack.retry.asyncio.sleep", AsyncMock(return_value=None))
 
     @pytest.mark.asyncio
     async def test_success_first_attempt(self):
@@ -359,10 +359,17 @@ class TestInitServices:
                                     with patch("kiro_crew.slack.gateway.SessionManager"):
                                         with patch("kiro_crew.slack.gateway.HistoryConsolidator"):
                                             with patch("kiro_crew.slack.gateway.ChannelHistory"):
-                                                with patch("kiro_crew.agent.rebuild_agent_config", return_value=Path("/tmp/a")):
+                                                with patch(
+                                                    "kiro_crew.agent.rebuild_agent_config",
+                                                    return_value=Path("/tmp/a"),
+                                                ):
                                                     with patch(
                                                         "asyncio.create_subprocess_exec",
-                                                        new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
+                                                        new=AsyncMock(
+                                                            return_value=_fake_async_proc(
+                                                                stdout=b"kiro-cli 1.30.0"
+                                                            )
+                                                        ),
                                                     ):
                                                         asyncio.run(orch._init_services())
 
@@ -394,10 +401,17 @@ class TestInitServices:
                                     with patch("kiro_crew.slack.gateway.SessionManager"):
                                         with patch("kiro_crew.slack.gateway.HistoryConsolidator"):
                                             with patch("kiro_crew.slack.gateway.ChannelHistory"):
-                                                with patch("kiro_crew.agent.rebuild_agent_config", return_value=Path("/tmp/a")):
+                                                with patch(
+                                                    "kiro_crew.agent.rebuild_agent_config",
+                                                    return_value=Path("/tmp/a"),
+                                                ):
                                                     with patch(
                                                         "asyncio.create_subprocess_exec",
-                                                        new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
+                                                        new=AsyncMock(
+                                                            return_value=_fake_async_proc(
+                                                                stdout=b"kiro-cli 1.30.0"
+                                                            )
+                                                        ),
                                                     ):
                                                         asyncio.run(orch._init_services())
 
@@ -856,12 +870,8 @@ class TestCheckForUpdates:
     async def test_no_update_available(self):
         orch = _make_orchestrator()
         orch.dashboard_state = _mock_dashboard_state()
-        with patch(
-            "kiro_crew.dashboard.handlers._do_update_check", new_callable=AsyncMock
-        ):
-            with patch(
-                "kiro_crew.dashboard.handlers._update_info", {"update_available": False}
-            ):
+        with patch("kiro_crew.dashboard.handlers._do_update_check", new_callable=AsyncMock):
+            with patch("kiro_crew.dashboard.handlers._update_info", {"update_available": False}):
                 await orch._check_for_updates()
 
     @pytest.mark.asyncio
@@ -872,6 +882,7 @@ class TestCheckForUpdates:
         orch._auto_apply_update = AsyncMock()
         import kiro_crew.dashboard.handlers as _h
         from kiro_crew.platform.governance import UpdatePins
+
         orig = _h._update_info.copy()
         # Create a config with auto_update=False
         fake_cfg = MagicMock()
@@ -1018,9 +1029,7 @@ class TestAutoApplyUpdate:
         proc = AsyncMock()
         proc.communicate = AsyncMock(return_value=(b"feat/test\n", b""))
         proc.returncode = 0
-        with patch.dict(
-            "os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}, clear=False
-        ):
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}, clear=False):
             with patch(
                 "asyncio.create_subprocess_exec",
                 new_callable=AsyncMock,
@@ -1060,9 +1069,7 @@ class TestBrazilInstallAndDeps:
         orch = _make_orchestrator()
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
-                with patch.object(
-                    GatewayOrchestrator, "_is_brazil_install", return_value=True
-                ):
+                with patch.object(GatewayOrchestrator, "_is_brazil_install", return_value=True):
                     asyncio.run(orch._check_missing_deps())  # should not raise, skips pip
 
 
@@ -1164,7 +1171,10 @@ class TestInitCron:
             new_callable=AsyncMock,
             return_value="cron result",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:j1", "run task")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:j1", "run task"),
+            ):
                 result = await callback(job)
 
         assert result == "cron result"
@@ -1618,7 +1628,10 @@ class TestInitCron:
             new_callable=AsyncMock,
             return_value="stable output",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:j2", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:j2", "run"),
+            ):
                 with patch("kiro_crew.sel.sel") as mock_sel:
                     mock_sel.return_value.log_tool_invocation = MagicMock()
                     result = await callback(job)
@@ -1680,7 +1693,10 @@ class TestInitCron:
             new_callable=AsyncMock,
             return_value="silent result",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:j3", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:j3", "run"),
+            ):
                 with patch("kiro_crew.sel.sel") as mock_sel:
                     mock_sel.return_value.log_tool_invocation = MagicMock()
                     result = await callback(job)
@@ -1759,14 +1775,20 @@ class TestInitSubagents:
         info = SubagentInfo(id="a1", task="t", parent_session_key="dashboard:s1")
         # Batch: two spawns + one done inside the 0.2s window -> one push.
         await on_event("subagent_spawn", info, {})
-        await on_event("subagent_spawn", SubagentInfo(id="a2", task="t", parent_session_key="dashboard:s1"), {})
+        await on_event(
+            "subagent_spawn", SubagentInfo(id="a2", task="t", parent_session_key="dashboard:s1"), {}
+        )
         await on_event("subagent_done", info, {"elapsed": 1.0})
         assert orch.dashboard_state.push_slots_update.call_count == 0  # debounced, not yet flushed
         await asyncio.sleep(0.3)
         assert orch.dashboard_state.push_slots_update.call_count == 1
 
         # A later lifecycle event schedules a fresh push.
-        await on_event("subagent_done", SubagentInfo(id="a2", task="t", parent_session_key="dashboard:s1"), {"elapsed": 1.0})
+        await on_event(
+            "subagent_done",
+            SubagentInfo(id="a2", task="t", parent_session_key="dashboard:s1"),
+            {"elapsed": 1.0},
+        )
         await asyncio.sleep(0.3)
         assert orch.dashboard_state.push_slots_update.call_count == 2
 
@@ -2113,9 +2135,7 @@ class TestInitDashboard:
 
     def test_init_mcp_discovery_handles_error(self):
         orch = _make_orchestrator()
-        with patch(
-            "kiro_crew.mcp_discovery.list_servers", side_effect=RuntimeError("fail")
-        ):
+        with patch("kiro_crew.mcp_discovery.list_servers", side_effect=RuntimeError("fail")):
             orch._init_mcp_discovery()  # should not raise
 
 
@@ -2211,7 +2231,10 @@ class TestCronFailurePaths:
             new_callable=AsyncMock,
             side_effect=RuntimeError("boom"),
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:jfail", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:jfail", "run"),
+            ):
                 with patch("kiro_crew.sel.sel") as mock_sel:
                     mock_sel.return_value.log_tool_invocation = MagicMock()
                     with pytest.raises(RuntimeError, match="boom"):
@@ -2279,7 +2302,10 @@ class TestCronFailurePaths:
             new_callable=AsyncMock,
             side_effect=RuntimeError("boom"),
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:jfail2", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:jfail2", "run"),
+            ):
                 with patch("kiro_crew.sel.sel") as mock_sel:
                     mock_sel.return_value.log_tool_invocation = MagicMock()
                     with pytest.raises(RuntimeError, match="boom"):
@@ -2343,7 +2369,10 @@ class TestCronFailurePaths:
             new_callable=AsyncMock,
             return_value="agent result",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:jmulti", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:jmulti", "run"),
+            ):
                 result = await callback(job)
 
         assert result == "agent result"
@@ -2368,12 +2397,8 @@ class TestRunGateway:
         with patch.object(cfg, "load_credentials", return_value={}):
             # The aggregate-cgroup-ceiling apply shells out to systemctl —
             # a host-service mutation the rootdir guard refuses; stub it.
-            with patch(
-                "kiro_crew.slack.gateway.ensure_agents_slice_limits", return_value=True
-            ):
-                with patch.object(
-                    GatewayOrchestrator, "run", new_callable=AsyncMock
-                ) as mock_run:
+            with patch("kiro_crew.slack.gateway.ensure_agents_slice_limits", return_value=True):
+                with patch.object(GatewayOrchestrator, "run", new_callable=AsyncMock) as mock_run:
                     await run_gateway(cfg, no_dashboard=True, no_crons=True)
         mock_run.assert_awaited_once()
 
@@ -2510,15 +2535,14 @@ class TestAutoApplyUpdateGitPath:
         refusals have their own tests in ``TestAutoApplyUpdatePreconditions`` and
         ``TestAutoApplyUpdateResetPath``.
         """
-        with patch(
-            "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="",
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.commits_ahead", return_value=0
+        with (
+            patch("kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="",
+            ),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=True),
+            patch("kiro_crew.slack.gateway.commits_ahead", return_value=0),
         ):
             yield
 
@@ -2597,7 +2621,10 @@ class TestRunMethod:
                     with patch("kiro_crew.slack.interactions.init"):
                         with patch("kiro_crew.slack.events.SeenCache"):
                             with patch("kiro_crew.session.cleanup_orphaned_sessions"):
-                                with patch("kiro_crew.dashboard.handlers._bg_mcp_probe", new_callable=AsyncMock):
+                                with patch(
+                                    "kiro_crew.dashboard.handlers._bg_mcp_probe",
+                                    new_callable=AsyncMock,
+                                ):
                                     with patch("os._exit"):
                                         with patch("resource.getrlimit", return_value=(256, 10240)):
                                             with patch("resource.setrlimit"):
@@ -2672,9 +2699,7 @@ class TestRunMethod:
                                     new_callable=AsyncMock,
                                 ):
                                     with patch("os._exit"):
-                                        with patch(
-                                            "resource.getrlimit", return_value=(256, 10240)
-                                        ):
+                                        with patch("resource.getrlimit", return_value=(256, 10240)):
                                             with patch("resource.setrlimit"):
                                                 await orch.run()
         finally:
@@ -2687,9 +2712,7 @@ class TestRunMethod:
         assert not pid_marker.exists()
 
     @pytest.mark.asyncio
-    async def test_run_stalled_marker_write_does_not_block_shutdown(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_run_stalled_marker_write_does_not_block_shutdown(self, tmp_path, monkeypatch):
         """A hung marker write times out; the marker is cleared and _shutdown runs.
 
         Regression: an unbounded ``await self._marker_write_task`` sat before
@@ -2756,9 +2779,7 @@ class TestRunMethod:
                                     new_callable=AsyncMock,
                                 ):
                                     with patch("os._exit"):
-                                        with patch(
-                                            "resource.getrlimit", return_value=(256, 10240)
-                                        ):
+                                        with patch("resource.getrlimit", return_value=(256, 10240)):
                                             with patch("resource.setrlimit"):
                                                 await orch.run()
         finally:
@@ -2836,9 +2857,7 @@ class TestRunMethod:
                                     new_callable=AsyncMock,
                                 ):
                                     with patch("os._exit"):
-                                        with patch(
-                                            "resource.getrlimit", return_value=(256, 10240)
-                                        ):
+                                        with patch("resource.getrlimit", return_value=(256, 10240)):
                                             with patch("resource.setrlimit"):
                                                 await orch.run()
         finally:
@@ -2943,7 +2962,10 @@ class TestCronSuccessReminder:
             new_callable=AsyncMock,
             return_value="same output",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:j_remind", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:j_remind", "run"),
+            ):
                 result = await callback(job)
 
         # Should have posted (reminder path)
@@ -3009,7 +3031,9 @@ class TestSubagentDone:
         info.elapsed = 5.0
         info.started = 0.0
 
-        with patch("kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock, return_value=None):
+        with patch(
+            "kiro_crew.dashboard.chat_runner._run_chat", new_callable=AsyncMock, return_value=None
+        ):
             await on_done(info)
 
         orch.dashboard_state.notify.assert_not_called()
@@ -3051,6 +3075,45 @@ class TestSubagentDone:
 
         await on_done(info)
         slot.queue_append.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_recovered_interruption_keeps_neutral_outcome_and_result_path(self):
+        from kiro_crew.constants import SUBAGENT_COMPLETION_META_KEY
+        from kiro_crew.subagent import SubagentInfo
+
+        orch, mock_sm = self._setup_orch_with_subagent_mgr()
+        on_done = mock_sm.call_args[1]["on_done"]
+
+        slot = MagicMock()
+        slot.running = True
+        slot.task = asyncio.ensure_future(asyncio.sleep(0))
+        await slot.task
+        slot.key = "busy-slot"
+        slot.mode = ""
+        slot._recovery_chat_triggered = False
+        slot._pending_subagent_failures = []
+        slot._subagents_inline_collected = set()
+        slot.queue_append = MagicMock()
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+
+        info = SubagentInfo(
+            id="recovered-1",
+            task="recover work",
+            parent_session_key="dashboard:busy-slot",
+            done=True,
+            error="interrupted by gateway restart",
+            result_path="/results/recovered-1.txt",
+            result_truncated=True,
+        )
+        info._recovered_outcome = "interrupted"
+
+        await on_done(info)
+
+        announce = slot.queue_append.call_args.args[0]
+        meta = slot.queue_append.call_args.kwargs["meta"][SUBAGENT_COMPLETION_META_KEY]
+        assert "interrupted by gateway restart" in announce
+        assert "/results/recovered-1.txt" in announce
+        assert meta["outcome"] == "interrupted"
 
     @pytest.mark.asyncio
     async def test_cron_parent_injects_result(self):
@@ -3403,15 +3466,14 @@ class TestAutoApplyUpdateVenvPath:
         refusals have their own tests in ``TestAutoApplyUpdatePreconditions`` and
         ``TestAutoApplyUpdateResetPath``.
         """
-        with patch(
-            "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="",
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.commits_ahead", return_value=0
+        with (
+            patch("kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="",
+            ),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=True),
+            patch("kiro_crew.slack.gateway.commits_ahead", return_value=0),
         ):
             yield
 
@@ -3434,7 +3496,10 @@ class TestAutoApplyUpdateVenvPath:
                         with patch.object(
                             GatewayOrchestrator, "_is_brazil_install", return_value=False
                         ):
-                            with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
+                            with patch(
+                                "kiro_crew.slack.gateway.build_frontend_async",
+                                new_callable=AsyncMock,
+                            ):
                                 with patch("os.execv", side_effect=OSError("test")):
                                     with patch("shutil.which", return_value=None):
                                         await orch._auto_apply_update()
@@ -3506,9 +3571,7 @@ class TestAutoApplyUpdateVenvPath:
                             ) as mock_build:
                                 with patch("os.execv", side_effect=OSError("test")):
                                     # Truthy: the optional kiro-cli step runs.
-                                    with patch(
-                                        "shutil.which", return_value="/usr/bin/kiro-cli"
-                                    ):
+                                    with patch("shutil.which", return_value="/usr/bin/kiro-cli"):
                                         # The gateway resolves _kill_and_reap
                                         # function-locally on every call, so
                                         # patching the source module reaches it.
@@ -3688,11 +3751,15 @@ class TestStartEmbeddings:
         orch = _make_orchestrator()
         orch.vector_memory = MagicMock(embed_fn=None, embed_fn_factory=None)
         fake_embed_fn = lambda text: [0.1]  # noqa: E731
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), \
-             patch("kiro_crew.slack.gateway.make_sync_embed_fn",
-                   return_value=fake_embed_fn) as mock_make, \
-             patch("kiro_crew.slack.gateway.start_background_model_download",
-                   return_value=None) as mock_start:
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=True),
+            patch(
+                "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=fake_embed_fn
+            ) as mock_make,
+            patch(
+                "kiro_crew.slack.gateway.start_background_model_download", return_value=None
+            ) as mock_start,
+        ):
             await orch._start_embeddings()
         # Factory wired unconditionally (lazy rebind), fn bound immediately.
         assert orch.vector_memory.embed_fn_factory is mock_make
@@ -3705,9 +3772,12 @@ class TestStartEmbeddings:
         orch = _make_orchestrator()
         orch.vector_memory = MagicMock(embed_fn=None, embed_fn_factory=None)
         fake_task = MagicMock()
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=False), \
-             patch("kiro_crew.slack.gateway.start_background_model_download",
-                   return_value=fake_task) as mock_start:
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=False),
+            patch(
+                "kiro_crew.slack.gateway.start_background_model_download", return_value=fake_task
+            ) as mock_start,
+        ):
             await orch._start_embeddings()
         # embed_fn stays unbound (lazy rebind picks it up once the model lands)
         # but the factory is wired and the background download task is stored.
@@ -3742,20 +3812,22 @@ class TestAutoMigrateMemory:
     @staticmethod
     def _ready_embedder():
         """A shared embedder whose model is loaded (wait_ready -> True)."""
-        return MagicMock(wait_ready=MagicMock(return_value=True), is_ready=MagicMock(return_value=True))
+        return MagicMock(
+            wait_ready=MagicMock(return_value=True), is_ready=MagicMock(return_value=True)
+        )
 
     @pytest.mark.asyncio
     async def test_migrates_when_not_migrated_and_legacy_present(self):
         orch, store = self._orch_with_store(migrated=False)
         set_migrated = AsyncMock()
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
-            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
-        ), patch(
-            "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
-        ), patch(
-            "kiro_crew.memory.legacy_memory_present", return_value=True
-        ), patch.object(
-            orch, "_set_memory_migrated", set_migrated
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=True),
+            patch("kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])),
+            patch(
+                "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
+            ),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=True),
+            patch.object(orch, "_set_memory_migrated", set_migrated),
         ):
             await orch._auto_migrate_memory()
         store.migrate_from_markdown.assert_called_once()
@@ -3772,14 +3844,14 @@ class TestAutoMigrateMemory:
     async def test_skips_migrate_when_already_migrated(self):
         orch, store = self._orch_with_store(migrated=True)
         set_migrated = AsyncMock()
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
-            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
-        ), patch(
-            "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
-        ), patch(
-            "kiro_crew.memory.legacy_memory_present", return_value=True
-        ), patch.object(
-            orch, "_set_memory_migrated", set_migrated
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=True),
+            patch("kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])),
+            patch(
+                "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
+            ),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=True),
+            patch.object(orch, "_set_memory_migrated", set_migrated),
         ):
             await orch._auto_migrate_memory()
         store.migrate_from_markdown.assert_not_called()
@@ -3796,14 +3868,12 @@ class TestAutoMigrateMemory:
         not_ready = MagicMock(
             wait_ready=MagicMock(return_value=False), is_ready=MagicMock(return_value=False)
         )
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
-            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
-        ), patch(
-            "kiro_crew.slack.gateway.get_shared_embedder", return_value=not_ready
-        ), patch(
-            "kiro_crew.memory.legacy_memory_present", return_value=True
-        ), patch.object(
-            orch, "_set_memory_migrated", AsyncMock()
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=True),
+            patch("kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])),
+            patch("kiro_crew.slack.gateway.get_shared_embedder", return_value=not_ready),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=True),
+            patch.object(orch, "_set_memory_migrated", AsyncMock()),
         ):
             await orch._auto_migrate_memory()
         not_ready.wait_ready.assert_called_once()
@@ -3813,12 +3883,11 @@ class TestAutoMigrateMemory:
     async def test_fresh_install_no_legacy_still_flips_migrated(self):
         orch, store = self._orch_with_store(migrated=False)
         set_migrated = AsyncMock()
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
-            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
-        ), patch(
-            "kiro_crew.memory.legacy_memory_present", return_value=False
-        ), patch.object(
-            orch, "_set_memory_migrated", set_migrated
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=True),
+            patch("kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=False),
+            patch.object(orch, "_set_memory_migrated", set_migrated),
         ):
             await orch._auto_migrate_memory()
         # No legacy → don't parse markdown, but still flip the flag + ack (0 counts).
@@ -3834,17 +3903,17 @@ class TestAutoMigrateMemory:
         # Model absent at migrate time, present after the download task resolves.
         presence = iter([False, False, True, True])
         orch._model_download_task = asyncio.ensure_future(asyncio.sleep(0))
-        with patch(
-            "kiro_crew.slack.gateway.model_file_present",
-            side_effect=lambda: next(presence, True),
-        ), patch(
-            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
-        ), patch(
-            "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
-        ), patch(
-            "kiro_crew.memory.legacy_memory_present", return_value=True
-        ), patch.object(
-            orch, "_set_memory_migrated", AsyncMock()
+        with (
+            patch(
+                "kiro_crew.slack.gateway.model_file_present",
+                side_effect=lambda: next(presence, True),
+            ),
+            patch("kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])),
+            patch(
+                "kiro_crew.slack.gateway.get_shared_embedder", return_value=self._ready_embedder()
+            ),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=True),
+            patch.object(orch, "_set_memory_migrated", AsyncMock()),
         ):
             await orch._auto_migrate_memory()
         # Migrated even though the model was absent; sweep ran after the wait.
@@ -3856,12 +3925,11 @@ class TestAutoMigrateMemory:
         orch, store = self._orch_with_store(migrated=False)
         store.migrate_from_markdown.side_effect = RuntimeError("boom")
         set_migrated = AsyncMock()
-        with patch("kiro_crew.slack.gateway.model_file_present", return_value=True), patch(
-            "kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])
-        ), patch(
-            "kiro_crew.memory.legacy_memory_present", return_value=True
-        ), patch.object(
-            orch, "_set_memory_migrated", set_migrated
+        with (
+            patch("kiro_crew.slack.gateway.model_file_present", return_value=True),
+            patch("kiro_crew.slack.gateway.make_sync_embed_fn", return_value=(lambda t: [0.1])),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=True),
+            patch.object(orch, "_set_memory_migrated", set_migrated),
         ):
             # Must not raise — boot survives.
             await orch._auto_migrate_memory()
@@ -4065,15 +4133,14 @@ class TestAutoApplyUpdateResetPath:
         refusals have their own tests in ``TestAutoApplyUpdatePreconditions`` and
         ``TestAutoApplyUpdateResetPath``.
         """
-        with patch(
-            "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="",
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.commits_ahead", return_value=0
+        with (
+            patch("kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="",
+            ),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=True),
+            patch("kiro_crew.slack.gateway.commits_ahead", return_value=0),
         ):
             yield
 
@@ -4141,9 +4208,7 @@ class TestAutoApplyUpdateResetPath:
                             await orch._auto_apply_update()
 
         # The destructive step never ran.
-        assert not any(
-            "reset" in [str(a) for a in args] for args in spawned
-        ), spawned
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
         # And nothing downstream of it ran either.
         mock_build.assert_not_awaited()
         mock_execv.assert_not_called()
@@ -4242,9 +4307,7 @@ class TestAutoApplyUpdateResetPath:
                                     await orch._auto_apply_update()
 
         git_calls = [
-            [str(a) for a in args]
-            for args in spawned
-            if args and str(args[0]).endswith("git")
+            [str(a) for a in args] for args in spawned if args and str(args[0]).endswith("git")
         ]
         assert git_calls, spawned
         for argv in git_calls:
@@ -4295,9 +4358,7 @@ class TestAutoApplyUpdateResetPath:
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                with patch(
-                    "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=None
-                ):
+                with patch("kiro_crew.slack.gateway.hidden_worktree_edits", return_value=None):
                     with patch("os.execv") as mock_execv:
                         with patch("shutil.which", return_value=None):
                             await orch._auto_apply_update()
@@ -4687,9 +4748,7 @@ class TestAutoApplyUpdateResetPath:
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                with patch(
-                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
-                ):
+                with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
                     with patch("os.execv") as mock_execv:
                         with patch("shutil.which", return_value=None):
                             await orch._auto_apply_update()
@@ -4715,9 +4774,7 @@ class TestAutoApplyUpdateResetPath:
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                with patch(
-                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
-                ):
+                with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
                     with patch("os.execv") as mock_execv:
                         with patch("shutil.which", return_value=None):
                             await orch._auto_apply_update()
@@ -4747,9 +4804,7 @@ class TestAutoApplyUpdateResetPath:
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                with patch(
-                    "kiro_crew.dep_sync.sync_or_reinstall", return_value=dep_sync.REFUSED
-                ):
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=dep_sync.REFUSED):
                     with patch(
                         "kiro_crew.slack.gateway.build_frontend_async",
                         new_callable=AsyncMock,
@@ -4787,9 +4842,7 @@ class TestAutoApplyUpdateResetPath:
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
-                with patch(
-                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
-                ):
+                with patch("kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock):
                     with patch("os.execv"):
                         with patch("shutil.which", return_value=None):
                             await orch._auto_apply_update()
@@ -4801,9 +4854,7 @@ class TestAutoApplyUpdateResetPath:
             and "--abbrev-ref" not in [str(a) for a in args]
         ]
         assert revparses, spawned
-        assert any("refs/remotes/origin/main^{commit}" in argv for argv in revparses), (
-            revparses
-        )
+        assert any("refs/remotes/origin/main^{commit}" in argv for argv in revparses), revparses
         # The bare form must not be what git is asked to resolve.
         assert not any("origin/main^{commit}" in argv for argv in revparses), revparses
 
@@ -5020,7 +5071,10 @@ class TestCronAcpRetry:
             return "retry success"
 
         with patch("kiro_crew.slack.gateway.stream_and_collect", side_effect=_fake_stream):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:jacp", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:jacp", "run"),
+            ):
                 result = await callback(job)
 
         assert result == "retry success"
@@ -5486,7 +5540,10 @@ class TestCronAckedItems:
             new_callable=AsyncMock,
             return_value="acked result",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:jack", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:jack", "run"),
+            ):
                 with patch("kiro_crew.sel.sel") as mock_sel:
                     mock_sel.return_value.log_tool_invocation = MagicMock()
                     result = await callback(job)
@@ -5655,9 +5712,14 @@ class TestRunSignalAndBgSession:
                             with patch("kiro_crew.slack.interactions.init"):
                                 with patch("kiro_crew.slack.events.SeenCache"):
                                     with patch("kiro_crew.session.cleanup_orphaned_sessions"):
-                                        with patch("kiro_crew.dashboard.handlers._bg_mcp_probe", new_callable=AsyncMock):
+                                        with patch(
+                                            "kiro_crew.dashboard.handlers._bg_mcp_probe",
+                                            new_callable=AsyncMock,
+                                        ):
                                             with patch("os._exit"):
-                                                with patch("resource.getrlimit", return_value=(256, 10240)):
+                                                with patch(
+                                                    "resource.getrlimit", return_value=(256, 10240)
+                                                ):
                                                     with patch("resource.setrlimit"):
                                                         await orch.run()
         finally:
@@ -5703,6 +5765,7 @@ class TestBgSessionDashboardBranch:
             orch._local_only = True
             orch._configured_host = None
             orch._dashboard_port = 6779
+
         orch._init_dashboard = _init_dash
 
         fresh_event = asyncio.Event()
@@ -5711,19 +5774,32 @@ class TestBgSessionDashboardBranch:
         with patch.object(loop, "add_signal_handler"):
             with patch("kiro_crew.shutdown_event", fresh_event):
                 with patch("kiro_crew.slack.gateway.shutdown_event", fresh_event):
-                    with patch("kiro_crew.slack.gateway.resolve_dashboard_host",
-                               return_value="127.0.0.1"):
-                        with patch("kiro_crew.slack.gateway.build_dashboard_url",
-                                   return_value="http://127.0.0.1:6779/?t=tok"):
-                            with patch("kiro_crew.slack.gateway.format_dashboard_urls",
-                                       return_value=["url-line-1", "url-line-2"]):
+                    with patch(
+                        "kiro_crew.slack.gateway.resolve_dashboard_host", return_value="127.0.0.1"
+                    ):
+                        with patch(
+                            "kiro_crew.slack.gateway.build_dashboard_url",
+                            return_value="http://127.0.0.1:6779/?t=tok",
+                        ):
+                            with patch(
+                                "kiro_crew.slack.gateway.format_dashboard_urls",
+                                return_value=["url-line-1", "url-line-2"],
+                            ):
                                 with patch("kiro_crew.slack.events.init_socket_mode"):
                                     with patch("kiro_crew.slack.interactions.init"):
                                         with patch("kiro_crew.slack.events.SeenCache"):
-                                            with patch("kiro_crew.session.cleanup_orphaned_sessions"):
-                                                with patch("kiro_crew.dashboard.handlers._bg_mcp_probe", new_callable=AsyncMock):
+                                            with patch(
+                                                "kiro_crew.session.cleanup_orphaned_sessions"
+                                            ):
+                                                with patch(
+                                                    "kiro_crew.dashboard.handlers._bg_mcp_probe",
+                                                    new_callable=AsyncMock,
+                                                ):
                                                     with patch("os._exit"):
-                                                        with patch("resource.getrlimit", return_value=(256, 10240)):
+                                                        with patch(
+                                                            "resource.getrlimit",
+                                                            return_value=(256, 10240),
+                                                        ):
                                                             with patch("resource.setrlimit"):
                                                                 await orch.run()
                                                                 # Let bg_session task drain
@@ -5766,6 +5842,7 @@ class TestBgSessionDashboardBranch:
             orch._local_only = True
             orch._configured_host = None
             orch._dashboard_port = 6779
+
         orch._init_dashboard = _init_dash
 
         # One ordered trace of both events. The URL lines are a distinctive
@@ -5787,17 +5864,24 @@ class TestBgSessionDashboardBranch:
         with patch.object(loop, "add_signal_handler"):
             with patch("kiro_crew.shutdown_event", fresh_event):
                 with patch("kiro_crew.slack.gateway.shutdown_event", fresh_event):
-                    with patch("kiro_crew.slack.gateway.resolve_dashboard_host",
-                               return_value="127.0.0.1"):
-                        with patch("kiro_crew.slack.gateway.build_dashboard_url",
-                                   return_value="http://127.0.0.1:6779/?t=tok"):
-                            with patch("kiro_crew.slack.gateway.format_dashboard_urls",
-                                       return_value=["url-line-1", "url-line-2"]):
+                    with patch(
+                        "kiro_crew.slack.gateway.resolve_dashboard_host", return_value="127.0.0.1"
+                    ):
+                        with patch(
+                            "kiro_crew.slack.gateway.build_dashboard_url",
+                            return_value="http://127.0.0.1:6779/?t=tok",
+                        ):
+                            with patch(
+                                "kiro_crew.slack.gateway.format_dashboard_urls",
+                                return_value=["url-line-1", "url-line-2"],
+                            ):
                                 with patch("builtins.print", _tracing_print):
                                     with patch("kiro_crew.slack.events.init_socket_mode"):
                                         with patch("kiro_crew.slack.interactions.init"):
                                             with patch("kiro_crew.slack.events.SeenCache"):
-                                                with patch("kiro_crew.session.cleanup_orphaned_sessions"):
+                                                with patch(
+                                                    "kiro_crew.session.cleanup_orphaned_sessions"
+                                                ):
                                                     with patch(
                                                         "kiro_crew.dashboard.handlers._bg_mcp_probe",
                                                         _tracing_probe,
@@ -5850,6 +5934,7 @@ class TestBgSessionDashboardBranch:
             orch._local_only = True
             orch._configured_host = None
             orch._dashboard_port = 6779
+
         orch._init_dashboard = _init_dash
 
         fresh_event = asyncio.Event()
@@ -5858,8 +5943,9 @@ class TestBgSessionDashboardBranch:
         with patch.object(loop, "add_signal_handler"):
             with patch("kiro_crew.shutdown_event", fresh_event):
                 with patch("kiro_crew.slack.gateway.shutdown_event", fresh_event):
-                    with patch("kiro_crew.slack.gateway.resolve_dashboard_host",
-                               return_value="127.0.0.1"):
+                    with patch(
+                        "kiro_crew.slack.gateway.resolve_dashboard_host", return_value="127.0.0.1"
+                    ):
                         with patch(
                             "kiro_crew.slack.gateway.format_dashboard_urls",
                             side_effect=RuntimeError("cannot format URL"),
@@ -5894,9 +5980,7 @@ class TestCheckMissingDepsPip:
         orch = _make_orchestrator()
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
-                with patch.object(
-                    GatewayOrchestrator, "_is_brazil_install", return_value=False
-                ):
+                with patch.object(GatewayOrchestrator, "_is_brazil_install", return_value=False):
                     mock_exec = AsyncMock(return_value=_fake_async_proc(returncode=0))
                     with patch("asyncio.create_subprocess_exec", mock_exec):
                         asyncio.run(orch._check_missing_deps())
@@ -5912,9 +5996,7 @@ class TestCheckMissingDepsPip:
         orch = _make_orchestrator()
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
-                with patch.object(
-                    GatewayOrchestrator, "_is_brazil_install", return_value=False
-                ):
+                with patch.object(GatewayOrchestrator, "_is_brazil_install", return_value=False):
                     mock_exec = AsyncMock(
                         return_value=_fake_async_proc(returncode=1, stderr=b"error")
                     )
@@ -5937,12 +6019,8 @@ class TestCheckMissingDepsPip:
         proc.communicate = MagicMock(side_effect=_communicate)
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
-                with patch.object(
-                    GatewayOrchestrator, "_is_brazil_install", return_value=False
-                ):
-                    with patch.object(
-                        GatewayOrchestrator, "_DEP_INSTALL_TIMEOUT_SECS", 0.05
-                    ):
+                with patch.object(GatewayOrchestrator, "_is_brazil_install", return_value=False):
+                    with patch.object(GatewayOrchestrator, "_DEP_INSTALL_TIMEOUT_SECS", 0.05):
                         with patch(
                             "asyncio.create_subprocess_exec",
                             AsyncMock(return_value=proc),
@@ -5995,12 +6073,8 @@ class TestCheckMissingDepsPip:
         orch = _make_orchestrator()
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
-                with patch.object(
-                    GatewayOrchestrator, "_is_brazil_install", return_value=False
-                ):
-                    with patch(
-                        "asyncio.create_subprocess_exec", AsyncMock(return_value=proc)
-                    ):
+                with patch.object(GatewayOrchestrator, "_is_brazil_install", return_value=False):
+                    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
                         task = asyncio.create_task(orch._check_missing_deps())
                         await asyncio.sleep(0.05)  # let it reach the await
                         task.cancel()
@@ -6131,12 +6205,8 @@ class TestInitServicesLoopResponsiveness:
 
         with patch("importlib.util.find_spec", return_value=None):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/proj"}):
-                with patch.object(
-                    GatewayOrchestrator, "_is_brazil_install", return_value=False
-                ):
-                    with patch(
-                        "asyncio.create_subprocess_exec", side_effect=_async_exec
-                    ):
+                with patch.object(GatewayOrchestrator, "_is_brazil_install", return_value=False):
+                    with patch("asyncio.create_subprocess_exec", side_effect=_async_exec):
                         with patch(
                             "subprocess.run",
                             side_effect=_blocking_run,
@@ -6146,9 +6216,7 @@ class TestInitServicesLoopResponsiveness:
                                 # Above every probe deadline so a regressed
                                 # run fails on the starvation assert below,
                                 # not on a torn-down timeout.
-                                await asyncio.wait_for(
-                                    orch._check_missing_deps(), timeout=60
-                                )
+                                await asyncio.wait_for(orch._check_missing_deps(), timeout=60)
                             finally:
                                 ticker_task.cancel()
         assert state["starved"] == [], (
@@ -6173,9 +6241,7 @@ class TestInitServicesLoopResponsiveness:
             side_effect=self._make_probe(state, "rebuild-index", result=3)
         )
         mock_vm_inst = MagicMock()
-        mock_vm_inst.init = MagicMock(
-            side_effect=self._make_probe(state, "vector-init")
-        )
+        mock_vm_inst.init = MagicMock(side_effect=self._make_probe(state, "vector-init"))
         with patch("kiro_crew.slack.gateway.MemoryStore", return_value=mock_mem_inst):
             with patch("kiro_crew.vector_memory.VectorMemoryStore") as mock_vm:
                 mock_vm.return_value = mock_vm_inst
@@ -6183,14 +6249,24 @@ class TestInitServicesLoopResponsiveness:
                     with patch("kiro_crew.slack.gateway.HookManager"):
                         with patch("kiro_crew.slack.gateway.LessonStore"):
                             with patch("kiro_crew.slack.gateway.ContextBuilder"):
-                                with patch("kiro_crew.slack.gateway.ConversationLog", return_value=MagicMock()):
+                                with patch(
+                                    "kiro_crew.slack.gateway.ConversationLog",
+                                    return_value=MagicMock(),
+                                ):
                                     with patch("kiro_crew.slack.gateway.SessionManager"):
                                         with patch("kiro_crew.slack.gateway.HistoryConsolidator"):
                                             with patch("kiro_crew.slack.gateway.ChannelHistory"):
-                                                with patch("kiro_crew.agent.rebuild_agent_config", return_value=Path("/tmp/a")):
+                                                with patch(
+                                                    "kiro_crew.agent.rebuild_agent_config",
+                                                    return_value=Path("/tmp/a"),
+                                                ):
                                                     with patch(
                                                         "asyncio.create_subprocess_exec",
-                                                        new=AsyncMock(return_value=_fake_async_proc(stdout=b"kiro-cli 1.30.0")),
+                                                        new=AsyncMock(
+                                                            return_value=_fake_async_proc(
+                                                                stdout=b"kiro-cli 1.30.0"
+                                                            )
+                                                        ),
                                                     ):
                                                         ticker_task = asyncio.create_task(_ticker())
                                                         try:
@@ -6275,7 +6351,10 @@ class TestCronSlackDeliveryFailure:
             new_callable=AsyncMock,
             return_value="result",
         ):
-            with patch("kiro_crew.slack.gateway.build_cron_session_context", return_value=("cron:jslack", "run")):
+            with patch(
+                "kiro_crew.slack.gateway.build_cron_session_context",
+                return_value=("cron:jslack", "run"),
+            ):
                 result = await callback(job)
 
         assert result == "result"
@@ -6352,9 +6431,7 @@ class TestDeliverCronResponse:
         orch.sessions.get_channel = MagicMock(return_value="C123")
         orch.sessions.get_thread = MagicMock(return_value="T456")
 
-        posted = await orch._deliver_cron_response(
-            "cron:job1", "pick one\n\n[OPTIONS: Yes | No]"
-        )
+        posted = await orch._deliver_cron_response("cron:job1", "pick one\n\n[OPTIONS: Yes | No]")
 
         assert posted is True
         body = slack.post_message.call_args.args[1]
@@ -6474,14 +6551,14 @@ class TestSlackSubagentCompletionPersistence:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info()
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="synthesized response",
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=False
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=False
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="synthesized response",
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=False),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=False),
         ):
             await on_done(info)
 
@@ -6509,14 +6586,14 @@ class TestSlackSubagentCompletionPersistence:
         # Response carries a credential-shaped token that must not reach disk raw.
         leaked = "result aws_secret_access_key=AKIAIOSFODNN7EXAMPLE done"
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value=leaked,
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=False
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=False
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value=leaked,
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=False),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=False),
         ):
             await on_done(info)
 
@@ -6532,14 +6609,14 @@ class TestSlackSubagentCompletionPersistence:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info()
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="response",
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=False
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="response",
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=True),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=False),
         ):
             await on_done(info)
 
@@ -6552,14 +6629,14 @@ class TestSlackSubagentCompletionPersistence:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info()
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="response",
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=False
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=True
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="response",
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=False),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=True),
         ):
             await on_done(info)
 
@@ -6573,14 +6650,14 @@ class TestSlackSubagentCompletionPersistence:
         info = self._make_info()
         orch.conv_log.append = MagicMock(side_effect=OSError("disk full"))
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="response",
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=False
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=False
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="response",
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=False),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=False),
         ):
             # Should not raise
             await on_done(info)
@@ -6617,14 +6694,14 @@ class TestSlackSubagentCompletionPersistence:
         # Slack delivery fails (best-effort), but injection already succeeded.
         orch.slack.post_message = AsyncMock(side_effect=RuntimeError("slack down"))
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="synthesized response",
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=False
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=False
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="synthesized response",
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=False),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=False),
         ):
             # Must not raise despite the Slack failure.
             await on_done(info)
@@ -6643,16 +6720,15 @@ class TestSlackSubagentCompletionPersistence:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info()
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            side_effect=[asyncio.TimeoutError(), "response text"],
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_temporary", return_value=False
-        ), patch(
-            "kiro_crew.slack.gateway.is_thread_incognito", return_value=False
-        ), patch(
-            "asyncio.sleep", new_callable=AsyncMock
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                side_effect=[asyncio.TimeoutError(), "response text"],
+            ),
+            patch("kiro_crew.slack.gateway.is_thread_temporary", return_value=False),
+            patch("kiro_crew.slack.gateway.is_thread_incognito", return_value=False),
+            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             await on_done(info)
 
@@ -6760,11 +6836,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("telegram:kirocrew:direct:12345")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="synthesized reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="synthesized reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_awaited_once_with(
@@ -6787,11 +6866,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("discord:kirocrew:direct:U999")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_awaited_once_with("C777", "reply", thread_id=None)
@@ -6823,11 +6905,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("telegram:kirocrew:direct:12345")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="synthesized reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="synthesized reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         orch.slack.post_message.assert_not_awaited()
@@ -6842,11 +6927,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("telegram:kirocrew:direct:12345")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="synthesized reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="synthesized reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)  # must not raise
 
         orch.dashboard_state.notify.assert_called()
@@ -6863,22 +6951,23 @@ class TestSubagentChannelTransportDelivery:
         # Origin link present at entry, gone after the first (timed-out)
         # injection attempt — exactly what reset() does to a live session.
         orch.sessions.get_origin_link = MagicMock(
-            side_effect=[ChannelLink("discord", channel_id="C777", thread_id="T1")]
-            + [None] * 8
+            side_effect=[ChannelLink("discord", channel_id="C777", thread_id="T1")] + [None] * 8
         )
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("discord:kirocrew:direct:U999")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            side_effect=[asyncio.TimeoutError, "reply after retry"],
-        ), patch("asyncio.sleep", new_callable=AsyncMock), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                side_effect=[asyncio.TimeoutError, "reply after retry"],
+            ),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
-        transport.send_message.assert_awaited_once_with(
-            "C777", "reply after retry", thread_id="T1"
-        )
+        transport.send_message.assert_awaited_once_with("C777", "reply after retry", thread_id="T1")
 
     @pytest.mark.asyncio
     async def test_peer_resolution_outcome_is_sel_audited(self):
@@ -6891,11 +6980,15 @@ class TestSubagentChannelTransportDelivery:
             on_done = mock_sm.call_args[1]["on_done"]
             info = self._make_info("telegram:kirocrew:direct:12345")
 
-            with patch(
-                "kiro_crew.slack.gateway.stream_and_collect",
-                new_callable=AsyncMock,
-                return_value="reply",
-            ), self._permit_governance(), patch("kiro_crew.slack.gateway.sel") as mock_sel:
+            with (
+                patch(
+                    "kiro_crew.slack.gateway.stream_and_collect",
+                    new_callable=AsyncMock,
+                    return_value="reply",
+                ),
+                self._permit_governance(),
+                patch("kiro_crew.slack.gateway.sel") as mock_sel,
+            ):
                 mock_sel.return_value.log_api_access = MagicMock()
                 await on_done(info)
 
@@ -6916,11 +7009,14 @@ class TestSubagentChannelTransportDelivery:
         info = self._make_info("telegram:kirocrew:direct:12345")
         leaked = "result aws_secret_access_key=AKIAIOSFODNN7EXAMPLE done"
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value=leaked,
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value=leaked,
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_awaited_once()
@@ -6937,11 +7033,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("telegram:kirocrew:forum:987:5")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="synthesized reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="synthesized reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_not_awaited()
@@ -6961,11 +7060,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("telegram:kirocrew:forum:987:5")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_awaited_once_with("987", "reply", thread_id="5")
@@ -6981,11 +7083,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("unified:kirocrew")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_awaited_once_with("12345", "reply", thread_id=None)
@@ -7001,11 +7106,14 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("discord:kirocrew:direct:U999")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.resolve_configured_target.assert_awaited_once_with("user:U999")
@@ -7017,17 +7125,18 @@ class TestSubagentChannelTransportDelivery:
         conversation/serviceUrl) degrades to notification-only, no send."""
         transport = self._fake_transport("teams")
         transport.resolve_configured_target = AsyncMock(return_value=None)
-        orch, mock_sm = self._setup(
-            parent_channel="teams:user@example.com", transport=transport
-        )
+        orch, mock_sm = self._setup(parent_channel="teams:user@example.com", transport=transport)
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("teams:kirocrew:direct:user@example.com")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="reply",
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         transport.send_message.assert_not_awaited()
@@ -7041,13 +7150,16 @@ class TestSubagentChannelTransportDelivery:
         on_done = mock_sm.call_args[1]["on_done"]
         info = self._make_info("telegram:kirocrew:direct:12345")
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value="reply",
-        ), patch(
-            "kiro_crew.platform.governance_profiles.vet_and_audit",
-            return_value=SimpleNamespace(permitted=False),
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.vet_and_audit",
+                return_value=SimpleNamespace(permitted=False),
+            ),
         ):
             await on_done(info)
 
@@ -7063,11 +7175,14 @@ class TestSubagentChannelTransportDelivery:
         info = self._make_info("telegram:kirocrew:direct:12345")
         long_reply = "\n".join(f"line {i} of the reply" for i in range(6))
 
-        with patch(
-            "kiro_crew.slack.gateway.stream_and_collect",
-            new_callable=AsyncMock,
-            return_value=long_reply,
-        ), self._permit_governance():
+        with (
+            patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value=long_reply,
+            ),
+            self._permit_governance(),
+        ):
             await on_done(info)
 
         assert transport.send_message.await_count > 1
@@ -7139,7 +7254,9 @@ class TestCountInFlightWork:
         orch = _make_orchestrator()
         state = MagicMock()
         state.sessions.active_providers.return_value = [
-            _provider(True), _provider(False), _provider(True)
+            _provider(True),
+            _provider(False),
+            _provider(True),
         ]
         orch.dashboard_state = state
         orch._session_tasks = {}
@@ -7151,9 +7268,7 @@ class TestCountInFlightWork:
         raising = MagicMock()
         raising.has_active_turn = MagicMock(side_effect=RuntimeError("boom"))
         state = MagicMock()
-        state.sessions.active_providers.return_value = [
-            no_attr, raising, _provider(True)
-        ]
+        state.sessions.active_providers.return_value = [no_attr, raising, _provider(True)]
         orch.dashboard_state = state
         orch._session_tasks = {}
         # no_attr skipped, raising treated as idle, only the active one counts.
@@ -7209,9 +7324,7 @@ class TestUnreadyChannelBadge:
             for key, value in values.items():
                 object.__setattr__(section, key, value)
         orch._cfg.load_credentials = lambda: {}
-        boot = tuple(
-            ChannelDescriptor(channel_type=name, start=AsyncMock()) for name in sections
-        )
+        boot = tuple(ChannelDescriptor(channel_type=name, start=AsyncMock()) for name in sections)
         return orch, boot
 
     def test_an_enabled_channel_missing_its_token_is_badged_with_the_reason(self):
@@ -7300,8 +7413,7 @@ class TestChannelTransportStartGate:
             "webex": AsyncMock(),
         }
         self._descriptors = tuple(
-            ChannelDescriptor(channel_type=name, start=mock)
-            for name, mock in mocks.items()
+            ChannelDescriptor(channel_type=name, start=mock) for name, mock in mocks.items()
         )
         return mocks
 
@@ -7498,9 +7610,7 @@ class TestProviderFailureDoesNotFallBackToLegacy:
         orch.dashboard_state = _mock_dashboard_state()
 
         provider = CommandProvider(check_command="c", apply_command="a")
-        monkeypatch.setattr(
-            "kiro_crew.platform.update_provider.resolve_provider", lambda: provider
-        )
+        monkeypatch.setattr("kiro_crew.platform.update_provider.resolve_provider", lambda: provider)
         boom = AsyncMock(side_effect=RuntimeError("provider exploded"))
         monkeypatch.setattr(orch, "_check_for_updates_via_provider", boom)
         legacy = AsyncMock()
@@ -7522,9 +7632,7 @@ class TestProviderFailureDoesNotFallBackToLegacy:
         def _boom():
             raise RuntimeError("policy unreadable")
 
-        monkeypatch.setattr(
-            "kiro_crew.platform.update_provider.resolve_provider", _boom
-        )
+        monkeypatch.setattr("kiro_crew.platform.update_provider.resolve_provider", _boom)
         legacy = AsyncMock()
         monkeypatch.setattr(orch, "_check_for_updates_legacy", legacy)
 
@@ -7555,9 +7663,7 @@ class TestWheelInstallerRejectsUnsafeCdnBase:
                 }
             }
         )
-        monkeypatch.setattr(
-            "kiro_crew.platform.update_layout.cdn_bases_are_safe", lambda: False
-        )
+        monkeypatch.setattr("kiro_crew.platform.update_layout.cdn_bases_are_safe", lambda: False)
         spawn = AsyncMock()
         monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
 
@@ -7601,9 +7707,7 @@ class TestWheelApplyReadsTheCapabilityCommand:
         # command SOURCE, which is platform-independent; the refusals themselves
         # are pinned by the two tests below.
         monkeypatch.setattr("kiro_crew.slack.gateway.sys.platform", "linux")
-        monkeypatch.setattr(
-            "kiro_crew.platform_compat.trusted_system_bin", lambda name: "/bin/sh"
-        )
+        monkeypatch.setattr("kiro_crew.platform_compat.trusted_system_bin", lambda name: "/bin/sh")
         monkeypatch.setattr(
             "kiro_crew.platform.update_provider._trusted_path_env",
             lambda: {"PATH": "/usr/bin:/bin"},
@@ -7695,6 +7799,7 @@ class TestWheelApplyReadsTheCapabilityCommand:
         await orch._auto_apply_wheel_update()
 
         spawn.assert_not_awaited()
+
     """The SSE snapshot renders the update badge from _update_info["available"],
     which only the legacy check writes. A provider carries its own result, so
     notifying without publishing it left the badge reading a stale False and the
@@ -8039,9 +8144,7 @@ class TestUncredentialedProbeRatchet:
         from kiro_crew.channels import builtin_channel_descriptors
 
         rostered = {descriptor.channel_type for descriptor in builtin_channel_descriptors()}
-        accounted = set(_uncredentialed_probe_operands()) | set(
-            _UNCREDENTIALED_PROBE_EXEMPTIONS
-        )
+        accounted = set(_uncredentialed_probe_operands()) | set(_UNCREDENTIALED_PROBE_EXEMPTIONS)
         assert rostered == accounted, (
             "rostered channels must have an uncredentialed probe row or an "
             "explicit config-only/token-driven exemption; "
@@ -8066,9 +8169,7 @@ class TestUncredentialedProbeRatchet:
         )
 
     def test_exemptions_are_not_credential_probe_rows(self) -> None:
-        overlap = set(_uncredentialed_probe_operands()) & set(
-            _UNCREDENTIALED_PROBE_EXEMPTIONS
-        )
+        overlap = set(_uncredentialed_probe_operands()) & set(_UNCREDENTIALED_PROBE_EXEMPTIONS)
         assert not overlap, (
             "a channel cannot be both credential-probed and exempt: " f"{sorted(overlap)}"
         )
@@ -8327,9 +8428,7 @@ class TestChannelSkipReasonAtTransportStart:
         assert self._channel_records(caplog) == []
 
     @pytest.mark.asyncio
-    async def test_teams_tenant_id_is_not_a_credential_operand(
-        self, caplog, monkeypatch
-    ) -> None:
+    async def test_teams_tenant_id_is_not_a_credential_operand(self, caplog, monkeypatch) -> None:
         # The trap the table must not fall into: the tenant id sits in config
         # right next to the two operands that count, but _teams_enabled never
         # reads it — app id + password present with NO tenant is fully
@@ -8401,15 +8500,15 @@ class TestAutoApplyUpdatePreconditions:
             proc.wait = AsyncMock(return_value=0)
             return proc
 
-        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
-            "asyncio.create_subprocess_exec", side_effect=_fake_exec
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="repository declares filter.evil.smudge",
-        ), patch(
-            "kiro_crew.slack.gateway.is_primary_branch", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        with (
+            patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="repository declares filter.evil.smudge",
+            ),
+            patch("kiro_crew.slack.gateway.is_primary_branch", return_value=True),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=True),
         ):
             await orch._auto_apply_update()
 
@@ -8441,15 +8540,15 @@ class TestAutoApplyUpdatePreconditions:
             proc.wait = AsyncMock(return_value=proc.returncode)
             return proc
 
-        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
-            "asyncio.create_subprocess_exec", side_effect=_fake_exec
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="",
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.commits_ahead", return_value=2
+        with (
+            patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="",
+            ),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=True),
+            patch("kiro_crew.slack.gateway.commits_ahead", return_value=2),
         ):
             await orch._auto_apply_update()
 
@@ -8472,15 +8571,15 @@ class TestAutoApplyUpdatePreconditions:
             proc.wait = AsyncMock(return_value=proc.returncode)
             return proc
 
-        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
-            "asyncio.create_subprocess_exec", side_effect=_fake_exec
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="",
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
-        ), patch(
-            "kiro_crew.slack.gateway.commits_ahead", return_value=None
+        with (
+            patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="",
+            ),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=True),
+            patch("kiro_crew.slack.gateway.commits_ahead", return_value=None),
         ):
             await orch._auto_apply_update()
 
@@ -8508,13 +8607,14 @@ class TestAutoApplyUpdatePreconditions:
             proc.wait = AsyncMock(return_value=0)
             return proc
 
-        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
-            "asyncio.create_subprocess_exec", side_effect=_fake_exec
-        ), patch(
-            "kiro_crew.slack.gateway.repo_exec_config_reason",
-            return_value="",
-        ), patch(
-            "kiro_crew.slack.gateway.tracks_upstream", return_value=False
+        with (
+            patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            patch(
+                "kiro_crew.slack.gateway.repo_exec_config_reason",
+                return_value="",
+            ),
+            patch("kiro_crew.slack.gateway.tracks_upstream", return_value=False),
         ):
             await orch._auto_apply_update()
 

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -880,7 +880,7 @@ class TestReaperOffloadsTheSweep:
             patch.object(asyncio.get_running_loop(), "run_in_executor", side_effect=_capture),
             patch.object(mgr, "_sample_live_costs") as sample,
             patch.object(mgr, "_rebuild_conversation_registry", new=AsyncMock()),
-            patch.object(mgr, "_drain_pending_outbox", new=AsyncMock()),
+            patch.object(mgr._run_recovery, "reconcile", new=AsyncMock()),
         ):
             task = asyncio.ensure_future(mgr._reaper_loop())
             await asyncio.sleep(0.05)

--- a/test/test_subagent_delivery_ttl_anchor.py
+++ b/test/test_subagent_delivery_ttl_anchor.py
@@ -92,6 +92,18 @@ class TestPendingDeliveryLedger:
         # Claimed once: a second drain of the same row owes nothing.
         assert slot.take_pending_subagent_deliveries([_ann("one"), _ann("two")]) == []
 
+    def test_error_tombstone_kind_survives_the_consumption_ledger(self):
+        slot = _ChatSlot("s1")
+        slot.note_pending_subagent_delivery(
+            _ann("one"), ["failed", "completed"], error_tombstone_ids={"failed"}
+        )
+
+        agent_ids = slot.take_pending_subagent_deliveries([_ann("one")])
+
+        assert agent_ids == ["failed", "completed"]
+        assert agent_ids.error_tombstone_ids == frozenset({"failed"})
+        assert slot.take_pending_subagent_deliveries([_ann("one")]) == []
+
     def test_empty_ids_record_nothing(self):
         """A failed member keeps the tombstone its own error path wrote, and a
         flush-only record has no folder — neither owes a mark."""
@@ -189,6 +201,32 @@ class TestDeferQueuedDelivery:
 
         assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
         assert info._delivery_queued is True
+
+    def test_shadow_fallback_preserves_its_error_tombstone_debt(self):
+        slot = _ChatSlot("s1")
+        info = _member(error="coordinator submission failed")
+        info._legacy_delivery_tombstone = True
+
+        _defer(slot, info)
+
+        assert slot._subagent_delivery_pending == {_key(COMPLETION): ["a1"]}
+        assert slot._subagent_error_tombstone_pending == {_key(COMPLETION): {"a1"}}
+        assert info._delivery_queued is True
+
+    def test_wave_digest_transfers_error_tombstone_kinds(self):
+        slot = _ChatSlot("s1")
+        info = _member("flusher")
+        info._digest_settle_ids = ["failed", "completed"]
+        info._digest_error_tombstone_ids = ["failed"]
+
+        _defer(slot, info)
+
+        assert slot._subagent_delivery_pending == {
+            _key(COMPLETION): ["flusher", "failed", "completed"]
+        }
+        assert slot._subagent_error_tombstone_pending == {_key(COMPLETION): {"failed"}}
+        assert info._digest_settle_ids == []
+        assert info._digest_error_tombstone_ids == []
 
     def test_stopped_durable_member_owes_acknowledgement_without_a_tombstone(self):
         """A user stop leaves ``error`` EMPTY (it is a neutral outcome), so the
@@ -415,6 +453,23 @@ class TestTeardownGateOnQueuedSettlement:
 
         assert (agent_root / info.id / "tombstone.json").exists()
         assert (agent_root / "evicted" / "tombstone.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_shadow_fallback_settles_with_error_retention(self, agent_root):
+        mgr = SubagentManager(sessions=MagicMock(), ctx_builder=MagicMock())
+        info = _member("failed", error="run coordinator submission failed after timeout")
+        _finished_run(info.id, agent_root)
+        mgr._agents[info.id] = info
+        mgr._agents.pop(info.id)  # dashboard clear evicted the live record
+
+        await mgr.settle_queued_delivery([info.id], error_tombstone_ids={info.id})
+
+        tombstone = json.loads(
+            (agent_root / info.id / "tombstone.json").read_text(encoding="utf-8")
+        )
+        assert tombstone["cause"] == "error"
+        assert tombstone["outcome"] == "failed"
+        assert tombstone["detail"] == "run coordinator submission failed after timeout"
 
     @pytest.mark.asyncio
     async def test_an_evicted_run_still_waits_for_its_teardown(self, agent_root):
@@ -896,9 +951,10 @@ class TestReaperDoesNotPruneAQueuedPromise:
         assert not (agent_root / info.id / "tombstone.json").exists()
 
     @pytest.mark.asyncio
-    async def test_gateway_idle_route_settles_only_after_turn_consumption(self):
-        """Dispatching an idle dashboard turn is not durable delivery; the
-        outbox debt clears only after the model consumes the completion."""
+    @pytest.mark.parametrize("legacy_error", [False, True])
+    async def test_gateway_idle_route_settles_only_after_turn_consumption(self, legacy_error):
+        """An idle dashboard dispatch settles durable and legacy-error debt
+        only after the model consumes the completion."""
         from test_subagent_scale import _mock_dashboard_state, _mock_sessions
 
         orch = _make_orchestrator()
@@ -930,7 +986,11 @@ class TestReaperDoesNotPruneAQueuedPromise:
             consumed.set()
 
         info = _member()
-        info._delivery_event_id = "event-1"
+        if legacy_error:
+            info.error = "coordinator submission failed"
+            info._legacy_delivery_tombstone = True
+        else:
+            info._delivery_event_id = "event-1"
         with patch("kiro_crew.slack.gateway._run_chat", side_effect=consume_turn):
             await on_done(info)
             assert info._delivery_queued is True
@@ -939,6 +999,10 @@ class TestReaperDoesNotPruneAQueuedPromise:
             await _settled(lambda: mock_sm_inst.settle_queued_delivery.await_count == 1)
 
         mock_sm_inst.settle_queued_delivery.assert_awaited_once_with([info.id])
+        claimed = mock_sm_inst.settle_queued_delivery.await_args.args[0]
+        assert claimed.error_tombstone_ids == (
+            frozenset({info.id}) if legacy_error else frozenset()
+        )
 
 
 def _make_orchestrator():

--- a/test/test_subagent_persistence.py
+++ b/test/test_subagent_persistence.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import time
 
 import pytest
 
+from kiro_crew.pinned_fs import supports_pinned_walk
+from kiro_crew.run_coordinator import MemoryRunCoordinator
 from kiro_crew.subagent_persistence import (
+    clear_tombstone_for_recovery,
     create_agent_folder,
     delete_agent_folder,
     list_orphans,
@@ -24,6 +28,10 @@ from kiro_crew.subagent_persistence import (
 # ``SubagentManager.spawn`` refuses -- registering no task -- while the host
 # looks short of memory, which is the runner's state, not this test's input.
 pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+requires_pinned_walk = pytest.mark.skipif(
+    not supports_pinned_walk(),
+    reason="spawn transcript reads require descriptor-pinned traversal",
+)
 
 
 @pytest.fixture()
@@ -38,7 +46,13 @@ def agent_root(tmp_path, monkeypatch):
 
 class TestCreateAgentFolder:
     def test_creates_state_json(self, agent_root):
-        path = create_agent_folder("abc123", task="do stuff", agent="kirocrew", parent_session="dashboard:default", max_turns=100)
+        path = create_agent_folder(
+            "abc123",
+            task="do stuff",
+            agent="kirocrew",
+            parent_session="dashboard:default",
+            max_turns=100,
+        )
         state = json.loads((path / "state.json").read_text(encoding="utf-8"))
         assert state["id"] == "abc123"
         assert state["task"] == "do stuff"
@@ -239,6 +253,68 @@ class TestMarkDelivered:
         create_agent_folder("mv2", task="t")
         mark_delivered("mv2")
         assert "mv2" not in [o["id"] for o in list_orphans()]
+
+
+class TestClearTombstoneForRecovery:
+    def test_confirms_agent_is_visible_to_recovery(self, agent_root):
+        create_agent_folder("recover1", task="t")
+        write_tombstone("recover1", cause="timeout", recovery_action="pending")
+
+        assert clear_tombstone_for_recovery("recover1") is True
+        assert "recover1" in [orphan["id"] for orphan in list_orphans()]
+
+    def test_fails_closed_when_tombstone_remains(self, agent_root, monkeypatch):
+        create_agent_folder("recover2", task="t")
+        tombstone = agent_root / "recover2" / "tombstone.json"
+        write_tombstone("recover2", cause="timeout", recovery_action="pending")
+        real_unlink = os.unlink
+
+        def refuse_tombstone_unlink(path, *args, dir_fd=None, **kwargs):
+            if path == tombstone or path == "tombstone.json":
+                raise PermissionError("read-only filesystem")
+            if dir_fd is None:
+                return real_unlink(path, *args, **kwargs)
+            return real_unlink(path, *args, dir_fd=dir_fd, **kwargs)
+
+        monkeypatch.setattr(os, "unlink", refuse_tombstone_unlink)
+
+        assert clear_tombstone_for_recovery("recover2") is False
+        assert tombstone.exists()
+
+    @pytest.mark.skipif(
+        not supports_pinned_walk() or os.unlink not in os.supports_dir_fd,
+        reason="descriptor-relative unlink is unavailable",
+    )
+    def test_directory_swap_cannot_redirect_unlink_and_verification(
+        self,
+        agent_root,
+        monkeypatch,
+    ):
+        create_agent_folder("recover3", task="original")
+        write_tombstone("recover3", cause="timeout", recovery_action="pending")
+        original = agent_root / "recover3"
+        displaced = agent_root / "displaced-original"
+        replacement = agent_root / "replacement"
+        replacement.mkdir()
+        (replacement / "tombstone.json").write_text("replacement", encoding="utf-8")
+        real_unlink = os.unlink
+        swapped = False
+
+        def swap_directory_then_unlink(path, *args, dir_fd=None, **kwargs):
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                original.rename(displaced)
+                replacement.rename(original)
+            if dir_fd is None:
+                return real_unlink(path, *args, **kwargs)
+            return real_unlink(path, *args, dir_fd=dir_fd, **kwargs)
+
+        monkeypatch.setattr(os, "unlink", swap_directory_then_unlink)
+
+        assert clear_tombstone_for_recovery("recover3") is True
+        assert not (displaced / "tombstone.json").exists()
+        assert (original / "tombstone.json").exists()
 
 
 # ── Slice 2: spawn() creates agent folder ────────────────────────────
@@ -460,10 +536,22 @@ class TestPerTurnStateUpdates:
 
         manager = SubagentManager(sessions=sessions, ctx_builder=ctx)
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch(
+                "kiro_crew.subagent.platform_compat.process_start_time",
+                return_value="42.0",
+            ),
+        ):
             info = manager.spawn("pid test", parent_session_key="dashboard:default")
-            await manager._tasks[info.id]
+            await asyncio.wait_for(manager._tasks[info.id], timeout=1)
 
+        run = await manager._coordinator.get_run(info.id)
+        assert run is not None
+        assert run.process_id == 0
+        assert run.process_start_id == ""
+        assert run.process_owned is False
         state = json.loads((agent_root / info.id / "state.json").read_text(encoding="utf-8"))
         assert state["pid"] == 42
         assert "pid_recorded_at" in state
@@ -491,7 +579,9 @@ class TestPerTurnStateUpdates:
         provider.approve_tool = AsyncMock()
 
         async def _stream(*_a, **_kw):
-            yield LLMEvent(kind=EVENT_PERMISSION_REQUEST, title="shell", request_id=1, tool_kind="mcp")
+            yield LLMEvent(
+                kind=EVENT_PERMISSION_REQUEST, title="shell", request_id=1, tool_kind="mcp"
+            )
             yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="result")
             yield LLMEvent(kind=EVENT_COMPLETE)
 
@@ -575,16 +665,20 @@ class TestTombstoneOnAbnormalExit:
         async def _hang(*a, **kw):
             await asyncio.sleep(999)
 
-        with patch.object(manager, "_run_inner", _hang), \
-             patch.object(manager, "_default_timeout", 0.01), \
-             patch("kiro_crew.subagent.Stats"), \
-             patch("kiro_crew.subagent.sel"), \
-             patch.object(manager, "_fire_event", new_callable=AsyncMock), \
-             patch.object(manager, "_on_done", new_callable=AsyncMock):
+        with (
+            patch.object(manager, "_run_inner", _hang),
+            patch.object(manager, "_default_timeout", 0.01),
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch.object(manager, "_fire_event", new_callable=AsyncMock),
+            patch.object(manager, "_on_done", new_callable=AsyncMock),
+        ):
             await manager._run(info)
 
         # Tombstone should still say "reaped", not "timeout"
-        ts = json.loads((agent_root / "reaped_timeout" / "tombstone.json").read_text(encoding="utf-8"))
+        ts = json.loads(
+            (agent_root / "reaped_timeout" / "tombstone.json").read_text(encoding="utf-8")
+        )
         assert ts["cause"] == "reaped"
         # Error should not be overwritten
         assert info.error == "reaped by reaper"
@@ -607,7 +701,9 @@ class TestTombstoneOnAbnormalExit:
 
         async def _many_tools(*_a, **_kw):
             for i in range(5):
-                yield LLMEvent(kind=EVENT_PERMISSION_REQUEST, title=f"tool{i}", request_id=i, tool_kind="mcp")
+                yield LLMEvent(
+                    kind=EVENT_PERMISSION_REQUEST, title=f"tool{i}", request_id=i, tool_kind="mcp"
+                )
 
         provider.stream = MagicMock(side_effect=lambda *a, **kw: _many_tools())
         sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
@@ -653,8 +749,8 @@ class TestTombstoneOnAbnormalExit:
         assert ts["cause"] == "error"
 
     @pytest.mark.asyncio
-    async def test_no_tombstone_on_success(self, agent_root):
-        """Successful completion should NOT write a tombstone."""
+    async def test_no_abnormal_tombstone_on_success(self, agent_root):
+        """Successful completion records only the delivered tombstone."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
@@ -684,14 +780,20 @@ class TestTombstoneOnAbnormalExit:
         ctx.hooks.on_tool_call = MagicMock()
         ctx.hooks.auto_approve_subagent_spawn = True
 
-        manager = SubagentManager(sessions=sessions, ctx_builder=ctx)
+        manager = SubagentManager(
+            sessions=sessions,
+            ctx_builder=ctx,
+            coordinator=MemoryRunCoordinator(),
+        )
 
         with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
             info = manager.spawn("success test", parent_session_key="dashboard:default")
             await manager._tasks[info.id]
+            await asyncio.gather(*manager._report_tasks)
 
         ts_path = agent_root / info.id / "tombstone.json"
-        assert not ts_path.exists()
+        tombstone = json.loads(ts_path.read_text(encoding="utf-8"))
+        assert tombstone["cause"] == "delivered"
 
 
 # ── Slice 6: Folder cleanup on normal completion ─────────────────────
@@ -786,9 +888,11 @@ class TestFolderCleanupOnSuccess:
 
         manager = SubagentManager(sessions=sessions, ctx_builder=ctx, on_done=_slow_on_done)
 
-        with patch("kiro_crew.subagent._ON_DONE_TIMEOUT", 0.01), \
-             patch("kiro_crew.subagent.Stats"), \
-             patch("kiro_crew.subagent.sel"):
+        with (
+            patch("kiro_crew.subagent._ON_DONE_TIMEOUT", 0.01),
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+        ):
             info = manager.spawn("delivery failure test", parent_session_key="dashboard:default")
             await manager._tasks[info.id]
 
@@ -816,6 +920,7 @@ class TestOrphanReconciliation:
         create_agent_folder("orphan1", task="old task", parent_session="dashboard:default")
         write_result_chunk("orphan1", "some result")
         from kiro_crew.subagent_persistence import update_state
+
         update_state("orphan1", pid=99999)  # dead PID
 
         with patch.object(manager, "_is_pid_alive", return_value=False):
@@ -858,9 +963,11 @@ class TestOrphanReconciliation:
         create_agent_folder("orphan3", task="stuck task")
         update_state("orphan3", pid=99999)
 
-        with patch.object(manager, "_is_pid_alive", return_value=True), \
-             patch.object(manager, "_is_orphan_process", return_value=True), \
-             patch.object(manager, "_kill_orphan_pid") as mock_kill:
+        with (
+            patch.object(manager, "_is_pid_alive", return_value=True),
+            patch.object(manager, "_is_orphan_process", return_value=True),
+            patch.object(manager, "_kill_orphan_pid") as mock_kill,
+        ):
             await manager._reconcile_orphans()
 
         mock_kill.assert_called_once_with(99999)
@@ -881,9 +988,11 @@ class TestOrphanReconciliation:
         create_agent_folder("recycled1", task="old task")
         update_state("recycled1", pid=99999)
 
-        with patch.object(manager, "_is_pid_alive", return_value=True), \
-             patch.object(manager, "_is_orphan_process", return_value=False), \
-             patch.object(manager, "_kill_orphan_pid") as mock_kill:
+        with (
+            patch.object(manager, "_is_pid_alive", return_value=True),
+            patch.object(manager, "_is_orphan_process", return_value=False),
+            patch.object(manager, "_kill_orphan_pid") as mock_kill,
+        ):
             await manager._reconcile_orphans()
 
         mock_kill.assert_not_called()
@@ -904,9 +1013,11 @@ class TestOrphanReconciliation:
         create_agent_folder("orphan_ts", task="ts task")
         update_state("orphan_ts", pid=88888, pid_recorded_at=1234567890.5)
 
-        with patch.object(manager, "_is_pid_alive", return_value=True), \
-             patch.object(manager, "_is_orphan_process", return_value=True) as mock_check, \
-             patch.object(manager, "_kill_orphan_pid"):
+        with (
+            patch.object(manager, "_is_pid_alive", return_value=True),
+            patch.object(manager, "_is_orphan_process", return_value=True) as mock_check,
+            patch.object(manager, "_kill_orphan_pid"),
+        ):
             await manager._reconcile_orphans()
 
         mock_check.assert_called_once_with(88888, 1234567890.5)
@@ -925,7 +1036,9 @@ class TestOrphanReconciliation:
 
         # Should not re-tombstone
         await manager._reconcile_orphans()
-        ts = json.loads((agent_root / "already_dead" / "tombstone.json").read_text(encoding="utf-8"))
+        ts = json.loads(
+            (agent_root / "already_dead" / "tombstone.json").read_text(encoding="utf-8")
+        )
         assert ts["cause"] == "timeout"  # unchanged
 
     @pytest.mark.asyncio
@@ -969,8 +1082,10 @@ class TestOrphanNotification:
         write_result_chunk("notif1", "the answer is 42")
         update_state("notif1", pid=99999)
 
-        with patch.object(manager, "_is_pid_alive", return_value=False), \
-             patch.object(manager, "_notify_orphan", new_callable=AsyncMock) as mock_notify:
+        with (
+            patch.object(manager, "_is_pid_alive", return_value=False),
+            patch.object(manager, "_notify_orphan", new_callable=AsyncMock) as mock_notify,
+        ):
             await manager._reconcile_orphans()
 
         mock_notify.assert_awaited_once()
@@ -991,8 +1106,10 @@ class TestOrphanNotification:
         create_agent_folder("notif2", task="lost task")
         update_state("notif2", pid=99999)
 
-        with patch.object(manager, "_is_pid_alive", return_value=False), \
-             patch.object(manager, "_notify_orphan", new_callable=AsyncMock) as mock_notify:
+        with (
+            patch.object(manager, "_is_pid_alive", return_value=False),
+            patch.object(manager, "_notify_orphan", new_callable=AsyncMock) as mock_notify,
+        ):
             await manager._reconcile_orphans()
 
         mock_notify.assert_awaited_once()
@@ -1020,8 +1137,15 @@ class TestOrphanNotification:
 
         state = {"id": "notif3", "task": "fallback task", "parent_session": "dashboard:default"}
 
-        with patch.object(manager, "_try_inject_orphan_notification", new_callable=AsyncMock, return_value=False), \
-             patch.object(manager, "_send_orphan_slack_dm", new_callable=AsyncMock) as mock_dm:
+        with (
+            patch.object(
+                manager,
+                "_try_inject_orphan_notification",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(manager, "_send_orphan_slack_dm", new_callable=AsyncMock) as mock_dm,
+        ):
             msg = await manager._notify_orphan("notif3", state, "delivered", True)
 
         mock_dm.assert_not_awaited()  # DM happens once, at digest time
@@ -1052,8 +1176,12 @@ class TestOrphanNotification:
             injected_meta = meta
             return True
 
-        with patch.object(manager, "_try_inject_orphan_notification", side_effect=_capture_inject), \
-             patch("kiro_crew.subagent._redact", side_effect=lambda m: f"[REDACTED]{m}") as mock_redact:
+        with (
+            patch.object(manager, "_try_inject_orphan_notification", side_effect=_capture_inject),
+            patch(
+                "kiro_crew.subagent._redact", side_effect=lambda m: f"[REDACTED]{m}"
+            ) as mock_redact,
+        ):
             await manager._notify_orphan("notif_redact", state, "delivered", True)
 
         # _redact must have been called before injection
@@ -1088,8 +1216,10 @@ class TestOrphanNotification:
             if call_count == 1:
                 raise RuntimeError("notification failed")
 
-        with patch.object(manager, "_is_pid_alive", return_value=False), \
-             patch.object(manager, "_notify_orphan", side_effect=_failing_notify):
+        with (
+            patch.object(manager, "_is_pid_alive", return_value=False),
+            patch.object(manager, "_notify_orphan", side_effect=_failing_notify),
+        ):
             await manager._reconcile_orphans()
 
         # Both orphans should be tombstoned despite notification failure
@@ -1156,7 +1286,9 @@ class TestSpawnStatusReadsFromAgentFolder:
         """read_state returns data for orphaned agents (not in memory)."""
         from kiro_crew.subagent_persistence import create_agent_folder, read_state, write_tombstone
 
-        create_agent_folder("orphan_status", task="orphaned task", parent_session="dashboard:default")
+        create_agent_folder(
+            "orphan_status", task="orphaned task", parent_session="dashboard:default"
+        )
         write_tombstone("orphan_status", cause="gateway_restart", recovery_action="delivered")
 
         state = read_state("orphan_status")
@@ -1164,6 +1296,7 @@ class TestSpawnStatusReadsFromAgentFolder:
         assert state["task"] == "orphaned task"
 
     @pytest.mark.asyncio
+    @requires_pinned_walk
     async def test_api_spawn_status_fallback_to_disk(self, agent_root):
         """api_spawn_status returns disk data when agent not in memory."""
         from unittest.mock import MagicMock
@@ -1255,7 +1388,9 @@ class TestRecordSlowCommand:
     def test_appends_multiple_lines(self, agent_root):
         record_slow_command("ag1", idle_secs=200)
         record_slow_command("ag2", idle_secs=300)
-        lines = (agent_root / "slow_commands.jsonl").read_text(encoding="utf-8").strip().splitlines()
+        lines = (
+            (agent_root / "slow_commands.jsonl").read_text(encoding="utf-8").strip().splitlines()
+        )
         assert len(lines) == 2
         assert {json.loads(lines[0])["id"], json.loads(lines[1])["id"]} == {"ag1", "ag2"}
 
@@ -1267,9 +1402,7 @@ def _slow_log_records(path):
     if not path.exists():
         return []
     return [
-        json.loads(line)
-        for line in path.read_text(encoding="utf-8").strip().splitlines()
-        if line
+        json.loads(line) for line in path.read_text(encoding="utf-8").strip().splitlines() if line
     ]
 
 
@@ -1285,9 +1418,7 @@ class TestRecordSlowCommandRotation:
 
     @pytest.fixture(autouse=True)
     def small_cap(self, monkeypatch):
-        monkeypatch.setattr(
-            "kiro_crew.subagent_persistence._SLOW_LOG_MAX_BYTES", self.CAP
-        )
+        monkeypatch.setattr("kiro_crew.subagent_persistence._SLOW_LOG_MAX_BYTES", self.CAP)
 
     def test_rotation_keeps_every_record(self, agent_root):
         """One rotation: older records land in ``.jsonl.1``, none are lost."""
@@ -1369,9 +1500,7 @@ class TestRecordSlowCommandRotation:
 
         live = agent_root / "slow_commands.jsonl"
         live.write_text("x" * (self.CAP + 10), encoding="utf-8")
-        lock_fd = os.open(
-            agent_root / "slow_commands.jsonl.lock", os.O_CREAT | os.O_RDWR, 0o600
-        )
+        lock_fd = os.open(agent_root / "slow_commands.jsonl.lock", os.O_CREAT | os.O_RDWR, 0o600)
         try:
             assert platform_compat.try_acquire_lock(lock_fd, exclusive=True)
             done = threading.Event()

--- a/test/test_subagent_reap_race.py
+++ b/test/test_subagent_reap_race.py
@@ -27,20 +27,26 @@ The design under test separates all of them:
   deliberately independent of ``done``, and executed under ``asyncio.shield`` so
   an interrupted claimer cannot strand the outcome.
 """
+
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from kiro_crew.run_coordinator import MemoryRunCoordinator
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 
 
 def _make_manager(max_concurrent: int = 4) -> SubagentManager:
     mgr = SubagentManager(
-        sessions=MagicMock(), ctx_builder=MagicMock(), max_concurrent=max_concurrent
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        max_concurrent=max_concurrent,
+        coordinator=MemoryRunCoordinator(),
     )
     mgr._fire_event = AsyncMock()
     mgr._write_tombstone = MagicMock()
@@ -73,6 +79,7 @@ async def _schedule_recovery(mgr: SubagentManager, info: SubagentInfo) -> None:
     task that then EXITS — arming it from the test body would sit through the
     real ``_RESET_TIMEOUT + 60`` handshake.
     """
+
     async def _arm() -> None:
         mgr._schedule_cancel_recovery(info)
 
@@ -147,9 +154,9 @@ async def test_done_set_during_reap_teardown_still_reports_and_frees_one_slot():
 
     assert len(_done_events(mgr)) == 1, "outcome was not reported exactly once"
     assert mgr._on_done.await_count == 1, "completion never reached the parent"
-    assert mgr._running_count == 0, (
-        f"slot not freed exactly once (_running_count={mgr._running_count})"
-    )
+    assert (
+        mgr._running_count == 0
+    ), f"slot not freed exactly once (_running_count={mgr._running_count})"
 
 
 @pytest.mark.asyncio
@@ -248,9 +255,7 @@ async def test_cancel_during_subagent_done_still_delivers_once():
     mgr._fire_event = AsyncMock(side_effect=_slow_event)
     mgr._on_done = AsyncMock(side_effect=_record_delivery)
 
-    task = asyncio.ensure_future(
-        mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped")
-    )
+    task = asyncio.ensure_future(mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped"))
     await asyncio.wait_for(entered.wait(), timeout=2)  # now inside the shielded report
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -282,9 +287,7 @@ async def test_cancel_during_on_done_produces_no_second_delivery():
 
     mgr._on_done = AsyncMock(side_effect=_slow_on_done)
 
-    task = asyncio.ensure_future(
-        mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped")
-    )
+    task = asyncio.ensure_future(mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped"))
     # Wait until _on_done is actually executing before cancelling — avoids a
     # race under heavy xdist load where asyncio.sleep(0.01) could expire after
     # _force_reap already completed, so the cancel would be a no-op.
@@ -440,7 +443,19 @@ async def test_cancel_all_readmits_an_undelivered_report_to_orphan_recovery(monk
     mgr = _make_manager()
     info = _info()
     cleared: list[str] = []
-    monkeypatch.setattr(mod, "clear_tombstone", lambda aid: (cleared.append(aid), True)[1])
+
+    event_loop_thread = threading.get_ident()
+
+    def _clear_tombstone(agent_id: str) -> bool:
+        assert threading.get_ident() != event_loop_thread
+        cleared.append(agent_id)
+        return True
+
+    monkeypatch.setattr(
+        mod,
+        "clear_tombstone_for_recovery",
+        _clear_tombstone,
+    )
 
     started = asyncio.Event()
 
@@ -461,9 +476,9 @@ async def test_cancel_all_readmits_an_undelivered_report_to_orphan_recovery(monk
     await mgr.cancel_all()
 
     assert task.cancelled(), "straggler should have been cancelled"
-    assert cleared == [info.id], (
-        "undelivered completion was left tombstoned — unrecoverable on restart"
-    )
+    assert cleared == [
+        info.id
+    ], "undelivered completion was left tombstoned — unrecoverable on restart"
 
 
 @pytest.mark.asyncio
@@ -480,7 +495,11 @@ async def test_cancel_all_keeps_the_tombstone_when_delivery_already_happened(mon
     mgr = _make_manager()
     info = _info()
     cleared: list[str] = []
-    monkeypatch.setattr(mod, "clear_tombstone", lambda aid: (cleared.append(aid), True)[1])
+    monkeypatch.setattr(
+        mod,
+        "clear_tombstone_for_recovery",
+        lambda aid: (cleared.append(aid), True)[1],
+    )
 
     delivered = asyncio.Event()
 
@@ -615,9 +634,9 @@ async def test_reap_suppression_marker_is_set_before_the_teardown_await():
         "respawn suppression was not set while teardown was suspended — a "
         "recovery handshake expiring here would respawn the run being killed"
     )
-    assert seen["recovery_deregistered"] is True, (
-        "recovery task was still registered while teardown was suspended"
-    )
+    assert (
+        seen["recovery_deregistered"] is True
+    ), "recovery task was still registered while teardown was suspended"
     await asyncio.sleep(0)
     assert recovery.cancelled(), "recovery task was never actually cancelled"
 
@@ -732,9 +751,9 @@ async def test_cancelled_teardown_still_releases_slot_and_gate():
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert mgr._running_count == 0, (
-        f"cancelled teardown leaked the slot (_running_count={mgr._running_count})"
-    )
+    assert (
+        mgr._running_count == 0
+    ), f"cancelled teardown leaked the slot (_running_count={mgr._running_count})"
     assert "a1b2c3d4" not in mgr._tasks, "cancelled teardown left the task registered"
 
 
@@ -773,7 +792,7 @@ async def test_run_does_not_block_on_its_report_during_shutdown():
     # Must return promptly even though the injection is wedged.
     await asyncio.wait_for(mgr._run(info), timeout=5)
 
-    assert wedged.is_set(), "report never started"
+    await asyncio.wait_for(wedged.wait(), timeout=1)
     pending = [t for t in mgr._report_tasks if not t.done()]
     assert pending, "report should still be pending, owned by cancel_all's drain"
     for t in pending:
@@ -820,8 +839,7 @@ async def test_user_stop_during_pending_recovery_is_not_recorded_as_failure():
         mod.Stats = orig  # type: ignore[assignment]
 
     assert failures == [], (
-        "a neutral user Stop was counted as a subagent failure by the "
-        "cancelled-recovery arm"
+        "a neutral user Stop was counted as a subagent failure by the " "cancelled-recovery arm"
     )
     assert info.error == "", f"user stop synthesized an error: {info.error!r}"
 
@@ -871,6 +889,6 @@ async def test_stop_during_pending_spawn_approval_reports_and_releases_once():
         "count permanently inflates apparent capacity"
     )
     total_reports = len(_done_events(mgr)) + len(announced)
-    assert total_reports == 1, (
-        f"terminal outcome delivered {total_reports} times, expected exactly once"
-    )
+    assert (
+        total_reports == 1
+    ), f"terminal outcome delivered {total_reports} times, expected exactly once"

--- a/test/test_subagent_scale.py
+++ b/test/test_subagent_scale.py
@@ -25,6 +25,7 @@ import pytest
 from kiro_crew.constants import SUBAGENT_COMPLETION_META_KEY
 from kiro_crew.run_coordinator import MemoryRunCoordinator
 from kiro_crew.subagent import SubagentInfo, SubagentManager
+from kiro_crew.subagent_completion_meta import OUTCOME_INTERRUPTED
 from kiro_crew.subagent_scale import SubagentEventCoalescer
 
 # ``SubagentManager.spawn`` refuses -- registering no task -- while the host
@@ -982,6 +983,53 @@ class TestWaveDigest:
         payload = finished[0].args[1]
         assert payload["total"] == 12 and payload["ok"] == 10
         assert payload["err"] == 2 and payload["stopped"] == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_finished_counts_recovered_interruption_as_non_success(self):
+        orch = _make_orchestrator()
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        slot = MagicMock()
+        slot.mode = "chat"
+        slot.running = False
+        slot.task = None
+        slot._orch_tracker = None
+        slot._subagent_deliveries_inflight = 0
+        orch.dashboard_state.get_slot = MagicMock(return_value=slot)
+        mgr, on_done = self._capture_on_done(orch)
+        total = 2
+
+        async def _fake_run_chat(
+            _state, _slot, _text, *, _directive_user_origin, _on_consumed
+        ):
+            assert _directive_user_origin is False
+            _on_consumed()
+
+        completed = self._member(0, total)
+        interrupted = self._member(1, total)
+        interrupted._recovered_outcome = OUTCOME_INTERRUPTED
+
+        with patch("kiro_crew.slack.gateway._run_chat", _fake_run_chat):
+            mgr.batch_members_pending = MagicMock(return_value=True)
+            await on_done(completed)
+            mgr.batch_members_pending = MagicMock(return_value=False)
+            await on_done(interrupted)
+            await _settle(lambda: slot.task is None)
+
+        finished = [
+            call
+            for call in orch.dashboard_state.broadcast_ws.call_args_list
+            if call.args and call.args[0] == "batch_finished"
+        ]
+        assert len(finished) == 1
+        payload = finished[0].args[1]
+        assert payload["total"] == 2
+        assert payload["ok"] == 1
+        assert payload["err"] == 1
+        assert payload["stopped"] == 0
+        assert payload["total"] == payload["ok"] + payload["err"] + payload["stopped"]
 
     @pytest.mark.asyncio
     async def test_held_members_marked_delivered_only_at_digest(self):

--- a/test/test_subagent_turn_resilience.py
+++ b/test/test_subagent_turn_resilience.py
@@ -974,9 +974,9 @@ def test_no_raw_cancel_outside_chokepoint():
     """Source scan: every raw ``.cancel()`` on a managed run task in
     subagent.py must route through ``_cancel_task_intentionally`` (the
     mechanical enforcement of the intentional-cancel marker contract).
-    Allowed raw sites: the chokepoint body itself, the reaper-loop task, and a
-    pending cancel-recovery scheduler task — none of the latter two are managed
-    runs, so the marker contract (and recovery) never applies to them."""
+    Allowed raw sites: the chokepoint body itself and observer or recovery
+    tasks — none of the latter are managed runs, so the marker contract (and
+    recovery) never applies to them."""
     import inspect
     from pathlib import Path
 
@@ -1003,8 +1003,9 @@ def test_no_raw_cancel_outside_chokepoint():
         # Shielded terminal-report tasks drained at shutdown — also not managed
         # runs; cancelling them cannot trigger a respawn.
         "report_task.cancel()",
-        # Coordinator lease-heartbeat tasks are observers, not managed runs.
-        # Cancelling them cannot trigger run recovery.
+        # Coordinator reconciliation and lease-heartbeat tasks are observers,
+        # not managed runs. Cancelling them cannot trigger run recovery.
+        "reconcile_task.cancel()",
         "lease_task.cancel()",
         # follow_up watchers (spawn_steer mode="follow_up") — observers, not
         # managed runs: no terminal marker applies, and cancelling one cannot
@@ -1029,6 +1030,7 @@ def test_no_raw_cancel_outside_chokepoint():
         and "recovery_task" not in line
         and "report_task" not in line
         and "lease_task" not in line
+        and "submit_task" not in line
     ]
     assert len(generic) == 1, (
         f"expected exactly one raw task.cancel() (the chokepoint body), " f"found: {generic}"


### PR DESCRIPTION
> Stacked change: **PR 6 of 7**
>
> Stack: #5277 → #5278 → #5279 → #5280 → #5281 → #5282 → #5283
> Base: #5281
> Next: #5283

## Problem / Motivation

Startup recovery understands legacy run files, but durable coordinator rows and leases need a fenced takeover path with safe orphan-process handling. Cancellation can also overlap coordinator admission, leaving terminal ownership ambiguous unless the submission and command claim settle definitively.

## Why it matters

Restart recovery must retain terminal output and pending delivery without killing an unrelated process after PID reuse, allowing two owners to complete one run, losing accepted work, or reporting both a local result and a later recovered interruption.

## What changed (motivation → approach → change)

- Adds a one-way legacy-state importer and coordinator recovery for expired leases, interrupted runs, and pending outbox events.
- Excludes locally active and queued run IDs from both legacy-folder import and recovery claims, preserving the coordinator identity of accepted local work.
- Retries the legacy importer during periodic recovery after a transient startup failure, so legacy state cannot remain stranded until another restart.
- Preserves recovered interruptions as a neutral fourth per-member outcome, exposes retained partial results to the parent, and counts them in the aggregate non-success tally so wave totals remain consistent.
- Persists PID, start identity, and ownership behind the active execution fence; agent-writable legacy process fields never authorize termination.
- Atomically withholds terminal outbox delivery while protected child identity remains, including across the recovery lease between reaper sweeps.
- Continues draining unrelated eligible completion events when one protected child cannot be reaped.
- Clears that identity under the current execution fence after normal dedicated-session teardown succeeds; teardown or clear failure leaves delivery pending for recovery.
- Allows stale process-write replay only for the identical stored identity; a replacement process must observe and write from the committed version.
- Uses descriptor-pinned, no-follow, nonblocking reads for legacy state and quarantines malformed, linked, hardlinked, oversized, or redaction-changing inputs.
- Pins recovery tombstone clearance to one no-follow run-directory descriptor on supporting hosts, so a concurrent directory replacement cannot redirect unlink or verification; fallback platforms resolve the path once.
- Reads retained transcripts through a pinned canonical trusted root while validating the caller's declared path spelling, including homes reached through a symlinked prefix.
- Treats a stable Linux/Windows process-identity mismatch as PID reuse: recovery never signals the replacement process and converges the original run to interrupted, while an unreadable or formatting-sensitive POSIX identity remains deferred.
- Strongly retains accepted-run admission until it reaches a definite durable or failed outcome, so task cancellation cannot cancel a queued coordinator write or abandon accepted execution.
- Treats every post-submit command-claim exception as uncertainty: a stable same-owner fence is adopted when available, otherwise durable recovery remains the sole terminal owner.
- Makes user Stop drain admission, resolve an ambiguous claim to a fence, and commit exactly one STOPPED result; a definite submit failure clears uncertainty and keeps the legacy reporter authoritative.
- Preserves a settled submit result across retained-task handoff, and yields Stop to a terminal or live newer recovery owner instead of retrying an already-taken claim forever.
- Drains retained submission, fallback, and terminal-report chains during shutdown and re-admits any unresolved owner when the outer shutdown boundary is cancelled.
- Offloads recovery tombstone clearance from the event loop during cancelled-shutdown re-admission and final shutdown settlement.
- Preserves live batch routing, queued consumption debt, and fixed diagnostics across fallback and recovery.
- Extends SQLite, shadow, security-posture, and system documentation for the recovery path.

## Tests

- `test/test_run_coordinator_recovery.py` covers legacy import, linked and swapped directory rejection, nonblocking file opens, repeated importer recovery, fenced takeover, process identity, pending delivery recovery, the cleanup-lease sweep that must keep terminal delivery blocked, per-run drain isolation when cleanup fails, and swapped-directory tombstone clearance.
- Coordinator contract and SQLite tests cover migrations, stale owners, claim uncertainty, and restart convergence.
- Wiring regressions cover delayed and failed submission, generic claim errors, ambiguous-claim Stop, single STOPPED delivery, callback-safe retained-task handoff, shutdown drain, tombstone clearance, and fallback delivery.
- The current stack-tip focused coordinator suite passes: 507 passed, 1 valid platform skip.
- Black, subprocess encoding, isort, flake8, Linux-parity mypy, docs, harness-parity, brand, and public-tree scrub gates pass at the stack tip.

## Manual verification

N/A — restart, import, process identity, cancellation, shutdown, and recovery delivery are covered by deterministic automated tests.

## Related Issues

No linked issue: this stack implements the locally reviewed durable run coordinator RFC.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

