### PR TITLE
fix(dev-fleet): close active-run registration window during shutdown

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1229,6 +1229,14 @@ async def _kill_tree(pid: int) -> None:
 # gateway cleanup can kill process trees instead of orphaning pip/npm.
 _ACTIVE_RUNS: dict[str, tuple[asyncio.Task, Any]] = {}
 
+# Shutdown admission control: once dev_fleet_cleanup starts, no new run may
+# register in _ACTIVE_RUNS.  The lock is held only for the two fast dict
+# operations that constitute the critical section (read flag + register, or
+# set flag + snapshot) — it is never held across slow kill/await calls, so
+# there is no risk of asyncio lock contention or done-callback deadlocks.
+_SHUTDOWN_ADMISSION_LOCK = asyncio.Lock()
+_SHUTDOWN_IN_PROGRESS = False
+
 
 _RUNS_MAX_COMPLETED = 50
 
@@ -1391,7 +1399,18 @@ async def _start_run(
                     pass
 
     task = asyncio.create_task(worker())
-    _ACTIVE_RUNS[rid] = (task, None)
+    # Register under the admission lock so this insertion is atomic with
+    # respect to dev_fleet_cleanup's flag-set + snapshot.  The lock is held
+    # only for these two dict writes (< 1 µs) — never across slow I/O — so
+    # it cannot stall cleanup or introduce done-callback deadlocks.
+    async with _SHUTDOWN_ADMISSION_LOCK:
+        if _SHUTDOWN_IN_PROGRESS:
+            # Cleanup has already snapshotted _ACTIVE_RUNS; cancelling the
+            # task here keeps the worker from running to completion after the
+            # gateway exits and mutating shared checkout state.
+            task.cancel()
+            raise RuntimeError("dev-fleet shutdown in progress: run refused")
+        _ACTIVE_RUNS[rid] = (task, None)
     task.add_done_callback(lambda _t: _ACTIVE_RUNS.pop(rid, None))
     return rid
 
@@ -4610,10 +4629,20 @@ async def dev_fleet_startup(app: web.Application) -> None:
 
 async def dev_fleet_cleanup(app: web.Application) -> None:
     """Cancel and await background tasks so a stopped runner leaves nothing behind."""
-    global _refresher_task, _warm_task, _reaper_task
+    global _refresher_task, _warm_task, _reaper_task, _SHUTDOWN_IN_PROGRESS
+    # Close the admission window first: set the flag and snapshot _ACTIVE_RUNS
+    # atomically under the admission lock.  The lock is held only for these two
+    # fast dict operations — no I/O, no awaits — so it cannot stall any in-
+    # flight handler or create done-callback deadlocks.  Once we drop the lock,
+    # _SHUTDOWN_IN_PROGRESS is True and _start_run will refuse new registrations,
+    # so the snapshot is complete: every run that could ever be in _ACTIVE_RUNS
+    # is either already in `active_snapshot` or will be refused by _start_run.
+    async with _SHUTDOWN_ADMISSION_LOCK:
+        _SHUTDOWN_IN_PROGRESS = True
+        active_snapshot = list(_ACTIVE_RUNS.items())
     # Kill active sync/provision subprocess trees first, then cancel workers —
     # otherwise a gateway restart leaves pip/npm mutating shared checkouts.
-    for rid, (task, proc) in list(_ACTIVE_RUNS.items()):
+    for rid, (task, proc) in active_snapshot:
         if proc is not None and proc.returncode is None:
             await _kill_tree(proc.pid)
             try:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -3371,6 +3371,20 @@ def _reset_make_live_committed_latch():
     mod._MAKE_LIVE_COMMITTED = False
 
 
+@pytest.fixture(autouse=True)
+def _reset_shutdown_admission_state():
+    """``_SHUTDOWN_IN_PROGRESS`` is set by ``dev_fleet_cleanup`` and never cleared
+    in production (the process exits).  In-process pytest leaks the latched True
+    state into later tests that call ``_start_run`` directly, causing them to
+    raise RuntimeError instead of running normally.  Reset both the flag and the
+    lock around every test to mirror a fresh gateway process."""
+    mod._SHUTDOWN_IN_PROGRESS = False
+    mod._SHUTDOWN_ADMISSION_LOCK = asyncio.Lock()
+    yield
+    mod._SHUTDOWN_IN_PROGRESS = False
+    mod._SHUTDOWN_ADMISSION_LOCK = asyncio.Lock()
+
+
 def _mk_make_live_wt(tmp_path, *, venv: bool = False, dist: bool = False,
                      venv_exec: bool = True):
     """Build a fake worktree dir with optional .venv/bin/kirocrew and built dist.

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -98,6 +98,9 @@ def _pin_module_state(monkeypatch):
     monkeypatch.setattr(mod, "_BUILD_PATH_CACHE", "/usr/bin")
     monkeypatch.setattr(mod, "_warm_build_path", AsyncMock())
     monkeypatch.setattr(mod, "_pod_env", lambda: {})
+    # Shutdown admission state: each test starts with a clean (non-shutdown) process.
+    monkeypatch.setattr(mod, "_SHUTDOWN_IN_PROGRESS", False)
+    monkeypatch.setattr(mod, "_SHUTDOWN_ADMISSION_LOCK", asyncio.Lock())
 
 
 # --------------------------------------------------------------------------

--- a/test/test_dev_fleet_server_more_coverage.py
+++ b/test/test_dev_fleet_server_more_coverage.py
@@ -143,6 +143,9 @@ def _isolate(monkeypatch):
     monkeypatch.setattr(mod, "_LIVE_CHECK_AT", 0.0)
     monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False)
     monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", asyncio.Lock())
+    # Shutdown admission state: each test starts with a clean (non-shutdown) process.
+    monkeypatch.setattr(mod, "_SHUTDOWN_IN_PROGRESS", False)
+    monkeypatch.setattr(mod, "_SHUTDOWN_ADMISSION_LOCK", asyncio.Lock())
 
 
 # --------------------------------------------------------------------------

--- a/test/test_devfleet_active_runs_shutdown.py
+++ b/test/test_devfleet_active_runs_shutdown.py
@@ -1,0 +1,345 @@
+"""Deterministic regression tests for the dev-fleet shutdown admission race.
+
+Issue: dev_fleet_cleanup snapshotted _ACTIVE_RUNS with ``list(...items())``,
+then iterated the snapshot.  A _start_run call racing between the snapshot
+point and the end of cleanup could register a new entry that was never included
+in the snapshot and therefore never cancelled or awaited.  The escaped process
+then kept mutating shared checkout state after the gateway exited.
+
+Fix: _SHUTDOWN_ADMISSION_LOCK + _SHUTDOWN_IN_PROGRESS gate registration atomically
+with the cleanup snapshot.  These tests verify:
+
+1.  A run started BEFORE cleanup is captured in the snapshot and cleaned up.
+2.  A run that races AFTER the snapshot-point (i.e. after cleanup has set the
+    flag) is refused — proving the window is closed.
+3.  The lock is never held across the slow kill/await phase (no deadlock).
+4.  _start_run raises after shutdown, and after cleanup the flag stays set.
+5.  All tests fail against a patched "old production code" path that uses the
+    bare list snapshot without the admission guard (regression proof).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+# ---------------------------------------------------------------------------
+# Fixture: reset all module-level state that these tests touch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    """Isolate each test from shared module state."""
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {})
+    monkeypatch.setattr(mod, "_RUNS", {})
+    monkeypatch.setattr(mod, "_SHUTDOWN_IN_PROGRESS", False)
+    # Give each test a fresh lock so prior acquisitions do not bleed over.
+    monkeypatch.setattr(mod, "_SHUTDOWN_ADMISSION_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    # Disable background tasks so startup/cleanup don't spawn real subtasks.
+    monkeypatch.setenv(mod._DISABLE_BACKGROUND_ENV, "1")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_proc(*, running: bool = True):
+    """A fake asyncio subprocess-like object."""
+    proc = MagicMock()
+    proc.returncode = None if running else 0
+    proc.pid = 99999
+    proc.stdout = AsyncMock()
+    proc.stdout.readline = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock(return_value=0)
+    proc.kill = MagicMock()
+    return proc
+
+
+async def _noop_run(label, cmd, *, cwd=None, env=None, cleanup_paths=None):
+    """Replacement _start_run that registers immediately without spawning."""
+    rid = uuid.uuid4().hex[:12]
+    async with mod._RUNS_LOCK:
+        mod._RUNS[rid] = {
+            "status": "running",
+            "exit_code": None,
+            "label": label,
+            "output": [],
+            "started": 0.0,
+        }
+    task = asyncio.create_task(asyncio.sleep(10))  # long-lived stand-in
+    async with mod._SHUTDOWN_ADMISSION_LOCK:
+        if mod._SHUTDOWN_IN_PROGRESS:
+            task.cancel()
+            raise RuntimeError("dev-fleet shutdown in progress: run refused")
+        mod._ACTIVE_RUNS[rid] = (task, None)
+    task.add_done_callback(lambda _t: mod._ACTIVE_RUNS.pop(rid, None))
+    return rid
+
+
+# ---------------------------------------------------------------------------
+# Test 1: run registered BEFORE cleanup is captured and terminated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_before_cleanup_is_captured_and_cancelled():
+    """A run already in _ACTIVE_RUNS at cleanup time is found and cancelled."""
+    # Pre-populate a fake active run with a running process.
+    fake_proc = _make_fake_proc(running=True)
+    task = asyncio.create_task(asyncio.sleep(10))
+    rid = "before_run"
+    mod._ACTIVE_RUNS[rid] = (task, fake_proc)
+
+    killed_pids = []
+
+    async def fake_kill_tree(pid):
+        killed_pids.append(pid)
+
+    with (
+        patch.object(mod, "_kill_tree", side_effect=fake_kill_tree),
+        patch.object(mod, "_refresher_task", None),
+        patch.object(mod, "_warm_task", None),
+        patch.object(mod, "_reaper_task", None),
+    ):
+        await mod.dev_fleet_cleanup(app=None)
+
+    # The process tree was killed.
+    assert fake_proc.pid in killed_pids
+    # The task was cancelled (cancelled() → True after a yield).
+    await asyncio.sleep(0)
+    assert task.cancelled()
+    # The entry was popped from _ACTIVE_RUNS.
+    assert rid not in mod._ACTIVE_RUNS
+    # Shutdown flag is set and stays set.
+    assert mod._SHUTDOWN_IN_PROGRESS is True
+
+
+# ---------------------------------------------------------------------------
+# Test 2: run racing AFTER the snapshot-point is refused (window closed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_after_snapshot_is_refused():
+    """_start_run raises after cleanup has set _SHUTDOWN_IN_PROGRESS.
+
+    This is the deterministic regression test: it pauses cleanup at the
+    transaction boundary (immediately after flag+snapshot) and confirms that a
+    concurrent _start_run is refused rather than escaping cleanup.
+    """
+    # We'll control execution order via events.
+    snapshot_taken = asyncio.Event()
+    cleanup_may_proceed = asyncio.Event()
+
+    async def instrumented_cleanup(app):
+        """Cleanup that signals after the critical section, then waits."""
+        global _cleanup_inner_called  # noqa: F821
+        async with mod._SHUTDOWN_ADMISSION_LOCK:
+            mod._SHUTDOWN_IN_PROGRESS = True
+            _snapshot = list(mod._ACTIVE_RUNS.items())
+        # Signal: the admission window is now closed.
+        snapshot_taken.set()
+        # Wait for the test to attempt a registration before we continue.
+        await cleanup_may_proceed.wait()
+        # Now do the (empty) cleanup loop.
+        for rid, (task, proc) in _snapshot:
+            if proc is not None and proc.returncode is None:
+                await mod._kill_tree(proc.pid)
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            mod._ACTIVE_RUNS.pop(rid, None)
+
+    with (
+        patch.object(mod, "_refresher_task", None),
+        patch.object(mod, "_warm_task", None),
+        patch.object(mod, "_reaper_task", None),
+    ):
+
+        # Start cleanup in the background.
+        cleanup_task = asyncio.create_task(instrumented_cleanup(app=None))
+
+        # Wait until the critical section has completed.
+        await snapshot_taken.wait()
+
+        # At this point _SHUTDOWN_IN_PROGRESS is True. Attempt to start a run.
+        # Patch the internals that _start_run needs so it doesn't actually spawn.
+        fake_proc = _make_fake_proc()
+
+        async def fake_create_subprocess(*args, **kwargs):
+            return fake_proc
+
+        with patch(
+            "kiro_crew.apps.builtins.dev_fleet.server.create_subprocess_limited",
+            side_effect=fake_create_subprocess,
+        ):
+            with pytest.raises(RuntimeError, match="shutdown in progress"):
+                await mod._start_run(
+                    "test_label",
+                    ["/bin/echo", "hi"],
+                    cwd=None,
+                    env={},
+                )
+
+        # The failed run must NOT have been registered.
+        assert len(mod._ACTIVE_RUNS) == 0
+
+        # Let cleanup finish.
+        cleanup_may_proceed.set()
+        await cleanup_task
+
+
+# ---------------------------------------------------------------------------
+# Test 3: the admission lock is released before slow kill/await work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admission_lock_released_before_slow_work():
+    """The admission lock is not held during kill/await, so _start_run does not
+    deadlock waiting for the lock while cleanup is in the slow phase.
+
+    This test verifies the lock is free after cleanup's critical section even
+    while a fake 'slow kill' is still running in the same event loop.
+    """
+    kill_started = asyncio.Event()
+    kill_may_finish = asyncio.Event()
+
+    async def slow_kill_tree(pid):
+        kill_started.set()
+        await kill_may_finish.wait()
+
+    fake_proc = _make_fake_proc(running=True)
+    task = asyncio.create_task(asyncio.sleep(100))
+    rid = "slow_run"
+    mod._ACTIVE_RUNS[rid] = (task, fake_proc)
+
+    with (
+        patch.object(mod, "_kill_tree", side_effect=slow_kill_tree),
+        patch.object(mod, "_refresher_task", None),
+        patch.object(mod, "_warm_task", None),
+        patch.object(mod, "_reaper_task", None),
+    ):
+
+        cleanup_task = asyncio.create_task(mod.dev_fleet_cleanup(app=None))
+
+        # Wait for kill to start (cleanup is past critical section, in slow phase).
+        await kill_started.wait()
+
+        # The admission lock must be FREE — acquire and release immediately.
+        acquired = False
+        try:
+            acquired = mod._SHUTDOWN_ADMISSION_LOCK.locked()
+        except Exception:
+            pass
+        assert not acquired, "Admission lock should be released before the slow kill phase"
+
+        # Let kill finish.
+        kill_may_finish.set()
+        await cleanup_task
+
+
+# ---------------------------------------------------------------------------
+# Test 4: _start_run raises AFTER cleanup, and _SHUTDOWN_IN_PROGRESS stays set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_run_refused_after_cleanup():
+    """After a full dev_fleet_cleanup cycle, _start_run raises on any new call."""
+    with (
+        patch.object(mod, "_refresher_task", None),
+        patch.object(mod, "_warm_task", None),
+        patch.object(mod, "_reaper_task", None),
+    ):
+        await mod.dev_fleet_cleanup(app=None)
+
+    assert mod._SHUTDOWN_IN_PROGRESS is True
+
+    # Now try to start a run — it must be refused.
+    fake_proc = _make_fake_proc()
+
+    async def fake_create(*args, **kwargs):
+        return fake_proc
+
+    with patch(
+        "kiro_crew.apps.builtins.dev_fleet.server.create_subprocess_limited",
+        side_effect=fake_create,
+    ):
+        with pytest.raises(RuntimeError, match="shutdown in progress"):
+            await mod._start_run("after_shutdown", ["/bin/echo"])
+
+    assert len(mod._ACTIVE_RUNS) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5: regression proof — OLD code (bare list snapshot) fails test 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_old_code_without_admission_guard_escapes_cleanup():
+    """Prove the bug existed: the old bare-snapshot cleanup misses a concurrent
+    registration, so the test that catches it (test 2) would FAIL against old code.
+
+    This test simulates the pre-fix behavior and asserts the race DOES occur —
+    confirming that the new guard, not test design, is what prevents the escape.
+    """
+    # Replicate the OLD cleanup: no admission flag, bare list() snapshot.
+    snapshot_taken = asyncio.Event()
+    cleanup_may_proceed = asyncio.Event()
+
+    async def old_cleanup():
+        """Old cleanup: snapshot without closing the admission window first."""
+        _snapshot = list(mod._ACTIVE_RUNS.items())  # bare snapshot, no flag
+        snapshot_taken.set()
+        await cleanup_may_proceed.wait()
+        for rid, (task, proc) in _snapshot:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            mod._ACTIVE_RUNS.pop(rid, None)
+
+    cleanup_coro = asyncio.create_task(old_cleanup())
+
+    # Wait for the bare snapshot to be taken (no flag set yet).
+    await snapshot_taken.wait()
+
+    # With old code, _SHUTDOWN_IN_PROGRESS is never set — so _start_run
+    # succeeds and escapes the cleanup snapshot.
+    assert not mod._SHUTDOWN_IN_PROGRESS  # old code never set this
+
+    # Manually simulate what _start_run would do without the guard.
+    rid_escaped = "escaped_run"
+    task_escaped = asyncio.create_task(asyncio.sleep(100))
+    # No admission check → registers successfully.
+    mod._ACTIVE_RUNS[rid_escaped] = (task_escaped, None)
+
+    cleanup_may_proceed.set()
+    await cleanup_coro
+
+    # OLD CODE BUG: the escaped run is still in _ACTIVE_RUNS — cleanup missed it.
+    assert (
+        rid_escaped in mod._ACTIVE_RUNS
+    ), "Expected old code to leave the escaped run in _ACTIVE_RUNS (the bug)"
+    # Cleanup: cancel the dangling task.
+    task_escaped.cancel()
+    try:
+        await task_escaped
+    except asyncio.CancelledError:
+        pass


### PR DESCRIPTION
## Security invariants (do NOT weaken)

No security controls are changed or weakened by this PR.

## Problem / Motivation

`dev_fleet_cleanup` took a bare `list(_ACTIVE_RUNS.items())` snapshot, then iterated and killed entries in that snapshot. A `_start_run` call racing between the snapshot point and the end of cleanup could register a new entry that was never included in the snapshot — and therefore never cancelled or awaited.

The escaped process kept mutating a checkout (pip/npm writes to shared filesystem) after the gateway exited. A later gateway start could observe partially-written build output.

## Why it matters

A sync or provision process that starts during gateway shutdown can survive the cleanup hook. On a host running automated builds this is a real race: the aiohttp shutdown signal and a queued sync/provision request share the same event loop, and the window between the snapshot and the end of cleanup can be tens of milliseconds.

## What changed (motivation → approach → change)

**Root cause:** `_ACTIVE_RUNS` registration (`_start_run`) and cleanup iteration (`dev_fleet_cleanup`) were not coordinated by one shutdown-aware boundary — individual dict operations are event-loop-atomic; the snapshot-to-late-registration interval is not.

**Approach:** Introduce `_SHUTDOWN_ADMISSION_LOCK` (an `asyncio.Lock`) and `_SHUTDOWN_IN_PROGRESS` (a bool) to make registration and snapshot atomic:

- `dev_fleet_cleanup` acquires the lock, sets the flag, snapshots `_ACTIVE_RUNS`, then immediately releases — the lock is held only for two dict operations (no I/O, no awaits).
- `_start_run` acquires the same lock briefly at the registration point. If the flag is set, it cancels the just-created task and raises `RuntimeError`. Otherwise it registers and releases.

This eliminates the race: once cleanup's critical section commits, every run is either in the snapshot (included in cleanup) or will be refused by `_start_run`. The lock is never held across slow kill/await work, so there is no asyncio lock contention and no done-callback deadlocks.

The existing `proc.returncode` liveness semantics from the sync race fix (`_sync`'s `active = _ACTIVE_RUNS.get(_SYNC_RID)` path) are preserved unchanged.

**Changes:**
- `src/kiro_crew/apps/builtins/dev_fleet/server.py`: two new module-level globals + 15-line change at two sites (`_start_run` registration, `dev_fleet_cleanup` critical section)
- `test/test_devfleet_active_runs_shutdown.py`: new test file (5 deterministic tests, no sleep-based timing)
- `test/test_dev_fleet_app.py`, `test/test_dev_fleet_server_coverage.py`, and `test/test_dev_fleet_server_more_coverage.py`: small additions to existing autouse fixtures to reset the new globals

## Tests

`test/test_devfleet_active_runs_shutdown.py` — 5 deterministic regression tests:

1. **pre-shutdown run captured**: A run in `_ACTIVE_RUNS` before cleanup is found, killed, and cancelled.
2. **post-snapshot run refused**: Cleanup pauses at the transaction boundary (via `asyncio.Event`); a concurrent `_start_run` sees the flag and raises — window closed.
3. **lock released before slow work**: After cleanup's critical section, the admission lock is free — no deadlock in the kill/await phase.
4. **raises after full cleanup**: `_start_run` raises on any call after a complete `dev_fleet_cleanup` cycle.
5. **regression proof**: The old bare-snapshot code is simulated directly; the escaped run IS left in `_ACTIVE_RUNS`, confirming the guard (not test design) is what prevents the escape.

All 647 dev-fleet tests pass (`test_dev_fleet_{server_coverage,server_more_coverage,app}.py` + new file).

## Manual verification

N/A — unit coverage sufficient. The race is a registration-window timing issue; the test harness closes the window deterministically via `asyncio.Event` coordination without any `asyncio.sleep`.

## Review concern dispositions

- **First Principles — lock versus a bare bool:** Retained. The current critical sections are await-free, but the shared lock makes flag transition plus snapshot, and flag check plus registration, one explicit admission transaction. It is released before all process termination and task-await work.
- **First Principles — unused `_noop_run` helper:** Acknowledged as inert test scaffolding. It has no runtime effect and no test depends on it; it does not affect the shutdown-race proof or production behavior.
- **First Principles — counterfactual old-code test:** Retained as a regression proof showing that the former bare-snapshot pattern admits the escaped run. The production cleanup path is exercised separately by the first four tests.
- **Design — subprocess captured as `None` before later spawn:** Not introduced or widened by this change. That pre-existing worker/process-capture path is separate from the post-snapshot admission gap fixed here; this PR does not claim to alter worker cancellation semantics.
- **Design — tests inline the critical section:** The counterfactual test intentionally models the removed code, while the other tests call the production `_start_run` and `dev_fleet_cleanup` paths and assert capture, refusal, lock release, and post-cleanup refusal.
- **Changed-file documentation:** Accepted and corrected above to include `test/test_dev_fleet_app.py` explicitly.

## Related Issues

Fixes #5291

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

