### PR TITLE
fix(dashboard): size transfer-bundle tail by message id (#4684)

### DIFF
--- a/src/kiro_crew/dashboard/session_transfer.py
+++ b/src/kiro_crew/dashboard/session_transfer.py
@@ -63,6 +63,13 @@ from kiro_crew import platform_compat
 from kiro_crew.agent_discovery import list_agents
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import kiro_sessions_dir
+
+# Layering: this module may import chat_handlers, never the reverse — the only
+# consumer of session_transfer is handlers_instances, which chat_handlers'
+# transitive graph does not reach. If chat_handlers ever needs session_transfer,
+# move _append_unflushed_tail and its collaborators down to chat_persistence
+# first rather than creating the cycle.
+from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import (
     _sync_dashboard_slots,
@@ -501,6 +508,13 @@ async def build_transfer_bundle_async(
 ) -> dict[str, Any]:
     """:func:`build_transfer_bundle` with the disk read off the event loop.
 
+    The two builders size the un-flushed tail DIFFERENTLY: this one keeps a
+    ``_disk_window_len`` boundary slice, valid only because the flush below runs
+    first — the save folds a durable injector's ``append_if_absent`` copy into
+    the window and advances the boundary, so the counter is honest by the time
+    the tail is snapshotted. The sync sibling cannot flush, so it sizes by
+    message id instead — see the comment at its tail merge.
+
     The transcript read is synchronous file IO plus JSON parsing over a whole
     session, which is exactly the "large synchronous file IO" the
     ``no-blocking-call-on-event-loop`` rule forbids on the loop: on a long
@@ -717,8 +731,6 @@ def _read_and_assemble(
     """
     history = _read_chained_history(state, session_key)
     history.extend(tail)
-    if not history:
-        history = list(tail)
     layer_b = _read_layer_b(layer_b_sid)
     if layer_b_sid and layer_b is None:
         # A sid was MAPPED but its files would not read -- pruned, over the size
@@ -746,7 +758,10 @@ def build_transfer_bundle(
 
     *history* supplies an already-read on-disk transcript so the blocking read
     can happen in a thread; when omitted it is read inline, which is fine for
-    tests and any caller not on the event loop.
+    tests and any caller not on the event loop. It must be the FULL chained
+    corpus (:func:`_read_chained_history`'s shape): the tail merge below indexes
+    it with ``slot._disk_older_count``, so a single-file or partial read would
+    mis-size the window region.
 
     *origin* is a human label for where the session came from (an instance name
     or ``"local"``); it is recorded for provenance and shown on arrival.
@@ -759,20 +774,23 @@ def build_transfer_bundle(
     # Append the resident messages that are not on disk yet, so the bundle carries
     # the tail the user can actually see.
     #
-    # The boundary is ``_disk_window_len`` — set by the save path to "how many
-    # window messages are now on disk" — NOT ``_resumed_count``, which only
-    # records how many messages were loaded when the slot was rehydrated. For a
-    # session created in this gateway run ``_resumed_count`` stays 0 no matter how
-    # many times it flushes, so using it appended the ENTIRE resident window on
-    # top of the disk history and duplicated every persisted turn.
-    #
-    # No ``_dirty`` gate: the boundary alone is authoritative, and the slice is
-    # empty when everything is persisted.
-    new_msgs = slot.messages[slot._disk_window_len :]
-    if new_msgs:
-        all_messages.extend(new_msgs)
-    if not all_messages:
-        all_messages = list(slot.messages)
+    # Sized by MESSAGE IDENTITY, not by ``_disk_window_len``. That counter
+    # advances only on the save and load paths, but a durable injector
+    # (``cron_inject``, ``workflow_inject``, ``crew_chat``) appends the same row
+    # to the window AND to disk without going through a save — the disk read
+    # above already returns the row while the counter has not moved, so a
+    # boundary slice starts one row too early and ships the injection twice.
+    # The read path rejected this exact estimator for this exact job (#4137,
+    # measured: substituting it broke the duplication regression) and replaced
+    # it with :func:`_append_unflushed_tail`, which matches window rows against
+    # the disk read by ``meta.mid`` — the id a durable injector stamps on both
+    # copies — falling back to an ordered body comparison when any row in the
+    # disk window region lacks an id, and merges in only the rows disk does not
+    # already hold. (The async sibling keeps its boundary snapshot: it flushes a
+    # dirty slot first, and the save both folds the injector's durable copy into
+    # the window and advances the boundary, so its slice is taken against a
+    # counter the flush just made honest.)
+    all_messages = _append_unflushed_tail(slot, all_messages)
     return _assemble_bundle(
         all_messages,
         slot.title if slot._titled else "",

--- a/test/test_session_transfer.py
+++ b/test/test_session_transfer.py
@@ -40,7 +40,9 @@ class _FakeLog:
         return list(self._messages)
 
 
-def _slot(messages, *, title="My session", titled=True, agent="", dirty=False, project=""):
+def _slot(
+    messages, *, title="My session", titled=True, agent="", dirty=False, project="", disk_older=0
+):
     return SimpleNamespace(
         key="slot-1",
         title=title,
@@ -51,6 +53,11 @@ def _slot(messages, *, title="My session", titled=True, agent="", dirty=False, p
         _dirty=dirty,
         _resumed_count=len(messages),
         _disk_window_len=len(messages),
+        # Frozen-prefix length for the id-based tail merge (_append_unflushed_tail
+        # scans the disk read from this offset). 0 fits fakes whose disk read IS
+        # the window; a test whose window is a tail of a longer transcript must
+        # override it with the real prefix length.
+        _disk_older_count=disk_older,
         _pending_rewrite=False,
         _dirty_gen=0,
         memory_mode="persistent",
@@ -97,7 +104,9 @@ def test_bundle_reads_full_history_not_just_resident_window():
     """A long session keeps only a tail in memory; the bundle must be complete."""
     on_disk = [{"role": "user", "content": f"turn {i}", "ts": ""} for i in range(10)]
     # slot.messages holds only the last two — bundling those would truncate.
-    slot = _slot(on_disk[-2:])
+    # disk_older=8 is what a real slot reports: eight on-disk rows precede the
+    # resident window, and the tail merge must scan only the window region.
+    slot = _slot(on_disk[-2:], disk_older=8)
     bundle = build_transfer_bundle(_state(on_disk), slot)
 
     assert len(bundle["messages"]) == 10
@@ -112,6 +121,115 @@ def test_bundle_appends_unflushed_tail():
     bundle = build_transfer_bundle(_state(on_disk), slot)
 
     assert [m["content"] for m in bundle["messages"]] == ["persisted", "not yet saved"]
+
+
+def test_durably_injected_row_is_not_duplicated_in_the_bundle():
+    """Regression for #4684 — mirrors #4137's duplication test on the read path.
+
+    A durable injector (``cron_inject``/``workflow_inject``/``crew_chat``) puts
+    the same row into the window AND onto disk with one ``meta.mid``, without a
+    save — so ``_disk_window_len`` does not move while the disk read already
+    returns the row. Sizing the un-flushed tail as
+    ``slot.messages[slot._disk_window_len:]`` then re-appends the injected row
+    on top of its own disk copy, and the exported bundle carries it twice.
+
+    Both rows here carry ids, so this exercises the id-matching arm — the one a
+    durable injector's rows actually take.
+    """
+    persisted = {"role": "user", "content": "hello", "ts": "t1", "meta": {"mid": "m-1"}}
+    injected = {
+        "role": "assistant",
+        "content": "cron result",
+        "ts": "t2",
+        "meta": {"mid": "m-2"},
+    }
+    slot = _slot([persisted])  # boundary == 1: the save never saw the injection
+    slot.messages = [persisted, dict(injected)]
+    bundle = build_transfer_bundle(_state([persisted, dict(injected)]), slot)
+
+    assert [m["content"] for m in bundle["messages"]] == ["hello", "cron result"], (
+        "a durably-injected row the disk read already returned was appended again"
+    )
+
+
+def test_durably_injected_row_is_not_duplicated_when_older_rows_have_no_id():
+    """Same contract on the ordered-comparison arm.
+
+    A transcript written before ids existed holds id-less rows, so the id arm is
+    ineligible (it requires EVERY window-region disk row to carry one) and the
+    tail must be sized by the ordered body walk instead — which must equally
+    refuse to re-append the injected row.
+    """
+    persisted = {"role": "user", "content": "hello", "ts": "t1"}  # pre-id era row
+    injected = {
+        "role": "assistant",
+        "content": "cron result",
+        "ts": "t2",
+        "meta": {"mid": "m-2"},
+    }
+    slot = _slot([persisted])
+    slot.messages = [persisted, dict(injected)]
+    bundle = build_transfer_bundle(_state([persisted, dict(injected)]), slot)
+
+    assert [m["content"] for m in bundle["messages"]] == ["hello", "cron result"], (
+        "a durably-injected row the disk read already returned was appended again"
+    )
+
+
+def test_genuinely_owed_row_still_travels_after_an_injection():
+    """Control, mirroring #4137's: a fix that merely stopped appending would pass
+    the duplication tests above and silently drop a real un-flushed turn here."""
+    persisted = {"role": "user", "content": "hello", "ts": "t1", "meta": {"mid": "m-1"}}
+    injected = {
+        "role": "assistant",
+        "content": "cron result",
+        "ts": "t2",
+        "meta": {"mid": "m-2"},
+    }
+    owed = {"role": "user", "content": "follow-up", "ts": "t3", "meta": {"mid": "m-3"}}
+    slot = _slot([persisted])
+    slot.messages = [persisted, dict(injected), owed]
+    bundle = build_transfer_bundle(_state([persisted, dict(injected)]), slot)
+
+    assert [m["content"] for m in bundle["messages"]] == [
+        "hello",
+        "cron result",
+        "follow-up",
+    ], "each turn must appear exactly once, with the owed turn last"
+
+
+def test_durably_injected_row_with_a_frozen_prefix_is_not_duplicated():
+    """The sync path's one new field dependency: ``_disk_older_count``.
+
+    The tail merge scans only the disk WINDOW region, ``all_msgs[disk_older:]``.
+    With two frozen-prefix rows ahead of the window, an off-by-one in that
+    offset would either let a prefix occurrence fund a false id match (dropping
+    an owed row) or re-append the injected row. Exercise the injection with a
+    non-zero prefix to pin the arithmetic.
+    """
+    prefix = [
+        {"role": "user", "content": "old 0", "ts": "t0", "meta": {"mid": "m-p0"}},
+        {"role": "assistant", "content": "old 1", "ts": "t0b", "meta": {"mid": "m-p1"}},
+    ]
+    persisted = {"role": "user", "content": "hello", "ts": "t1", "meta": {"mid": "m-1"}}
+    injected = {
+        "role": "assistant",
+        "content": "cron result",
+        "ts": "t2",
+        "meta": {"mid": "m-2"},
+    }
+    owed = {"role": "user", "content": "follow-up", "ts": "t3", "meta": {"mid": "m-3"}}
+    slot = _slot([persisted], disk_older=2)
+    slot.messages = [persisted, dict(injected), owed]
+    bundle = build_transfer_bundle(_state(prefix + [persisted, dict(injected)]), slot)
+
+    assert [m["content"] for m in bundle["messages"]] == [
+        "old 0",
+        "old 1",
+        "hello",
+        "cron result",
+        "follow-up",
+    ], "each turn must appear exactly once, prefix intact, owed turn last"
 
 
 def test_bundle_title_marker_does_not_compound_across_hops():
@@ -338,14 +456,17 @@ async def test_import_offloads_agent_resolution_and_skips_it_when_unhinted(monke
     monkeypatch.setattr(st.asyncio, "to_thread", real_to_thread)
 
 
-def test_bundle_boundary_is_the_disk_window_not_the_resume_count():
-    """Regression: the persisted boundary is ``_disk_window_len``, not ``_resumed_count``.
+def test_bundle_ignores_the_resume_count_and_ships_each_turn_once():
+    """Regression, restated for the id-based tail (#4684).
 
-    ``_resumed_count`` records how many messages were loaded when the slot was
-    REHYDRATED, so for a session created in this gateway run it stays 0 no matter
-    how often the slot flushes. Slicing on it appended the entire resident window
-    on top of the disk history and duplicated every persisted turn — the ordinary
-    case, not an edge case.
+    Originally this pinned "the boundary is ``_disk_window_len``, not
+    ``_resumed_count``": slicing on the resume count (0 for a slot created in
+    this gateway run) appended the entire resident window on top of the disk
+    history and duplicated every persisted turn. The sync builder no longer
+    slices on ANY counter — the tail is sized by message identity — so the
+    surviving contract is the one that always mattered: with two of three
+    window rows already on disk, each turn appears exactly once and the
+    un-flushed one still travels, regardless of what either counter says.
     """
     persisted = [
         {"role": "user", "content": "one", "ts": ""},


### PR DESCRIPTION
## Problem / Motivation

`build_transfer_bundle` (`src/kiro_crew/dashboard/session_transfer.py`) sizes the un-flushed tail of an exported session bundle as `slot.messages[slot._disk_window_len:]`. That counter advances only on the save and load paths, but a durable injector (`cron_inject.py`, `workflow_inject.py`, `crew_chat.py`) appends the same row to the resident window AND persists it to disk via `append_if_absent` with one shared `meta.mid`, without going through a save. The disk read then already returns the row while the counter has not moved, so the slice starts one row too early and the bundle carries the injection twice. PR #4137 rejected this exact estimator for this exact job on the read path, measured: substituting it broke `test_transient_window_row_does_not_duplicate_the_tail`.

Reachability, stated plainly: the shipped export endpoint (`handlers_instances.api_instances_send_session`) routes through `build_transfer_bundle_async`, which is NOT exposed -- an injector's `slot.append` marks the slot dirty (`state.py:2291`), the async builder flushes a dirty slot before snapshotting its tail (`session_transfer.py`), and the save folds the `append_if_absent` copy into the window (`chat_persistence.py:1440-1452`) and advances the boundary (`:2113`), so its counter is honest by the time the tail is cut. The sync builder is the documented entry for tests and off-loop callers; this PR removes the desynced estimator from that path rather than fixing a duplication reachable through today's send button.

## Why it matters

Any present or future off-loop caller of the sync builder -- the module's own docstring invites them -- silently ships a transcript with a duplicated turn after a cron/workflow injection, and the receiving instance materialises the corrupted copy. It is the same trap the read path already paid to measure and remove (#4137); leaving it in the sibling function is how it gets reintroduced. Two estimator strategies for one job, one of them known-wrong, is also standing drift.

## What changed (motivation -> approach -> change)

Symptom: an injected row appears twice in the exported bundle. Root cause: the tail is sized by a window-length counter that durable injectors structurally desync (they write disk + window with no save). Change: route the sync builder's tail through `chat_handlers._append_unflushed_tail` -- the id-based merge #4137 established -- which matches window rows against the disk read by `meta.mid` (the id an injector stamps on both copies), falls back to the ordered body walk when the disk window region has missing/mixed ids, and merges in only the rows disk does not already hold. The counter dependency disappears from this path, along with the now-dead `if not all_messages` fallback (and its identical dead twin in `_read_and_assemble`). The async sibling deliberately keeps its boundary slice -- its pre-snapshot flush is what makes that counter honest -- and its docstring now says so instead of claiming the two builders are the same. A layering comment at the new import records the direction constraint (session_transfer may import chat_handlers, never the reverse).

## Tests

All in `test/test_session_transfer.py`, each red against the previous slice (mutation-verified by restoring the old estimator in place):

- `test_durably_injected_row_is_not_duplicated_in_the_bundle` -- the id-matching arm, the one an injector's rows actually take.
- `test_durably_injected_row_is_not_duplicated_when_older_rows_have_no_id` -- the ordered-comparison arm (pre-id-era transcripts).
- `test_durably_injected_row_with_a_frozen_prefix_is_not_duplicated` -- non-zero `_disk_older_count`, pinning the window-region offset arithmetic the sync path newly depends on.
- `test_genuinely_owed_row_still_travels_after_an_injection` -- control: a fix that merely stopped appending would pass the three above and fail this.
- `test_bundle_ignores_the_resume_count_and_ships_each_turn_once` -- the prior boundary test, rewritten to the invariant that survives the estimator change.
- The fake-slot helper gains an overridable `_disk_older_count`; the long-history test now models the realistic frozen prefix (`disk_older=8`).

Gates: `isort` / `flake8` / `mypy` clean; `test_session_transfer.py` 134/134 and `test_dashboard_chat.py` 645/645 green; full suite's 82 fails + 2 errors reproduced byte-identical on pristine base (host-env: sandbox confinement, AF_UNIX path length), none touching this area.

## Manual verification

N/A -- unit coverage sufficient: the changed function is pure data-flow over a fake-able slot/log pair, and the shipped async endpoint is intentionally unchanged.

Closes #4684
