### PR TITLE
refactor: drop redundant json.JSONDecodeError from except tuples that already catch ValueError (#5287)

### DIFF
--- a/scripts/update_contributors.py
+++ b/scripts/update_contributors.py
@@ -403,7 +403,7 @@ def main(argv: list[str]) -> int:
         try:
             raw = json.load(sys.stdin)
             records = _coerce_records(raw)
-        except (json.JSONDecodeError, ValueError) as exc:
+        except ValueError as exc:
             print(f"::error::update_contributors: {exc}", file=sys.stderr)
             return 1
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2264,7 +2264,7 @@ def _load_existing_config(
     """
     try:
         config = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError, ValueError):
+    except (OSError, ValueError):
         config = None
     if not isinstance(config, dict):
         return build_agent_config(gated_off=gated_off), True
@@ -2591,7 +2591,7 @@ def migrate_agent_specs() -> int:
     for spec_path in sorted(kiro_agents_dir_path().glob("*.json")):
         try:
             data = json.loads(spec_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError, ValueError):
+        except (OSError, ValueError):
             continue
         if not isinstance(data, dict):
             continue
@@ -2721,7 +2721,7 @@ def agent_spec_path(name: str) -> Path | None:
             continue
         try:
             data = _read_spec_capped(spec_path)
-        except (json.JSONDecodeError, OSError, ValueError):
+        except (OSError, ValueError):
             continue
         if not isinstance(data, dict):
             continue
@@ -2794,7 +2794,7 @@ def reset_agent_model(name: str) -> tuple[Path, str]:
         )
     try:
         data = _read_spec_capped(spec_path)
-    except (json.JSONDecodeError, OSError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         raise FileNotFoundError(f"could not read agent spec {spec_path}: {exc}") from exc
     if not isinstance(data, dict):
         raise FileNotFoundError(f"agent spec {spec_path} is not readable as a JSON object")
@@ -3205,7 +3205,7 @@ def _durable_tool_aliases(path: Path) -> tuple[bool, object]:
         return (False, None)
     try:
         on_disk = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return (True, None)
     return (True, on_disk.get("toolAliases") if isinstance(on_disk, dict) else None)
 

--- a/src/kiro_crew/agent_state.py
+++ b/src/kiro_crew/agent_state.py
@@ -57,7 +57,7 @@ def _state_path() -> Path:
 def _read() -> dict:
     try:
         data = json.loads(_state_path().read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+    except (FileNotFoundError, OSError, ValueError):
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -146,7 +146,7 @@ def _registration_source(app_name: str) -> tuple[AppManifest | None, Path]:
                 AppManifest.from_json_file(shipped_root / "app.json"),
                 shipped_root,
             )
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
+        except (OSError, ValueError) as exc:
             logger.warning(
                 "App %s: shipped resource manifest is unreadable: %s",
                 app_name,

--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -2177,7 +2177,7 @@ def _read_workflow_cycle_offset(campaign_id: str) -> int:
         return 0
     try:
         return int(json.loads(p.read_text()).get("cycle_offset", 0) or 0)
-    except (json.JSONDecodeError, OSError, ValueError, TypeError):
+    except (OSError, ValueError, TypeError):
         return 0
 
 
@@ -2320,7 +2320,7 @@ async def _poll_workflow_campaign(
                             ),
                             error_message="Workflow run snapshot lost after 1h — run likely evicted or crashed.",
                         )
-                except (json.JSONDecodeError, OSError, ValueError, TypeError):
+                except (OSError, ValueError, TypeError):
                     pass
             return
         # ALL snapshot processing runs under the campaign's transition lock:

--- a/src/kiro_crew/apps/builtins/crew_companion/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/backend/routes.py
@@ -21,7 +21,6 @@ caller can usefully retry one and not the other.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from functools import wraps
 from typing import Any, Awaitable, Callable
@@ -120,7 +119,7 @@ async def _body(request: web.Request) -> dict[str, Any]:
     """Parse a JSON object body, treating anything else as empty."""
     try:
         parsed = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return {}
     return parsed if isinstance(parsed, dict) else {}
 

--- a/src/kiro_crew/apps/builtins/crew_companion/pack_transfer.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/pack_transfer.py
@@ -172,7 +172,7 @@ def fetch_petdex_pet(raw_input: Any) -> dict[str, Any]:
 
     try:
         manifest = _get(PETDEX_MANIFEST_URL, as_json=True)
-    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError) as exc:
+    except (urllib.error.URLError, OSError, ValueError) as exc:
         logger.warning("crew-companion: PetDex manifest fetch failed: %s", exc)
         return {"ok": False, "error": "Could not reach PetDex"}
 
@@ -210,7 +210,7 @@ def fetch_petdex_pet(raw_input: Any) -> dict[str, Any]:
             if isinstance(detail, dict):
                 display_name = str(detail.get("displayName") or display_name)
                 description = str(detail.get("description") or "")
-        except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        except (urllib.error.URLError, OSError, ValueError):
             logger.debug("crew-companion: PetDex pet.json unavailable")
 
     return {

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1525,7 +1525,7 @@ async def _fetch_pr_head_oid(branch: str, repo: str | None = None) -> str | None
         if data.get("state") != "MERGED":
             return None
         return data.get("headRefOid")
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return None
 
 
@@ -1687,7 +1687,7 @@ def _load_dev_fleet_cfg() -> dict:
             if not p.is_file():
                 continue
             raw = json.loads(p.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError, ValueError):
+        except (OSError, ValueError):
             continue
         if isinstance(raw, dict) and isinstance(raw.get("dev_fleet"), dict):
             section.update(raw["dev_fleet"])
@@ -2745,7 +2745,7 @@ async def _pod_up(name: str) -> dict:
             }
     try:
         return {"ok": True, **json.loads(stdout)}
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return {"ok": True, "output": stdout}
 
 

--- a/src/kiro_crew/apps/builtins/mochi/stats_service.py
+++ b/src/kiro_crew/apps/builtins/mochi/stats_service.py
@@ -179,7 +179,7 @@ def parse_stats_json(raw: str, now_ms: int) -> CompanionStats:
     """Parse persisted stats; any corruption yields defaults, never a throw."""
     try:
         parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return create_default_stats(now_ms)
     if not isinstance(parsed, dict):
         return create_default_stats(now_ms)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py
@@ -210,7 +210,7 @@ def read_entries() -> list[LedgerEntry]:
                     continue
                 try:
                     entry = LedgerEntry.from_dict(json.loads(line))
-                except (json.JSONDecodeError, TypeError, ValueError):
+                except (TypeError, ValueError):
                     logger.warning(
                         "ops-mission-control: skipping malformed ledger line %d", line_no
                     )

--- a/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
@@ -105,7 +105,7 @@ async def _json_object(
     """
     try:
         body = await request.json(loads=_strict_loads)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return None, _bad_request("invalid JSON", "invalid_json")
     if not isinstance(body, dict):
         return None, _bad_request("body must be a JSON object", "body_not_object")

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -485,7 +485,7 @@ async def _json_body(request: web.Request) -> tuple[dict | None, web.Response | 
     """Parse a JSON object body, or return the 400 to send back."""
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+    except (ValueError, UnicodeDecodeError):
         return None, web.json_response(
             {"error": "request body must be JSON", "code": "body_not_json"}, status=400
         )

--- a/src/kiro_crew/apps/discovery.py
+++ b/src/kiro_crew/apps/discovery.py
@@ -6,7 +6,6 @@ Discovers builtins by scanning the filesystem: each subdirectory of
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -152,7 +151,7 @@ def discover_builtin_apps(builtins_dir: Path | None = None) -> list[dict[str, An
                 continue
             apps.append(_manifest_to_builtin_dict(manifest))
             logger.debug("Discovered builtin app: %s v%s", manifest.name, manifest.version)
-        except (json.JSONDecodeError, ValueError) as exc:
+        except ValueError as exc:
             logger.warning("Failed to parse builtin manifest %s: %s", manifest_path, exc)
         except Exception:
             logger.warning(

--- a/src/kiro_crew/apps/execution.py
+++ b/src/kiro_crew/apps/execution.py
@@ -284,7 +284,7 @@ def builtin_app_agents() -> dict[str, str]:
                     if not agent_path.is_file() or not agent_path.is_relative_to(root):
                         continue
                     agent_doc = json.loads(agent_path.read_text(encoding="utf-8"))
-                except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+                except (OSError, UnicodeError, ValueError):
                     continue
                 if not isinstance(agent_doc, dict):
                     continue

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -273,7 +273,7 @@ def _validate_source_path(source: Path) -> list[str]:
         return errors
     try:
         manifest = AppManifest.from_json_file(manifest_path)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         errors.append(f"invalid {APP_MANIFEST_FILENAME}: {exc}")
         return errors
     errors.extend(manifest.validate(app_root=source))

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -98,7 +98,7 @@ def _read_cache() -> dict[str, Any] | None:
             return None
         age = time.time() - path.stat().st_mtime
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, ValueError):
         return None
     if not isinstance(data, dict):
         return None

--- a/src/kiro_crew/apps/official_category_order.py
+++ b/src/kiro_crew/apps/official_category_order.py
@@ -96,7 +96,7 @@ def _read_cache() -> dict[str, Any] | None:
             return None
         age = time.time() - path.stat().st_mtime
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, ValueError):
         return None
     if not isinstance(data, dict):
         return None

--- a/src/kiro_crew/apps/official_editorial.py
+++ b/src/kiro_crew/apps/official_editorial.py
@@ -92,7 +92,7 @@ def _read_cache() -> dict[str, Any] | None:
             return None
         age = time.time() - path.stat().st_mtime
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, ValueError):
         return None
     if not isinstance(data, dict):
         return None

--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -2228,7 +2228,6 @@ class ArtifactStore:
             except (
                 ArtifactError,
                 OSError,
-                json.JSONDecodeError,
                 ValueError,
                 TypeError,
             ) as exc:
@@ -2299,7 +2298,6 @@ class ArtifactStore:
             except (
                 ArtifactError,
                 OSError,
-                json.JSONDecodeError,
                 ValueError,
                 TypeError,
             ) as exc:
@@ -2384,7 +2382,6 @@ class ArtifactStore:
             except (
                 ArtifactError,
                 OSError,
-                json.JSONDecodeError,
                 ValueError,
                 TypeError,
             ):
@@ -2440,7 +2437,6 @@ class ArtifactStore:
             except (
                 ArtifactError,
                 OSError,
-                json.JSONDecodeError,
                 ValueError,
                 TypeError,
             ):
@@ -2485,7 +2481,6 @@ class ArtifactStore:
             except (
                 ArtifactError,
                 OSError,
-                json.JSONDecodeError,
                 ValueError,
                 TypeError,
             ):

--- a/src/kiro_crew/cli_config.py
+++ b/src/kiro_crew/cli_config.py
@@ -288,6 +288,6 @@ def _parse_value(raw: str) -> object:
         pass
     try:
         return json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         pass
     return raw

--- a/src/kiro_crew/computer_use/cli.py
+++ b/src/kiro_crew/computer_use/cli.py
@@ -465,7 +465,7 @@ def _coerce(raw: str) -> Any:
     """
     try:
         value = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return raw
     if isinstance(value, (bool, int, float)) and not isinstance(value, str):
         return value

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -1101,7 +1101,7 @@ def _diff_dropped_message_lines(old_lines: list[str], new_lines: list[str]) -> l
             continue
         try:
             kept_serialized.add(json.dumps(json.loads(ln), sort_keys=True))
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             continue
     dropped: list[str] = []
     for ln in old_lines:
@@ -1109,7 +1109,7 @@ def _diff_dropped_message_lines(old_lines: list[str], new_lines: list[str]) -> l
             continue
         try:
             normalized = json.dumps(json.loads(ln), sort_keys=True)
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             dropped.append(ln)  # corrupted line → archive it
             continue
         if normalized not in kept_serialized:
@@ -1570,7 +1570,7 @@ def _frozen_prefix_and_foreign_appends(
             continue
         try:
             entry = json.loads(ln)
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             continue  # corrupt window-region line — not a preservable message
         if not isinstance(entry, dict) or entry.get("_type") == "metadata":
             continue

--- a/src/kiro_crew/dashboard/chat_pins.py
+++ b/src/kiro_crew/dashboard/chat_pins.py
@@ -117,7 +117,7 @@ async def api_chat_pins_create(request: web.Request) -> web.Response:
         if body_error.status == 400 and body_error.text:
             try:
                 error_body = json.loads(body_error.text)
-            except (json.JSONDecodeError, ValueError):
+            except ValueError:
                 error_body = {}
             if error_body.get("code") == "body_not_object":
                 return web.json_response(

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -2849,7 +2849,7 @@ def _flush_segment(
         try:
             parsed = json.loads(cls_val)
             return isinstance(parsed, dict) and parsed.get("kind") == "stop_event"
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             return False
 
     # Walk backwards to find the start of the trailing chunk/stop_event run.

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -1655,7 +1655,7 @@ def _read_memory_mode(path: "Path") -> str | None:
     first, _sep, _rest = head.partition(b"\n")
     try:
         d = json.loads(first.decode("utf-8", "replace"))
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return None
     if not isinstance(d, dict) or d.get("_type") != "metadata":
         return None

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -1245,12 +1245,12 @@ async def api_agent_detail(request: web.Request) -> web.Response:
         denied = await _require_owner(request, f"agent_detail.{request.method.lower()}")
         if denied is not None:
             return denied
-    # Parse body early so JSONDecodeError returns 400, not 404 from the file loop.
+    # Parse body early so a malformed body returns 400, not 404 from the file loop.
     patch_body = None
     if request.method == "PATCH":
         try:
             patch_body = await request.json()
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             return web.json_response({"error": "invalid JSON"}, status=400)
         # Valid JSON is not necessarily an object. A top-level array makes
         # ``"skills" in patch_body`` a LIST-membership test (true for

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -81,7 +81,7 @@ async def api_reveal_path(request: web.Request) -> web.Response:
     """POST /api/reveal — reveal a file/folder in Finder or open with default app."""
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return web.json_response({"error": "invalid JSON body"}, status=400)
     path = body.get("path", "")
     action = body.get("action", "reveal")  # "reveal" or "open"
@@ -122,7 +122,7 @@ async def api_outbox_notify(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
 
         _sel().log_tool_invocation(
             session_key="api",
@@ -429,7 +429,7 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
         return web.json_response({"ok": True, "skipped": "no_slack"})
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         _sel().log_tool_invocation(
             session_key="api",
             source="api",
@@ -2680,7 +2680,7 @@ def _known_project_dirs(slot_projects: list[str]) -> list[str]:
     fp = config_dir() / "recent_projects.json"
     try:
         recent = json.loads(fp.read_text(encoding="utf-8")) if fp.is_file() else []
-    except (json.JSONDecodeError, OSError, ValueError):
+    except (OSError, ValueError):
         recent = []
     if isinstance(recent, list):
         dirs.extend(d for d in recent if isinstance(d, str) and d)

--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -328,7 +328,7 @@ def _token_from_json(read_id: str, now: datetime) -> tuple[str, datetime] | None
         return None
     try:
         data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError, TypeError):
+    except (ValueError, TypeError):
         return None
     if not isinstance(data, dict):
         return None
@@ -376,7 +376,7 @@ def _token_from_sqlite(db: Path, now: datetime) -> tuple[str, datetime] | None:
                 continue
             try:
                 blob = json.loads(row[0])
-            except (json.JSONDecodeError, ValueError, TypeError):
+            except (ValueError, TypeError):
                 continue
             if not isinstance(blob, dict):
                 continue

--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 
 from aiohttp import web
@@ -33,7 +32,7 @@ async def api_secrets_set(request: web.Request) -> web.Response:
     """
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return web.json_response({"error": "Invalid JSON body", "code": "invalid_json"}, status=400)
 
     # A JSON body can legally be an array, string or number, and `name`/`value`

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -652,7 +652,7 @@ async def _fetch_whoami(kiro_bin: str) -> dict[str, object]:
         if m:
             out_map["_profile_arn"] = m.group(0)[:200]
         return out_map
-    except (asyncio.TimeoutError, json.JSONDecodeError, ValueError, OSError):
+    except (asyncio.TimeoutError, ValueError, OSError):
         logger.debug("whoami identity fetch failed", exc_info=True)
         return {}
     except Exception:

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -2498,7 +2498,7 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
         raise SourceProviderError(
             f"Could not reach Jira at {ref.host}: {type(exc).__name__}"
         ) from exc
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         raise SourceProviderError(
             f"Jira returned an unparseable response for {issue_key}."
         ) from exc

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -432,7 +432,7 @@ def _iter_export_cycles(
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     yield obj, shard_day
         except (OSError, UnicodeDecodeError):

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -143,7 +143,7 @@ def _get_config(request: web.Request) -> dict:
     try:
         data = json.loads(config_path().read_text(encoding="utf-8"))
         return data.get("dashboard", {}).get("terminal", {})
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, ValueError):
         return {}
 
 
@@ -916,7 +916,7 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
             elif msg.type == web.WSMsgType.TEXT:
                 try:
                     ctrl = json.loads(msg.data)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     continue
                 if ctrl.get("type") == "resize":
                     try:

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -196,7 +196,7 @@ def slot_spend(days: int = SPEND_WINDOW_DAYS) -> dict[str, dict[str, float]]:
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(obj, dict) or obj.get("_type") != "tokens":
                         continue
@@ -402,7 +402,7 @@ def context_occupancy(days: int = 14) -> dict[str, Any]:
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(obj, dict) or obj.get("_type") != "tokens":
                         continue
@@ -536,7 +536,7 @@ def context_trace(slot: str, days: int = 14) -> dict[str, Any]:
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(obj, dict) or obj.get("_type") != "tokens":
                         continue
@@ -652,7 +652,7 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(obj, dict) or obj.get("_type") != "tokens":
                         continue
@@ -1371,7 +1371,7 @@ def _parse_token_history() -> dict[str, Any]:
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(obj, dict) or obj.get("_type") != "tokens":
                         continue
@@ -1572,7 +1572,7 @@ def _parse_sessions() -> dict:
                 for line in fh:
                     try:
                         obj = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(obj, dict):
                         continue

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5846,7 +5846,7 @@ class DashboardState:
                 self._chat_pins = []
                 return
             raw = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        except (UnicodeDecodeError, ValueError) as exc:
             # Malformed content — treat as empty (data corruption).
             logger.warning("chat_pins.json has malformed content: %s", exc)
             self._chat_pins = []

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -215,7 +215,7 @@ def _run_json_detail(args: list[str]) -> tuple[Any | None, bool]:
         return None, False
     try:
         return json.loads(proc.stdout or ""), False
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         logger.debug("tailscale %s produced non-JSON output: %s", " ".join(args), exc)
         return None, False
 

--- a/src/kiro_crew/dashboard/tailnet_serve.py
+++ b/src/kiro_crew/dashboard/tailnet_serve.py
@@ -294,7 +294,7 @@ def serve_state(port: int) -> ServeState:
         )
     try:
         doc = json.loads(out or "")
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         # An empty document is what a node with no serve config returns, and that
         # is a genuine "nothing configured" rather than an unknown. Anything else
         # unparseable is unknown.

--- a/src/kiro_crew/doctor_deadpath.py
+++ b/src/kiro_crew/doctor_deadpath.py
@@ -292,7 +292,7 @@ def _walk_spec(spec_path: Path) -> tuple[list[DeadPath], str | None]:
         return [], f"not valid UTF-8 ({exc})"
     try:
         data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         return [], f"malformed JSON ({exc})"
     if not isinstance(data, dict):
         return [], "top-level JSON is not an object"

--- a/src/kiro_crew/eval/judge.py
+++ b/src/kiro_crew/eval/judge.py
@@ -100,6 +100,6 @@ class LLMJudge:
             end = raw.rindex("}") + 1
             data = json.loads(raw[start:end])
             return JudgeVerdict(score=float(data["score"]), reason=data.get("reason", ""))
-        except (ValueError, KeyError, json.JSONDecodeError):
+        except (ValueError, KeyError):
             logger.warning("Judge returned unparseable response: %s", raw[:200])
             return JudgeVerdict(score=0, reason=f"parse_error: {raw[:100]}")

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -3993,7 +3993,7 @@ class ConversationLog:
                     continue
                 try:
                     data = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     continue
                 if not isinstance(data, dict) or data.get("_type") == "metadata":
                     continue
@@ -4134,7 +4134,7 @@ class ConversationLog:
                     for _, line in zip(range(5), f):
                         try:
                             d = json.loads(line.strip())
-                        except (json.JSONDecodeError, ValueError):
+                        except ValueError:
                             continue
                         if d.get("_type") == "metadata" and is_incognito_transcript(
                             d.get("memory_mode")
@@ -5485,7 +5485,7 @@ class ConversationLog:
                     continue
                 try:
                     normalized = json.dumps(json.loads(ln), sort_keys=True)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     dropped.append(ln)  # corrupted line → archive it
                     continue
                 if normalized not in kept_serialized:

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -982,7 +982,7 @@ def _identity_claims(key: str, value: object) -> list[str]:
 
     try:
         blob = json.loads(value if isinstance(value, (str, bytes)) else str(value))
-    except (json.JSONDecodeError, ValueError, TypeError):
+    except (ValueError, TypeError):
         return []
     if not isinstance(blob, dict):
         return []

--- a/src/kiro_crew/knowledge/embedder.py
+++ b/src/kiro_crew/knowledge/embedder.py
@@ -176,7 +176,7 @@ def bytes_to_floats(data: bytes) -> list[float]:
     # so one bad row is skipped instead of aborting the dedup sweep.
     try:
         parsed = json.loads(data)
-    except (json.JSONDecodeError, TypeError, ValueError, UnicodeDecodeError):
+    except (TypeError, ValueError, UnicodeDecodeError):
         parsed = None
     else:
         if isinstance(parsed, list):

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -251,7 +251,7 @@ def _extract_tool_input_strings(tool_input: str) -> list[str]:
         return []
     try:
         parsed = json.loads(tool_input)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         # Not JSON — treat the raw string as a path/command candidate
         return [tool_input]
     if isinstance(parsed, str):

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -1841,7 +1841,7 @@ class Backend:
             partial = json.loads(prefix.split("\n", 1)[0]) if prefix.strip().endswith("}") else None
             if isinstance(partial, dict):
                 msg_id = partial.get("id")
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        except (ValueError, UnicodeDecodeError):
             pass
         # If prefix-parse failed, try a targeted regex for "id": value.
         if msg_id is None:
@@ -1850,7 +1850,7 @@ class Backend:
             if m:
                 try:
                     msg_id = json.loads(m.group(1))
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     pass
         if msg_id is not None:
             pending = self._pending_requests.pop(str(msg_id), None)

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -268,7 +268,7 @@ def _parse_auto_approve(raw: str) -> list[str]:
         parsed = json.loads(raw)
         if isinstance(parsed, list):
             return [str(s) for s in parsed if s]
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         pass
     # Back-compat: legacy CSV form.
     return [s for s in raw.split(",") if s]
@@ -723,7 +723,7 @@ async def run_bridge(
                 msg = json.loads(line)
                 if isinstance(msg, dict) and "method" in msg and "id" in msg:
                     _outstanding_ids.add(msg["id"])
-            except (json.JSONDecodeError, ValueError, TypeError):
+            except (ValueError, TypeError):
                 pass
             try:
                 # Serialize with _recaller_loop's _write_frame writes on the
@@ -827,7 +827,7 @@ async def run_bridge(
                             # A response (has id, no method) — clear from
                             # outstanding set.
                             _outstanding_ids.discard(msg["id"])
-                except (json.JSONDecodeError, ValueError, TypeError):
+                except (ValueError, TypeError):
                     pass
                 # Control frames are gateway<->stub only; never forward to
                 # kiro-cli stdout.

--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -703,7 +703,7 @@ def _read_message(stdin) -> dict[str, Any] | None:
                     continue
                 body = b"".join(chunks)
                 return json.loads(body.decode("utf-8"))
-            except (ValueError, json.JSONDecodeError):
+            except ValueError:
                 continue
         # Bare JSON line (backwards compat)
         try:

--- a/src/kiro_crew/mcp_tools/apps.py
+++ b/src/kiro_crew/mcp_tools/apps.py
@@ -391,7 +391,7 @@ def ops_mission_control_api(name: str, args: dict[str, Any]) -> str:
     if _omc_body_raw:
         try:
             _omc_parsed = json.loads(_omc_body_raw)
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             return "Error: body_json is not valid JSON."
         if not isinstance(_omc_parsed, dict):
             return "Error: body_json must encode a JSON object."

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -1009,7 +1009,7 @@ def _read_json(
         return None
     try:
         return _parse_json5(text) if json5 else json.loads(text)
-    except (json.JSONDecodeError, ValueError, RecursionError):
+    except (ValueError, RecursionError):
         scan.diagnostic(category, "invalid_config")
         return None
 

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -1484,7 +1484,7 @@ class SecurityEventLog:
                             continue
                         try:
                             data = json.loads(line)
-                        except (json.JSONDecodeError, ValueError):
+                        except ValueError:
                             # Truncated/corrupt line — skip backward to the last
                             # complete record rather than resetting the chain to
                             # genesis. Flag it so the corruption is not hidden.
@@ -1963,7 +1963,7 @@ class SecurityEventLog:
                 for line in self._iter_lines_backward(path, pin=pin):
                     try:
                         data = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         continue
                     if not isinstance(data, dict):
                         continue
@@ -2035,7 +2035,7 @@ class SecurityEventLog:
         for line in self._iter_lines_backward(path, pin=pin):
             try:
                 data = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
+            except ValueError:
                 continue
             if isinstance(data, dict) and self._record_signature_matches(data):
                 return True
@@ -2260,7 +2260,7 @@ class SecurityEventLog:
         for line in self._iter_lines_backward(path):
             try:
                 data = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
+            except ValueError:
                 continue
             if not isinstance(data, dict):
                 continue

--- a/src/kiro_crew/session_digest.py
+++ b/src/kiro_crew/session_digest.py
@@ -113,7 +113,7 @@ def _scan_transcript(path: Path) -> tuple[str, int]:
                     continue
                 try:
                     record = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     # Malformed line: skip, don't lose the rest
                     logger.debug("digest: skipping malformed line in %s", path)
                     continue
@@ -155,7 +155,7 @@ def _scan_cli_log(path: Path) -> tuple[int, int]:
                     continue
                 try:
                     record = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     continue
 
                 if not isinstance(record, dict):
@@ -193,7 +193,7 @@ def _first_message_from_cli(path: Path) -> str:
                     continue
                 try:
                     record = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
+                except ValueError:
                     continue
 
                 if not isinstance(record, dict):

--- a/src/kiro_crew/slack/interactions.py
+++ b/src/kiro_crew/slack/interactions.py
@@ -450,7 +450,7 @@ async def _handle_shortcut_submission(payload: dict) -> None:
 
     try:
         meta = json.loads(view.get("private_metadata", "{}"))
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
         meta = {}
 
     orig_channel = meta.get("channel", "")
@@ -2653,7 +2653,7 @@ async def _handle_session_resume(
 
     try:
         val = json.loads(action.get("value", "{}"))
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
         val = {"key": action.get("value", "")}
 
     session_key = val.get("key", "")
@@ -2779,7 +2779,7 @@ async def _handle_resume_choice(
 
     try:
         val = json.loads(action.get("value", "{}"))
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
         return
 
     session_key = val.get("key", "")
@@ -2902,7 +2902,7 @@ async def _handle_resume_choice(
                 for ln in lines:
                     try:
                         d = json.loads(ln.strip())
-                    except (ValueError, json.JSONDecodeError):
+                    except ValueError:
                         continue
                     if d.get("_type"):
                         continue

--- a/src/kiro_crew/slack/sessions_view.py
+++ b/src/kiro_crew/slack/sessions_view.py
@@ -199,7 +199,7 @@ def _collect_recent_sessions(
         for line in lines:
             try:
                 d = json.loads(line.strip())
-            except (ValueError, json.JSONDecodeError):
+            except ValueError:
                 continue
             if d.get("_type") == "metadata":
                 title = d.get("title") or title

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1517,7 +1517,7 @@ class TaskRunner:
             return
         try:
             items = json.loads(raw)
-        except (json.JSONDecodeError, ValueError, OSError) as exc:
+        except (ValueError, OSError) as exc:
             # Never silently discard run state on a corrupt/truncated file:
             # surface the corruption loudly and preserve the bad file as a
             # sidecar for recovery instead of returning an empty registry.

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -1041,7 +1041,7 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
 
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         return web.json_response({"error": "invalid JSON"}, status=400)
 
     if not isinstance(body, dict):

--- a/src/kiro_crew/webex/client.py
+++ b/src/kiro_crew/webex/client.py
@@ -488,7 +488,7 @@ class WebexClient:
                             return {}
                         try:
                             return await resp.json(content_type=None)
-                        except (json.JSONDecodeError, ValueError):
+                        except ValueError:
                             return {}
                     # Response bodies are externally-derived; log status only.
                     logger.warning("Webex API %s %s failed: http=%s", method, path, resp.status)

--- a/test/test_jsondecodeerror_redundancy_ratchet.py
+++ b/test/test_jsondecodeerror_redundancy_ratchet.py
@@ -1,0 +1,67 @@
+"""No except tuple may pair ``json.JSONDecodeError`` with a bare ``ValueError``.
+
+``json.JSONDecodeError`` subclasses ``ValueError``, so a handler naming both
+catches exactly what ``ValueError`` alone catches -- the extra member is dead
+weight that invites cargo-cult copies. Issue #5287 removed 94 such sites; this
+ratchet keeps the count at zero. flake8 here carries no bugbear plugin, so
+B014 does not enforce this and the pattern re-accumulates without a guard.
+
+The scope rule is deliberately narrow: a tuple pairing ``json.JSONDecodeError``
+with classes that are NOT ``ValueError`` (``OSError``, ``KeyError``,
+``UnicodeDecodeError``, ...) is load-bearing and legal -- there the member is
+what catches parse errors at all. Only the combination with a bare
+``ValueError`` in the same tuple is redundant.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = (ROOT / "src" / "kiro_crew", ROOT / "test", ROOT / "scripts")
+
+
+def _is_json_decode_error(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "JSONDecodeError"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "json"
+    )
+
+
+def _is_bare_value_error(node: ast.expr) -> bool:
+    return isinstance(node, ast.Name) and node.id == "ValueError"
+
+
+def _redundant_handlers(tree: ast.AST) -> list[int]:
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler) or node.type is None:
+            continue
+        if not isinstance(node.type, ast.Tuple):
+            continue
+        members = node.type.elts
+        if any(_is_json_decode_error(m) for m in members) and any(
+            _is_bare_value_error(m) for m in members
+        ):
+            offenders.append(node.lineno)
+    return offenders
+
+
+def test_no_except_tuple_pairs_jsondecodeerror_with_bare_valueerror() -> None:
+    offenders: list[str] = []
+    for root in SCAN_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue  # not this ratchet's job
+            for lineno in _redundant_handlers(tree):
+                offenders.append(f"{path.relative_to(ROOT)}:{lineno}")
+    assert not offenders, (
+        "except tuples pairing json.JSONDecodeError with a bare ValueError "
+        "(the member is redundant -- JSONDecodeError subclasses ValueError, "
+        f"drop it; see #5287): {offenders}"
+    )

--- a/test/test_stub_bridge_liveness.py
+++ b/test/test_stub_bridge_liveness.py
@@ -142,7 +142,7 @@ async def test_slow_call_not_killed_when_pongs_arrive() -> None:
                 if isinstance(msg, dict) and msg.get("type") == _BRIDGE_PING_TYPE:
                     pong = json.dumps({"type": _BRIDGE_PONG_TYPE}) + "\n"
                     self._feed.feed_data(pong.encode())
-            except (json.JSONDecodeError, ValueError):
+            except ValueError:
                 pass
 
         async def drain(self) -> None:
@@ -351,7 +351,7 @@ def _safe_json_get_type(data: bytes) -> str:
         msg = json.loads(data)
         if isinstance(msg, dict):
             return msg.get("type", "")
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
         pass
     return ""
 


### PR DESCRIPTION
## Problem / Motivation

`json.JSONDecodeError` is a subclass of `ValueError`, so an except tuple naming both -- `except (json.JSONDecodeError, ValueError)` -- catches exactly what `except ValueError` alone catches. The redundant member is dead weight: it suggests the two are distinct cases, invites cargo-cult copies, and pads 94 handlers across the codebase. #5284 removed one instance; this PR removes the rest.

## Why it matters

Every reader of these handlers pays a small comprehension tax working out whether the pairing is meaningful. It never is -- but the codebase also has 217+ sites where `json.JSONDecodeError` is paired with classes that are NOT `ValueError` (`OSError`, `IndexError`, `UnicodeError`), and there the member is load-bearing. The redundant sites blur that distinction, making the load-bearing ones harder to recognize.

## What changed (motivation -> approach -> change)

- Removed the redundant `json.JSONDecodeError` member from every except tuple that also contains a bare `ValueError`: the 86 single-line sites the issue enumerated, plus 5 multiline tuples in `src/kiro_crew/artifacts.py` that the issue's line-based grep could not see, plus 3 sites outside `src/kiro_crew/` (`scripts/update_contributors.py`, `test/test_stub_bridge_liveness.py`). A tuple reduced to one member drops the parens (`except ValueError:`); `as`-clauses, comments, and indentation are untouched.
- Scope guard honored: all 217 tuples pairing `json.JSONDecodeError` with non-`ValueError` classes are untouched (count identical before/after), as are the `UnicodeDecodeError` sibling cases the issue calls out of scope.
- Dropped 3 `import json` lines left unused by the removal (`apps/builtins/crew_companion/backend/routes.py`, `apps/discovery.py`, `dashboard/handlers/secrets.py`) -- remaining `json` mentions in those files are `request.json()` method calls and docstring text.
- Added `test/test_jsondecodeerror_redundancy_ratchet.py`: an AST ratchet asserting no except tuple in `src/kiro_crew/`, `test/`, or `scripts/` pairs `json.JSONDecodeError` with a bare `ValueError`. flake8 here has no bugbear plugin, so B014 does not enforce this and the pattern would re-accumulate without a guard. The ratchet is what caught the 5 multiline `artifacts.py` sites.
- Reworded one comment (`dashboard/handlers/agents.py`) that named `JSONDecodeError` next to a handler that now reads `except ValueError:`.

Pure simplification -- no behavior change at any edited site.

## Tests

- `isort --check-only src/kiro_crew test` -- clean
- `flake8 src/kiro_crew test scripts/update_contributors.py` -- clean
- `mypy src/kiro_crew/` -- no issues in 1039 files
- Full `pytest`: 61914 passed; the 86 failures + 2 errors are byte-identical to a pristine `origin/main` run in the same environment (sandbox/host-env noise: AF_UNIX path length, sensitive-path denials, peer-auth 403s) -- verified by running the exact failing test IDs on an unmodified base worktree
- New ratchet test mutation-verified: reintroducing an offending tuple in `tips.py` turns it red naming the exact `file:line`
- Targeted re-run after the multiline extension: `test_artifacts.py` + `test_stub_bridge_liveness.py` + the ratchet -- 262 passed

## Manual verification

Spot-checked edited files to confirm no non-`ValueError` tuple was touched; verified the one remaining `json.JSONDecodeError` in `artifacts.py` (line 2903) pairs with `ArtifactError` only and is correctly untouched.

## Screenshots / video

Not applicable (backend-only, no user-facing change).

## Related Issues

Closes #5287

## Checklist

- [x] Single commit, conventional-commit title
- [x] Backend gates green (isort / flake8 / mypy / pytest)
- [x] No behavior change; scope guard verified

## Contribution License Agreement

- [x] I agree to license this contribution under the repository's license.
