### PR TITLE
refactor(connections): drop a redundant except, a double lookup, a pragma

### DIFF
--- a/src/kiro_crew/connections/alias_record.py
+++ b/src/kiro_crew/connections/alias_record.py
@@ -99,11 +99,10 @@ Both directions are safe on every row, simultaneously:
   claimed. Rows 4/5 resolve to ``E``, which by construction contains only pairs
   this pass wrote. Rows 7/8/9 claim nothing. And on every row invariant 3 still
   requires the whole triple to match, so an edited alias is never claimed.
-* **Never permanently strands a generated alias.** Rows 4/5 -- the boundary that
-  previously left an alias emitted but unrecorded forever -- now resolve to
-  ``E``, so the interrupted transaction is RECONCILED by the next pass rather
-  than abandoned. Rows 2/3 leave the spec unchanged, so there is nothing to
-  strand. Row 1 fails closed for the same reason.
+* **Never permanently strands a generated alias.** Rows 4/5 resolve to ``E``, so
+  an interrupted transaction is RECONCILED by the next pass rather than
+  abandoned. Rows 2/3 leave the spec unchanged, so there is nothing to strand.
+  Row 1 fails closed for the same reason.
 
 Rows 7 and 9 are where a generated pair does become permanently the user's:
 losing the record file outright, or losing the spec generation the record
@@ -321,7 +320,7 @@ def load_claimed(fingerprint: str) -> frozenset[EmittedAlias]:
         return frozenset()
     try:
         data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         logger.debug("Ignoring malformed Connections alias record", exc_info=True)
         return frozenset()
     if not isinstance(data, dict) or data.get("version") != _RECORD_VERSION:

--- a/src/kiro_crew/connections/status.py
+++ b/src/kiro_crew/connections/status.py
@@ -126,9 +126,7 @@ def _load_connected_since() -> dict[str, str] | None:
     """
     try:
         raw = json.loads(_connection_state_path().read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return {}
-    except ValueError:
+    except (FileNotFoundError, ValueError):
         return {}
     except OSError:
         return None

--- a/src/kiro_crew/connections/tool_aliases.py
+++ b/src/kiro_crew/connections/tool_aliases.py
@@ -258,9 +258,12 @@ def _parse_tool_refs(tools: Iterable[object]) -> tuple[bool, dict[str, set[str] 
         if not tool or tool == _SERVER_WILDCARD:
             per_server[server] = None
             continue
-        if per_server.get(server, set()) is None:
-            continue
-        per_server.setdefault(server, set()).add(tool)  # type: ignore[union-attr]
+        # ``setdefault`` returns the existing value untouched, so a server already
+        # resolved to whole-server exposure (``None``) is left that way: a narrower
+        # per-tool ref adds nothing to what a whole-server ref already mounts.
+        named = per_server.setdefault(server, set())
+        if named is not None:
+            named.add(tool)
     return global_all, per_server
 
 


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change under `src/kiro_crew/connections/`; no
frontend path is touched and nothing renders differently.

## Problem / Motivation

Three readability defects in `src/kiro_crew/connections/`, each a place where the
code says something the reader then has to disprove:

- `alias_record.load_claimed` catches `(json.JSONDecodeError, ValueError)`.
  `json.JSONDecodeError` **is** a `ValueError`, so the tuple's first member is
  dead — it reads as two distinct failure modes when there is one.
- `status._load_connected_since` spells the same `return {}` twice, in two
  adjacent `except` clauses, ahead of the `except OSError: return None` that
  makes the ordering load-bearing. A reader has to check three clauses to learn
  there are two outcomes.
- `tool_aliases._parse_tool_refs` looks a server up twice — `per_server.get(server,
  set())` and then `per_server.setdefault(server, set())` — and carries a
  `# type: ignore[union-attr]` because the second lookup's `None` case is
  unprovable to mypy across the intervening `continue`.

Plus one comment: the `alias_record` module docstring narrated its own history
("the boundary that **previously** left an alias emitted but unrecorded forever
-- **now** resolve to `E`"), which `AGENTS.md` forbids — comments state current
behaviour in present tense.

## Why it matters

None of these is a bug, and that is the point: they are the cost this module
charges every future reader of a security-adjacent area. `load_claimed` decides
whether the alias pass may **delete** an entry out of a file the user also edits,
and `_parse_tool_refs` decides which MCP tools are treated as mounted. A
suppressed type error and a redundant exception class are exactly the noise that
makes the next reviewer of those functions spend their attention in the wrong
place. The stale narration is worse than untidy: it tells a reader the current
code has a history it no longer has.

## What changed (motivation → approach → change)

A behaviour-preserving pass over one module (`connections`), no other module
touched. The detector for the two mechanically decidable classes
(`shadow-import`, `chained-ternary`) reports **0 actionable sites** tree-wide, so
this is a judgment-class pass under that campaign's rules.

- **`alias_record.py`** — `except (json.JSONDecodeError, ValueError)` →
  `except ValueError`. `issubclass(json.JSONDecodeError, ValueError)` is `True`,
  so the caught set is unchanged. The docstring's "malformed JSON" wording still
  holds.
- **`alias_record.py`** — the "Never permanently strands a generated alias"
  bullet is restated in present tense. Every claim it now makes was re-verified
  against the state table above it and against `load_claimed` /
  `begin_transaction` / `commit_transaction`: rows 4/5 resolve to `E`, rows 2/3
  leave the spec unchanged, row 1 fails closed. No constraint was dropped.
- **`status.py`** — the two `return {}` clauses merge into
  `except (FileNotFoundError, ValueError)`, still ahead of `except OSError:
  return None`. Order is preserved, so `FileNotFoundError` still returns `{}`
  rather than falling through to the `OSError` clause.
- **`tool_aliases.py`** — one `setdefault` replaces the get-then-setdefault pair,
  binding the result and guarding on it. This is what removes the
  `# type: ignore[union-attr]`: mypy narrows the bound name where it could not
  narrow a re-lookup. A three-line comment records *why* leaving an existing
  `None` alone is correct (a per-tool ref adds nothing to what a whole-server ref
  already mounts) — the fact the deleted `get` guard encoded and did not explain.

**Deliberately NOT changed**, so the omissions read as decisions:

- `l0_drift`, `l0_record` and `l0_probe` each catch
  `(OSError, UnicodeDecodeError, json.JSONDecodeError, ...)`. Those two are
  *siblings* under `ValueError`, not a subclass pair, so collapsing them would
  **widen** the caught set. Left alone.
- `resolve_tool_aliases`'s `len(set(slugs)) < 2` looks like a redundant `set()`
  over unique slugs, but the parameter is typed `Mapping[str, Collection[str]]`
  and a `Collection` may carry duplicates, which would make `len(slugs)` disagree.
  Left alone.
- `registry._validate_provider`'s `authorization_server` block (33 lines) is a
  near-exact re-implementation of `l0_probe._validate_issuer`. That is a real
  duplication of an SSRF guard and worth removing — but it is a cross-module
  reshape of a security check with error-message compatibility to preserve, and a
  cleanup PR is the wrong place for a reviewer to have to diff one. Left for a
  dedicated change.
- `registry.get_tier` accepts a float (`1.0 in (1, 2, 3)` is `True`) where
  `_validate_provider` rejects one. That is a latent defect, not a
  simplification, and belongs in its own PR.
- `alias_record.load_claimed` wraps its `read_text(encoding="utf-8")` in
  `except OSError`, but `UnicodeDecodeError` is a `ValueError`, so a non-UTF-8
  record file raises out of a function whose docstring promises "Empty on every
  failure". Reproduced: writing `b"\xff\xfe not utf8"` to the record path makes
  `load_claimed` raise instead of returning `frozenset()`. Four siblings in this
  same package (`registry.py`, `l0_record.py`, `l0_drift.py`, `l0_probe.py`) all
  name `UnicodeDecodeError` explicitly, so this one is the outlier. It is
  pre-existing and byte-identical on `main`, and fixing it would CHANGE behaviour
  — which is exactly what must not ride inside a cleanup PR. Left for a
  dedicated fix.

## Review

Before opening, the diff went to a five-lens read-only review fleet — AUTOSDE
blocking rules, behaviour preservation, import semantics and test coupling,
comment accuracy, and a per-contract mirror of `code-review.yml` /
`codex-review.yml` / `claude-review.yml`. **Zero findings survived**, and each
lens tried to falsify rather than confirm: the "missing file now falls through to
`except OSError` and returns `None`" hypothesis was tested and refuted (clause
order preserved), and the `setdefault` rewrite was checked for the truthiness
trap (`if named:` would have dropped every server's first tool — the code uses
`is not None`). The only thing the fleet surfaced is the pre-existing
`UnicodeDecodeError` gap recorded above, which I reproduced and deliberately did
not fix here.

## Tests

No test changes: this PR adds no behaviour to lock in, and every changed line is
already covered. `test/test_connections_status.py` asserts
`_load_connected_since()` returns `{}` for a missing/damaged file and `None` for
an unreadable one — the exact tri-state the merged `except` clauses had to
preserve — and `test/test_connections_tool_aliases.py` covers the whole-server /
per-tool / wildcard exposure matrix that `_parse_tool_refs` resolves.

Equivalence was proven mechanically rather than argued:

- `_parse_tool_refs`: old and new bodies run over **3,616 generated ref
  sequences** (length 0–3 over an alphabet including `*`, `@s`, `@s/`, `@s/*`,
  `@s/a`, `@s/a/b`, `@`, `@/a`, a builtin name, a non-string and `""`), compared
  on both the resulting dict **and its key insertion order**. Zero mismatches.
- `status._load_connected_since`: the old three-clause and new two-clause forms
  compared across `FileNotFoundError`, `NotADirectoryError`, `IsADirectoryError`,
  `PermissionError`, `OSError`, `JSONDecodeError`, `ValueError` and
  `UnicodeDecodeError`. Identical verdict on all eight.

Suites run green (652 + 880 tests): `test_connections_status`,
`test_connections_tool_aliases`, `test_connections_registry`,
`test_connections_mint`, `test_connections_l0_probe`,
`test_connections_kiro_spec_fields`, `test_connections_oauth_relay`,
`test_mcp_server_alias`, plus `test_security`, `test_mcp_oauth_banner`,
`test_agent`, `test_agent_source_ownership_durability`,
`test_agent_import_hoist`, `test_ci_surface_tests`.

## Manual verification

N/A — unit coverage sufficient. Nothing here is reachable only through a live
provider: the three sites are a JSON parse, a file read and a pure ref parser,
all exercised directly by the suites above.

Gates green on the CI-parity Python 3.12 venv: `flake8`, `isort --check-only`,
`mypy src/kiro_crew` (0 errors — which is also what proves the removed
`type: ignore` is genuinely unneeded), `check_brand_name.py`,
`check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`.

Backend-only diff: nothing under `website/`, `.github/`, `scripts/` or `docs/`
is touched, so the `changes` job reports `only_backend=true` and the frontend
suites cannot newly fail.

## Related Issues

no linked issue: routine module-simplification sweep, not filed work.
