### PR TITLE
fix(dev-fleet): revalidate make-live artifacts inside the cutover lock

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -5628,29 +5628,52 @@ async def _make_live(path: str, dry_run: bool = False,
         )}
 
     kcbin = real / ".venv" / "bin" / "kirocrew"
-    if not kcbin.is_file():
-        return {"ok": False, "code": "missing_venv", "error": (
-            f"{real.name} has no .venv/bin/kirocrew — Provision it first "
-            "(row menu \u2192 Provision) before making it live"
-        )}
-    # A present-but-non-executable binary is worse than a missing one: the
-    # drop-in gets written and the old gateway is stopped, but the replacement
-    # can never start (systemd ExecStart requires +x) — leaving NO gateway
-    # running. Gate on the exec bit with a DISTINCT, actionable code.
-    if not os.access(kcbin, os.X_OK):
-        return {"ok": False, "code": "venv_not_executable", "error": (
-            f"{real.name} has a non-executable .venv/bin/kirocrew — run "
-            "`chmod +x` on it or re-Provision the worktree before making it "
-            "live (a non-executable binary stops the live gateway but cannot "
-            "start the replacement, leaving no gateway running)"
-        )}
     dist_index = real / "src" / "kiro_crew" / "static" / "dist" / "index.html"
-    if not dist_index.is_file():
-        return {"ok": False, "code": "missing_dist", "error": (
-            f"{real.name} has no built dashboard "
-            "(src/kiro_crew/static/dist/index.html) — run Pull+Build first; "
-            "cutover without a built dist serves a broken dashboard"
-        )}
+
+    def _validate_artifacts_sync() -> tuple[str, str] | None:
+        """Check the CLI binary and built dist on the executor thread.
+
+        Returns ``(code, error)`` when a required artifact is absent or
+        non-executable, ``None`` when both are present and the binary is
+        executable.  Running off the event loop prevents a slow or
+        network-backed filesystem from stalling all gateway requests.
+        """
+        if not kcbin.is_file():
+            return ("missing_venv", (
+                f"{real.name} has no .venv/bin/kirocrew — Provision it first "
+                "(row menu \u2192 Provision) before making it live"
+            ))
+        # A present-but-non-executable binary is worse than a missing one: the
+        # drop-in gets written and the old gateway is stopped, but the
+        # replacement can never start (systemd ExecStart requires +x) — leaving
+        # NO gateway running.  Gate on the exec bit with a DISTINCT, actionable
+        # code.
+        if not os.access(kcbin, os.X_OK):
+            return ("venv_not_executable", (
+                f"{real.name} has a non-executable .venv/bin/kirocrew — run "
+                "`chmod +x` on it or re-Provision the worktree before making "
+                "it live (a non-executable binary stops the live gateway but "
+                "cannot start the replacement, leaving no gateway running)"
+            ))
+        if not dist_index.is_file():
+            return ("missing_dist", (
+                f"{real.name} has no built dashboard "
+                "(src/kiro_crew/static/dist/index.html) — run Pull+Build "
+                "first; cutover without a built dist serves a broken dashboard"
+            ))
+        return None
+
+    # Early probe: surface an obvious missing-artifact error before reaching
+    # the plan or the lock.  Not authoritative — a concurrent provision or
+    # rebuild can change these artifacts between this check and the cutover
+    # lock below.  The authoritative re-validation happens inside the lock.
+    _loop = asyncio.get_running_loop()
+    artifact_err = await _loop.run_in_executor(
+        subprocess_executor(), _validate_artifacts_sync
+    )
+    if artifact_err is not None:
+        code, msg = artifact_err
+        return {"ok": False, "code": code, "error": msg}
 
     try:
         plan = _make_live_plan(real, kcbin, svc=svc if can_restart else None,
@@ -5693,6 +5716,16 @@ async def _make_live(path: str, dry_run: bool = False,
                 "a cutover has been scheduled; the gateway is restarting — "
                 "retry after it comes back"
             )}
+        # Re-validate artifacts inside the lock: a concurrent provision or
+        # rebuild may have changed the binary or dist between the early probe
+        # above and now.  The cutover commits the exact state on disk at this
+        # moment, so these are the artifacts it actually stages.
+        artifact_err = await _loop.run_in_executor(
+            subprocess_executor(), _validate_artifacts_sync
+        )
+        if artifact_err is not None:
+            code, msg = artifact_err
+            return {"ok": False, "code": code, "error": msg}
         # Snapshot the prior live target BEFORE staging so a failed cutover can
         # be rolled back — a persisted pointer would otherwise silently activate
         # on the NEXT unrelated restart. Staging itself is atomic (temp file +

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -9020,3 +9020,124 @@ async def test_gateway_start_id_foreground_fallback(monkeypatch, tmp_path):
          patch.object(mod, "shutil",
                       MagicMock(which=MagicMock(return_value=None))):
         assert await mod._gateway_start_id() is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: make-live artifact validation inside the cutover lock
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@_POSIX_ONLY
+async def test_make_live_artifact_changed_before_lock_is_revalidated(
+    monkeypatch, tmp_path
+):
+    """Artifacts that are valid at early-probe time but gone before the lock
+    is acquired are caught by the in-lock re-validation.
+
+    A side-effecting lock wrapper removes the venv binary at the instant the
+    lock is acquired, reproducing a concurrent provision that replaces the
+    binary between the early check and the commit.  The cutover must refuse
+    with ``missing_venv`` and must NOT write the pointer.
+
+    Without the production fix the early probe passes, the lock is acquired,
+    and the cutover proceeds to write the pointer and stage a restart — the
+    stale validation is never repeated and the race window is not closed.
+    This test proves the ordering by observing the final response code and
+    the pointer-file state.
+    """
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    _stub_make_live(monkeypatch, wt, pointer_dir=ptr_dir)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False)
+
+    kcbin = wt / ".venv" / "bin" / "kirocrew"
+
+    # Wrap _MAKE_LIVE_LOCK so that entering the lock removes the binary,
+    # simulating a concurrent rebuild that completes between the early probe
+    # and the lock-acquire.
+    real_lock = asyncio.Lock()
+
+    class _SideEffectLock:
+        """Proxy that removes *kcbin* when the lock body is entered."""
+
+        def locked(self) -> bool:
+            return real_lock.locked()
+
+        async def __aenter__(self):
+            await real_lock.__aenter__()
+            # Binary vanishes at the moment the lock body begins.
+            kcbin.unlink(missing_ok=True)
+            return self
+
+        async def __aexit__(self, *args):
+            return await real_lock.__aexit__(*args)
+
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", _SideEffectLock())
+
+    res = await mod._make_live(str(wt), dry_run=False)
+
+    assert res["ok"] is False, (
+        "cutover must be refused when the binary disappears inside the lock; "
+        "got ok=True — the in-lock re-validation is absent or not running"
+    )
+    assert res["code"] == "missing_venv", (
+        f"expected missing_venv from in-lock re-validation, got {res.get('code')!r}"
+    )
+    ptr_file = ptr_dir / "live_target.json"
+    assert not ptr_file.exists(), (
+        "the live-target pointer must NOT be written when in-lock re-validation fails"
+    )
+
+
+@pytest.mark.asyncio
+@_POSIX_ONLY
+async def test_make_live_artifact_checks_are_executor_offloaded(
+    monkeypatch, tmp_path
+):
+    """The artifact filesystem checks (``is_file`` / ``os.access``) are
+    submitted to ``loop.run_in_executor`` rather than called inline on the
+    event loop, preventing a slow or network-backed filesystem from stalling
+    all Dev Fleet requests.
+
+    The test wraps ``subprocess_executor()`` to record every callable submitted
+    via ``loop.run_in_executor``.  A helper named ``_validate_artifacts_sync``
+    must be submitted at least twice — once for the early probe and once for
+    the in-lock re-validation — proving the checks are offloaded.
+
+    Without the production fix, the checks are plain synchronous expressions
+    (``kcbin.is_file()``, ``os.access()``, ``dist_index.is_file()``) executed
+    inline; no callable named ``_validate_artifacts_sync`` is ever submitted.
+    """
+    wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
+    ptr_dir = tmp_path / "ptr"
+    _stub_make_live(monkeypatch, wt, pointer_dir=ptr_dir)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_COMMITTED", False)
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", asyncio.Lock())
+
+    submitted_qualnames: list[str] = []
+
+    # Intercept every run_in_executor call by wrapping the event loop's method.
+    # asyncio.get_running_loop() inside _make_live returns the SAME object that
+    # asyncio.get_event_loop() returns under pytest-asyncio's per-test loop.
+    # We patch the loop object's method directly so the intercept is in place
+    # when _make_live calls loop.run_in_executor(…).
+    running_loop = asyncio.get_running_loop()
+    real_run_in_executor = running_loop.run_in_executor
+
+    async def _recording_run_in_executor(executor, fn, *args):
+        submitted_qualnames.append(fn.__qualname__)
+        return await real_run_in_executor(executor, fn, *args)
+
+    monkeypatch.setattr(running_loop, "run_in_executor", _recording_run_in_executor)
+
+    await mod._make_live(str(wt), dry_run=False)
+
+    validate_submissions = [
+        q for q in submitted_qualnames if "_validate_artifacts_sync" in q
+    ]
+    assert len(validate_submissions) >= 2, (
+        "artifact validation must be submitted to the executor at least twice "
+        "(early probe + in-lock re-validation); "
+        f"all submitted callables: {submitted_qualnames!r}.  "
+        "Zero entries means the checks are still inline on the event loop."
+    )


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Make Live validates the CLI binary (`.venv/bin/kirocrew`) and the built frontend
(`static/dist/index.html`) with synchronous `is_file` / `os.access` calls that
run outside the final single-flight cutover lock, directly on the asyncio event
loop.

## Why it matters

Two independent failure modes:

1. **TOCTOU race.** A concurrent provision or rebuild can replace the venv or dist
   bundle after the checks pass but before the lock is acquired. The cutover then
   commits a pointer to a worktree whose artifacts are in mid-rebuild — the
   gateway restarts into a broken state.
2. **Event-loop stall.** On a slow or network-backed filesystem the inline
   `is_file` / `os.access` calls block all Dev Fleet requests — including health
   polling — for the duration of the I/O. This has been observed to stall the
   whole gateway until the filesystem recovers.

## What changed (motivation → approach → change)

Root cause: `kcbin.is_file()`, `os.access(kcbin, os.X_OK)`, and
`dist_index.is_file()` were three consecutive synchronous expressions on the event
loop, placed between two `_MAKE_LIVE_LOCK` sections rather than inside the final
one.

Fix: introduce `_validate_artifacts_sync` — a synchronous closure over the two
artifact paths — and submit it to `subprocess_executor()` via
`loop.run_in_executor()` twice:

1. **Early probe** (before `_make_live_plan` and the lock): surfaces an obvious
   missing-artifact error quickly for the common case. Not authoritative — a
   concurrent rebuild can still change the artifacts in the window between this
   check and the lock.
2. **Authoritative in-lock re-validation** (inside `async with _MAKE_LIVE_LOCK`,
   after the committed-latch check): validates the exact artifacts the cutover is
   about to stage. This closes the TOCTOU window.

The executor offload applies to both calls, keeping the event loop responsive
regardless of filesystem latency.

Cancel and dry-run paths are unchanged: dry-run exits before reaching the lock,
and cancel takes a separate `same_as_running` code path that was already
executor-offloaded.

## Tests

- **`test_make_live_artifact_changed_before_lock_is_revalidated`** — a
  side-effecting lock wrapper removes the venv binary at lock-entry time,
  reproducing a concurrent rebuild. Asserts the cutover refuses with
  `missing_venv` and does not write the pointer. Fails without the fix (pre-fix
  code never re-validates inside the lock; the cutover completes on stale data).
- **`test_make_live_artifact_checks_are_executor_offloaded`** — intercepts
  `loop.run_in_executor` on the running loop and records submitted callable names.
  Asserts `_validate_artifacts_sync` appears at least twice (early probe +
  in-lock). Fails without the fix (checks are inline on the event loop; no
  `_validate_artifacts_sync` is ever submitted).

Both tests are `_POSIX_ONLY` (skipped on Windows), matching the POSIX-only
make-live semantics already in the test file.

## Manual verification

N/A — unit coverage sufficient. The fix touches no UI surface and has no
integration-level dependency; the behavioral invariant (refuse when artifacts
are invalid, proceed when valid) is fully covered by the existing 33 make-live
tests plus the two new regression tests.

<!-- no-visual-delta -->
**Why no screenshot:** Pure backend fix with no user-visible UI change; the
diff touches only `server.py` and `test_dev_fleet_app.py`.

## Related Issues

Fixes #5290

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(dev-fleet): revalidate make-live artifacts inside the cutover lock`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
