### PR TITLE
fix(i18n): exclude opaque children from render-scan text runs

### DIFF
--- a/website/scripts/lib/render-scan.mjs
+++ b/website/scripts/lib/render-scan.mjs
@@ -325,10 +325,11 @@ export function scanDocument(opts) {
    * the COMPUTED family, not the class list: `.msg-content pre` sets the font in
    * `index.css`, where no `font-mono` token appears.
    */
+  const OPAQUE_SELECTOR = 'code, pre, kbd, samp, [data-i18n-opaque]'
+  const monoFont = el => /mono/i.test(getComputedStyle(el).fontFamily || '')
   const isOpaque = el => {
-    if (el.closest('code, pre, kbd, samp, [data-i18n-opaque]')) return true
-    const fam = getComputedStyle(el).fontFamily || ''
-    return /mono/i.test(fam)
+    if (el.closest(OPAQUE_SELECTOR)) return true
+    return monoFont(el)
   }
 
   /**
@@ -421,10 +422,29 @@ export function scanDocument(opts) {
     return d.startsWith('inline') || inlineTags.has(node.tagName)
   }
 
+  /**
+   * Whether an element's SUBTREE holds opaque content the run walk must not join
+   * through. Tag/attribute opacity is one `querySelector`; the computed-mono
+   * half of the `isOpaque` contract is not selector-expressible, so it is
+   * probed per descendant — memoized per element, and inline wrappers are
+   * small, so the probe stays cheap next to the loop's own per-element style
+   * reads.
+   */
+  const opaqueWithin = new WeakMap()
+  const containsOpaque = el => {
+    let v = opaqueWithin.get(el)
+    if (v === undefined) {
+      v = !!el.querySelector(OPAQUE_SELECTOR) || [...el.querySelectorAll('*')].some(monoFont)
+      opaqueWithin.set(el, v)
+    }
+    return v
+  }
+
   for (const el of document.body.querySelectorAll('*')) {
     if (!visible(el) || inVirtualList(el) || isOpaque(el)) continue
 
-    // Group DIRECT children into maximal inline runs; a block child ends the run.
+    // Group DIRECT children into maximal inline runs; a block child ends the
+    // run, an opaque child is skipped without ending it.
     let run = []
     const flush = () => {
       if (!run.length) return
@@ -452,6 +472,19 @@ export function scanDocument(opts) {
       }
     }
     for (const node of el.childNodes) {
+      // An opaque child (kbd/code/samp/[data-i18n-opaque]/mono — the same
+      // subtrees the element loop skips), or an inline wrapper with opaque
+      // content INSIDE it (a keycap container span), is exempt data, not
+      // prose. Joining through it — the run is built from `textContent` —
+      // would charge that Latin (keycaps, inline code) to the surrounding
+      // run, un-exempting it. So it is SKIPPED, and deliberately without
+      // flushing: the prose on either side stays ONE run, so a sentence
+      // spliced from several catalog keys around a keycap or code term still
+      // raises the multi-unit fragment signal (a real reorder defect —
+      // flushing here would let it pass). No prose is lost: a skipped wrapper
+      // is itself visited by the element loop, where its own text forms runs;
+      // a fully opaque subtree is skipped there by design.
+      if (node.nodeType === 1 && (isOpaque(node) || containsOpaque(node))) continue
       if (isInline(node)) run.push(node)
       else flush()
     }

--- a/website/src/components/ShortcutsModal.tsx
+++ b/website/src/components/ShortcutsModal.tsx
@@ -73,12 +73,7 @@ export function ShortcutRow({ label, keys }: { label: string; keys: string[] }) 
   return (
     <div className="flex items-center justify-between py-1.5 px-2 rounded-md hover:bg-bg-hover transition-colors">
       <span className="text-[13px] text-text">{label}</span>
-      {/* Keycaps are Latin on every keyboard, like code and file paths, so the
-          cap container is opaque data to the i18n render scan. A div rather
-          than a span: the scan merges inline children into the row's text run
-          before the opaque check, so the container must be block-level for the
-          label's own coverage to survive intact. */}
-      <div data-i18n-opaque className="flex items-center gap-1">{keys.map((p, i) => <span key={i} className="flex items-center gap-1">{i > 0 && <span className="text-muted text-[11px]">+</span>}<Kbd>{p}</Kbd></span>)}</div>
+      <span className="flex items-center gap-1">{keys.map((p, i) => <span key={i} className="flex items-center gap-1">{i > 0 && <span className="text-muted text-[11px]">+</span>}<Kbd>{p}</Kbd></span>)}</span>
     </div>
   )
 }

--- a/website/src/i18n/renderScan.test.ts
+++ b/website/src/i18n/renderScan.test.ts
@@ -18,7 +18,7 @@ import enXA from './locales/en-XA.json'
 import glossary from './glossary.json'
 import {
   splitUnits, isFiller, latinLeaks, gradeRun, dntViolations, expansionBudget,
-  browserBundle, ALWAYS_LATIN, PSEUDO_PAD,
+  browserBundle, scanDocument, ALWAYS_LATIN, PSEUDO_PAD,
 } from '../../scripts/lib/render-scan.mjs'
 
 const flat = (obj, prefix = '', out = {}) => {
@@ -240,5 +240,76 @@ describe('the pseudolocale invariants the scanner depends on', () => {
       if (latinLeaks(inner).length) offenders.push(v)
     }
     expect(offenders).toEqual([])
+  })
+})
+
+describe('scanDocument — an opaque child is skipped, not joined', () => {
+  // `scanDocument` normally runs inside the gate's real browser; happy-dom is
+  // enough for the RUN-WALK topology under test here because inline-ness falls
+  // back to the tag list and `isOpaque` is a `closest()` call. What happy-dom
+  // cannot answer (computed display from CSS classes, mono font detection)
+  // stays covered by the CI gate itself.
+  const mount = (html: string) => {
+    document.body.replaceChildren(document.createRange().createContextualFragment(html))
+  }
+  const pseudoScan = () => scanDocument({ mode: 'pseudo' })
+
+  it('does not charge <kbd> keycap text to the surrounding prose run', () => {
+    mount('<div><span>[Þŕèşş ···]</span> <kbd>Ctrl</kbd></div>')
+    expect(pseudoScan().filter(f => f.kind === 'latin-leak')).toEqual([])
+  })
+
+  it('still reports prose on the far side of an opaque child', () => {
+    // The opaque child is skipped, not the rest of the walk: text around it
+    // stays in the run and is graded.
+    mount('<div><kbd>K</kbd> hardcoded prose</div>')
+    const leaks = pseudoScan().filter(f => f.kind === 'latin-leak').map(f => f.detail)
+    expect(leaks).toContain('hardcoded')
+    expect(leaks).toContain('prose')
+  })
+
+  it('an inline [data-i18n-opaque] child is excluded from the run', () => {
+    mount(
+      '<div><span>[Ĺàbèĺ ···]</span><span data-i18n-opaque>Alt</span></div>')
+    expect(pseudoScan().filter(f => f.kind === 'latin-leak')).toEqual([])
+  })
+
+  it('an inline wrapper AROUND opaque content is excluded too', () => {
+    // The ShortcutRow shape: the keycaps sit inside a plain span container, so
+    // the opaque element is a grandchild. The run is built from `textContent`,
+    // which reaches through the wrapper — so the wrapper must be skipped.
+    mount(
+      '<div><span>[Ĵùɱþ ţø çĥàţ ···]</span><span><span>+</span><kbd>Alt</kbd></span></div>')
+    expect(pseudoScan().filter(f => f.kind === 'latin-leak')).toEqual([])
+  })
+
+  it('a wrapper around a computed-monospace child is excluded too', () => {
+    // Mono is the other half of the opaque contract and is not
+    // selector-expressible, so the descendant probe must read computed style
+    // (the PerformanceTab machine-identity strip: a plain span wrapping a
+    // font-mono strong).
+    mount(
+      '<div><span>[Ĥøşţñàɱè ···]</span><span><strong style="font-family: monospace">Ctrl</strong></span></div>')
+    expect(pseudoScan().filter(f => f.kind === 'latin-leak')).toEqual([])
+  })
+
+  it('still grades prose inside a wrapper that also carries a keycap', () => {
+    // Skipping the wrapper must not exempt the wrapper's own prose: the
+    // element loop visits it and grades its text around the keycap.
+    mount(
+      '<div><span>press <kbd>K</kbd> anytime</span></div>')
+    const leaks = pseudoScan().filter(f => f.kind === 'latin-leak').map(f => f.detail)
+    expect(leaks).toContain('press')
+    expect(leaks).toContain('anytime')
+  })
+
+  it('keeps the multi-unit fragment signal across an opaque child', () => {
+    // The opaque child is skipped WITHOUT ending the run: a sentence spliced
+    // from several catalog keys around a keycap or code term is a real
+    // reorder defect (the fix is one key with interpolation), and flushing at
+    // the boundary would let it pass unseen.
+    mount(
+      '<div><span>[Ûñìţ øñè·]</span><kbd>⌘</kbd><span>[Ûñìţ ţŵø·]</span></div>')
+    expect(pseudoScan().filter(f => f.signature === 'multi-unit')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## What is the problem?

The i18n render scanner's run walk (`website/scripts/lib/render-scan.mjs`) groups an element's DIRECT children into text runs and joins every INLINE child into the parent's run via `textContent`. `<kbd>`, `<code>`, and `[data-i18n-opaque]` subtrees are already exempted by the element classifier (`isOpaque`), but because the run is assembled before that exemption applies to children, their text still lands in the surrounding prose's run and is charged as untranslated Latin. An exemption that does not exempt.

## Why this issue matters to the user

Keycap text ("Alt", "Ctrl", "K") is Latin on every keyboard by design, yet the gate reported it as missing translation work: 410 recorded findings on the `settings-shortcuts` surface alone, almost all of them keycap noise. That noise buries the real findings, trains readers to ignore the gate, and forced a layout workaround: ShortcutRow had to use a block-level `div` with `data-i18n-opaque` (PR #4807) just to keep its label's coverage intact, while three sibling sites (SearchEverywhereRow, the modal footer, the settings ShortcutsPanel recorder) carried the same leak with no workaround.

## How our fix solves it

Chain from symptom to root cause: keycap leaks happen because runs are built from `textContent`, which reaches through inline children; the opaque exemption only guards the element loop, not run assembly; so the run walk must stop at opaque content.

The run walk now SKIPS (excludes from the run, without ending it):
- an opaque child itself (`kbd`/`code`/`samp`/`[data-i18n-opaque]`/computed-mono, the same `isOpaque` contract the element loop uses), and
- an inline wrapper that CONTAINS opaque content (the ShortcutRow shape, where keycaps sit inside a plain span container). Tag/attribute opacity is one `querySelector`; the computed-mono half is not selector-expressible, so a memoized per-element probe (`containsOpaque`) reads descendant computed style.

Skipped rather than flushed, deliberately: the prose around the opaque child stays ONE run, so a sentence spliced from several catalog keys around a keycap or code term still raises the multi-unit fragment signal (a real reorder defect that flushing would hide). No prose is lost: a skipped wrapper is itself visited by the element loop, where its own text forms runs and is graded on its own. With the scanner fixed, the block-level `data-i18n-opaque` workaround on ShortcutRow is retired (back to a plain span container); the `FeaturedSpotlight` uses of the attribute are dynamic-data markers, not this workaround, and stay.

## What tests we did

- 7 new unit tests in `website/src/i18n/renderScan.test.ts` (happy-dom): direct `<kbd>` child, prose around an opaque child stays graded, inline `[data-i18n-opaque]` child, wrapper-around-keycap (ShortcutRow shape), wrapper-around-computed-mono (PerformanceTab shape), prose inside a wrapper that also carries a keycap (lost-coverage guard), and the multi-unit fragment signal still firing across an opaque boundary. Mutation probes: reverting the skip reddens 3 tests; dropping the mono half of the descendant probe reddens 1. File total 40/40 green.
- `I18N_BASE_REF=$(git merge-base HEAD main) npm run i18n:render`: PASS [vs-base], no surface got worse; `settings-shortcuts.text` live count drops from 410 to 0, whole-app live total drops to text=718 layout=2 latent=12 (the debt record is a report and is left as-is, per its own design).
- `npx tsc -b` clean; `npm run build` clean; full `npm run test`: vitest 22,945 passed; the electron node:test suite's 41 failures are byte-identical on a pristine `main` worktree (host-owned, verified by diffing failure sets).
- `BRAND_BASE_REF=main python3 scripts/check_brand_name.py` clean; jscpd exit 0 (its one clone is pre-existing capture scripts).

## Any other suggestions on the work

The ShortcutRow change is a DOM-only revert of the workaround (div to span, same flex classes) with no visual delta. The render-baseline ledger now overstates by ~1.6k findings tree-wide; refreshing it is deliberately left to a dedicated run of `--build --update` so this PR's diff stays reviewable.

Closes #4867


<!-- no-visual-delta -->
**Why no screenshot:** The only component change reverts ShortcutRow's cap container from a block `div` carrying `data-i18n-opaque` back to a plain `span` with the identical flex class list; `display: flex` comes from the same classes, so the rendered layout is unchanged. Everything else is CI-tooling (the scanner script) and test code.

