### PR TITLE
fix(ops-mission-control): lock the keystone stores down before publishing

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
@@ -122,10 +122,6 @@ OPERATOR_ONLY_KEYS: tuple[str, ...] = (
     PRIMARY_KEY,
 )
 
-#: Owner-only, matching the secret file. The value is not a credential, but it IS a control
-#: whose confidentiality and integrity both matter, so it gets the same lockdown.
-_POLICY_FILE_MODE = 0o600
-
 
 def policy_path() -> Path:
     """Absolute path to the keystone policy file (honors ``KIROCREW_HOME``)."""
@@ -181,19 +177,19 @@ class _PolicyLock:
 
 
 def _write(data: dict[str, Any]) -> None:
+    # Locked down BEFORE the payload is published, same as the secret store:
+    # ``atomic_write`` applies the owner-only DACL to its temp file ahead of the
+    # content and the rename, so a lockdown failure leaves the PREVIOUS ceiling
+    # in place. It implies 0o600 on POSIX, so the explicit mode is gone.
+    #
+    # The post-publish spelling this replaces unlinked the ceiling it had just
+    # written, which is worse than it sounds: with the file gone every reader
+    # silently falls back to its caller-supplied default, so a transient icacls
+    # failure did not surface as "the ceiling is missing" but as "the ceiling
+    # says whatever the default is". Fail-loud is unchanged -- the write still
+    # raises when the lockdown cannot be applied.
     payload = json.dumps(data, indent=2, sort_keys=True)
-    atomic_write(policy_path(), payload, mode=_POLICY_FILE_MODE)
-    # Fail-loud lockdown, same as the secret store: ``atomic_write``'s mode covers POSIX,
-    # and this applies the owner-only DACL on Windows. A lockdown failure must not leave the
-    # ceiling world-readable, so unlink and re-raise rather than continue.
-    try:
-        platform_compat.restrict_to_owner(policy_path())
-    except OSError:
-        try:
-            policy_path().unlink()
-        except OSError:
-            logger.exception("failed to remove ops policy file after lockdown failure")
-        raise
+    atomic_write(policy_path(), payload, restrict_to_owner=True)
 
 
 def read_mode(default: str) -> str:

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
@@ -54,10 +54,6 @@ logger = logging.getLogger(__name__)
 #: rename cannot silently drop the keystone protection.
 SECRETS_FILENAME = "ops_mission_control_secrets.json"
 
-#: Owner-only mode for the secret file (POSIX). Windows gets an owner-only DACL
-#: via ``platform_compat.restrict_to_owner``.
-_SECRET_FILE_MODE = 0o600
-
 #: Value returned to callers in place of a stored secret. Secrets are write-only
 #: over the API: the UI shows whether a field is set, never what it is.
 REDACTED_PLACEHOLDER = "••••••••"
@@ -218,20 +214,21 @@ class KeystoneFileBackend:
         return _SecretLock(self._path)
 
     def _write(self, data: dict[str, dict[str, str]]) -> None:
+        # Locked down BEFORE the payload is published, not after. ``atomic_write``
+        # applies the owner-only DACL to its temp file before any content reaches
+        # it and before the rename, so a lockdown failure raises with the
+        # PREVIOUS store still on disk and nothing to clean up. It implies
+        # 0o600 on POSIX, so the explicit mode is gone rather than duplicated.
+        #
+        # The post-publish spelling this replaces had already written the new
+        # file, which left its failure path unlinking a store that by then held
+        # EVERY provider token -- this is a read-modify-write of the whole
+        # document -- so one transient icacls failure logged every integration
+        # out. Fail-loud is unchanged: ``restrict_on_error`` defaults to
+        # "raise", so a secret that cannot be protected is still never
+        # published.
         payload = json.dumps(data, indent=2, sort_keys=True)
-        atomic_write(self._path, payload, mode=_SECRET_FILE_MODE)
-        # Fail-loud lockdown. ``atomic_write``'s mode covers POSIX; this also
-        # applies an owner-only DACL on Windows, where POSIX mode bits are not
-        # enforced. A lockdown failure must not leave a world-readable token on
-        # disk, so we unlink and re-raise rather than continue.
-        try:
-            platform_compat.restrict_to_owner(self._path)
-        except OSError:
-            try:
-                self._path.unlink()
-            except OSError:
-                logger.exception("failed to remove secret file after lockdown failure")
-            raise
+        atomic_write(self._path, payload, restrict_to_owner=True)
 
     # -- SecretBackend -----------------------------------------------------
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_lockdown.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_lockdown.py
@@ -1,0 +1,165 @@
+"""Locking a store down must not be able to destroy the store.
+
+Both keystone-floor stores in this app published their payload first and applied
+the owner-only lockdown afterwards:
+
+    atomic_write(path, payload, mode=0o600)     # already published
+    try:
+        platform_compat.restrict_to_owner(path)
+    except OSError:
+        path.unlink()                            # deletes the PUBLISHED file
+        raise
+
+The unlink is there for a real reason — a secret that cannot be protected must
+not stay on disk — but by the time it runs the previous, healthy store has
+already been replaced. Both writers are read-modify-write over the WHOLE
+document, so the file that gets unlinked holds every provider token, or the
+entire autonomy ceiling, not just the value being saved. One transient lockdown
+failure (an `icacls` hiccup on Windows, where the DACL call is the one that can
+actually fail) therefore destroys the lot.
+
+``atomic_write(restrict_to_owner=True)`` applies the lockdown to the TEMP file
+before any content reaches it and before the rename, so a lockdown failure
+raises with the previous store still in place and nothing left to unlink. These
+tests pin the surviving-store property, not the implementation: they assert what
+is readable after a failed save.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+class _HomeIsolated(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self._prev = os.environ.get("KIROCREW_HOME")
+        os.environ["KIROCREW_HOME"] = str(self.tmp)
+
+    def tearDown(self) -> None:
+        if self._prev is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._prev
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+class TestSecretStoreSurvivesALockdownFailure(_HomeIsolated):
+    """The provider-token store. Losing this logs every integration out."""
+
+    def _backend(self):
+        from kiro_crew.apps.builtins.ops_mission_control.backend.secrets import (
+            KeystoneFileBackend,
+        )
+
+        return KeystoneFileBackend()
+
+    def test_a_failed_lockdown_does_not_delete_the_existing_tokens(self):
+        backend = self._backend()
+        backend.put("pagerduty", "api_token", "pd-live-token")
+        self.assertEqual(backend.get("pagerduty", "api_token"), "pd-live-token")
+
+        # The lockdown is the one step that can fail on an otherwise healthy
+        # filesystem: on Windows it is an icacls/DACL call, not a mode bit.
+        # Patched on the platform_compat module so it intercepts the call
+        # wherever it is made from -- the store itself, or atomic_write.
+        with mock.patch(
+            "kiro_crew.platform_compat.restrict_to_owner",
+            side_effect=OSError("icacls: transient failure"),
+        ):
+            with self.assertRaises(OSError):
+                backend.put("datadog", "api_key", "dd-key")
+
+        self.assertEqual(
+            self._backend().get("pagerduty", "api_token"),
+            "pd-live-token",
+            "a failed lockdown destroyed the existing provider tokens: the store "
+            "was published before it was locked down, so the failure path "
+            "unlinked a file that already held every credential",
+        )
+
+    def test_a_failed_lockdown_does_not_publish_the_new_secret(self):
+        """Fail-loud is preserved: the unprotected value must not land either."""
+        backend = self._backend()
+        backend.put("pagerduty", "api_token", "pd-live-token")
+
+        with mock.patch(
+            "kiro_crew.platform_compat.restrict_to_owner",
+            side_effect=OSError("icacls: transient failure"),
+        ):
+            with self.assertRaises(OSError):
+                backend.put("datadog", "api_key", "dd-key")
+
+        self.assertEqual(
+            self._backend().get("datadog", "api_key"),
+            "",
+            "a secret the process could not protect was published anyway",
+        )
+
+    def test_a_temp_file_failure_also_leaves_the_store_intact(self):
+        """Preservation control: the other failure mode must stay non-destructive.
+
+        Passes on both trees by design — it is here so a future 'simplification'
+        that reintroduces a post-publish cleanup has something to fail against.
+        """
+        backend = self._backend()
+        backend.put("pagerduty", "api_token", "pd-live-token")
+
+        with mock.patch("tempfile.mkstemp", side_effect=OSError(28, "No space left on device")):
+            with self.assertRaises(OSError):
+                backend.put("datadog", "api_key", "dd-key")
+
+        self.assertEqual(self._backend().get("pagerduty", "api_token"), "pd-live-token")
+
+
+class TestPolicyStoreSurvivesALockdownFailure(_HomeIsolated):
+    """The autonomy ceiling. Losing this drops the app to its default mode."""
+
+    def _policy(self):
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        return policy_store
+
+    def test_a_failed_lockdown_does_not_delete_the_existing_ceiling(self):
+        policy_store = self._policy()
+        policy_store.set_ceiling(mode="act", rules=[{"provider": "pagerduty"}])
+        self.assertEqual(policy_store.read_mode("read"), "act")
+
+        with mock.patch(
+            "kiro_crew.platform_compat.restrict_to_owner",
+            side_effect=OSError("icacls: transient failure"),
+        ):
+            with self.assertRaises(OSError):
+                policy_store.set_ceiling(mode="read")
+
+        self.assertEqual(
+            policy_store.read_mode("read-DEFAULT-MEANS-FILE-GONE"),
+            "act",
+            "a failed lockdown deleted the autonomy ceiling file; the app would "
+            "fall back to its default mode with no record that a ceiling was set",
+        )
+
+    def test_the_ceiling_file_is_still_owner_only_after_a_successful_write(self):
+        """Preservation: the security property the unlink existed to protect."""
+        policy_store = self._policy()
+        policy_store.set_ceiling(mode="act")
+
+        path = policy_store.policy_path()
+        self.assertTrue(path.exists(), "the ceiling was not written at all")
+        self.assertEqual(
+            json.loads(path.read_text(encoding="utf-8")).get("mode"),
+            "act",
+            "the ceiling did not round-trip",
+        )
+        if os.name == "posix":
+            self.assertEqual(
+                path.stat().st_mode & 0o777,
+                0o600,
+                "the ceiling is readable beyond its owner",
+            )


### PR DESCRIPTION
## Problem / Motivation

Both keystone-floor stores in Ops Mission Control published their payload first and applied the owner-only lockdown afterwards:

```python
atomic_write(path, payload, mode=0o600)      # already published
try:
    platform_compat.restrict_to_owner(path)
except OSError:
    path.unlink()                            # deletes the PUBLISHED file
    raise
```

The unlink exists for a real reason — a secret that cannot be protected must not stay on disk — but by the time it runs, the previous healthy store has already been replaced. Both writers are a read-modify-write over the **whole document**, so the file being unlinked holds *every* provider token, or the *entire* autonomy ceiling, not just the value being saved.

| Site | What one transient lockdown failure destroys |
|---|---|
| `backend/secrets.py::_SecretStore._write` | every stored provider token — PagerDuty, Datadog, all of them |
| `backend/policy_store.py::_write` | the whole autonomy ceiling (`mode` + `autonomy_rules`) |

On Windows the lockdown is an `icacls`/DACL call, which is precisely the step that can fail on an otherwise healthy filesystem — the mode bits POSIX relies on are not enforced there, which is why the separate call exists at all.

The policy store fails worse than it looks. With the ceiling file gone, every reader falls back to its caller-supplied default, so the failure does not surface as "the ceiling is missing" but as "the ceiling says whatever the default is."

## Why it matters

Silent, unrecoverable loss of the two files this app treats as its security floor, triggered by a *transient* error on a path whose whole purpose is to protect them. The failure is worst exactly when it is least expected: a save that fails to tighten permissions deletes credentials that were already safely on disk and already correctly locked down.

There is no recovery — the tokens are gone and every integration is logged out — and no signal that a ceiling was ever configured.

## What changed (motivation → approach → change)

**Motivation** — the step that protects the store must not be able to destroy it.

**Approach** — publish last. `atomic_write` already offers exactly this ordering, so this is a conversion to an existing helper, not a new mechanism. Its `restrict_to_owner=True` applies `platform_compat.restrict_to_owner` to the **temp file before any content reaches it** and before the rename, so a lockdown failure raises while the previous store is still the file on disk.

**Change** — both sites become:

```python
payload = json.dumps(data, indent=2, sort_keys=True)
atomic_write(path, payload, restrict_to_owner=True)
```

and the `try/except/unlink` is **deleted**, not reordered — with the failure happening before publication there is nothing left to clean up.

Three consequences worth stating rather than leaving implied:

- **Fail-loud is unchanged.** `restrict_on_error` defaults to `"raise"`, so a payload the process cannot protect is still never published. That is asserted directly, not assumed.
- **`_SECRET_FILE_MODE` / `_POLICY_FILE_MODE` are removed.** `restrict_to_owner` implies `0o600` on POSIX and `atomic_write` *rejects* a conflicting explicit `mode`, so each constant lost its last consumer.
- **Both writers now refuse a planted parent link.** `restrict_to_owner=True` also implies `_refuse_linked_parent`, so a pre-planted parent symlink or junction can no longer redirect either write. That is a strict improvement neither site had, and it arrives as a property of the helper rather than as new code here.

**Scope: Tier 1 only.** #5307 lists seven sites. The other five carry a post-publish *window* but no unlink, so they cannot destroy an existing store — a materially different severity. One of them (`mcp_gateway` spool) is documented in `docs/system-specs/modules/mcp-apps.md`, which under AGENTS.md must be updated in the same commit as the behaviour it documents; folding that in here would mix a data-loss fix with a spec change. They are left for their own change.

Two production files, 26 insertions / 33 deletions.

## Tests

New `src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_lockdown.py`. Every test asserts what is **readable after a failed save**, not how the write is implemented, so the conversion is pinned by outcome:

| Test | Behavior locked in |
|---|---|
| `TestSecretStore…::test_a_failed_lockdown_does_not_delete_the_existing_tokens` | a lockdown failure leaves previously-saved provider tokens readable |
| `TestSecretStore…::test_a_failed_lockdown_does_not_publish_the_new_secret` | fail-loud preserved — the unprotected value does not land either |
| `TestSecretStore…::test_a_temp_file_failure_also_leaves_the_store_intact` | preservation: the ENOSPC path stays non-destructive |
| `TestPolicyStore…::test_a_failed_lockdown_does_not_delete_the_existing_ceiling` | the ceiling survives, so readers do not silently fall back to a default |
| `TestPolicyStore…::test_the_ceiling_file_is_still_owner_only_after_a_successful_write` | preservation: the security property the unlink existed to protect (POSIX mode asserted where mode bits are enforced) |

The lockdown is patched on **`kiro_crew.platform_compat.restrict_to_owner`**, the module attribute both trees call through — the store directly before this change, `atomic_write` after it. That is what makes the fail-before valid: the same patch intercepts the same call on both sides, so the test is not merely detecting that a symbol moved.

Fail-before / pass-after, with both production files reverted to `origin/main` and the tests left in place:

```
FAILED TestSecretStoreSurvivesALockdownFailure::test_a_failed_lockdown_does_not_delete_the_existing_tokens
  - AssertionError: '' != 'pd-live-token'
FAILED TestPolicyStoreSurvivesALockdownFailure::test_a_failed_lockdown_does_not_delete_the_existing_ceiling
  - AssertionError: 'read-DEFAULT-MEANS-FILE-GONE' != 'act'

2 failed, 3 passed
```

`''` and `'read-DEFAULT-MEANS-FILE-GONE'` are the data loss itself: the token store came back empty, and the ceiling reader fell through to the sentinel default because the file no longer existed.

The three preservation tests pass on **both** trees by design — they guard against over-correcting into "never lock down" or "never fail loud", and are reported as controls rather than folded into the fail-before count.

```
pytest .../ops_mission_control/tests/test_store_lockdown.py -q          5 passed
pytest .../ops_mission_control/tests/ -q               914 passed, 46 skipped
```

Gates: `flake8` · `isort --check-only` · `black --check` all clean on the three changed files. None of them is in `.github/black-baseline.txt`, so all three are held to `black` and are formatted.

## Manual verification

N/A — unit coverage sufficient: the defect is a failure-ordering property, and the tests drive the real `KeystoneFileBackend.put` and `policy_store.set_ceiling` with the real `atomic_write`, injecting the failure at the one call that genuinely fails in production. Reproducing by hand means inducing a transient `icacls` failure on Windows mid-save, which is what the injected `OSError` stands in for.

## Related Issues

Refs #5307 — Tier 1 (the two sites carrying the unlink-the-published-store data loss).

Sibling, not a dependency: #5302 converts a different set of files (`aws_consent.py`, `session_transfer.py`, `tips.py`, `weixin/client.py`) for the same underlying reason. `atomic_write(restrict_to_owner=...)` is already on `main`, so this change does not wait on it, and the two touch no common file.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no spec documents these two writers' lockdown ordering; the Tier 2 site that *is* documented is deliberately out of scope
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
