### PR TITLE
fix(mcp): advertise caller identity for the computer and dashboard servers

### DIFF
--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -165,7 +165,10 @@ all, so the spec is byte-for-byte unchanged there. Pinned by
 `test_computer_use_registration.py::TestDataHomePin`.
 
 **Session identity.** The shim resolves it with
-`mcp_core._resolve_session_key_strict()` — the env `KIROCREW_SESSION_KEY`, else
+`mcp_core._resolve_session_key_strict()` — the gateway-injected per-call caller
+block first (the shim advertises `kirocrew.caller-identity`, so gatewayd injects
+one whenever it can name the caller — the only source that holds on a pooled
+backend serving many sessions), else the env `KIROCREW_SESSION_KEY`, else
 `KIROCREW_HOST_PID` plus the HMAC sidecar signed with the keystone-protected
 `sel_hmac.key`. It is used for the audit record and for the live-view relay's
 attribution, **not** as an authorization input: an unresolved key does not refuse the
@@ -195,8 +198,13 @@ sessions observing the same window overwrote each other's element indices — an
 one's own `verify_fingerprint` still passed, because both trees describe the same
 window, so the wrong-target action had nothing reporting it. kiro-cli spawns one shim
 per session, so the shim's own pid separates the namespaces exactly as far as the
-sessions are genuinely separate. Read at call time rather than captured at import, so
-a forked child cannot inherit its parent's string and re-alias with it.
+sessions are genuinely separate — in the 1:1 shim topology. On a POOLED backend one
+process serves many sessions, so the pid separates only what the injected caller
+block does not already name: co-tenants gatewayd CAN name get real per-session keys,
+and the residual — two or more co-tenants it cannot name sharing one
+`unresolved:<pid>` namespace — is tracked as #5322. Read at call time rather than
+captured at import, so a forked child cannot inherit its parent's string and
+re-alias with it.
 
 The prefix is deliberate: this is a namespace separator, not attribution, and an audit
 reader must not mistake a pid for a resolved identity. And it is a namespacing fix

--- a/docs/system-specs/modules/mcp-shareability.md
+++ b/docs/system-specs/modules/mcp-shareability.md
@@ -43,7 +43,7 @@ The bulk stub action consults whichever of the two the global sharing switch mak
 
 ## Session-bound by construction, which is not the same as "ours"
 
-The `disqualified` reason `first_party_session_scoped` names a server that resolves the calling session from its own PROCESS — an env var, a pid walk — so one backend can only ever serve one session correctly. It is decided by which servers actually consume the injected caller block, not by matching a name against Kiro Crew's managed set: `kirocrew-core` advertises the caller-identity extension and consumes that block, while `kirocrew-cron` does not. Keying it on authorship disqualified the first for a property only the second has.
+The `disqualified` reason `first_party_session_scoped` names a server that resolves the calling session from its own PROCESS — an env var, a pid walk — so one backend can only ever serve one session correctly. It is decided by which servers actually consume the injected caller block, not by matching a name against Kiro Crew's managed set: keying it on authorship once disqualified `kirocrew-core` — which advertised the extension and consumed the block from the start — for a property only its unadopted siblings had. All four managed servers now advertise and consume the block (`kirocrew-core` from the start, `kirocrew-cron` since #4622's fix, `kirocrew-computer` and `kirocrew-dashboard` since #4659). Advertising is necessary but not sufficient for the shareable classification: `kirocrew-computer` stays session-bound deliberately, because a caller the gateway cannot name proceeds under `unresolved:<pid>` and unnamed co-tenants on a pooled backend would share that one snapshot namespace (#5322) — see `_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD` in `mcp_discovery.py`. The classification stays per-server because the next managed server starts unadopted, exactly as these did.
 
 `mcp_discovery.managed_server_is_session_bound` answers from a module-level set, `_MANAGED_SERVERS_CALLER_AWARE`, and deliberately imports nothing: the assessment must answer WITHOUT a handshake (the probe cannot spawn on every host — Windows, macOS >= 26 — and has not run at all before the first probe cycle), and it is consulted on every render, so importing a server module to read its `ADVERTISE_CALLER_IDENTITY` would execute package code from an editable checkout on a path the sandbox never confines. `test/test_mcp_managed_caller_identity.py::test_the_classification_reads_no_module_at_import_time` pins that refusal.
 
@@ -184,7 +184,7 @@ That split is also the export contract. The telemetry layer requires low-cardina
 | `observed_hazard` | refuted | Ledger entry; detail is the hazard code. **One of only two durable grounds for refusing to share, because it happened rather than being inferred.** |
 | `not_stdio` | disqualified | No stdio pipe — out of scope, not unsafe. **The other durable ground, and the only remaining `disqualified` code.** |
 | `handshake_not_reproducible` | note | Pre-flight saw a divergent replayed surface (capabilities, protocol version, `serverInfo` shape, or the tool list). Reported and gates nothing: see below. |
-| `session_bound_by_construction` | disqualified | A managed server that resolves its caller from its own process rather than the injected caller block. Kept gating because `mcp_cron._check_cron_job_ownership` treats a falsy session key as *allow*, so a pooled backend reading EMPTY skips the ownership check rather than merely losing a feature -- and no routing-shaped hazard code would ever record it. |
+| `session_bound_by_construction` | disqualified | A managed server that resolves its caller from its own process rather than the injected caller block -- or that consumes the block yet is deliberately withheld from the shareable classification. Kept gating because `mcp_cron._check_cron_job_ownership` treats a falsy session key as *allow*, so a pooled backend reading EMPTY skips the ownership check rather than merely losing a feature -- and no routing-shaped hazard code would ever record it. Current producer: `kirocrew-computer` (advertises, but unnamed co-tenants share one `unresolved:<pid>` snapshot namespace, #5322). |
 | `rotating_secret_env` | note | Declares an env name excluded from the pool key. Detail is the name. Not emitted for a name in `mcp_gateway.pool_identity_env`, which IS in the pool key. |
 | `degrades_when_shared` | note | `resources.subscribe` or `logging`; detail names which. |
 | `not_probed` | unknown | No handshake was observed. |
@@ -238,8 +238,12 @@ and `mcp_cron._check_cron_job_ownership` returns *allow* on a falsy session key,
 a pooled cron skips ownership entirely. That is a cross-session authorization
 failure, and it is the one case the retreat cannot backstop: both hazard codes
 describe frames that could not be routed, so serving the wrong session's data
-produces no record. It stays a disqualifier until the managed servers it names
-consume the injected caller block (#4622).
+produces no record. The producers have narrowed as managed servers adopted the
+caller block (#4622, #4659); today the code has one deliberate producer --
+`kirocrew-computer`, which advertises and consumes the block but whose UNNAMED
+co-tenants would share one `unresolved:<pid>` snapshot namespace on a pooled
+backend (#5322) -- and it remains the conservative default for the next managed
+server, which starts unadopted exactly as the others did.
 
 `*.listChanged` is deliberately absent from all of the above: those notifications
 are global broadcasts (`backend._GLOBAL_BROADCAST_NOTIFICATIONS`) and are safe to

--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -28,11 +28,15 @@ auditing happen IN THE GATEWAY (``computer_use/tools.py`` →
   down the process kiro-cli is talking to, and this file is byte-identical in
   behavior on macOS, Linux and Windows.
 
-Identity is resolved with :func:`mcp_core._resolve_session_key_strict` — the env
-var, or ``KIROCREW_HOST_PID`` plus the HMAC sidecar signed with the
-keystone-protected ``sel_hmac.key``. The lenient resolver is deliberately NOT
-used: it walks ``/proc`` ancestors over ``session_pid_<pid>.txt``, which
-``mcp_core`` itself documents as "agent-writable and therefore forgeable".
+Identity is resolved with :func:`mcp_core._resolve_session_key_strict` — the
+gateway-injected per-call caller block first (this server advertises
+``kirocrew.caller-identity``, so gatewayd injects one whenever it can name the
+caller — the only identity source that works on a pooled backend serving many
+sessions), then the env var, then ``KIROCREW_HOST_PID`` plus the HMAC sidecar
+signed with the keystone-protected ``sel_hmac.key``. The lenient resolver is
+deliberately NOT used: it walks ``/proc`` ancestors over
+``session_pid_<pid>.txt``, which ``mcp_core`` itself documents as
+"agent-writable and therefore forgeable".
 
 **An unresolved key is NOT a refusal.** It is forwarded empty and the call proceeds.
 Neither accepted source exists for a GUI-launched kiro-cli on macOS —
@@ -155,9 +159,13 @@ ERR_GATEWAY_UNREACHABLE = (
 # class this feature can produce.
 #
 # The fix is a per-PROCESS identity, not a refusal. kiro-cli spawns one shim process
-# per session, so the shim's own pid separates the namespaces exactly as far as the
-# sessions are actually separate — and it does so without reinstating the
-# unattended-surface refusal that was removed by product decision. It is
+# per session, so in the 1:1 shim topology the pid separates the namespaces exactly
+# as far as the sessions are actually separate — and it does so without reinstating
+# the unattended-surface refusal that was removed by product decision. On a POOLED
+# backend one process serves many sessions, so the pid separates only what the
+# injected caller block does not already name: co-tenants gatewayd can name get real
+# per-session keys, and the residual — unnamed co-tenants sharing one
+# ``unresolved:<pid>`` namespace — is tracked as #5322. It is
 # deliberately NOT presented as trustworthy attribution: the prefix names it as
 # unresolved so an audit reader cannot mistake a pid for a session identity.
 UNRESOLVED_SESSION_PREFIX = "unresolved:"
@@ -768,6 +776,37 @@ def _invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]
     return decoded
 
 
+#: Whether this server advertises ``kirocrew.caller-identity`` — i.e. whether it
+#: consumes the per-call caller block gatewayd injects instead of reading identity
+#: from its own process. True here because it does: the session key forwarded to
+#: the gateway comes from :func:`mcp_core._resolve_session_key_strict`, whose
+#: first source is that block.
+#:
+#: Advertising is not cosmetic. ``mcp_gateway/backend.py`` strips any client-forged
+#: caller block from EVERY forwarded request and re-injects its own only when the
+#: backend advertised this capability — so without the advertisement the block
+#: never arrives, and this server's resolver reads an empty identity no matter how
+#: correctly it is written. Nothing declines to POOL an unadvertised backend
+#: (``rewriter.UNPOOLABLE_SERVERS`` is empty and documents that the capability is
+#: read only to decide injection), so the unadvertised state was not "per-session
+#: spawn" — it was pooled AND identity-blind. For this server that silently
+#: degraded every pooled call to the unresolved-identity path: the call still
+#: proceeds (by product decision), but the audit trail loses attribution it was
+#: built to carry.
+#:
+#: A module-level constant rather than a bare argument below so the value is
+#: readable without executing :func:`run_mcp_server`, and so
+#: ``test/test_mcp_managed_caller_identity.py`` can assert it against the argument
+#: actually handed to the shim.
+ADVERTISE_CALLER_IDENTITY = True
+
+
 def run_mcp_server() -> None:
     """Run the MCP stdio server — reads JSON-RPC from stdin, writes to stdout."""
-    run_mcp_stdio_loop(SERVER_NAME, SERVER_VERSION, _list_tools, _call_tool)
+    run_mcp_stdio_loop(
+        SERVER_NAME,
+        SERVER_VERSION,
+        _list_tools,
+        _call_tool,
+        advertise_caller_identity=ADVERTISE_CALLER_IDENTITY,
+    )

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -46,12 +46,18 @@ require authorization needs its own keystone leaf, and being merely unreferenced
 in the default spec is not that. Session control (driving or stopping another
 session) is that shape.
 
-Identity posture: these tools use the NON-strict session resolver (inherited
-from the ``mcp_core`` request helpers). The header is ATTRIBUTION here, not
-authorization — the endpoints authorize on the internal secret, and the session
-a move targets is named explicitly by slot key, never derived from the caller's
-identity. The strict resolver would fail closed in sandboxed sessions without
-protecting anything, since no effect here reads the header.
+Identity posture: two resolvers, for two different jobs. The SEL invocation log
+(``_call_tool``) uses the NON-strict resolver — that header is ATTRIBUTION, and
+a lenient misattribution there is tolerable. Every decision that SCOPES what a
+caller may see or verify-writes — ``_visible_chat_slots``,
+``_refuse_tree_shaping_if_unverifiable``, and ``chat_folder_move_session``'s own
+caller check (the one tool here that writes to a session other than the
+caller's) — uses :func:`mcp_core._resolve_session_key_strict`, whose first
+source is the gateway-injected per-call caller block — the only identity that
+holds on a pooled backend serving many sessions (this server advertises
+``kirocrew.caller-identity`` so gatewayd injects one; see
+``ADVERTISE_CALLER_IDENTITY``). An unverifiable caller is refused by those
+paths, never waved through on the lenient walk.
 """
 
 from __future__ import annotations
@@ -900,6 +906,37 @@ def _call_tool(name: str, raw_args: dict[str, Any]) -> str:
     )
 
 
+#: Whether this server advertises ``kirocrew.caller-identity`` — i.e. whether it
+#: consumes the per-call caller block gatewayd injects instead of reading identity
+#: from its own process. True here because it does: every scoping decision
+#: (``_visible_chat_slots``, ``_refuse_tree_shaping_if_unverifiable``) resolves
+#: the caller through :func:`mcp_core._resolve_session_key_strict`, whose first
+#: source is that block.
+#:
+#: Advertising is not cosmetic. ``mcp_gateway/backend.py`` strips any client-forged
+#: caller block from EVERY forwarded request and re-injects its own only when the
+#: backend advertised this capability — so without the advertisement the block
+#: never arrives, and this server's resolver reads an empty identity no matter how
+#: correctly it is written. Nothing declines to POOL an unadvertised backend
+#: (``rewriter.UNPOOLABLE_SERVERS`` is empty and documents that the capability is
+#: read only to decide injection), so the unadvertised state was not "per-session
+#: spawn" — it was pooled AND identity-blind. For this server that fail-closed
+#: every scoped tool on a pooled backend: an unverifiable caller is refused, so
+#: the tools stopped working for exactly the sessions pooling was built to serve.
+#:
+#: A module-level constant rather than a bare argument below so the value is
+#: readable without executing :func:`run_mcp_server`, and so
+#: ``test/test_mcp_managed_caller_identity.py`` can assert it against the argument
+#: actually handed to the shim.
+ADVERTISE_CALLER_IDENTITY = True
+
+
 def run_mcp_server() -> None:
     """Run the MCP stdio server — reads JSON-RPC from stdin, writes to stdout."""
-    run_mcp_stdio_loop(SERVER_NAME, SERVER_VERSION, _list_tools, _call_tool)
+    run_mcp_stdio_loop(
+        SERVER_NAME,
+        SERVER_VERSION,
+        _list_tools,
+        _call_tool,
+        advertise_caller_identity=ADVERTISE_CALLER_IDENTITY,
+    )

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -908,10 +908,13 @@ _MANAGED_SERVER_TOOL_MODULES = {
 }
 
 
-#: Managed servers that advertise ``kirocrew.caller-identity`` -- that is, the ones
-#: consuming the per-call caller block gatewayd injects instead of reading identity
-#: from their own process. Every other name in ``_MANAGED_SERVER_SUBCOMMANDS``
-#: resolves the session from its process and can serve only one at a time.
+#: Managed servers that advertise ``kirocrew.caller-identity`` AND are safe to
+#: classify shareable -- the ones consuming the per-call caller block gatewayd
+#: injects instead of reading identity from their own process, whose behaviour
+#: for a caller the gateway CANNOT name is also pooling-safe (refusal, or a
+#: correctly separated namespace). A name absent from this set reads as
+#: session-bound: either it does not consume the block at all, or it is in
+#: ``_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD`` below.
 #:
 #: A NAME SET rather than a runtime read of each module's own constant. Reading the
 #: constant means ``importlib.import_module`` on the request path, which executes
@@ -928,7 +931,26 @@ _MANAGED_SERVER_TOOL_MODULES = {
 #: argument actually handed to the shim. That check imports the modules in the
 #: TEST process, where running package code is the point rather than a hazard.
 _MANAGED_SERVERS_CALLER_AWARE: frozenset[str] = frozenset(
-    {"kirocrew-core", "kirocrew-cron"}
+    {"kirocrew-core", "kirocrew-cron", "kirocrew-dashboard"}
+)
+
+#: Managed servers that ADVERTISE the capability but are deliberately withheld
+#: from ``_MANAGED_SERVERS_CALLER_AWARE`` — advertising is necessary for the
+#: not-session-bound classification but not sufficient. ``kirocrew-computer``
+#: consumes the injected caller block (its pooled attribution is correct for
+#: every caller the gateway can name), but a caller the gateway CANNOT name
+#: proceeds under ``unresolved:<pid>`` by product decision — and on a pooled
+#: backend that pid is the shared process, so two unnamed co-tenants collapse
+#: onto one ``SnapshotIndex`` namespace and can act on each other's element
+#: indices (#5322). Unnamed is the NORMAL case on macOS, the only platform
+#: with a computer-use driver, so recommending co-tenancy would recommend the
+#: collision. Contrast ``kirocrew-dashboard``, which refuses an unidentified
+#: caller and is therefore safe to classify shareable. Remove this exception
+#: when #5322 gives unnamed callers isolated namespaces;
+#: ``test_mcp_managed_caller_identity.py`` pins it so it cannot silently
+#: persist or silently widen.
+_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD: frozenset[str] = frozenset(
+    {"kirocrew-computer"}
 )
 
 

--- a/src/kiro_crew/mcp_gateway/shareability.py
+++ b/src/kiro_crew/mcp_gateway/shareability.py
@@ -345,9 +345,14 @@ def assess(
     #    something is observed" posture cannot cover: both hazard codes are
     #    routing-shaped, so a server serving the wrong session's data without ever
     #    emitting an unroutable frame produces no ledger entry. There is no retreat
-    #    to fall back on, so the gate stays until the servers it names consume the
-    #    injected caller block (#4622) -- at which point the input has no producer
-    #    and this branch is deleted rather than relaxed.
+    #    to fall back on. The set of producers has narrowed as managed servers
+    #    adopted the caller block (#4622, #4659), but the branch keeps two jobs:
+    #    ``kirocrew-computer`` advertises yet stays session-bound deliberately
+    #    (its UNNAMED co-tenants would share one ``unresolved:<pid>`` snapshot
+    #    namespace, #5322), and the conservative default for a future managed
+    #    server missing from ``_MANAGED_SERVERS_CALLER_AWARE`` (pinned by
+    #    ``test_a_managed_server_missing_from_the_aware_set_reads_as_session_bound``)
+    #    must land HERE, as a disqualifier, rather than in the shareable set.
     #
     #    Checked BEFORE the probe gate: it is a config fact, true whether or not
     #    the server ever started.

--- a/test/test_mcp_managed_caller_identity.py
+++ b/test/test_mcp_managed_caller_identity.py
@@ -73,28 +73,62 @@ def test_the_constant_matches_what_the_server_advertises(name: str, monkeypatch)
 
 
 @pytest.mark.parametrize("name", sorted(_SERVE_ENTRY))
-def test_session_bound_is_the_inverse_of_advertising(name: str, monkeypatch) -> None:
+def test_session_bound_follows_advertising_modulo_the_withheld_set(name: str, monkeypatch) -> None:
+    """Session-bound is the inverse of advertising, EXCEPT the documented set.
+
+    Advertising is necessary for the shareable classification but not
+    sufficient: ``_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD`` names servers
+    whose pooled attribution is correct for every caller the gateway can name
+    but whose UNNAMED co-tenants would collide (#5322), so they are kept
+    session-bound deliberately. Every other server must follow the inverse
+    rule exactly.
+    """
     module_name = _MANAGED_SERVER_TOOL_MODULES[name]
     advertised = _advertised_by_serve_entry(module_name, _SERVE_ENTRY[name], monkeypatch)
-    assert managed_server_is_session_bound(name) is (not advertised)
+    withheld = name in mcp_discovery._MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD
+    if withheld:
+        assert managed_server_is_session_bound(name) is True
+    else:
+        assert managed_server_is_session_bound(name) is (not advertised)
+
+
+def test_the_withheld_set_is_a_real_exception_not_a_stale_one(monkeypatch) -> None:
+    """Each withheld name must be managed, actually advertise, and not also
+    be claimed caller-aware — otherwise the exception is stale (the server
+    stopped advertising, or #5322 landed and the name was promoted without
+    deleting it here) or self-contradictory.
+    """
+    withheld = mcp_discovery._MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD
+    assert withheld <= set(_MANAGED_SERVER_TOOL_MODULES)
+    assert not (withheld & mcp_discovery._MANAGED_SERVERS_CALLER_AWARE)
+    for name in withheld:
+        module_name = _MANAGED_SERVER_TOOL_MODULES[name]
+        advertised = _advertised_by_serve_entry(module_name, _SERVE_ENTRY[name], monkeypatch)
+        assert advertised, (
+            f"{name} is in the advertising-but-withheld set but its serve entry "
+            "does not advertise — the exception no longer describes the server."
+        )
 
 
 def test_the_concrete_verdicts_are_spelled_out() -> None:
     """The concrete answers the dashboard renders, spelled out.
 
     Kept alongside the derived checks above because those pass just as happily if
-    every managed server flipped at once. ``kirocrew-core`` and ``kirocrew-cron``
-    both consume the injected caller block, so neither is session-bound.
-    ``kirocrew-computer`` and ``kirocrew-dashboard`` do not advertise yet -- they
-    are pooled all the same (nothing declines to pool an unadvertised backend), so
-    what this verdict records is our own unfinished adoption, not a property of
-    those servers. It flips when they adopt it, and the reason code can be deleted
-    once nothing produces it.
+    every managed server flipped at once. ``kirocrew-core``, ``kirocrew-cron``
+    and ``kirocrew-dashboard`` consume the injected caller block and refuse or
+    safely namespace an unidentified caller, so none is session-bound.
+    ``kirocrew-computer`` also advertises and consumes the block (#4659 — its
+    pooled attribution is correct for every caller the gateway can name), but
+    it stays session-bound DELIBERATELY: an unnamed caller proceeds under
+    ``unresolved:<pid>``, which on a pooled backend is one shared namespace for
+    every unnamed co-tenant (#5322) — and unnamed is the normal case on macOS,
+    the only platform with a driver. It flips when #5322 gives unnamed callers
+    isolated namespaces.
     """
     assert managed_server_is_session_bound("kirocrew-core") is False
     assert managed_server_is_session_bound("kirocrew-cron") is False
     assert managed_server_is_session_bound("kirocrew-computer") is True
-    assert managed_server_is_session_bound("kirocrew-dashboard") is True
+    assert managed_server_is_session_bound("kirocrew-dashboard") is False
 
 
 def test_a_third_party_server_is_not_claimed_either_way() -> None:

--- a/test/test_mcp_pool_identity_computer_dashboard.py
+++ b/test/test_mcp_pool_identity_computer_dashboard.py
@@ -1,0 +1,208 @@
+"""``kirocrew-computer`` and ``kirocrew-dashboard`` resolve the calling session
+from the injected caller block.
+
+The exact state #4622 described and fixed for ``kirocrew-cron``: both servers
+already routed identity through :func:`mcp_core._resolve_session_key_strict`,
+whose FIRST source is the gateway-injected per-call caller block — but neither
+advertised ``kirocrew.caller-identity``, and ``mcp_gateway/backend.py`` strips
+any stub-supplied block from every forwarded request and re-injects its own only
+for a backend that advertised. Nothing declines to pool an unadvertised backend
+(``rewriter.UNPOOLABLE_SERVERS`` is empty), so not advertising bought a shared
+process that never received an identity: pooled and identity-blind.
+
+The gateway half — that gatewayd injects the block into a backend that
+advertises, and that co-tenant sessions arrive distinguishable — is proven
+end-to-end by ``test_mcp_gateway_pool_integ.py``
+(``test_two_stubs_on_one_backend_are_told_apart``), and the advertisement itself
+is ratcheted against ``_MANAGED_SERVERS_CALLER_AWARE`` by
+``test_mcp_managed_caller_identity.py``. What THIS file pins is the server half
+for these two servers, mirroring ``test_mcp_cron_caller_identity.py``:
+
+1. The caller block WINS over the process environment — asserted with the
+   environment naming a DIFFERENT session, because a test that merely reads the
+   block back would also pass if the block were being ignored in favour of an
+   environment that happened to agree.
+2. With no block, the environment still resolves, so a non-gateway launch is
+   not regressed.
+3. Each server's documented no-identity posture is preserved: computer-use
+   proceeds under an ``unresolved:<pid>`` namespace (refusing was removed by
+   product decision), while the dashboard's tree-shaping tools refuse
+   (deny-by-default over shared structure).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kiro_crew import mcp_computer, mcp_dashboard
+from kiro_crew.mcp_caller import CallerContext, set_current_caller
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_identity(monkeypatch):
+    """No identity of any kind unless a test grants one.
+
+    Identity is granted per test rather than by a shared fixture: part of this
+    module is about what happens when there is none.
+    """
+    monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+    monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
+    set_current_caller(None)
+    yield
+    set_current_caller(None)
+
+
+def _as_session(key: str) -> None:
+    """Arrive the way a pooled forwarded call does: carrying a caller block."""
+    set_current_caller(CallerContext(session_key=key, session_type="dashboard"))
+
+
+# --- kirocrew-computer ------------------------------------------------------
+#
+# The one place identity leaves this server is the ``session_key`` argument of
+# ``_invoke`` (it becomes the gateway request's session header), so that is
+# where these tests observe it.
+
+
+@pytest.fixture
+def computer_invocations(monkeypatch) -> dict[str, Any]:
+    """Enable the feature and capture what ``_call_tool_inner`` forwards."""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(mcp_computer.enable_state, "is_enabled", lambda: True)
+
+    def _fake_invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        captured["session_key"] = session_key
+        return {"text": "ok"}
+
+    monkeypatch.setattr(mcp_computer, "_invoke", _fake_invoke)
+    return captured
+
+
+def test_computer_forwards_the_block_identity_over_the_environment(
+    monkeypatch, computer_invocations
+) -> None:
+    """The whole bug in one assertion.
+
+    The environment names a DIFFERENT session than the block. A pooled backend's
+    environment can only ever name one session (or, in practice, none), so the
+    block has to outrank it rather than merely be consulted.
+    """
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:from-env")
+    _as_session("dashboard:from-block")
+
+    assert mcp_computer._call_tool_inner("computer_get_state", {}) == "ok"
+    assert computer_invocations["session_key"] == "dashboard:from-block"
+
+
+def test_computer_falls_back_to_the_environment_without_a_block(
+    monkeypatch, computer_invocations
+) -> None:
+    """A non-gateway launch has no block to read and must not be regressed."""
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:from-env")
+
+    assert mcp_computer._call_tool_inner("computer_get_state", {}) == "ok"
+    assert computer_invocations["session_key"] == "dashboard:from-env"
+
+
+def test_computer_still_proceeds_unidentified_under_a_process_namespace(
+    computer_invocations,
+) -> None:
+    """No identity is not a refusal here — that posture must survive adoption.
+
+    The unattended-surface rule was removed by product decision: "we could not
+    name the session" must not become "you may not drive the desktop". The call
+    proceeds under the ``unresolved:<pid>`` namespace, which is honest about
+    being a separator rather than an authenticated identity.
+    """
+    assert mcp_computer._call_tool_inner("computer_get_state", {}) == "ok"
+    assert computer_invocations["session_key"].startswith(mcp_computer.UNRESOLVED_SESSION_PREFIX)
+
+
+# --- kirocrew-dashboard -----------------------------------------------------
+#
+# Identity decides SCOPE here: which sessions a caller may see, and whether it
+# may reshape the shared folder tree at all. Both go through
+# ``_resolve_session_key_strict``, so both read the block first.
+
+
+def _rows(*rows: dict[str, Any]) -> Any:
+    """A canned ``_get_rows`` returning *rows* for every endpoint."""
+    return lambda _path: (list(rows), None)
+
+
+def test_dashboard_scopes_the_session_list_by_the_block_identity(
+    monkeypatch,
+) -> None:
+    """Each co-tenant sees its OWN app's sessions, not another's.
+
+    The environment names a session owned by a different app than the block.
+    If the environment won, the visible set would be app-b's — one session's
+    scope applied to another's call, the co-tenancy failure pooling makes
+    possible.
+    """
+    monkeypatch.setattr(
+        mcp_dashboard,
+        "_get_rows",
+        _rows(
+            {"key": "from-block", "app": "app-a"},
+            {"key": "from-env", "app": "app-b"},
+            {"key": "other-a", "app": "app-a"},
+            {"key": "other-b", "app": "app-b"},
+        ),
+    )
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:from-env")
+    _as_session("dashboard:from-block")
+
+    visible, err = mcp_dashboard._visible_chat_slots()
+    assert err is None
+    assert sorted(r["key"] for r in visible) == ["from-block", "other-a"]
+
+
+def test_dashboard_verifies_tree_writes_against_the_block_identity(
+    monkeypatch,
+) -> None:
+    """The verified key handed to every tree write is the block's, not the env's."""
+    monkeypatch.setattr(
+        mcp_dashboard,
+        "_get_rows",
+        _rows({"key": "from-block"}, {"key": "from-env", "app": "app-b"}),
+    )
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:from-env")
+    _as_session("dashboard:from-block")
+
+    caller_key, err = mcp_dashboard._refuse_tree_shaping_if_unverifiable("moving")
+    assert err is None
+    assert caller_key == "dashboard:from-block"
+
+
+def test_dashboard_falls_back_to_the_environment_without_a_block(
+    monkeypatch,
+) -> None:
+    """A non-gateway launch has no block to read and must not be regressed."""
+    monkeypatch.setattr(mcp_dashboard, "_get_rows", _rows({"key": "from-env"}))
+    monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:from-env")
+
+    caller_key, err = mcp_dashboard._refuse_tree_shaping_if_unverifiable("moving")
+    assert err is None
+    assert caller_key == "dashboard:from-env"
+
+
+def test_dashboard_refuses_an_unidentified_caller(monkeypatch) -> None:
+    """Deny-by-default over shared structure — that posture must survive adoption.
+
+    An unidentified caller can still share a pooled backend with identified ones
+    (gatewayd forwards ``caller=None`` when a stub registers without a key), so
+    empty identity does not imply a 1:1 transport and must not carry authority
+    over the shared folder tree.
+    """
+    monkeypatch.setattr(mcp_dashboard, "_get_rows", _rows())
+
+    caller_key, err = mcp_dashboard._refuse_tree_shaping_if_unverifiable("moving")
+    assert caller_key == ""
+    assert err is not None and "cannot verify" in err
+
+    visible, list_err = mcp_dashboard._visible_chat_slots()
+    assert visible == []
+    assert list_err is not None and "cannot verify" in list_err


### PR DESCRIPTION
## Problem / Motivation

kirocrew-computer and kirocrew-dashboard are pooled and identity-blind -- the exact state #4622 described and fixed for kirocrew-cron. Two facts combine: `mcp_gateway/backend.py` strips any stub-supplied `_meta` caller block from every forwarded request and re-injects its own ONLY when the backend advertised `kirocrew.caller-identity` (neither server advertised), and nothing declines to pool an unadvertised backend (`rewriter.UNPOOLABLE_SERVERS` is empty). So not advertising bought a shared process that never received an identity.

## Why it matters

Both servers already resolve identity through `mcp_core._resolve_session_key_strict`, whose FIRST source is the injected caller block -- the server half was always correct, but on a pooled backend the block never arrived, so the resolver read empty for every co-tenant:

- **kirocrew-computer** silently degraded every pooled call to the `unresolved:<pid>` audit namespace -- the trail lost the attribution it was built to carry, and unnamed co-tenants collapsed onto one snapshot namespace.
- **kirocrew-dashboard** fail-closed: `_visible_chat_slots` and the tree-shaping verifier refuse an unverifiable caller, so the scoped tools stopped working for exactly the sessions pooling was built to serve.

## What changed (motivation -> approach -> change)

Same one-line-class adoption #4622 landed for cron (read from its merged diff, PR #4632):

1. Both serve entry points now pass `advertise_caller_identity=ADVERTISE_CALLER_IDENTITY` to `run_mcp_stdio_loop`, with the constant module-level so the parity ratchet in `test_mcp_managed_caller_identity.py` can read it without serving.
2. `kirocrew-dashboard` joins `mcp_discovery._MANAGED_SERVERS_CALLER_AWARE` (it refuses an unidentified caller, so it is safe to classify shareable). `kirocrew-computer` advertises but is deliberately WITHHELD from the shareable classification via the new `_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD` set: an unnamed caller proceeds under `unresolved:<pid>` by product decision, and on a pooled backend unnamed co-tenants would share that one snapshot namespace (#5322) -- unnamed is the NORMAL case on macOS, the only platform with a driver. The exception is pinned by a ratchet so it can neither silently persist after #5322 nor be promoted without deleting it.
3. Docs brought in sync in the same commit (AGENTS.md same-commit rule): `mcp-shareability.md` (its core-vs-cron contrast predated even cron's adoption), `computer-use.md` (resolution order now names the block first; the one-shim-per-session premise qualified for the pooled topology), and both module docstrings (the dashboard one claimed attribution-only identity while the code scopes and verify-writes on the strict resolver).

The `session_bound_by_construction` disqualifier now has no producer and is KEPT deliberately as the conservative default for the next unadopted managed server -- the three comments that prescribed deleting it now say so instead.

Residual split out as #5322 (pre-existing, narrowed by this PR): two or more co-tenants gatewayd cannot name still share one `unresolved:<pid>` snapshot namespace on a pooled computer-use backend.

## Tests

- New `test/test_mcp_pool_identity_computer_dashboard.py`, mirroring #4632's: the caller block outranks a process environment naming a DIFFERENT session, observed at each server's real consumption point (the session key handed to the computer gateway invoke; the dashboard's per-session list scoping and tree-write verification), the environment still resolves without a block (non-gateway launch not regressed), and each server's documented no-identity posture survives adoption (computer proceeds under `unresolved:<pid>`; dashboard refuses).
- `test_mcp_managed_caller_identity.py` concrete verdicts flip to not-session-bound; the existing parity ratchets pin the advertisement itself against the discovery set.
- Mutation-verified: un-advertising the serve entry reddens both parity ratchets; dropping the names from the discovery set reddens the spelled-out verdicts; resolving env before the block reddens exactly the block-over-env test.
- Full gates: isort, flake8, mypy (1039 files clean), full pytest (61,899 passed; the 77 failures are byte-identical on pristine base -- host-environment only), `test_mcp_gateway_pool_integ.py` 4/4 including the co-tenant told-apart test.

## Manual verification

N/A -- unit coverage sufficient: the gateway-injection half is exercised end-to-end by the existing `test_two_stubs_on_one_backend_are_told_apart` integration test, which drives real stub processes through a real gatewayd.

Closes #4659
