### PR TITLE
fix: scope app-backend adoption to the probed local address (#5261)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,7 +437,7 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Process RSS (live) / peak RSS / CPU | `proc_rss_bytes()` / `proc_peak_rss_bytes()` / `proc_cpu_seconds()` | `resource.getrusage` (`ru_maxrss` is a high-water mark, never a live reading, and its unit is KiB on Linux but bytes on macOS) |
 | Available host memory | `host_available_mib()` (0 = unknown, never 0 = no memory) | `/proc/meminfo` directly (Linux-only, so the bound built on it silently vanishes on macOS and Windows) |
 | FD soft limit | `raise_nofile_soft_limit(n)` | `resource.setrlimit` |
-| Port to PID | `find_listening_pids(port)` / `listening_pid_tool_available()` | `lsof` directly |
+| Port to PID | `find_listening_pids(port)` / `listening_pid_tool_available()`; `find_port_listeners(port)` when ownership must be scoped to the local address actually probed | `lsof` directly |
 | Spawn a system tool (`ps`, `lsof`, `netstat`, `taskkill`) | `trusted_system_bin(name)`, treating `None` as "unavailable" | a bare argv name (resolved through a `PATH` that can lead with same-uid-writable dirs) |
 | strftime no-pad | `strftime(dt, "%-I")` | bare `dt.strftime("%-I")` (`ValueError` on Windows) |
 

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -178,6 +178,86 @@ def _listening_pids(port: int) -> list[int]:
         return []
 
 
+def _probe_adoption_health(port: int, health_path: str) -> bool:
+    """Whether ``127.0.0.1:port`` answers the manifest's health check (< 400)."""
+
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}{health_path}",
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            return bool(resp.status < 400)
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def _capture_adopted_owners(
+    app_name: str, port: int, health_path: str
+) -> tuple[list[int], dict[int, str]] | None:
+    """Owner PIDs + start-time identities for the backend answering on loopback.
+
+    The health probe and the owner lookup are separate observations, so the
+    responder can exit between them and the lookup would attribute ownership to
+    a bystander (e.g. a coexisting v6-only wildcard listener the probe never
+    reached). Close that window with a consistency sandwich: capture owners and
+    identities, then require the health check to STILL answer and the owner set
+    to read back unchanged. Any drift means the observations do not describe one
+    stable backend — refuse adoption; the next start simply re-probes.
+
+    Returns ``None`` (with a logged reason) when no owner is attributable, an
+    owner's start-time identity is unreadable (an owner that cannot be
+    positively named later cannot be stopped — refuse rather than adopt a
+    backend the gateway could never revoke), or the sandwich detects drift.
+    """
+    owners: list[int] = platform_compat.loopback_owner_pids(
+        platform_compat.find_port_listeners(port)
+    )
+    if not owners:
+        logger.warning(
+            "App %s: cannot record owning PIDs on 127.0.0.1:%d "
+            "(port->PID tool unavailable?) — skipping adoption",
+            app_name, port,
+        )
+        return None
+    start_times: dict[int, str] = {}
+    for pid in owners:
+        st = _proc_start_time(pid)
+        if st is not None:
+            start_times[pid] = st
+    if set(start_times) != set(owners):
+        # An owner with no readable identity could never be signalled later —
+        # stop and uninstall would skip it, leaving a third-party backend
+        # running after its trust was revoked. Adoption is only offered when
+        # every owner can be positively named, so refusal here fails closed:
+        # the gateway declines to manage what it could not later stop.
+        logger.warning(
+            "App %s: start-time identity unreadable for owner PID(s) %s on "
+            "port %d — refusing adoption (an owner that cannot be identified "
+            "cannot be stopped later)",
+            app_name, sorted(set(owners) - set(start_times)), port,
+        )
+        return None
+    if not _probe_adoption_health(port, health_path):
+        logger.warning(
+            "App %s: backend on port %d stopped answering its health check "
+            "while ownership was being recorded — skipping adoption",
+            app_name, port,
+        )
+        return None
+    owners_recheck = platform_compat.loopback_owner_pids(
+        platform_compat.find_port_listeners(port)
+    )
+    if set(owners_recheck) != set(owners):
+        logger.warning(
+            "App %s: port %d owners changed while ownership was being recorded "
+            "(%s -> %s) — skipping adoption",
+            app_name, port, owners, owners_recheck,
+        )
+        return None
+    return owners, start_times
+
+
 def _pid_is_self_or_descendant_of(pid: int, ancestor: int) -> bool:
     """Whether *pid* is *ancestor* or is descended from it (bounded walk)."""
 
@@ -270,6 +350,12 @@ class AppProcess:
     started_at: float = 0.0
     log_path: str = ""
     adopted_pids: list[int] = field(default_factory=list)
+    # PID-reuse guard for the adopted set: pid -> platform_compat.process_start_time
+    # token captured at adoption. stop signals a recorded PID only when its live
+    # start time still POSITIVELY matches (same convention as the spawned-backend
+    # reap); a missing or mismatched token means the PID may name another process
+    # now, and it is never signalled.
+    adopted_start_times: dict[int, str] = field(default_factory=dict)
     # True only for the transient placeholder a single-flighting spawn inserts while it
     # allocates a port + launches the process; replaced by the real record on success or
     # popped on failure. Concurrent start_app_backend calls see it and skip duplicate spawn.
@@ -611,16 +697,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 s.settimeout(1)
                 s.connect(("127.0.0.1", port))
             # Port occupied — probe health endpoint before giving up
-            healthy = False
-            try:
-                req = urllib.request.Request(
-                    f"http://127.0.0.1:{port}{manifest.backend.healthCheck}",
-                    method="GET",
-                )
-                with urllib.request.urlopen(req, timeout=3) as resp:
-                    healthy = resp.status < 400
-            except (urllib.error.URLError, OSError):
-                pass
+            healthy = _probe_adoption_health(port, manifest.backend.healthCheck)
 
             if healthy:
                 try:
@@ -630,32 +707,29 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                     )
                 except Exception as exc:
                     logger.debug("SEL audit failed for app %s backend adopt: %s", app_name, exc)
-                # Record PIDs listening on this port at adoption time
-                adopted_pids: list[int] = []
-                try:
-                    lsof_result = subprocess.run(
-                        ["lsof", "-ti", f":{port}", "-sTCP:LISTEN"],
-                        capture_output=True, text=True, timeout=5,
-                    )
-                    if lsof_result.returncode == 0 and lsof_result.stdout.strip():
-                        for pid_str in lsof_result.stdout.strip().split("\n"):
-                            try:
-                                adopted_pids.append(int(pid_str.strip()))
-                            except ValueError:
-                                pass
-                except (OSError, subprocess.TimeoutExpired):
-                    pass
-                if not adopted_pids:
-                    logger.warning(
-                        "App %s: cannot record PIDs on port %d (lsof unavailable?) — skipping adoption",
-                        app_name, port,
-                    )
+                # Record owning PIDs at adoption time, scoped to the listener
+                # the health probe actually reached. The probe above only ever
+                # talks to 127.0.0.1:<port>; loopback_owner_pids mirrors the
+                # kernel's most-specific-bind dispatch (exact 127.0.0.1 beats a
+                # v4 wildcard, which beats a dual-stack v6 one), so a process
+                # holding a different local address — or a v6-only wildcard
+                # next to the real v4 owner — was never health-checked and is
+                # not recorded. Each owner's start-time identity rides along so
+                # stop can refuse a recycled PID, and the capture is sandwiched
+                # between health checks so a responder that exits mid-capture
+                # cannot hand ownership to a bystander.
+                adopted = _capture_adopted_owners(
+                    app_name, port, manifest.backend.healthCheck
+                )
+                if adopted is None:
                     return None
+                adopted_pids, adopted_start_times = adopted
                 logger.info("App %s: healthy instance already on port %d — adopting (pids=%s)", app_name, port, adopted_pids)
                 ap = AppProcess(
                     app_name=app_name, port=port, pid=0, proc=None,
                     healthy=True, started_at=time.time(), log_path=str(log_path),
                     adopted_pids=adopted_pids,
+                    adopted_start_times=adopted_start_times,
                 )
                 # Adopted (externally-managed) backends are deliberately NOT
                 # recorded for the startup stale-reap: the reap SIGTERMs a whole
@@ -664,7 +738,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 # If the gateway dies, the external instance keeps running and is
                 # simply re-probed and re-adopted on the next start — so reaping it
                 # would kill a healthy service we would immediately re-adopt. stop's
-                # adopted path kills only the lsof-revalidated PIDs for this reason.
+                # adopted path kills only the re-validated PIDs for this reason.
                 with _lock:
                     _processes[app_name] = ap
                     _allocated_ports[app_name] = port
@@ -1131,36 +1205,56 @@ def stop_app_backend(app_name: str) -> bool:
                     _allocated_ports.setdefault(app_name, ap.port)
             return False
         try:
-            target_pids: set[int] = set(ap.adopted_pids)
-
-            # Verify adopted PIDs still belong to this port (guards against
-            # PID recycling between adoption and stop).
-            try:
-                lsof_result = subprocess.run(
-                    ["lsof", "-ti", f":{ap.port}", "-sTCP:LISTEN"],
-                    capture_output=True, text=True, timeout=5,
+            # PID-reuse guard: signal a recorded PID only when its live
+            # start-time identity still POSITIVELY matches the token captured
+            # at adoption (same convention as the spawned-backend reap). This
+            # is process identity, not a port/address heuristic, so every
+            # recycling shape — same address, another local address, a
+            # v6-only wildcard, or a non-listener — fails the match and is
+            # never signalled. A PID with no recorded token (identity was
+            # unreadable at adoption) or an unreadable live value reads as
+            # "identity unconfirmed" and is skipped, per the
+            # process_start_time contract: do not kill what you cannot name.
+            target_pids: set[int] = set()
+            unconfirmed: list[int] = []
+            for pid in ap.adopted_pids:
+                recorded_st = ap.adopted_start_times.get(pid)
+                if recorded_st is not None and _proc_start_time(pid) == recorded_st:
+                    target_pids.add(pid)
+                elif platform_compat.pid_exists(pid):
+                    unconfirmed.append(pid)
+            if unconfirmed:
+                logger.warning(
+                    "Adopted backend for %s on port %s: skipping live PIDs %s — "
+                    "start-time identity does not match the adoption record "
+                    "(recycled PID or unreadable identity); not signalling them",
+                    app_name, ap.port, unconfirmed,
                 )
-                if lsof_result.returncode == 0 and lsof_result.stdout.strip():
-                    current_pids: set[int] = set()
-                    for pid_str in lsof_result.stdout.strip().split("\n"):
-                        try:
-                            current_pids.add(int(pid_str.strip()))
-                        except ValueError:
-                            pass
-                    # Only kill PIDs that are both adopted AND still on this port
-                    target_pids = target_pids & current_pids
-            except (OSError, subprocess.TimeoutExpired):
-                # lsof unavailable at stop time — proceed with adopted PIDs
-                # (they were validated at adoption time)
-                pass
 
             pids: list[int] = []
             for pid in target_pids:
                 if pid <= 0:
                     continue
                 try:
-                    # kill_pid: os.kill on POSIX, taskkill /F on Windows.
-                    platform_compat.kill_pid(pid, platform_compat.SIGTERM)
+                    # Identity-PINNED (kill_pid_pinned): on Windows the handle
+                    # that re-verifies the start time stays open across the
+                    # terminate, so the PID taskkill resolves cannot have been
+                    # recycled between the identity check above and the signal.
+                    # False means the pin could not be established (the process
+                    # exited since the check) — nothing to stop, skip it.
+                    # POSIX delegates straight through to os.kill.
+                    if (
+                        platform_compat.kill_pid_pinned(
+                            pid, ap.adopted_start_times[pid], platform_compat.SIGTERM
+                        )
+                        is False
+                    ):
+                        logger.info(
+                            "Adopted backend for %s: pid %d exited before the "
+                            "pinned SIGTERM — nothing to signal",
+                            app_name, pid,
+                        )
+                        continue
                     pids.append(pid)
                 except (ProcessLookupError, OSError):
                     pass
@@ -1177,12 +1271,27 @@ def stop_app_backend(app_name: str) -> bool:
             # Escalate to SIGKILL if still alive
             escalated: list[int] = []
             for pid in pids:
-                # pid_exists (not os.kill(pid,0), which terminates on Windows);
-                # kill_pid dispatches os.kill / taskkill per platform.
-                if platform_compat.pid_exists(pid):
+                # pid_exists (not os.kill(pid,0), which terminates on Windows).
+                # The graceful-shutdown wait above is exactly the window in
+                # which the backend can exit and its PID be recycled, and
+                # SIGKILL is the destructive half — so the escalation re-reads
+                # the start-time identity here (this is what covers POSIX,
+                # where kill_pid_pinned delegates straight through) and the
+                # pinned kill then holds the Windows handle across the signal.
+                if (
+                    platform_compat.pid_exists(pid)
+                    and _proc_start_time(pid) == ap.adopted_start_times[pid]
+                ):
                     try:
-                        platform_compat.kill_pid(pid, platform_compat.SIGKILL)
-                        escalated.append(pid)
+                        if (
+                            platform_compat.kill_pid_pinned(
+                                pid,
+                                ap.adopted_start_times[pid],
+                                platform_compat.SIGKILL,
+                            )
+                            is not False
+                        ):
+                            escalated.append(pid)
                     except (ProcessLookupError, OSError):
                         pass
             if escalated:

--- a/src/kiro_crew/dashboard/port_reclaim.py
+++ b/src/kiro_crew/dashboard/port_reclaim.py
@@ -84,9 +84,15 @@ def _listeners_on_port(port: int) -> list[int] | None:
         if not platform_compat.listening_pid_tool_available():
             return None
         return platform_compat.find_listening_pids(port)
+    # Resolve lsof from the trusted system directories, never from PATH: a
+    # same-uid-writable dir leading PATH could otherwise substitute the tool
+    # whose output decides which PIDs get signalled.
+    lsof_bin = platform_compat.trusted_system_bin("lsof")
+    if lsof_bin is None:
+        return None
     try:
         out = subprocess.check_output(
-            ["lsof", "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
+            [lsof_bin, "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
             text=True,
             stderr=subprocess.DEVNULL,
             timeout=5,

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -27,7 +27,7 @@ import time
 import zlib
 from ctypes import wintypes  # type aliases only; imports cleanly on every platform
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping, Optional
+from typing import Any, Callable, Iterator, Mapping, NamedTuple, Optional
 
 from kiro_crew.executors import subprocess_executor
 
@@ -1853,15 +1853,96 @@ def listening_pid_tool_available() -> bool:
     return trusted_system_bin(listening_pid_tool()) is not None
 
 
-def find_listening_pids(port: int) -> list[int]:
-    """Return PIDs with a LISTEN socket on TCP *port* (best-effort, deduped).
+class PortListener(NamedTuple):
+    """One LISTEN socket on a TCP port: the owning PID plus the local address
+    it bound, so callers can scope port ownership to the address they actually
+    probed instead of claiming every listener on the port."""
 
-    POSIX: ``lsof -ti TCP:<port> -sTCP:LISTEN``.
-    Windows: parse ``netstat -ano`` (no lsof; netstat ships in-box). Matches
-    rows whose local address ends in ``:<port>`` and whose state is LISTENING,
-    taking the PID from the last column. Returns ``[]`` on any failure (caller
-    treats "no PID found" as "nothing to stop"; use listening_pid_tool_available()
-    to tell a genuine empty result apart from the tool being absent).
+    pid: int
+    #: Normalized local host part, brackets stripped: ``"127.0.0.1"``,
+    #: ``"0.0.0.0"``, ``"::"``, ``"::1"``, a specific interface address, or
+    #: ``"*"`` (lsof prints the wildcard bind of either family as ``*``).
+    address: str
+    #: Address family: ``"4"``, ``"6"``, or ``""`` when the source did not say.
+    #: Load-bearing for wildcards — lsof spells both families ``*``, and only
+    #: the family tells a v4 wildcard apart from a possibly-v6-only one.
+    family: str = ""
+
+
+# Local addresses whose listener can receive a connect to ``127.0.0.1``: the v4
+# loopback itself, the v4 wildcard, lsof's family-agnostic wildcard ``*``, and
+# the v6 wildcard ``::`` (dual-stack sockets accept v4-mapped loopback; treating
+# it as non-covering would refuse adoption of a legitimately ``[::]``-bound
+# backend, which is the breaking direction). ``::1`` is deliberately absent: a
+# v6-loopback-only listener can never answer a probe addressed to 127.0.0.1.
+_LOOPBACK_COVERING_ADDRESSES = frozenset({"127.0.0.1", "0.0.0.0", "*", "::"})
+
+# Bound so a wedged lsof (stale mount, jammed process table) degrades to "no
+# listener found" instead of hanging every caller of the port->PID lookup; the
+# Windows netstat branch carries its own inline bound.
+_LSOF_TIMEOUT_SECS = 5
+
+
+def _normalize_local_address(address: str) -> str:
+    """Bare lowercase host part: brackets stripped, v4-mapped prefix removed."""
+    addr = address.strip().strip("[]").lower()
+    if addr.startswith("::ffff:"):
+        # v4-mapped form of a v4 address; compare the embedded v4 part.
+        addr = addr[len("::ffff:"):]
+    return addr
+
+
+def address_covers_loopback(address: str) -> bool:
+    """Whether a listener bound to *address* can receive a ``127.0.0.1`` connect.
+
+    Used to scope port ownership to the address a health probe actually talked
+    to: a listener on some other specific local address shares the port number
+    but was never the thing that answered the probe.
+    """
+    return _normalize_local_address(address) in _LOOPBACK_COVERING_ADDRESSES
+
+
+def loopback_owner_pids(listeners: list[PortListener]) -> list[int]:
+    """PIDs of the listener(s) a successful ``127.0.0.1:<port>`` connect reached.
+
+    Mirrors the kernel's most-specific-bind dispatch — the first non-empty
+    tier wins, and every PID within it is returned (pre-fork / multi-worker
+    backends legitimately share one listening socket):
+
+    1. Exact v4-loopback binds (``127.0.0.1``, incl. the v4-mapped spelling):
+       when one exists the kernel routes a loopback connect to it, so wildcard
+       listeners on the same port never saw the probe.
+    2. IPv4 wildcard binds: a v4 connect reaches the v4 wildcard socket in
+       preference to a dual-stack v6 one.
+    3. Remaining loopback-covering binds (the v6 wildcard, or one whose family
+       the source did not report): callers only ask after a successful
+       127.0.0.1 probe, so when nothing more specific exists, what is left
+       must have been the responder (a dual-stack socket).
+
+    Tier 2 is what keeps an unrelated ``IPV6_V6ONLY`` wildcard process from
+    being claimed alongside the real v4 owner sharing its port.
+    """
+    exact = [e for e in listeners if _normalize_local_address(e.address) == "127.0.0.1"]
+    if exact:
+        return list(dict.fromkeys(e.pid for e in exact))
+    covering = [e for e in listeners if address_covers_loopback(e.address)]
+    v4 = [e for e in covering if e.family == "4"]
+    if v4:
+        return list(dict.fromkeys(e.pid for e in v4))
+    return list(dict.fromkeys(e.pid for e in covering))
+
+
+def find_port_listeners(port: int) -> list[PortListener]:
+    """Return (pid, local address) for each LISTEN socket on TCP *port*.
+
+    Best-effort, deduped on (pid, address, family), never raises. POSIX asks
+    ``lsof -nP -iTCP:<port> -sTCP:LISTEN -Fptn`` (field output per socket:
+    ``p<pid>``, ``t<IPv4|IPv6>``, ``n<addr>:<port>``); Windows parses
+    ``netstat -ano`` (no lsof; netstat ships in-box), matching rows whose
+    local address ends in ``:<port>`` and whose state is LISTENING. Returns
+    ``[]`` on any failure (callers treat "no listener found" as "nothing to
+    stop"; use listening_pid_tool_available() to tell a genuine empty result
+    apart from the tool being absent).
     """
     if IS_POSIX:
         lsof_bin = trusted_system_bin("lsof")
@@ -1869,13 +1950,43 @@ def find_listening_pids(port: int) -> list[int]:
             return []
         try:
             out = subprocess.check_output(
-                [lsof_bin, "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
+                # -n/-P keep addresses and ports numeric so the field parse
+                # below never sees a resolved host or service name; the t
+                # (type) field carries the family, without which the two
+                # wildcard binds are indistinguishable (both print ``*``).
+                [lsof_bin, "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-Fptn"],
                 text=True,
                 stderr=subprocess.DEVNULL,
+                timeout=_LSOF_TIMEOUT_SECS,
             )
-        except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        except (FileNotFoundError, subprocess.SubprocessError, OSError):
+            # CalledProcessError included: lsof exits non-zero when nothing
+            # matches the filter, which is the ordinary "port is free" answer.
             return []
-        return list(dict.fromkeys(int(p) for p in out.split() if p.strip().isdigit()))
+        suffix = f":{port}"
+        listeners: list[PortListener] = []
+        seen: set[PortListener] = set()
+        cur_pid: int | None = None
+        cur_family = ""
+        for line in out.splitlines():
+            if not line:
+                continue
+            tag, value = line[0], line[1:]
+            if tag == "p":
+                cur_pid = int(value) if value.isdigit() else None
+                cur_family = ""
+            elif tag == "t":
+                cur_family = {"IPv4": "4", "IPv6": "6"}.get(value, "")
+            elif tag == "n" and cur_pid is not None and value.endswith(suffix):
+                # ``n127.0.0.1:8080`` / ``n*:8080`` / ``n[::1]:8080`` — strip
+                # the port suffix and the v6 brackets to the bare host part.
+                entry = PortListener(
+                    cur_pid, value[: -len(suffix)].strip("[]"), cur_family
+                )
+                if entry not in seen:
+                    seen.add(entry)
+                    listeners.append(entry)
+        return listeners
     # Windows: netstat -ano. Lines look like:
     #   TCP    127.0.0.1:7777         0.0.0.0:0    LISTENING    17152   (IPv4)
     #   TCP    [::1]:7777             [::]:0       LISTENING    17152   (IPv6)
@@ -1907,7 +2018,8 @@ def find_listening_pids(port: int) -> list[int]:
     except (FileNotFoundError, subprocess.SubprocessError, OSError, ValueError):
         return []
     suffix = f":{port}"
-    pids: list[int] = []
+    listeners = []
+    seen = set()
     for line in out.splitlines():
         parts = line.split()
         # Expect: proto local foreign state pid.
@@ -1938,10 +2050,29 @@ def find_listening_pids(port: int) -> list[int]:
             continue
         pid_str = parts[-1]
         if pid_str.isdigit():
-            pids.append(int(pid_str))
-    # Dedup: a dual-stack listener appears in BOTH a TCP4 row (0.0.0.0:port)
-    # and a TCP6 row ([::]:port) under the same PID — collapse to one entry.
-    return list(dict.fromkeys(pids))
+            # The bracketed address form is what distinguishes v4 vs v6 on
+            # Windows netstat output (the proto column says "TCP" for both).
+            entry = PortListener(
+                int(pid_str),
+                local[: -len(suffix)].strip("[]"),
+                "6" if local.startswith("[") else "4",
+            )
+            if entry not in seen:
+                seen.add(entry)
+                listeners.append(entry)
+    return listeners
+
+
+def find_listening_pids(port: int) -> list[int]:
+    """Return PIDs with a LISTEN socket on TCP *port* (best-effort, deduped).
+
+    Address-agnostic accessor over :func:`find_port_listeners` for callers that
+    only care whether/which processes hold the port. A dual-stack listener
+    appears once per bound address (``0.0.0.0`` and ``::``) under the same PID —
+    collapsed to one entry here, first-seen order preserved. Same failure
+    contract: ``[]`` on any failure, never raises.
+    """
+    return list(dict.fromkeys(entry.pid for entry in find_port_listeners(port)))
 
 
 def process_command_line(pid: int) -> str:
@@ -2556,6 +2687,41 @@ def kill_process_tree_pinned(
         # while this process object is still referenced, so the PID cannot have
         # been recycled onto a different process in between.
         return kill_process_tree(pid, sig)
+    finally:
+        _close_process_handle(handle)
+
+
+def kill_pid_pinned(pid: int, expected_start_time: str, sig: int = SIGTERM) -> bool:
+    """Kill *pid* only while its verified identity is PINNED OPEN.
+
+    Single-process variant of :func:`kill_process_tree_pinned` — same Windows
+    guarantee (the query handle that verified the creation time stays open
+    across the terminate, so the PID ``taskkill`` resolves cannot have been
+    recycled between the check and the signal), delegating to :func:`kill_pid`
+    instead of tearing down the tree. Returns ``False`` — without signalling —
+    when the handle cannot be opened or the identity does not match; callers
+    treat that as "identity unconfirmed, do not kill". On a match it delegates
+    to :func:`kill_pid` and propagates its exceptions unchanged.
+
+    POSIX delegates straight through: ``os.kill`` is issued in-process by the
+    same interpreter that did the check and there is no handle to hold; the
+    residual probe-to-signal window there is the pre-existing one callers
+    mitigate by re-confirming identity before destructive escalation.
+    """
+    if not IS_WINDOWS:
+        return kill_pid(pid, sig)
+    handle = _open_process_query_handle(pid)
+    if handle is None:
+        return False
+    try:
+        identity = _windows_process_handle_identity(handle)
+        # (pid, creation_time, exit_time) -- the creation half is the identity.
+        if identity is None or str(identity[1]) != expected_start_time:
+            return False
+        # The handle stays open for the whole call: taskkill resolves the PID
+        # while this process object is still referenced, so the PID cannot have
+        # been recycled onto a different process in between.
+        return kill_pid(pid, sig)
     finally:
         _close_process_handle(handle)
 

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -167,9 +167,9 @@ def _record_runs(
     """Record every run argv, optionally failing the call.
 
     Both entry points, because this module has two: the dependency installers go
-    through ``run_limited`` (resource limits applied post-exec), while the nvm and
-    lsof probes are plain ``subprocess.run`` -- they carry no resource policy, so
-    there was nothing for the limiter to deliver for them.
+    through ``run_limited`` (resource limits applied post-exec), while the nvm
+    probe is a plain ``subprocess.run`` -- it carries no resource policy, so
+    there was nothing for the limiter to deliver for it.
     """
 
     calls: list[list[str]] = []
@@ -185,6 +185,16 @@ def _record_runs(
     monkeypatch.setattr(bmod, "run_limited", _run)
     monkeypatch.setattr(bmod.subprocess, "run", _run)
     return calls
+
+
+def _stub_listeners(monkeypatch: pytest.MonkeyPatch, listeners: list[Any]) -> None:
+    """Pin the port->PID lookup the adoption path reads its owners from.
+
+    ``find_port_listeners`` never raises and folds every failure (tool absent,
+    wedged probe) into ``[]``, so an empty stub covers the unavailable case too.
+    """
+
+    monkeypatch.setattr(bmod.platform_compat, "find_port_listeners", lambda _port: listeners)
 
 
 # ---------------------------------------------------------------------------
@@ -654,18 +664,69 @@ class TestAdoptExistingInstance:
     ) -> None:
         port = bmod._MIN_PORT + 6
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(
+        _stub_listeners(
             monkeypatch,
-            # A non-numeric line must be skipped, not abort the adoption.
-            result=SimpleNamespace(returncode=0, stdout="111\nbogus\n222\n"),
+            [
+                # Pre-fork workers legitimately share the listening socket.
+                bmod.platform_compat.PortListener(111, "127.0.0.1", "4"),
+                bmod.platform_compat.PortListener(222, "127.0.0.1", "4"),
+            ],
         )
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
         ap = self._run(port)
         assert ap is not None
         assert ap.proc is None
         assert ap.healthy is True
         assert ap.adopted_pids == [111, 222]
+        # Start-time identity is captured per owner so stop can refuse a
+        # recycled PID later.
+        assert ap.adopted_start_times == {111: "st-111", 222: "st-222"}
         assert bmod._processes["adoptee"] is ap
         assert bmod._allocated_ports["adoptee"] == port
+
+    def test_adoption_records_only_the_probed_address_owner(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ownership is claimed per address, not per port.
+
+        Two processes legally share a port on different local addresses; only
+        the one covering the health-checked 127.0.0.1 was ever validated, so
+        recording the other would hand stop_app_backend an unrelated process
+        to signal.
+        """
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
+        _stub_listeners(
+            monkeypatch,
+            [
+                bmod.platform_compat.PortListener(111, "127.0.0.1", "4"),
+                bmod.platform_compat.PortListener(999, "192.168.1.5", "4"),
+            ],
+        )
+        ap = self._run(bmod._MIN_PORT + 16)
+        assert ap is not None
+        assert ap.adopted_pids == [111]
+
+    def test_adoption_excludes_a_v6only_wildcard_beside_the_v4_owner(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """lsof spells both wildcard binds ``*`` — only the family separates a
+        v4 owner from an unrelated IPV6_V6ONLY listener sharing its port, and
+        the latter never saw the 127.0.0.1 health probe."""
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
+        _stub_listeners(
+            monkeypatch,
+            [
+                bmod.platform_compat.PortListener(111, "*", "4"),
+                bmod.platform_compat.PortListener(999, "*", "6"),
+            ],
+        )
+        ap = self._run(bmod._MIN_PORT + 17)
+        assert ap is not None
+        assert ap.adopted_pids == [111]
 
     def test_adoption_survives_an_audit_sink_failure(
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
@@ -677,7 +738,8 @@ class TestAdoptExistingInstance:
 
         monkeypatch.setattr(bmod, "sel", _boom)
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="333\n"))
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
+        _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(333, "127.0.0.1", "4")])
         ap = self._run(bmod._MIN_PORT + 7)
         assert ap is not None
         assert ap.adopted_pids == [333]
@@ -688,18 +750,84 @@ class TestAdoptExistingInstance:
         """Adopting without PIDs would leave a backend we can never stop."""
 
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=1, stdout=""))
+        _stub_listeners(monkeypatch, [])
         with caplog.at_level(logging.WARNING):
             assert self._run(bmod._MIN_PORT + 8) is None
-        assert any("cannot record PIDs" in r.message for r in caplog.records)
+        assert any("cannot record owning PIDs" in r.message for r in caplog.records)
         assert "adoptee" not in bmod._processes
 
-    def test_adoption_is_refused_when_the_pid_probe_is_unavailable(
+    def test_adoption_is_refused_when_only_other_addresses_listen(
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """No loopback-covering owner means the probed backend cannot be
+        attributed — adopting the other-address listener would be adopting a
+        process that never answered the health check."""
+
         monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(999, "192.168.1.5", "4")])
         assert self._run(bmod._MIN_PORT + 9) is None
+        assert "adoptee" not in bmod._processes
+
+    def test_adoption_is_refused_when_an_owner_identity_is_unreadable(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An owner that cannot be positively named can never be signalled
+        later: stop and uninstall would skip it, leaving a third-party backend
+        running after its trust was revoked. Refuse the adoption instead."""
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: None)
+        _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")])
+        with caplog.at_level(logging.WARNING):
+            assert self._run(bmod._MIN_PORT + 20) is None
+        assert any("refusing adoption" in r.message for r in caplog.records)
+        assert "adoptee" not in bmod._processes
+
+    def test_adoption_is_refused_when_owners_change_mid_capture(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The consistency sandwich: if the responder exits between the health
+        probe and the owner capture, the lookup would attribute ownership to a
+        bystander (e.g. a coexisting v6-only wildcard) — the re-read owner set
+        differs, so adoption is refused instead of recording the bystander."""
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
+        seqs = [
+            [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")],
+            [bmod.platform_compat.PortListener(999, "*", "6")],
+        ]
+        monkeypatch.setattr(
+            bmod.platform_compat, "find_port_listeners", lambda _port: seqs.pop(0)
+        )
+        with caplog.at_level(logging.WARNING):
+            assert self._run(bmod._MIN_PORT + 18) is None
+        assert any("owners changed" in r.message for r in caplog.records)
+        assert "adoptee" not in bmod._processes
+
+    def test_adoption_is_refused_when_health_lapses_mid_capture(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The re-probe half of the sandwich: a backend that stops answering
+        its health check while ownership is being recorded is not a stable
+        adoptee — whatever the owner lookup returned may describe a corpse or
+        a bystander."""
+
+        calls = {"n": 0}
+
+        def _urlopen(*_a: Any, **_k: Any) -> Any:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _FakeResp(200)
+            raise urllib.error.URLError("gone mid-capture")
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
+        _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")])
+        with caplog.at_level(logging.WARNING):
+            assert self._run(bmod._MIN_PORT + 19) is None
+        assert any("stopped answering" in r.message for r in caplog.records)
+        assert "adoptee" not in bmod._processes
 
     def test_an_unhealthy_occupant_blocks_the_spawn_instead_of_colliding(
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -1084,9 +1212,12 @@ class TestStopAdoptedBackend:
     @pytest.fixture()
     def kills(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, int]]:
         recorded: list[tuple[int, int]] = []
-        monkeypatch.setattr(
-            bmod.platform_compat, "kill_pid", lambda pid, sig: recorded.append((pid, sig))
-        )
+
+        def _pinned_kill(pid: int, _start_time: str, sig: int) -> bool:
+            recorded.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", _pinned_kill)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
         return recorded
 
@@ -1110,29 +1241,117 @@ class TestStopAdoptedBackend:
         assert bmod._processes["ext"] is ap
         assert bmod._allocated_ports["ext"] == ap.port
 
-    def test_only_pids_still_listening_on_the_port_are_signalled(
+    def test_only_identity_verified_pids_are_signalled(
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Revalidation guards against a PID recycled since adoption."""
+        """Revalidation is process identity, not a port heuristic: a PID whose
+        live start time no longer matches the adoption record was recycled and
+        must not be signalled, whatever it listens on now."""
 
-        self._track(adopted_pids=[111, 222], healthy=True)
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="111\n999\n"))
+        self._track(
+            adopted_pids=[111, 222],
+            adopted_start_times={111: "st-111", 222: "st-222"},
+            healthy=True,
+        )
+        monkeypatch.setattr(
+            bmod, "_proc_start_time", lambda pid: {111: "st-111", 222: "st-999"}.get(pid)
+        )
+        # 222 stays alive (it is the recycled process we must not touch);
+        # 111 dies on SIGTERM so no SIGKILL escalation muddies the record.
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda pid: pid == 222)
         assert bmod.stop_app_backend("ext") is True
         assert kills == [(111, bmod.platform_compat.SIGTERM)]
 
-    def test_an_unavailable_pid_probe_falls_back_to_the_adopted_set(
+    def test_a_recycled_pid_is_not_signalled_even_when_it_listens(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The exact residual the identity guard closes: the adopted backend
+        exits, the OS recycles its PID onto ANOTHER listener of the same port
+        (any local address, including a v6-only wildcard) — the start-time
+        mismatch keeps it from being signalled."""
+
+        self._track(adopted_pids=[111], adopted_start_times={111: "st-old"}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st-recycled")
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        with caplog.at_level(logging.WARNING):
+            assert bmod.stop_app_backend("ext") is True
+        assert kills == []
+        assert any("identity does not match" in r.message for r in caplog.records)
+
+    def test_an_exited_backend_signals_nothing(
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        """A dead PID reads back no start time: nothing to signal, no warning
+        spam for a process that simply finished."""
+
+        self._track(adopted_pids=[111], adopted_start_times={111: "st-111"}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: None)
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
         assert bmod.stop_app_backend("ext") is True
-        assert kills == [(111, bmod.platform_compat.SIGTERM)]
+        assert kills == []
+
+    def test_a_pid_recycled_during_the_graceful_wait_is_not_sigkilled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The escalation re-reads identity: a PID whose start time changed
+        during the 2s graceful wait was recycled and must not receive the
+        destructive SIGKILL, on any platform."""
+
+        recorded: list[tuple[int, int]] = []
+
+        def _pinned_kill(pid: int, _start_time: str, sig: int) -> bool:
+            recorded.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", _pinned_kill)
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        self._track(adopted_pids=[111], adopted_start_times={111: "st"}, healthy=True)
+        # Identity matches for the SIGTERM selection, then flips before the
+        # escalation re-read (the PID was recycled during the graceful wait).
+        reads = iter(["st", "st-recycled"])
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: next(reads))
+        assert bmod.stop_app_backend("ext") is True
+        assert recorded == [(111, bmod.platform_compat.SIGTERM)]
+
+    def test_a_pin_refusal_signals_nothing_and_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """kill_pid_pinned returning False means the process exited between the
+        identity check and the pin — there is nothing left to stop, and no
+        signal may be sent to whatever holds the PID now."""
+
+        self._track(adopted_pids=[111], adopted_start_times={111: "st"}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
+        monkeypatch.setattr(
+            bmod.platform_compat, "kill_pid_pinned", lambda _pid, _st, _sig: False
+        )
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        with caplog.at_level(logging.INFO):
+            assert bmod.stop_app_backend("ext") is True
+        assert any("pinned SIGTERM" in r.message for r in caplog.records)
+
+    def test_an_unreadable_identity_is_never_signalled(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No token was recorded at adoption (identity unreadable): the PID can
+        no longer be positively named, so it is skipped — fail toward not
+        killing, per the process_start_time contract."""
+
+        self._track(adopted_pids=[111], adopted_start_times={}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st-live")
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        assert bmod.stop_app_backend("ext") is True
+        assert kills == []
 
     def test_nonpositive_recorded_pids_are_never_signalled(
         self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self._track(adopted_pids=[0, -1], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        self._track(
+            adopted_pids=[0, -1],
+            adopted_start_times={0: "st-0", -1: "st-1"},
+            healthy=True,
+        )
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: {0: "st-0", -1: "st-1"}.get(pid))
         assert bmod.stop_app_backend("ext") is True
         assert kills == []
 
@@ -1140,12 +1359,15 @@ class TestStopAdoptedBackend:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         recorded: list[tuple[int, int]] = []
-        monkeypatch.setattr(
-            bmod.platform_compat, "kill_pid", lambda pid, sig: recorded.append((pid, sig))
-        )
+
+        def _pinned_kill(pid: int, _start_time: str, sig: int) -> bool:
+            recorded.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", _pinned_kill)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
-        self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        self._track(adopted_pids=[111], adopted_start_times={111: "st"}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
         assert bmod.stop_app_backend("ext") is True
         assert recorded == [
             (111, bmod.platform_compat.SIGTERM),
@@ -1155,13 +1377,13 @@ class TestStopAdoptedBackend:
     def test_an_unsignalable_pid_is_skipped_not_fatal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def _denied(_pid: int, _sig: int) -> None:
+        def _denied(_pid: int, _start_time: str, _sig: int) -> bool:
             raise ProcessLookupError
 
-        monkeypatch.setattr(bmod.platform_compat, "kill_pid", _denied)
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", _denied)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
-        self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        self._track(adopted_pids=[111], adopted_start_times={111: "st"}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
         assert bmod.stop_app_backend("ext") is True
 
     def test_an_unexpected_stop_failure_restores_tracking(
@@ -1169,12 +1391,12 @@ class TestStopAdoptedBackend:
     ) -> None:
         """Losing the record would orphan the backend with no way to retry."""
 
-        def _bad(_pid: int, _sig: int) -> None:
+        def _bad(_pid: int, _start_time: str, _sig: int) -> bool:
             raise ValueError("bad signal")
 
-        monkeypatch.setattr(bmod.platform_compat, "kill_pid", _bad)
-        ap = self._track(adopted_pids=[111], healthy=True)
-        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", _bad)
+        ap = self._track(adopted_pids=[111], adopted_start_times={111: "st"}, healthy=True)
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
         with caplog.at_level(logging.WARNING):
             assert bmod.stop_app_backend("ext") is False
         assert any("Failed to stop adopted backend" in r.message for r in caplog.records)
@@ -1746,7 +1968,7 @@ class TestDefensiveBranches:
         assert bmod.stop_app_backend("ext") is False
         assert "ext" in bmod._processes
 
-    def test_a_garbled_pid_probe_line_is_skipped_during_an_adopted_stop(
+    def test_an_adopted_stop_kill_path_survives_an_audit_sink_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def _no_sel() -> Any:
@@ -1755,14 +1977,18 @@ class TestDefensiveBranches:
         killed: list[tuple[int, int]] = []
         monkeypatch.setattr(bmod, "sel", _no_sel)
         monkeypatch.setattr(bmod, "_wait_for_pids", lambda _pids, timeout=2.0: None)
-        monkeypatch.setattr(
-            bmod.platform_compat, "kill_pid", lambda pid, sig: killed.append((pid, sig))
-        )
+
+        def _pinned_kill(pid: int, _start_time: str, sig: int) -> bool:
+            killed.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid_pinned", _pinned_kill)
         monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
-        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="111\nnope\n"))
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "st")
         with bmod._lock:
             bmod._processes["ext"] = AppProcess(
-                app_name="ext", port=9100, pid=0, proc=None, adopted_pids=[111], healthy=True
+                app_name="ext", port=9100, pid=0, proc=None, adopted_pids=[111],
+                adopted_start_times={111: "st"}, healthy=True
             )
         assert bmod.stop_app_backend("ext") is True
         assert killed == [

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2129,12 +2129,62 @@ class TestFindListeningPidsErrors:
         assert pc.find_listening_pids(59998) == []
 
     def test_dedupes_pids_from_lsof_output(self, monkeypatch):
-        # lsof can emit the same PID multiple times (one row per fd); the helper
-        # must dedupe while preserving first-seen order.
+        # lsof can emit the same (pid, address) socket multiple times (one row
+        # per fd) and one PID can hold several addresses on the port; the PID
+        # accessor must dedupe while preserving first-seen order.
         if not pc.IS_POSIX:
             pytest.skip("POSIX lsof branch")
-        monkeypatch.setattr(pc.subprocess, "check_output", lambda *a, **k: "111\n111\n222\n")
+        blob = "p111\nn127.0.0.1:7777\nn127.0.0.1:7777\nn*:7777\np222\nn[::1]:7777\n"
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *a, **k: blob)
         assert pc.find_listening_pids(7777) == [111, 222]
+
+    def test_posix_listeners_carry_their_local_address(self, monkeypatch):
+        # The lsof -Fptn field output attributes each LISTEN socket's local
+        # address AND family to its owning PID, so callers can scope ownership
+        # to the address they actually probed (family is what tells the two
+        # wildcard binds apart — lsof prints both as ``*``). v6 brackets are
+        # stripped; rows for a different port (defensive — the -i filter
+        # already scopes) and malformed p-lines are ignored.
+        if not pc.IS_POSIX:
+            pytest.skip("POSIX lsof branch")
+        blob = (
+            "p111\n"
+            "tIPv4\n"
+            "n127.0.0.1:7777\n"
+            "p222\n"
+            "tIPv6\n"
+            "n[::1]:7777\n"
+            "tIPv4\n"
+            "n192.168.1.5:7777\n"
+            "pbogus\n"
+            "n10.0.0.1:7777\n"
+            "p333\n"
+            "tIPv4\n"
+            "n*:7778\n"
+        )
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *a, **k: blob)
+        assert pc.find_port_listeners(7777) == [
+            pc.PortListener(111, "127.0.0.1", "4"),
+            pc.PortListener(222, "::1", "6"),
+            pc.PortListener(222, "192.168.1.5", "4"),
+        ]
+
+    def test_posix_lookup_is_bounded_by_a_timeout(self, monkeypatch):
+        # A wedged lsof (stale mount, jammed process table) must degrade to
+        # "no listener found" instead of hanging every port->PID caller: the
+        # spawn carries a timeout, and its expiry folds into [].
+        if not pc.IS_POSIX:
+            pytest.skip("POSIX lsof branch")
+        captured: dict = {}
+
+        def _capture(argv, **kwargs):
+            captured["argv"] = list(argv)
+            captured["kwargs"] = kwargs
+            raise subprocess.TimeoutExpired(argv, kwargs.get("timeout", 0))
+
+        monkeypatch.setattr(pc.subprocess, "check_output", _capture)
+        assert pc.find_port_listeners(7777) == []
+        assert captured["kwargs"].get("timeout") == pc._LSOF_TIMEOUT_SECS
 
     def _fake_netstat(self, blob: str):
         """Return a fake subprocess.check_output that returns *blob*."""
@@ -2223,6 +2273,25 @@ class TestFindListeningPidsErrors:
         monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
         assert pc.find_listening_pids(7777) == [44]
 
+    def test_windows_listeners_carry_their_local_address(self, monkeypatch):
+        # The netstat parse attributes each row's local address to its PID so
+        # callers can scope ownership to the address they probed; a dual-stack
+        # listener keeps one entry per bound address, v6 brackets stripped.
+        blob = (
+            "  TCP    0.0.0.0:7777           0.0.0.0:0              LISTENING       99\n"
+            "  TCP    [::]:7777              [::]:0                 LISTENING       99\n"
+            "  TCP    192.168.1.5:7777       0.0.0.0:0              LISTENING       55\n"
+        )
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        _fake_windows_bins(monkeypatch)
+        monkeypatch.setattr(pc.subprocess, "check_output", self._fake_netstat(blob))
+        assert pc.find_port_listeners(7777) == [
+            pc.PortListener(99, "0.0.0.0", "4"),
+            pc.PortListener(99, "::", "6"),
+            pc.PortListener(55, "192.168.1.5", "4"),
+        ]
+
     @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows netstat branch")
     def test_windows_finds_real_ipv6_loopback_listener(self):
         # End-to-end guard on a live host: bind AF_INET6 to ::1 at an ephemeral
@@ -2240,6 +2309,79 @@ class TestFindListeningPidsErrors:
             assert os.getpid() in pids, f"expected pid {os.getpid()} in {pids}"
         finally:
             s.close()
+
+
+class TestAddressCoversLoopback:
+    @pytest.mark.parametrize(
+        "address",
+        ["127.0.0.1", "0.0.0.0", "*", "::", "[::]", "::ffff:127.0.0.1", " 0.0.0.0 "],
+    )
+    def test_loopback_covering_addresses(self, address):
+        assert pc.address_covers_loopback(address) is True
+
+    @pytest.mark.parametrize(
+        "address",
+        # ::1 cannot receive a connect addressed to 127.0.0.1, so a
+        # v6-loopback-only listener is deliberately NOT loopback-covering.
+        ["::1", "[::1]", "192.168.1.5", "10.0.0.1", "fe80::1", "127.0.0.2", ""],
+    )
+    def test_other_addresses_do_not_cover_loopback(self, address):
+        assert pc.address_covers_loopback(address) is False
+
+
+class TestLoopbackOwnerPids:
+    """The most-specific-bind dispatch tiers of :func:`loopback_owner_pids`."""
+
+    def test_an_exact_loopback_bind_beats_wildcards(self):
+        # The kernel routes a 127.0.0.1 connect to the exact bind, so wildcard
+        # listeners on the same port never saw the probe and are not owners.
+        listeners = [
+            pc.PortListener(111, "127.0.0.1", "4"),
+            pc.PortListener(999, "*", "4"),
+            pc.PortListener(888, "::", "6"),
+        ]
+        assert pc.loopback_owner_pids(listeners) == [111]
+
+    def test_a_v4_wildcard_beats_a_possibly_v6only_wildcard(self):
+        # An unrelated IPV6_V6ONLY wildcard next to the real v4 owner must not
+        # be claimed: a v4 connect reaches the v4 wildcard socket, never the
+        # v6-only one. lsof spells both ``*`` — the family is the separator.
+        listeners = [
+            pc.PortListener(111, "*", "4"),
+            pc.PortListener(999, "*", "6"),
+        ]
+        assert pc.loopback_owner_pids(listeners) == [111]
+
+    def test_a_lone_v6_wildcard_is_the_responder(self):
+        # Callers only ask after a successful 127.0.0.1 probe; with nothing
+        # more specific on the port, the v6 wildcard must be dual-stack and is
+        # the adopted owner (refusing it would break [::]-bound externally
+        # managed backends).
+        listeners = [pc.PortListener(77, "::", "6")]
+        assert pc.loopback_owner_pids(listeners) == [77]
+
+    def test_multi_worker_backends_share_ownership(self):
+        # Pre-fork / multi-worker backends legitimately share one listening
+        # socket: every PID in the winning tier is recorded.
+        listeners = [
+            pc.PortListener(11, "127.0.0.1", "4"),
+            pc.PortListener(12, "127.0.0.1", "4"),
+            pc.PortListener(999, "*", "4"),
+        ]
+        assert pc.loopback_owner_pids(listeners) == [11, 12]
+
+    def test_unknown_family_wildcards_fall_to_the_covering_tier(self):
+        # A source that reported no family (old lsof output) still resolves:
+        # the covering tier keeps adoption working rather than refusing it.
+        listeners = [
+            pc.PortListener(11, "*"),
+            pc.PortListener(22, "192.168.1.5"),
+        ]
+        assert pc.loopback_owner_pids(listeners) == [11]
+
+    def test_no_covering_listener_yields_no_owner(self):
+        listeners = [pc.PortListener(999, "192.168.1.5", "4")]
+        assert pc.loopback_owner_pids(listeners) == []
 
 
 class TestKillAsyncVariants:
@@ -3439,3 +3581,81 @@ class TestKillProcessTreePinned:
         assert pc.kill_process_tree_pinned(4321, recorded) is True
         # The exit half moves as the process dies and must never be the identity.
         assert pc.kill_process_tree_pinned(4321, "888") is False
+
+
+class TestKillPidPinned:
+    """Single-process variant of the pinned kill: same handle-lifetime
+    invariant as :class:`TestKillProcessTreePinned`, delegating to ``kill_pid``
+    instead of the tree teardown. Driven through the module seams with
+    ``IS_WINDOWS`` patched so every case runs on every platform."""
+
+    HANDLE = 4242
+
+    def _wire(self, monkeypatch, *, handle=HANDLE, identity=(4321, 777, None)):
+        opened: list[int] = []
+        closed: list[int] = []
+        killed: list[tuple[int, int]] = []
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+
+        def _open(pid):
+            opened.append(pid)
+            return handle
+
+        def _identity(h):
+            assert h == handle, "the identity must be read from the handle just opened"
+            return identity
+
+        def _close(h):
+            closed.append(h)
+
+        def _kill(pid, sig):
+            killed.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(pc, "_open_process_query_handle", _open)
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", _identity)
+        monkeypatch.setattr(pc, "_close_process_handle", _close)
+        monkeypatch.setattr(pc, "kill_pid", _kill)
+        return opened, closed, killed
+
+    def test_a_matching_identity_kills_and_then_releases_the_handle(self, monkeypatch):
+        opened, closed, killed = self._wire(monkeypatch)
+
+        assert pc.kill_pid_pinned(4321, "777", pc.SIGTERM) is True
+
+        assert opened == [4321]
+        assert killed == [(4321, pc.SIGTERM)]
+        assert closed == [self.HANDLE]
+
+    def test_a_mismatched_identity_never_invokes_the_kill(self, monkeypatch):
+        _, closed, killed = self._wire(monkeypatch, identity=(4321, 999, None))
+
+        assert pc.kill_pid_pinned(4321, "777", pc.SIGKILL) is False
+
+        assert killed == []
+        assert closed == [self.HANDLE], "the handle must still be released"
+
+    def test_an_unopenable_process_never_invokes_the_kill(self, monkeypatch):
+        _, closed, killed = self._wire(monkeypatch, handle=None)
+
+        assert pc.kill_pid_pinned(4321, "777", pc.SIGTERM) is False
+
+        assert killed == []
+        assert closed == [], "nothing was opened, so nothing may be closed"
+
+    def test_an_unreadable_identity_never_invokes_the_kill(self, monkeypatch):
+        _, closed, killed = self._wire(monkeypatch, identity=None)
+
+        assert pc.kill_pid_pinned(4321, "777", pc.SIGTERM) is False
+
+        assert killed == []
+        assert closed == [self.HANDLE]
+
+    def test_posix_delegates_straight_through(self, monkeypatch):
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "kill_pid", lambda pid, sig: killed.append((pid, sig)) or True)
+
+        assert pc.kill_pid_pinned(4321, "777", pc.SIGTERM) is True
+        assert killed == [(4321, pc.SIGTERM)]

--- a/test/test_port_reclaim.py
+++ b/test/test_port_reclaim.py
@@ -315,3 +315,33 @@ def test_listeners_windows_tool_absent_returns_none(monkeypatch) -> None:
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", True)
     monkeypatch.setattr(pr.platform_compat, "listening_pid_tool_available", lambda: False)
     assert pr._listeners_on_port(5476) is None
+
+
+def test_listeners_posix_resolves_lsof_from_trusted_dirs(monkeypatch) -> None:
+    """The POSIX branch spawns the trusted-directory lsof, never a PATH-resolved
+    one: PATH can lead with a same-uid-writable dir, and this probe's output
+    decides which PIDs get signalled."""
+    monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(pr.platform_compat, "trusted_system_bin", lambda name: "/usr/bin/lsof")
+    argvs: list[list[str]] = []
+
+    def _check_output(argv, **_kwargs):
+        argvs.append(list(argv))
+        return "4242\n"
+
+    monkeypatch.setattr(pr.subprocess, "check_output", _check_output)
+    assert pr._listeners_on_port(5476) == [4242]
+    assert argvs and argvs[0][0] == "/usr/bin/lsof"
+
+
+def test_listeners_posix_tool_absent_returns_none(monkeypatch) -> None:
+    """No trusted lsof must read as "cannot determine" (wait/retry), never as
+    "no holder" -- and nothing may be spawned in that case."""
+    monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(pr.platform_compat, "trusted_system_bin", lambda name: None)
+
+    def _never(*_a, **_k):  # pragma: no cover - guards the refusal
+        raise AssertionError("spawned despite no trusted lsof")
+
+    monkeypatch.setattr(pr.subprocess, "check_output", _never)
+    assert pr._listeners_on_port(5476) is None

--- a/test/test_port_reclaim_cov80.py
+++ b/test/test_port_reclaim_cov80.py
@@ -38,11 +38,15 @@ def test_listeners_posix_parses_and_dedupes_lsof_output(monkeypatch) -> None:
         return "1234\n1234\n5678\n\nnot-a-pid\n"
 
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(
+        pr.platform_compat, "trusted_system_bin", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(pr.subprocess, "check_output", _check_output)
 
     assert pr._listeners_on_port(5476) == [1234, 5678]
-    # The LISTEN filter matters: a client socket on the port is not a holder.
-    assert calls == [["lsof", "-ti", "TCP:5476", "-sTCP:LISTEN"]]
+    # The LISTEN filter matters: a client socket on the port is not a holder;
+    # the binary comes from the trusted system directories, never from PATH.
+    assert calls == [["/usr/bin/lsof", "-ti", "TCP:5476", "-sTCP:LISTEN"]]
 
 
 def test_listeners_posix_lsof_missing_returns_none(monkeypatch) -> None:
@@ -51,6 +55,9 @@ def test_listeners_posix_lsof_missing_returns_none(monkeypatch) -> None:
     def _boom(_cmd, **_kw):
         raise FileNotFoundError("lsof")
 
+    monkeypatch.setattr(
+        pr.platform_compat, "trusted_system_bin", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
     monkeypatch.setattr(pr.subprocess, "check_output", _boom)
     assert pr._listeners_on_port(5476) is None
@@ -62,6 +69,9 @@ def test_listeners_posix_wedged_lsof_returns_none(monkeypatch) -> None:
     def _timeout(_cmd, **_kw):
         raise subprocess.TimeoutExpired(cmd="lsof", timeout=5)
 
+    monkeypatch.setattr(
+        pr.platform_compat, "trusted_system_bin", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
     monkeypatch.setattr(pr.subprocess, "check_output", _timeout)
     assert pr._listeners_on_port(5476) is None
@@ -73,6 +83,9 @@ def test_listeners_posix_no_match_returns_empty_list(monkeypatch) -> None:
     def _nonzero(_cmd, **_kw):
         raise subprocess.CalledProcessError(returncode=1, cmd="lsof")
 
+    monkeypatch.setattr(
+        pr.platform_compat, "trusted_system_bin", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
     monkeypatch.setattr(pr.subprocess, "check_output", _nonzero)
     assert pr._listeners_on_port(5476) == []

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -293,7 +293,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # recorded, rendered through ``str()``. Nothing here is agent-influenced.
         "platform_compat.py::process_start_time",
         "apps/backend.py::_resolve_nvm_path",
-        "apps/backend.py::stop_app_backend",
         # py-spy attach for `kirocrew perf sample --pid`: fixed list-argv (no
         # shell=True), binary resolved via shutil.which rather than from input,
         # and every value is either a range-validated int (pid/seconds/rate) or a
@@ -950,7 +949,7 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "platform_compat.py::open_with_default_app",
         "platform_compat.py::_current_user_sid",
         "platform_compat.py::_posix_process_parent_map",
-        "platform_compat.py::find_listening_pids",
+        "platform_compat.py::find_port_listeners",
         "platform_compat.py::find_python_interpreter",
         "platform_compat.py::kill_pid",
         "platform_compat.py::kill_process_tree",


### PR DESCRIPTION
## Problem / Motivation

App-backend adoption identifies the process it takes over **by port alone, not by address**. `apps/backend.py` recorded owning PIDs from a port-wide probe (an inline PATH-resolved `lsof -ti :<port>`), which selects every LISTEN socket on the port regardless of local address. So if a healthy app backend holds `127.0.0.1:<port>` and an unrelated process holds a different local address on the same port, both PIDs are recorded at adoption, both survive the stop-path intersection, and `stop_app_backend` SIGTERMs/SIGKILLs both — even though the health probe only ever talked to `127.0.0.1:<port>`. Two processes binding one port on different local addresses is legal on both platforms, so no misconfiguration is needed to reach this.

## Why it matters

Stopping an app backend can terminate a process Kiro Crew never adopted and never health-checked — user data loss in whatever that process was doing. The two "obvious" narrowings do not work and are deliberately NOT implemented (per the issue): loopback-only ownership would refuse adoption of externally-managed `0.0.0.0`-bound backends (adoption's own use case), and refusing multiple PIDs would break pre-fork / multi-worker backends.

## What changed (motivation → approach → change)

Symptom → root cause: the shared port→PID helper `platform_compat.find_listening_pids` discards the local address, so no caller *can* scope ownership to the address it probed.

Approach: make the helper address-aware and give the adoption path the kernel's own dispatch semantics.

- **`platform_compat.find_port_listeners(port) -> list[PortListener(pid, address, family)]`** — POSIX asks `lsof -nP -iTCP:<port> -sTCP:LISTEN -Fptn` (field output; the `t` family field is load-bearing because lsof prints both wildcard binds as `*`); Windows keeps the existing `netstat -ano` parse, now retaining the local address and deriving family from the bracket form. Output shapes were verified empirically against real sockets (v4 loopback, v4 wildcard, v6-only wildcard, dual-stack, and the same-port v4+v6only pair).
- **`find_listening_pids` stays** as the address-agnostic accessor (thin wrapper), so `cli_server.py`, `gateway_lock.py`, `port_resolution.py`, and `port_reclaim.py`'s Windows arm keep their exact behaviour with zero call-site changes.
- **`loopback_owner_pids(listeners)`** mirrors most-specific-bind dispatch: exact `127.0.0.1` binds beat an IPv4 wildcard, which beats a dual-stack `::` — so an unrelated `IPV6_V6ONLY` wildcard next to the real v4 owner is never claimed, while `0.0.0.0`-bound and lone `[::]`-bound externally-managed backends still adopt. Multi-worker backends sharing a socket all land in one tier and are all recorded.
- **Adoption** (`apps/backend.py`) records `loopback_owner_pids(find_port_listeners(port))` together with each owner's `process_start_time` identity token, inside a consistency sandwich (health must still answer and the owner set must read back unchanged after capture, else adoption is refused); **stop** signals a recorded PID only when its live start time still positively matches that token — process identity, not a port/address heuristic, so every PID-recycling shape (same address, another local address, a v6-only wildcard, a non-listener) fails the match and is never signalled. This is the same PID-reuse convention the spawned-backend reap already uses, and the signal itself goes through a new `kill_pid_pinned` (single-process sibling of `kill_process_tree_pinned`), which on Windows holds the identity-verifying query handle open across the terminate so the PID cannot be recycled between the check and the `taskkill`.

Folded-in adjacent fixes on the same port→PID surface (from the issue):
1. `dashboard/port_reclaim.py` resolves `lsof` via `trusted_system_bin` instead of PATH (per AGENTS.md).
2. The POSIX branch now carries `timeout=5` (the Windows branch already had `timeout=10`), so a wedged `lsof` degrades to "no owner recorded" instead of hanging the adoption path.

AGENTS.md's cross-platform shim table row is updated in the same commit.

## Tests

- `test_platform_compat.py`: lsof `-Fptn` field parse (addresses + families, malformed `p`-lines, foreign-port rows), POSIX timeout pinned to the spawn kwargs, netstat address+family extraction, `address_covers_loopback` truth table (`::1` deliberately non-covering), and a `TestLoopbackOwnerPids` tier suite (exact-beats-wildcard, v4-wildcard-beats-v6only-wildcard, lone dual-stack adopts, multi-worker shares ownership, unknown-family falls through safely).
- `test_apps_backend_coverage.py`: adoption records only the probed-address owner (two PIDs, two addresses → one recorded) plus its start-time identity; the v6only-wildcard-beside-v4-owner scenario; refusal when only other-address listeners exist; the mid-capture TOCTOU sandwich (owner drift and health lapse each refuse adoption); stop-path identity revalidation (identity-verified PID signalled; recycled PID skipped with a warning even when it listens on the port; exited PID signals nothing; unreadable identity never signalled).
- `test_port_reclaim.py` / `test_port_reclaim_cov80.py`: lsof resolved from trusted dirs (argv pinned), tool-absent returns `None` with nothing spawned.
- `test_spawn_audit.py` allowlist updated: `stop_app_backend` no longer spawns; `find_port_listeners` is the spawn site.
- `prove.py` verdict: **PROVEN** (reverting the production hunks fails the new tests at assertion, not collection).

## Manual verification

lsof `-Fptn` output shapes were captured against real bound sockets on Linux, including the ambiguous same-port `0.0.0.0` + `IPV6_V6ONLY [::]` pair (`tIPv4`/`tIPv6` disambiguate two `*:port` rows). Full backend suite: 61819 passed; the 3 failures in `test_app_manager.py::TestMalformedMcpUrlIsSkippedNotFatal` reproduce identically on a clean `origin/main` worktree on this host (pre-existing, unrelated).

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no watched frontend path is touched and no rendered pixel changes.

## Related Issues

Closes #5261

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff



