### PR TITLE
fix(dev-fleet): add synchronous per-worktree provision singleflight guard

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -690,6 +690,13 @@ export default function DevFleetPage() {
   // so the fleet-driven reattach below never starts a second poll loop for a
   // run this session is already polling.
   const provAttachedRef = useRef<Set<string>>(new Set())
+  // Synchronous per-worktree in-flight guard for the provision() entry point.
+  // React state updates are asynchronous: setProv({ status: 'starting' })
+  // does not disable the Provision button until the next render commit.
+  // A rapid double-click therefore sends two POST requests before any re-render.
+  // This ref is checked and set BEFORE the first `await`, so the second click
+  // in the same render turn is blocked synchronously rather than racing the DOM.
+  const provInFlightRef = useRef<Set<string>>(new Set())
   // Poll-loop lifecycle: loops exit when the component unmounts or a run is
   // explicitly dismissed — otherwise navigation would leak up-to-900-request
   // closures, and dismissing the stepper would be undone by the next tick.
@@ -1045,6 +1052,20 @@ export default function DevFleetPage() {
   }
 
   async function provision(name: string) {
+    // Synchronous guard: blocks re-entry before React re-renders the button into
+    // its disabled state. A rapid double-click fires both event handlers in the
+    // same render turn (before any setState takes effect), so checking React state
+    // here would NOT catch the second click.  provInFlightRef is updated
+    // synchronously and persists across renders, so it reliably blocks the second
+    // invocation whether it arrives in the same turn or in a later one while the
+    // request is still awaited. The finally block releases the guard after the
+    // request/polling lifecycle exits; remounting creates a fresh ref.
+    if (provInFlightRef.current.has(name)) {
+      // The first invocation already owns the API request, polling, and UI state.
+      // Returning here prevents both a duplicate POST and a second poll loop.
+      return
+    }
+    provInFlightRef.current.add(name)
     const startedAt = Date.now()
     clearTimeout(provDoneTimersRef.current[name])
     setProvLogOpen((o) => { const n = { ...o }; delete n[name]; return n })
@@ -1072,6 +1093,11 @@ export default function DevFleetPage() {
       notify(msg, { type: 'error' })
       setProv((p) => ({ ...p, [name]: { status: 'failed', failed: true, lines: [msg], startedAt, exit: null } }))
       setProvLogOpen((o) => ({ ...o, [name]: true }))
+    } finally {
+      // Release the per-name guard so a retry after failure or dismissal can
+      // re-enter.  pollProvisionRun already owns its completion lifecycle;
+      // this only gates the entry point.
+      provInFlightRef.current.delete(name)
     }
   }
 

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -1729,3 +1729,125 @@ describe('DevFleetPage restart handshake', () => {
     }
   }, 12000)
 })
+
+// ─── Issue #5294: synchronous per-worktree in-flight guard ────────────────────
+// The Provision button's busy state lives in React prov[] state.  setState is
+// async: the button only becomes disabled after the next render commit.  A rapid
+// double-click fires BOTH onClick handlers in the same render turn, so the second
+// click sees prov.status===undefined (unchanged) and fires a second POST.
+//
+// The fix: provInFlightRef is checked and set SYNCHRONOUSLY before the first
+// await, so the second invocation is blocked regardless of React render timing.
+//
+// These tests verify the invariants at the component level by invoking the
+// handler twice in one render turn (fireEvent × 2 with no await between them).
+describe('provision singleflight guard (issue #5294)', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  const FLEET_UNPROV = {
+    worktrees: [
+      { name: 'main', is_main: true, running: false, has_dist: true, behind: 0 },
+      { name: 'unprov', is_main: false, running: false, has_dist: false, behind: 0 },
+    ],
+  }
+
+  it('regression: only one POST is sent for two rapid clicks (proves guard works)', async () => {
+    // Two fireEvent.click calls with no render between them (same render turn)
+    // simulate the rapid double-click scenario described in issue #5294.
+    // The synchronous guard in provInFlightRef blocks the second invocation
+    // before the first async handler's `await` returns — only ONE POST reaches
+    // the backend regardless of how fast the user clicks.
+    // IMPORTANT: this test proves the fix is effective; see the comment in the
+    // production code for why React setState alone cannot block the second click.
+    let provisionPosts = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_UNPROV), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) {
+        provisionPosts++
+        return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-sf-' + provisionPosts }), { status: 200 }))
+      }
+      // run poll stays running forever so the first provision is still in-flight
+      if (u.includes('/run?id=')) return Promise.resolve(new Response(JSON.stringify({ status: 'running', output: [] }), { status: 200 }))
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    const btn = screen.getByText('Provision')
+    // Rapid double-click: both clicks in the same render turn (no await between).
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    // Wait for async work to settle.
+    await waitFor(() => expect(provisionPosts).toBeGreaterThan(0), { timeout: 4000 })
+    // The synchronous guard blocks the second click — exactly one POST sent.
+    expect(provisionPosts).toBe(1)
+  }, 10000)
+
+  it('guard is released after a failure so the user can retry provisioning', async () => {
+    // After a failed provision the user dismisses the error and clicks Provision
+    // again.  The guard must be cleared in the finally block so this retry can
+    // proceed rather than being silently blocked.
+    let posts = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_UNPROV), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) {
+        posts++
+        return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-retry-' + posts }), { status: 200 }))
+      }
+      if (u.includes('/run?id=run-retry-1')) {
+        // First run fails immediately.
+        return Promise.resolve(new Response(JSON.stringify({ status: 'done', exit_code: 1, output: ['npm ERR! failed'] }), { status: 200 }))
+      }
+      if (u.includes('/run?id=run-retry-2')) {
+        // Second run stays running (we only care that the POST went out).
+        return Promise.resolve(new Response(JSON.stringify({ status: 'running', output: [] }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    // First click — provision fails.
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(screen.getByLabelText('Dismiss provision status')).toBeInTheDocument(), { timeout: 6000 })
+    // Dismiss the failure stepper.
+    fireEvent.click(screen.getByLabelText('Dismiss provision status'))
+    await waitFor(() => expect(screen.getByText('Provision')).toBeInTheDocument(), { timeout: 3000 })
+    // Retry — must succeed (guard was released in finally).
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(posts).toBe(2), { timeout: 4000 })
+  }, 20000)
+
+  it('guard cleans up cleanly after a successful provision so a subsequent provision can be started', async () => {
+    // After a successful run the stepper auto-clears and the row shows Provision
+    // again.  A click on that restored button must not be silently blocked by a
+    // stale guard entry.
+    let posts = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) {
+        // After success, fleet still shows has_dist:false so Provision is re-shown.
+        return Promise.resolve(new Response(JSON.stringify(FLEET_UNPROV), { status: 200 }))
+      }
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/pod/provision')) {
+        posts++
+        return Promise.resolve(new Response(JSON.stringify({ ok: true, run_id: 'run-ok-' + posts }), { status: 200 }))
+      }
+      if (u.includes('/run?id=')) {
+        return Promise.resolve(new Response(JSON.stringify({ status: 'done', exit_code: 0, output: ['done'] }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderWithProviders(<DevFleetPage />, { route: '/dev-fleet' })
+    await waitFor(() => expect(screen.getByText('unprov')).toBeInTheDocument())
+    // First provision succeeds and clears.
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(screen.getByText('Provision')).toBeInTheDocument(), { timeout: 6000 })
+    // Second provision — must not be silently swallowed.
+    fireEvent.click(screen.getByText('Provision'))
+    await waitFor(() => expect(posts).toBe(2), { timeout: 4000 })
+  }, 20000)
+})


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

A rapid double-click on the Provision button in the Dev Fleet page sends two
`POST /pod/provision` requests before React commits the first state update. The
button's busy state (`prov.status === 'starting'`) lives in React state, which
is updated asynchronously — the button is not disabled until the next render
commit. Both event handlers therefore see an unchanged `prov` state and both
proceed to fire a request.

The backend already deduplicates the second request and the frontend reattaches
to the existing run, so duplicate provision work is prevented downstream. The
second POST is still unnecessary: it exercises the backend lock/reply path and
the frontend reattach path for an action the UI already knows is in flight.
Preventing it closes the render-latency race at its source while retaining both
downstream mechanisms as defense in depth.

## Why it matters

Each rapid double-click currently adds a redundant localhost request and backend
single-flight response. Eliminating that request reduces avoidable work and makes
the Provision entry point idempotent at the UI boundary instead of relying only
on downstream deduplication. The backend guard and existing reattach handling
remain unchanged as safety nets.

## What changed (motivation → approach → change)

Root cause: the button disable state depends on a React re-render that has not
happened yet when the second click fires.

Approach: add a synchronous per-worktree guard (`provInFlightRef`, a
`useRef<Set<string>>`) that is checked and set **before the first `await`** in
`provision()`. Because `useRef` updates are synchronous and persist across
renders, the second click sees the guard immediately — no render latency.

Changes:
- **`website/src/pages/DevFleetPage.tsx`**: add `provInFlightRef`; add an
  entry-point guard in `provision()` that returns early for a duplicate-name
  call; release the guard in `finally` so retries after failure or completion
  are not silently blocked.
- **`website/src/test/DevFleetPage.test.tsx`**: add a `'provision singleflight
  guard (issue #5294)'` suite with three focused tests covering rapid-double-click
  dedup, retry after failure, and retry after success. Existing single-flight
  reattach behavior remains covered by the pre-existing component test.

## Tests

Three new component tests in `DevFleetPage.test.tsx`:

1. **regression: only one POST for two rapid clicks** — `fireEvent.click` twice
   with no `await` between, asserts `provisionPosts === 1`.
2. **retry after failure** — first run exits with code 1; user dismisses; second
   click sends a second POST (guard was cleared in `finally`).
3. **retry after success** — first run exits with code 0; stepper clears; second
   click sends a second POST (guard cleared on completion).

The pre-existing `ok:false + run_id` test continues to cover reattachment without
a false failure. All 81 DevFleetPage tests pass (78 existing tests plus 3 new
regression tests).

## Manual verification

N/A — the bug is a race between two same-render-turn click handlers. Component
tests with `fireEvent` × 2 and no intervening `await` reproduce the exact
scenario deterministically. A browser verification would require a precisely
timed double-click during a slow network; the component test is the reliable
evidence.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** The diff adds a `useRef` guard and a `finally` block
inside `provision()` with no JSX or styling changes. No rendered surface is
different before vs after; the change affects only async-request deduplication
behavior that is not visible in a static screenshot.

## Related Issues

Fixes #5294

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(dev-fleet): ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->