### PR TITLE
fix: route raster magic-byte checks through the shared sniffer (#4315)

### DIFF
--- a/src/kiro_crew/apps/builtins/mochi/petdex_import.py
+++ b/src/kiro_crew/apps/builtins/mochi/petdex_import.py
@@ -32,6 +32,8 @@ from urllib.parse import urlparse
 
 import aiohttp
 
+from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
+
 logger = logging.getLogger(__name__)
 
 #: Where the petdex CLI installs pets. Fixed by that CLI, not configurable.
@@ -59,14 +61,12 @@ _MAX_SHEET_BYTES = 16 * 1024 * 1024
 #: Total seconds for one import, connect through last byte.
 _TIMEOUT_SECS = 30
 
-#: Accepted sheet formats, by magic bytes. The renderer decodes the sheet in an
-#: <img>, so the browser is the real parser -- this only keeps non-images out.
-_MAGIC: tuple[tuple[bytes, str], ...] = (
-    (b"\x89PNG\r\n\x1a\n", "image/png"),
-    (b"GIF87a", "image/gif"),
-    (b"GIF89a", "image/gif"),
-    (b"\xff\xd8\xff", "image/jpeg"),
-)
+#: Accepted sheet formats. The renderer decodes the sheet in an <img>, so the
+#: browser is the real parser -- this only keeps non-images out. Detection is
+#: the shared raster sniffer (:mod:`kiro_crew.messaging.raster`); this local
+#: allowlist keeps the accept-set exactly as before (notably: BMP, which the
+#: sniffer knows, stays rejected here).
+_ALLOWED_SHEET_MIMES = frozenset({"image/png", "image/gif", "image/jpeg", "image/webp"})
 
 _PET_JSON_NAME = "pet.json"
 #: Sheet names the CLI writes, in preference order.
@@ -120,13 +120,10 @@ def _assert_allowed_url(url: str) -> None:
 
 
 def _sniff_mime(blob: bytes) -> str:
-    for magic, mime in _MAGIC:
-        if blob.startswith(magic):
-            return mime
-    # WebP is RIFF<size>WEBP, so the tag is not a plain prefix.
-    if blob[:4] == b"RIFF" and blob[8:12] == b"WEBP":
-        return "image/webp"
-    raise PetdexError("the spritesheet is not a recognized image")
+    mime = sniff_raster_mime(blob[:SNIFF_BYTES])
+    if mime is None or mime not in _ALLOWED_SHEET_MIMES:
+        raise PetdexError("the spritesheet is not a recognized image")
+    return mime
 
 
 def parse_pet_json(text: str) -> dict[str, str]:

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -79,6 +79,7 @@ from kiro_crew.apps.manager import is_app_enabled
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.hooks import FileTooLargeError
+from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
 from kiro_crew.security import (
     REDACTED_CREDENTIAL_TAG,
     is_sensitive_path,
@@ -169,22 +170,17 @@ _INLINE_BITMAP_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Magic-number prefixes for the bitmap formats above. A `data:image/...;base64,`
-# label is agent-authored and therefore a CLAIM, not a fact — excising on the
-# label alone would let a model smuggle a credential past the scanner simply by
-# wrapping it in a fake bitmap URI (`data:image/png;base64,AKIA…`, which is all
-# base64-alphabet and so matches the body pattern). So a blob is excised only if
-# its decoded head actually begins with a real raster signature. Verifying the
-# first few bytes is enough and stays O(1) per blob: a genuine raster always
-# carries its signature, and a smuggled secret essentially never decodes into one.
-_BITMAP_MAGIC: tuple[bytes, ...] = (
-    b"\x89PNG\r\n\x1a\n",  # PNG
-    b"\xff\xd8\xff",  # JPEG
-    b"GIF87a",  # GIF
-    b"GIF89a",
-    b"RIFF",  # WebP (RIFF container; "WEBP" follows the 4-byte size)
-    b"BM",  # BMP
-)
+# A `data:image/...;base64,` label is agent-authored and therefore a CLAIM, not
+# a fact — excising on the label alone would let a model smuggle a credential
+# past the scanner simply by wrapping it in a fake bitmap URI
+# (`data:image/png;base64,AKIA…`, which is all base64-alphabet and so matches
+# the body pattern). So a blob is excised only if its decoded head actually
+# begins with a real raster signature, as decided by the shared sniffer
+# (:mod:`kiro_crew.messaging.raster`). Verifying the first few bytes is enough
+# and stays O(1) per blob: a genuine raster always carries its signature, and a
+# smuggled secret essentially never decodes into one. The shared sniffer also
+# checks WebP's form tag at offset 8, so a bare `RIFF` container (e.g. a WAVE
+# audio file) no longer counts as a bitmap here.
 
 # AVIF/HEIF put a 4-byte box length BEFORE the `ftyp` brand, so the signature is
 # at an offset rather than at byte 0.
@@ -226,7 +222,7 @@ _BITMAP_URI_TERMINATORS: frozenset[str] = frozenset("\"'`)<>,;]}\\ \t\r\n\f\v")
 
 def _has_bitmap_signature(raw: bytes) -> bool:
     """Whether *raw*'s first bytes are a known raster signature."""
-    if raw.startswith(_BITMAP_MAGIC):
+    if sniff_raster_mime(raw[:SNIFF_BYTES]) is not None:
         return True
     return raw[_BITMAP_FTYP_OFFSET : _BITMAP_FTYP_OFFSET + len(_BITMAP_FTYP_MAGIC)] == (
         _BITMAP_FTYP_MAGIC
@@ -273,7 +269,7 @@ def _scanned_bitmap_bytes(b64_body: str) -> tuple[bytes | None, bool]:
     nothing on the honest path.
 
     The guard that keeps :data:`_INLINE_BITMAP_RE`'s excision from becoming a
-    smuggling channel — see :data:`_BITMAP_MAGIC`. It asks TWO questions, and the
+    smuggling channel — see :func:`_has_bitmap_signature`. It asks TWO questions, and the
     second one is why the whole blob is decoded rather than just its head:
 
     1. **Does it start like a raster?** A `data:image/...;base64,` label is written

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -33,6 +33,7 @@ from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.hooks import safe_read_prefix
 from kiro_crew.messaging.link import is_channel_session_key
+from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.sandbox import popen_limited, sandboxed_spawn_argv
 from kiro_crew.security import (
@@ -856,19 +857,35 @@ def _open_rb_nofollow(path: str) -> int:
 
 # Magic-byte signatures for content-type validation at the upload boundary
 # (CWE-434). The extension is attacker-controlled, so binary types are verified
-# against their file signature BEFORE the bytes are written. Text formats (and
+# against their file signature BEFORE the bytes are written. Raster types are
+# verified by the shared sniffer (:mod:`kiro_crew.messaging.raster`), so all
+# consumers agree on what counts as each image type (including WebP's form tag
+# at offset 8, which a bare ``RIFF`` prefix would not check). Text formats (and
 # SVG, which is XML) have no reliable magic and remain gated by the extension
 # allowlist only.
 _ZIP_CONTAINER_EXTS = {".docx", ".xlsx", ".pptx", ".odt", ".ods", ".odp", ".zip"}
+#: Raster extensions and the mime :func:`sniff_raster_mime` must report for
+#: the claimed extension to be accepted.
+_RASTER_EXT_MIME: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".bmp": "image/bmp",
+    ".webp": "image/webp",
+}
+#: Non-raster binary types that still carry a reliable leading signature.
 _MAGIC_PREFIXES: dict[str, tuple[bytes, ...]] = {
-    ".png": (b"\x89PNG\r\n\x1a\n",),
-    ".jpg": (b"\xff\xd8\xff",),
-    ".jpeg": (b"\xff\xd8\xff",),
-    ".gif": (b"GIF87a", b"GIF89a"),
-    ".bmp": (b"BM",),
     ".pdf": (b"%PDF-",),
     ".gz": (b"\x1f\x8b",),
 }
+#: Read-path extras the shared raster table does not cover (served by
+#: ``api_file_raw`` but never accepted at the upload boundary).
+_READ_PATH_EXTRA_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"II\x2a\x00", "image/tiff"),
+    (b"MM\x00\x2a", "image/tiff"),
+    (b"\x00\x00\x01\x00", "image/x-icon"),
+)
 
 
 def _content_matches_ext(ext: str, data: bytes) -> bool:
@@ -884,8 +901,9 @@ def _content_matches_ext(ext: str, data: bytes) -> bool:
         # OOXML / ODF / zip all begin with a local-file-header, empty-archive,
         # or spanned-archive PK signature.
         return data[:4] in (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
-    if ext == ".webp":
-        return data[:4] == b"RIFF" and data[8:12] == b"WEBP"
+    expected = _RASTER_EXT_MIME.get(ext)
+    if expected is not None:
+        return sniff_raster_mime(data[:SNIFF_BYTES]) == expected
     prefixes = _MAGIC_PREFIXES.get(ext)
     if prefixes is None:
         return True  # text / svg / unknown — nothing to enforce
@@ -1763,7 +1781,7 @@ async def api_file_raw(request: web.Request) -> web.Response:
             if st.st_size > _MAX_UPLOAD_BYTES:
                 _log("denied", path)
                 return web.json_response({"error": "file too large"}, status=413)
-            header = f.read(12)
+            header = f.read(SNIFF_BYTES)
             f.seek(0)
             data = f.read()
     except OSError as exc:
@@ -1772,22 +1790,13 @@ async def api_file_raw(request: web.Request) -> web.Response:
             return web.json_response({"error": "symlinks not allowed"}, status=403)
         _log("failure", path)
         return web.json_response({"error": "cannot read file"}, status=500)
-    _image_magic = (
-        (b"\x89PNG", "image/png"),
-        (b"\xff\xd8\xff", "image/jpeg"),
-        (b"GIF87a", "image/gif"),
-        (b"GIF89a", "image/gif"),
-        (b"BM", "image/bmp"),
-        (b"II\x2a\x00", "image/tiff"),
-        (b"MM\x00\x2a", "image/tiff"),
-        (b"\x00\x00\x01\x00", "image/x-icon"),
-    )
-    content_type = None
-    # WebP: RIFF....WEBP compound signature
-    if header[:4] == b"RIFF" and header[8:12] == b"WEBP":
-        content_type = "image/webp"
-    else:
-        for magic, mime in _image_magic:
+    # Raster types are detected by the shared sniffer
+    # (kiro_crew.messaging.raster), which requires the full PNG signature and
+    # WebP's form tag at offset 8 — so a RIFF/WAVE audio file is not served as
+    # an image. TIFF and ICO keep local rows (_READ_PATH_EXTRA_MAGIC).
+    content_type = sniff_raster_mime(header)
+    if content_type is None:
+        for magic, mime in _READ_PATH_EXTRA_MAGIC:
             if header.startswith(magic):
                 content_type = mime
                 break

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -54,6 +54,7 @@ from kiro_crew.knowledge.retrieval import HybridRetriever
 from kiro_crew.knowledge.spend import source_spend
 from kiro_crew.knowledge.sync import SyncScheduler
 from kiro_crew.knowledge.watcher import KnowledgeWatcher
+from kiro_crew.messaging.raster import SNIFF_BYTES
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
 
@@ -1400,7 +1401,7 @@ async def ingest_file(request: web.Request) -> web.Response:
     try:
         total_size = 0
         # Capture the leading bytes so the claimed extension can be verified
-        # against the file signature; 16 bytes covers every prefix in the
+        # against the file signature; SNIFF_BYTES covers every signature in the
         # sibling gate (PNG magic is 8, WEBP needs bytes 8:12, zip/PDF fewer).
         head = bytearray()
         while True:
@@ -1413,8 +1414,8 @@ async def ingest_file(request: web.Request) -> web.Response:
                 Path(tmp.name).unlink(missing_ok=True)
                 return web.json_response(
                     {"error": f"file too large (max {_MAX_INGEST_FILE_SIZE // (1024 * 1024)} MB)"}, status=413)
-            if len(head) < 16:
-                head.extend(chunk[: 16 - len(head)])
+            if len(head) < SNIFF_BYTES:
+                head.extend(chunk[: SNIFF_BYTES - len(head)])
             tmp.write(chunk)
         tmp.close()
 

--- a/test/test_dashboard_files_coverage.py
+++ b/test/test_dashboard_files_coverage.py
@@ -417,6 +417,28 @@ class TestFileRaw:
             assert "not a recognized format" in (await resp.json())["error"]
 
     @pytest.mark.asyncio
+    async def test_riff_wave_audio_is_not_served_as_an_image(self, tmp_path, mock_sel):
+        # RIFF alone is not WebP: the shared sniffer checks the form tag at
+        # offset 8, so a WAVE audio file is not a recognized format here.
+        f = tmp_path / "sound.webp"
+        f.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 8)
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 403
+            assert "not a recognized format" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_a_truncated_png_signature_is_not_recognized(self, tmp_path, mock_sel):
+        # The shared sniffer requires PNG's full 8-byte signature; the old
+        # local table matched a 4-byte prefix. Aligning every consumer on the
+        # canonical signature is the point of the de-duplication.
+        f = tmp_path / "trunc.png"
+        f.write_bytes(b"\x89PNGxxxx" + b"\x00" * 8)
+        async with TestClient(TestServer(self._client_app())) as client:
+            resp = await client.get(f"/api/file-raw?path={f}")
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
     async def test_forbidden_path_is_400(self, mock_sel):
         with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=None):
             async with TestClient(TestServer(self._client_app())) as client:
@@ -1156,6 +1178,27 @@ class TestContentMatchesExt:
         assert files_mod._content_matches_ext(".gif", b"GIF89a")
         assert files_mod._content_matches_ext(".pdf", b"%PDF-1.4")
         assert files_mod._content_matches_ext(".gz", b"\x1f\x8b\x08")
+
+    def test_raster_accept_set_is_unchanged_by_the_shared_sniffer(self):
+        # Snapshot of the accept-set from before the shared-sniffer migration:
+        # every raster extension still accepts its own true signature.
+        accepted = {
+            ".png": b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            ".jpg": b"\xff\xd8\xff\xe0" + b"\x00" * 12,
+            ".jpeg": b"\xff\xd8\xff\xe1" + b"\x00" * 12,
+            ".gif": b"GIF87a" + b"\x00" * 10,
+            ".bmp": b"BM" + b"\x00" * 14,
+            ".webp": b"RIFF\x10\x00\x00\x00WEBPVP8 ",
+        }
+        for ext, payload in accepted.items():
+            assert files_mod._content_matches_ext(ext, payload), ext
+
+    def test_a_riff_wave_payload_is_rejected_for_every_raster_ext(self):
+        # A RIFF/WAVE audio file shares WebP's RIFF prefix; the shared sniffer
+        # checks the form tag at offset 8, so it is not an image of any kind.
+        wave = b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 8
+        for ext in (".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"):
+            assert not files_mod._content_matches_ext(ext, wave), ext
 
     def test_unsignable_extensions_pass_through(self):
         # No reliable magic for text or SVG: the extension allowlist is the gate.

--- a/test/test_mochi_petdex_import.py
+++ b/test/test_mochi_petdex_import.py
@@ -151,9 +151,25 @@ class TestSniffMime:
         assert pdx._sniff_mime(_WEBP) == "image/webp"
         assert pdx._sniff_mime(_PNG) == "image/png"
 
+    def test_recognises_jpeg_and_gif(self) -> None:
+        assert pdx._sniff_mime(b"\xff\xd8\xff\xe0" + b"\x00" * 12) == "image/jpeg"
+        assert pdx._sniff_mime(b"GIF89a" + b"\x00" * 10) == "image/gif"
+
     def test_rejects_a_non_image(self) -> None:
         with pytest.raises(pdx.PetdexError):
             pdx._sniff_mime(b"#!/bin/sh\nrm -rf /\n")
+
+    def test_rejects_a_riff_wave_payload(self) -> None:
+        # Shares WebP's RIFF prefix but carries the WAVE form tag at offset 8;
+        # the shared sniffer checks the tag, so this is not an image.
+        with pytest.raises(pdx.PetdexError):
+            pdx._sniff_mime(b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 8)
+
+    def test_rejects_bmp_even_though_the_shared_sniffer_knows_it(self) -> None:
+        # petdex never accepted BMP; the local allowlist keeps that exact
+        # accept-set on top of the shared sniffer.
+        with pytest.raises(pdx.PetdexError):
+            pdx._sniff_mime(b"BM" + b"\x00" * 14)
 
 
 class TestInstalledPets:

--- a/test/test_pptx_maker_routes.py
+++ b/test/test_pptx_maker_routes.py
@@ -746,6 +746,26 @@ class TestRedactArtifactHelper(unittest.TestCase):
         blob = base64.b64encode(b"\x89PNG\r\n\x1a\n" + _raster_body(64)).decode()
         self.assertIsNotNone(routes._scanned_bitmap_bytes(blob)[0])
 
+    def test_the_signature_check_accepts_every_bitmap_format(self) -> None:
+        # The pre-existing accept-set: PNG/JPEG/GIF/BMP and real WebP via the
+        # shared sniffer, plus the retained offset-4 ftyp check for HEIC/AVIF.
+        for raw in (
+            b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            b"\xff\xd8\xff\xe0" + b"\x00" * 12,
+            b"GIF87a" + b"\x00" * 10,
+            b"GIF89a" + b"\x00" * 10,
+            b"BM" + b"\x00" * 14,
+            b"RIFF\x10\x00\x00\x00WEBPVP8 ",
+            b"\x00\x00\x00\x18ftypheic" + b"\x00" * 8,
+        ):
+            self.assertTrue(routes._has_bitmap_signature(raw), raw)
+
+    def test_a_bare_riff_container_is_no_longer_a_bitmap(self) -> None:
+        # The old local table matched any RIFF container, so a WAVE audio blob
+        # counted as a bitmap. The shared sniffer requires WebP's form tag at
+        # offset 8 — this tightening is the intended fix, not a regression.
+        self.assertFalse(routes._has_bitmap_signature(b"RIFF\x24\x00\x00\x00WAVEfmt "))
+
 
 class TestConfigRoutes(_RoutesFixture):
     async def test_get_reports_the_resolved_deck_root(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

The repo has ONE shared raster magic-byte table at `src/kiro_crew/messaging/raster.py` (`sniff_raster_mime()` / `SNIFF_BYTES`, added by #4313), but four call sites still carried their own duplicate, prefix-only tables, so a fix to one never reached the others. The concrete drift: a prefix-only table accepts a RIFF/WAVE **audio** file as a WebP **image**, which the shared sniffer rejects by checking the `WEBP` form tag at offset 8.

## Why it matters

Content-signature gates exist to stop attacker-controlled extensions/labels from smuggling non-image bytes (CWE-434). Four independently drifting copies of "what is an image" mean the upload boundary, the file-read endpoint, the petdex importer, and the pptx credential scanner each answer that question differently — and each future signature fix has to be found and repeated four times.

## What changed (motivation → approach → change)

Route the raster formats at each site through the shared `sniff_raster_mime(...)` / `SNIFF_BYTES`, preserving each site's local extras and accept-set:

1. `dashboard/handlers/files.py` `_content_matches_ext` (upload boundary): raster extensions compare `sniff_raster_mime(data[:SNIFF_BYTES])` against the expected mime via a new `_RASTER_EXT_MIME` map; `_MAGIC_PREFIXES` keeps only the non-raster `.pdf`/`.gz` rows; the hand-written webp branch is gone. Zip-container and text branches untouched.
2. `dashboard/handlers/files.py` file-read mime probe: shared sniffer first, then the locally-retained TIFF/ICO rows (hoisted to module-level `_READ_PATH_EXTRA_MAGIC`) and the existing SVG/PDF branches. The header read is `SNIFF_BYTES` to match the sniffer contract.
3. `mochi/petdex_import.py` `_sniff_mime`: shared sniffer filtered through a local `{png, gif, jpeg, webp}` allowlist, so **BMP stays rejected** exactly as today.
4. `pptx_maker/backend/routes.py` `_has_bitmap_signature`: shared sniffer plus the retained offset-4 `ftyp` (HEIC/AVIF) check.

**Intended tightenings (stated, not silent):**
- The pptx bare-`RIFF` row is gone: a RIFF/WAVE audio blob no longer counts as a bitmap. This is the fix, not a regression — the tightening is fail-closed (a non-bitmap blob stays in the regular `redact()` text path).
- The file-read probe now requires PNG's full 8-byte signature where the old local row matched a 4-byte prefix; the upload boundary always required the full signature, so the 4-byte row was itself duplicate drift.

Also adopted from review: `dashboard/handlers/knowledge.py` (the one external consumer of `_content_matches_ext`) now imports `SNIFF_BYTES` instead of hardcoding `16` for its head capture, so a future `SNIFF_BYTES` growth cannot silently under-read the ingest gate.

Import-graph note: `petdex_import.py` and `pptx_maker/backend/routes.py` previously had no `kiro_crew.messaging` import; pulling in `messaging.raster` executes the package `__init__`, which eagerly imports the messaging modules. Neither module is on the gateway boot path (apps load on demand, and the gateway already imports messaging), so this costs nothing at runtime; making `raster.py` a leaf module is a possible follow-up if the app import graph should stay narrow.

Pre-existing, unchanged: `.tif/.tiff/.ico` are not in the upload allowlist and `_content_matches_ext` never validated them; the read path still serves TIFF/ICO via its local rows.

## Tests

Per site, a RIFF/WAVE payload is rejected and the pre-existing accept-set is pinned:
- `test_dashboard_files_coverage.py`: upload-boundary accept-set snapshot per raster extension; RIFF/WAVE rejected for every raster extension; file-read 403 for RIFF/WAVE and for a truncated 4-byte PNG prefix (pins the stated tightening).
- `test_mochi_petdex_import.py`: jpeg/gif accepted; RIFF/WAVE rejected; BMP rejected (pins the no-BMP rule the local allowlist preserves).
- `test_pptx_maker_routes.py`: signature accept-set snapshot (PNG/JPEG/GIF/BMP/WebP + offset-4 `ftyp` HEIC); bare RIFF container no longer a bitmap (pins the stated tightening).

Local gates: isort / flake8 / mypy / black baseline all green; full backend suite **62021 passed, 331 skipped, 6 xfailed, 0 failed**.

## Manual verification

N/A — unit coverage sufficient: every changed predicate is a pure function over leading bytes, exercised directly plus through the aiohttp handlers in the test suite.

## Related Issues

Closes #4315

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior comments updated in place
- [x] No secrets, credentials, or internal references in the diff
