### PR TITLE
fix(security): lock down secret files before content, not after (#5285)

### DIFF
--- a/src/kiro_crew/aws_consent.py
+++ b/src/kiro_crew/aws_consent.py
@@ -83,10 +83,6 @@ SERVICE_LABELS: dict[str, str] = {
     SERVICE_TRANSCRIBE: "Amazon Transcribe",
 }
 
-#: Owner-only, matching the other keystone leaves. The value is not a
-#: credential, but it IS an authorization whose integrity matters.
-_CONSENT_FILE_MODE = 0o600
-
 #: Lock filename beside the consent file -- NOT the file itself, because
 #: ``atomic_write`` renames a new inode over it and a lock on the old inode
 #: protects nothing. Same placement and reasoning as
@@ -206,8 +202,15 @@ def _preserve_if_unreadable() -> None:
     stamp = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
     sidecar = path.with_name(f"{path.name}.corrupt-{stamp}")
     try:
-        atomic_write(sidecar, raw, mode=_CONSENT_FILE_MODE)
-        platform_compat.restrict_to_owner(sidecar)
+        # restrict_to_owner=True locks the temp file down BEFORE the preserved
+        # contents reach it (the previous post-rename lockdown left them readable
+        # under the inherited DACL on Windows for the write window, issue #5285)
+        # and implies the owner-only POSIX mode. The default
+        # restrict_on_error="raise" surfaces a lockdown failure into this
+        # except, where the whole preservation attempt is already warn-only —
+        # and because the failure now happens before the rename, a sidecar that
+        # could not be protected never exists at the final path at all.
+        atomic_write(sidecar, raw, restrict_to_owner=True)
         logger.warning(
             "AWS consent store was unreadable; preserved the previous contents at %s "
             "before recording a new confirmation",
@@ -249,19 +252,24 @@ class _ConsentLock:
 
 def _write_all(data: dict[str, Any]) -> None:
     path = aws_consent_path()
-    atomic_write(path, json.dumps(data, indent=2, sort_keys=True), mode=_CONSENT_FILE_MODE)
-    # Fail-loud lockdown, same as the sibling keystone stores: ``atomic_write``'s
-    # mode covers POSIX and this applies the owner-only DACL on Windows. A
-    # lockdown failure must not leave an authorization record world-writable,
-    # so unlink and re-raise rather than continue.
-    try:
-        platform_compat.restrict_to_owner(path)
-    except OSError:
-        try:
-            path.unlink()
-        except OSError:
-            logger.exception("failed to remove AWS consent file after lockdown failure")
-        raise
+    # Fail-loud lockdown BEFORE any content lands, same as the sibling keystone
+    # stores: ``restrict_to_owner=True`` applies the owner-only DACL to the temp
+    # file before the payload reaches it (the previous post-rename lockdown left
+    # the authorization record readable under the inherited DACL on Windows for
+    # the write window, issue #5285) and implies the owner-only POSIX mode. The
+    # default ``restrict_on_error="raise"`` refuses to write a record it cannot
+    # protect.
+    #
+    # No cleanup on failure any more. Every failure inside ``atomic_write`` —
+    # lockdown, payload write (ENOSPC), rename — happens BEFORE the final path
+    # is touched: the helper removes its temp file and re-raises, so an
+    # unprotectable record never exists at ``path`` at all. The unlink the old
+    # code ran existed to remove a NEW store already PUBLISHED at a wide DACL
+    # when its post-write lockdown failed; that state is unreachable now, and
+    # keeping the unlink would instead delete the previous, healthy,
+    # already-locked-down store on any transient failure (both pre-push
+    # reviews flagged exactly that data loss).
+    atomic_write(path, json.dumps(data, indent=2, sort_keys=True), restrict_to_owner=True)
 
 
 def read_grant(service: str) -> Grant | None:

--- a/src/kiro_crew/dashboard/session_transfer.py
+++ b/src/kiro_crew/dashboard/session_transfer.py
@@ -70,7 +70,6 @@ from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot
-from kiro_crew.platform_compat import restrict_to_owner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -417,29 +416,37 @@ def _write_layer_b_files(layer_b: dict[str, Any], agent: str) -> str | None:
             # concurrent writers cannot collide on a deterministic ``.tmp`` name
             # (an ENOENT race the previous hand-rolled write here was exposed to),
             # and it retries the Windows rename window.
-            atomic_write(path, text, mode=0o600)
+            #
+            # ``restrict_to_owner=True`` applies the owner-only lockdown to the
+            # temp file BEFORE any content reaches it — POSIX mode bits are
+            # meaningless against NTFS ACLs, and the previous post-rename
+            # ``restrict_to_owner`` call left Layer B readable under the
+            # inherited DACL for the whole write window (issue #5285). It
+            # implies 0o600 on POSIX, and the default
+            # ``restrict_on_error="raise"`` keeps this site FAIL CLOSED.
             try:
-                # POSIX mode bits are meaningless against NTFS ACLs, so on Windows
-                # this call is the ONLY thing making the file owner-only -- the
-                # ``mode=0o600`` above is a no-op there. It raises for documented,
-                # reachable reasons (it refuses to apply a half-configured DACL
-                # when the invoking user's SID will not resolve).
-                restrict_to_owner(path)
+                atomic_write(path, text, restrict_to_owner=True)
             except OSError:
                 # FAIL CLOSED. This is the model's whole context window; leaving it
                 # readable by other local accounts on a shared machine is worse
                 # than not resuming, and this feature already has an honest
                 # fallback for exactly that -- returning ``None`` imports the
                 # session transcript-only. Both files go, not just this one: the
-                # pair is useless alone and the ``.json`` carries context too.
+                # pair is useless alone and the ``.json`` carries context too
+                # (a lockdown failure on the SECOND file leaves the first,
+                # already-published one behind otherwise).
                 #
                 # This overrides the warn-and-continue precedent in
                 # ``handlers/weixin_qr.py``. That path has no fallback -- refusing
                 # breaks the feature outright -- whereas refusing here costs only
                 # resume fidelity, so the same trade resolves the other way.
+                #
+                # The outer ``except Exception`` below performs the same
+                # cleanup as a backstop for non-OSError failures; keep the two
+                # paths in sync.
                 logger.warning(
-                    "session_transfer: could not restrict Layer B permissions on %s; "
-                    "discarding it and importing transcript-only",
+                    "session_transfer: could not write owner-only Layer B file %s; "
+                    "discarding the pair and importing transcript-only",
                     path.name,
                     exc_info=True,
                 )

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -24,7 +24,6 @@ from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.context import ContextBuilder
 from kiro_crew.llm_helpers import run_bg_oneliner
-from kiro_crew.platform_compat import restrict_to_owner
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST
 from kiro_crew.tips_text import truncate_summary
@@ -356,17 +355,20 @@ def _save_state(st: TipsState) -> None:
         + "\n",
         # Owner-only: generated tips embed memory-derived content (preferences,
         # projects, recent activity) — must not be world-readable on shared
-        # machines. mode also corrects permissions of pre-existing 0644 files
-        # on the next write (atomic replace).
-        mode=0o600,
+        # machines. restrict_to_owner locks the temp file down BEFORE any content
+        # reaches it (a post-rename lockdown left the payload readable under the
+        # inherited DACL on Windows for the write window, issue #5285), implies
+        # 0o600 on POSIX — which also corrects permissions of pre-existing 0644
+        # files on the next write (atomic replace) — and applies the owner-only
+        # DACL on Windows, where mode bits are a no-op. Warn-and-continue: a
+        # lockdown failure must not break tips persistence, but it must be
+        # visible. The linked-parent refusal restrict_to_owner also implies is
+        # NOT covered by restrict_on_error — it raises unconditionally, which is
+        # correct for a secret-adjacent writer (#4381) and unreachable here in
+        # practice: the parent is config_dir(), a trust anchor.
+        restrict_to_owner=True,
+        restrict_on_error="warn",
     )
-    # mode= only sets POSIX bits; on Windows an owner-only DACL is needed too.
-    # Warn-and-continue: a lockdown failure must not break tips persistence,
-    # but it must be visible.
-    try:
-        restrict_to_owner(path)
-    except OSError:
-        logger.warning("Could not restrict tips_state.json to owner", exc_info=True)
 
 
 # ── Cache ──

--- a/src/kiro_crew/weixin/client.py
+++ b/src/kiro_crew/weixin/client.py
@@ -26,7 +26,7 @@ from urllib.parse import quote
 
 import aiohttp
 
-from kiro_crew.platform_compat import restrict_to_owner
+from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger(__name__)
 
@@ -145,21 +145,32 @@ def _account_dir(home: str) -> Path:
 def save_weixin_account(home: str, *, account_id: str, token: str, base_url: str, user_id: str = "") -> None:
     """Persist account credentials owner-only.
 
-    The file holds the bot credential, so it is locked down with
-    :func:`platform_compat.restrict_to_owner` — a bare ``chmod(0o600)`` is a no-op
-    against Windows ACLs.
+    The file holds the bot credential, so ``atomic_write(restrict_to_owner=True)``
+    applies :func:`platform_compat.restrict_to_owner` to the temp file BEFORE any
+    content byte reaches it — a bare ``chmod(0o600)`` is a no-op against Windows
+    ACLs, and locking down only after the write left the token readable under the
+    directory's inherited DACL for the whole write window (issue #5285).
+    ``restrict_on_error="warn"`` keeps this site's existing policy: a lockdown
+    failure must not cost the credential write, but it must be visible. That
+    policy covers the lockdown only — the linked-parent refusal implied by
+    ``restrict_to_owner=True`` raises unconditionally, which is the right
+    behavior for a credential writer: a pre-planted link under
+    ``<home>/weixin/accounts`` (a directory this code creates) is hostile
+    (#4381).
     """
     path = _account_dir(home) / f"{account_id}.json"
-    _atomic_json_write(path, {
+    payload = {
         "token": token,
         "base_url": base_url,
         "user_id": user_id,
         "saved_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    })
-    try:
-        restrict_to_owner(str(path))
-    except OSError:
-        logger.warning("weixin: could not restrict account file permissions", exc_info=True)
+    }
+    atomic_write(
+        path,
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        restrict_to_owner=True,
+        restrict_on_error="warn",
+    )
 
 
 def load_weixin_account(home: str, account_id: str) -> Optional[Dict[str, Any]]:

--- a/test/test_aws_consent.py
+++ b/test/test_aws_consent.py
@@ -150,6 +150,139 @@ class TestGrantIsOnTheKeystoneFloor:
         mode = stat.S_IMODE(os.stat(aws_consent_path()).st_mode)
         assert mode == 0o600
 
+    def test_write_lockdown_precedes_content(self, home, monkeypatch):
+        """The authorization record must never exist in a file that has not
+        been locked down yet.
+
+        On Windows the POSIX mode bits are a no-op, so the owner-only DACL from
+        ``restrict_to_owner`` is the only protection; applying it after the
+        rename left the record readable under the inherited ACL for the write
+        window (issue #5285). Asserted by measuring the file's SIZE at lockdown
+        time — zero means no payload byte existed yet. A post-write stat passes
+        on the buggy ordering too, so it would not be a regression test.
+        """
+        from kiro_crew import platform_compat
+
+        sizes: list[int] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring_restrict(target):
+            sizes.append(os.stat(target).st_size)
+            return real_restrict(target)
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _measuring_restrict)
+
+        _grant()
+
+        assert sizes, "premise: the lockdown ran at all"
+        assert (
+            sizes[0] == 0
+        ), f"the file already held payload bytes when it was locked down: {sizes[0]} bytes"
+
+    def test_sidecar_preservation_lockdown_precedes_content(self, home, monkeypatch):
+        """The corrupt-store sidecar carries whatever the old store held, so its
+        write gets the same lockdown-before-content ordering (issue #5285)."""
+        from kiro_crew import platform_compat
+        from kiro_crew.config.loader import aws_consent_path
+
+        aws_consent_path().write_text("not json{", encoding="utf-8")
+        sizes: list[int] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring_restrict(target):
+            sizes.append(os.stat(target).st_size)
+            return real_restrict(target)
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _measuring_restrict)
+
+        _grant()
+
+        # One lockdown for the preserved sidecar, then one for the new store,
+        # in that order — both applied while their file was still empty. Later
+        # calls belong to the SEL audit trail ``record_grant`` appends to (an
+        # already-converted, out-of-scope consumer), so only the first two are
+        # this site's.
+        assert len(sizes) >= 2, f"expected sidecar + store lockdowns: {sizes}"
+        assert sizes[:2] == [
+            0,
+            0,
+        ], f"a file already held payload bytes when it was locked down: {sizes[:2]}"
+
+    def test_a_failed_lockdown_refuses_and_leaves_no_store(self, home, monkeypatch):
+        """The fail-loud policy survives the conversion: a record that cannot be
+        locked down is refused (the OSError propagates), and — starting from an
+        empty home — no consent store at ANY permission exists afterwards, which
+        the read side treats as "no consent"."""
+        from kiro_crew import platform_compat
+        from kiro_crew.config.loader import aws_consent_path
+
+        def _refuse(_target):
+            raise OSError("cannot resolve the invoking user's SID")
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _refuse)
+
+        with pytest.raises(OSError):
+            _grant()
+
+        assert not aws_consent_path().exists(), "an unprotectable store was left behind"
+        assert aws_consent.read_grant(aws_consent.SERVICE_POLLY) is None
+
+    def test_a_failed_lockdown_preserves_the_previous_store(self, home, monkeypatch):
+        """A failed NEW write must not destroy the PREVIOUS, healthy store.
+
+        Every failure inside ``atomic_write`` happens before the rename, so the
+        final path still holds the last successfully written (and locked-down)
+        record. Both pre-push reviews flagged the alternative — an unlink on any
+        OSError — as data loss: one transient failure would have wiped every
+        recorded authorization. The empty-home test above cannot see that
+        destruction, so this variant seeds a real grant first.
+        """
+        from kiro_crew import platform_compat
+        from kiro_crew.config.loader import aws_consent_path
+
+        _grant()  # a healthy, locked-down store exists
+        before = aws_consent_path().read_bytes()
+
+        def _refuse(_target):
+            raise OSError("cannot resolve the invoking user's SID")
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _refuse)
+
+        with pytest.raises(OSError):
+            _grant(aws_consent.SERVICE_TRANSCRIBE)
+
+        assert aws_consent_path().read_bytes() == before, "the previous store was altered"
+        assert (
+            aws_consent.read_grant(aws_consent.SERVICE_POLLY) is not None
+        ), "a failed new grant destroyed the previously recorded authorization"
+
+    def test_a_failed_payload_write_preserves_the_previous_store(self, home, monkeypatch):
+        """Same property for an ordinary write failure (disk full while creating
+        the temp file), which never even reaches the lockdown: the OSError
+        propagates and the previous store survives byte-identical."""
+        import tempfile
+
+        from kiro_crew.config.loader import aws_consent_path
+
+        _grant()  # a healthy, locked-down store exists
+        before = aws_consent_path().read_bytes()
+
+        def _no_space(*_a, **_kw):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(tempfile, "mkstemp", _no_space)
+
+        with pytest.raises(OSError):
+            _grant(aws_consent.SERVICE_TRANSCRIBE)
+
+        # No undo needed: the assertions below only READ (Path.read_bytes /
+        # read_grant), which never calls tempfile.mkstemp — and undo would also
+        # revert the home fixture's KIROCREW_HOME (same monkeypatch instance).
+        assert aws_consent_path().read_bytes() == before, "the previous store was altered"
+        assert (
+            aws_consent.read_grant(aws_consent.SERVICE_POLLY) is not None
+        ), "a transient write failure destroyed the previously recorded authorization"
+
 
 class TestGate:
     def test_no_grant_refuses(self, home):

--- a/test/test_session_transfer.py
+++ b/test/test_session_transfer.py
@@ -2735,13 +2735,19 @@ def test_a_mapped_but_unreadable_layer_b_is_reported_as_withheld(monkeypatch):
 def test_layer_b_is_discarded_when_owner_lockdown_fails(monkeypatch, tmp_path):
     """Fail CLOSED, and leave nothing behind.
 
-    On Windows the ``mode=0o600`` on the write is a no-op, so the DACL call is the
-    only thing making the file owner-only -- if it raises, the context is readable
-    by other local accounts on a shared machine. Refusing costs only resume
-    fidelity (the import lands transcript-only), so it is the cheaper side of the
-    trade. Both files must go: the pair is useless alone and the ``.json`` carries
-    context too.
+    On Windows the POSIX mode bits are a no-op, so the owner-only DACL applied by
+    ``atomic_write(restrict_to_owner=True)`` is the only thing making the file
+    owner-only -- if it fails, the context would be readable by other local
+    accounts on a shared machine. Refusing costs only resume fidelity (the import
+    lands transcript-only), so it is the cheaper side of the trade. Both files
+    must go: the pair is useless alone and the ``.json`` carries context too.
+
+    The lockdown seam lives inside ``atomic_write`` now (it locks the temp file
+    down BEFORE any content reaches it, issue #5285), so the failure is injected
+    at ``platform_compat.restrict_to_owner`` -- the module-level function the
+    helper calls -- not at a name in this module.
     """
+    from kiro_crew import platform_compat
     from kiro_crew.dashboard import session_transfer as st
 
     monkeypatch.setattr(st, "kiro_sessions_dir", lambda: tmp_path)
@@ -2749,7 +2755,7 @@ def test_layer_b_is_discarded_when_owner_lockdown_fails(monkeypatch, tmp_path):
     def _refuse(_path):
         raise OSError("cannot resolve the invoking user's SID")
 
-    monkeypatch.setattr(st, "restrict_to_owner", _refuse)
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _refuse)
 
     got = st._write_layer_b_files(
         {"envelope": {"session_id": "old"}, "events": '{"kind":"Prompt"}\n'}, "agent"
@@ -2758,6 +2764,41 @@ def test_layer_b_is_discarded_when_owner_lockdown_fails(monkeypatch, tmp_path):
     assert got is None, "returned a sid for context it could not protect"
     leftovers = [p.name for p in tmp_path.iterdir()]
     assert leftovers == [], f"left unprotected context on disk: {leftovers}"
+
+
+def test_layer_b_lockdown_precedes_content(monkeypatch, tmp_path):
+    """The context window must never exist in a file that has not been locked
+    down yet.
+
+    On Windows the POSIX mode bits are a no-op, so the owner-only DACL is the
+    only protection; applying it after the rename left Layer B readable under
+    the inherited ACL for the write window (issue #5285). Asserted by measuring
+    each file's SIZE at the moment its lockdown is applied — zero means no
+    payload byte existed yet. A post-write stat passes on the buggy ordering
+    too, so it would not be a regression test.
+    """
+    from kiro_crew import platform_compat
+    from kiro_crew.dashboard import session_transfer as st
+
+    monkeypatch.setattr(st, "kiro_sessions_dir", lambda: tmp_path)
+    sizes: list[int] = []
+    real_restrict = platform_compat.restrict_to_owner
+
+    def _measuring_restrict(target):
+        sizes.append(os.stat(target).st_size)
+        return real_restrict(target)
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _measuring_restrict)
+
+    got = st._write_layer_b_files(
+        {"envelope": {"session_id": "old"}, "events": '{"kind":"Prompt"}\n'}, "agent"
+    )
+
+    assert got is not None
+    assert len(sizes) == 2, f"expected one lockdown per file of the pair: {sizes}"
+    assert sizes == [0, 0], (
+        f"a file already held payload bytes when it was locked down: {sizes}"
+    )
 
 
 def test_import_preserves_the_thinking_signature_verbatim(monkeypatch, tmp_path):

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -756,6 +756,51 @@ class TestStateFilePermissions:
             _save_state(TipsState())
             assert (st_file.stat().st_mode & 0o777) == 0o600
 
+    def test_lockdown_precedes_content(self, tmp_path: Path, monkeypatch) -> None:
+        """The memory-derived payload must never exist in a file that has not
+        been locked down yet.
+
+        On Windows the POSIX mode bits are a no-op, so the owner-only DACL from
+        ``restrict_to_owner`` is the only protection; applying it after the
+        rename left the state readable under the inherited ACL for the write
+        window (issue #5285). Asserted by measuring the file's SIZE at lockdown
+        time — zero means no payload byte existed yet. A post-write stat passes
+        on the buggy ordering too, so it would not be a regression test.
+        """
+        from kiro_crew import platform_compat
+
+        sizes: list[int] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring_restrict(target):
+            sizes.append(Path(target).stat().st_size)
+            return real_restrict(target)
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _measuring_restrict)
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            _save_state(TipsState(tips=[{"id": "x", "why": "references user projects"}]))
+
+        assert sizes, "premise: the lockdown ran at all"
+        assert sizes[0] == 0, (
+            f"the file already held payload bytes when it was locked down: {sizes[0]} bytes"
+        )
+
+    def test_a_failed_lockdown_still_persists_the_state(self, tmp_path: Path, monkeypatch) -> None:
+        """``restrict_on_error="warn"`` keeps this site's established policy: a
+        lockdown failure must not break tips persistence, but it must be
+        visible (the helper logs it)."""
+        from kiro_crew import platform_compat
+
+        def _refuse(_target):
+            raise OSError("read-only ACL store")
+
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _refuse)
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            _save_state(TipsState(dismissed_docs=["a.md"]))
+            st_file = tmp_path / "tips_state.json"
+            assert st_file.is_file(), "warn policy must keep the write"
+            assert json.loads(st_file.read_text())["dismissed_docs"] == ["a.md"]
+
 
 class TestTipFieldAllowlist:
     """Codex round-12 (HIGH): unknown/extra LLM fields must never survive parse.

--- a/test/test_weixin.py
+++ b/test/test_weixin.py
@@ -150,6 +150,57 @@ def test_account_credentials_are_owner_only(tmp_path):
     assert path.stat().st_mode & 0o077 == 0
 
 
+def test_account_credentials_lockdown_precedes_content(tmp_path, monkeypatch):
+    """The token must never exist in a file that has not been locked down yet.
+
+    On Windows the POSIX mode bits are a no-op, so the owner-only DACL from
+    ``restrict_to_owner`` is the only protection; applying it after the write
+    left the bot credential readable under the parent directory's inherited ACL
+    for the whole write window (issue #5285). Asserted by measuring the file's
+    SIZE at the moment the lockdown is applied — zero means no payload byte
+    existed yet. A post-write stat passes on the buggy ordering too, so it
+    would not be a regression test.
+    """
+    from kiro_crew import platform_compat
+
+    sizes: list[int] = []
+    real_restrict = platform_compat.restrict_to_owner
+
+    def _measuring_restrict(target):
+        sizes.append(os.stat(target).st_size)
+        return real_restrict(target)
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _measuring_restrict)
+
+    save_weixin_account(str(tmp_path), account_id="acct1", token="s3cr3t", base_url="https://x")
+
+    assert sizes, "premise: the lockdown ran at all"
+    assert (
+        sizes[0] == 0
+    ), f"the file already held payload bytes when it was locked down: {sizes[0]} bytes"
+
+
+def test_account_credentials_survive_a_failed_lockdown(tmp_path, monkeypatch):
+    """``restrict_on_error="warn"`` keeps this site's established policy: the
+    credential write matters more than the permissions, so a lockdown failure
+    is logged but must not cost the account file."""
+    from kiro_crew import platform_compat
+
+    def _refuse(_target):
+        raise OSError("cannot resolve the invoking user's SID")
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _refuse)
+
+    save_weixin_account(
+        str(tmp_path), account_id="acct1", token="s3cr3t", base_url="https://x", user_id="u9"
+    )
+
+    loaded = load_weixin_account(str(tmp_path), "acct1")
+    assert loaded is not None, "warn policy must keep the write"
+    assert loaded["token"] == "s3cr3t"
+    assert loaded["user_id"] == "u9"
+
+
 # ── renderer ──────────────────────────────────────────────────────────────────
 def test_normalize_markdown_collapses_blank_runs_outside_fences():
     assert normalize_markdown("a\n\n\n\nb") == "a\n\nb"


### PR DESCRIPTION
## What

Converts the four remaining write-then-restrict secret writers to the shared `atomic_write(restrict_to_owner=True, restrict_on_error=...)` helper, which applies `platform_compat.restrict_to_owner` to the **temp file before any content byte reaches it**. Previously each site wrote the payload to its final path first and locked it down afterwards — on Windows, where POSIX mode bits are a no-op against NTFS ACLs, the secret existed under the directory's inherited DACL for the whole write window.

Closes #5285

## Per-site conversion (failure policy old → new)

| Site | Payload | Old | New |
|---|---|---|---|
| `weixin/client.py` `save_weixin_account` | bot token | `_atomic_json_write` with **no mode at all** (umask default) + warn-only post-write lockdown | `restrict_on_error="warn"` (policy kept, mode tightened to 0o600) |
| `tips.py` `_save_state` | memory-derived preferences/projects | `mode=0o600` + warn-only post-rename lockdown | `restrict_on_error="warn"`; the corrects-preexisting-0644 property survives (`restrict_to_owner` implies 0o600) |
| `dashboard/session_transfer.py` Layer B pair | the model's whole context window | fail-closed: unlink BOTH files + return None | **kept identically** — the except moved onto the `atomic_write` call |
| `aws_consent.py` sidecar + `_write_all` | authorization records | fail-loud: raise (`_write_all` also unlinked the store) | raise kept; **the unlink is deliberately not ported** (below) |

## Why `_write_all` no longer unlinks

Both pre-push model-pinned reviews (GPT 5.6 + Opus 5) independently flagged the ported unlink as **BLOCKING data loss**: in the new ordering every `atomic_write` failure (lockdown, ENOSPC, rename retry exhaustion) happens **before the rename**, so the final path still holds the *previous, healthy, already-locked-down* store — the unlink could only ever delete that. The state the old unlink existed for (a NEW store already published at a wide DACL when its post-write lockdown failed) is unreachable now: an unprotectable record never exists at the final path at all. Two new tests seed a real grant, inject each failure mode, and assert the previous store survives byte-identical; both fail on the unlink variant (verified).

## Port-vs-delete for `save_weixin_account`

The issue floats deleting the `save_weixin_account`/`load_weixin_account` pair (grep shows only `test/test_weixin.py` consumes them; review confirmed there is **no production caller in `src/`**). This PR **ports** it: removing a module-level API plus its tests is a human scope call, not part of a mechanical security conversion. A maintainer can still choose deletion separately. The module-level `_atomic_json_write` helper stays — `ContextTokenStore` (reply-context tokens) still uses it and is not in the issue's scope.

## Tests

- **Ordering pinned per site**: the file's size at the moment `restrict_to_owner` runs must be **zero** (lockdown-before-content). A post-write `stat(0o600)` check passes on the buggy code too, so it would not be a regression test. All five ordering tests verified failing on the pre-fix implementation (fail-before evidence).
- **Both failure policies**: warn keeps the write (weixin round-trip, tips state), raise refuses it (session_transfer discards the pair and returns None; aws_consent propagates and preserves the previous store — lockdown-failure and disk-full variants).
- `test_layer_b_is_discarded_when_owner_lockdown_fails` moves its failure injection to `platform_compat.restrict_to_owner` — the seam the shared helper actually calls (the old `st.restrict_to_owner` name no longer exists).

## Behavior notes

- `restrict_to_owner=True` implies the linked-parent refusal (#4381), which is fail-hard regardless of `restrict_on_error`; noted at the warn sites. Reachability at those sites is negligible (parents are the config-dir trust anchor / a directory this code creates).
- The aws_consent corrupt-store **sidecar** now never exists at its final path when its lockdown fails (previously it was left behind at a wide DACL); the whole preservation attempt stays warn-only as before.
- `_CONSENT_FILE_MODE` deleted — it lost its last consumer.

## Out of scope (per #5240)

The legacy `write_config_atomically` DACL residual (`security.py`/`agents.py`/`manager.py`/`cli_setup.py`/`memory.py`/`cli_chat.py`), and the two dashboard handlers owned by open PR #5269 (`dashboard/handlers/messaging.py`, `dashboard/handlers/weixin_qr.py`) — this branch has zero file overlap with #5269 (confirmed against its file list).

## Verification

- Full backend `pytest`: **61786 passed** (pre-amend base run; post-amend delta re-verified via the four affected test modules + `test_atomic_write_capabilities.py`, 436 passed)
- `isort`/`flake8`/`mypy`: touched files clean; repo-wide output byte-identical to `main`
- `black --target-version py310` on all non-baseline touched files
- Pre-push dual model-pinned review: GPT 5.6 Sol + Opus 5, both BLOCKING findings resolved (the cross-hit unlink), 3 advisories adopted, 2 documented here