### PR TITLE
fix: harden run coordinator lifecycle races

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -966,7 +966,6 @@ test/test_prepare_pr_profiles.py
 test/test_prepare_pr_status.py
 test/test_previous_result_read_off_loop.py
 test/test_process_tree.py
-test/test_process_tree_kill.py
 test/test_project_alias.py
 test/test_project_git.py
 test/test_project_git_status_log.py
@@ -1107,7 +1106,6 @@ test/test_stt_endpointing.py
 test/test_stt_stream_cov80.py
 test/test_stub_bridge_liveness.py
 test/test_stuck_turn_watchdog.py
-test/test_subagent.py
 test/test_subagent_context_groups.py
 test/test_subagent_continuable.py
 test/test_subagent_cost.py

--- a/docs/request-for-change/rfc-durable-run-coordinator.md
+++ b/docs/request-for-change/rfc-durable-run-coordinator.md
@@ -407,12 +407,21 @@ One transaction:
 
 1. verifies the fence and legal transition;
 2. writes `observed_state=terminal` and the outcome;
-3. inserts a stable pending outbox event; and
+3. inserts a stable outbox event (pending for asynchronous delivery, or already
+   delivered when the synchronous response is the delivery); and
 4. marks the execution command applied.
 
 Repeating the same completion returns the existing event. A conflicting second
 outcome is rejected and recorded as a diagnostic; first durable terminal
 outcome wins, matching the current terminal-record guard.
+
+The execution command's same-fence empty-result fill also verifies the current
+run owner and lease epoch. Recovery takeover therefore fences an old executor
+even when its command claim record still carries the earlier matching epoch.
+Synchronous non-batch admission rejection commits an already-delivered event so
+the counted HTTP error is not followed by a duplicate parent turn. Batch
+rejections keep a pending event with their wave metadata and route through the
+normal completion consumer.
 
 #### Delivery
 

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -19,7 +19,9 @@ command ID and idempotency key before HTTP; spawn/continue also preassign the
 visible run ID. The gateway validates all-or-none identity fields by key presence,
 so an empty reserved field cannot select the identity-free compatibility path. It
 recomputes the canonical semantic SHA-256 hash and fails closed on key/payload
-conflicts. An
+conflicts. The hash is computed from the caller's canonical payload, but the
+durable command record stores only the redacted task and argument values; the
+manager receives the original values only through the live in-memory call. An
 exact replay returns the stored run/control response without repeating the
 manager effect. Before a stored execution response exists, an exact retry may
 claim and execute a command that is still `PENDING`, because no owner has
@@ -49,7 +51,11 @@ control results are redacted before both durable persistence and synchronous
 return. Every pending execution or control response carries an explicit error
 so callers cannot mistake uncertain acceptance for success. Lifecycle MCP tools
 render transport-uncertain results as unknown outcomes with an explicit
-do-not-retry instruction instead of an ordinary retryable error. The legacy lost-wave
+do-not-retry instruction instead of an ordinary retryable error. A stored manager rejection
+retains `counted: true` for wave accounting. When the lookup follows transport
+uncertainty,
+`command_pending` preserves that uncertainty and never enters lost-wave
+accounting because the gateway may still apply it. The legacy lost-wave
 endpoint remains for unkeyed compatibility callers. The authenticated DELETE
 endpoint accepts the same additive identity for idempotent cancellation, with
 its optional fixed-shape JSON body bounded by the shared request limit.
@@ -60,16 +66,21 @@ After the manager boundary, a control exception is rethrown only when its
 rejected command outcome commits. An execution exception is rejected only when
 the manager confirms that the run never registered; after that rejection commits,
 the authority returns a typed counted failure whose durable result is reused by
-exact retries and lookup. A registered run, or a registration lookup that itself
-fails, retains its claim and surfaces typed outcome uncertainty because the child
-may still be executing. Any failed or rejected settlement is likewise uncertain;
-an exact retry is not safe after a legacy side effect may have occurred.
+exact retries and lookup. An already-terminal registered rejection remains
+authoritative when the manager raises after registration and follows the same
+durable rejection path. A nonterminal registered run, or a registration lookup
+that itself fails, retains its claim and surfaces typed outcome uncertainty
+because the child may still be executing. Any failed or rejected settlement is
+likewise uncertain; an exact retry is not safe after a legacy side effect may
+have occurred.
 
 The command fence has its own expiry and monotonic claim epoch. Expiry makes a
 command eligible for takeover; it does not discard a completed side effect's
 matching result unless a newer claimant has actually advanced the epoch.
 Control commands therefore never acquire, renew, or invalidate the live
 executor's run lease.
+Ordinary controls use a short claim; cancellation alone uses a 22-minute claim
+because its manager effect includes the bounded 20-minute parent-delivery wait.
 Rejected legacy admission is durably reflected as a rejected command and failed
 terminal run. A claimed execution with an uncertain crash is not automatically
 replayed. Accepted keyed runs carry `_coordinator_admitted`, preventing `_run`
@@ -131,11 +142,16 @@ though the original HTTP caller has already returned. Later lifecycle work owns
 any execution-time renewal. Orderly shutdown removes the manager's queued entry
 before committing that rejection, so an already-scheduled drain cannot start work
 whose durable command is terminal. If orderly-shutdown settlement fails, authority
-shutdown stays pending and retries while retaining the command fence, facade,
-and lease heartbeat instead of abandoning accepted work in a claimed state. A
+shutdown retries while retaining the command fence, facade, and lease heartbeat.
+Settlement is bounded: if repeated attempts cannot prove a terminal command or a
+newer claimant, shutdown logs the durable debt, clears the local facade cache,
+and stops its lease heartbeat so another owner can take over after lease expiry
+rather than wedging gateway shutdown. A
 durable lookup releases that local shutdown debt when the command is already
 terminal or a newer claim owns it, so a legitimate takeover cannot wedge the
-retiring gateway.
+retiring gateway. An immediate manager rejection whose terminal commit fails is
+retained with the same command/run fence and retried through orderly shutdown;
+a durable terminal record or newer command claim releases that local debt.
 An active or queued legacy manager record with the requested run id rejects the
 keyed request before coordinator submission, so the rejected request cannot
 reserve the older run's durable identity. A synchronous manager reservation
@@ -160,23 +176,48 @@ the HTTP response is explicitly transport-uncertain and counted. The MCP caller
 resolves the stable idempotency key. A lookup distinguishes an unclaimed
 `PENDING` command from a `CLAIMED` command: the caller replays the exact keyed
 request once only for `PENDING`, while `CLAIMED` remains outcome-uncertain and is
-never recorded as a lost submission.
+never recorded as a lost submission. Ordinary executor `Exception` failures
+enter the durable rejection path, while process-level `BaseException` signals
+such as cancellation, `KeyboardInterrupt`, and `SystemExit` always propagate
+instead of being converted into a spawn result.
+
+The command result has one durable ownership rule. `_run` may mark an execution
+command applied with an empty result when it wins the child-start race; the same
+command fence may then fill that empty result exactly once while its run lease
+still has the same owner and epoch. Recovery takeover fences a late fill, and
+conflicting results remain rejected. If the synchronous manager facade rejects,
+or raises before registering a run, the authority retains the failed facade
+result until it commits the failed run and outbox event atomically, then stores
+the applied response. If the facade raises after registering non-terminal work,
+the authority reports outcome uncertainty and leaves the manager lifecycle
+intact instead of cancelling a possibly started child and leaking its scheduler
+slot. A retry resumes a failed terminal commit without invoking the manager
+again. If the response fill fails after the terminal commit, the counted
+response still returns and later replays derive the failure from the terminal
+run. A command-only rejection never terminalizes a run without an outbox event.
+After restart, a terminal failed, stopped, or interrupted run takes precedence
+over an empty command result, so an exact POST replay cannot report an already
+terminal execution as newly spawned.
 
 An exact execution claim also acquires the run lease. The authority passes its
 run fence, command, and optimistic version through the synchronous facade and
 queue payload. `_run` commits `starting` before child startup, `_run_inner`
 commits `running` after session creation and before the prompt, and a 30-second
-heartbeat renews the 90-second lease. A terminal failed, stopped, or interrupted
-run wins lookup reconstruction when its execution command has no stored facade
-result, so pre-start cancellation cannot replay as a successful spawn. Control
+heartbeat renews the 90-second lease. A queued or approval-gated keyed execution
+starts an authority-owned heartbeat as soon as the synchronous facade returns
+its waiting record, closing the pre-execution wait before `_run` explicitly
+takes over lifecycle renewal. Queue cancellation, queue-drain rejection, and
+approval denial stop that heartbeat by committing and delivering a terminal
+coordinator outcome. Orderly shutdown cancels both heartbeat owners. Control
 claims still never touch the execution lease.
 
 The port defines typed desired/observed state, terminal outcomes, idempotent
 commands, execution leases with fencing epochs, optimistic lifecycle versions,
 and delivery claims with an independent fencing epoch. The in-memory adapter is
 the executable contract oracle; it is not a restart store. Command records
-persist the canonical payload, hash, independent claim fence, and bounded
-response JSON. Controls may target runs created before the coordinator, so their
+persist a redacted canonical payload, the hash of the original canonical
+request, independent claim fence, and bounded response JSON. Controls may target
+runs created before the coordinator, so their
 command row does not require a matching canonical run row.
 The stored task and model fields are credential-redacted, UTF-8-safe, and
 bounded before hashing; the unredacted prompt remains only in the live executor.
@@ -298,11 +339,16 @@ both STARTING attempts fail, it leaves the command claimed for recovery and
 does not apply command settlement against an unknown lifecycle state.
 
 For a coordinator-admitted run, `complete()` verifies the execution fence and
-optimistic version, writes the terminal outcome, and inserts one pending outbox
+the exact optimistic version supplied by the original attempt, writes the
+terminal outcome, and inserts one pending outbox
 event in the same SQLite transaction. The payload contains bounded, redacted
 routing metadata, a 4,000-character result summary, and `result_path`; it never
 copies the full transcript. Replaying the completion returns the same
-`event_id`; a conflicting outcome is rejected. Lease expiry makes the run
+`event_id` only when the original fence, expected version, and completion
+payload match; stale-version and conflicting-outcome replays are rejected.
+Lease renewal is monotonic and never shortens either the run or command claim.
+Outbox release rejects non-finite retry deadlines instead of creating an event
+that can never become claimable. Lease expiry makes the run
 eligible for takeover but does not itself invalidate the monotonic fence, so
 the current epoch may still commit its terminal result after host suspend if no
 recovery owner has advanced the epoch first.
@@ -324,32 +370,55 @@ only when its execution command is already durably `REJECTED`; the run transitio
 and pending outbox insert remain one transaction. The stored run identity is
 authoritative when the transient rejection view omits parent or agent metadata.
 
-`OutboxDeliveryAdapter` claims one FIFO event immediately before each delivery,
-increments the delivery claim epoch, and invokes existing gateway routing. Its
-accepted path retains the stable event identity and retries transient
+A synchronous non-batch facade rejection returns the counted error in the HTTP
+response and commits its terminal event already delivered, so the same failure
+cannot arrive later as a duplicate parent turn. Batch rejections remain pending,
+preserve `batch_id` and `batch_total`, and settle their wave through the
+ordinary completion consumer. The
+live authority handoff registers that batch identity by run before the terminal
+transaction makes its event claimable, so an overlapping periodic drain builds
+the same live delivery context. Durable labels alone never reconstruct volatile
+digest state after restart. Exception-derived rejections also retain the
+caller's `silent` delivery policy in their durable payload.
+
+`OutboxDeliveryAdapter` drains a bounded FIFO batch by claiming each event only
+when its destination is about to run, or claims one exact event. Each claim
+increments the delivery epoch before invoking existing gateway routing. It
+retains the stable identity of an accepted event and retries transient
 durable-ack failures without invoking the destination again. If the original
 claim expires, it reclaims that identity for acknowledgement only, so a
-prolonged coordinator outage cannot redeliver an already accepted completion.
-Its 22-minute lease covers the bounded parent-injection and teardown budgets, so a
-valid slow callback cannot be claimed concurrently. It acknowledges only after
-that callback accepts the event. Exceptions and callback-reported routing failures
-release the matching claim with bounded, overflow-safe exponential backoff.
-Intentional dashboard-queue and digest holds retain the lease-length delay. A
-permanently rejected execution fence stops its
-reporter; periodic recovery owns the nonterminal run rather than an impossible
-retry loop or a duplicate legacy delivery. A queued or immediately dispatched
-dashboard turn and a wave-digest hold defer acknowledgement instead: the event
-remains unavailable to background drainers for one lease window, and the
-consumption/digest-settlement hooks retry transient coordinator errors before
-returning and acknowledge every terminal outcome only after the parent consumes
-it. An acknowledgement that waited for the claim lock rechecks the live fence
-before reclaiming, so it cannot miss a claim installed while it waited. A failed
-or rejected release retains the original delivery fence so an
-immediate consumer acknowledgement can still settle the claimed event. If that
-acknowledgement races a successful release of the original claim,
-it reclaims the stable event identity and settles the new fence. Legacy delivered
-tombstones remain limited to successful runs, while teardown gates retain their
-compatibility role.
+prolonged coordinator outage cannot redeliver an already accepted completion. It
+acknowledges only after that callback accepts the event. Exceptions and callback-reported
+routing failures release the matching claim with bounded, overflow-safe exponential
+backoff. The default 22-minute claim covers the 20-minute
+parent-injection cap plus teardown, and the adapter never holds its local claim
+lock while invoking routing, so routing may acknowledge the same event without
+deadlock. An acknowledgement that waited for the claim lock rechecks the live
+fence before reclaiming, so it cannot miss a claim installed while it waited. A
+dashboard queue or wave-digest hold defers instead: the event stays
+pending but is unavailable to ordinary drainers for one lease window;
+queue-consumption/digest-settlement hooks can claim it explicitly and
+acknowledge that exact stable identity immediately. If acknowledgement races
+the adapter's release of the original claim, it reclaims the stable event
+identity and settles the new fence. Deferred manager contexts survive retries,
+preventing repeated WebSocket, parent-callback, or wave-accounting effects.
+A failed or rejected release retains the original delivery fence so an
+immediate consumer acknowledgement can still settle the claimed event. Legacy
+delivered tombstones and teardown gates remain compatibility mirrors and
+retention guards.
+Pre-start queue cancellation, queue-drain rejection, and approval denial use
+the same digest-settlement path as ordinary terminal execution, so the event
+that closes a batch also acknowledges siblings already held by that digest.
+A permanently rejected execution fence stops its reporter; periodic recovery
+owns the nonterminal run rather than an impossible retry loop or a duplicate
+legacy delivery. Both queued and immediately dispatched dashboard turns defer
+acknowledgement until the model consumes the prompt. The consumption and digest
+settlement hooks retry transient coordinator errors before returning and
+acknowledge every terminal outcome. This includes failed and stopped durable
+events, which owe an outbox acknowledgement after consumption without receiving
+a legacy delivered tombstone. Legacy delivered tombstones remain limited to
+successful runs so failed and stopped artifacts keep their post-mortem retention
+window.
 
 Delivery retries retain their manager context. Lifecycle events, orchestration
 tracking, and wave accounting run once; every composed wave chunk keeps a
@@ -1048,11 +1117,13 @@ Startup converges both compatibility and coordinator state:
    be reaped before any completion delivery writes a tombstone that removes the
    folder from the compatibility scan. Its routing metadata never authorizes
    delivery. `LegacyRunImporter` then reads known fields from legacy folders and creates only
-   missing coordinator rows. For an existing nonterminal row it may retain a
-   previously empty `result.txt` path, but agent-writable state and tombstone
-   files never overwrite an existing coordinator row's lifecycle state,
-   outcome, error, ownership, or version; fenced recovery is the only terminal
-   authority for native rows. Legacy `pid`, `pid_start_id`, and
+   missing coordinator rows. An existing row is returned unchanged before
+   validating or applying agent-writable legacy content, so replay cannot mutate
+   even an empty result path or be blocked by a later malformed legacy file.
+   Agent-writable state and tombstone files never overwrite an existing
+   coordinator row's lifecycle state, outcome, error, ownership, or version;
+   fenced recovery is the only terminal authority for native rows. Legacy `pid`,
+   `pid_start_id`, and
    `process_owned` fields are never imported and never authorize a signal. The
    importer never rewrites or deletes `state.json`, `result.txt`, or
    `tombstone.json`. Each scan submits its parsed records as one coordinator
@@ -1085,8 +1156,8 @@ Startup converges both compatibility and coordinator state:
    uses the process creation FILETIME on Windows. Dedicated executions
    persist this opaque identity beside the PID before the child receives a
    prompt; a protected coordinator write failure aborts execution, while the
-   legacy `state.json` mirror remains best-effort. Shared
-   sessions persist the runtime PID for attribution but mark it non-owned and
+   legacy `state.json` mirror remains best-effort and runs off the event loop.
+   Shared sessions persist the runtime PID for attribution but mark it non-owned and
    never persist a kill-authorizing start identity, because that process also
    hosts the parent and other sessions. On Windows the compatibility layer
    keeps the verified process handle pinned across tree termination so PID
@@ -1109,10 +1180,13 @@ Startup converges both compatibility and coordinator state:
    path is retained. Outbox rehydration preserves that explicit fourth outcome
    even though the explanatory error is non-empty, and the parent announcement
    points at the retained partial result instead of rendering an ordinary
-   failure. Recovery never claims or replays its execution command. A terminal
-   cleanup claim never replaces the committed outcome or outbox payload; after
-   the child is absent or verified termination succeeds, it only clears the
-   protected process identity under the recovery fence.
+   failure. Recovery never claims or replays its execution command. When its
+   command has no stored facade result, keyed lookup derives an explicit
+   `run_interrupted` response from this terminal row instead of reporting the
+   command as pending or spawned. A terminal cleanup claim never replaces the
+   committed outcome or outbox payload; after the child is absent or verified
+   termination succeeds, it only clears the protected process identity under
+   the recovery fence.
 5. Coordinator-authenticated terminal pending outbox events drain through the
    same fenced delivery adapter after protected terminal-child cleanup. If a
    terminal child identity is unreadable, unverified, or cannot be terminated,
@@ -1123,10 +1197,14 @@ Startup converges both compatibility and coordinator state:
    That exclusion is per run: an unreapable terminal child does not prevent the
    same drain pass from delivering unrelated eligible completion events.
    Normal execution follows the same boundary: its terminal reporter waits for
-   dedicated-session teardown, clears the protected process identity with the
-   current execution fence only after reset succeeds, and then claims the event.
-   A failed teardown or rejected clear leaves the event pending for fenced
-   recovery instead of blocking the run task or delivering early.
+   dedicated-session teardown and rechecks the coordinator-pinned PID and process
+   start identity after every reset outcome, including timeout, exception, and
+   forced-kill fallback. The forced-kill path also awaits bounded child reaping so
+   a zombie cannot be mistaken for a surviving execution. Only confirmed child
+   absence or PID reuse clears the protected process identity with the current
+   execution fence before claiming the event. An unreadable identity, failed
+   teardown, or rejected clear leaves the event pending for fenced recovery
+   instead of blocking the run task or delivering early.
    Legacy tombstones create no outbox event and therefore cannot route a
    completion from their untrusted metadata.
 

--- a/src/kiro_crew/run_coordinator/memory.py
+++ b/src/kiro_crew/run_coordinator/memory.py
@@ -374,23 +374,9 @@ class MemoryRunCoordinator:
             if existing is not None:
                 event_id = self._outbox_by_run_type.get((request.run_id, request.event_type))
                 existing_event = self._outbox.get(event_id) if event_id else None
-                # Legacy files are evidence, not lifecycle authority. A crash
-                # can leave a durable coordinator row before result.txt is
-                # written, so retain that path for the fenced recovery which
-                # follows. Never copy terminal state, outcome, error, owner, or
-                # version from an agent-writable tombstone into an existing row.
-                if (
-                    existing.observed_state is not ObservedState.TERMINAL
-                    and not existing.result_path
-                    and request.result_path
-                ):
-                    existing = replace(existing, result_path=request.result_path)
-                    self._runs[request.run_id] = existing
-                    return self._result(
-                        CoordinatorDecision.APPLIED,
-                        CoordinatorReason.TRANSITIONED,
-                        LegacyImportReceipt(existing, existing_event, created=False),
-                    )
+                # Legacy files are agent-writable evidence, not lifecycle
+                # authority. Once the coordinator owns an identity, replay may
+                # observe it but cannot validate or mutate it from stale files.
                 return self._result(
                     CoordinatorDecision.UNCHANGED,
                     CoordinatorReason.IDEMPOTENT_REPLAY,
@@ -682,6 +668,37 @@ class MemoryRunCoordinator:
             )
             if command.status in (CommandStatus.APPLIED, CommandStatus.REJECTED):
                 if matching:
+                    result_fill = (
+                        command.status is CommandStatus.APPLIED
+                        and status is CommandStatus.APPLIED
+                        and not command.rejection_reason
+                        and not command.result_json
+                        and not rejection_reason
+                        and bool(result_json)
+                    )
+                    if result_fill and command.operation in _EXECUTION_COMMANDS:
+                        run = self._runs.get(command.run_id)
+                        if (
+                            run is None
+                            or run.owner_id != command.owner_id
+                            or run.lease_epoch != command.lease_epoch
+                        ):
+                            return self._result(
+                                CoordinatorDecision.REJECTED,
+                                CoordinatorReason.STALE_FENCE,
+                            )
+                    if result_fill:
+                        command = replace(
+                            command,
+                            result_json=result_json,
+                            updated_at=self._clock(),
+                        )
+                        self._commands[command.command_id] = command
+                        return self._result(
+                            CoordinatorDecision.APPLIED,
+                            CoordinatorReason.TRANSITIONED,
+                            command,
+                        )
                     if (
                         command.status is not status
                         or command.rejection_reason != rejection_reason
@@ -746,7 +763,12 @@ class MemoryRunCoordinator:
     ) -> CoordinatorResult[RunRecord]:
         async with self._lock:
             now = self._clock()
-            validated = self._validate_transition(command.run_id, fence, expected_version, now=now)
+            validated = self._validate_transition(
+                command.run_id,
+                fence,
+                expected_version,
+                now=now,
+            )
             if isinstance(validated, CoordinatorResult):
                 current = self._runs.get(command.run_id)
                 if not (
@@ -791,7 +813,12 @@ class MemoryRunCoordinator:
     ) -> CoordinatorResult[RunRecord]:
         async with self._lock:
             now = self._clock()
-            validated = self._validate_transition(run_id, fence, expected_version, now=now)
+            validated = self._validate_transition(
+                run_id,
+                fence,
+                expected_version,
+                now=now,
+            )
             if isinstance(validated, CoordinatorResult):
                 current = self._runs.get(run_id)
                 if not (
@@ -832,7 +859,12 @@ class MemoryRunCoordinator:
     ) -> CoordinatorResult[RunRecord]:
         async with self._lock:
             now = self._clock()
-            validated = self._validate_transition(run_id, fence, expected_version, now=now)
+            validated = self._validate_transition(
+                run_id,
+                fence,
+                expected_version,
+                now=now,
+            )
             if isinstance(validated, CoordinatorResult):
                 current = self._runs.get(run_id)
                 if not (
@@ -895,7 +927,12 @@ class MemoryRunCoordinator:
 
         async with self._lock:
             now = self._clock()
-            validated = self._validate_transition(run_id, fence, expected_version, now=now)
+            validated = self._validate_transition(
+                run_id,
+                fence,
+                expected_version,
+                now=now,
+            )
             if isinstance(validated, CoordinatorResult):
                 current = self._runs.get(run_id)
                 if not (
@@ -979,6 +1016,7 @@ class MemoryRunCoordinator:
             # Expiry makes a run eligible for takeover; the monotonic epoch is
             # the fence. Let the current epoch commit its terminal result when
             # no recovery owner won that race, including after host suspend.
+            now = self._clock()
             validated = self._validate_transition(
                 completion.run_id,
                 fence,
@@ -1020,14 +1058,16 @@ class MemoryRunCoordinator:
                 destination=completion.destination,
                 event_type=completion.event_type,
                 payload_json=completion.payload_json,
-                status=DeliveryState.PENDING,
+                status=completion.delivery_state,
                 attempts=0,
                 available_at=now,
                 claim_owner="",
                 claim_expires_at=0.0,
                 claim_epoch=0,
                 created_at=now,
-                delivered_at=None,
+                delivered_at=(
+                    now if completion.delivery_state is DeliveryState.DELIVERED else None
+                ),
             )
             self._outbox[event.event_id] = event
             self._outbox_by_run_type[key] = event.event_id

--- a/src/kiro_crew/run_coordinator/models.py
+++ b/src/kiro_crew/run_coordinator/models.py
@@ -175,6 +175,7 @@ class RunCompletion:
     destination: str
     payload_json: str
     terminal_at: float
+    delivery_state: DeliveryState = DeliveryState.PENDING
 
 
 @dataclass(frozen=True)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -7402,13 +7402,6 @@ class GatewayOrchestrator:
                         _injection_slot.task = _task
                         self.dashboard_state._background_tasks.add(_task)
                         _task.add_done_callback(self.dashboard_state._background_tasks.discard)
-                        _arm_queued_delivery_settlement(
-                            self.dashboard_state,
-                            _injection_slot,
-                            _task,
-                            [announce],
-                            _consumed,
-                        )
 
                         def _on_inject_done(t: asyncio.Task) -> None:  # type: ignore[type-arg]
                             if _injection_slot.task is t:

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -499,6 +499,7 @@ _STEER_STARTUP_POLL_SECS = 0.5
 # latency is irrelevant next to permanent wedging.
 _WAVE_STUCK_SECS = 1800
 _RESET_TIMEOUT = 30.0  # max seconds for session reset in finally block
+_SIGKILL_REAP_TIMEOUT = 1.0  # max seconds to reap the owned child after SIGKILL
 _RECOVERY_SLOT_WAIT_SECS = 60.0
 _REPORT_DRAIN_TIMEOUT = (
     30.0  # max seconds cancel_all() waits for shielded terminal reports to drain
@@ -1700,7 +1701,7 @@ class SubagentManager:
         # Keyed async callers durably admit commands before invoking the
         # compatibility executor. Legacy synchronous callers remain mirrored
         # at async run entry during migration.
-        self._coordinator = coordinator or SQLiteRunCoordinator()
+        self._coordinator = coordinator if coordinator is not None else SQLiteRunCoordinator()
         self._coordinator_owner_id = f"gateway:{uuid.uuid4().hex}"
         self.command_authority = SubagentCommandAuthority(
             self._coordinator,
@@ -2169,6 +2170,9 @@ class SubagentManager:
     async def _clear_terminal_process(self, info: SubagentInfo) -> bool:
         return await self._terminal._clear_terminal_process_impl(info)
 
+    async def _protected_process_stopped(self, info: SubagentInfo) -> bool:
+        return await self._terminal._protected_process_stopped_impl(info)
+
     def _info_from_outbox(self, event: OutboxEvent) -> SubagentInfo:
         return self._terminal._info_from_outbox_impl(event)
 
@@ -2369,6 +2373,27 @@ class SubagentManager:
 
     async def announce_durable_rejection(self, info: SubagentInfo | AdmittedExecution) -> None:
         return await self._admission.announce_durable_rejection_impl(info)
+
+    def prepare_coordinator_rejection(
+        self,
+        run_id: str,
+        *,
+        batch_id: str = "",
+        batch_total: int = 0,
+    ) -> None:
+        """Prepare live delivery before a rejection event becomes claimable."""
+
+        for task_key in (f"reject-{run_id}", run_id):
+            report_task = self._tasks.pop(task_key, None)
+            if report_task is not None:
+                report_task.cancel()
+        if batch_id:
+            self._outbox_live_run_batches[run_id] = (batch_id, batch_total)
+
+    async def deliver_coordinator_event(self, event_id: str) -> None:
+        """Route one already-durable completion through the fenced outbox."""
+
+        await self._outbox_delivery.drain_once(event_id=event_id)
 
     def _rollback_unstarted_registration(
         self,

--- a/src/kiro_crew/subagent_command_authority.py
+++ b/src/kiro_crew/subagent_command_authority.py
@@ -18,14 +18,19 @@ from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 
 from .run_coordinator.models import (
+    CommandClaim,
     CommandFence,
     CommandOperation,
     CommandStatus,
     CoordinatorDecision,
+    DeliveryState,
     ObservedState,
     OwnerLease,
+    RunCompletion,
     RunCoordinator,
+    RunFence,
     RunOutcome,
+    RunRecord,
     SubmitControl,
     SubmitRun,
 )
@@ -33,8 +38,13 @@ from .security import redact_credentials, redact_exfiltration_urls
 
 _CONTROL_LEASE_SECS = 30.0
 _SHUTDOWN_SETTLEMENT_RETRY_SECS = 1.0
-logger = logging.getLogger(__name__)
+_SHUTDOWN_SETTLEMENT_MAX_ATTEMPTS = 3
+# Cancellation includes the manager's bounded 20-minute parent-delivery wait.
+# The extra two minutes cover termination and the durable finish write without
+# forcing unrelated control commands to remain claimed after a gateway crash.
+_CANCEL_CONTROL_LEASE_SECS = 22.0 * 60.0
 EXECUTION_LEASE_SECONDS = 90.0
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -59,6 +69,15 @@ class AdmittedExecution:
     batch_id: str = ""
     batch_total: int = 0
     silent: bool = False
+
+
+@dataclass(frozen=True)
+class _PendingExecutionFailure:
+    result: Any
+    claim: CommandClaim
+    run: RunRecord
+    batch_id: str
+    batch_total: int
 
 
 class AuthorityError(RuntimeError):
@@ -128,6 +147,7 @@ class SubagentCommandAuthority:
         self._execution_results: dict[str, Any] = {}
         self._waiting_executions: dict[str, tuple[CommandFence, str]] = {}
         self._waiting_execution_keys: dict[str, str] = {}
+        self._pending_execution_failures: dict[str, _PendingExecutionFailure] = {}
         self._lease_tasks: dict[str, asyncio.Task[None]] = {}
 
     @staticmethod
@@ -249,6 +269,21 @@ class SubagentCommandAuthority:
                 "code": f"run_{run.outcome.value}",
                 "counted": True,
             }
+        if stored is not None and stored.done and stored.error:
+            code = (
+                cls._continue_error_code(stored.error)
+                if command.operation is CommandOperation.CONTINUE
+                else "spawn_rejected"
+            )
+            stored_response: dict[str, object] = {
+                "found": True,
+                "id": run_id,
+                "error": stored.error,
+                "code": code,
+            }
+            if stored.counted:
+                stored_response["counted"] = True
+            return stored_response
         if command.status is CommandStatus.REJECTED:
             error = (
                 stored.error
@@ -420,6 +455,11 @@ class SubagentCommandAuthority:
             task=task,
             arguments=kwargs,
         )
+        persisted_payload_json = json.dumps(
+            _redact_result(json.loads(payload_json)),
+            separators=(",", ":"),
+            sort_keys=True,
+        )
 
         async def admit() -> Any:
             existing = await self._before_side_effect(
@@ -467,10 +507,10 @@ class SubagentCommandAuthority:
                         command_id=identity.command_id,
                         idempotency_key=identity.idempotency_key,
                         payload_hash=payload_hash,
-                        payload_json=payload_json,
+                        payload_json=persisted_payload_json,
                         parent_session=str(kwargs.get("parent_session_key") or ""),
-                        agent=str(kwargs.get("agent") or ""),
-                        task=task,
+                        agent=_redact(str(kwargs.get("agent") or "")),
+                        task=_redact(task),
                         conversation_key=conversation_key,
                         operation=operation,
                     )
@@ -485,6 +525,36 @@ class SubagentCommandAuthority:
             if receipt.run is None:
                 raise AuthorityUnavailable("execution receipt omitted the run record")
             if not receipt.created:
+                if (
+                    not receipt.command.result_json
+                    and receipt.run.observed_state is ObservedState.TERMINAL
+                    and receipt.run.outcome is not None
+                    and receipt.run.outcome is not RunOutcome.COMPLETED
+                ):
+                    try:
+                        replay_payload = json.loads(receipt.command.payload_json)
+                    except (TypeError, ValueError):
+                        replay_payload = {}
+                    replay_arguments = replay_payload.get("arguments", {})
+                    if not isinstance(replay_arguments, dict):
+                        replay_arguments = {}
+                    self._pending_execution_failures.pop(receipt.command.command_id, None)
+                    self._execution_results.pop(receipt.run.run_id, None)
+                    return AdmittedExecution(
+                        receipt.run.run_id,
+                        _redact(receipt.run.task),
+                        done=True,
+                        error=receipt.run.error or f"run ended {receipt.run.outcome.value}",
+                        batch_id=str(replay_arguments.get("batch_id") or ""),
+                        batch_total=int(replay_arguments.get("batch_total") or 0),
+                        silent=bool(replay_arguments.get("silent")),
+                    )
+                pending_failure = self._pending_execution_failures.get(receipt.command.command_id)
+                if pending_failure is not None:
+                    return await self._persist_execution_failure(
+                        receipt.command.command_id,
+                        pending_failure,
+                    )
                 if receipt.run.run_id in self._execution_results:
                     return self._execution_results[receipt.run.run_id]
                 replay = self._manager.get(receipt.run.run_id)
@@ -565,42 +635,41 @@ class SubagentCommandAuthority:
                 if not isinstance(exc, Exception):
                     raise
                 try:
-                    registered = self._manager.get(receipt.run.run_id) is not None
+                    registered = self._manager.get(receipt.run.run_id)
                 except Exception as lookup_exc:
                     raise AuthorityOutcomeUncertain(
-                        "execution registration outcome is uncertain"
+                        "manager acceptance could not be determined"
                     ) from lookup_exc
-                if registered:
-                    # The manager may schedule the child before a later audit or
-                    # callback raises. Rejecting here would make durable replay
-                    # report failure while that registered child keeps running.
-                    raise AuthorityOutcomeUncertain(
-                        "execution failed after manager registration"
-                    ) from exc
-                local_result = AdmittedExecution(
-                    receipt.run.run_id,
-                    receipt.run.task,
-                    done=True,
-                    error=_redact(str(exc) or type(exc).__name__),
-                    batch_id=str(kwargs.get("batch_id") or ""),
-                    batch_total=int(kwargs.get("batch_total") or 0),
-                    silent=bool(kwargs.get("silent")),
-                )
-                result_json = self._encode_execution_result(local_result, receipt.run.run_id)
-                try:
-                    await self._finish_failed_side_effect(
-                        claim.command_fence,
-                        exc,
-                        "execution",
-                        result_json=result_json,
+                if registered is not None:
+                    if not bool(getattr(registered, "done", False)) or not str(
+                        getattr(registered, "error", "") or ""
+                    ):
+                        raise AuthorityOutcomeUncertain(
+                            "manager accepted execution before reporting a local failure"
+                        ) from exc
+                    local_result = registered
+                else:
+                    local_result = AdmittedExecution(
+                        receipt.run.run_id,
+                        receipt.run.task,
+                        done=True,
+                        error=_redact(str(exc) or type(exc).__name__),
+                        batch_id=str(kwargs.get("batch_id") or ""),
+                        batch_total=int(kwargs.get("batch_total") or 0),
+                        silent=bool(kwargs.get("silent")),
                     )
-                except AuthorityOutcomeUncertain:
-                    if local_result.batch_id:
-                        await self._manager.announce_durable_rejection(local_result)
-                    raise
-                if local_result.batch_id:
-                    await self._manager.announce_durable_rejection(local_result)
-                return local_result
+                    pending_failure = _PendingExecutionFailure(
+                        local_result,
+                        claim,
+                        receipt.run,
+                        local_result.batch_id,
+                        local_result.batch_total,
+                    )
+                    self._pending_execution_failures[receipt.command.command_id] = pending_failure
+                    return await self._persist_execution_failure(
+                        receipt.command.command_id,
+                        pending_failure,
+                    )
             waiting = bool(
                 getattr(
                     local_result,
@@ -620,45 +689,176 @@ class SubagentCommandAuthority:
                 self._waiting_execution_keys[receipt.run.run_id] = identity.idempotency_key
                 self._start_execution_heartbeat(receipt.run.run_id, claim.fence)
                 return local_result
-            status = (
-                CommandStatus.APPLIED
-                if self._execution_succeeded(local_result)
-                else CommandStatus.REJECTED
-            )
-            try:
-                finished = await self._coordinator.finish_command(
-                    claim.command_fence,
-                    status,
-                    rejection_reason=("" if status is CommandStatus.APPLIED else "legacy_rejected"),
-                    result_json=result_json,
+            if not self._execution_succeeded(local_result):
+                pending_failure = _PendingExecutionFailure(
+                    local_result,
+                    claim,
+                    receipt.run,
+                    str(getattr(local_result, "batch_id", "") or kwargs.get("batch_id") or ""),
+                    int(getattr(local_result, "batch_total", 0) or kwargs.get("batch_total") or 0),
                 )
-            except Exception as exc:
-                if status is CommandStatus.REJECTED and bool(
-                    getattr(local_result, "batch_id", False)
-                ):
-                    await self._manager.announce_durable_rejection(local_result)
-                raise AuthorityOutcomeUncertain(
-                    "execution result was not durably finished"
-                ) from exc
-            if finished.decision is CoordinatorDecision.REJECTED:
-                if status is CommandStatus.REJECTED and bool(
-                    getattr(local_result, "batch_id", False)
-                ):
-                    await self._manager.announce_durable_rejection(local_result)
-                raise AuthorityOutcomeUncertain(
-                    f"execution result was not durably finished: {self._reason(finished)}"
+                self._pending_execution_failures[receipt.command.command_id] = pending_failure
+                return await self._persist_execution_failure(
+                    receipt.command.command_id,
+                    pending_failure,
                 )
-            if status is CommandStatus.REJECTED:
-                if getattr(local_result, "batch_id", ""):
-                    await self._manager.announce_durable_rejection(local_result)
-                return self._decode_execution_result(
-                    result_json,
-                    receipt.run.run_id,
-                    receipt.run.task,
-                )
+            await self._finish_execution_result(claim, result_json)
             return local_result
 
         return await self._coalesce(identity, payload_hash, admit)
+
+    async def _persist_execution_failure(
+        self,
+        command_id: str,
+        pending: _PendingExecutionFailure,
+    ) -> Any:
+        event_id = await self._complete_execution_failure(
+            pending.claim,
+            pending.run,
+            pending.result,
+            batch_id=pending.batch_id,
+            batch_total=pending.batch_total,
+        )
+        safe_result = AdmittedExecution(
+            id=str(getattr(pending.result, "id", pending.run.run_id) or pending.run.run_id),
+            task=_redact(pending.run.task),
+            done=bool(getattr(pending.result, "done", True)),
+            error=_redact(
+                str(getattr(pending.result, "error", "") or "manager rejected execution")
+            ),
+            queued=bool(getattr(pending.result, "queued", False)),
+            batch_id=pending.batch_id,
+            batch_total=pending.batch_total,
+            silent=bool(getattr(pending.result, "silent", False)),
+            counted=bool(getattr(pending.result, "counted", True)),
+        )
+        result_json = self._encode_execution_result(safe_result, pending.run.run_id)
+        try:
+            await self._finish_execution_result(pending.claim, result_json)
+        except Exception:
+            # The terminal run and its outbox event are already durable.  A
+            # command-result fill is useful for exact response reconstruction,
+            # but it cannot turn that counted terminal outcome back into an
+            # uncounted transport failure.  Replays fall back to the terminal
+            # run when this best-effort fill is unavailable.
+            logger.exception(
+                "Failed to store the facade result for terminal run %s",
+                pending.run.run_id,
+            )
+        self._execution_results.pop(pending.run.run_id, None)
+        self._pending_execution_failures.pop(command_id, None)
+        if pending.batch_id:
+            try:
+                await self._deliver_execution_failure(event_id)
+            except Exception:
+                logger.exception(
+                    "Durable execution rejection delivery failed for event %s",
+                    event_id,
+                )
+        return safe_result
+
+    async def _finish_execution_result(self, claim: Any, result_json: str) -> None:
+        try:
+            finished = await self._coordinator.finish_command(
+                claim.command_fence,
+                CommandStatus.APPLIED,
+                result_json=result_json,
+            )
+        except Exception as exc:
+            raise AuthorityOutcomeUncertain("execution result was not durably finished") from exc
+        if finished.decision is CoordinatorDecision.REJECTED:
+            raise AuthorityOutcomeUncertain(
+                f"execution result was not durably finished: {self._reason(finished)}"
+            )
+
+    async def _complete_execution_failure(
+        self,
+        claim: CommandClaim,
+        run: RunRecord,
+        local_result: Any,
+        *,
+        batch_id: str,
+        batch_total: int,
+    ) -> str:
+        if claim.fence is None:
+            raise AuthorityUnavailable("execution failure omitted its run fence")
+        try:
+            latest_run = await self._coordinator.get_run(run.run_id)
+        except Exception as exc:
+            raise AuthorityOutcomeUncertain(
+                "execution rejection lifecycle could not be refreshed"
+            ) from exc
+        if latest_run is not None and latest_run.observed_state is not ObservedState.TERMINAL:
+            run = latest_run
+        error = _redact(str(getattr(local_result, "error", "") or "manager rejected execution"))
+        task = _redact(run.task)
+        try:
+            stored_payload = json.loads(claim.command.payload_json)
+        except (TypeError, ValueError):
+            stored_payload = {}
+        stored_arguments = stored_payload.get("arguments", {})
+        if not isinstance(stored_arguments, dict):
+            stored_arguments = {}
+        requested_model = _redact(
+            str(getattr(local_result, "requested_model", "") or stored_arguments.get("model") or "")
+        )
+        payload_json = json.dumps(
+            {
+                "id": run.run_id,
+                "parent_session_key": run.parent_session,
+                "agent": _redact(run.agent),
+                "task": task[:1000],
+                "outcome": RunOutcome.FAILED.value,
+                "error": error[:2000],
+                "result_path": str(getattr(local_result, "result_path", "") or ""),
+                "result_summary": "",
+                "result_truncated": False,
+                "user_stopped": False,
+                "silent": bool(getattr(local_result, "silent", False)),
+                "batch_id": batch_id,
+                "batch_total": batch_total,
+                "elapsed": float(getattr(local_result, "elapsed", 0.0) or 0.0),
+                "conversation_key": run.conversation_key,
+                "resolved_model": _redact(str(getattr(local_result, "resolved_model", ""))),
+                "requested_model": requested_model,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        try:
+            completed = await self._coordinator.complete(
+                RunCompletion(
+                    run_id=run.run_id,
+                    outcome=RunOutcome.FAILED,
+                    result_path=str(getattr(local_result, "result_path", "") or ""),
+                    error=error,
+                    event_type="subagent_completion",
+                    destination=run.parent_session,
+                    payload_json=payload_json,
+                    terminal_at=self._clock(),
+                    delivery_state=(DeliveryState.PENDING if batch_id else DeliveryState.DELIVERED),
+                ),
+                claim.fence,
+                run.version,
+            )
+        except Exception as exc:
+            raise AuthorityOutcomeUncertain(
+                "execution rejection was not durably completed"
+            ) from exc
+        if completed.value is None or completed.decision is CoordinatorDecision.REJECTED:
+            raise AuthorityOutcomeUncertain(
+                f"execution rejection was not durably completed: {self._reason(completed)}"
+            )
+        if batch_id:
+            self._manager.prepare_coordinator_rejection(
+                run.run_id,
+                batch_id=batch_id,
+                batch_total=batch_total,
+            )
+        return completed.value.event_id
+
+    async def _deliver_execution_failure(self, event_id: str) -> None:
+        await self._manager.deliver_coordinator_event(event_id)
 
     async def steer(self, identity: CommandIdentity, run_id: str, message: str) -> tuple[bool, str]:
         payload = {"message": message, "mode": "interrupt"}
@@ -761,7 +961,13 @@ class SubagentCommandAuthority:
             claim = await self._before_side_effect(
                 self._coordinator.claim_command(
                     identity.command_id,
-                    self._owner_lease(),
+                    self._owner_lease(
+                        control_seconds=(
+                            _CANCEL_CONTROL_LEASE_SECS
+                            if operation is CommandOperation.CANCEL
+                            else _CONTROL_LEASE_SECS
+                        )
+                    ),
                 ),
                 "control claim",
             )
@@ -812,7 +1018,7 @@ class SubagentCommandAuthority:
 
         return await self._coalesce(identity, payload_hash, admit_and_apply)
 
-    def _start_execution_heartbeat(self, run_id: str, fence: Any) -> None:
+    def _start_execution_heartbeat(self, run_id: str, fence: RunFence) -> None:
         if run_id in self._lease_tasks:
             return
 
@@ -843,7 +1049,40 @@ class SubagentCommandAuthority:
     async def close(self) -> None:
         """Settle accepted queue work before stopping its lease renewals."""
 
-        while self._waiting_executions:
+        for _attempt in range(_SHUTDOWN_SETTLEMENT_MAX_ATTEMPTS):
+            if not self._pending_execution_failures:
+                break
+            settlement_failed = False
+            for command_id, pending in tuple(self._pending_execution_failures.items()):
+                if await self._release_superseded_execution_failure(
+                    command_id,
+                    pending,
+                ):
+                    continue
+                try:
+                    await self._persist_execution_failure(command_id, pending)
+                except Exception:
+                    if await self._release_superseded_execution_failure(
+                        command_id,
+                        pending,
+                    ):
+                        continue
+                    settlement_failed = True
+                    logger.warning(
+                        "Execution rejection %s was not durable during shutdown; retrying",
+                        pending.run.run_id,
+                        exc_info=True,
+                    )
+            if self._pending_execution_failures:
+                await self._sleep(_SHUTDOWN_SETTLEMENT_RETRY_SECS if settlement_failed else 0.0)
+        if self._pending_execution_failures:
+            logger.error(
+                "Leaving %d execution rejections for durable lease takeover during shutdown",
+                len(self._pending_execution_failures),
+            )
+        for _attempt in range(_SHUTDOWN_SETTLEMENT_MAX_ATTEMPTS):
+            if not self._waiting_executions:
+                break
             settlement_failed = False
             for run_id in tuple(self._waiting_executions):
                 try:
@@ -864,19 +1103,59 @@ class SubagentCommandAuthority:
                         exc_info=True,
                     )
             if settlement_failed:
-                # Orderly shutdown must remain pending while an accepted command
-                # is still claimed. Returning would let loop teardown cancel its
-                # heartbeat and strand a command that exact replay cannot run.
-                await asyncio.sleep(_SHUTDOWN_SETTLEMENT_RETRY_SECS)
+                await self._sleep(_SHUTDOWN_SETTLEMENT_RETRY_SECS)
+        if self._waiting_executions:
+            logger.error(
+                "Leaving %d waiting executions for durable lease takeover during shutdown",
+                len(self._waiting_executions),
+            )
         tasks = list(self._lease_tasks.values())
         self._lease_tasks.clear()
         self._execution_results.clear()
         self._waiting_executions.clear()
         self._waiting_execution_keys.clear()
+        self._pending_execution_failures.clear()
         for task in tasks:
             task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _release_superseded_execution_failure(
+        self,
+        command_id: str,
+        pending: _PendingExecutionFailure,
+    ) -> bool:
+        """Release local rejection debt after durable state owns the outcome."""
+
+        try:
+            receipt = await self._coordinator.get_command_by_key(
+                pending.claim.command.idempotency_key
+            )
+        except Exception:
+            return False
+        if receipt is None or receipt.command.command_id != command_id:
+            return False
+        command = receipt.command
+        fence = pending.claim.command_fence
+        terminal_run = (
+            receipt.run is not None and receipt.run.observed_state is ObservedState.TERMINAL
+        )
+        terminal_command = command.status in (
+            CommandStatus.APPLIED,
+            CommandStatus.REJECTED,
+        )
+        newer_claim = command.owner_id != fence.owner_id or command.claim_epoch != fence.claim_epoch
+        if not terminal_run and not terminal_command and not newer_claim:
+            return False
+        if self._pending_execution_failures.get(command_id) is pending:
+            self._pending_execution_failures.pop(command_id, None)
+        self._execution_results.pop(pending.run.run_id, None)
+        logger.info(
+            "Execution rejection %s was settled or superseded by durable command claim %s",
+            pending.run.run_id,
+            command.claim_epoch,
+        )
+        return True
 
     async def stop_execution_heartbeat(self, run_id: str) -> None:
         """Stop the queue lease after the manager starts or terminals the run."""
@@ -1006,11 +1285,16 @@ class SubagentCommandAuthority:
                         )
         await self.stop_execution_heartbeat(run_id)
 
-    def _owner_lease(self, *, execution: bool = False) -> OwnerLease:
+    def _owner_lease(
+        self,
+        *,
+        execution: bool = False,
+        control_seconds: float = _CONTROL_LEASE_SECS,
+    ) -> OwnerLease:
         return OwnerLease(
             owner_id=self._owner_id,
             lease_expires_at=self._clock()
-            + (EXECUTION_LEASE_SECONDS if execution else _CONTROL_LEASE_SECS),
+            + (EXECUTION_LEASE_SECONDS if execution else control_seconds),
         )
 
     @staticmethod

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -736,6 +736,9 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             except RuntimeError:
                 pass  # no running loop (sync/test context)
 
+        # These callbacks can fail before any task owns the registered record.
+        # Roll that provisional registration back so it cannot retain a slot or
+        # make the command authority mistake a phantom record for accepted work.
         try:
             parent_trusted = (
                 parent_session_key
@@ -992,6 +995,10 @@ class SpawnAdmissionCoordinator(ManagerComponent):
             and params.get("_coordinator_fence") is not None
         )
         if coordinator_rejection and drained is not None:
+            # The synchronous caller that received the original queued record
+            # no longer exists.  Bind the drained rejection back to its durable
+            # fence and report it through the coordinator instead of leaving an
+            # authority heartbeat renewing work that can never start.
             report_task = self._manager._tasks.pop(f"reject-{drained.id}", None)
             if report_task is not None:
                 report_task.cancel()

--- a/src/kiro_crew/subagent_manager/cancellation.py
+++ b/src/kiro_crew/subagent_manager/cancellation.py
@@ -82,12 +82,7 @@ class CancellationCoordinator(ManagerComponent):
                             info.id,
                         )
                         raise RuntimeError("original task teardown timed out")
-                if (
-                    info.done
-                    or info.user_stopped
-                    or info._reap_started
-                    or info.reaped
-                ):
+                if info.done or info.user_stopped or info._reap_started or info.reaped:
                     info._recovering = False
                     return
                 if self._manager._shutting_down:
@@ -98,12 +93,7 @@ class CancellationCoordinator(ManagerComponent):
                 # never pushes the pool past max_concurrent.
                 deadline = time.time() + _RECOVERY_SLOT_WAIT_SECS
                 while True:
-                    if (
-                        info.done
-                        or info.user_stopped
-                        or info._reap_started
-                        or info.reaped
-                    ):
+                    if info.done or info.user_stopped or info._reap_started or info.reaped:
                         info._recovering = False
                         return
                     if self._manager._shutting_down:

--- a/src/kiro_crew/subagent_manager/terminal.py
+++ b/src/kiro_crew/subagent_manager/terminal.py
@@ -11,14 +11,15 @@ if TYPE_CHECKING:
         _ON_DONE_TIMEOUT,
         _OUTBOX_RESULT_SUMMARY_LEN,
         _RESET_TIMEOUT,
+        _SIGKILL_REAP_TIMEOUT,
         _TERMINAL_RETRY_SECONDS,
         EXECUTION_LEASE_SECONDS,
         OUTCOME_INTERRUPTED,
         SUBAGENT_COMPLETION_PREFIX,
         AuthorityOutcomeUncertain,
         CoordinatorDecision,
-        OwnerLease,
         OutboxEvent,
+        OwnerLease,
         RunCompletion,
         RunOutcome,
         Stats,
@@ -107,6 +108,28 @@ class TerminalCoordinator(ManagerComponent):
         info._coordinator_version = result.value.version
         info._coordinator_process_protected = False
         return True
+
+    async def _protected_process_stopped_impl(self, info: SubagentInfo) -> bool:
+        """Prove that the coordinator-pinned child no longer owns its PID."""
+
+        run = await self._manager._coordinator.get_run(info.id)
+        if run is None or not run.process_owned or run.process_id <= 1 or not run.process_start_id:
+            return True
+        liveness = await asyncio.to_thread(platform_compat.pid_liveness, run.process_id)
+        if liveness == platform_compat.PID_DEAD:
+            return True
+        current_start_id = await asyncio.to_thread(
+            platform_compat.process_identity_token,
+            run.process_id,
+        )
+        if current_start_id is None:
+            return False
+        durable_pair = platform_compat.is_durable_process_identity_token(
+            run.process_start_id
+        ) and platform_compat.is_durable_process_identity_token(current_start_id)
+        if durable_pair or platform_compat.IS_WINDOWS:
+            return current_start_id != run.process_start_id
+        return False
 
     async def _record_process_identity_impl(self, info: SubagentInfo, session_key: str) -> None:
         """Persist protected process identity before any child prompt can run."""
@@ -381,12 +404,15 @@ class TerminalCoordinator(ManagerComponent):
                     settle_digest=True,
                     teardown_done=None,
                 )
+            else:
+                self._manager._outbox_live_run_batches.pop(event.run_id, None)
             self._manager._outbox_contexts[event.event_id] = context
         info = context.info
         info._delivery_event_id = event.event_id
         # A deferred destination already accepted this stable event into its
-        # own queue or digest. Background retries keep its durable identity
-        # pending for acknowledgement without repeating routing or accounting.
+        # own queue or digest. Exact claims remain available to the eventual
+        # consumer for acknowledgement, but a background drain must not replay
+        # lifecycle callbacks or count the same wave member twice.
         if info._digest_held or info._delivery_queued:
             return False
         info._delivery_failed = False
@@ -901,6 +927,12 @@ class TerminalCoordinator(ManagerComponent):
         if recovery_task and not recovery_task.done():
             recovery_task.cancel()
 
+        # A protected coordinator row keeps its terminal event unclaimable until
+        # teardown is proven.  Preserve that proof across the terminal commit;
+        # otherwise the reaper waits forever while its own process guard blocks
+        # the immediate outbox drain.
+        process_stopped = asyncio.Event() if info._coordinator_process_protected else None
+
         if info._session_sharing:
             # Session-sharing subagent: NEVER SIGKILL the shared runtime —
             # the parent session owns it and other co-tenants may be active.
@@ -947,6 +979,19 @@ class TerminalCoordinator(ManagerComponent):
                 await self._manager._sigkill_session(session_key)
             except Exception:
                 logger.exception("Reaper: reset failed for %s", agent_id)
+            if process_stopped is not None:
+                try:
+                    if await self._protected_process_stopped_impl(info):
+                        process_stopped.set()
+                except Exception:
+                    # A registry reset or kill attempt is not proof that the
+                    # coordinator-pinned child exited. Recovery retains the PID
+                    # fence whenever the process identity cannot be checked.
+                    logger.warning(
+                        "Reaper: protected process check failed for %s",
+                        agent_id,
+                        exc_info=True,
+                    )
 
         # Snapshot "parked on a never-answered spawn approval" BEFORE the
         # intentional cancel below, because the flag's owner clears it in a
@@ -1047,6 +1092,7 @@ class TerminalCoordinator(ManagerComponent):
                     f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s (reaper)"
                 ),
                 mark_delivered_on_success=False,
+                process_stopped=process_stopped,
                 # This member's own result is NOT marked delivered (it was
                 # reaped, not completed) — but if it was the wave member whose
                 # `_on_done` flushed the batch digest, its SIBLINGS' successful
@@ -1143,6 +1189,19 @@ class TerminalCoordinator(ManagerComponent):
                     pass
             # Sweep children that escaped to different PGIDs
             await loop.run_in_executor(subprocess_executor(), _kill_escaped_children, child_pids)
+            process = getattr(client, "_process", None)
+            if process is not None and getattr(process, "pid", None) == pid:
+                try:
+                    await asyncio.wait_for(
+                        process.wait(),
+                        timeout=_SIGKILL_REAP_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Reaper: PID %d did not exit after SIGKILL for %s",
+                        pid,
+                        session_key,
+                    )
         except Exception:
             logger.exception("Reaper: SIGKILL failed for %s", session_key)
 

--- a/test/test_mcp_core_wait.py
+++ b/test/test_mcp_core_wait.py
@@ -192,7 +192,7 @@ def test_spawn_run_resolves_machine_coded_coordinator_uncertainty() -> None:
 
 
 def test_pending_command_lookup_preserves_transport_uncertainty() -> None:
-    """A pending durable row must not close a batch member as completed."""
+    """A durable pending row may still execute and must not close its batch early."""
     pending = {
         "found": True,
         "id": "durable1",

--- a/test/test_process_tree_kill.py
+++ b/test/test_process_tree_kill.py
@@ -3,6 +3,7 @@
 Covers the killpg + escaped child sweep logic added to fix orphaned
 kiro-cli sessions.
 """
+
 from __future__ import annotations
 
 import signal
@@ -180,7 +181,10 @@ class TestSigkillSessionProcessTree:
     """Tests for SubagentManager._sigkill_session() process tree cleanup."""
 
     def _make_manager(
-        self, pid: int, child_pids: dict[int, int | None] | None = None, start_time: int | None = 100
+        self,
+        pid: int,
+        child_pids: dict[int, int | None] | None = None,
+        start_time: int | None = 100,
     ):
         provider = _make_provider(pid, child_pids, start_time=start_time)
         sessions = _mock_sessions_with_provider(provider)
@@ -219,6 +223,27 @@ class TestSigkillSessionProcessTree:
 
         mock_killpg.assert_called_once_with(54321, signal.SIGKILL)
         mock_sweep.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sigkill_waits_for_owned_process_to_be_reaped(self):
+        """A delivered SIGKILL is not success until the child has been reaped."""
+        mgr = self._make_manager(pid=54321)
+        process = MagicMock()
+        process.pid = 54321
+        process.wait = AsyncMock(return_value=-signal.SIGKILL)
+        mgr._sessions._sessions["subagent:test1"].provider._client._process = process
+
+        with (
+            patch("kiro_crew.subagent.os.killpg"),
+            patch("kiro_crew.subagent.os.getpgid", return_value=54321),
+            patch("kiro_crew.acp.client._get_child_pids", return_value=[]),
+            patch("kiro_crew.acp.client._kill_escaped_children"),
+            patch("kiro_crew.acp.client._get_start_time", return_value=100),
+            patch("kiro_crew.acp.client._is_our_child", return_value=True),
+        ):
+            await mgr._sigkill_session("subagent:test1")
+
+        process.wait.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sigkill_fallback_on_killpg_failure(self):

--- a/test/test_run_coordinator_contract.py
+++ b/test/test_run_coordinator_contract.py
@@ -691,7 +691,95 @@ async def test_exact_execution_command_claim_and_finish_are_idempotent(
 
 
 @pytest.mark.asyncio
-async def test_execution_rejection_retains_fence_for_terminal_outbox_commit(
+async def test_execution_finish_can_fill_result_after_starting_wins_race(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    await coordinator.submit(_request())
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("admission", clock.value + 10),
+    )
+    assert claim is not None
+    assert claim.fence is not None
+    assert claim.run is not None
+
+    started = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        claim.run.version,
+    )
+    filled = await coordinator.finish_command(
+        claim.command_fence,
+        CommandStatus.APPLIED,
+        result_json='{"id":"run-1","queued":false}',
+    )
+    queried = await coordinator.get_command_by_key("key-1")
+
+    assert started.decision is CoordinatorDecision.APPLIED
+    assert filled.decision is CoordinatorDecision.APPLIED
+    assert filled.value is not None
+    assert filled.value.result_json == '{"id":"run-1","queued":false}'
+    assert queried is not None
+    assert queried.command == filled.value
+
+
+@pytest.mark.asyncio
+async def test_execution_finish_cannot_fill_result_after_recovery_supersedes_lease(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    await coordinator.submit(_request())
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("admission", clock.value + 10),
+    )
+    assert claim is not None
+    assert claim.fence is not None
+    assert claim.run is not None
+    started = await coordinator.mark_starting(
+        claim.command,
+        claim.fence,
+        claim.run.version,
+    )
+    assert started.value is not None
+    clock.value += 11
+    recovery = await coordinator.claim_recovery(
+        OwnerLease("recovery", clock.value + 10),
+        1,
+    )
+    assert len(recovery) == 1
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id="run-1",
+            outcome=RunOutcome.INTERRUPTED,
+            result_path="",
+            error="interrupted by recovery",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"error":"interrupted by recovery"}',
+            terminal_at=clock.value,
+        ),
+        recovery[0].fence,
+        recovery[0].run.version,
+    )
+    assert completed.decision is CoordinatorDecision.APPLIED
+
+    stale_fill = await coordinator.finish_command(
+        claim.command_fence,
+        CommandStatus.APPLIED,
+        result_json='{"id":"run-1","queued":false}',
+    )
+
+    assert stale_fill.decision is CoordinatorDecision.REJECTED
+    assert stale_fill.reason is CoordinatorReason.STALE_FENCE
+    queried = await coordinator.get_command_by_key("key-1")
+    assert queried is not None
+    assert queried.command.result_json == ""
+
+
+@pytest.mark.asyncio
+async def test_command_rejection_does_not_bypass_terminal_outbox_transition(
     coordinator: RunCoordinator,
     clock: FakeClock,
 ) -> None:
@@ -714,6 +802,7 @@ async def test_execution_rejection_retains_fence_for_terminal_outbox_commit(
     assert run.observed_state is ObservedState.ACCEPTED
     assert run.outcome is None
     assert run.error == ""
+    assert await coordinator.claim_outbox(OwnerLease("delivery", clock.value + 10), 1) == []
     assert await coordinator.claim_commands(OwnerLease("executor", clock.value + 10), limit=1) == []
 
 
@@ -1096,7 +1185,46 @@ async def test_completion_is_atomic_when_event_identity_generation_fails(
     with pytest.raises(RuntimeError, match="identity source unavailable"):
         await coordinator.complete(completion, claim.fence, running.version)
 
-    assert await coordinator.get_run("run-1") == running
+    run = await coordinator.get_run("run-1")
+    receipt = await coordinator.get_command_by_key("key-1")
+    assert run == running
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.CLAIMED
+
+
+@pytest.mark.asyncio
+async def test_synchronous_completion_commits_an_already_delivered_event(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    claim, running = await _claimed_running(coordinator, clock)
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id="run-1",
+            outcome=RunOutcome.FAILED,
+            result_path="",
+            error="rejected synchronously",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"error":"rejected synchronously"}',
+            terminal_at=clock.value,
+            delivery_state=DeliveryState.DELIVERED,
+        ),
+        claim.fence,
+        expected_version=running.version,
+    )
+
+    assert completed.decision is CoordinatorDecision.APPLIED
+    assert completed.value is not None
+    assert completed.value.status is DeliveryState.DELIVERED
+    assert completed.value.delivered_at == clock.value
+    assert (
+        await coordinator.claim_outbox(
+            OwnerLease("delivery", clock.value + 10),
+            1,
+        )
+        == []
+    )
 
 
 @pytest.mark.asyncio
@@ -1405,7 +1533,7 @@ async def test_terminal_run_lease_cannot_be_renewed(
 
 
 @pytest.mark.asyncio
-async def test_transition_uses_one_clock_sample_for_fence_and_timestamp() -> None:
+async def test_memory_transition_uses_one_clock_sample_for_fence_and_timestamp() -> None:
     ticks: list[float] = []
 
     def stepping_clock() -> float:
@@ -1418,6 +1546,7 @@ async def test_transition_uses_one_clock_sample_for_fence_and_timestamp() -> Non
             OwnerLease(owner_id="gateway-1", lease_expires_at=105.0), limit=1
         )
     )[0]
+    assert claim.run is not None
     ticks[:] = [104.0, 106.0]
 
     starting = await coordinator.mark_starting(
@@ -1734,6 +1863,42 @@ async def test_legacy_import_and_recovery_claim_are_idempotent_and_fenced(
 
 
 @pytest.mark.asyncio
+async def test_existing_legacy_import_replays_before_validating_stale_file_shape(
+    coordinator: RunCoordinator,
+) -> None:
+    request = LegacyRunImport(
+        run_id="legacy-replay",
+        parent_session="dashboard:parent",
+        agent="kirocrew",
+        task="old work",
+        conversation_key="",
+        observed_state=ObservedState.RUNNING,
+        outcome=None,
+        result_path="",
+        error="",
+        created_at=10.0,
+        updated_at=20.0,
+        terminal_at=None,
+        source_version="legacy-state-v1",
+    )
+    created = await coordinator.import_legacy(request)
+
+    replay = await coordinator.import_legacy(
+        replace(
+            request,
+            observed_state=ObservedState.TERMINAL,
+            outcome=None,
+            event_type="subagent_completion",
+            delivery_state=None,
+        )
+    )
+
+    assert created.decision is CoordinatorDecision.APPLIED
+    assert replay.decision is CoordinatorDecision.UNCHANGED
+    assert replay.reason is CoordinatorReason.IDEMPOTENT_REPLAY
+
+
+@pytest.mark.asyncio
 async def test_recovery_claims_terminal_run_with_owned_process_until_cleanup(
     coordinator: RunCoordinator,
     clock: FakeClock,
@@ -1875,7 +2040,7 @@ async def test_legacy_terminal_import_preserves_delivery_state(
 
 
 @pytest.mark.asyncio
-async def test_legacy_import_retains_result_evidence_without_terminalizing_existing_run(
+async def test_legacy_import_cannot_mutate_existing_run_from_result_evidence(
     coordinator: RunCoordinator,
 ) -> None:
     submitted = await coordinator.submit(_request(run_id="shadow-run"))
@@ -1903,10 +2068,56 @@ async def test_legacy_import_retains_result_evidence_without_terminalizing_exist
         )
     )
 
-    assert imported.decision is CoordinatorDecision.APPLIED
+    assert imported.decision is CoordinatorDecision.UNCHANGED
     assert imported.value is not None
     assert imported.value.run.observed_state is ObservedState.ACCEPTED
     assert imported.value.run.outcome is None
     assert imported.value.run.error == ""
-    assert imported.value.run.result_path == "/tmp/shadow-run/result.txt"
+    assert imported.value.run.result_path == ""
     assert imported.value.event is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_legacy_import_cannot_override_claimed_authoritative_run(
+    coordinator: RunCoordinator,
+    clock: FakeClock,
+) -> None:
+    submitted = await coordinator.submit(_request(run_id="live-authoritative"))
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        submitted.value.command.command_id,
+        OwnerLease("executor", clock.value + 90.0),
+    )
+    assert claim is not None and claim.run is not None
+
+    imported = await coordinator.import_legacy(
+        LegacyRunImport(
+            run_id="live-authoritative",
+            parent_session="dashboard:parent",
+            agent="kirocrew",
+            task="old work",
+            conversation_key="",
+            observed_state=ObservedState.TERMINAL,
+            outcome=RunOutcome.INTERRUPTED,
+            result_path="/tmp/result.txt",
+            error="stale tombstone",
+            created_at=10.0,
+            updated_at=20.0,
+            terminal_at=20.0,
+            source_version="legacy-state-v1",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json='{"id":"live-authoritative"}',
+            delivery_state=DeliveryState.PENDING,
+        )
+    )
+
+    run = await coordinator.get_run("live-authoritative")
+    assert imported.decision is CoordinatorDecision.UNCHANGED
+    assert run is not None
+    assert run.observed_state is ObservedState.ACCEPTED
+    assert run.outcome is None
+    assert run.error == ""
+    assert run.owner_id == claim.run.owner_id
+    assert run.lease_epoch == claim.run.lease_epoch
+    assert run.version == claim.run.version

--- a/test/test_run_coordinator_delivery.py
+++ b/test/test_run_coordinator_delivery.py
@@ -678,6 +678,34 @@ async def test_startup_kills_surviving_child_before_delivering_its_completion(
 
 
 @pytest.mark.asyncio
+async def test_live_coordinator_delivery_retains_batch_context() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-live-batch")
+    event = await _completed_event(coordinator, clock, "run-live-batch")
+    delivered: list[tuple[str, int, str]] = []
+
+    async def capture(info: SubagentInfo) -> None:
+        delivered.append((info.batch_id, info.batch_total, info._delivery_event_id))
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=capture,
+        coordinator=coordinator,
+    )
+
+    manager.prepare_coordinator_rejection(
+        event.run_id,
+        batch_id="wave-live",
+        batch_total=3,
+    )
+    await manager._outbox_delivery.drain_once(event_id=event.event_id)
+
+    assert delivered == [("wave-live", 3, event.event_id)]
+    assert coordinator._outbox[event.event_id].status is DeliveryState.DELIVERED
+
+
+@pytest.mark.asyncio
 async def test_startup_reconciliation_does_not_reprocess_deferred_outbox_as_orphan(
     monkeypatch,
 ) -> None:
@@ -1443,6 +1471,31 @@ async def test_digest_held_shadow_fallback_keeps_error_tombstone(monkeypatch, tm
     tombstone = json.loads((tmp_path / info.id / "tombstone.json").read_text(encoding="utf-8"))
     assert tombstone["cause"] == "error"
     assert tombstone["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_deferred_manager_event_does_not_repeat_parent_callbacks() -> None:
+    clock = _Clock()
+    coordinator = MemoryRunCoordinator(clock=clock, id_factory=lambda: "event-1")
+    event = await _completed_event(coordinator, clock, "run-1")
+    calls = 0
+
+    async def defer(info: SubagentInfo) -> None:
+        nonlocal calls
+        calls += 1
+        info._delivery_queued = True
+
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        on_done=defer,
+        coordinator=coordinator,
+    )
+
+    await manager._outbox_delivery.drain_once(event_id=event.event_id)
+    await manager._outbox_delivery.drain_once(event_id=event.event_id)
+
+    assert calls == 1
 
 
 @pytest.mark.asyncio

--- a/test/test_run_coordinator_recovery.py
+++ b/test/test_run_coordinator_recovery.py
@@ -380,6 +380,28 @@ async def test_legacy_import_accepts_a_symlinked_trusted_data_home(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_macos_start_token_drift_does_not_clear_live_process_protection(monkeypatch):
+    from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+    clock = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0])
+    await _record_protected_process(coordinator, clock, "live-run", 4321, "recorded-token")
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+    info = SubagentInfo(id="live-run", task="work")
+    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(platform_compat, "IS_MACOS", True)
+    monkeypatch.setattr(platform_compat, "pid_liveness", lambda _pid: platform_compat.PID_ALIVE)
+    monkeypatch.setattr(platform_compat, "process_identity_token", lambda _pid: "drifted-token")
+
+    assert await manager._protected_process_stopped(info) is False
+
+
+@pytest.mark.asyncio
 @requires_symlinks
 @requires_pinned_tree_walk
 async def test_legacy_import_rejects_linked_folder_before_directory_probe(tmp_path, monkeypatch):

--- a/test/test_run_coordinator_wiring.py
+++ b/test/test_run_coordinator_wiring.py
@@ -49,6 +49,22 @@ def test_subagent_manager_preserves_injected_coordinator_identity() -> None:
     assert manager.command_authority._manager is manager
 
 
+def test_subagent_manager_preserves_a_falsy_injected_coordinator() -> None:
+    class FalsyCoordinator(MemoryRunCoordinator):
+        def __bool__(self) -> bool:
+            return False
+
+    coordinator = FalsyCoordinator()
+    manager = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+    )
+
+    assert manager._coordinator is coordinator
+    assert manager.command_authority._coordinator is coordinator
+
+
 @pytest.mark.asyncio
 async def test_execution_heartbeat_reacquires_an_expired_command_lease(monkeypatch) -> None:
     clock = [100.0]

--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -369,7 +369,8 @@ class TestSessionSharingSpawn:
             patch("kiro_crew.subagent.sel"),
         ):
             info = manager.spawn("test task", parent_session_key="dashboard:slot1")
-            await _wait_until_done(info)
+            run_task = manager._tasks[info.id]
+            await run_task
 
         # Legacy path: get_or_create called, runtime NOT called
         sessions.get_or_create.assert_awaited()

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -153,7 +153,9 @@ class TestSpawnWithoutApprovalCallback:
             sessions=sessions,
             ctx_builder=ctx,
         )
-        info = SubagentInfo(id="test01", task="tool approval task", parent_session_key="slack:C123:T456")
+        info = SubagentInfo(
+            id="test01", task="tool approval task", parent_session_key="slack:C123:T456"
+        )
 
         with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
             await manager._run_inner(info, "subagent:test01")
@@ -161,9 +163,9 @@ class TestSpawnWithoutApprovalCallback:
         # Subagent session should be created with parent_policy="auto"
         sessions.get_or_create.assert_awaited_once()
         call_kwargs = sessions.get_or_create.call_args.kwargs
-        assert call_kwargs.get("approval_policy") == "auto", (
-            f"Expected approval_policy=auto, got {call_kwargs}"
-        )
+        assert (
+            call_kwargs.get("approval_policy") == "auto"
+        ), f"Expected approval_policy=auto, got {call_kwargs}"
 
     @pytest.mark.asyncio
     async def test_spawn_without_callback_yolo_on_executes(self) -> None:
@@ -283,9 +285,7 @@ class TestSpawnWithoutApprovalCallback:
             max_concurrent=1,
             on_done=on_done,
         )
-        manager.command_authority.reject_waiting_execution = AsyncMock(
-            side_effect=reject_waiting
-        )
+        manager.command_authority.reject_waiting_execution = AsyncMock(side_effect=reject_waiting)
         manager._scheduler.enqueue(
             {
                 "task": "",
@@ -388,7 +388,10 @@ class TestSpawnWithoutApprovalCallback:
 
         assert queued is not None and queued.queued is True
         # The queued member is invisible to `running`-based checks...
-        assert not any(a.parent_session_key == "cron:j1" and a.queued is False and a.id == queued.id for a in manager.running)
+        assert not any(
+            a.parent_session_key == "cron:j1" and a.queued is False and a.id == queued.id
+            for a in manager.running
+        )
         # ...but the pending-work predicates must still report it.
         assert manager.queued_count_for("cron:j1") == 1
         assert manager.has_pending_work_for("cron:j1") is True
@@ -447,6 +450,61 @@ class TestSpawnWithApprovalCallback:
         assert info.error == "spawn rejected"
         assert info.result == ""
         on_done_callback.assert_awaited_once_with(info)
+
+    def test_pre_task_policy_failure_rolls_back_registration_and_capacity(self) -> None:
+        def policy_failure() -> bool:
+            raise RuntimeError("policy unavailable")
+
+        manager = SubagentManager(
+            sessions=_mock_sessions(),
+            ctx_builder=_mock_ctx_builder(),
+            max_concurrent=1,
+            is_yolo=policy_failure,
+        )
+
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
+            with pytest.raises(RuntimeError, match="policy unavailable"):
+                manager.spawn("fails before task ownership", _preassigned_id="pre-task-failure")
+
+            assert manager.get("pre-task-failure") is None
+            assert "pre-task-failure" not in manager._tasks
+            assert manager.running_count == 0
+
+            manager._is_yolo = lambda: False
+            next_info = manager.spawn("capacity remains usable")
+
+        assert next_info is not None
+        assert next_info.queued is False
+        assert manager.running_count == 0
+
+    @pytest.mark.asyncio
+    async def test_keyed_pre_task_policy_failure_is_durably_rejected(self) -> None:
+        def policy_failure() -> bool:
+            raise RuntimeError("policy unavailable")
+
+        coordinator = MemoryRunCoordinator()
+        manager = SubagentManager(
+            sessions=_mock_sessions(),
+            ctx_builder=_mock_ctx_builder(),
+            max_concurrent=1,
+            is_yolo=policy_failure,
+            coordinator=coordinator,
+        )
+        identity = CommandIdentity(
+            run_id="keyed-pre-task-failure",
+            command_id="command-keyed-pre-task-failure",
+            idempotency_key="key-keyed-pre-task-failure",
+        )
+
+        result = await manager.command_authority.spawn(identity, "fails before task ownership")
+
+        assert result.done is True
+        assert result.error == "policy unavailable"
+        assert manager.get(identity.run_id) is None
+        assert manager.running_count == 0
+        receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+        assert receipt is not None
+        assert receipt.command.status is CommandStatus.APPLIED
 
     @pytest.mark.asyncio
     async def test_keyed_approval_rejection_finishes_durable_command(self) -> None:
@@ -554,9 +612,7 @@ class TestSpawnWithApprovalCallback:
             approval_gate.set()
             await first_task
 
-        assert await manager.command_authority.lookup_response(
-            queued_identity.idempotency_key
-        ) == {
+        assert await manager.command_authority.lookup_response(queued_identity.idempotency_key) == {
             "found": True,
             "id": queued_identity.run_id,
             "error": "run stopped before execution",
@@ -1019,8 +1075,10 @@ class TestSubagentReaper:
         manager._agents["done0001"] = info
 
         # Run one real reaper sweep — first sleep succeeds, second raises CancelledError
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "asyncio.sleep", AsyncMock(side_effect=[None, asyncio.CancelledError])
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("asyncio.sleep", AsyncMock(side_effect=[None, asyncio.CancelledError])),
         ):
             with pytest.raises(asyncio.CancelledError):
                 await manager._reaper_loop()
@@ -1057,9 +1115,12 @@ class TestSubagentReaper:
         # _sigkill_session is async (offloaded the Windows taskkill
         # to subprocess_executor via kill_process_tree_async), so callers now
         # await it — the patch must be AsyncMock or asyncio complains.
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent._RESET_TIMEOUT", 0.1
-        ), patch.object(manager, "_sigkill_session", new_callable=AsyncMock) as mock_kill:
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent._RESET_TIMEOUT", 0.1),
+            patch.object(manager, "_sigkill_session", new_callable=AsyncMock) as mock_kill,
+        ):
             await manager._force_reap("hang0001", info, _TIMEOUT_SECS + 60)
 
         assert info.done is True
@@ -1088,9 +1149,12 @@ class TestSubagentReaper:
         manager._running_count = 1
 
         # _sigkill_session is async — patch with AsyncMock.
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent._RESET_TIMEOUT", 0.1
-        ), patch.object(manager, "_sigkill_session", new_callable=AsyncMock):
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent._RESET_TIMEOUT", 0.1),
+            patch.object(manager, "_sigkill_session", new_callable=AsyncMock),
+        ):
             await manager._run(info)
 
         # Should complete without hanging
@@ -1567,8 +1631,10 @@ class TestOnDoneTimeout:
             is_yolo=lambda: True,
         )
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1),
         ):
             info = manager.spawn("timeout test", parent_session_key="dashboard:test-slot")
             assert info is not None
@@ -1602,8 +1668,10 @@ class TestOnDoneTimeout:
             is_yolo=lambda: True,
         )
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1),
         ):
             info = manager.spawn("path test", parent_session_key="dashboard:slot-x")
             assert info is not None
@@ -1645,8 +1713,10 @@ class TestOnDoneTimeout:
         manager._agents["hang0002"] = info
         manager._running_count = 1
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1),
         ):
             await manager._force_reap("hang0002", info, _TIMEOUT_SECS + 60)
 
@@ -1679,8 +1749,11 @@ class TestOnDoneTimeout:
         info.error = "Timed out after 30 minutes"
         manager._agents["done0001"] = info
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), \
-             patch.object(manager, "_write_tombstone") as mock_ts:
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch.object(manager, "_write_tombstone") as mock_ts,
+        ):
             await manager._force_reap("done0001", info, _TIMEOUT_SECS + 60)
 
         assert info.reaped is True
@@ -1723,8 +1796,10 @@ class TestOnDoneTimeout:
             is_yolo=lambda: True,
         )
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent._ON_DONE_TIMEOUT", 0.1),
         ):
             info = manager.spawn("timeout reset test", parent_session_key="dashboard:slot-1")
             assert info is not None
@@ -2032,9 +2107,11 @@ class TestSpawnMemoryGuard:
             max_concurrent=3,
         )
 
-        with patch("kiro_crew.subagent.check_memory_available", return_value=(False, 2.5)), \
-             patch("kiro_crew.subagent.KiroCrewConfig") as mock_cfg, \
-             patch("kiro_crew.subagent.sel") as mock_sel:
+        with (
+            patch("kiro_crew.subagent.check_memory_available", return_value=(False, 2.5)),
+            patch("kiro_crew.subagent.KiroCrewConfig") as mock_cfg,
+            patch("kiro_crew.subagent.sel") as mock_sel,
+        ):
             mock_cfg.load.return_value.agent.spawn_min_memory_gb = 4.0
             mock_sel.return_value.log_tool_invocation = MagicMock()
 
@@ -2181,7 +2258,8 @@ class TestSubagentPostToolUseHook:
         # once for PostToolUse. Verify the PostToolUse call carried the cached
         # tool_name (with "Running: " stripped) and the tool_response payload.
         post_calls = [
-            c for c in manager.hook_store.fire.await_args_list
+            c
+            for c in manager.hook_store.fire.await_args_list
             if c.args and c.args[0] == "PostToolUse"
         ]
         assert len(post_calls) == 1, (
@@ -2241,7 +2319,8 @@ class TestSubagentPostToolUseHook:
             await manager._run_inner(info, "subagent:t02")
 
         post_calls = [
-            c for c in manager.hook_store.fire.await_args_list
+            c
+            for c in manager.hook_store.fire.await_args_list
             if c.args and c.args[0] == "PostToolUse"
         ]
         assert len(post_calls) == 1
@@ -2462,12 +2541,15 @@ class TestSubagentUsageRow:
         )
 
         persist = AsyncMock()
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist
-        ), patch(
-            "kiro_crew.dashboard.handlers.usage.read_context_tokens",
-            MagicMock(return_value=(999, 200000)),
-            create=True,
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist),
+            patch(
+                "kiro_crew.dashboard.handlers.usage.read_context_tokens",
+                MagicMock(return_value=(999, 200000)),
+                create=True,
+            ),
         ):
             await manager._run_inner(info, "subagent:usage01")
 
@@ -2506,17 +2588,21 @@ class TestSubagentUsageRow:
         )
 
         persist = AsyncMock()
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist
-        ), patch(
-            "kiro_crew.dashboard.handlers.usage.read_context_tokens",
-            MagicMock(return_value=(1, 2)),
-            create=True,
-        ), patch(
-            # The shared parent runtime reports the parent's agent.
-            "kiro_crew.dashboard.handlers.usage.read_effective_agent",
-            MagicMock(return_value="kirocrew"),
-            create=True,
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.dashboard.handlers.usage.persist_token_record_async", persist),
+            patch(
+                "kiro_crew.dashboard.handlers.usage.read_context_tokens",
+                MagicMock(return_value=(1, 2)),
+                create=True,
+            ),
+            patch(
+                # The shared parent runtime reports the parent's agent.
+                "kiro_crew.dashboard.handlers.usage.read_effective_agent",
+                MagicMock(return_value="kirocrew"),
+                create=True,
+            ),
         ):
             await manager._run_inner(info, "subagent:usage02")
 
@@ -2584,9 +2670,12 @@ class TestIdentityTrustedChildParentPolicyAuto:
         assert event.child_low_fidelity and event.child_mcp_identity_trusted
         manager, info, provider = self._manager_and_stream(event)
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent.update_state"
-        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent.update_state"),
+            patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True),
+        ):
             await manager._run_inner(info, "subagent:idmcp01")
 
         provider.approve_tool.assert_awaited_once_with(7001)
@@ -2600,9 +2689,12 @@ class TestIdentityTrustedChildParentPolicyAuto:
         assert event.child_low_fidelity and not event.child_mcp_identity_trusted
         manager, info, provider = self._manager_and_stream(event)
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent.update_state"
-        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent.update_state"),
+            patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True),
+        ):
             await manager._run_inner(info, "subagent:idmcp01")
 
         provider.approve_tool.assert_not_awaited()
@@ -2616,9 +2708,12 @@ class TestIdentityTrustedChildParentPolicyAuto:
         manager, info, provider = self._manager_and_stream(event)
         manager._sessions.get_approval_policy = MagicMock(return_value="")
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent.update_state"
-        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent.update_state"),
+            patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True),
+        ):
             await manager._run_inner(info, "subagent:idmcp01")
 
         provider.approve_tool.assert_not_awaited()
@@ -2669,9 +2764,12 @@ class TestChildEscalationLimit:
             side_effect=lambda _i, cause: tombstones.append(cause)
         )
 
-        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
-            "kiro_crew.subagent.update_state"
-        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent.update_state"),
+            patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True),
+        ):
             await manager._run_inner(info, "subagent:esc01")
 
         assert tombstones == ["child_escalation_limit"]

--- a/test/test_subagent_command_authority.py
+++ b/test/test_subagent_command_authority.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 from dataclasses import dataclass
 from typing import Any
@@ -18,7 +19,10 @@ from kiro_crew.run_coordinator import (
     CoordinatorReason,
     CoordinatorResult,
     MemoryRunCoordinator,
+    ObservedState,
     OwnerLease,
+    RunCompletion,
+    RunOutcome,
     SubmitRun,
 )
 from kiro_crew.subagent import SubagentInfo, SubagentManager
@@ -118,6 +122,7 @@ class _Info:
     batch_id: str = ""
     batch_total: int = 0
     _coordinator_waiting: bool = False
+    silent: bool = False
 
 
 class _Manager:
@@ -129,7 +134,9 @@ class _Manager:
         self.followup_calls: list[tuple[str, str]] = []
         self.cancel_calls: list[str] = []
         self.release_calls: list[str] = []
-        self.announced: list[_Info] = []
+        self.delivered_events: list[str] = []
+        self.delivered_batches: list[tuple[str, int]] = []
+        self.prepared_batches: list[tuple[str, str, int]] = []
         self.infos: dict[str, _Info] = {}
         self._queue: list[dict[str, Any]] = []
         self.reserved_run_ids: set[str] = set()
@@ -202,6 +209,31 @@ class _Manager:
     async def announce_durable_rejection(self, info: _Info) -> None:
         self.announced.append(info)
 
+    async def deliver_coordinator_event(
+        self,
+        event_id: str,
+        *,
+        batch_id: str = "",
+        batch_total: int = 0,
+    ) -> None:
+        self.delivered_events.append(event_id)
+        self.delivered_batches.append((batch_id, batch_total))
+
+    def prepare_coordinator_rejection(
+        self,
+        run_id: str,
+        *,
+        batch_id: str = "",
+        batch_total: int = 0,
+    ) -> None:
+        self.prepared_batches.append((run_id, batch_id, batch_total))
+
+
+class _RegisteredThenRaisesManager(_Manager):
+    def spawn(self, task: str, **kwargs: Any) -> _Info:
+        super().spawn(task, **kwargs)
+        raise RuntimeError("post-registration audit failed")
+
 
 class _UnclaimableCoordinator(MemoryRunCoordinator):
     async def claim_command(self, command_id, owner):
@@ -229,6 +261,7 @@ class _RejectingManager(_Manager):
             error="spawn refused by governance",
             batch_id=str(kwargs.get("batch_id") or ""),
             batch_total=int(kwargs.get("batch_total") or 0),
+            silent=bool(kwargs.get("silent")),
         )
 
     def continue_conversation(self, conversation_id: str, task: str, **kwargs: Any) -> _Info:
@@ -248,12 +281,6 @@ class _SlowCancelManager(_Manager):
     async def cancel(self, run_id: str) -> bool:
         self._clock[0] += 31.0
         return await super().cancel(run_id)
-
-
-class _RegisteredThenRaisesManager(_Manager):
-    def spawn(self, task: str, **kwargs: Any) -> _Info:
-        super().spawn(task, **kwargs)
-        raise RuntimeError("post-registration audit failed")
 
 
 class _RaisesBeforeRegistrationManager(_Manager):
@@ -288,6 +315,71 @@ class _RejectFinishCoordinator(MemoryRunCoordinator):
             CoordinatorReason.VERSION_CONFLICT,
             None,
         )
+
+
+class _RaisingManager(_Manager):
+    def spawn(self, task: str, **kwargs: Any) -> _Info:
+        self.spawn_calls.append((task, kwargs))
+        raise RuntimeError("provider refused startup")
+
+
+class _FailFirstCompletionCoordinator(MemoryRunCoordinator):
+    def __init__(self) -> None:
+        super().__init__()
+        self.completion_calls = 0
+
+    async def complete(self, completion, fence, expected_version):
+        self.completion_calls += 1
+        if self.completion_calls == 1:
+            return CoordinatorResult(
+                CoordinatorDecision.REJECTED,
+                CoordinatorReason.VERSION_CONFLICT,
+                None,
+            )
+        return await super().complete(completion, fence, expected_version)
+
+
+class _RejectEveryCompletionCoordinator(MemoryRunCoordinator):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.completion_calls = 0
+
+    async def complete(self, completion, fence, expected_version):
+        self.completion_calls += 1
+        return CoordinatorResult(
+            CoordinatorDecision.REJECTED,
+            CoordinatorReason.VERSION_CONFLICT,
+            None,
+        )
+
+
+class _RaiseAfterCompletionCoordinator(MemoryRunCoordinator):
+    def __init__(self) -> None:
+        super().__init__()
+        self.completion_calls = 0
+
+    async def complete(self, completion, fence, expected_version):
+        self.completion_calls += 1
+        result = await super().complete(completion, fence, expected_version)
+        if self.completion_calls == 1:
+            raise OSError("coordinator response was lost")
+        return result
+
+
+class _FailFirstFinishCoordinator(MemoryRunCoordinator):
+    def __init__(self) -> None:
+        super().__init__()
+        self.finish_calls = 0
+
+    async def finish_command(self, fence, status, rejection_reason="", result_json=""):
+        self.finish_calls += 1
+        if self.finish_calls == 1:
+            return CoordinatorResult(
+                CoordinatorDecision.REJECTED,
+                CoordinatorReason.VERSION_CONFLICT,
+                None,
+            )
+        return await super().finish_command(fence, status, rejection_reason, result_json)
 
 
 def _identity(suffix: str, *, key: str | None = None) -> CommandIdentity:
@@ -562,11 +654,21 @@ async def test_keyed_batch_rejection_announces_after_durable_settlement() -> Non
     observed_statuses: list[CommandStatus] = []
 
     class ObservingManager(_RejectingManager):
-        async def announce_durable_rejection(self, info: _Info) -> None:
+        async def deliver_coordinator_event(
+            self,
+            event_id: str,
+            *,
+            batch_id: str = "",
+            batch_total: int = 0,
+        ) -> None:
             receipt = await coordinator.get_command_by_key(identity.idempotency_key)
             assert receipt is not None
             observed_statuses.append(receipt.command.status)
-            await super().announce_durable_rejection(info)
+            await super().deliver_coordinator_event(
+                event_id,
+                batch_id=batch_id,
+                batch_total=batch_total,
+            )
 
     manager = ObservingManager()
     authority = SubagentCommandAuthority(coordinator, manager)
@@ -578,17 +680,17 @@ async def test_keyed_batch_rejection_announces_after_durable_settlement() -> Non
         batch_total=2,
     )
 
-    assert [info.id for info in manager.announced] == [result.id]
-    assert [info.error for info in manager.announced] == [result.error]
-    assert observed_statuses == [CommandStatus.REJECTED]
+    assert result.error == "spawn refused by governance"
+    assert len(manager.delivered_events) == 1
+    assert observed_statuses == [CommandStatus.APPLIED]
 
 
 @pytest.mark.asyncio
-async def test_keyed_batch_rejection_settlement_failure_is_announced() -> None:
+async def test_keyed_batch_rejection_completion_failure_is_not_delivered() -> None:
     manager = _RejectingManager()
-    authority = SubagentCommandAuthority(_FinishUnavailableCoordinator(), manager)
+    authority = SubagentCommandAuthority(_FailFirstCompletionCoordinator(), manager)
 
-    with pytest.raises(AuthorityOutcomeUncertain):
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
         await authority.spawn(
             _identity("batch-rejection-unsettled"),
             "reject this batch spawn",
@@ -596,8 +698,8 @@ async def test_keyed_batch_rejection_settlement_failure_is_announced() -> None:
             batch_total=2,
         )
 
-    assert len(manager.announced) == 1
-    assert manager.announced[0].error == "spawn refused by governance"
+    assert manager.delivered_events == []
+    assert manager.prepared_batches == []
 
 
 @pytest.mark.asyncio
@@ -655,9 +757,15 @@ async def test_keyed_queued_spawn_renews_lease_before_manager_registration() -> 
         run = await coordinator.get_run(identity.run_id)
         if run is not None and run.lease_expires_at > 180.0:
             break
-    run = await coordinator.get_run(identity.run_id)
-    assert run is not None
-    assert run.lease_expires_at > 200.0
+    clock[0] = 200.0
+
+    assert (
+        await coordinator.claim_recovery(
+            OwnerLease("recovery", clock[0] + 90.0),
+            1,
+        )
+        == []
+    )
     await authority.close()
 
 
@@ -684,23 +792,25 @@ async def test_post_effect_finish_failure_is_reported_as_transport_uncertainty()
 
 
 @pytest.mark.asyncio
-async def test_manager_exception_settlement_failure_is_outcome_uncertain() -> None:
+async def test_manager_exception_result_fill_failure_keeps_durable_failure() -> None:
     manager = _RaisesBeforeRegistrationManager()
-    authority = SubagentCommandAuthority(_FinishUnavailableCoordinator(), manager)
+    coordinator = _FinishUnavailableCoordinator()
+    authority = SubagentCommandAuthority(coordinator, manager)
     identity = _identity("exception-settlement-unavailable")
 
-    with pytest.raises(AuthorityOutcomeUncertain, match="failure was not durably finished"):
-        await authority.spawn(
-            identity,
-            "child may have started",
-            batch_id="exception-wave",
-            batch_total=2,
-        )
+    result = await authority.spawn(identity, "child may have started")
+    run = await coordinator.get_run(identity.run_id)
+    lookup = await authority.lookup_response(identity.idempotency_key)
 
     assert [task for task, _kwargs in manager.spawn_calls] == ["child may have started"]
-    assert len(manager.announced) == 1
-    assert manager.announced[0].batch_id == "exception-wave"
-    assert manager.announced[0].batch_total == 2
+    assert result.done is True
+    assert result.error == "pre-registration admission failed"
+    assert run is not None
+    assert run.observed_state is ObservedState.TERMINAL
+    assert run.outcome is RunOutcome.FAILED
+    assert lookup is not None
+    assert lookup["code"] == "run_failed"
+    assert lookup["counted"] is True
 
 
 @pytest.mark.asyncio
@@ -746,11 +856,21 @@ async def test_platform_failure_before_registration_closes_batch_member() -> Non
     assert result.error == "platform policy unavailable"
     assert result.batch_id == "batchplatform"
     assert result.batch_total == 2
-    assert len(manager.announced) == 1
-    assert manager.announced[0] == result
+    assert len(manager.delivered_events) == 1
+    events = await coordinator.claim_outbox(
+        OwnerLease("delivery", 10**12),
+        1,
+        event_id=manager.delivered_events[0],
+    )
+    assert len(events) == 1
+    payload = json.loads(events[0].payload_json)
+    assert payload["batch_id"] == "batchplatform"
+    assert payload["batch_total"] == 2
     receipt = await coordinator.get_command_by_key(identity.idempotency_key)
     assert receipt is not None
-    assert receipt.command.status is CommandStatus.REJECTED
+    assert receipt.command.status is CommandStatus.APPLIED
+    assert receipt.run is not None
+    assert receipt.run.outcome is RunOutcome.FAILED
 
 
 @pytest.mark.asyncio
@@ -760,7 +880,7 @@ async def test_manager_exception_after_registration_keeps_command_claimed() -> N
     authority = SubagentCommandAuthority(coordinator, manager)
     identity = _identity("registered-exception")
 
-    with pytest.raises(AuthorityOutcomeUncertain, match="after manager registration"):
+    with pytest.raises(AuthorityOutcomeUncertain, match="manager accepted execution"):
         await authority.spawn(identity, "registered child keeps running")
 
     receipt = await coordinator.get_command_by_key(identity.idempotency_key)
@@ -807,6 +927,293 @@ async def test_uncertain_control_exception_keeps_command_claimed() -> None:
     with pytest.raises(AuthorityOutcomeUncertain, match="control outcome"):
         await restarted.cancel(identity, "target-run")
     assert manager.cancel_calls == ["target-run"]
+
+
+@pytest.mark.asyncio
+async def test_post_registration_manager_failure_preserves_live_execution() -> None:
+    manager = _RegisteredThenRaisesManager()
+    coordinator = MemoryRunCoordinator()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("registered-then-raised")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="manager accepted"):
+        await authority.spawn(identity, "child may already be running")
+
+    run = await coordinator.get_run(identity.run_id)
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert run is not None
+    assert run.observed_state is not ObservedState.TERMINAL
+    assert run.outcome is None
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.CLAIMED
+    assert manager.prepared_batches == []
+
+
+@pytest.mark.asyncio
+async def test_post_registration_exception_preserves_terminal_manager_rejection() -> None:
+    class TerminalRegisteredThenRaisesManager(_Manager):
+        def spawn(self, task: str, **kwargs: Any) -> _Info:
+            info = super().spawn(task, **kwargs)
+            info.done = True
+            info.error = "spawn refused by governance"
+            raise RuntimeError("post-registration audit failed")
+
+    manager = TerminalRegisteredThenRaisesManager()
+    coordinator = MemoryRunCoordinator()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("terminal-registered-then-raised")
+
+    result = await authority.spawn(identity, "preserve the manager rejection")
+    replay = await authority.spawn(identity, "preserve the manager rejection")
+    lookup = await authority.lookup_response(identity.idempotency_key)
+
+    assert result.error == "spawn refused by governance"
+    assert replay.error == "spawn refused by governance"
+    assert lookup is not None
+    assert lookup["error"] == "spawn refused by governance"
+
+
+@pytest.mark.asyncio
+async def test_post_registration_rejection_uses_latest_run_version() -> None:
+    class AdvancingCoordinator(MemoryRunCoordinator):
+        def __init__(self) -> None:
+            super().__init__()
+            self.claim = None
+            self.advance_on_lookup = False
+            self.advanced = False
+
+        async def claim_command(self, command_id, owner):
+            claim = await super().claim_command(command_id, owner)
+            self.claim = claim
+            return claim
+
+        async def get_run(self, run_id):
+            if self.advance_on_lookup and not self.advanced:
+                self.advanced = True
+                assert self.claim is not None
+                assert self.claim.run is not None
+                assert self.claim.fence is not None
+                started = await super().mark_starting(
+                    self.claim.command,
+                    self.claim.fence,
+                    self.claim.run.version,
+                )
+                assert started.value is not None
+            return await super().get_run(run_id)
+
+    coordinator = AdvancingCoordinator()
+
+    class TerminalRegisteredThenRaisesManager(_Manager):
+        def spawn(self, task: str, **kwargs: Any) -> _Info:
+            info = super().spawn(task, **kwargs)
+            info.done = True
+            info.error = "spawn refused after start"
+            coordinator.advance_on_lookup = True
+            raise RuntimeError("post-registration audit failed")
+
+    authority = SubagentCommandAuthority(coordinator, TerminalRegisteredThenRaisesManager())
+    identity = _identity("terminal-rejection-after-start")
+
+    result = await authority.spawn(identity, "use the latest lifecycle version")
+
+    run = await coordinator.get_run(identity.run_id)
+    assert coordinator.advanced is True
+    assert result.error == "spawn refused after start"
+    assert run is not None
+    assert run.observed_state is ObservedState.TERMINAL
+    assert run.outcome is RunOutcome.FAILED
+
+
+@pytest.mark.asyncio
+async def test_post_registration_exception_never_becomes_clean_success() -> None:
+    class CleanTerminalThenRaisesManager(_Manager):
+        def spawn(self, task: str, **kwargs: Any) -> _Info:
+            info = super().spawn(task, **kwargs)
+            info.done = True
+            raise RuntimeError("post-registration audit failed")
+
+    manager = CleanTerminalThenRaisesManager()
+    coordinator = MemoryRunCoordinator()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("clean-terminal-then-raised")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="manager accepted"):
+        await authority.spawn(identity, "do not report a clean result")
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.CLAIMED
+
+
+@pytest.mark.asyncio
+async def test_close_retries_terminal_manager_rejection_until_durable() -> None:
+    class TerminalRegisteredThenRaisesManager(_Manager):
+        def spawn(self, task: str, **kwargs: Any) -> _Info:
+            info = super().spawn(task, **kwargs)
+            info.done = True
+            info.error = "spawn refused by governance"
+            raise RuntimeError("post-registration audit failed")
+
+    coordinator = _FailFirstCompletionCoordinator()
+    authority = SubagentCommandAuthority(coordinator, TerminalRegisteredThenRaisesManager())
+    identity = _identity("shutdown-terminal-rejection")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "preserve the manager rejection")
+
+    await authority.close()
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert coordinator.completion_calls == 2
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.APPLIED
+    assert receipt.run is not None
+    assert receipt.run.observed_state is ObservedState.TERMINAL
+    assert receipt.run.outcome is RunOutcome.FAILED
+    assert authority._pending_execution_failures == {}
+
+
+@pytest.mark.asyncio
+async def test_close_releases_rejection_after_lost_completion_response() -> None:
+    class TerminalRegisteredThenRaisesManager(_Manager):
+        def spawn(self, task: str, **kwargs: Any) -> _Info:
+            info = super().spawn(task, **kwargs)
+            info.done = True
+            info.error = "spawn refused by governance"
+            raise RuntimeError("post-registration audit failed")
+
+    coordinator = _RaiseAfterCompletionCoordinator()
+    authority = SubagentCommandAuthority(coordinator, TerminalRegisteredThenRaisesManager())
+    identity = _identity("shutdown-committed-rejection")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "preserve the committed rejection")
+
+    await authority.close()
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert coordinator.completion_calls == 1
+    assert receipt is not None
+    assert receipt.run is not None
+    assert receipt.run.observed_state is ObservedState.TERMINAL
+    assert receipt.run.outcome is RunOutcome.FAILED
+    assert authority._pending_execution_failures == {}
+
+
+@pytest.mark.asyncio
+async def test_close_releases_rejection_after_command_terminalizes() -> None:
+    coordinator = _RejectEveryCompletionCoordinator()
+    authority = SubagentCommandAuthority(coordinator, _RejectingManager())
+    identity = _identity("shutdown-terminal-command")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "preserve the command outcome")
+    pending = authority._pending_execution_failures[identity.command_id]
+    await coordinator.finish_command(pending.claim.command_fence, CommandStatus.APPLIED)
+
+    await authority.close()
+
+    assert coordinator.completion_calls == 1
+    assert authority._pending_execution_failures == {}
+
+
+@pytest.mark.asyncio
+async def test_close_releases_rejection_after_command_claim_takeover() -> None:
+    clock = [100.0]
+    coordinator = _RejectEveryCompletionCoordinator(clock=lambda: clock[0])
+    authority = SubagentCommandAuthority(
+        coordinator,
+        _RejectingManager(),
+        clock=lambda: clock[0],
+    )
+    identity = _identity("shutdown-newer-claim")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "defer to the new owner")
+    clock[0] = 200.0
+    replacement = await coordinator.claim_command(
+        identity.command_id,
+        OwnerLease("replacement", 290.0),
+    )
+    assert replacement is not None
+
+    await authority.close()
+
+    assert coordinator.completion_calls == 1
+    assert authority._pending_execution_failures == {}
+
+
+@pytest.mark.asyncio
+async def test_close_bounds_pending_failure_settlement_during_coordinator_outage() -> None:
+    async def yielding_sleep(_delay: float) -> None:
+        await asyncio.sleep(0)
+
+    coordinator = _RejectEveryCompletionCoordinator()
+    authority = SubagentCommandAuthority(
+        coordinator,
+        _RejectingManager(),
+        sleep=yielding_sleep,
+    )
+    identity = _identity("shutdown-pending-outage")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "bound shutdown retries")
+
+    await asyncio.wait_for(authority.close(), timeout=0.2)
+
+    assert coordinator.completion_calls == 1 + 3
+    assert authority._pending_execution_failures == {}
+    assert authority._lease_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_close_yields_while_superseded_failure_cache_changes() -> None:
+    """Shutdown settlement cannot monopolize the loop on a replaced cache entry."""
+    authority = SubagentCommandAuthority(MemoryRunCoordinator(), _Manager())
+    authority._pending_execution_failures["command-1"] = object()  # type: ignore[assignment]
+    marker_ran = False
+    observations: list[bool] = []
+
+    async def run_marker() -> None:
+        nonlocal marker_ran
+        await asyncio.sleep(0)
+        marker_ran = True
+
+    async def release_superseded(command_id: str, _pending: object) -> bool:
+        observations.append(marker_ran)
+        if len(observations) == 3:
+            authority._pending_execution_failures.pop(command_id, None)
+        return True
+
+    authority._release_superseded_execution_failure = release_superseded  # type: ignore[method-assign]
+    marker_task = asyncio.create_task(run_marker())
+
+    await authority.close()
+    await marker_task
+
+    assert any(observations)
+
+
+@pytest.mark.asyncio
+async def test_manager_base_exception_is_never_converted_to_spawn_failure() -> None:
+    class GatewayAbort(BaseException):
+        pass
+
+    class InterruptingManager(_Manager):
+        def spawn(self, task: str, **kwargs: Any) -> _Info:
+            self.spawn_calls.append((task, kwargs))
+            raise GatewayAbort("operator interrupted gateway")
+
+    coordinator = MemoryRunCoordinator()
+    authority = SubagentCommandAuthority(coordinator, InterruptingManager())
+    identity = _identity("keyboard-interrupt")
+
+    with pytest.raises(GatewayAbort, match="operator interrupted gateway"):
+        await authority.spawn(identity, "do not swallow interrupts")
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.CLAIMED
 
 
 @pytest.mark.asyncio
@@ -914,6 +1321,27 @@ async def test_close_rejects_waiting_execution_before_dropping_lease() -> None:
 
 
 @pytest.mark.asyncio
+async def test_close_bounds_waiting_settlement_when_coordinator_stays_unavailable() -> None:
+    async def yielding_sleep(_delay: float) -> None:
+        await asyncio.sleep(0)
+
+    manager = _Manager(register_spawn=False)
+    coordinator = _FinishUnavailableCoordinator()
+    authority = SubagentCommandAuthority(coordinator, manager, sleep=yielding_sleep)
+    identity = _identity("shutdown-persistent-outage")
+    await authority.spawn(identity, "wait durably")
+
+    await asyncio.wait_for(authority.close(), timeout=0.2)
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.CLAIMED
+    assert authority._waiting_executions == {}
+    assert authority._pending_execution_failures == {}
+    assert authority._lease_tasks == {}
+
+
+@pytest.mark.asyncio
 async def test_close_unqueues_waiting_execution_before_durable_rejection() -> None:
     manager = _QueuedManager(register_spawn=False)
     queue_present_at_finish: list[bool] = []
@@ -985,6 +1413,46 @@ async def test_close_releases_waiting_state_after_command_takeover() -> None:
     assert identity.run_id not in authority._waiting_executions
     assert identity.run_id not in authority._execution_results
     assert identity.run_id not in authority._lease_tasks
+
+
+@pytest.mark.asyncio
+async def test_keyed_approval_wait_renews_lease_until_manager_takes_over() -> None:
+    clock = [100.0]
+    heartbeat_ticks: asyncio.Queue[None] = asyncio.Queue()
+
+    async def controlled_sleep(_delay: float) -> None:
+        await heartbeat_ticks.get()
+
+    manager = _Manager()
+    coordinator = MemoryRunCoordinator(clock=lambda: clock[0])
+    authority = SubagentCommandAuthority(
+        coordinator,
+        manager,
+        clock=lambda: clock[0],
+        sleep=controlled_sleep,
+    )
+    identity = _identity("approval-heartbeat")
+    original_spawn = manager.spawn
+
+    def awaiting_approval(task: str, **kwargs: Any) -> _Info:
+        info = original_spawn(task, **kwargs)
+        info._coordinator_waiting = True
+        return info
+
+    manager.spawn = awaiting_approval  # type: ignore[method-assign]
+
+    await authority.spawn(identity, "wait for approval")
+    clock[0] = 180.0
+    heartbeat_ticks.put_nowait(None)
+    for _ in range(10):
+        await asyncio.sleep(0)
+        run = await coordinator.get_run(identity.run_id)
+        if run is not None and run.lease_expires_at > 180.0:
+            break
+    clock[0] = 200.0
+
+    assert await coordinator.claim_recovery(OwnerLease("recovery", 290.0), 1) == []
+    await authority.stop_execution_heartbeat(identity.run_id)
 
 
 @pytest.mark.asyncio
@@ -1107,7 +1575,8 @@ async def test_exact_replay_reclaims_never_claimed_spawn() -> None:
 @pytest.mark.asyncio
 async def test_lookup_response_reconstructs_rejected_spawn() -> None:
     coordinator = MemoryRunCoordinator()
-    authority = SubagentCommandAuthority(coordinator, _RejectingManager())
+    manager = _RejectingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
     identity = _identity("rejected-spawn")
 
     await authority.spawn(identity, "denied")
@@ -1119,6 +1588,40 @@ async def test_lookup_response_reconstructs_rejected_spawn() -> None:
         "code": "spawn_rejected",
         "counted": True,
     }
+    run = await coordinator.get_run(identity.run_id)
+    assert run is not None
+    assert run.observed_state.value == "terminal"
+    assert run.outcome is RunOutcome.FAILED
+    events = await coordinator.claim_outbox(OwnerLease("delivery", 10**12), 1)
+    assert events == []
+    assert manager.delivered_events == []
+
+
+@pytest.mark.asyncio
+async def test_non_batch_rejection_is_already_delivered() -> None:
+    class DeliveryFailingManager(_RejectingManager):
+        async def deliver_coordinator_event(
+            self,
+            event_id: str,
+            *,
+            batch_id: str = "",
+            batch_total: int = 0,
+        ) -> None:
+            raise OSError("parent delivery unavailable")
+
+    coordinator = MemoryRunCoordinator()
+    manager = DeliveryFailingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("non-batch-delivery-failure")
+
+    result = await authority.spawn(identity, "denied")
+    replay = await authority.spawn(identity, "denied")
+    events = await coordinator.claim_outbox(OwnerLease("redrive", 10**12), 1)
+
+    assert result.error == "spawn refused by governance"
+    assert replay.error == result.error
+    assert len(manager.spawn_calls) == 1
+    assert events == []
 
 
 @pytest.mark.asyncio
@@ -1136,6 +1639,314 @@ async def test_lookup_response_reconstructs_rejected_continuation() -> None:
         "code": "conversation_busy",
         "counted": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_batch_rejection_preserves_wave_metadata_and_routes_one_event() -> None:
+    coordinator = MemoryRunCoordinator()
+    manager = _RejectingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("batch-rejection")
+    agent_secret = "AKIAIOSFODNN7EXAMPLE"
+    complete = coordinator.complete
+
+    async def complete_after_batch_registration(*args, **kwargs):
+        assert manager.prepared_batches == []
+        return await complete(*args, **kwargs)
+
+    coordinator.complete = complete_after_batch_registration  # type: ignore[method-assign]
+
+    result = await authority.spawn(
+        identity,
+        "denied",
+        batch_id="batchone",
+        batch_total=3,
+        silent=True,
+        agent=agent_secret,
+    )
+
+    assert result.done is True
+    assert result.error == "spawn refused by governance"
+    assert len(manager.delivered_events) == 1
+    assert manager.prepared_batches == [(identity.run_id, "batchone", 3)]
+    event_id = manager.delivered_events[0]
+    events = await coordinator.claim_outbox(
+        OwnerLease("delivery", 10**12),
+        1,
+        event_id=event_id,
+    )
+    assert len(events) == 1
+    assert '"batch_id":"batchone"' in events[0].payload_json
+    assert '"batch_total":3' in events[0].payload_json
+    assert '"silent":true' in events[0].payload_json
+    assert agent_secret not in json.loads(events[0].payload_json)["agent"]
+
+
+@pytest.mark.asyncio
+async def test_continuation_rejection_preserves_conversation_and_model_identity() -> None:
+    coordinator = MemoryRunCoordinator()
+    manager = _RejectingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("continuation-rejection-identity")
+
+    await authority.continue_conversation(
+        identity,
+        "conversation-one",
+        "denied",
+        batch_id="batch-continuation",
+        batch_total=2,
+        model="review-model",
+    )
+
+    events = await coordinator.claim_outbox(
+        OwnerLease("delivery", 10**12),
+        1,
+        event_id=manager.delivered_events[0],
+    )
+    assert len(events) == 1
+    payload = json.loads(events[0].payload_json)
+    assert payload["conversation_key"] == "subagent:conversation-one"
+    assert payload["requested_model"] == "review-model"
+    assert payload["resolved_model"] == ""
+
+
+@pytest.mark.asyncio
+async def test_manager_exception_returns_counted_batch_failure_without_rethrow() -> None:
+    coordinator = MemoryRunCoordinator()
+    manager = _RaisingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("batch-exception")
+
+    result = await authority.spawn(
+        identity,
+        "start",
+        batch_id="batchtwo",
+        batch_total=2,
+        silent=True,
+    )
+
+    assert result.done is True
+    assert result.error == "provider refused startup"
+    assert result.batch_id == "batchtwo"
+    assert result.batch_total == 2
+    assert len(manager.spawn_calls) == 1
+    assert len(manager.delivered_events) == 1
+    events = await coordinator.claim_outbox(
+        OwnerLease("delivery", 10**12),
+        1,
+        event_id=manager.delivered_events[0],
+    )
+    assert len(events) == 1
+    assert json.loads(events[0].payload_json)["silent"] is True
+
+
+@pytest.mark.asyncio
+async def test_transient_completion_failure_resumes_without_reinvoking_manager() -> None:
+    coordinator = _FailFirstCompletionCoordinator()
+    manager = _RejectingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("retry-rejection")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "denied")
+    result = await authority.spawn(identity, "denied")
+
+    assert result.done is True
+    assert result.error == "spawn refused by governance"
+    assert coordinator.completion_calls == 2
+    assert len(manager.spawn_calls) == 1
+    assert manager.delivered_events == []
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.APPLIED
+    assert receipt.command.result_json
+    assert receipt.run is not None
+    assert receipt.run.outcome is RunOutcome.FAILED
+    events = await coordinator.claim_outbox(OwnerLease("delivery", 10**12), 1)
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_post_commit_completion_failure_stays_counted_and_replays_without_manager() -> None:
+    coordinator = _RaiseAfterCompletionCoordinator()
+    manager = _RejectingManager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("lost-completion-response")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await authority.spawn(identity, "denied", batch_id="batchlost", batch_total=2)
+    result = await authority.spawn(
+        identity,
+        "denied",
+        batch_id="batchlost",
+        batch_total=2,
+    )
+
+    assert result.done is True
+    assert result.error == "spawn refused by governance"
+    assert len(manager.spawn_calls) == 1
+    assert coordinator.completion_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_replay_preserves_batch_metadata_and_redacts_task() -> None:
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    coordinator = _RaiseAfterCompletionCoordinator()
+    manager = _RejectingManager()
+    identity = _identity("terminal-replay-metadata")
+
+    with pytest.raises(AuthorityOutcomeUncertain, match="not durably completed"):
+        await SubagentCommandAuthority(coordinator, manager).spawn(
+            identity,
+            f"inspect credential {secret}",
+            batch_id="batch-replay",
+            batch_total=4,
+            silent=True,
+        )
+    replay = await SubagentCommandAuthority(coordinator, _Manager()).spawn(
+        identity,
+        f"inspect credential {secret}",
+        batch_id="batch-replay",
+        batch_total=4,
+        silent=True,
+    )
+
+    assert secret not in replay.task
+    assert replay.batch_id == "batch-replay"
+    assert replay.batch_total == 4
+    assert replay.silent is True
+
+
+@pytest.mark.asyncio
+async def test_execution_admission_never_persists_raw_task_or_arguments() -> None:
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    coordinator = MemoryRunCoordinator()
+    manager = _Manager()
+    authority = SubagentCommandAuthority(coordinator, manager)
+    identity = _identity("redacted-admission")
+
+    await authority.spawn(
+        identity,
+        f"inspect credential {secret}",
+        model=f"served-{secret}",
+    )
+
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.run is not None
+    assert secret not in receipt.run.task
+    assert secret not in receipt.command.payload_json
+    assert secret in manager.spawn_calls[0][0]
+    assert secret in manager.spawn_calls[0][1]["model"]
+
+
+@pytest.mark.asyncio
+async def test_restart_reconstructs_failure_after_completion_before_result_fill() -> None:
+    coordinator = _FailFirstFinishCoordinator()
+    first_manager = _RejectingManager()
+    identity = _identity("restart-failure")
+
+    first = await SubagentCommandAuthority(coordinator, first_manager).spawn(identity, "denied")
+    assert first.done is True
+    assert first.error == "spawn refused by governance"
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.APPLIED
+    assert receipt.command.result_json == ""
+    assert receipt.run is not None
+    assert receipt.run.outcome is RunOutcome.FAILED
+
+    replay_manager = _Manager()
+    replay = await SubagentCommandAuthority(coordinator, replay_manager).spawn(
+        identity,
+        "denied",
+    )
+
+    assert replay.done is True
+    assert replay.error == "spawn refused by governance"
+    assert replay_manager.spawn_calls == []
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_remains_counted_when_result_fill_fails() -> None:
+    coordinator = _FailFirstFinishCoordinator()
+    manager = _RejectingManager()
+    identity = _identity("batch-fill-failure")
+
+    result = await SubagentCommandAuthority(coordinator, manager).spawn(
+        identity,
+        "denied",
+        batch_id="batchthree",
+        batch_total=2,
+    )
+
+    assert result.done is True
+    assert result.error == "spawn refused by governance"
+    assert len(manager.delivered_events) == 1
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+    assert receipt is not None
+    assert receipt.command.result_json == ""
+    assert receipt.run is not None
+    assert receipt.run.outcome is RunOutcome.FAILED
+
+
+@pytest.mark.asyncio
+async def test_exact_spawn_replay_claims_a_submission_left_pending() -> None:
+    coordinator = _FirstClaimUnavailableCoordinator()
+    identity = _identity("preclaim-recovery")
+    with pytest.raises(AuthorityUnavailable, match="still pending"):
+        await SubagentCommandAuthority(coordinator, _Manager()).spawn(
+            identity,
+            "wait durably",
+        )
+    replay_manager = _Manager()
+
+    replay = await SubagentCommandAuthority(coordinator, replay_manager).spawn(
+        identity,
+        "wait durably",
+    )
+
+    assert replay.done is False
+    assert replay.error == ""
+    assert len(replay_manager.spawn_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_exact_spawn_replay_preserves_stored_acceptance_after_later_failure() -> None:
+    coordinator = MemoryRunCoordinator()
+    first_manager = _Manager()
+    identity = _identity("accepted-then-failed")
+    first = await SubagentCommandAuthority(coordinator, first_manager).spawn(
+        identity,
+        "start normally",
+    )
+    call_kwargs = first_manager.spawn_calls[0][1]
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id=identity.run_id,
+            outcome=RunOutcome.FAILED,
+            result_path="",
+            error="runtime failed later",
+            event_type="subagent_completion",
+            destination="",
+            payload_json="{}",
+            terminal_at=10**6,
+        ),
+        call_kwargs["_coordinator_fence"],
+        call_kwargs["_coordinator_version"],
+    )
+    assert completed.decision is CoordinatorDecision.APPLIED
+    replay_manager = _Manager()
+
+    replay = await SubagentCommandAuthority(coordinator, replay_manager).spawn(
+        identity,
+        "start normally",
+    )
+
+    assert replay.done is False
+    assert replay.error == ""
+    assert replay.id == first.id
+    assert replay_manager.spawn_calls == []
 
 
 @pytest.mark.asyncio
@@ -1293,3 +2104,92 @@ async def test_control_finish_failure_is_uncertain_and_never_replays_side_effect
         await restarted.steer(identity, "target-run", "course correct")
 
     assert manager.steer_calls == [("target-run", "course correct")]
+
+
+@pytest.mark.asyncio
+async def test_cancel_claim_covers_the_bounded_parent_delivery_wait() -> None:
+    now = [100.0]
+    manager = _Manager()
+
+    async def slow_cancel(run_id: str) -> bool:
+        manager.cancel_calls.append(run_id)
+        now[0] += 60.0
+        return True
+
+    manager.cancel = slow_cancel  # type: ignore[method-assign]
+    coordinator = await _coordinator_with_target("target-run", clock=lambda: now[0])
+    authority = SubagentCommandAuthority(
+        coordinator,
+        manager,
+        clock=lambda: now[0],
+    )
+    identity = _identity("slow-cancel")
+
+    assert await authority.cancel(identity, "target-run") is True
+    receipt = await coordinator.get_command_by_key(identity.idempotency_key)
+
+    assert receipt is not None
+    assert receipt.command.status is CommandStatus.APPLIED
+    assert manager.cancel_calls == ["target-run"]
+
+
+@pytest.mark.asyncio
+async def test_lookup_reports_recovered_claimed_execution_as_interrupted() -> None:
+    now = [100.0]
+    coordinator = MemoryRunCoordinator(clock=lambda: now[0])
+    identity = _identity("recovered-claimed")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id=identity.run_id,
+            command_id=identity.command_id,
+            idempotency_key=identity.idempotency_key,
+            payload_hash="hash",
+            payload_json=(
+                '{"arguments":{},"operation":"spawn","run_id":"'
+                + identity.run_id
+                + '","task":"inspect"}'
+            ),
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        identity.command_id,
+        OwnerLease("dead-gateway", 110.0),
+    )
+    assert claim is not None
+    now[0] = 111.0
+    recovery_claims = await coordinator.claim_recovery(
+        OwnerLease("recovery", 200.0),
+        1,
+    )
+    assert len(recovery_claims) == 1
+    recovery_claim = recovery_claims[0]
+    completed = await coordinator.complete(
+        RunCompletion(
+            run_id=identity.run_id,
+            outcome=RunOutcome.INTERRUPTED,
+            result_path="",
+            error="interrupted by gateway restart",
+            event_type="subagent_completion",
+            destination="dashboard:parent",
+            payload_json="{}",
+            terminal_at=now[0],
+        ),
+        recovery_claim.fence,
+        recovery_claim.run.version,
+    )
+    assert completed.value is not None
+    authority = SubagentCommandAuthority(coordinator, _Manager())
+
+    assert await authority.lookup_response(identity.idempotency_key) == {
+        "found": True,
+        "id": identity.run_id,
+        "error": "interrupted by gateway restart",
+        "code": "run_interrupted",
+        "counted": True,
+    }

--- a/test/test_subagent_reap_race.py
+++ b/test/test_subagent_reap_race.py
@@ -37,7 +37,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kiro_crew.run_coordinator import MemoryRunCoordinator
+from kiro_crew.run_coordinator import (
+    CommandOperation,
+    MemoryRunCoordinator,
+    OwnerLease,
+    SubmitRun,
+)
 from kiro_crew.subagent import SubagentInfo, SubagentManager
 
 
@@ -214,6 +219,204 @@ async def test_uncontested_reap_reports_once():
     assert mgr._on_done.await_count == 1
     assert info.done is True and info.reaped is True
     mgr._write_tombstone.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("process_alive", [False, True])
+async def test_force_reap_checks_protected_process_before_outbox_delivery(
+    monkeypatch,
+    process_alive,
+):
+    """Session removal alone must not clear a protected process identity."""
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.pid_liveness",
+        lambda _pid: ("alive" if process_alive else "dead"),
+    )
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.process_identity_token",
+        lambda _pid: "start-1",
+    )
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-1")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="a1b2c3d4",
+            command_id="command-1",
+            idempotency_key="key-1",
+            payload_hash="hash-1",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-1",
+        OwnerLease("executor", 10**12),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+
+    mgr = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=AsyncMock(),
+    )
+    mgr._fire_event = AsyncMock()
+    mgr._write_tombstone = MagicMock()
+    mgr._record_cost = MagicMock()
+    mgr._sessions.reset = AsyncMock(return_value=True)
+    info = _info(parent_session_key="dashboard:parent")
+    info._coordinator_admitted = True
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+    await mgr._coordinator_mark_starting(info)
+    await mgr._coordinator_mark_running(info)
+    await mgr._coordinator_record_process(info, 4321, "start-1", True)
+
+    await asyncio.wait_for(
+        mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped"),
+        timeout=0.2,
+    )
+
+    run = await coordinator.get_run(info.id)
+    assert run is not None
+    assert run.process_owned is process_alive
+    if process_alive:
+        mgr._on_done.assert_not_awaited()
+    else:
+        mgr._on_done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_reap_rechecks_protected_process_after_reset_timeout(monkeypatch):
+    """A successful SIGKILL must unblock the fenced terminal delivery."""
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.pid_liveness",
+        lambda _pid: "dead",
+    )
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-timeout")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="a1b2c3d4",
+            command_id="command-timeout",
+            idempotency_key="key-timeout",
+            payload_hash="hash-timeout",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-timeout",
+        OwnerLease("executor", 10**12),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+
+    mgr = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=AsyncMock(),
+    )
+    mgr._fire_event = AsyncMock()
+    mgr._write_tombstone = MagicMock()
+    mgr._record_cost = MagicMock()
+    mgr._sessions.reset = AsyncMock(side_effect=asyncio.TimeoutError)
+    mgr._sigkill_session = AsyncMock()
+    info = _info(parent_session_key="dashboard:parent")
+    info._coordinator_admitted = True
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+    await mgr._coordinator_mark_starting(info)
+    await mgr._coordinator_mark_running(info)
+    await mgr._coordinator_record_process(info, 4321, "start-1", True)
+
+    await asyncio.wait_for(
+        mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped"),
+        timeout=0.2,
+    )
+
+    run = await coordinator.get_run(info.id)
+    assert run is not None
+    assert run.process_owned is False
+    mgr._sigkill_session.assert_awaited_once_with("subagent:a1b2c3d4")
+    mgr._on_done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_reap_treats_recycled_pid_as_original_process_stopped(monkeypatch):
+    """A live PID with another start identity cannot keep the old run fenced."""
+    monkeypatch.setattr("kiro_crew.subagent._TERMINAL_RETRY_SECONDS", 0.0)
+    monkeypatch.setattr("kiro_crew.subagent.platform_compat.IS_LINUX", True)
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.pid_liveness",
+        lambda _pid: "alive",
+    )
+    monkeypatch.setattr(
+        "kiro_crew.subagent.platform_compat.process_identity_token",
+        lambda _pid: "v1:linux:replacement-start:boot",
+    )
+    coordinator = MemoryRunCoordinator(id_factory=lambda: "event-recycled")
+    submitted = await coordinator.submit(
+        SubmitRun(
+            run_id="a1b2c3d4",
+            command_id="command-recycled",
+            idempotency_key="key-recycled",
+            payload_hash="hash-recycled",
+            payload_json="{}",
+            parent_session="dashboard:parent",
+            agent="reviewer",
+            task="inspect",
+            conversation_key="",
+            operation=CommandOperation.SPAWN,
+        )
+    )
+    assert submitted.value is not None
+    claim = await coordinator.claim_command(
+        "command-recycled",
+        OwnerLease("executor", 10**12),
+    )
+    assert claim is not None and claim.run is not None and claim.fence is not None
+
+    mgr = SubagentManager(
+        sessions=MagicMock(),
+        ctx_builder=MagicMock(),
+        coordinator=coordinator,
+        on_done=AsyncMock(),
+    )
+    mgr._fire_event = AsyncMock()
+    mgr._write_tombstone = MagicMock()
+    mgr._record_cost = MagicMock()
+    mgr._sessions.reset = AsyncMock(return_value=True)
+    info = _info(parent_session_key="dashboard:parent")
+    info._coordinator_admitted = True
+    info._coordinator_command = claim.command
+    info._coordinator_fence = claim.fence
+    info._coordinator_version = claim.run.version
+    await mgr._coordinator_mark_starting(info)
+    await mgr._coordinator_mark_running(info)
+    await mgr._coordinator_record_process(info, 4321, "v1:linux:original-start:boot", True)
+
+    await asyncio.wait_for(
+        mgr._force_reap("a1b2c3d4", info, elapsed=1.0, reason="reaped"),
+        timeout=0.2,
+    )
+
+    run = await coordinator.get_run(info.id)
+    assert run is not None
+    assert run.process_owned is False
+    mgr._on_done.assert_awaited_once()
 
 
 # ── the shield: an interrupted claimer still delivers ────────────────


### PR DESCRIPTION
> Stacked change: **PR 7 of 7**
>
> Stack: #5277 → #5278 → #5279 → #5280 → #5281 → #5282 → #5283
> Base: #5282

## Problem / Motivation

Adversarial review of the assembled stack exposed narrow races around pre-start leases, terminal result filling, batch delivery, stale recovery fences, PID reuse, and uncertain transport responses.

## Why it matters

These windows occur at crash and concurrency boundaries, where a false success, duplicate child, lost completion, stale acknowledgement, or leaked capacity slot would undermine the coordinator's core guarantees.

## What changed (motivation → approach → change)

- Heartbeats admitted work before queue and approval waits can expire its execution lease.
- Makes stored command results authoritative on exact replay while reconstructing terminal recovery only when the durable result is empty.
- Registers live batch identity before a rejection event becomes claimable, preserving silent delivery and accounting across drains, retries, restart, and digest settlement.
- Preserves a registered non-terminal manager lifecycle when post-registration work raises, reporting typed outcome uncertainty instead of cancelling the child.
- Tightens terminal/outbox fencing, protected PID/start-identity checks, bounded shutdown settlement, and canonical rejection replay metadata.
- Keeps protected terminal events withheld without letting one failed cleanup stall unrelated completions.
- Propagates cancellation and process-control `BaseException` signals instead of converting them into durable spawn failures.
- Preserves a manager-recorded terminal rejection when post-registration work raises; only an unregistered failure synthesizes an exception-derived outcome.
- Retains an unsettled terminal manager rejection through orderly shutdown until its fenced completion is durable or a newer durable owner supersedes it.
- Closes late coordinator-claim and deferred-delivery acknowledgement races without allowing local and recovery paths to report the same completion.
- Retains durable delivery debt for failed or stopped events until the idle turn consumes the event.
- Adds deterministic regressions for each reviewed crash window and race.

## Tests

- Expanded authority, MCP uncertainty, coordinator contract, delivery, recovery, security, error-contract, and protected-process teardown regression suites.
- The current stack-tip focused coordinator suite passes: 507 passed, 1 valid platform skip.
- Black, subprocess encoding, isort, flake8, Linux-parity mypy, docs, brand, harness-parity, and public-tree scrub gates pass at the stack head.

## Manual verification

N/A — this PR hardens backend crash and concurrency paths with deterministic regression tests.

## Related Issues

No linked issue: this stack implements the locally reviewed durable run coordinator RFC.

## Pattern harvest

Rule candidate: review-prompt
Pattern: every crash or cancellation path must preserve its durable fence and keep terminal and delivery settlement monotonic and single-consumer.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
