### PR TITLE
fix(dev-fleet): redact main_repo field in fleet API response

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2258,7 +2258,7 @@ async def _build_fleet() -> dict:
     return {
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "worktrees": wts,
-        "main_repo": _repo(),
+        "main_repo": _redact(_repo()),
         "main_repo_inferred": MAIN_REPO_INFERRED,
         "base_branch": BASE_BRANCH,
         "build_pending": _build_pending(),

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -6139,6 +6139,29 @@ async def test_fleet_payload_marks_an_inferred_main_checkout():
 
 
 @pytest.mark.asyncio
+async def test_fleet_payload_redacts_credentials_in_main_repo():
+    sensitive = f"/tmp/ghp_{'A' * 40}/checkout"
+    with patch.object(mod, "_repo", return_value=sensitive):
+        fleet = await _fleet_with(
+            [{"path": "/repo", "branch": "main", "is_main": True}]
+        )
+
+    assert "ghp_" not in fleet["main_repo"]
+    assert "[REDACTED" in fleet["main_repo"]
+
+
+@pytest.mark.asyncio
+async def test_fleet_payload_preserves_ordinary_main_repo_path():
+    ordinary = "/home/user/oss/KiroCrew"
+    with patch.object(mod, "_repo", return_value=ordinary):
+        fleet = await _fleet_with(
+            [{"path": "/repo", "branch": "main", "is_main": True}]
+        )
+
+    assert fleet["main_repo"] == ordinary
+
+
+@pytest.mark.asyncio
 async def test_fleet_payload_discloses_why_pods_are_unavailable():
     """_POD_ERROR used to be computed and then read by NOTHING, so a non-Linux
     user got pod controls that silently failed. It must reach the payload."""


### PR DESCRIPTION
## Problem / Motivation

The `/api/fleet` endpoint returns a `main_repo` field containing the resolved
checkout path. The field was serialised directly from `_repo()` without passing
through the canonical `_redact()` helper used by every other path-bearing field
in the same response (`path`, `branch`, `staged_target`).

## Why it matters

A checkout path that happens to embed a credential pattern (e.g. a token
accidentally placed in a directory name) would be forwarded verbatim to the
dashboard payload. The inconsistency also makes the redaction contract harder to
audit: readers of `_build_fleet` had to hold both the wrapped and unwrapped cases
in their head simultaneously.

## What changed (motivation → approach → change)

Root cause: `"main_repo": _repo()` was the only path-bearing field in
`_build_fleet`'s return dict that bypassed `_redact()`. The sibling fields
(`path`, `branch`, `staged_target`, etc.) all use the wrapper.

Fix: wrap `_repo()` in `_redact()` at the single serialisation site, exactly as
`staged_target` is already treated:

```python
# before
"main_repo": _repo(),
# after
"main_repo": _redact(_repo()),
```

For ordinary checkout paths `_redact` is a no-op (it passes the string through
unchanged), so setup / inferred-checkout UX is not affected.

## Tests

Two behavioral tests in `test/test_dev_fleet_app.py` use the existing fleet fixture:

- `test_fleet_payload_redacts_credentials_in_main_repo` proves a credential-like path segment cannot reach `main_repo` verbatim.
- `test_fleet_payload_preserves_ordinary_main_repo_path` proves normal checkout paths remain unchanged.

The source-text assertions were removed; behavior, not implementation spelling, is the contract.

## Manual verification

N/A — unit coverage sufficient. The fix is a single-line wrapper addition at the
serialisation site; the helper is already tested across the codebase.

<!-- no-visual-delta -->
**Why no screenshot:** pure backend change to a JSON API field; no rendered UI
delta. The `main_repo` display in the inferred-checkout banner reads the
already-redacted value unchanged for ordinary paths.

## Related Issues

Fixes #5293

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
