### PR TITLE
fix(security): lock MCP overlays and the live-target pointer before publishing

### DIFF
--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -1485,15 +1485,26 @@ def rewrite_agents(
         _collect_target_env(new_spec.get("mcpServers", {}), target_env)
         target = overlay_dir / path.name
         try:
-            # Atomic + 0600: temp-file + os.replace (via atomic_write) so a
-            # live session reading this overlay through the bind-mount never
+            # Atomic + owner-only: temp-file + os.replace (via atomic_write) so
+            # a live session reading this overlay through the bind-mount never
             # sees a truncated spec (which would make the agent's MCP servers
             # vanish mid-run), and the passed-through non-poolable / HTTP-SSE
             # env blocks (tokens / API keys) are never world-readable. Matches
             # the env sidecar and settings overlay.
-            atomic_write(target, json.dumps(new_spec, indent=2) + "\n", mode=0o600)
-            if not platform_compat.IS_POSIX:
-                platform_compat.restrict_to_owner(target)
+            #
+            # `restrict_to_owner=True` locks the TEMP file down before any
+            # content reaches it, which is what makes "never world-readable"
+            # true on Windows too. Applying the DACL after the rename left the
+            # tokens published under the directory's inherited ACL for the
+            # length of that call; on POSIX the mode landed on the temp already,
+            # so only Windows carried the window. A lockdown failure now raises
+            # before publication and is handled by the same `except OSError`
+            # below, so the overlay is skipped rather than published unprotected.
+            atomic_write(
+                target,
+                json.dumps(new_spec, indent=2) + "\n",
+                restrict_to_owner=True,
+            )
         except OSError as exc:
             logger.warning("failed to write overlay %s: %s", target, exc)
             overlay_write_failed = True
@@ -1557,19 +1568,16 @@ def rewrite_agents(
                 # Malformed source (mcpServers not a dict): normalize rather
                 # than propagate the broken shape into a freshly-written overlay.
                 new_settings["mcpServers"] = {}
-            # Atomic + 0600: temp-file + os.replace (via atomic_write) so a
-            # live session reading this overlay through the bind-mount never
-            # sees a truncated mcp.json (which would make its MCP servers
-            # vanish mid-run), and the passed-through non-poolable / HTTP-SSE
-            # env blocks (tokens / API keys) are never world-readable. Matches
-            # the env sidecar and per-agent overlay.
+            # Atomic + owner-only, same contract as the per-agent overlay
+            # above: the temp file is locked down before any content reaches it,
+            # so the passed-through env blocks (tokens / API keys) are never
+            # world-readable on any platform, and a lockdown failure raises
+            # before publication instead of leaving an unprotected mcp.json.
             atomic_write(
                 settings_overlay_path,
                 json.dumps(new_settings, indent=2) + "\n",
-                mode=0o600,
+                restrict_to_owner=True,
             )
-            if not platform_compat.IS_POSIX:
-                platform_compat.restrict_to_owner(settings_overlay_path)
             logger.info(
                 "mcp-gateway rewriter: global mcp.json overlay written, "
                 "%d poolable server(s) relocated to per-agent overlays (overlay=%s)",

--- a/src/kiro_crew/service/live_target.py
+++ b/src/kiro_crew/service/live_target.py
@@ -45,7 +45,6 @@ import os
 import sys
 from pathlib import Path
 
-from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import loader
 
@@ -58,7 +57,6 @@ EXEC_MARKER = "KIROCREW_LIVE_EXECED"
 #: Owner-only: the pointer is a code-execution input, and mode does not isolate
 #: another process running as the same UID, but a world-writable one would be
 #: strictly worse.
-_MODE = 0o600
 
 _FILENAME = "live_target.json"
 
@@ -191,12 +189,14 @@ def write_target(checkout: Path | str) -> Path:
     payload = json.dumps({"checkout": str(resolved)}, indent=2) + "\n"
     path = pointer_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write(path, payload, mode=_MODE)
-    # atomic_write's mode is a POSIX permission bit and a no-op on Windows, which
-    # would leave a code-execution input inheriting the directory's ACL there.
-    # restrict_to_owner applies the owner-only DACL instead, so the pointer is
-    # owner-only on every platform.
-    platform_compat.restrict_to_owner(path)
+    # Owner-only on every platform, applied to the temp file BEFORE the
+    # content and before the rename. A POSIX mode bit alone is a no-op on
+    # Windows, which would leave this — a code-execution input read at every
+    # startup — inheriting the directory's ACL; applying the DACL after the
+    # rename merely shortened that exposure instead of removing it.
+    # `restrict_to_owner` implies 0o600 on POSIX, so no explicit mode is
+    # needed, and it refuses a planted parent link on the way.
+    atomic_write(path, payload, restrict_to_owner=True)
     return resolved
 
 
@@ -227,13 +227,13 @@ def restore(prior: str | None) -> bool:
             path.unlink(missing_ok=True)
         else:
             path.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write(path, prior, mode=_MODE)
-            # Harden the restored file for the same reason write_target does:
-            # atomic_write's mode is a POSIX permission bit and a no-op on
-            # Windows, so without this the pointer — a code-execution input read
-            # at every startup — would come back inheriting the directory's ACL.
-            # A rollback must not be the step that widens access to it.
-            platform_compat.restrict_to_owner(path)
+            # Locked down before publication for the same reason write_target
+            # does it: a rollback must not be the step that widens access to
+            # the pointer. The best-effort contract is unchanged — a lockdown
+            # failure raises OSError and is caught below as `return False`,
+            # and now leaves the previous pointer in place rather than a
+            # freshly published one nobody protected.
+            atomic_write(path, prior, restrict_to_owner=True)
         return True
     except OSError:
         return False

--- a/test/test_live_target.py
+++ b/test/test_live_target.py
@@ -22,9 +22,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from kiro_crew import platform_compat
 from kiro_crew.service.live_target import (
     _FILENAME,
-    _MODE,
     EXEC_MARKER,
     InvalidTarget,
     maybe_reexec,
@@ -290,23 +290,38 @@ class TestWriteTarget:
             # Windows has no POSIX bits: write_target applies an owner-only DACL
             # through restrict_to_owner, which the next test pins directly.
             pytest.skip("POSIX permission bits are not meaningful here")
-        assert pointer_path().stat().st_mode & 0o777 == _MODE
+        # 0o600 is what restrict_to_owner implies on POSIX; asserted as the
+        # literal now that the module no longer carries a mode constant.
+        assert pointer_path().stat().st_mode & 0o777 == 0o600
 
     def test_applies_owner_only_lockdown(self, tmp_path, monkeypatch):
-        """restrict_to_owner is called on the written pointer.
+        """The owner-only lockdown runs, and runs BEFORE the pointer is published.
 
         This is the only owner-only mechanism on Windows, where atomic_write's
         mode argument is a no-op, so it must be asserted independently of the
-        POSIX bit check above.
+        POSIX bit check above. It is applied to the temp file inside
+        atomic_write, so what is pinned here is that it ran against a file in
+        the pointer's own directory while the pointer itself did not yet exist —
+        a lockdown landing after publication would leave the pointer, which is a
+        code-execution input read at every startup, briefly unprotected.
         """
         seen: list = []
-        monkeypatch.setattr(
-            "kiro_crew.service.live_target.platform_compat.restrict_to_owner",
-            lambda path: seen.append(Path(path)),
-        )
+        published_at_call: list = []
+        real = platform_compat.restrict_to_owner
+
+        def _record(path):
+            seen.append(Path(path))
+            published_at_call.append(pointer_path().exists())
+            return real(path)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _record)
         checkout = _make_valid_checkout(tmp_path)
         write_target(checkout)
-        assert seen == [pointer_path()]
+        assert seen, "no owner-only lockdown was applied to the pointer"
+        assert all(p.parent == pointer_path().parent for p in seen), seen
+        assert not any(published_at_call), (
+            "the lockdown ran after the pointer was already published"
+        )
 
     def test_round_trips_through_read_target(self, tmp_path):
         checkout = _make_valid_checkout(tmp_path)
@@ -368,19 +383,27 @@ class TestSnapshotRestore:
         """
         hardened: list = []
         monkeypatch.setattr(
-            "kiro_crew.service.live_target.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
+            "kiro_crew.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
         path = pointer_path()
         path.parent.mkdir(parents=True, exist_ok=True)
 
         assert restore('{"checkout": "/old/path"}\n') is True
 
-        assert hardened == [path], "restore must harden the file it wrote"
+        # The lockdown lands on atomic_write's temp file, in the pointer's own
+        # directory, BEFORE the rename -- so the restored pointer is never
+        # briefly present under an inherited ACL. Asserting it never runs on
+        # the final path is what pins that ordering.
+        assert hardened, "restore must harden the file it wrote"
+        assert all(Path(h).parent == path.parent for h in hardened), hardened
+        assert path not in [Path(h) for h in hardened], (
+            "the DACL was applied to the published pointer instead of before it"
+        )
 
     def test_restore_none_does_not_harden_a_deleted_pointer(self, tmp_path, monkeypatch):
         """Deleting leaves no file, so there is nothing to apply a DACL to."""
         hardened: list = []
         monkeypatch.setattr(
-            "kiro_crew.service.live_target.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
+            "kiro_crew.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
         path = pointer_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("anything")
@@ -395,7 +418,7 @@ class TestSnapshotRestore:
         def boom(_path):
             raise OSError(5, "icacls failed")
 
-        monkeypatch.setattr("kiro_crew.service.live_target.platform_compat.restrict_to_owner", boom)
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", boom)
         path = pointer_path()
         path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/test/test_lockdown_before_publish.py
+++ b/test/test_lockdown_before_publish.py
@@ -1,0 +1,183 @@
+"""A secret-bearing file must be locked down BEFORE it is published.
+
+Applying the owner-only lockdown after ``atomic_write`` has already renamed the
+payload into place leaves a window in which the file exists at its final path
+under whatever permissions it inherited. Two writers did that:
+
+* ``mcp_gateway/rewriter.py`` — the per-agent and settings MCP overlays, which
+  carry passed-through ``env`` blocks (tokens / API keys). Its lockdown was also
+  guarded by ``if not platform_compat.IS_POSIX``, so on POSIX the overlay relied
+  entirely on ``atomic_write``'s mode and on Windows it got the DACL only after
+  publication.
+* ``service/live_target.py`` — the live-target pointer, which is a
+  code-execution input read at every startup.
+
+``atomic_write(restrict_to_owner=True)`` applies the lockdown to the temp file
+before any content reaches it and before the rename, so the payload never exists
+unprotected at its final path and a lockdown failure publishes nothing at all.
+
+The assertions here are about ORDER and OUTCOME rather than about which platform
+is running: each records the state of the FINAL path at the moment the lockdown
+runs, which is a property both platforms must satisfy.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from test_live_target import _make_valid_checkout
+
+# ── live-target pointer ──────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_the_pointer_is_locked_down_before_it_is_published(_home) -> None:
+    """The lockdown must not see a file already at the pointer's final path."""
+    from kiro_crew.service import live_target
+
+    seen_at_call: list[bool] = []
+    real = None
+    from kiro_crew import platform_compat
+
+    real = platform_compat.restrict_to_owner
+
+    def _recording(path):
+        seen_at_call.append(live_target.pointer_path().exists())
+        return real(path)
+
+    with patch("kiro_crew.platform_compat.restrict_to_owner", side_effect=_recording):
+        live_target.write_target(_make_valid_checkout(_home))
+
+    assert seen_at_call, "the pointer was written without any owner-only lockdown at all"
+    assert not any(seen_at_call), (
+        "the lockdown ran while the pointer was already published at its final "
+        "path: the file existed there unprotected until that call returned"
+    )
+
+
+def test_a_pointer_that_cannot_be_locked_down_is_not_published(_home) -> None:
+    """Fail-closed: a failed lockdown must leave the PREVIOUS pointer in place."""
+    from kiro_crew.service import live_target
+
+    live_target.write_target(_make_valid_checkout(_home))
+    before = live_target.snapshot()
+    assert before, "scaffold: the first pointer was never written"
+
+    second_root = _home / "second"
+    second_root.mkdir()
+    other = _make_valid_checkout(second_root)
+
+    with patch(
+        "kiro_crew.platform_compat.restrict_to_owner",
+        side_effect=OSError("icacls: transient failure"),
+    ):
+        with pytest.raises(OSError):
+            live_target.write_target(other)
+
+    assert live_target.snapshot() == before, (
+        "a pointer whose lockdown failed replaced the previous one anyway; the "
+        "gateway would exec a target that was never protected"
+    )
+
+
+def test_restore_still_reports_failure_instead_of_raising(_home) -> None:
+    """Preservation: ``restore`` is best-effort by contract and returns False."""
+    from kiro_crew.service import live_target
+
+    live_target.write_target(_make_valid_checkout(_home))
+    prior = live_target.snapshot()
+
+    with patch(
+        "kiro_crew.platform_compat.restrict_to_owner",
+        side_effect=OSError("icacls: transient failure"),
+    ):
+        assert live_target.restore(prior) is False, (
+            "restore raised instead of reporting failure, which would lose the "
+            "original cutover error it was unwinding"
+        )
+
+
+# ── MCP overlays ─────────────────────────────────────────────────────────────
+
+
+def _agent_source(tmp_path: Path) -> Path:
+    source_dir = tmp_path / "agents"
+    source_dir.mkdir()
+    spec = {
+        "name": "test-agent",
+        "mcpServers": {
+            "myserver": {
+                "command": "echo",
+                "args": ["hello"],
+                "env": {"SECRET_TOKEN": "s3cr3t"},
+                "poolable": True,
+            }
+        },
+    }
+    (source_dir / "test-agent.json").write_text(json.dumps(spec), encoding="utf-8")
+    return source_dir
+
+
+def test_the_agent_overlay_is_locked_down_before_publication(tmp_path: Path) -> None:
+    """On EVERY platform, and before the overlay reaches its final path.
+
+    The previous spelling ran the lockdown only when ``IS_POSIX`` was false, so
+    on POSIX this assertion fails because nothing locked the overlay down at
+    all, and on Windows it fails because the overlay was already published when
+    the lockdown ran. Both are the same defect seen from different platforms.
+    """
+    from kiro_crew import platform_compat
+    from kiro_crew.mcp_gateway.rewriter import rewrite_agents
+
+    source_dir = _agent_source(tmp_path)
+    overlay_dir = tmp_path / "overlay"
+    locked: list[Path] = []
+    real = platform_compat.restrict_to_owner
+
+    def _recording(path):
+        p = Path(path)
+        # Scoped to the overlay directory. The rewriter also persists a
+        # fingerprint file there, whose own temp is locked down after the
+        # overlay is published -- correct for that file, and not what this test
+        # is about, so the assertions below name the overlay spec explicitly
+        # rather than timing every call in the directory.
+        if p.parent == overlay_dir:
+            locked.append(p)
+        return real(path)
+
+    with patch("kiro_crew.platform_compat.restrict_to_owner", side_effect=_recording):
+        rewrite_agents(
+            source_dir=source_dir,
+            overlay_dir=overlay_dir,
+            socket_path=tmp_path / "gw.sock",
+            work_dir=tmp_path / "wd",
+            sandbox_mode="auto",
+            approval_mode="interactive",
+            stub_servers=frozenset(["myserver"]),
+        )
+
+    published = overlay_dir / "test-agent.json"
+    assert locked, (
+        "no owner-only lockdown was applied in the overlay directory on this "
+        "platform; the overlay carries passed-through env blocks (tokens / API "
+        "keys) and must not depend on POSIX mode bits alone"
+    )
+    assert published not in locked, (
+        "the lockdown was applied to the overlay AFTER it was published at its "
+        f"final path, leaving it briefly readable: {locked}"
+    )
+    assert any(
+        p.name.endswith(".tmp") for p in locked
+    ), f"the overlay was never locked down before publication: {locked}"
+    assert (overlay_dir / "test-agent.json").is_file(), (
+        "the overlay was not published at all — the lockdown change must not "
+        "stop the rewriter producing its output"
+    )

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -613,12 +613,16 @@ def test_rewriter_calls_restrict_to_owner_on_windows(
     # because the non-POSIX guard in the write path fires.
     env_sidecars = [p for p in restricted_paths if "stubs" in str(p.parent)]
     assert env_sidecars, f"env sidecar file not restricted: {restricted_paths}"
-    # The overlay agent spec lives in overlay/ directory
-    overlay_specs = [
-        p for p in restricted_paths
-        if p.suffix == ".json" and p.parent.name == "overlay"
-    ]
-    assert overlay_specs, f"overlay spec file not restricted: {restricted_paths}"
+    # The overlay agent spec lives in the overlay/ directory. Its lockdown is
+    # applied by atomic_write to the TEMP file, before the rename, so what is
+    # asserted is that a file in overlay/ was restricted and that the published
+    # .json never was -- a DACL landing on the published path would mean the
+    # spec, which carries passed-through env blocks, existed unprotected first.
+    overlay_locked = [p for p in restricted_paths if p.parent.name == "overlay"]
+    assert overlay_locked, f"overlay spec file not restricted: {restricted_paths}"
+    assert not [p for p in overlay_locked if p.suffix == ".json"], (
+        f"the overlay spec was restricted after publication: {overlay_locked}"
+    )
 
 
 def test_rewriter_overlay_dirs_are_traversable_on_posix(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem / Motivation

Three secret-bearing writers applied their owner-only lockdown **after** `atomic_write` had already renamed the payload into place:

```python
atomic_write(path, payload, mode=0o600)
if not platform_compat.IS_POSIX:          # overlays only
    platform_compat.restrict_to_owner(path)
```

Between the rename and that call, the file exists at its final path under whatever permissions it inherited from the directory.

| Site | Payload | Exposure |
|---|---|---|
| `mcp_gateway/rewriter.py` per-agent overlay | passed-through `env` blocks — tokens / API keys | POSIX: **never locked down at all**; Windows: locked down only after publication |
| `mcp_gateway/rewriter.py` settings overlay | same | same |
| `service/live_target.py::write_target` | the live-target pointer — a **code-execution input read at every startup** | locked down after publication on every platform |
| `service/live_target.py::restore` | same, on the rollback path | same |

The overlays are the worse half, and not merely by a window. Their lockdown sat behind `if not platform_compat.IS_POSIX`, so on POSIX **nothing applied it** — the overlay relied entirely on `atomic_write`'s mode argument — and on Windows, where that mode argument is a documented no-op, the DACL arrived only once the file was already published.

## Why it matters

These are the files the rest of the security model assumes are owner-only. The overlay carries credentials the gateway passes through to MCP servers; the live-target pointer decides **which checkout the gateway executes**, so another local account able to write it gets code execution at the next startup.

An exposure window that opens only under a directory whose ACL happens to be permissive is exactly the kind that no test notices and no operator can observe after the fact.

## What changed (motivation → approach → change)

**Motivation** — a file that must be owner-only must never exist at its final path before it is.

**Approach** — publish last, using the helper that already does this. `atomic_write(restrict_to_owner=True)` applies `platform_compat.restrict_to_owner` to the **temp file, before any content reaches it and before the rename**. That is a conversion to an existing contract, not a new mechanism, and it deletes the platform conditional rather than duplicating it.

**Change** — all four sites become `atomic_write(path, payload, restrict_to_owner=True)`, and the trailing lockdown call is removed.

Consequences, stated rather than implied:

- **The platform conditional is gone.** `restrict_to_owner` is cross-platform (chmod on POSIX, DACL on Windows), so the overlay is now locked down on POSIX too — where previously nothing did it.
- **`_MODE` is removed** and `live_target` no longer imports `platform_compat` at all: `restrict_to_owner` implies `0o600` on POSIX, and `atomic_write` *rejects* a conflicting explicit `mode`.
- **All four now refuse a planted parent link.** `restrict_to_owner=True` implies `_refuse_linked_parent`, so a pre-planted symlink or junction can no longer redirect these writes. A strict improvement that arrives as a property of the helper.
- **Failure policy is preserved per site**, which is the part a conversion like this most easily gets wrong:
  - overlays — the raise lands in the rewriter's existing `except OSError`, so the overlay is still logged and marked `overlay_write_failed`; it is now *skipped* rather than published unprotected;
  - `write_target` — still raises;
  - `restore` — still returns `False` rather than raising, keeping its best-effort contract.

**Scope.** #5307 Tier 2 lists five sites; this is four of them. Site 7 (the `mcp_gateway` spool) hand-rolls an `os.open(O_CREAT|O_TRUNC)` **directly at the final path** — a different and larger change — and is documented in `docs/system-specs/modules/mcp-apps.md`, which AGENTS.md requires be updated in the same commit as the behaviour it documents. Mixing that in would couple a spec change to this one.

Two production files, 83 insertions / 48 deletions including tests.

## Tests

New `test/test_lockdown_before_publish.py` asserts **order and outcome**, not platform:

| Test | Behavior locked in |
|---|---|
| `test_the_pointer_is_locked_down_before_it_is_published` | at the moment the lockdown runs, the pointer does not yet exist at its final path |
| `test_a_pointer_that_cannot_be_locked_down_is_not_published` | a failed lockdown leaves the **previous** pointer in place |
| `test_restore_still_reports_failure_instead_of_raising` | preservation: `restore`'s best-effort `False` contract is unchanged |
| `test_the_agent_overlay_is_locked_down_before_publication` | a file in `overlay/` is locked down, and the published `.json` never is |

The overlay test is deliberately **platform-independent**: on POSIX the old code fails it because nothing locked the overlay down at all, and on Windows it fails because the lockdown ran after publication. Same defect, two platforms, one assertion — no `IS_POSIX` simulation needed.

**Three existing tests pinned the old mechanism and were repointed, each strengthened rather than relaxed** — they now assert the lockdown ran *and* that it never ran on the published path:

- `test_live_target.py::TestWriteTarget::test_applies_owner_only_lockdown`
- `test_live_target.py::TestSnapshotRestore::test_restore_reapplies_the_owner_only_dacl`
- `test_mcp_gateway_rewriter.py::test_rewriter_calls_restrict_to_owner_on_windows`

`test_writes_owner_only_permissions` kept its assertion and now names `0o600` literally, since the module no longer carries a mode constant.

Fail-before / pass-after, with both production files reverted to `origin/main` and all tests left in place:

```
FAILED test_lockdown_before_publish.py::test_the_pointer_is_locked_down_before_it_is_published
  - AssertionError: the lockdown ran while the pointer was already published at its final path
FAILED test_lockdown_before_publish.py::test_a_pointer_that_cannot_be_locked_down_is_not_published
  - AssertionError: a pointer whose lockdown failed replaced the previous one anyway
FAILED test_lockdown_before_publish.py::test_the_agent_overlay_is_locked_down_before_publication
  - AssertionError: the lockdown was applied to the overlay AFTER it was published
FAILED test_live_target.py::TestWriteTarget::test_applies_owner_only_lockdown
FAILED test_live_target.py::TestSnapshotRestore::test_restore_reapplies_the_owner_only_dacl
FAILED test_mcp_gateway_rewriter.py::test_rewriter_calls_restrict_to_owner_on_windows

6 failed, 72 passed
```

```
pytest test/test_lockdown_before_publish.py test/test_live_target.py -q         44 passed, 6 skipped
pytest test/test_mcp_gateway_rewriter*.py -q                                    73 passed, 3 skipped
pytest <rewriter, fingerprint, apps_spool, stub_paths, live_target,
        lockdown_before_publish, service> -q                       442 passed, 58 skipped
```

Gates: `flake8` · `isort --check-only` clean on all five changed files. `black --check` clean on the two **not** in `.github/black-baseline.txt` (`service/live_target.py`, the new test); `rewriter.py`, `test_live_target.py` and `test_mcp_gateway_rewriter.py` are baselined and are left unformatted rather than graduated off it.

## Manual verification

N/A — unit coverage sufficient: the defect is a failure-ordering and platform-coverage property, and every test drives the real `write_target`, `restore` and `rewrite_agents` with the real `atomic_write`, observing the lockdown at the exact call that performs it. The Windows-only half of the exposure is asserted without simulating Windows, so the same assertions hold on the CI runner and on a developer's box.

## Related Issues

Refs #5307 — Tier 2, sites 3–6.

Sibling, not a dependency: #5310 covers Tier 1 (the two Ops Mission Control stores, where the same post-publish lockdown was paired with an `unlink` and so destroyed the previous store). No file overlaps. #5302 converts a third, disjoint set of files for the same underlying reason.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — no spec documents these four writers' lockdown ordering; the Tier 2 site that *is* documented is deliberately out of scope
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
