### PR TITLE
fix(doctor): coerce non-object agent spec before MCP reads (#5309)

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -486,10 +486,21 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
        the error head plus any captured stderr tail from the child — which
        usually contains the real cause (FindupException, ImportError, etc.)
        that would otherwise only exist in kiro-cli's per-session log.
+
+    A spec that cannot be read as a JSON object — unreadable, unparseable,
+    or valid JSON that is not an object — degrades to an empty config: every
+    managed server then reports as missing and the file is never rewritten.
     """
     try:
         agent_data = json.loads(agent_path.read_text(encoding="utf-8"))
     except Exception:
+        agent_data = {}
+    if not isinstance(agent_data, dict):
+        # Valid JSON that is not an object (a list, a scalar) parses fine but
+        # every .get() below would raise. Doctor exists to diagnose a broken
+        # config, not die on one — treat it like the unparseable case, but say
+        # what is actually wrong so the missing-server lines below make sense.
+        print("  ❌ agent spec is not a JSON object — re-run `kirocrew setup`")
         agent_data = {}
 
     tools = agent_data.get("tools", [])

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3608,6 +3608,40 @@ class TestDoctorMcpTools:
         # No probe attempted since no server spec survived the parse failure.
         probe_mock.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "content", ["[1, 2, 3]", "42", "null", "true", '"a string"']
+    )
+    def test_valid_json_non_object_agent_config_does_not_crash(
+        self, tmp_path, capsys, content
+    ):
+        """A spec that is valid JSON but not an object (a list, a scalar,
+        null) parses fine, so the json.loads try/except never fires — but
+        every .get() on the result would raise AttributeError. Doctor must
+        coerce it to an empty config, say what is wrong, and report cleanly,
+        same as the truncated case above — and it must never rewrite the
+        user's file with the coerced empty config."""
+        from kiro_crew.cli_doctor import _doctor_mcp_tools
+
+        agent_path = tmp_path / "kirocrew.json"
+        agent_path.write_text(content)
+
+        issues: list[str] = []
+        with self._mock_probe({}) as probe_mock:
+            _doctor_mcp_tools(agent_path, issues)
+
+        out = capsys.readouterr().out
+        # The defect itself is named, not just its downstream symptoms.
+        assert "agent spec is not a JSON object" in out
+        # Empty config → both managed servers report missing from mcpServers.
+        assert "@kirocrew-core: ❌ missing from mcpServers" in out
+        assert "@kirocrew-cron: ❌ missing from mcpServers" in out
+        # No probe attempted since no server spec survived the coercion.
+        probe_mock.assert_not_called()
+        # The no-clobber contract: doctor diagnoses the broken spec, it never
+        # persists the coerced empty config over the user's original file.
+        assert agent_path.read_text() == content
+        assert "Auto-fixed" not in out
+
 
 class TestDoctorStt:
     """Tests for doctor Speech-to-Text section."""


### PR DESCRIPTION
## Problem / Motivation

`kirocrew doctor`'s MCP Tools section reads the agent spec with `json.loads` inside a try/except that guards only parse **failure**, then calls `agent_data.get("tools", [])`. A spec that is valid JSON but not an object -- `[1, 2, 3]`, `42`, `null` -- parses fine, so the guard never fires and the `.get()` raises `AttributeError`, crashing the section.

## Why it matters

Doctor runs precisely when something is already wrong with the install. A diagnostic that dies on the broken config it exists to diagnose leaves the user with a traceback instead of a verdict -- the worst possible place to raise.

## What changed (motivation -> approach -> change)

The parse-failure fallback already degrades to an empty config; a parse **success with the wrong shape** should land in the same place. `_doctor_mcp_tools` now coerces a non-dict `json.loads` result to `{}` before any read, prints a line naming the actual defect (`agent spec is not a JSON object -- re-run \`kirocrew setup\``, whose advice is real: setup's `_load_existing_config` rebuilds a non-dict spec), and the docstring documents the degrade-to-empty behavior. With the coerced `{}`, every managed server exits at the `name not in mcps` continue, so `config_changed` stays false and the auto-fix rewrite can never persist the empty config over the user's file -- a property the test now pins as a contract.

## Tests

- Extended `TestDoctorMcpTools` with `test_valid_json_non_object_agent_config_does_not_crash`, parametrized over the whole non-object family (`[1, 2, 3]`, `42`, `null`, `true`, `"a string"`; `null` guards against a future `or {}` refactor behaving differently). Asserts the defect line, the missing-server reports, no probe, **and** no-clobber (`agent_path.read_text() == content`, no `Auto-fixed` line).
- Mutation-verified: without the coercion both original params fail with the exact `AttributeError` from the issue; green with it.
- Gates: `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1039 files clean), full `pytest` -- 61927 passed; the 88 failures + 2 errors reproduce identically at the pristine base (sandbox/AF_UNIX host-env classes, zero in this diff's blast radius).

## Manual verification

Ran `_doctor_mcp_tools` against `[1,2,3]`, `42`, `null`, `true`, `"a string"` spec files: clean report, file bytes untouched, no probe attempted.

## Screenshots / video

N/A -- CLI text output only.

## Related Issues

Closes #5309
