### PR TITLE
fix(slack): forward the renderer's user id to chat.startStream

### DIFF
--- a/src/kiro_crew/slack/renderer.py
+++ b/src/kiro_crew/slack/renderer.py
@@ -218,11 +218,17 @@ class SlackRenderer(Renderer):
         self.slack = slack
         self.channel = channel
         self.thread_ts = thread_ts
-        # The sending user — passed to DashboardContributor.decorate_reply on the
-        # final outbound text so a composed edition can refresh its auth window /
-        # append an expiry footer on the transport reply path too (native
-        # handle_message already wires decorate_reply; this closes the gap so the
-        # DEFAULT non-review Slack traffic gets the same treatment). "" in OSS.
+        # The sending user. Two consumers:
+        #   * DashboardContributor.decorate_reply on the final outbound text, so a
+        #     composed edition can refresh its auth window / append an expiry
+        #     footer on the transport reply path too (native handle_message
+        #     already wires decorate_reply; this closes the gap so the DEFAULT
+        #     non-review Slack traffic gets the same treatment).
+        #   * chat.startStream recipient routing. Slack rejects the call with
+        #     ``missing_recipient_user_id`` when it is absent, and the renderer
+        #     then silently demotes to the non-streaming chat.update surface, so
+        #     dropping this value kills streaming for the whole transport path.
+        # Empty when the caller has no sender id; both consumers no-op on "".
         self._user_id = user_id
         # Message ts to react to (the user's triggering message). Falls back
         # to thread_ts so reactions still attach when not supplied separately.
@@ -304,7 +310,9 @@ class SlackRenderer(Renderer):
 
     async def _ensure_stream(self) -> str:
         if self._stream_ts is None:
-            ts = await self.slack.start_stream(self.channel, self.thread_ts or "")
+            ts = await self.slack.start_stream(
+                self.channel, self.thread_ts or "", user_id=self._user_id or None
+            )
             if ts:
                 self._stream_ts = ts
                 self._use_slack_stream = True
@@ -321,7 +329,9 @@ class SlackRenderer(Renderer):
         """Stop the dead stream and start a fresh one (native ``_rotate_stream``)."""
         if self._stream_ts:
             await self.slack.stop_stream(self.channel, self._stream_ts)
-        new_ts = await self.slack.start_stream(self.channel, self.thread_ts or "")
+        new_ts = await self.slack.start_stream(
+            self.channel, self.thread_ts or "", user_id=self._user_id or None
+        )
         if new_ts:
             self._stream_ts = new_ts
         else:

--- a/test/test_slack_renderer.py
+++ b/test/test_slack_renderer.py
@@ -19,6 +19,7 @@ from kiro_crew.acp.types import (
     AcpEvent,
 )
 from kiro_crew.messaging import APPROVAL_INTERACTIVE, TurnDriver
+from kiro_crew.slack.client import RealSlackClient
 from kiro_crew.slack.renderer import (
     _STATUS_WORKING,
     TOOL_APPROVE_ACTION_PREFIX,
@@ -42,7 +43,10 @@ class _RecSlack:
         return f"ts-{self._n}"
 
     async def start_stream(self, channel, thread_ts, **kw):
-        self.calls.append(("start_stream", {"channel": channel, "thread_ts": thread_ts}))
+        self.calls.append((
+            "start_stream",
+            {"channel": channel, "thread_ts": thread_ts, "user_id": kw.get("user_id")},
+        ))
         return self._ts()
 
     async def append_stream(self, channel, ts, text):
@@ -766,3 +770,81 @@ class TestShowThinking:
         assert thinking, rec.calls
         assert "AKIA1234567890ABCDEX" not in thinking[0]
         assert "[REDACTED: credential]" in thinking[0]
+
+
+class _RecWeb:
+    """Records outgoing Slack Web API bodies (stands in for AsyncWebClient)."""
+
+    def __init__(self):
+        self.bodies: list[tuple[str, dict]] = []
+
+    async def api_call(self, method, json=None):
+        self.bodies.append((method, dict(json or {})))
+        return {"ok": True, "ts": f"ts-{len(self.bodies)}"}
+
+
+def _real_client_with_recorder():
+    """A RealSlackClient whose transport is recorded instead of sent.
+
+    ``__new__`` skips ``__init__`` so no bot token is needed; the only attribute
+    the streaming calls touch beyond ``_web`` is the channel->team cache, which
+    is already ``getattr``-guarded for exactly this case.
+    """
+    client = RealSlackClient.__new__(RealSlackClient)
+    web = _RecWeb()
+    client._web = web
+    return client, web
+
+
+def _start_stream_bodies(web):
+    return [body for method, body in web.bodies if method == "chat.startStream"]
+
+
+class TestStreamRecipientRouting:
+    """chat.startStream needs recipient routing, and the renderer holds it.
+
+    Slack rejects the call with ``missing_recipient_user_id`` when the field is
+    absent; the renderer then demotes to the non-streaming chat.update surface,
+    which still produces a correct reply. That is why these assertions read the
+    OUTGOING request body rather than the rendered text -- a test that only
+    checks the reply text passes either way.
+    """
+
+    def test_open_stream_sends_recipient_user_id(self):
+        client, web = _real_client_with_recorder()
+        renderer = SlackRenderer(client, "C1", "t1", reactions_enabled=False, user_id="U123")
+        asyncio.run(renderer._ensure_stream())
+        bodies = _start_stream_bodies(web)
+        assert len(bodies) == 1, web.bodies
+        assert bodies[0]["recipient_user_id"] == "U123", bodies[0]
+
+    def test_rotated_stream_sends_recipient_user_id(self):
+        client, web = _real_client_with_recorder()
+        renderer = SlackRenderer(client, "C1", "t1", reactions_enabled=False, user_id="U123")
+        asyncio.run(renderer._ensure_stream())
+        asyncio.run(renderer._rotate_stream())
+        bodies = _start_stream_bodies(web)
+        assert len(bodies) == 2, web.bodies
+        assert all(b["recipient_user_id"] == "U123" for b in bodies), bodies
+
+    def test_absent_user_id_omits_the_field(self):
+        """No sender id => the same request as before, not an empty recipient."""
+        client, web = _real_client_with_recorder()
+        renderer = SlackRenderer(client, "C1", "t1", reactions_enabled=False)
+        asyncio.run(renderer._ensure_stream())
+        bodies = _start_stream_bodies(web)
+        assert len(bodies) == 1, web.bodies
+        assert "recipient_user_id" not in bodies[0], bodies[0]
+
+    def test_driver_turn_forwards_user_id_on_both_call_sites(self):
+        """Whole-turn coverage: the initial open and the rotation both carry it."""
+        rec = _FlakyAppendSlack()  # first append fails => one rotation
+        renderer = SlackRenderer(rec, "C1", "t1", reactions_enabled=False, user_id="U123")
+        provider = _Provider([
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="hi"),
+            AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+        ])
+        asyncio.run(TurnDriver(provider, renderer, approval_mode="auto").run("x"))
+        opens = [kw for m, kw in rec.calls if m == "start_stream"]
+        assert len(opens) == 2, rec.calls
+        assert [kw["user_id"] for kw in opens] == ["U123", "U123"], opens


### PR DESCRIPTION
## Problem / Motivation

Slack replies never stream on the `SlackRenderer` transport path. Every turn calls
`chat.startStream`, Slack rejects it with `missing_recipient_user_id`, and the renderer
falls back to the non-streaming `chat.update` surface. The answer still arrives, so
nothing looks broken -- it just lands as one finished block instead of streaming in,
with no task-plan surface.

## Why it matters

That path is the DEFAULT non-review Slack traffic, so streaming is dead for it
entirely. It fails open, which is why it went unnoticed: the only marker is a
`WARNING` in the gateway log, and the reply is still correct. Each turn also burns one
wasted `chat.startStream` API call.

## What changed (motivation -> approach -> change)

Symptom: `{'ok': False, 'error': 'missing_recipient_user_id'}` on every
`chat.startStream` from the renderer path, then a silent demotion to `chat.update`.

Root cause: `start_stream` takes both recipient routing fields as optional keyword
arguments, and only one of the two caller families passes them. `handler.py` threads
`team_id=` and `user_id=`; `renderer.py` called `start_stream(self.channel,
self.thread_ts or "")` with neither. The user id was already available at the
renderer -- `events.py` passes the sender id into `handle_message_transport`,
`transport_dispatch` constructs the renderer with `user_id=`, and the renderer stores
it as `self._user_id`. It was threaded all the way in and then dropped at the last
step.

Change: forward `user_id=self._user_id or None` at both `start_stream` call sites (the
initial open in `_ensure_stream` and the rotation in `_rotate_stream`). Keeping `or
None` leaves today's behaviour untouched when the id is genuinely absent, so this can
only stop discarding a value that is present; it cannot regress the empty case.

Two things deliberately NOT changed:

- `team_id` at these sites. The client's channel-to-team cache already resolves it and
  the renderer carries no team id.
- The same cache trick for `user_id`. A channel belongs to exactly one workspace, so
  channel-to-team is an invariant and safe to cache; a channel has many users, so a
  channel-to-last-known-user cache would route the recipient to whoever spoke
  previously. The value has to come from the caller, which already has it.

The stale comment on `self._user_id` (which described only the `decorate_reply`
consumer and read as if the field were empty) now names both consumers and why
dropping the value kills streaming.

## Tests

`test/test_slack_renderer.py`, new `TestStreamRecipientRouting`. The assertions read
the OUTGOING `chat.startStream` request body rather than the reply text, because the
fallback still produces a correct reply and hides this bug from any text-level check.
Three of the four run a real `RealSlackClient` over a recording transport, so the
coverage spans renderer -> client -> request body:

- `test_open_stream_sends_recipient_user_id` -- the initial open carries
  `recipient_user_id`.
- `test_rotated_stream_sends_recipient_user_id` -- so does the rotation.
- `test_absent_user_id_omits_the_field` -- with no sender id the request is unchanged,
  not `recipient_user_id: ""`.
- `test_driver_turn_forwards_user_id_on_both_call_sites` -- whole-turn coverage
  through `TurnDriver` with an append failure to force one rotation.

Mutation probe: reverting only `renderer.py` reds exactly the three routing tests
(`KeyError: 'recipient_user_id'`) and leaves the empty-case guard green.

Local gates: `test_slack_renderer.py` 35/35 plus the slack transport/client suites
(90 passed total), flake8 clean, isort clean, mypy clean on the changed module,
baselined black gate passed, brand-name gate passed.

## Manual verification

N/A -- reaching the real failure needs a configured Slack workspace with an
Enterprise-Grid-style install; the unit coverage asserts the exact request field Slack
rejected on, which is what the log evidence in the issue names.

Closes #5318
