### PR TITLE
fix(dev-fleet): invalidate merged PR cache when branch head changes

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1450,7 +1450,7 @@ async def _pr_query_one(owner_repo: str, branch: str) -> dict | None:
     # dropped from the payload by _redact_pr (which skips `_`-prefixed keys).
     rc, stdout, _ = await _run_cmd(
         ["gh", "pr", "list", "--repo", owner_repo, "--head", branch,
-         "--json", "number,state,url,isDraft,title,body", "--state", "all", "--limit", "1"],
+         "--json", "number,state,url,isDraft,title,body,headRefOid", "--state", "all", "--limit", "1"],
         timeout=15,
     )
     if rc != 0:
@@ -1462,6 +1462,7 @@ async def _pr_query_one(owner_repo: str, branch: str) -> dict | None:
         return None
     if pr is not None:
         pr["_repo"] = owner_repo
+        pr["_head_oid"] = pr.pop("headRefOid", None)
         if "body" in pr:
             pr["_body"] = pr.pop("body") or ""
     return pr
@@ -1529,8 +1530,17 @@ async def _fetch_pr_head_oid(branch: str, repo: str | None = None) -> str | None
         return None
 
 
-async def _pr_status_cached(branch: str) -> dict | None:
-    """Return cached PR status for a branch."""
+async def _pr_status_cached(branch: str, head_oid: str | None = None) -> dict | None:
+    """Return cached PR status for a branch.
+
+    *head_oid* is the full current worktree HEAD commit.  When provided and
+    the cached entry records a MERGED verdict whose stored head OID
+    differs from *head_oid*, the entry is treated as stale and a fresh lookup is
+    performed.  This prevents a permanently-cached MERGED result from surviving
+    a branch name being reused for a new head commit.  Callers that do not have
+    the head OID readily available may omit *head_oid*; the cache then degrades
+    to the previous behaviour (MERGED is terminal, non-MERGED expires via TTL).
+    """
     if not branch or branch == BASE_BRANCH:
         return None
     now = time.time()
@@ -1539,10 +1549,37 @@ async def _pr_status_cached(branch: str) -> dict | None:
         # Only MERGED is permanently terminal — a CLOSED PR can be reopened,
         # so its cache entry must expire via the normal TTL.
         is_terminal = (ent.get("data") or {}).get("state") == "MERGED"
-        if is_terminal or (now - ent["ts"]) < _PR_TTL:
+        if is_terminal:
+            # Invalidate a MERGED entry when the caller supplies a head OID
+            # that differs from the one recorded at cache-write time.  A changed
+            # head means the branch was reused for new work; the old MERGED
+            # verdict no longer describes the current commits.
+            cached_head = ent.get("cached_head")
+            if head_oid and cached_head != head_oid:
+                # Head changed (or entry was written without a head OID) —
+                # fall through to a fresh fetch below.
+                pass
+            else:
+                return ent.get("data")
+        elif (now - ent["ts"]) < _PR_TTL:
             return ent.get("data")
     data = await _fetch_pr_status(branch)
-    _PR_CACHE[branch] = {"data": data, "ts": time.time()}
+    if (
+        data
+        and data.get("state") == "MERGED"
+        and head_oid
+        and data.get("_head_oid") != head_oid
+    ):
+        # GitHub may return the old merged PR when a branch name is reused
+        # before a replacement PR exists. A local head contained in the PR
+        # head is still fully shipped (for example, remote commits landed
+        # before merge); only a divergent head means this verdict is stale.
+        pr_head_oid = data.get("_head_oid")
+        if not pr_head_oid or not await _head_contained_in_pr(
+            _repo(), head_oid, pr_head_oid
+        ):
+            data = None
+    _PR_CACHE[branch] = {"data": data, "ts": time.time(), "cached_head": head_oid}
     return data
 
 
@@ -1889,11 +1926,13 @@ async def _git(
 
 async def _git_info(path: str) -> dict:
     info: dict = {
-        "branch": None, "head": None, "dirty": False,
+        "branch": None, "head": None, "head_oid": None, "dirty": False,
         "ahead": 0, "behind": 0, "last_updated_at": None,
     }
     info["branch"] = await _git(path, "rev-parse", "--abbrev-ref", "HEAD")
-    info["head"] = await _git(path, "rev-parse", "--short=7", "HEAD")
+    full_head = await _git(path, "rev-parse", "HEAD")
+    info["head_oid"] = full_head
+    info["head"] = full_head[:7] if full_head else None
     st = await _git(path, "status", "--porcelain")
     if st is not None:
         info["dirty"] = len(st) > 0
@@ -2171,7 +2210,7 @@ async def _build_fleet() -> dict:
         branch = wt.get("branch")
         is_main = wt.get("is_main", False)
         g = await _git_info(path)
-        pr = (await _pr_status_cached(branch)) if branch else None
+        pr = (await _pr_status_cached(branch, g.get("head_oid"))) if branch else None
         name = Path(path).name if not is_main else BASE_BRANCH
 
         # Pod status (best-effort)
@@ -2330,7 +2369,7 @@ async def _worktree_detail(name: str) -> dict:
     branch = wt.get("branch")
     is_main = wt.get("is_main", False)
     g = await _git_info(path)
-    pr = (await _pr_status_cached(branch)) if branch else None
+    pr = (await _pr_status_cached(branch, g.get("head_oid"))) if branch else None
     own_commits = await _own_commits_count(path)
 
     remote = await _upstream_remote()
@@ -2951,7 +2990,8 @@ async def _worktree_remove(
                 if dirty else "cannot verify worktree state (git status failed)"
             )}
 
-    pr = (await _pr_status_cached(branch)) if branch else None
+    _rm_head_oid = (await _git(path, "rev-parse", "HEAD")) if branch else None
+    pr = (await _pr_status_cached(branch, _rm_head_oid)) if branch else None
     own = await _own_commits_count(path)
 
     if not force and not _is_pr_merged(pr):
@@ -3882,7 +3922,10 @@ async def _prunable(path: str, branch: str | None) -> dict:
     The race guard in _worktree_remove handles the edge case of commits pushed
     after the PR was merged by comparing branch OID to the PR's headRefOid.
     """
-    pr = (await _pr_status_cached(branch)) if branch else None
+    # Resolve the full HEAD once so cache invalidation cannot alias distinct
+    # commits that share an abbreviated prefix. Reuse it for the merge guard.
+    head_oid = (await _git(path, "rev-parse", "HEAD")) if branch else None
+    pr = (await _pr_status_cached(branch, head_oid)) if branch else None
     own = await _own_commits_count(path)
     dirty = await _real_dirty(path)
     try:
@@ -3898,14 +3941,13 @@ async def _prunable(path: str, branch: str | None) -> dict:
         # Same squash-safe race guard removal enforces: commits pushed AFTER
         # the merge mean the branch OID diverged from the PR head — surface it
         # at preview time instead of letting the candidate fail every run.
-        oid = await _git(path, "rev-parse", "HEAD")
         pr_oid = await _fetch_pr_head_oid(branch, repo=(pr or {}).get("_repo")) if branch else None
-        if not oid or not pr_oid:
+        if not head_oid or not pr_oid:
             # Cannot verify the squash-safe guard: removal would refuse this
             # anyway, so never present it as a candidate (fail-closed verdict
             # keeps preview and execution consistent).
             return {**base, "ok": False, "code": "merged_unverified"}
-        if not await _head_contained_in_pr(path, oid, pr_oid):
+        if not await _head_contained_in_pr(path, head_oid, pr_oid):
             return {**base, "ok": False, "code": "merged_new_commits"}
         return {**base, "ok": True, "code": "merged"}
     if own == 0 and not dirty:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -273,17 +273,22 @@ async def test_remove_refuses_when_branch_oid_diverged():
     """Squash-safe race guard: branch OID != PR headRefOid -> refuse removal."""
     import kiro_crew.apps.builtins.dev_fleet.server as mod
 
+    full_head = "a" * 40
+    cache = AsyncMock(return_value={"state": "MERGED"})
+    git = AsyncMock(return_value=full_head)
     with patch.object(mod, "_find_worktree", new_callable=AsyncMock,
                       return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None)), \
          patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False), \
-         patch.object(mod, "_pr_status_cached", new_callable=AsyncMock, return_value={"state": "MERGED"}), \
+         patch.object(mod, "_pr_status_cached", cache), \
          patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3), \
-         patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"), \
-         patch.object(mod, "_fetch_pr_head_oid", new_callable=AsyncMock, return_value="bbb2222"), \
+         patch.object(mod, "_git", git), \
+         patch.object(mod, "_fetch_pr_head_oid", new_callable=AsyncMock, return_value="b" * 40), \
          patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"):
         result = await mod._worktree_remove("feat-x", force=False)
     assert result["ok"] is False
     assert "OID diverged" in result["error"]
+    git.assert_any_await("/fake/wt", "rev-parse", "HEAD")
+    cache.assert_awaited_once_with("feat-x", full_head)
 
 
 @pytest.mark.asyncio
@@ -5983,19 +5988,22 @@ async def test_pr_query_one_carries_title_and_hides_body():
     payload = json.dumps([{
         "number": 42, "state": "OPEN",
         "url": "https://github.com/o/r/pull/42", "isDraft": False,
-        "title": "My PR title", "body": "Fixes #7",
+        "title": "My PR title", "body": "Fixes #7", "headRefOid": "a" * 40,
     }])
     with patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, payload, "")):
         pr = await mod._pr_query_one("o/r", "feat/x")
     assert pr is not None
     assert pr["title"] == "My PR title"
     assert pr["_body"] == "Fixes #7"
+    assert pr["_head_oid"] == "a" * 40
     assert "body" not in pr  # moved to internal _body
+    assert "headRefOid" not in pr
     redacted = mod._redact_pr(pr)
     assert redacted["title"] == "My PR title"
     assert redacted["number"] == 42
     assert "_body" not in redacted  # internal fields dropped from payload
     assert "_repo" not in redacted
+    assert "_head_oid" not in redacted
 
 
 # --- _build_context: parses PR body + commits, builds links ---

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -211,6 +211,32 @@ async def test_load_fallback_repos_empty_when_remote_listing_fails(monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# Git info identity
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_git_info_returns_full_oid_and_short_display_head(monkeypatch):
+    full_head = "a" * 40
+
+    async def fake_git(_path, *args, **_kwargs):
+        values = {
+            ("rev-parse", "--abbrev-ref", "HEAD"): "feat/cache",
+            ("rev-parse", "HEAD"): full_head,
+            ("status", "--porcelain"): "",
+            ("rev-list", "--count", "HEAD..origin/main"): "0",
+            ("log", "-1", "--format=%ct"): "123",
+        }
+        return values.get(args)
+
+    monkeypatch.setattr(mod, "_git", fake_git)
+    monkeypatch.setattr(mod, "_upstream_remote", AsyncMock(return_value="origin"))
+
+    info = await mod._git_info("/wt")
+
+    assert info["head_oid"] == full_head
+    assert info["head"] == full_head[:7]
+
+
+# --------------------------------------------------------------------------
 # PR cache + html base
 # --------------------------------------------------------------------------
 @pytest.mark.asyncio
@@ -254,6 +280,142 @@ async def test_pr_status_cached_fresh_entry_is_served(monkeypatch):
 
     assert (await mod._pr_status_cached("feat"))["state"] == "OPEN"
     fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_merged_same_head_retains_terminal_cache(monkeypatch):
+    """Same branch + same head OID → MERGED entry remains terminal (no refetch)."""
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {"feat": {"data": {"state": "MERGED"}, "ts": 0.0, "cached_head": "a" * 40}},
+    )
+
+    result = await mod._pr_status_cached("feat", head_oid="a" * 40)
+    assert result is not None and result["state"] == "MERGED"
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_merged_new_head_invalidates_and_refetches(monkeypatch):
+    """Same branch + new head OID → stale MERGED entry is discarded; fresh lookup runs."""
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {"feat": {"data": {"state": "MERGED"}, "ts": 0.0, "cached_head": "a" * 40}},
+    )
+
+    result = await mod._pr_status_cached("feat", head_oid="b" * 40)
+    # The stale MERGED entry must NOT be returned after a head change.
+    assert result is not None and result["state"] == "OPEN"
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_rejects_old_merged_pr_for_reused_head(monkeypatch):
+    old_head = "a" * 40
+    new_head = "b" * 40
+    fetch = AsyncMock(return_value={"state": "MERGED", "_head_oid": old_head})
+    contained = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(mod, "_head_contained_in_pr", contained)
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {"feat": {"data": {"state": "MERGED"}, "ts": 0.0, "cached_head": old_head}},
+    )
+
+    result = await mod._pr_status_cached("feat", head_oid=new_head)
+
+    assert result is None
+    contained.assert_awaited_once_with(mod._repo(), new_head, old_head)
+    assert mod._PR_CACHE["feat"]["data"] is None
+    assert mod._PR_CACHE["feat"]["cached_head"] == new_head
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_accepts_local_ancestor_of_merged_pr_head(monkeypatch):
+    local_head = "a" * 40
+    pr_head = "b" * 40
+    fetch = AsyncMock(return_value={"state": "MERGED", "_head_oid": pr_head})
+    contained = AsyncMock(return_value=True)
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(mod, "_head_contained_in_pr", contained)
+    monkeypatch.setattr(mod, "_PR_CACHE", {})
+
+    result = await mod._pr_status_cached("feat", head_oid=local_head)
+
+    assert result is not None and result["state"] == "MERGED"
+    contained.assert_awaited_once_with(mod._repo(), local_head, pr_head)
+    assert mod._PR_CACHE["feat"]["cached_head"] == local_head
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_accepts_fetched_merged_pr_for_same_head(monkeypatch):
+    head = "a" * 40
+    fetch = AsyncMock(return_value={"state": "MERGED", "_head_oid": head})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(mod, "_PR_CACHE", {})
+
+    result = await mod._pr_status_cached("feat", head_oid=head)
+
+    assert result is not None and result["state"] == "MERGED"
+    assert mod._PR_CACHE["feat"]["cached_head"] == head
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_merged_no_head_oid_remains_terminal(monkeypatch):
+    """Callers that omit head_oid continue to treat MERGED as terminal (fail-soft)."""
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {"feat": {"data": {"state": "MERGED"}, "ts": 0.0, "cached_head": "a" * 40}},
+    )
+
+    result = await mod._pr_status_cached("feat")  # no head_oid
+    assert result is not None and result["state"] == "MERGED"
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_lookup_failure_does_not_cache_stale_merged(monkeypatch):
+    """When the fresh lookup returns None (gh failure), the cache stores None safely."""
+    fetch = AsyncMock(return_value=None)
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {"feat": {"data": {"state": "MERGED"}, "ts": 0.0, "cached_head": "a" * 40}},
+    )
+
+    result = await mod._pr_status_cached("feat", head_oid="b" * 40)
+    assert result is None
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pr_status_cached_null_cached_head_invalidated_by_new_head(monkeypatch):
+    """Entry written without head_oid (cached_head=None) is invalidated when a head-bearing
+    caller provides a head_oid — prevents re-armed staleness after no-head write-back."""
+    fetch = AsyncMock(return_value={"state": "OPEN"})
+    monkeypatch.setattr(mod, "_fetch_pr_status", fetch)
+    # Simulate a cache entry that was written by a no-head caller (cached_head missing/None).
+    monkeypatch.setattr(
+        mod,
+        "_PR_CACHE",
+        {"feat": {"data": {"state": "MERGED"}, "ts": 0.0, "cached_head": None}},
+    )
+
+    result = await mod._pr_status_cached("feat", head_oid="a" * 40)
+    # An unknown cached identity cannot match a known full head, so refetch.
+    assert result is not None and result["state"] == "OPEN"
+    fetch.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -884,6 +1046,23 @@ async def test_prunable_active_worktree_is_kept(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=3))
     monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
     assert (await mod._prunable(str(tmp_path), "feat"))["code"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_prunable_passes_full_head_oid_to_pr_status_cached(monkeypatch, tmp_path):
+    """Prune cache invalidation uses full commit identity for branch reuse."""
+    full_head = "a" * 40
+    cache = AsyncMock(return_value=None)
+    monkeypatch.setattr(mod, "_pr_status_cached", cache)
+    monkeypatch.setattr(mod, "_own_commits_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(mod, "_real_dirty", AsyncMock(return_value=False))
+    git = AsyncMock(return_value=full_head)
+    monkeypatch.setattr(mod, "_git", git)
+
+    await mod._prunable(str(tmp_path), "feat")
+
+    git.assert_awaited_once_with(str(tmp_path), "rev-parse", "HEAD")
+    cache.assert_awaited_once_with("feat", full_head)
 
 
 @pytest.mark.asyncio

--- a/test/test_dev_fleet_server_more_coverage.py
+++ b/test/test_dev_fleet_server_more_coverage.py
@@ -378,8 +378,10 @@ async def test_pr_query_one_none_on_empty_result(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_pr_query_one_moves_body_to_internal_key(monkeypatch):
-    """``body`` becomes ``_body`` so _redact_pr drops it from the payload."""
-    payload = json.dumps([{"number": 7, "state": "OPEN", "body": None}])
+    """Body and head identity become internal fields omitted from the payload."""
+    payload = json.dumps([
+        {"number": 7, "state": "OPEN", "body": None, "headRefOid": "a" * 40}
+    ])
     seen = _run_cmd_queue(monkeypatch, [(0, payload, "")])
 
     pr = await mod._pr_query_one("o/r", "feat/x")
@@ -387,7 +389,9 @@ async def test_pr_query_one_moves_body_to_internal_key(monkeypatch):
     assert pr is not None
     assert pr["_repo"] == "o/r"
     assert pr["_body"] == ""
+    assert pr["_head_oid"] == "a" * 40
     assert "body" not in pr
+    assert "headRefOid" not in pr
     assert "--head" in seen[0] and "feat/x" in seen[0]
 
 


### PR DESCRIPTION
## Problem / Motivation

Dev Fleet caches a merged pull-request result permanently by branch name. When a developer later creates new work under the same branch name, the old MERGED result remains authoritative for the fleet display, prune candidates, and removal explanations.

## Why it matters

A worktree whose branch was previously merged can be displayed as shipped (MERGED badge, eligible prune candidate) even when it contains entirely new, unmerged commits. The mismatch misleads the developer about the status of their current work and can cause confusing prune explanations.

## What changed (motivation → approach → change)

**Root cause:** a MERGED cache entry was keyed only by branch name. Even after a local head change triggered a refresh, GitHub could return the branch name’s old merged PR when no replacement PR existed, allowing that old verdict to be cached permanently under the new head.

**Approach:** bind terminal cache entries to full commit identity at both boundaries: the local worktree HEAD and the PR head returned by GitHub.

**Changes:**

1. `_git_info` resolves the full HEAD once, exposes it internally as `head_oid`, and derives the existing seven-character display value from it. Fleet polling adds no git or network call.
2. Fleet, detail, direct removal, and prune callers all pass the full OID to `_pr_status_cached`. Prune reuses that same value for its containment guard.
3. The existing PR query requests `headRefOid` and stores it as internal `_head_oid`; `_redact_pr` omits it from the response payload.
4. A fetched MERGED result becomes terminal when the full local head exactly matches or is contained in `_head_oid`; this preserves valid merged status when remote commits landed before merge. A divergent old merged PR returned for a reused branch is treated as no current PR and remains eligible for normal TTL refresh.
5. Entries written without identity are treated as unknown provenance and are refreshed when a full head is available.

## Tests

Regression coverage across `test_dev_fleet_server_coverage.py`, `test_dev_fleet_server_more_coverage.py`, and `test_dev_fleet_app.py` verifies:

- same full head retains a terminal MERGED entry; a changed full head refetches
- unknown cache provenance is invalidated by a known head
- a divergent old merged PR returned for a reused branch is rejected rather than recached
- a fetched merged PR matching or containing the current local head remains terminal
- `_git_info` preserves seven-character display output while carrying the full OID
- fleet/detail/prune/removal callers forward full identity
- GitHub `headRefOid` remains internal and is omitted from the fleet payload
- lookup failures remain fail-soft

All 651 affected Dev Fleet tests pass; one platform-specific test is skipped.

## Manual verification

N/A — the affected logic is a pure in-process cache with no external integration points. Unit coverage is sufficient: the cache read/write path, the invalidation branch, the guard correctness, and the fail-soft cases are all exercised directly.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend cache logic with no user-visible UI change.

## Related Issues

Fixes #5292

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(dev-fleet): invalidate merged PR cache when branch head changes`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
