### PR TITLE
fix(mcp): route pooled resource updates by subscribed URI (#4624)

### DIFF
--- a/docs/system-specs/modules/mcp-shareability.md
+++ b/docs/system-specs/modules/mcp-shareability.md
@@ -186,7 +186,7 @@ That split is also the export contract. The telemetry layer requires low-cardina
 | `handshake_not_reproducible` | note | Pre-flight saw a divergent replayed surface (capabilities, protocol version, `serverInfo` shape, or the tool list). Reported and gates nothing: see below. |
 | `session_bound_by_construction` | disqualified | A managed server that resolves its caller from its own process rather than the injected caller block. Kept gating because `mcp_cron._check_cron_job_ownership` treats a falsy session key as *allow*, so a pooled backend reading EMPTY skips the ownership check rather than merely losing a feature -- and no routing-shaped hazard code would ever record it. |
 | `rotating_secret_env` | note | Declares an env name excluded from the pool key. Detail is the name. Not emitted for a name in `mcp_gateway.pool_identity_env`, which IS in the pool key. |
-| `degrades_when_shared` | note | `resources.subscribe` or `logging`; detail names which. |
+| `degrades_when_shared` | note | `logging`; detail is `logging_level`. |
 | `not_probed` | unknown | No handshake was observed. |
 | `declares_caller_identity` | declared | Advertises the caller-identity extension. |
 | `preflight_passed` / `preflight_not_run` | declared | Whether the declaration has actually been tested. `preflight_passed` is emitted only when the pass ran AND found no divergence, so it never appears beside `handshake_not_reproducible`. |
@@ -212,14 +212,16 @@ Measured against that, four codes were disqualifying on an inference:
   co-tenant of one process the same answer, exactly as an unpooled process does
   within its lifetime. The row is also re-derived every pass rather than frozen, so
   a wrong one lives until the next measurement instead of for ever.
-- `degrades_when_shared` — neither capability leaks, because
+- `degrades_when_shared` — the capability does not leak, because
   `backend._notification_owner` already DROPS an unattributable request-scoped
-  notification rather than broadcasting it. And neither is a property of the
-  server: both are gaps in this broker. `notifications/resources/updated` is
-  attributable without a request id, since the broker saw which stub subscribed to
-  which URI; it simply keeps no subscription table. Log verbosity is likewise
-  fixable by emitting at the finest level any tenant asked for and filtering down
-  per stub.
+  notification rather than broadcasting it. And it is not a property of the
+  server: it is a gap in this broker. Log verbosity is fixable by emitting at the
+  finest level any tenant asked for and filtering down per stub.
+  `notifications/resources/updated` carries no entry here because it needs none:
+  the broker keeps the `uri -> {stub_uuid}` subscription table
+  (`backend._resource_subscriptions`) and delivers each update to exactly the
+  stubs subscribed to its URI. The table's contract is delete-not-relax — an
+  entry leaves the moment the broker learns to attribute the frames it covers.
 - `rotating_secret_env` — a secret-prefixed key is never forwarded into a shared
   backend at all (`gatewayd._declared_non_secret_env`), so a pooled backend
   receives *nobody's* secret rather than the wrong session's. What pooling costs is
@@ -245,9 +247,19 @@ consume the injected caller block (#4622).
 are global broadcasts (`backend._GLOBAL_BROADCAST_NOTIFICATIONS`) and are safe to
 fan out to every attached stub.
 
-Two DIFFERENT detection modes, because a capability and a flag inside one are different claims:
-
-- `resources.subscribe` is a **flag** — `{"subscribe": false}` is the server explicitly saying it does not subscribe, so truthiness is the right test and an explicit `false` must not count against it.
-- `logging` is a **capability** — in MCP an empty object is the standard way to advertise one that takes no sub-options, so `{"logging": {}}` means `logging/setLevel` IS supported. Presence is the right test; truthiness read a server that advertises logging as one that does not. What it costs on a shared backend is that the last caller's level wins and a log line tied to one caller's in-flight call is dropped — noisier logs and missing lines, which is why it is a note.
+Degradation detection is by PRESENCE of the capability key: in MCP an empty
+object is the standard way to advertise a capability that takes no sub-options,
+so `{"logging": {}}` means `logging/setLevel` IS supported, and truthiness would
+read a server that advertises logging as one that does not. What logging costs on
+a shared backend is that the last caller's level wins and a log line tied to one
+caller's in-flight call is dropped — noisier logs and missing lines, which is why
+it is a note. A flag-leaf entry — one whose leaf can be `false`, the server
+explicitly declining the capability — needs a truthiness test instead, and adding
+one to `_SHARED_BACKEND_DEGRADATIONS` means adding a per-entry detection mode
+alongside it. `resources.subscribe` is deliberately NOT in the table: the broker
+keeps a `uri -> {stub_uuid}` subscription table (`backend._resource_subscriptions`)
+and delivers each `notifications/resources/updated` to exactly the stubs
+subscribed to its URI, so subscriptions survive pooling and there is nothing to
+warn the operator about.
 
 Tool annotations (`readOnlyHint` and friends) exist only from MCP 2025-03-26 onward, while the handshake negotiates `2024-11-05`. They are therefore treated as opportunistic positive evidence: present means something, absent means nothing. The negotiated version is deliberately unchanged — raising it alters real handshake semantics with third-party servers, which is a separate decision that should be made with data (the recorded `protocolVersion` is what will supply it).

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -167,17 +167,57 @@ HARD_WEDGE_CEILING_SECS = 2100.0
 # never trip it.
 _STUB_INBOX_MAXSIZE = 4096
 
+# Upper bound on the number of distinct URIs one stub may hold resource
+# subscriptions for. Same guard class as ``_STUB_INBOX_MAXSIZE``: table
+# entries are created by stub input and freed only on unsubscribe, a server
+# refusal, or detach, so without a bound one misbehaving tenant could grow
+# the shared broker's table (and gateway RSS) without limit. Generous — a
+# real client subscribes to a handful of URIs. Past the cap a subscribe is
+# answered locally with a JSON-RPC error instead of being forwarded.
+_RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB = 1024
+
+# Upper bound on the orphaned-lease set (URIs whose gateway-originated
+# release the server refused with nobody left to route to). Same guard
+# class: entries accumulate for the backend's lifetime across detached
+# stubs, so a server that keeps refusing releases would otherwise grow the
+# set without bound. The set is telemetry hygiene (hazard suppression),
+# not correctness — evicting an arbitrary entry risks at most one unfair
+# hazard row, while an unbounded set is unbounded gateway memory.
+_ORPHANED_LEASES_MAX = 1024
+
+# Upper bound on a subscribable resource URI's LENGTH. The per-stub cap
+# bounds how MANY subscriptions a stub holds, not their bytes: without a
+# length bound, repeated accepted subscriptions to distinct near-frame-limit
+# URIs retain gigabytes of dictionary keys. Real resource URIs are short;
+# 8 KiB is far beyond any legitimate identifier. Overlong URIs are refused
+# locally before any table stores them.
+_RESOURCE_URI_MAX_LEN = 8192
+
+# JSON-RPC error code for a gateway-refused request (server-defined range).
+_JSONRPC_SERVER_ERROR = -32000
+
 # Server->client notifications that reflect backend-wide state identical for
 # every co-pooled tenant, so they are safe to fan out when we cannot attribute
 # them to a single owning stub. Everything else (progress, logging/message,
-# cancelled, resource-update) is request- or subscription-scoped: broadcasting
-# an unattributable one would leak one tenant's content to co-tenants — a
-# disclosure the non-pooled baseline never had — so those are dropped instead.
+# cancelled) is request-scoped: broadcasting an unattributable one would leak
+# one tenant's content to co-tenants — a disclosure the non-pooled baseline
+# never had — so those are dropped instead. ``notifications/resources/updated``
+# is subscription-scoped, not request-scoped, and is routed by the
+# ``uri -> {stub_uuid}`` table instead (``Backend._resource_update_targets``).
 _GLOBAL_BROADCAST_NOTIFICATIONS: frozenset[str] = frozenset({
     "notifications/tools/list_changed",
     "notifications/prompts/list_changed",
     "notifications/resources/list_changed",
 })
+
+# MCP resource-subscription wire methods and the notification they scope.
+# ``notifications/resources/updated`` carries only a URI — no request id — so
+# request-scoped attribution can never route it. The broker instead records
+# which stub sent ``resources/subscribe`` for which URI and delivers each
+# update to exactly those stubs (see ``Backend._resource_subscriptions``).
+_RESOURCES_SUBSCRIBE_METHOD = "resources/subscribe"
+_RESOURCES_UNSUBSCRIBE_METHOD = "resources/unsubscribe"
+_RESOURCES_UPDATED_NOTIFICATION = "notifications/resources/updated"
 
 
 def _is_heartbeat_id(msg_id: Any) -> bool:
@@ -228,6 +268,30 @@ class _PendingRequest:
     # == ``_APPS_STUB_SENTINEL``): the future the stdout pump resolves with the
     # backend's resources/read response so the parked fetch coroutine wakes.
     apps_future: Optional["asyncio.Future[dict[str, Any]]"] = None
+    # ``params.uri`` of a forwarded ``resources/subscribe`` /
+    # ``resources/unsubscribe``, captured so the response arm can apply the
+    # lease transition the reply confirms or refuses. Empty for every other
+    # method.
+    resource_uri: str = ""
+    # For a ``resources/subscribe``/``unsubscribe`` on an identity-capable
+    # server: the caller whose block was injected into the forward. Recorded
+    # into ``_grant_callers`` when the server GRANTS, so a later release can
+    # be sent as the principal that actually holds the grant — releasing as
+    # the connection (or as whatever caller a claim rekey later mapped the
+    # stub to) would be adjudicated as a different principal and could
+    # revoke a co-tenant's live subscription.
+    caller: Optional["CallerContext"] = None
+    # Set only on a gateway-originated post-respawn subscribe replay
+    # (stub_uuid == ``_RELEASE_STUB_SENTINEL``): the stub whose routing grant
+    # the replayed subscribe re-establishes on success.
+    replay_stub: str = ""
+    # The stub that ORIGINATED a subscribe later converted to the lease
+    # sentinel (retract, eviction, detach). Sentinelizing removes the
+    # pending from ``stub_uuid``-keyed accounting, and without this the
+    # per-stub subscription cap loses sight of it — a stub cycling
+    # subscribe/unsubscribe against an unresponsive server would grow the
+    # pending table without bound. Cap accounting only; never routed to.
+    origin_stub: str = ""
 
 
 def _strip_caller_meta(msg: dict[str, Any]) -> dict[str, Any]:
@@ -285,6 +349,25 @@ MCP_APPS_ENV_FALSE = ("0", "false", "no", "off")
 # :meth:`Backend._read_ui_resource` instead of any stub — mirrors the
 # ``"__init__"`` sentinel used for the gateway-driven initialize handshake.
 _APPS_STUB_SENTINEL = "__apps__"
+
+# Sentinel ``stub_uuid`` for gateway-originated lease maintenance on the
+# resource-subscription table: the ``resources/unsubscribe`` issued when the
+# last subscriber of a URI detaches without unsubscribing (so the server does
+# not keep firing updates nobody will receive), and the ``resources/subscribe``
+# replayed after a transparent respawn (so a live subscription survives the
+# backend swap). Responses are consumed in :meth:`Backend._route_backend_line`.
+_RELEASE_STUB_SENTINEL = "__release__"
+
+
+def _is_success_response(msg: dict[str, Any]) -> bool:
+    """Whether a JSON-RPC response frame is a settled SUCCESS: it must carry
+    a ``result`` and no ``error``. A malformed frame with neither is not a
+    grant — mutating the resource-subscription routing table on its strength
+    would let a co-tenant start (or stop) receiving updates on a verdict the
+    server never actually delivered, so lease transitions treat it as a
+    refusal (fail closed)."""
+    return "error" not in msg and "result" in msg
+
 
 # Deadline for the out-of-band ``resources/read`` round-trip. On timeout the
 # original tools/call response is delivered unmodified — the app render is
@@ -480,6 +563,80 @@ class Backend:
     # original id restored.
     _forward_id_seq: int = 0
     _pending_requests: dict[str, "_PendingRequest"] = field(default_factory=dict)
+    # Resource-subscription routing table: ``uri -> {stub_uuid}``, the set of
+    # stubs whose ``resources/subscribe`` the server ACCEPTED. Grants are
+    # recorded on the server's response, never at forward time, so an update
+    # racing an unconfirmed subscribe fails closed (dropped) instead of being
+    # delivered on a subscription the server may yet refuse — including a
+    # refusal made on per-caller authorization grounds. The notification
+    # carries only the URI — never resource content — so delivering it to a
+    # stub whose subscription for that URI was accepted discloses nothing
+    # across tenants.
+    _resource_subscriptions: dict[str, set[str]] = field(default_factory=dict)
+    # Lease bookkeeping for the coalesced (identity-less) path. A URI in
+    # ``_lease_awaiting_grant`` has its first subscribe forwarded and not yet
+    # answered; stubs joining during that window are parked in
+    # ``_lease_pending_riders`` as ``(stub_uuid, original_id)`` and answered
+    # with the server's actual verdict, so no stub is ever told "subscribed"
+    # on the strength of a lease that then fails to materialize. A URI in
+    # ``_lease_awaiting_release`` has its final unsubscribe forwarded and not
+    # yet answered; routing keeps the leaving stub until the server confirms,
+    # because a failed unsubscribe means the server retained the subscription
+    # and dropping routing early would silently discard live updates.
+    _lease_awaiting_grant: set[str] = field(default_factory=set)
+    _lease_awaiting_release: set[str] = field(default_factory=set)
+    _lease_pending_riders: dict[str, list[tuple[str, Any]]] = field(default_factory=dict)
+    # Final unsubscribes arriving while a URI's release is already in flight
+    # park here as ``(stub_uuid, original_id)`` — the release need not belong
+    # to the parking stub (its owner may have detached), so refusing would
+    # dead-end a legitimate leave. Exactly one release stays in flight per
+    # URI; every waiter settles on that one verdict: success drops the
+    # waiter from routing and answers it, refusal keeps it routed and hands
+    # it the server's error so it knows the unsubscribe did not take effect.
+    _lease_release_waiters: dict[str, list[tuple[str, Any]]] = field(default_factory=dict)
+    # Subscribes arriving while a URI's release is in flight park here. The
+    # ordered stream only orders the WRITES; the server may ANSWER out of
+    # order, so forwarding a replacement subscribe beside the release could
+    # land a grant the release then destroys upstream while local routing
+    # keeps the subscriber — silent update loss. A confirmed release drains
+    # these into one fresh forwarded subscribe (first parker as forwarder,
+    # the rest as riders); a refusal means the server retained the lease, so
+    # they join the still-live entry locally.
+    _lease_replacement_subscribes: dict[str, list[tuple[str, Any]]] = field(
+        default_factory=dict)
+    # Identity-capable servers only: the caller whose subscribe the server
+    # GRANTED, keyed ``(uri, stub_uuid)`` and recorded at response time — the
+    # only moment the grant principal is known for certain. A release for a
+    # departing stub is sent as THIS caller (never the connection's caller at
+    # teardown, and never a last-writer map: a claim rekey after the grant
+    # makes both identify the wrong principal and revoke a co-tenant's live
+    # subscription). Dropped when the grant is released or the entry pruned.
+    _grant_callers: dict[tuple[str, str], "CallerContext"] = field(
+        default_factory=dict)
+    # URIs whose upstream subscription is known RETAINED with no subscriber
+    # left to route to — a gateway-originated release was refused. Updates for
+    # these are dropped WITHOUT recording a hazard: the frames are a
+    # consequence of the broker's own lease handling, and recording them
+    # would withdraw the server's pooling recommendation for behaviour that
+    # is correct. Cleared when a later release succeeds or a new grant makes
+    # the URI attributable again.
+    _orphaned_leases: set[str] = field(default_factory=set)
+    # Replay-target URIs preserved at death. An in-flight replay lives only
+    # in ``_pending_requests`` (routing commits on the server's grant), so a
+    # replacement that dies before its replay responses arrive would erase
+    # those URIs in the backend-gone cleanup — and the NEXT respawn's
+    # ``resource_subscription_uris`` capture would find them nowhere,
+    # permanently darkening the subscription. Written once by
+    # ``_broadcast_backend_gone`` (terminal state, size bounded by the
+    # pending table it snapshots), read by the capture.
+    _gone_replay_uris: dict[str, set[str]] = field(default_factory=dict)
+    # Per-stub rekey generation, bumped by ``evict_stub_subscriptions``. A
+    # multi-URI replay awaits between writes; a claim landing mid-loop
+    # evicts the pendings written SO FAR, but the loop would keep writing
+    # the remaining URIs under the old owner — this counter lets the replay
+    # notice the rekey between writes and stop (fail closed: the new owner
+    # subscribes on its own).
+    _rekey_generation: dict[str, int] = field(default_factory=dict)
     # Initialize-cache state — first stub triggers an upstream handshake,
     # later stubs receive a synthesized response built from the cached result.
     _init_result: Optional[dict[str, Any]] = None
@@ -643,6 +800,170 @@ class Backend:
         )
         return inbox
 
+    async def evict_stub_subscriptions(self, stub_uuid: str) -> int:
+        """Evict ``stub_uuid``'s resource subscriptions because its stub is
+        being REKEYED to a different caller (warm-pool ``claim``) — the stub
+        stays attached, but grants belong to the OLD principal: without
+        eviction the new session would keep receiving the old session's
+        resource-update URIs (which can carry tokens or presigned params).
+
+        Ownership of caller-binding lives at the gatewayd connection layer;
+        this is the backend-side clearance it invokes at the moment of the
+        rekey. Identity-capable grants are released AS the grant-time caller
+        (shared-caller guard applies: the last sharer's eviction releases);
+        identity-less routing drops the stub with a last-subscriber release.
+        Returns the number of URIs evicted. In-flight and parked subscribe
+        transitions are RETRACTED (each id answered with a cancellation
+        error, pendings scoped so a late grant releases instead of routing):
+        a subscribe sent under the old owner must not land its grant on the
+        rekeyed stub. In-flight unsubscribes are SENTINELIZED (mirror of
+        ``detach_stub``): their table effects are already applied, but the
+        response would otherwise deliver under the OLD owner's request id
+        into the rekeyed stub's stream — an id the new owner may have
+        already reused for its own request.
+        """
+        # Bump FIRST, before any table work and any await: an in-flight
+        # replay loop checks this between its writes, and the bump must be
+        # visible from the moment the rekey is decided.
+        self._rekey_generation[stub_uuid] = (
+            self._rekey_generation.get(stub_uuid, 0) + 1
+        )
+        # --- retract in-flight/parked subscribe transitions (commit all
+        # table changes first, then reply; replies can re-enter via a
+        # full-inbox detach) ---
+        rekey_error = {
+            "code": _JSONRPC_SERVER_ERROR,
+            "message": "resources/subscribe retracted: stub ownership changed",
+        }
+        retract_replies: list[Any] = []
+        for table in (
+            self._lease_pending_riders,
+            self._lease_replacement_subscribes,
+            self._lease_release_waiters,
+        ):
+            for uri in list(table):
+                mine = [r for r in table[uri] if r[0] == stub_uuid]
+                if not mine:
+                    continue
+                remaining = [r for r in table[uri] if r[0] != stub_uuid]
+                if remaining:
+                    table[uri] = remaining
+                else:
+                    del table[uri]
+                retract_replies.extend(rid for _u, rid in mine if rid is not None)
+        for p in self._pending_requests.values():
+            if (
+                p.stub_uuid == stub_uuid
+                and p.method == _RESOURCES_UNSUBSCRIBE_METHOD
+                and p.resource_uri
+            ):
+                # The release was sent under the OLD owner: its response
+                # would otherwise deliver under the old request id into the
+                # rekeyed stub's stream — an id the new owner may have
+                # already reused. Sentinelize (mirror of ``detach_stub``):
+                # the response settles silently, table effects stay applied.
+                p.origin_stub = stub_uuid
+                p.stub_uuid = _RELEASE_STUB_SENTINEL
+                p.original_id = None
+                continue
+            if (
+                p.stub_uuid == stub_uuid
+                and p.method == _RESOURCES_SUBSCRIBE_METHOD
+                and p.resource_uri
+            ):
+                if p.original_id is not None:
+                    retract_replies.append(p.original_id)
+                riders = (
+                    []
+                    if self.supports_caller_identity
+                    else self._lease_pending_riders.get(p.resource_uri, [])
+                )
+                if riders:
+                    p.stub_uuid, p.original_id = riders.pop(0)
+                else:
+                    # Sentinelize keeping ``caller``: the late grant then
+                    # finds no replay stub and releases the lease AS the
+                    # old principal instead of routing it to the new owner.
+                    p.origin_stub = stub_uuid
+                    p.stub_uuid = _RELEASE_STUB_SENTINEL
+                    p.original_id = None
+                continue
+            if (
+                p.stub_uuid == _RELEASE_STUB_SENTINEL
+                and p.method == _RESOURCES_SUBSCRIBE_METHOD
+                and p.replay_stub == stub_uuid
+            ):
+                # An in-flight REPLAY targets the rekeyed stub by its
+                # ``replay_stub`` back-reference, not by ``stub_uuid`` — the
+                # subscribe retraction above cannot see it.  Left attached,
+                # its late grant would commit routing (and, on an
+                # identity-capable server, a grant-caller record) for a stub
+                # the OLD owner subscribed but the NEW owner now holds.
+                # Scope it to release-on-grant, exactly as the replay
+                # write-failure path does: nobody consumes the grant, so it
+                # releases instead of routing.
+                p.replay_stub = ""
+        # --- commit ALL routing-table removals before the FIRST await:
+        # the claim path reassigns the owner then awaits this eviction, so
+        # any frame routed during an await must already see the stub gone
+        # from the tables ---
+        evicted = 0
+        releases: list[tuple[str, Optional[CallerContext]]] = []
+        if self.supports_caller_identity:
+            # Walk the ROUTING TABLE, not ``_grant_callers``: a routed grant
+            # can lack a caller record (the grant arm records one only when
+            # the accepted subscribe carried caller metadata), and keying
+            # the eviction on the records alone would leave that entry
+            # routed — the new owner would keep receiving the old owner's
+            # URIs. Mirror of ``detach_stub``: known-caller grants release
+            # as their principal; unknown-caller grants are knowingly
+            # RETAINED and orphan-marked (a bare release would be
+            # adjudicated as the wrong principal).
+            id_emptied: list[str] = []
+            for uri, subscribers in self._resource_subscriptions.items():
+                if stub_uuid in subscribers:
+                    subscribers.discard(stub_uuid)
+                    evicted += 1
+                    if not subscribers:
+                        id_emptied.append(uri)
+            departed_keys = [
+                key for key in self._grant_callers if key[1] == stub_uuid
+            ]
+            for uri, _stub in departed_keys:
+                grant_caller = self._grant_callers.pop((uri, stub_uuid))
+                shared = any(
+                    other != stub_uuid
+                    and self._grant_callers.get((uri, other)) == grant_caller
+                    for other in self._resource_subscriptions.get(uri, set())
+                )
+                if not shared:
+                    releases.append((uri, grant_caller))
+            for uri in id_emptied:
+                del self._resource_subscriptions[uri]
+                if not any(u == uri for u, _c in releases):
+                    while len(self._orphaned_leases) >= _ORPHANED_LEASES_MAX:
+                        self._orphaned_leases.pop()
+                    self._orphaned_leases.add(uri)
+        else:
+            emptied: list[str] = []
+            for uri, subscribers in list(self._resource_subscriptions.items()):
+                if stub_uuid in subscribers:
+                    subscribers.discard(stub_uuid)
+                    evicted += 1
+                    if not subscribers:
+                        emptied.append(uri)
+            for uri in emptied:
+                del self._resource_subscriptions[uri]
+                if uri not in self._lease_awaiting_release:
+                    releases.append((uri, None))
+        # --- state committed; now the awaits ---
+        for reply_id in retract_replies:
+            await self._reply_locally(stub_uuid, reply_id, error=rekey_error)
+        for uri, release_caller in releases:
+            await self._release_upstream_subscriptions(
+                [uri], caller=release_caller)
+        return evicted
+
     async def detach_stub(self, stub_uuid: str) -> int:
         """Drop ``stub_uuid``'s inbox and clean up any pending requests
         owned by it. Returns the remaining refcount so the caller can
@@ -651,11 +972,145 @@ class Backend:
         async with self._inbox_lock:
             self._stub_inboxes.pop(stub_uuid, None)
             self.refcount = len(self._stub_inboxes)
-        # Drop any pending-request entries owned by the departing stub
-        # so the stdout pump does not try to send into a dead inbox.
+        # Bounded-table hygiene. (A replay in flight for a detached stub is
+        # already handled at grant time: a replay grant is honoured only
+        # while its stub is still attached.)
+        self._rekey_generation.pop(stub_uuid, None)
+        # A departing stub parked as a rider expects no further reply. This
+        # prune runs BEFORE the pending scan below: the scan promotes the
+        # first parked rider into the departing stub's in-flight subscribe,
+        # and a duplicate parking owned by the departing stub itself would
+        # otherwise be promoted — recording a phantom subscriber that blocks
+        # the release and swallows updates.
+        for uri in list(self._lease_pending_riders):
+            remaining = [
+                r for r in self._lease_pending_riders[uri] if r[0] != stub_uuid
+            ]
+            if remaining:
+                self._lease_pending_riders[uri] = remaining
+            else:
+                del self._lease_pending_riders[uri]
+        # Likewise a departing stub parked behind an in-flight release.
+        for uri in list(self._lease_release_waiters):
+            remaining = [
+                r for r in self._lease_release_waiters[uri] if r[0] != stub_uuid
+            ]
+            if remaining:
+                self._lease_release_waiters[uri] = remaining
+            else:
+                del self._lease_release_waiters[uri]
+        # And a departing stub whose replacement subscribe is parked.
+        for uri in list(self._lease_replacement_subscribes):
+            remaining = [
+                r for r in self._lease_replacement_subscribes[uri]
+                if r[0] != stub_uuid
+            ]
+            if remaining:
+                self._lease_replacement_subscribes[uri] = remaining
+            else:
+                del self._lease_replacement_subscribes[uri]
+        # Drop any pending-request entries owned by the departing stub so the
+        # stdout pump does not try to send into a dead inbox — EXCEPT an
+        # in-flight coalesced lease transition, whose response still has to
+        # settle shared state: a subscribe with parked riders is handed to the
+        # first rider (which then receives the server's verdict under its own
+        # id); one without riders is converted to the lease sentinel so a
+        # granted-but-unwanted lease is released instead of leaking.
         stale = [fid for fid, p in self._pending_requests.items() if p.stub_uuid == stub_uuid]
         for fid in stale:
+            p = self._pending_requests.get(fid)
+            if p is None:
+                continue
+            if p.resource_uri and p.method == _RESOURCES_SUBSCRIBE_METHOD:
+                # BOTH regimes: dropping the pending would drop the server's
+                # verdict — a late identity grant would strand the upstream
+                # lease with nobody to release it. Coalesced: hand it to the
+                # first parked rider; otherwise (including every identity
+                # pending, which never has riders) convert to the sentinel,
+                # whose grant arm releases a granted-but-unwanted lease as
+                # ``pending.caller`` — the right principal.
+                riders = (
+                    []
+                    if self.supports_caller_identity
+                    else self._lease_pending_riders.get(p.resource_uri, [])
+                )
+                if riders:
+                    p.stub_uuid, p.original_id = riders.pop(0)
+                else:
+                    p.origin_stub = stub_uuid
+                    p.stub_uuid = _RELEASE_STUB_SENTINEL
+                    p.original_id = None
+                continue
+            if p.resource_uri and p.method == _RESOURCES_UNSUBSCRIBE_METHOD:
+                # Let the release-in-flight settle silently; the table entry
+                # is pruned below either way.
+                p.origin_stub = stub_uuid
+                p.stub_uuid = _RELEASE_STUB_SENTINEL
+                p.original_id = None
+                continue
             self._pending_requests.pop(fid, None)
+        # Drop the departing stub from the resource-subscription table so a
+        # later ``notifications/resources/updated`` is not routed toward a
+        # departed stub — and release upstream whatever the departure
+        # strands. Identity-less: release when the departing stub was a
+        # URI's LAST subscriber (the one shared lease). Identity-capable:
+        # every grant is per caller, so the departing stub's grant is
+        # released AS the caller recorded at grant time — unless another
+        # still-routed stub shares that same caller for the URI (two stubs
+        # claimed to one session hold ONE per-caller grant upstream;
+        # releasing on the first detach would kill the survivor's updates).
+        # Without a release the server keeps firing updates nobody will
+        # receive, each landing in the deny-by-default drop and unfairly
+        # recording a hazard against the server for a gap that is ours.
+        # ALL table transitions commit before the release writes (a write
+        # can re-enter detach via a full-inbox drop).
+        emptied = []
+        for uri, subscribers in self._resource_subscriptions.items():
+            subscribers.discard(stub_uuid)
+            if not subscribers:
+                emptied.append(uri)
+        if self.supports_caller_identity:
+            identity_releases: list[tuple[str, CallerContext]] = []
+            departed_keys = [
+                key for key in self._grant_callers if key[1] == stub_uuid
+            ]
+            for uri, _stub in departed_keys:
+                grant_caller = self._grant_callers.pop((uri, stub_uuid))
+                shared = any(
+                    other != stub_uuid
+                    and self._grant_callers.get((uri, other)) == grant_caller
+                    for other in self._resource_subscriptions.get(uri, set())
+                )
+                if not shared:
+                    identity_releases.append((uri, grant_caller))
+            for uri in emptied:
+                del self._resource_subscriptions[uri]
+                if not any(u == uri for u, _c in identity_releases):
+                    # Routed grant with no recorded caller (identity server,
+                    # grant predates tracking or replay went unrecorded): a
+                    # bare release would be adjudicated as the wrong
+                    # principal, so the lease is knowingly RETAINED — mark
+                    # it orphaned so its updates are dropped without
+                    # charging a hazard to a blameless server.
+                    while len(self._orphaned_leases) >= _ORPHANED_LEASES_MAX:
+                        self._orphaned_leases.pop()
+                    self._orphaned_leases.add(uri)
+            for uri, grant_caller in identity_releases:
+                await self._release_upstream_subscriptions(
+                    [uri], caller=grant_caller)
+        else:
+            to_release = []
+            for uri in emptied:
+                del self._resource_subscriptions[uri]
+                # A URI whose release is already in flight (final
+                # unsubscribe forwarded, response pending) is not released
+                # twice; its awaiting-release flag stays up so the
+                # converted-to-sentinel response settles it (marking the
+                # lease orphaned on a refusal).
+                if uri not in self._lease_awaiting_release:
+                    to_release.append(uri)
+            if to_release:
+                await self._release_upstream_subscriptions(to_release)
         # Initialize-cache cleanup: if the departing stub was mid-wait for
         # a cached initialize reply, drop it from the pending list.
         self._init_pending = [
@@ -720,6 +1175,15 @@ class Backend:
             # one-initialized-per-backend invariant.
             return
 
+        if method in (_RESOURCES_SUBSCRIBE_METHOD, _RESOURCES_UNSUBSCRIBE_METHOD):
+            # Subscription lease bookkeeping. Returns True when the request
+            # was answered locally (a later subscriber joining a held lease,
+            # or a non-final unsubscribe) and must NOT reach the backend —
+            # the server holds one subscription per URI, and forwarding
+            # either frame would break a co-tenant's live subscription.
+            if await self._handle_resource_subscription(stub_uuid, method, msg):
+                return
+
         # Request/response rewrite: only requests carry both method AND id.
         # Pure notifications (method, no id) and pure responses (id, no
         # method) pass through without rewrite. Pure responses are kiro-cli
@@ -735,6 +1199,7 @@ class Backend:
                 progress_token = None
                 tool_name = ""
                 tool_arguments = None
+                resource_uri = ""
                 _params = msg.get("params")
                 if isinstance(_params, dict):
                     _meta = _params.get("_meta")
@@ -747,6 +1212,10 @@ class Backend:
                         _args = _params.get("arguments")
                         if isinstance(_args, dict):
                             tool_arguments = _args
+                    if method in (_RESOURCES_SUBSCRIBE_METHOD, _RESOURCES_UNSUBSCRIBE_METHOD):
+                        _uri = _params.get("uri")
+                        if isinstance(_uri, str):
+                            resource_uri = _uri
                 self._pending_requests[fid] = _PendingRequest(
                     stub_uuid=stub_uuid, original_id=orig_id, method=str(method or ""),
                     t_start_ms=time.monotonic() * 1000.0,
@@ -754,6 +1223,8 @@ class Backend:
                     session_key=(caller.session_key if caller is not None else ""),
                     tool_name=tool_name,
                     tool_arguments=tool_arguments,
+                    resource_uri=resource_uri,
+                    caller=(caller if resource_uri else None),
                 )
             elif method == "notifications/cancelled":
                 # A cancellation is a notification (method, no top-level id);
@@ -1062,8 +1533,63 @@ class Backend:
                 pending.stub_uuid, inbox,
                 (json.dumps(err, separators=(",", ":")) + "\n").encode("utf-8"),
             )
+        # Preserve replay-target URIs BEFORE the clear: an in-flight replay
+        # is the only record of its URI (routing commits on grant), and this
+        # backend dying is exactly the case where the grant never arrives.
+        # The next respawn's ``resource_subscription_uris`` capture reads
+        # these; a rekey-evicted replay has ``replay_stub == ""`` and is
+        # correctly NOT preserved (the old owner's URI must not follow the
+        # rekeyed stub).
+        for pending in self._pending_requests.values():
+            if (
+                pending.replay_stub
+                and pending.method == _RESOURCES_SUBSCRIBE_METHOD
+                and pending.resource_uri
+            ):
+                self._gone_replay_uris.setdefault(
+                    pending.replay_stub, set()
+                ).add(pending.resource_uri)
         self._pending_requests.clear()
         self._init_pending.clear()
+        # Parked lease work is NOT in ``_pending_requests``: a rider waiting
+        # on an in-flight grant, a replacement subscribe parked behind a
+        # release, and an unsubscribe waiting on a release verdict each hold
+        # a client request id that only a backend response would settle —
+        # and no response is coming. Answer each with the same synthetic
+        # error so no client id hangs forever (a replay parking carries no
+        # id and drops silently), then clear the lease coordination state:
+        # it gates writes onto a wire that no longer exists. The routing
+        # table ``_resource_subscriptions`` is deliberately KEPT — the
+        # transparent respawn reads it to replay live subscriptions onto the
+        # replacement backend. A full-inbox detach during these replies can
+        # re-enter teardown paths; the tables were already cleared above the
+        # replies, so re-entry finds them empty.
+        parked: list[tuple[str, Any]] = []
+        for table in (
+            self._lease_pending_riders,
+            self._lease_replacement_subscribes,
+            self._lease_release_waiters,
+        ):
+            for entries in table.values():
+                parked.extend(entries)
+            table.clear()
+        self._lease_awaiting_grant.clear()
+        self._lease_awaiting_release.clear()
+        for parked_uuid, parked_id in parked:
+            if parked_id is None:
+                continue
+            inbox = inboxes.get(parked_uuid)
+            if inbox is None:
+                continue
+            err = {
+                "jsonrpc": "2.0",
+                "id": parked_id,
+                "error": {"code": -32000, "message": f"backend gone: {reason}"},
+            }
+            await self._enqueue_to_stub(
+                parked_uuid, inbox,
+                (json.dumps(err, separators=(",", ":")) + "\n").encode("utf-8"),
+            )
 
     async def run_stdout_pump(self) -> None:
         """Read backend stdout line-by-line and route each line back to the
@@ -1247,6 +1773,132 @@ class Backend:
                 if fut is not None and not fut.done():
                     fut.set_result(msg)
                 return
+            if pending.stub_uuid == _RELEASE_STUB_SENTINEL:
+                # Gateway-originated lease maintenance (release after the last
+                # subscriber detached, a post-respawn replay, or a transition
+                # orphaned by its forwarder retracting/detaching mid-flight).
+                # Riders that parked on the URI after the orphaning are
+                # settled on the server's verdict exactly as the normal grant
+                # arm settles them — dropping a parking here would leave that
+                # stub's subscribe swallowed with no response, hung forever.
+                if pending.method == _RESOURCES_SUBSCRIBE_METHOD and pending.resource_uri:
+                    orphan_uri = pending.resource_uri
+                    self._lease_awaiting_grant.discard(orphan_uri)
+                    riders = self._lease_pending_riders.pop(orphan_uri, [])
+                    if _is_success_response(msg):
+                        granted: set[str] = set()
+                        # A replay grant is honoured only while its stub is
+                        # still attached — detach cannot see a sentinel-owned
+                        # pending, so this is where a mid-replay disconnect is
+                        # caught; granting the dead UUID would pin the lease
+                        # to a stub that can never drain it.
+                        if (
+                            pending.replay_stub
+                            and pending.replay_stub in self._stub_inboxes
+                        ):
+                            granted.add(pending.replay_stub)
+                        granted.update(rider_uuid for rider_uuid, _ in riders)
+                        # Routing is committed BEFORE any reply is awaited: a
+                        # reply into a full inbox detaches its stub, which
+                        # prunes the live table — updating the table from a
+                        # local set afterwards would reinsert the detached
+                        # UUID and route updates at a stub that is gone.
+                        if granted:
+                            self._resource_subscriptions.setdefault(
+                                orphan_uri, set()).update(granted)
+                            self._orphaned_leases.discard(orphan_uri)
+                            if (
+                                self.supports_caller_identity
+                                and pending.caller is not None
+                                and pending.replay_stub in granted
+                            ):
+                                # A replayed identity grant is held by the
+                                # replay's caller — record it so a later
+                                # detach can release as the right principal.
+                                self._grant_callers[
+                                    (orphan_uri, pending.replay_stub)
+                                ] = pending.caller
+                        elif orphan_uri not in self._resource_subscriptions:
+                            # A granted lease nobody wants: release on the
+                            # spot, as the caller that took it (a replay's
+                            # grant belongs to the replay's principal).
+                            await self._release_upstream_subscriptions(
+                                [orphan_uri], caller=pending.caller)
+                        for rider_uuid, rider_id in riders:
+                            await self._reply_locally(rider_uuid, rider_id, result={})
+                    else:
+                        error_obj = msg.get("error")
+                        # A refusal proves the server holds no lease; a
+                        # MALFORMED frame (no error either) proves nothing —
+                        # the subscribe may well have taken. Denying routing
+                        # while keeping such a lease would strand it live
+                        # upstream, with every later update charged to the
+                        # server as a hazard, so an unsettled verdict with
+                        # nobody routed releases the lease on the spot.
+                        if error_obj is None and (
+                            orphan_uri not in self._resource_subscriptions
+                        ):
+                            await self._release_upstream_subscriptions(
+                                [orphan_uri], caller=pending.caller)
+                        for rider_uuid, rider_id in riders:
+                            await self._reply_locally(
+                                rider_uuid, rider_id,
+                                error=error_obj if isinstance(error_obj, dict) else {
+                                    "code": _JSONRPC_SERVER_ERROR,
+                                    "message": "resources/subscribe refused by server",
+                                },
+                            )
+                elif pending.method == _RESOURCES_UNSUBSCRIBE_METHOD and pending.resource_uri:
+                    # A gateway-originated (or detach-orphaned) release
+                    # settled. On success the lease is cleanly gone; on a
+                    # refusal with nobody left to route to, the server has
+                    # RETAINED a subscription that is now a consequence of
+                    # the broker's own lease handling — its updates are
+                    # dropped without recording a hazard, so the server is
+                    # not condemned for behaviour that is correct. A
+                    # MALFORMED release response is DELIBERATELY treated as
+                    # a refusal here too: on the routing axis that fails
+                    # closed, and on the hazard-ledger axis it fails open
+                    # (orphan-marked, so unknowable frames are forgiven
+                    # rather than charged to the server).
+                    _rel_uri = pending.resource_uri
+                    self._lease_awaiting_release.discard(_rel_uri)
+                    waiters = self._lease_release_waiters.pop(_rel_uri, [])
+                    if _is_success_response(msg):
+                        self._orphaned_leases.discard(_rel_uri)
+                        subscribers = self._resource_subscriptions.get(_rel_uri)
+                        if subscribers is not None:
+                            for waiter_uuid, _waiter_id in waiters:
+                                subscribers.discard(waiter_uuid)
+                            if not subscribers:
+                                del self._resource_subscriptions[_rel_uri]
+                        for waiter_uuid, waiter_id in waiters:
+                            await self._reply_locally(
+                                waiter_uuid, waiter_id, result={})
+                        await self._drain_replacement_subscribes(
+                            _rel_uri, released=True)
+                    else:
+                        if _rel_uri not in self._resource_subscriptions:
+                            while len(self._orphaned_leases) >= _ORPHANED_LEASES_MAX:
+                                self._orphaned_leases.pop()
+                            self._orphaned_leases.add(_rel_uri)
+                        error_obj = msg.get("error")
+                        for waiter_uuid, waiter_id in waiters:
+                            await self._reply_locally(
+                                waiter_uuid, waiter_id,
+                                error=error_obj if isinstance(error_obj, dict) else {
+                                    "code": _JSONRPC_SERVER_ERROR,
+                                    "message": "resources/unsubscribe "
+                                               "refused by server",
+                                },
+                            )
+                        await self._drain_replacement_subscribes(
+                            _rel_uri, released=False)
+                return
+            if pending.resource_uri and pending.method in (
+                _RESOURCES_SUBSCRIBE_METHOD, _RESOURCES_UNSUBSCRIBE_METHOD
+            ):
+                await self._on_resource_subscription_response(pending, msg)
             # MCP Apps interception: a tools/call result carrying a ui://
             # resource is parked (the response is held off the stub) while an
             # out-of-band resources/read fetches the app payload. When it
@@ -1261,6 +1913,40 @@ class Backend:
             self.touch()
             return
         if method is not None and msg_id is None:
+            # Subscription-scoped: ``notifications/resources/updated`` carries
+            # no request id, so it is attributed by URI — delivered to every
+            # stub subscribed to that URI and only those. This arm is
+            # TERMINAL: URI is the only permitted attribution for this
+            # notification, so an update for a URI nobody subscribed to is
+            # dropped here (deny-by-default, hazard recorded) and never falls
+            # through to request-scoped attribution — a server-supplied
+            # ``_meta.relatedRequestId`` must not hand one tenant a URI that
+            # only a co-tenant ever named.
+            if method == _RESOURCES_UPDATED_NOTIFICATION:
+                targets = self._resource_update_targets(msg)
+                for target_uuid in targets:
+                    await self._deliver_to_stub(target_uuid, msg)
+                if not targets:
+                    _params = msg.get("params")
+                    _uri = _params.get("uri") if isinstance(_params, dict) else None
+                    if isinstance(_uri, str) and _uri in self._orphaned_leases:
+                        # A retained lease the broker failed to release: the
+                        # update is a consequence of OUR lease handling, so
+                        # it is dropped without condemning the server.
+                        # The URI is deliberately NOT logged — resource URIs
+                        # can carry tokens or presigned query parameters.
+                        logger.debug(
+                            "backend pid=%s dropping resources/updated for "
+                            "an orphaned lease (no hazard)", self.pid,
+                        )
+                    else:
+                        logger.debug(
+                            "backend pid=%s dropping resources/updated for a "
+                            "URI no stub subscribed to (never routed by "
+                            "request id)", self.pid,
+                        )
+                        self._record_hazard(hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION)
+                return
             # Attribute request-scoped notifications (progress, or a log tied
             # to an in-flight call) to their owning stub so they are not leaked
             # to co-pooled tenants sharing this backend.
@@ -1499,6 +2185,796 @@ class Backend:
             inboxes = list(self._stub_inboxes.items())
         for stub_uuid, inbox in inboxes:
             await self._enqueue_to_stub(stub_uuid, inbox, payload)
+
+    async def _handle_resource_subscription(
+        self, stub_uuid: str, method: str, msg: dict[str, Any]
+    ) -> bool:
+        """Apply subscription-lease bookkeeping for a stub-forwarded
+        ``resources/subscribe`` / ``resources/unsubscribe``; return ``True``
+        when the request was answered locally and must not be forwarded.
+
+        Routing grants are recorded on the server's RESPONSE, never at
+        forward time, so the table only ever names stubs whose subscription
+        the server actually accepted (fail-closed: an update racing the
+        response is dropped, not mis-routed).
+
+        Two regimes, split on ``supports_caller_identity``:
+
+        - An identity-capable server authorizes per caller, so EVERY
+          subscribe is forwarded with its own caller block and every stub
+          gets its own upstream authorization decision — no local coalescing
+          on the subscribe side (``_on_resource_subscription_response``
+          records the per-stub grant).
+        - An identity-less server sees every co-tenant as one principal, so
+          duplicate traffic tells it nothing; only lease TRANSITIONS reach
+          it. The first subscriber's subscribe takes the lease; a stub
+          arriving while that grant is in flight is PARKED and answered with
+          the server's actual verdict, never a premature success; a stub
+          arriving after the grant joins locally with the MCP empty result
+          (exactly as the initialize cache answers later stubs). A non-final
+          unsubscribe is answered locally; the final one is forwarded and the
+          routing entry is kept until the server confirms, because a failed
+          unsubscribe means the server RETAINED the subscription and dropping
+          routing early would silently discard live updates.
+
+        A request without a well-formed ``params.uri`` string is forwarded
+        verbatim with no table change: the backend rejects it with its own
+        error, and an entry keyed on garbage could never match an update.
+        """
+        params = msg.get("params")
+        uri = params.get("uri") if isinstance(params, dict) else None
+        if not isinstance(uri, str) or not uri:
+            return False
+        original_id = msg.get("id")
+        if len(uri) > _RESOURCE_URI_MAX_LEN:
+            # The per-stub cap bounds subscription COUNT, not bytes: 1024
+            # accepted near-frame-limit URIs would retain gigabytes of
+            # dictionary keys. Refuse locally before any table stores the
+            # key; the URI itself is never logged.
+            await self._reply_locally(
+                stub_uuid, original_id,
+                error={
+                    "code": _JSONRPC_SERVER_ERROR,
+                    "message": "resource URI exceeds the maximum supported "
+                               "length",
+                },
+            )
+            return True
+        if original_id is None:
+            # An id-less subscribe/unsubscribe is a notification-shaped frame
+            # the MCP spec does not define. No response can ever settle the
+            # lease transition it would start, so mutating lease state on it
+            # would wedge the URI permanently (later subscribers park behind
+            # a grant whose response never comes), and forwarding it would
+            # open a server-side subscription the broker never routes.
+            # Swallow it: a request without an id expects no reply.
+            return True
+        if method == _RESOURCES_SUBSCRIBE_METHOD:
+            # Cap check precedes EVERY subscribe branch, so a capped stub can
+            # neither open new leases nor keep joining co-tenants' URIs.
+            if self._stub_subscription_count(stub_uuid) >= _RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB:
+                # The URI is deliberately NOT logged: resource URIs can carry
+                # credentials (tokens, presigned query params) and this line
+                # lands in the operator's plain-text log.
+                logger.warning(
+                    "backend pid=%s stub=%s at resource-subscription cap (%d); "
+                    "refusing subscribe",
+                    self.pid, stub_uuid, _RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB,
+                )
+                await self._reply_locally(
+                    stub_uuid, original_id,
+                    error={
+                        "code": _JSONRPC_SERVER_ERROR,
+                        "message": "resource subscription limit reached",
+                    },
+                )
+                return True
+            if any(
+                p.stub_uuid == stub_uuid
+                and p.method == _RESOURCES_UNSUBSCRIBE_METHOD
+                and p.resource_uri == uri
+                for p in self._pending_requests.values()
+            ):
+                # This stub's own unsubscribe for the URI is still in flight.
+                # Its response may arrive AFTER a new grant (out-of-order
+                # server) and would then erase it — the releasing stub and the
+                # re-subscriber are the same uuid, so the per-stub discard
+                # cannot tell them apart. Refuse the resubscribe; the client
+                # retries once the unsubscribe settles.
+                await self._reply_locally(
+                    stub_uuid, original_id,
+                    error={
+                        "code": _JSONRPC_SERVER_ERROR,
+                        "message": "resources/unsubscribe for this URI is "
+                                   "still in flight; retry after it completes",
+                    },
+                )
+                return True
+            if self.supports_caller_identity:
+                # Per-caller authorization: the server must see this stub's
+                # own subscribe (the caller block is injected downstream).
+                return False
+            if uri in self._lease_awaiting_grant:
+                self._lease_pending_riders.setdefault(uri, []).append(
+                    (stub_uuid, original_id))
+                return True
+            subscribers = self._resource_subscriptions.get(uri)
+            if subscribers is not None and uri not in self._lease_awaiting_release:
+                subscribers.add(stub_uuid)
+                await self._reply_locally(stub_uuid, original_id, result={})
+                return True
+            if uri in self._lease_awaiting_release:
+                # A release for this URI is in flight. The one wire orders
+                # the WRITES, but the server may ANSWER out of order — a
+                # replacement grant landing before the release would leave
+                # local routing keeping this subscriber while the release
+                # then destroys the lease upstream: silent update loss.
+                # Park until the release settles; the drain either joins a
+                # retained lease locally or takes a fresh one with a
+                # subscribe forwarded strictly AFTER the release settled.
+                self._lease_replacement_subscribes.setdefault(uri, []).append(
+                    (stub_uuid, original_id))
+                return True
+            # First subscriber: forward to take the lease.
+            self._lease_awaiting_grant.add(uri)
+            return False
+        # --- resources/unsubscribe ---
+        if self.supports_caller_identity:
+            # Retract this stub's own in-flight subscribe for the URI first
+            # (mirror of the coalesced retract arm): its grant may be
+            # answered AFTER this unsubscribe on an out-of-order server,
+            # which would record routing for a stub that already left —
+            # stranding the upstream lease. Sentinelize keeping ``caller``
+            # so the late grant releases as the right principal; commit the
+            # transitions, then reply.
+            retracted_ids: list[Any] = []
+            for p in self._pending_requests.values():
+                if (
+                    p.stub_uuid == stub_uuid
+                    and p.method == _RESOURCES_SUBSCRIBE_METHOD
+                    and p.resource_uri == uri
+                ):
+                    if p.original_id is not None:
+                        retracted_ids.append(p.original_id)
+                    p.origin_stub = stub_uuid
+                    p.stub_uuid = _RELEASE_STUB_SENTINEL
+                    p.original_id = None
+            if retracted_ids:
+                retract_error = {
+                    "code": _JSONRPC_SERVER_ERROR,
+                    "message": "resources/subscribe retracted by a later "
+                               "unsubscribe",
+                }
+                for retracted_id in retracted_ids:
+                    await self._reply_locally(
+                        stub_uuid, retracted_id, error=retract_error)
+                if stub_uuid not in self._resource_subscriptions.get(uri, set()):
+                    # Nothing granted yet: the retract settles everything —
+                    # the sentinelized pending releases any late grant, so
+                    # the unsubscribe is truthfully answered locally.
+                    await self._reply_locally(stub_uuid, original_id, result={})
+                    return True
+            # A stub that holds NO grant for this URI must be answered
+            # locally, never forwarded: the server adjudicates an
+            # unsubscribe by CALLER, so a non-holder's forwarded frame
+            # would remove a same-caller HOLDER's live lease while that
+            # holder stayed locally routed — updates silently stop. (The
+            # retract arm above already handled the in-flight-subscribe
+            # case; this covers a stub with nothing outstanding at all.)
+            if stub_uuid not in self._resource_subscriptions.get(uri, set()):
+                await self._reply_locally(stub_uuid, original_id, result={})
+                return True
+            # Two stubs claimed to one session hold ONE per-caller grant
+            # upstream: forwarding either stub's unsubscribe would destroy
+            # the survivor's subscription while it stays locally routed.
+            # When another routed stub shares this stub's grant caller,
+            # settle locally — drop only this stub — and leave the upstream
+            # lease to the last sharer (same guard the detach path applies).
+            grant_caller = self._grant_callers.get((uri, stub_uuid))
+            if grant_caller is not None and any(
+                other != stub_uuid
+                and self._grant_callers.get((uri, other)) == grant_caller
+                for other in self._resource_subscriptions.get(uri, set())
+            ):
+                self._grant_callers.pop((uri, stub_uuid), None)
+                subscribers = self._resource_subscriptions.get(uri)
+                if subscribers is not None:
+                    subscribers.discard(stub_uuid)
+                    if not subscribers:
+                        del self._resource_subscriptions[uri]
+                await self._reply_locally(stub_uuid, original_id, result={})
+                return True
+            # Sole holder (or unknown grant): forward, and mutate routing on
+            # the response.
+            return False
+        if uri in self._lease_awaiting_grant:
+            # Retract while the grant is in flight. Every subscribe id this
+            # stub has outstanding for the URI is ANSWERED (with a
+            # cancellation error) before its parking or pending is removed or
+            # reassigned — a request silently dropped from the tables would
+            # hang in the client's id table forever. A parked rider is then
+            # unparked; the FORWARDER's pending is promoted to the first
+            # remaining rider, or converted to the lease sentinel so a
+            # granted-but-unwanted lease is released.
+            retract_error = {
+                "code": _JSONRPC_SERVER_ERROR,
+                "message": "resources/subscribe retracted by a later unsubscribe",
+            }
+            riders = self._lease_pending_riders.get(uri, [])
+            retracted = [r for r in riders if r[0] == stub_uuid]
+            self._lease_pending_riders[uri] = [r for r in riders if r[0] != stub_uuid]
+            # EVERY table transition is committed before the first reply is
+            # awaited: a reply into a full inbox detaches the stub, and
+            # detach both mutates the pending table mid-iteration and
+            # re-decides the very promotion this arm is making — the late
+            # reassignment would overwrite detach's promoted rider with the
+            # sentinel, leaving that rider's subscribe unanswered forever.
+            forwarder_reply_id: Any = None
+            forwarder_retracted = False
+            for p in self._pending_requests.values():
+                if (
+                    p.stub_uuid == stub_uuid
+                    and p.method == _RESOURCES_SUBSCRIBE_METHOD
+                    and p.resource_uri == uri
+                ):
+                    forwarder_retracted = True
+                    forwarder_reply_id = p.original_id
+                    remaining = self._lease_pending_riders.get(uri, [])
+                    if remaining:
+                        p.stub_uuid, p.original_id = remaining.pop(0)
+                    else:
+                        p.origin_stub = stub_uuid
+                        p.stub_uuid = _RELEASE_STUB_SENTINEL
+                        p.original_id = None
+                    break
+            for _retracted_uuid, retracted_id in retracted:
+                await self._reply_locally(stub_uuid, retracted_id, error=retract_error)
+            if forwarder_retracted:
+                await self._reply_locally(
+                    stub_uuid, forwarder_reply_id, error=retract_error)
+            await self._reply_locally(stub_uuid, original_id, result={})
+            return True
+        parked_replacements = [
+            r for r in self._lease_replacement_subscribes.get(uri, [])
+            if r[0] == stub_uuid
+        ]
+        if parked_replacements:
+            # This stub parked a replacement subscribe behind an in-flight
+            # release and now unsubscribes: leaving the parking in place
+            # would let the release drain re-subscribe a stub that has
+            # since asked to leave. Retract the parking (committed before
+            # any reply is awaited), answer each parked subscribe id with
+            # the cancellation error, then fall through — the routing
+            # checks below answer the unsubscribe itself truthfully.
+            remaining_repl = [
+                r for r in self._lease_replacement_subscribes[uri]
+                if r[0] != stub_uuid
+            ]
+            if remaining_repl:
+                self._lease_replacement_subscribes[uri] = remaining_repl
+            else:
+                del self._lease_replacement_subscribes[uri]
+            repl_retract_error = {
+                "code": _JSONRPC_SERVER_ERROR,
+                "message": "resources/subscribe retracted by a later "
+                           "unsubscribe",
+            }
+            for _parked_uuid, parked_id in parked_replacements:
+                await self._reply_locally(
+                    stub_uuid, parked_id, error=repl_retract_error)
+        subscribers = self._resource_subscriptions.get(uri)
+        if subscribers is not None and stub_uuid not in subscribers:
+            # A stub unsubscribing a URI it never held must not tear down a
+            # co-tenant's live lease.
+            await self._reply_locally(stub_uuid, original_id, result={})
+            return True
+        if subscribers is not None and len(subscribers) > 1:
+            subscribers.discard(stub_uuid)
+            await self._reply_locally(stub_uuid, original_id, result={})
+            return True
+        if uri in self._lease_awaiting_release:
+            # A final release for this URI is already in flight — and it may
+            # belong to a stub that has since detached, so a refusal would
+            # dead-end this stub: still routed, told to retry by a message
+            # nothing acts on. Park behind the one in-flight release instead
+            # (mirroring how the grant side parks riders) and settle on its
+            # verdict. Forwarding a second release would race two responses
+            # against one shared awaiting-release flag. Parkings are counted
+            # against the same per-stub cap as subscriptions — a repeated
+            # unsubscribe under a slow server must not grow the waiter list
+            # without bound.
+            parked = sum(
+                1
+                for waiters in self._lease_release_waiters.values()
+                for waiter_uuid, _waiter_id in waiters
+                if waiter_uuid == stub_uuid
+            )
+            if parked >= _RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB:
+                # The URI is deliberately NOT logged: resource URIs can
+                # carry credentials.
+                logger.warning(
+                    "backend pid=%s stub=%s at release-waiter cap (%d); "
+                    "refusing unsubscribe",
+                    self.pid, stub_uuid, _RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB,
+                )
+                await self._reply_locally(
+                    stub_uuid, original_id,
+                    error={
+                        "code": _JSONRPC_SERVER_ERROR,
+                        "message": "resource subscription limit reached",
+                    },
+                )
+                return True
+            self._lease_release_waiters.setdefault(uri, []).append(
+                (stub_uuid, original_id))
+            return True
+        if subscribers is None:
+            # Nothing tracked for this URI and no release in flight: there
+            # is no lease to protect, so the server answers the stray
+            # unsubscribe truthfully itself (forwarded unflagged — its
+            # response mutates no lease state).
+            return False
+        # Last subscriber: release the lease upstream. Routing keeps the stub
+        # until the server confirms (see _on_resource_subscription_response).
+        self._lease_awaiting_release.add(uri)
+        return False
+
+    async def _on_resource_subscription_response(
+        self, pending: "_PendingRequest", msg: dict[str, Any]
+    ) -> None:
+        """Apply the lease transition a subscribe/unsubscribe RESPONSE
+        confirms or refuses. The wire is one ordered stream, so transitions
+        arrive in the order their requests were forwarded.
+        """
+        uri = pending.resource_uri
+        ok = _is_success_response(msg)
+        if pending.method == _RESOURCES_SUBSCRIBE_METHOD:
+            if self.supports_caller_identity:
+                # Per-stub grant: only the caller the server accepted routes.
+                if ok:
+                    self._resource_subscriptions.setdefault(uri, set()).add(
+                        pending.stub_uuid)
+                    self._orphaned_leases.discard(uri)
+                    if pending.caller is not None:
+                        # Grant-time is the only moment the grant principal
+                        # is certain; detach releases with this caller.
+                        self._grant_callers[(uri, pending.stub_uuid)] = (
+                            pending.caller)
+                elif "error" not in msg:
+                    # UNSETTLED verdict (neither result nor error): the
+                    # subscribe may well have taken upstream, and recording
+                    # nothing would strand a live per-caller lease firing
+                    # updates that route nowhere. Release it as the caller
+                    # that took it — the same fail-closed release the
+                    # coalesced arms apply to malformed verdicts.
+                    await self._release_upstream_subscriptions(
+                        [uri], caller=pending.caller)
+                return
+            # Coalesced grant: the forwarder and every parked rider settle on
+            # the server's one verdict — success grants all of them, refusal
+            # grants none, and no rider was ever told "subscribed" early.
+            self._lease_awaiting_grant.discard(uri)
+            riders = self._lease_pending_riders.pop(uri, [])
+            if ok:
+                # Commit the whole grant BEFORE any reply is awaited: a reply
+                # into a full inbox detaches its stub, and when that empties
+                # the entry detach deletes it from the table — later adds
+                # through the stale set alias would then grant riders into a
+                # set the routing table no longer holds.
+                granted = self._resource_subscriptions.setdefault(uri, set())
+                granted.add(pending.stub_uuid)
+                granted.update(rider_uuid for rider_uuid, _ in riders)
+                self._orphaned_leases.discard(uri)
+                for rider_uuid, rider_id in riders:
+                    await self._reply_locally(rider_uuid, rider_id, result={})
+                return
+            error_obj = msg.get("error")
+            # A refusal proves the server holds no lease; a MALFORMED frame
+            # (no error either) proves nothing — the subscribe may have
+            # taken, and denying routing while keeping it would strand a
+            # live lease whose every update is charged to the server as a
+            # hazard. An unsettled verdict with nobody routed releases it.
+            if error_obj is None and uri not in self._resource_subscriptions:
+                await self._release_upstream_subscriptions([uri])
+            for rider_uuid, rider_id in riders:
+                await self._reply_locally(
+                    rider_uuid, rider_id,
+                    error=error_obj if isinstance(error_obj, dict) else {
+                        "code": _JSONRPC_SERVER_ERROR,
+                        "message": "resources/subscribe refused by server",
+                    },
+                )
+            return
+        # --- unsubscribe response ---
+        if self.supports_caller_identity:
+            if ok:
+                self._grant_callers.pop((uri, pending.stub_uuid), None)
+                subscribers = self._resource_subscriptions.get(uri)
+                if subscribers is not None:
+                    subscribers.discard(pending.stub_uuid)
+                    if not subscribers:
+                        del self._resource_subscriptions[uri]
+            return
+        if uri not in self._lease_awaiting_release:
+            return
+        self._lease_awaiting_release.discard(uri)
+        waiters = self._lease_release_waiters.pop(uri, [])
+        if ok:
+            # Release confirmed: drop the releasing stub and every parked
+            # waiter — all committed BEFORE any reply is awaited. A server
+            # may answer concurrent requests out of order, so a replacement
+            # subscribe forwarded behind this release can have been granted
+            # already — deleting the whole entry would silently discard that
+            # fresh grant.
+            subscribers = self._resource_subscriptions.get(uri)
+            if subscribers is not None:
+                subscribers.discard(pending.stub_uuid)
+                for waiter_uuid, _waiter_id in waiters:
+                    subscribers.discard(waiter_uuid)
+                if not subscribers:
+                    del self._resource_subscriptions[uri]
+            for waiter_uuid, waiter_id in waiters:
+                await self._reply_locally(waiter_uuid, waiter_id, result={})
+            await self._drain_replacement_subscribes(uri, released=True)
+            return
+        # On a refusal the server RETAINED the subscription, so routing keeps
+        # the entry; the unsubscribing stub receives the server's error and
+        # knows its unsubscribe did not take effect — and so does every
+        # parked waiter, which stays routed and may retry (the flag is down,
+        # so a retry forwards a fresh release).
+        error_obj = msg.get("error")
+        for waiter_uuid, waiter_id in waiters:
+            await self._reply_locally(
+                waiter_uuid, waiter_id,
+                error=error_obj if isinstance(error_obj, dict) else {
+                    "code": _JSONRPC_SERVER_ERROR,
+                    "message": "resources/unsubscribe refused by server",
+                },
+            )
+        await self._drain_replacement_subscribes(uri, released=False)
+
+    def resource_subscription_uris(self, stub_uuid: str) -> list[str]:
+        """URIs whose routing table names ``stub_uuid`` — the set a
+        transparent respawn must replay onto the replacement backend."""
+        routed = {
+            uri for uri, subscribers in self._resource_subscriptions.items()
+            if stub_uuid in subscribers
+        }
+        # An in-flight replay has not committed routing yet (routing is
+        # recorded only on the server's grant): if the replacement dies
+        # before its replay responses arrive, those URIs are in neither the
+        # routing table nor any pending the next respawn can see — captured
+        # from pendings here, or the subscription goes permanently dark.
+        routed.update(
+            p.resource_uri
+            for p in self._pending_requests.values()
+            if p.replay_stub == stub_uuid
+            and p.method == _RESOURCES_SUBSCRIBE_METHOD
+            and p.resource_uri
+        )
+        # URIs whose replay was in flight when THIS backend died: the
+        # backend-gone cleanup preserved them here because clearing the
+        # pending table erased their only record.
+        routed.update(self._gone_replay_uris.get(stub_uuid, ()))
+        return sorted(routed)
+
+    async def replay_resource_subscriptions(
+        self, stub_uuid: str, uris: list[str], *,
+        caller: Optional[CallerContext] = None,
+    ) -> None:
+        """Re-establish ``stub_uuid``'s subscriptions on a freshly respawned
+        backend, so a live subscription survives the transparent backend swap
+        instead of silently going dark (kiro-cli never learns the old backend
+        died, so it will never re-subscribe on its own).
+
+        Gateway-originated: each URI is re-subscribed under the lease
+        sentinel and the stub's routing grant is recorded only on the
+        server's success (a refusal leaves the update undelivered —
+        fail-closed — rather than mis-attributed). On an identity-capable
+        server the replay carries the connection's authoritative caller
+        block, so the server adjudicates it as the same caller that held the
+        original subscription; without a caller to inject there the replay is
+        skipped entirely, because a bare subscribe would be adjudicated as
+        the connection and could be refused — again failing closed.
+
+        A WRITE failure raises :class:`BackendGone` (the replacement's pipe
+        is already broken, so the respawn cannot succeed): swallowing it
+        would report a successful respawn whose subscriptions are silently
+        dark forever. Pendings for URIs written before the failure are
+        scoped to release-on-grant — with the respawn failed nobody will
+        consume those grants, so each late success releases its lease
+        instead of pinning it to a stub the caller is tearing down.
+        """
+        if self.supports_caller_identity and caller is None:
+            logger.debug(
+                "backend pid=%s skipping subscription replay for stub=%s: "
+                "identity-capable server and no caller context to inject",
+                self.pid, stub_uuid,
+            )
+            return
+        replay_generation = self._rekey_generation.get(stub_uuid, 0)
+        for uri in uris:
+            if self._rekey_generation.get(stub_uuid, 0) != replay_generation:
+                # A claim rekeyed this stub mid-replay. The eviction
+                # retracted the pendings written so far, but continuing
+                # would write the REMAINING URIs under the old owner and
+                # route their grants to the new one. Stop here — fail
+                # closed, the new owner subscribes on its own.
+                logger.debug(
+                    "backend pid=%s stopping subscription replay for "
+                    "stub=%s: stub was rekeyed mid-replay", self.pid,
+                    stub_uuid,
+                )
+                return
+            if stub_uuid in self._resource_subscriptions.get(uri, set()):
+                continue
+            if not self.supports_caller_identity:
+                # Identity-less: the server holds ONE subscription per URI,
+                # so a replay flows through the same per-URI lease
+                # coordination as a stub subscribe — two uncoordinated
+                # replays would put two grants in flight, and a later final
+                # unsubscribe would then release the server's single
+                # subscription while the other stub stayed locally routed.
+                # A replay parking carries no reply id (_reply_locally
+                # no-ops on None), so it settles silently on the verdict.
+                subscribers = self._resource_subscriptions.get(uri)
+                if uri in self._lease_awaiting_grant:
+                    self._lease_pending_riders.setdefault(uri, []).append(
+                        (stub_uuid, None))
+                    continue
+                if subscribers is not None and uri not in self._lease_awaiting_release:
+                    subscribers.add(stub_uuid)
+                    continue
+                if uri in self._lease_awaiting_release:
+                    self._lease_replacement_subscribes.setdefault(uri, []).append(
+                        (stub_uuid, None))
+                    continue
+                self._lease_awaiting_grant.add(uri)
+            fid = self._next_forward_id()
+            self._pending_requests[fid] = _PendingRequest(
+                stub_uuid=_RELEASE_STUB_SENTINEL, original_id=None,
+                method=_RESOURCES_SUBSCRIBE_METHOD, resource_uri=uri,
+                replay_stub=stub_uuid,
+                caller=caller,
+                t_start_ms=time.monotonic() * 1000.0,
+            )
+            replay_msg: dict[str, Any] = {
+                "jsonrpc": "2.0", "id": fid,
+                "method": _RESOURCES_SUBSCRIBE_METHOD,
+                "params": {"uri": uri},
+            }
+            if self.supports_caller_identity and caller is not None:
+                replay_msg = _inject_caller_meta(replay_msg, caller)
+            try:
+                await _write_json_line(self.stdin, replay_msg)
+            except Exception as exc:
+                self._pending_requests.pop(fid, None)
+                if not self.supports_caller_identity:
+                    # Unwind the lease claim so the URI is not wedged
+                    # awaiting a grant that was never written.
+                    self._lease_awaiting_grant.discard(uri)
+                # Scope any EARLIER replay pendings written in this pass to
+                # release-on-grant: their responses may still arrive, and
+                # with the respawn reported failed nobody consumes the
+                # grants — an attached replay_stub would pin each lease to
+                # a stub the caller is about to tear down.
+                for p in self._pending_requests.values():
+                    if (
+                        p.stub_uuid == _RELEASE_STUB_SENTINEL
+                        and p.method == _RESOURCES_SUBSCRIBE_METHOD
+                        and p.replay_stub == stub_uuid
+                    ):
+                        p.replay_stub = ""
+                # No URI in the line: resource URIs can carry credentials.
+                logger.debug(
+                    "backend pid=%s could not replay a resource "
+                    "subscription (write failed)", self.pid,
+                )
+                raise BackendGone(
+                    "subscription replay write failed on the replacement "
+                    "backend"
+                ) from exc
+
+    async def _reply_locally(
+        self,
+        stub_uuid: str,
+        original_id: Any,
+        *,
+        result: Optional[dict[str, Any]] = None,
+        error: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Answer a stub's request from the gateway without involving the
+        backend. A request without an id expects no reply, so none is sent."""
+        if original_id is None:
+            return
+        reply: dict[str, Any] = {"jsonrpc": "2.0", "id": original_id}
+        if error is not None:
+            reply["error"] = error
+        else:
+            reply["result"] = result if result is not None else {}
+        await self._deliver_to_stub(stub_uuid, reply)
+
+    def _stub_subscription_count(self, stub_uuid: str) -> int:
+        """Subscription load ``stub_uuid`` holds or is acquiring: confirmed
+        table grants, its own forwarded subscribes still awaiting the server,
+        and rider parkings — each counted INDIVIDUALLY, duplicates included.
+        Grants land on the response, so distinct-URI counting would let a
+        stub repeat one URI's subscribe unboundedly while the grant is in
+        flight, growing the rider list without limit under a slow server."""
+        confirmed = sum(
+            1 for subscribers in self._resource_subscriptions.values()
+            if stub_uuid in subscribers
+        )
+        in_flight = sum(
+            1 for p in self._pending_requests.values()
+            if p.stub_uuid == stub_uuid
+            and p.method == _RESOURCES_SUBSCRIBE_METHOD
+            and p.resource_uri
+        )
+        # Subscribes this stub originated that were since converted to the
+        # lease sentinel (retracted by an unsubscribe, an eviction, or a
+        # detach) but whose server response is still outstanding. Without
+        # these a stub cycling subscribe/unsubscribe against an
+        # unresponsive server would slip every cycle's pending out of its
+        # count and grow the table without bound.
+        sentinel_retained = sum(
+            1 for p in self._pending_requests.values()
+            if p.stub_uuid == _RELEASE_STUB_SENTINEL
+            and p.origin_stub == stub_uuid
+            and p.method == _RESOURCES_SUBSCRIBE_METHOD
+            and p.resource_uri
+        )
+        parked = sum(
+            1
+            for riders in self._lease_pending_riders.values()
+            for rider_uuid, _rider_id in riders
+            if rider_uuid == stub_uuid
+        )
+        replacement = sum(
+            1
+            for parkers in self._lease_replacement_subscribes.values()
+            for parker_uuid, _parker_id in parkers
+            if parker_uuid == stub_uuid
+        )
+        return confirmed + in_flight + sentinel_retained + parked + replacement
+
+    async def _drain_replacement_subscribes(
+        self, uri: str, *, released: bool
+    ) -> None:
+        """Settle subscribes that parked while ``uri``'s release was in
+        flight. On a CONFIRMED release the lease is gone, so the parkers
+        take it afresh with ONE forwarded subscribe — first parker as the
+        forwarder, the rest parked as riders settling on the same verdict —
+        serialized strictly AFTER the release on the wire. On a refusal the
+        server RETAINED the lease, so parkers join the still-live entry
+        locally (state committed before replies); when detach has pruned the
+        entry out from under a retained lease, a fresh subscribe is
+        forwarded instead (idempotent on the server's live subscription, and
+        its grant re-establishes routing).
+        """
+        parked = self._lease_replacement_subscribes.pop(uri, [])
+        if not parked:
+            return
+        subscribers = self._resource_subscriptions.get(uri)
+        if not released and subscribers is not None:
+            subscribers.update(parker_uuid for parker_uuid, _ in parked)
+            for parker_uuid, parker_id in parked:
+                await self._reply_locally(parker_uuid, parker_id, result={})
+            return
+        # Take the lease afresh with ONE subscribe forwarded under the
+        # sentinel, every parker riding on its verdict: success grants and
+        # answers each parker ({} for a stub subscribe, silently for an
+        # id-less replay parking), refusal answers each with the server's
+        # error. The sentinel arm owns exactly this settle already.
+        fid = self._next_forward_id()
+        self._pending_requests[fid] = _PendingRequest(
+            stub_uuid=_RELEASE_STUB_SENTINEL, original_id=None,
+            method=_RESOURCES_SUBSCRIBE_METHOD, resource_uri=uri,
+            t_start_ms=time.monotonic() * 1000.0,
+        )
+        self._lease_awaiting_grant.add(uri)
+        self._lease_pending_riders.setdefault(uri, []).extend(parked)
+        try:
+            await _write_json_line(self.stdin, {
+                "jsonrpc": "2.0", "id": fid,
+                "method": _RESOURCES_SUBSCRIBE_METHOD,
+                "params": {"uri": uri},
+            })
+        except Exception:
+            # Backend going away: unwind and answer every parker — an id
+            # silently dropped from the tables hangs in the client forever.
+            self._pending_requests.pop(fid, None)
+            self._lease_awaiting_grant.discard(uri)
+            remaining = [
+                r for r in self._lease_pending_riders.get(uri, [])
+                if r not in parked
+            ]
+            if remaining:
+                self._lease_pending_riders[uri] = remaining
+            else:
+                self._lease_pending_riders.pop(uri, None)
+            err = {
+                "code": _JSONRPC_SERVER_ERROR,
+                "message": "resources/subscribe could not be forwarded "
+                           "(backend going away)",
+            }
+            for parker_uuid, parker_id in parked:
+                await self._reply_locally(parker_uuid, parker_id, error=err)
+
+    async def _release_upstream_subscriptions(
+        self, uris: list[str], *, caller: Optional[CallerContext] = None,
+    ) -> None:
+        """Send a gateway-originated ``resources/unsubscribe`` for each URI
+        whose last subscriber departed without unsubscribing. Best-effort: a
+        backend that is already dying takes its subscriptions with it.
+
+        On an identity-capable server pass the caller that HOLDS the grant:
+        the release is adjudicated per principal, so a bare unsubscribe
+        (adjudicated as the connection) would be refused — or worse, revoke
+        a different principal's live subscription.
+        """
+        for uri in uris:
+            fid = self._next_forward_id()
+            self._pending_requests[fid] = _PendingRequest(
+                stub_uuid=_RELEASE_STUB_SENTINEL, original_id=None,
+                method=_RESOURCES_UNSUBSCRIBE_METHOD, resource_uri=uri,
+                t_start_ms=time.monotonic() * 1000.0,
+            )
+            if not self.supports_caller_identity:
+                # Mark the release in flight BEFORE writing: without the
+                # flag a replacement subscribe takes the first-subscriber
+                # path and forwards BESIDE this release, racing its answer
+                # order — the same silent update loss the stub-forwarded
+                # release path parks against. The sentinel response arm
+                # clears the flag and drains any parked replacements on the
+                # server's verdict. Identity-capable servers never coalesce
+                # (every subscribe forwards per caller), so the flag is not
+                # consulted there and setting it would only go stale.
+                self._lease_awaiting_release.add(uri)
+            release_msg: dict[str, Any] = {
+                "jsonrpc": "2.0", "id": fid,
+                "method": _RESOURCES_UNSUBSCRIBE_METHOD,
+                "params": {"uri": uri},
+            }
+            if self.supports_caller_identity and caller is not None:
+                release_msg = _inject_caller_meta(release_msg, caller)
+            try:
+                await _write_json_line(self.stdin, release_msg)
+            except Exception:
+                # Per-URI, not terminal: one failed write must not leak every
+                # remaining server-side lease (the pipe may also be gone, in
+                # which case the dying backend takes them all anyway).
+                self._pending_requests.pop(fid, None)
+                self._lease_awaiting_release.discard(uri)
+                # The lease is now RETAINED upstream through the broker's
+                # own failure: mark it orphaned so its later updates are
+                # dropped without charging a hazard to a blameless server.
+                while len(self._orphaned_leases) >= _ORPHANED_LEASES_MAX:
+                    self._orphaned_leases.pop()
+                self._orphaned_leases.add(uri)
+                # No URI in the line: resource URIs can carry credentials.
+                logger.debug(
+                    "backend pid=%s could not release a resource "
+                    "subscription (backend going away)", self.pid,
+                )
+                continue
+
+    def _resource_update_targets(self, msg: dict[str, Any]) -> set[str]:
+        """Return the stubs subscribed to an incoming
+        ``notifications/resources/updated``'s URI — empty when the URI is
+        missing, malformed, or has no subscribers (the caller then applies
+        the deny-by-default drop).
+
+        Returns a COPY: delivery awaits per stub, and a full inbox detaches
+        its stub mid-fan-out, which mutates the underlying table.
+        """
+        params = msg.get("params")
+        if not isinstance(params, dict):
+            return set()
+        uri = params.get("uri")
+        if not isinstance(uri, str) or not uri:
+            return set()
+        return set(self._resource_subscriptions.get(uri, ()))
 
     def _notification_owner(self, msg: dict[str, Any]) -> Optional[str]:
         """Best-effort attribution of a server->client notification to the one

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -1766,7 +1766,9 @@ def _audit_peer_identity_denied(reason: str, peer_pid: int | None, stub_uuid: st
         logger.debug("SEL audit emit for peer identity denial failed", exc_info=True)
 
 
-def _apply_claim(frame: dict[str, Any]) -> dict[str, Any]:
+async def _apply_claim(
+    frame: dict[str, Any], pool: Optional["BackendPool"] = None
+) -> dict[str, Any]:
     """Apply a ``claim`` frame to every indexed connection of the target PID.
 
     Returns the ack frame. Validation is deny-by-default: a non-integer or
@@ -1818,7 +1820,13 @@ def _apply_claim(frame: dict[str, Any]) -> dict[str, Any]:
     # be rejected.
     raw_token = frame.get("pid_start_id")
     claim_token = raw_token if isinstance(raw_token, str) else None
-    for conn in conns:
+    # Pass 1: retarget every eligible connection SYNCHRONOUSLY (no awaits)
+    # before any eviction runs — see the wrong-principal note below.
+    retargeted: list[tuple[Any, str]] = []
+    # Snapshot: the eviction below AWAITS, and a connection disconnecting
+    # during that await mutates the live ``conns`` set mid-iteration —
+    # aborting the claim with no ack and leaving the remaining stubs stale.
+    for conn in list(conns):
         recorded_token = conn.pid_start_ids.get(pid)
         if claim_token is not None and recorded_token is not None and claim_token != recorded_token:
             skipped += 1
@@ -1839,7 +1847,33 @@ def _apply_claim(frame: dict[str, Any]) -> dict[str, Any]:
         old_key = conn.caller.session_key if conn.caller is not None else ""
         if old_key == updated_caller.session_key:
             continue  # already correct — idempotent re-claim
+        # Reassign the owner BEFORE any eviction awaits — and reassign
+        # EVERY eligible connection before the FIRST eviction awaits (the
+        # second pass below): an eviction yields, and a sibling connection
+        # still carrying the old caller during that await would forward
+        # its frames as the previous session — wrong-principal execution.
+        # A subscribe arriving during an await must likewise already be
+        # authorized as the NEW caller on every connection.
         conn.caller = updated_caller
+        retargeted.append((conn, old_key))
+    # Pass 2: all connections now carry the new owner; run the evictions.
+    for conn, old_key in retargeted:
+        if pool is not None:
+            # The stub changed OWNER: its resource subscriptions belong to
+            # the old principal, and without eviction the new session would
+            # keep receiving the old session's resource-update URIs (which
+            # can carry tokens or presigned params). Caller-binding
+            # ownership lives here at the connection layer, so this is the
+            # one moment the clearance fires; the backend releases upstream
+            # as the grant-time caller.
+            for backend in pool.backends_hosting_stub(conn.stub_uuid):
+                try:
+                    await backend.evict_stub_subscriptions(conn.stub_uuid)
+                except Exception:
+                    logger.exception(
+                        "claim: subscription eviction failed for stub %s",
+                        conn.stub_uuid,
+                    )
         updated += 1
         _audit_caller_claimed(old_key, updated_caller.session_key, conn.pool_label, "allowed")
         logger.info(
@@ -2111,7 +2145,7 @@ async def _handle_connection(
     # (fixes warm-pool re-claim staleness). Validation + auditing live in
     # ``_apply_claim``.
     if register.get("type") == "claim":
-        await _write_json_line(writer, _apply_claim(register))
+        await _write_json_line(writer, await _apply_claim(register, pool))
         return
 
     # Abort-push short-circuit (one-shot control connection from the main
@@ -2681,6 +2715,8 @@ async def _handle_connection(
                     backend,
                     inbox,
                     writer_task,
+                    caller=caller,
+                    conn=conn,
                 )
                 if recovered is None:
                     # Genuinely unrecoverable (no captured init, circuit
@@ -2901,6 +2937,8 @@ async def _respawn_backend_for_stub(
     old_backend: Backend,
     old_inbox: Optional["asyncio.Queue[bytes]"],
     old_writer_task: Optional[asyncio.Task[None]],
+    caller: Optional[CallerContext] = None,
+    conn: Optional[_StubConn] = None,
 ) -> Optional[tuple[Backend, "asyncio.Queue[bytes]", asyncio.Task[None]]]:
     """Rebuild a fresh backend for ``stub_uuid`` after its shared backend
     died and re-bind this stub to it transparently.
@@ -2941,6 +2979,13 @@ async def _respawn_backend_for_stub(
                 # catch a hang). Mirrors _write_json_line's bounded drain.
                 await asyncio.wait_for(writer.drain(), timeout=_WRITE_REPLY_TIMEOUT_SECS)
 
+    # Captured BEFORE detach (which prunes them): the URIs whose live
+    # subscriptions must be replayed onto the replacement backend, or they
+    # silently go dark — kiro-cli never learns the old backend died, so it
+    # will never re-subscribe on its own.
+    replay_uris: list[str] = []
+    with contextlib.suppress(Exception):
+        replay_uris = old_backend.resource_subscription_uris(stub_uuid)
     with contextlib.suppress(Exception):
         await old_backend.detach_stub(stub_uuid)
 
@@ -2995,6 +3040,47 @@ async def _respawn_backend_for_stub(
             )
             return None
         new_inbox = await new_backend.attach_stub(stub_uuid)
+        if replay_uris and conn is not None:
+            # Rekey race: a ``claim`` frame can retarget this connection's
+            # identity during the awaits above (acquire + prime). The
+            # captured URIs belong to the OLD principal — replaying them
+            # now would resubscribe the old owner's resources onto the
+            # rekeyed stub, the exact leak ``evict_stub_subscriptions``
+            # exists to prevent. Recheck the live owner at the last moment
+            # and skip the replay when it changed (fail closed: the new
+            # owner subscribes on its own; the old owner's leases on the
+            # dead backend died with it).
+            live_key = conn.caller.session_key if conn.caller is not None else ""
+            captured_key = caller.session_key if caller is not None else ""
+            if live_key != captured_key:
+                logger.info(
+                    "respawn skipping subscription replay (owner rekeyed "
+                    "mid-respawn) stub=%s pool=%s",
+                    stub_uuid,
+                    pool_key.human_readable(),
+                )
+                replay_uris = []
+        if replay_uris:
+            # A server refusal of an individual replayed subscribe is
+            # fail-closed by design (the update goes undelivered, never
+            # mis-attributed). A WRITE failure is different: the fresh
+            # backend's pipe is already broken, so reporting this respawn
+            # as a success would hand the stub a backend whose replayed
+            # subscriptions are silently dark forever. Give up loudly —
+            # the caller tears the stub down and kiro-cli reconnects.
+            try:
+                await new_backend.replay_resource_subscriptions(
+                    stub_uuid, replay_uris, caller=caller
+                )
+            except BackendGone as exc:
+                logger.info(
+                    "respawn give-up (subscription replay failed) " "stub=%s pool=%s: %s",
+                    stub_uuid,
+                    pool_key.human_readable(),
+                    exc,
+                )
+                await new_backend.detach_stub(stub_uuid)
+                return None
     finally:
         # A private backend never took a reservation, and releasing one would
         # decrement a POOLED connection sharing this digest (see

--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -921,6 +921,21 @@ class BackendPool:
         digest = key.stable_hash()
         self._reserved_digests[digest] = self._reserved_digests.get(digest, 0) + 1
 
+    def backends_hosting_stub(self, stub_uuid: str) -> list["Backend"]:
+        """Live backends whose inbox table names ``stub_uuid`` — normally at
+        most one; a list because a stub mid-respawn can transiently appear
+        on two. Covers BOTH pooled and exclusive (private) backends: a
+        private stub rekeys the same way a pooled one does, and omitting it
+        would leave the previous caller's subscriptions routing to the new
+        owner. Read-only snapshot for callers that must reach the backend a
+        stub is attached to (e.g. the claim rekey's subscription eviction).
+        """
+        return [
+            b
+            for b in (*self._backends.values(), *self._exclusive.values())
+            if stub_uuid in b._stub_inboxes
+        ]
+
     def unreserve(self, key: PoolKey) -> None:
         """Release the in-flight reservation for ``key``.
 

--- a/src/kiro_crew/mcp_gateway/shareability.py
+++ b/src/kiro_crew/mcp_gateway/shareability.py
@@ -85,36 +85,33 @@ ROTATING_SECRET_ENV_PREFIXES: tuple[str, ...] = ("AWS_SECRET", "AWS_SESSION", "O
 # not withhold a recommendation. Two reasons, and the second is the load-bearing
 # one.
 #
-# First, neither is a leak. The broker already refuses to guess: an unattributable
+# First, it is not a leak. The broker already refuses to guess: an unattributable
 # request-scoped notification is DROPPED (deny-by-default in
 # ``backend._notification_owner``) rather than broadcast, so no co-tenant ever
 # receives another tenant's content.
 #
-# Second, and this is why they inform rather than gate: **both describe a gap in
+# Second, and this is why it informs rather than gates: **it describes a gap in
 # OUR broker, not a property of the server.** A proxy that can correlate a frame
 # to a caller can route it, and correlation is a feature we can build:
-#
-# ``resources.subscribe`` -- ``notifications/resources/updated`` carries no
-# request id, but it does not need one. The broker saw which stub sent
-# ``resources/subscribe`` for which URI, so a ``uri -> {stub_uuid}`` table routes
-# the update exactly. It does not keep one today, which is the actual defect. The
-# notification also carries only the URI and not the resource's content, so the
-# failure it currently causes is a subscription that stops firing.
 #
 # ``logging`` -- ``logging/setLevel`` is process-global, but a proxy can emit at
 # the finest level any tenant asked for and filter DOWN per stub, giving each
 # tenant the verbosity it requested from one process.
 #
-# Withholding pooling for either would be charging the operator for work we have
-# not done. Both are filed as broker gaps instead; when the broker learns to
-# attribute them, these entries are deleted rather than relaxed.
+# Withholding pooling for it would be charging the operator for work we have
+# not done. It is filed as a broker gap instead, and the contract on this table
+# is that an entry is DELETED — not relaxed — the moment the broker learns to
+# attribute the frames it covers. ``resources.subscribe`` is absent from this
+# table under exactly that contract: the broker keeps a ``uri -> {stub_uuid}``
+# subscription table (``backend._resource_subscriptions``) and routes each
+# ``notifications/resources/updated`` to the stubs subscribed to its URI, so
+# subscriptions survive pooling and there is nothing to warn about.
 #
 # ``*.listChanged`` is deliberately NOT here: those notifications are global
 # broadcasts (``backend._GLOBAL_BROADCAST_NOTIFICATIONS``) and are safe to
 # fan out to every attached stub.
-_SHARED_BACKEND_DEGRADATIONS: tuple[tuple[tuple[str, ...], str, str], ...] = (
-    (("resources", "subscribe"), "resources_subscribe", "truthy"),
-    (("logging",), "logging_level", "present"),
+_SHARED_BACKEND_DEGRADATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("logging",), "logging_level"),
 )
 
 
@@ -234,24 +231,22 @@ def rotating_secret_env(
 def _shared_backend_degradations(capabilities: dict) -> list[Reason]:
     """Capabilities whose behaviour degrades on a shared backend.
 
-    Pure information: see the table's comment for why each of these is a gap in
+    Pure information: see the table's comment for why each entry is a gap in
     our own broker rather than a property of the server, which is what makes
-    gating on them charging the operator for work we have not done.
+    gating on it charging the operator for work we have not done.
 
-    Two detection modes, because a capability and a flag inside one are different
-    claims:
-
-    ``truthy`` -- the leaf is a FLAG. ``resources: {"subscribe": false}`` is the
-    server explicitly saying it does not subscribe, so it must not count against
+    Detection is by PRESENCE of the capability key. In MCP an empty object is
+    the standard way to advertise a capability that takes no sub-options, so
+    ``{"logging": {}}`` means ``logging/setLevel`` is supported; testing
+    truthiness there would read a server that advertises logging as one that
+    does not. A flag-leaf entry — one whose leaf can be ``false``, the server
+    explicitly declining the capability — needs a truthiness test instead, so
+    adding one to the table means adding a per-entry detection mode alongside
+    it; the table deliberately carries no such machinery while no entry needs
     it.
-
-    ``present`` -- the leaf IS the capability. In MCP an empty object is the
-    standard way to advertise a capability that takes no sub-options, so
-    ``{"logging": {}}`` means ``logging/setLevel`` is supported. Testing
-    truthiness there read a server that advertises logging as one that does not.
     """
     out: list[Reason] = []
-    for path, code, mode in _SHARED_BACKEND_DEGRADATIONS:
+    for path, code in _SHARED_BACKEND_DEGRADATIONS:
         node: object = capabilities
         missing = False
         for key in path:
@@ -261,8 +256,7 @@ def _shared_backend_degradations(capabilities: dict) -> list[Reason]:
             node = node[key]
         if missing:
             continue
-        if mode == "present" or node:
-            out.append(Reason("degrades_when_shared", code))
+        out.append(Reason("degrades_when_shared", code))
     return out
 
 

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -756,7 +756,7 @@ class TestBackendGoneHandling:
         replacement = asyncio.create_task(asyncio.Event().wait(), name="cov-drain")
         respawn_args: list[tuple[Any, ...]] = []
 
-        async def _respawn(*args: Any):
+        async def _respawn(*args: Any, **kwargs: Any):
             # Mirror the real helper's contract: it stops the old inbox drain
             # before handing back a fresh backend, so the two writer tasks
             # never race onto the same socket.

--- a/test/test_mcp_gateway_backend_coverage.py
+++ b/test/test_mcp_gateway_backend_coverage.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import time
 from typing import Any, Optional, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -148,6 +149,22 @@ def _line(obj: Any) -> bytes:
 
 async def _drain(inbox: "asyncio.Queue[bytes]") -> dict:
     return json.loads(inbox.get_nowait().decode("utf-8"))
+
+
+async def _settle_lease(backend: Backend, *, error: Optional[dict] = None) -> None:
+    """Answer the newest forwarded subscribe/unsubscribe with the server's
+    verdict (success by default), driving the lease transition its response
+    confirms or refuses."""
+    fid = next(
+        f for f, p in reversed(list(backend._pending_requests.items()))
+        if p.resource_uri
+    )
+    msg: dict[str, Any] = {"id": fid}
+    if error is not None:
+        msg["error"] = error
+    else:
+        msg["result"] = {}
+    await backend._route_backend_line(_line(msg))
 
 
 async def _settle(backend: Backend) -> None:
@@ -1086,6 +1103,855 @@ class TestRouteBackendLine:
         assert inbox1.empty() and inbox2.empty()
 
     @pytest.mark.asyncio
+    async def test_resource_update_reaches_only_the_subscriber(self) -> None:
+        """A ``notifications/resources/updated`` is attributed by URI: the stub
+        whose ``resources/subscribe`` the server accepted receives it, and a
+        co-pooled tenant that never subscribed receives nothing."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1  # server's own reply
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        delivered = await _drain(inbox1)
+        assert delivered["method"] == "notifications/resources/updated"
+        assert delivered["params"]["uri"] == "file:///watched.txt"
+        assert inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_resource_update_reaches_every_subscriber_of_the_uri(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        # s2 joined a confirmed lease, so its subscribe is answered locally.
+        assert (await _drain(inbox2))["result"] == {}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///shared.txt"},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/resources/updated"
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_subscribe_is_answered_locally_not_forwarded(self) -> None:
+        """The server holds ONE subscription per URI, so only the FIRST
+        subscriber's subscribe reaches it; a stub joining a confirmed lease
+        receives the MCP empty result from the gateway."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 7, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 7
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 7, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        upstream = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(upstream) == 1
+        assert await _drain(inbox2) == {"jsonrpc": "2.0", "id": 7, "result": {}}
+
+    @pytest.mark.asyncio
+    async def test_rider_parked_during_grant_gets_the_server_verdict(self) -> None:
+        """A stub subscribing while the first subscribe is still in flight is
+        PARKED, not told an early success: it is answered only when the
+        server's verdict arrives, with that verdict."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        for stub in ("s1", "s2"):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": 9, "method": "resources/subscribe",
+                "params": {"uri": "file:///shared.txt"},
+            })
+        # Grant still in flight: the rider has NO reply yet.
+        assert inbox2.empty()
+        upstream = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(upstream) == 1
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 9
+        assert await _drain(inbox2) == {"jsonrpc": "2.0", "id": 9, "result": {}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///shared.txt"},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/resources/updated"
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_refused_subscribe_grants_nobody(self) -> None:
+        """A server refusal of the forwarded subscribe settles the forwarder
+        AND every parked rider on that refusal: nobody routes, and nobody was
+        told "subscribed" on the strength of a lease that never materialized
+        (the refusal may be made on per-caller authorization grounds)."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        for stub in ("s1", "s2"):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": 5, "method": "resources/subscribe",
+                "params": {"uri": "file:///denied.txt"},
+            })
+        await _settle_lease(backend, error={"code": -32002, "message": "access denied"})
+        refusal1 = await _drain(inbox1)
+        assert refusal1["id"] == 5 and "error" in refusal1
+        refusal2 = await _drain(inbox2)
+        assert refusal2["id"] == 5 and refusal2["error"]["code"] == -32002
+        assert backend._resource_subscriptions == {}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///denied.txt"},
+        }))
+        assert inbox1.empty() and inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_update_racing_the_grant_is_dropped_not_guessed(self) -> None:
+        """Routing grants land on the RESPONSE, so an update arriving while
+        the grant is still in flight fails closed (dropped) rather than being
+        delivered on a subscription the server has not yet accepted."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_resource_update_for_unsubscribed_uri_keeps_deny_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A URI nobody subscribed to must not be guessed at: the update is
+        dropped and the unattributable-notification hazard is recorded."""
+        recorded: list[str] = []
+
+        def _capture(name: str, code: str, identity: Any) -> bool:
+            recorded.append(code)
+            return True
+
+        monkeypatch.setattr(backend_mod.hazards, "record_observed", _capture)
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///other.txt"},
+        }))
+        assert inbox1.empty() and inbox2.empty()
+        assert recorded == [backend_mod.hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION]
+
+    @pytest.mark.asyncio
+    async def test_resource_update_is_never_routed_by_related_request_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The URI arm is TERMINAL: a server-supplied ``_meta.relatedRequestId``
+        on a resources/updated must not hand a co-tenant a URI only another
+        tenant ever named. With no subscriber for the URI the update is
+        dropped and the hazard recorded, even though the relatedRequestId
+        resolves to a live pending request."""
+        recorded: list[str] = []
+
+        def _capture(name: str, code: str, identity: Any) -> bool:
+            recorded.append(code)
+            return True
+
+        monkeypatch.setattr(backend_mod.hazards, "record_observed", _capture)
+        backend = _make_backend()
+        inbox_v = await backend.attach_stub("victim")
+        inbox_a = await backend.attach_stub("attacker-adjacent")
+        # The victim subscribes (granted), then unsubscribes (confirmed) —
+        # the table is empty again.
+        await backend.forward_from_stub("victim", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///victim-private.txt"},
+        })
+        await _settle_lease(backend)
+        await backend.forward_from_stub("victim", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///victim-private.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox_v))["id"] == 1
+        assert (await _drain(inbox_v))["id"] == 2
+        assert backend._resource_subscriptions == {}
+        # A co-tenant holds an ordinary in-flight tools/call.
+        await backend.forward_from_stub("attacker-adjacent", {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "t"},
+        })
+        fid = next(
+            f for f, p in backend._pending_requests.items()
+            if p.stub_uuid == "attacker-adjacent"
+        )
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///victim-private.txt",
+                       "_meta": {"relatedRequestId": fid}},
+        }))
+        assert inbox_v.empty() and inbox_a.empty()
+        assert recorded == [backend_mod.hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION]
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_stops_resource_update_delivery(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        # The last subscriber's unsubscribe releases the upstream lease …
+        upstream = [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        assert len(upstream) == 1
+        # … and routing drops the stub once the server CONFIRMS the release.
+        assert backend._resource_subscriptions != {}
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {}
+        assert (await _drain(inbox1))["id"] == 1
+        assert (await _drain(inbox1))["id"] == 2
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_release_response_keeps_replacement_grant(self) -> None:
+        """A server may answer concurrent requests out of order, so a
+        replacement subscribe is never forwarded BESIDE an in-flight
+        release — the reverse answer order would leave routing keeping a
+        subscriber whose lease the release then destroyed upstream. The
+        replacement PARKS; the confirmed release drains it into a fresh
+        forwarded subscribe, serialized strictly after the release, and its
+        grant routes the replacement."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        # Parked, not forwarded: exactly one subscribe has gone upstream.
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1
+        assert inbox2.empty()
+        # The release confirms; the drain forwards the fresh subscribe.
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 2
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 2
+        assert inbox2.empty()  # still fail-closed until the grant
+        await _settle_lease(backend)  # the fresh subscribe is granted
+        assert (await _drain(inbox2))["id"] == 3
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_failed_final_unsubscribe_keeps_routing(self) -> None:
+        """A refused unsubscribe means the server RETAINED the subscription:
+        routing must keep the stub, or live updates are silently discarded
+        while the client believes (from the error it received) that it is
+        still subscribed."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend, error={"code": -32000, "message": "busy"})
+        assert (await _drain(inbox1))["id"] == 1
+        refusal = await _drain(inbox1)
+        assert refusal["id"] == 2 and "error" in refusal
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s1"}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_prunes_only_the_unsubscribing_stub(self) -> None:
+        """One tenant's unsubscribe must not silence a co-tenant: the routing
+        entry survives AND the upstream lease is kept — the non-final
+        unsubscribe is answered locally instead of being forwarded to the one
+        shared server-side subscription."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        assert (await _drain(inbox2))["result"] == {}
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        # Answered locally; no unsubscribe reached the backend.
+        assert (await _drain(inbox1)) == {"jsonrpc": "2.0", "id": 2, "result": {}}
+        assert not [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///shared.txt"},
+        }))
+        assert inbox1.empty()
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_stray_unsubscribe_never_tears_down_a_co_tenants_lease(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        # s2 never subscribed; its unsubscribe must not reach the server.
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        assert (await _drain(inbox2))["result"] == {}
+        assert not [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///shared.txt"},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_identity_server_gets_every_subscribe_and_grants_per_stub(self) -> None:
+        """An identity-capable server authorizes per caller, so EVERY
+        subscribe is forwarded (no local coalescing) and each stub routes only
+        on its OWN grant — one stub's refusal neither grants it nor disturbs a
+        co-tenant's accepted subscription."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        for stub, req_id in (("s1", 1), ("s2", 2)):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": req_id, "method": "resources/subscribe",
+                "params": {"uri": "file:///acl.txt"},
+            })
+        upstream = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(upstream) == 2
+        fids = {p.stub_uuid: f for f, p in backend._pending_requests.items()}
+        await backend._route_backend_line(_line({"id": fids["s1"], "result": {}}))
+        await backend._route_backend_line(_line({
+            "id": fids["s2"], "error": {"code": -32002, "message": "denied"},
+        }))
+        assert (await _drain(inbox1))["id"] == 1
+        refusal = await _drain(inbox2)
+        assert refusal["id"] == 2 and "error" in refusal
+        assert backend._resource_subscriptions == {"file:///acl.txt": {"s1"}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///acl.txt"},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/resources/updated"
+        assert inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_stub_detach_drops_its_subscriptions(self) -> None:
+        """A departed stub's routing entries go with it, and — as the URI's
+        last subscriber — the upstream subscription is released so the server
+        does not keep firing updates nobody will receive."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await backend.detach_stub("s1")
+        assert backend._resource_subscriptions == {}
+        release = [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        assert len(release) == 1
+        assert release[0]["params"] == {"uri": "file:///watched.txt"}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_detach_keeps_upstream_lease_while_a_subscriber_remains(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        assert (await _drain(inbox2))["result"] == {}
+        await backend.detach_stub("s1")
+        assert not [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///shared.txt"},
+        }))
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_detach_of_inflight_forwarder_promotes_the_parked_rider(self) -> None:
+        """When the stub whose subscribe is awaiting the server detaches, the
+        first parked rider inherits the pending response: the grant settles
+        the rider (with the server's verdict under the rider's id) instead of
+        being dropped as unroutable and wedging the lease."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        for stub, req_id in (("s1", 1), ("s2", 9)):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": req_id, "method": "resources/subscribe",
+                "params": {"uri": "file:///shared.txt"},
+            })
+        await backend.detach_stub("s1")
+        await _settle_lease(backend)
+        verdict = await _drain(inbox2)
+        assert verdict["id"] == 9 and verdict["result"] == {}
+        assert backend._resource_subscriptions == {"file:///shared.txt": {"s2"}}
+
+    @pytest.mark.asyncio
+    async def test_orphaned_grant_is_released_not_leaked(self) -> None:
+        """A grant whose forwarder detached with no rider is a lease nobody
+        wants: on the server's success it is released on the spot rather than
+        left firing updates into the deny-by-default drop."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.detach_stub("s1")
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {}
+        release = [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        assert len(release) == 1
+
+    @pytest.mark.asyncio
+    async def test_respawn_replay_restores_routing_on_grant(self) -> None:
+        """Transparent respawn replays a stub's subscriptions onto the fresh
+        backend: routing returns once the server grants the replayed
+        subscribe, so a live subscription survives the backend swap."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.replay_resource_subscriptions("s1", ["file:///watched.txt"])
+        replays = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(replays) == 1
+        # No grant yet: fail-closed until the server accepts.
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert inbox1.empty()
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s1"}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_rider_after_retract_settles_on_the_orphan_grant(self) -> None:
+        """Subscribe, unsubscribe before the grant, then a co-tenant
+        subscribes before the response: the orphaned grant's verdict settles
+        the parked rider (granted and answered) instead of dropping its
+        parking and leaving the subscribe hung forever."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        # The retract answers BOTH of s1's ids: the outstanding subscribe
+        # with a cancellation error, the unsubscribe with success.
+        cancelled = await _drain(inbox1)
+        assert cancelled["id"] == 1 and "error" in cancelled
+        assert (await _drain(inbox1))["id"] == 2  # local retract reply
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        assert inbox2.empty()  # parked, not answered early
+        await _settle_lease(backend)
+        assert await _drain(inbox2) == {"jsonrpc": "2.0", "id": 3, "result": {}}
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_replay_carries_caller_identity_on_identity_server(self) -> None:
+        """On an identity-capable server the respawn replay is adjudicated as
+        the same caller that held the original subscription: the replayed
+        subscribe carries the connection's caller block."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        await backend.attach_stub("s1")
+        await backend.replay_resource_subscriptions(
+            "s1", ["file:///acl.txt"],
+            caller=CallerContext(session_key="dashboard:abc"),
+        )
+        replays = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(replays) == 1
+        assert CALLER_META_KEY in replays[0]["params"]["_meta"]
+
+    @pytest.mark.asyncio
+    async def test_replay_skipped_on_identity_server_without_caller(self) -> None:
+        """Without a caller to inject, a bare replay would be adjudicated as
+        the connection rather than the original caller — so it is skipped
+        entirely (fail-closed) instead of risking a wrong-principal grant or
+        refusal."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        await backend.attach_stub("s1")
+        await backend.replay_resource_subscriptions("s1", ["file:///acl.txt"])
+        assert not [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert backend._pending_requests == {}
+
+    @pytest.mark.asyncio
+    async def test_replay_grant_for_a_detached_stub_releases_the_lease(self) -> None:
+        """Detach cannot see a sentinel-owned replay pending, so the response
+        arm must catch the mid-replay disconnect itself: a grant for a stub
+        that is no longer attached is released, never recorded against the
+        dead UUID (which would pin the lease to a stub that cannot drain it)."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.replay_resource_subscriptions("s1", ["file:///watched.txt"])
+        await backend.detach_stub("s1")
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {}
+        release = [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        assert len(release) == 1
+
+    @pytest.mark.asyncio
+    async def test_refused_orphan_release_suppresses_the_false_hazard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Final unsubscribe in flight, the stub disconnects, and the server
+        REFUSES the release: the retained subscription's updates are a
+        consequence of the broker's own lease handling, so they are dropped
+        without recording a hazard — while an update for a genuinely unknown
+        URI still records one."""
+        recorded: list[str] = []
+
+        def _capture(name: str, code: str, identity: Any) -> bool:
+            recorded.append(code)
+            return True
+
+        monkeypatch.setattr(backend_mod.hazards, "record_observed", _capture)
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        # A third tenant keeps refcount above the single-client threshold
+        # after s1 departs, so the control hazard below is recordable.
+        await backend.attach_stub("s3")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.detach_stub("s1")
+        # The server refuses the (now sentinel-owned) release.
+        await _settle_lease(backend, error={"code": -32000, "message": "busy"})
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert recorded == []
+        # A genuinely unknown URI still records the hazard.
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///never-named.txt"},
+        }))
+        assert recorded == [backend_mod.hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION]
+
+    @pytest.mark.asyncio
+    async def test_repeated_same_uri_subscribes_count_toward_the_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rider parkings are counted individually, duplicates included:
+        repeating one URI's subscribe while the grant is in flight must not
+        grow the rider list unboundedly under a slow server."""
+        monkeypatch.setattr(backend_mod, "_RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB", 3)
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        for req_id in (1, 2, 3, 4):
+            await backend.forward_from_stub("s1", {
+                "jsonrpc": "2.0", "id": req_id, "method": "resources/subscribe",
+                "params": {"uri": "file:///same.txt"},
+            })
+        # 1st forwarded (in flight), 2nd and 3rd parked, 4th refused at cap.
+        refusal = await _drain(inbox1)
+        assert refusal["id"] == 4 and "error" in refusal
+        assert len(backend._lease_pending_riders["file:///same.txt"]) == 2
+        upstream = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(upstream) == 1
+
+    @pytest.mark.asyncio
+    async def test_retracted_inflight_subscribe_ids_are_answered_not_hung(self) -> None:
+        """Subscribe (id 1), subscribe again (id 2, parked), then unsubscribe
+        (id 3) before the grant arrives: BOTH outstanding subscribe ids
+        receive a cancellation error and the unsubscribe receives success —
+        no id is silently dropped from the tables to hang in the client's id
+        table forever."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        for req_id in (1, 2):
+            await backend.forward_from_stub("s1", {
+                "jsonrpc": "2.0", "id": req_id, "method": "resources/subscribe",
+                "params": {"uri": "file:///watched.txt"},
+            })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        replies = {}
+        while not inbox1.empty():
+            reply = await _drain(inbox1)
+            replies[reply["id"]] = reply
+        assert set(replies) == {1, 2, 3}
+        assert "error" in replies[1] and "error" in replies[2]
+        assert replies[3]["result"] == {}
+        # The orphaned grant settles via the sentinel: on success it is
+        # released rather than granted to the departed interest.
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {}
+        release = [f for f in _frames(backend) if f.get("method") == "resources/unsubscribe"]
+        assert len(release) == 1
+
+    @pytest.mark.asyncio
+    async def test_same_stub_resubscribe_during_pending_unsubscribe_is_refused(self) -> None:
+        """The releasing stub and the re-subscriber share one uuid, so a late
+        out-of-order unsubscribe confirmation would erase the fresh grant.
+        The resubscribe is refused locally while the unsubscribe is in
+        flight; once it settles, a fresh subscribe succeeds normally."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        refusal = await _drain(inbox1)
+        assert refusal["id"] == 3 and "error" in refusal
+        await _settle_lease(backend)  # release confirms
+        assert (await _drain(inbox1))["id"] == 2
+        assert backend._resource_subscriptions == {}
+        # A fresh subscribe after settlement succeeds normally.
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 4
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s1"}}
+
+    @pytest.mark.asyncio
+    async def test_subscription_cap_is_refused_locally(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cap precedes EVERY subscribe branch — including joining a
+        co-tenant's confirmed lease — and counts in-flight grants, so a stub
+        can neither queue unbounded subscribes nor keep joining URIs."""
+        monkeypatch.setattr(backend_mod, "_RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB", 1)
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///one.txt"},
+        })
+        # In-flight grant already counts: a second subscribe is refused.
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///two.txt"},
+        })
+        refusal = await _drain(inbox1)
+        assert refusal["id"] == 2 and "error" in refusal
+        upstream = [f for f in _frames(backend) if f.get("method") == "resources/subscribe"]
+        assert len(upstream) == 1
+        # A capped stub cannot join a co-tenant's confirmed lease either.
+        await _settle_lease(backend)
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///one.txt"},
+        })
+        assert (await _drain(inbox2))["result"] == {}
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/subscribe",
+            "params": {"uri": "file:///one.txt"},
+        })
+        capped = await _drain(inbox2)
+        assert capped["id"] == 4 and "error" in capped
+
+    @pytest.mark.asyncio
+    async def test_full_inbox_detach_during_fanout_does_not_break_delivery(self) -> None:
+        """Fan-out iterates a COPY of the target set: a full inbox detaches
+        its stub mid-fan-out (mutating the table) and the surviving subscriber
+        still receives the update."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        await _settle_lease(backend)
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///shared.txt"},
+        })
+        assert (await _drain(inbox2))["result"] == {}
+        while not inbox1.full():
+            inbox1.put_nowait(b"{}")
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///shared.txt"},
+        }))
+        assert "s1" not in backend._stub_inboxes
+        assert (await _drain(inbox2))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("params", [None, "not-a-dict", {}, {"uri": 7}, {"uri": ""}])
+    async def test_malformed_subscribe_params_record_nothing(self, params: Any) -> None:
+        """A subscribe without a usable ``params.uri`` string leaves the table
+        untouched: the backend will reject the request anyway, and a garbage
+        key could never match an incoming update's URI."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        msg: dict[str, Any] = {"jsonrpc": "2.0", "id": 1, "method": "resources/subscribe"}
+        if params is not None:
+            msg["params"] = params
+        await backend.forward_from_stub("s1", msg)
+        assert backend._resource_subscriptions == {}
+        assert backend._lease_awaiting_grant == set()
+
+    @pytest.mark.asyncio
+    async def test_malformed_resource_update_is_dropped_not_broadcast(self) -> None:
+        """An update without a usable URI cannot be attributed and must fall to
+        the deny-by-default drop even while subscriptions exist."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox1))["id"] == 1
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": 7},
+        }))
+        await backend._route_backend_line(
+            _line({"method": "notifications/resources/updated"}))
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
     async def test_server_request_routed_via_related_request_id(self) -> None:
         backend = _make_backend()
         inbox1 = await backend.attach_stub("s1")
@@ -1140,6 +2006,1488 @@ class TestRouteBackendLine:
         inbox = await backend.attach_stub("s1")
         await backend._route_backend_line(_line({"jsonrpc": "2.0"}))
         assert inbox.empty()
+
+
+# --- subscription response hardening ----------------------------------------
+
+
+def _fill_inbox(inbox: "asyncio.Queue[bytes]") -> None:
+    """Fill a stub's inbox to its cap so the NEXT delivery into it trips
+    the slow-stub guard and detaches the stub mid-reply."""
+    while True:
+        try:
+            inbox.put_nowait(b"x")
+        except asyncio.QueueFull:
+            return
+
+
+class TestSubscriptionResponseHardening:
+    """Response-path invariants for the lease broker: a malformed response
+    is never a grant, only one final release is in flight per URI, and every
+    routing / pending-owner transition is committed BEFORE a reply is
+    awaited (a reply can detach its stub, which prunes the very tables a
+    late commit would then re-decide)."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_subscribe_response_grants_nothing(self) -> None:
+        """A response with neither ``result`` nor ``error`` is not a grant:
+        routing on it would start delivering updates on a verdict the server
+        never settled. The forwarder still receives the raw frame; the
+        parked rider is refused, not granted."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        fid = next(f for f, p in backend._pending_requests.items() if p.resource_uri)
+        await backend._route_backend_line(_line({"id": fid}))  # malformed
+        assert backend._resource_subscriptions == {}
+        # An UNSETTLED verdict proves nothing: the subscribe may have taken,
+        # so the possibly-live lease is released rather than stranded
+        # upstream firing updates that get charged to the server as hazards.
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert (await _drain(inbox1))["id"] == 1  # raw frame, no grant
+        refusal = await _drain(inbox2)
+        assert refusal["id"] == 2 and "error" in refusal
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert inbox1.empty() and inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_malformed_replay_response_grants_nothing(self) -> None:
+        """The sentinel-owned respawn replay applies the same success gate:
+        a frame with neither ``result`` nor ``error`` grants no routing —
+        and the possibly-live lease is released, not stranded."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.replay_resource_subscriptions("s1", ["file:///watched.txt"])
+        fid = next(f for f, p in backend._pending_requests.items() if p.resource_uri)
+        await backend._route_backend_line(_line({"id": fid}))  # malformed
+        assert backend._resource_subscriptions == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+
+    @pytest.mark.asyncio
+    async def test_refused_subscribe_response_does_not_release(self) -> None:
+        """A settled REFUSAL proves the server holds no lease, so no
+        gateway-originated release is issued for it."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend, error={"code": -32000, "message": "no"})
+        await _drain(inbox1)
+        assert backend._resource_subscriptions == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert releases == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_unsubscribe_response_keeps_routing(self) -> None:
+        """A malformed release response is treated as a refusal: the entry
+        is kept (fail closed) instead of assuming the server released."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        fid = next(f for f, p in backend._pending_requests.items() if p.resource_uri)
+        await backend._route_backend_line(_line({"id": fid}))  # malformed
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s1"}}
+        assert "file:///watched.txt" not in backend._lease_awaiting_release
+
+    @pytest.mark.asyncio
+    async def test_repeat_final_unsubscribe_parks_behind_inflight_release(
+        self,
+    ) -> None:
+        """A second final unsubscribe while the first's release is in flight
+        is PARKED, not forwarded: forwarding it would race two responses
+        against one shared awaiting-release flag, and a refusal+success pair
+        would leave local routing granting a lease the server has released.
+        Every waiter settles on the one in-flight release's verdict."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        assert inbox1.empty()  # parked, not answered early
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(upstream) == 1
+        # The one in-flight release settles as a refusal: the server kept
+        # the lease, routing keeps the stub, the waiter is told the truth,
+        # and the flag is down so a later retry can release cleanly.
+        await _settle_lease(backend, error={"code": -32000, "message": "no"})
+        # The waiter's local reply lands first; the forwarder's raw server
+        # frame is delivered afterwards by the routing path.
+        waiter_reply = await _drain(inbox1)
+        assert waiter_reply["id"] == 3 and "error" in waiter_reply
+        raw = await _drain(inbox1)
+        assert raw["id"] == 2 and "error" in raw
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s1"}}
+        assert "file:///watched.txt" not in backend._lease_awaiting_release
+        assert backend._lease_release_waiters == {}
+
+    @pytest.mark.asyncio
+    async def test_release_waiter_settles_on_success(self) -> None:
+        """A parked final unsubscribe is answered with success — and its
+        stub dropped from routing — when the in-flight release confirms."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)  # release confirmed
+        assert await _drain(inbox1) == {"jsonrpc": "2.0", "id": 3, "result": {}}
+        raw = await _drain(inbox1)
+        assert raw["id"] == 2 and "result" in raw
+        assert backend._resource_subscriptions == {}
+        assert backend._lease_release_waiters == {}
+
+    @pytest.mark.asyncio
+    async def test_cotenant_final_unsubscribe_survives_releasers_detach(
+        self,
+    ) -> None:
+        """A co-tenant subscribing while another stub's final release is in
+        flight parks as a replacement; the releaser detaching (its release
+        becomes sentinel-owned) must not strand that parking. The settled
+        release drains it into a fresh grant, and the co-tenant's own later
+        final unsubscribe releases cleanly."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # final release forwarded, in flight
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # parks as a replacement behind the release
+        assert backend._lease_replacement_subscribes == {
+            "file:///watched.txt": [("s2", 3)]}
+        await backend.detach_stub("s1")  # release becomes sentinel-owned
+        assert backend._lease_replacement_subscribes == {
+            "file:///watched.txt": [("s2", 3)]}  # parking survives
+        await _settle_lease(backend)  # the release confirms; drain forwards
+        await _settle_lease(backend)  # the fresh subscribe is granted
+        assert (await _drain(inbox2))["id"] == 3
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # s2's own final release forwards normally
+        await _settle_lease(backend)
+        assert (await _drain(inbox2))["id"] == 4
+        assert backend._resource_subscriptions == {}
+        assert backend._lease_release_waiters == {}
+        assert backend._lease_replacement_subscribes == {}
+
+    @pytest.mark.asyncio
+    async def test_detached_waiter_is_pruned_not_replied(self) -> None:
+        """A waiter that detaches while parked expects no further reply and
+        must not linger in the waiter table."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # parked
+        await backend.detach_stub("s1")
+        assert backend._lease_release_waiters == {}
+        await _settle_lease(backend)  # sentinel-owned release settles cleanly
+        assert backend._resource_subscriptions == {}
+
+    @pytest.mark.asyncio
+    async def test_sentinel_grant_commits_routing_before_rider_replies(
+        self,
+    ) -> None:
+        """A rider whose grant reply detaches it (full inbox) must not be
+        reinserted into the routing table by a commit made after the
+        replies — updates would then route at a stub that is gone."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        full_inbox = await backend.attach_stub("full")
+        ok_inbox = await backend.attach_stub("ok")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # retract: the in-flight grant is now sentinel-owned
+        cancelled = await _drain(inbox1)
+        assert cancelled["id"] == 1 and "error" in cancelled
+        assert (await _drain(inbox1))["id"] == 2  # local retract success
+        await backend.forward_from_stub("full", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("ok", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        _fill_inbox(full_inbox)
+        await _settle_lease(backend)  # grant arrives under the sentinel
+        assert "full" not in backend._stub_inboxes  # detached mid-reply
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"ok"}}
+        assert (await _drain(ok_inbox))["id"] == 4
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_grant_commits_every_rider_before_replies(self) -> None:
+        """The coalesced grant commits the forwarder AND every rider before
+        any reply: a mid-loop detach that empties the entry would otherwise
+        delete it from the table, stranding later riders in a stale set
+        alias that no longer routes."""
+        backend = _make_backend()
+        s1_inbox = await backend.attach_stub("s1")
+        s2_inbox = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # s1 rides behind its own grant
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        _fill_inbox(s1_inbox)
+        await _settle_lease(backend)  # s1's rider reply detaches s1
+        assert "s1" not in backend._stub_inboxes
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        assert await _drain(s2_inbox) == {"jsonrpc": "2.0", "id": 3, "result": {}}
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert (await _drain(s2_inbox))["method"] == "notifications/resources/updated"
+
+    @pytest.mark.asyncio
+    async def test_retract_commits_promotion_before_replies(self) -> None:
+        """The forwarder's retract reply can detach the retracting stub
+        (full inbox). The surviving rider's promotion must already be
+        committed, or detach's own promotion is overwritten with the
+        sentinel and that rider's subscribe hangs unanswered forever."""
+        backend = _make_backend()
+        s1_inbox = await backend.attach_stub("s1")
+        s2_inbox = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # rider behind s1's in-flight grant
+        _fill_inbox(s1_inbox)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # retract; the error reply into the full inbox detaches s1
+        assert "s1" not in backend._stub_inboxes
+        p = next(p for p in backend._pending_requests.values() if p.resource_uri)
+        assert p.stub_uuid == "s2" and p.original_id == 2
+        await _settle_lease(backend)
+        granted_reply = await _drain(s2_inbox)
+        assert granted_reply["id"] == 2 and "result" in granted_reply
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+
+    @pytest.mark.asyncio
+    async def test_orphan_drop_log_omits_the_uri(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Resource URIs can carry tokens or presigned query parameters, so
+        the orphaned-lease drop line must not persist them in the log."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        secret_uri = "https://bucket/object?sig=TOPSECRET"
+        backend._orphaned_leases.add(secret_uri)
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.mcp_gateway.backend"):
+            await backend._route_backend_line(_line({
+                "method": "notifications/resources/updated",
+                "params": {"uri": secret_uri},
+            }))
+        assert "orphaned lease" in caplog.text
+        assert "TOPSECRET" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_replay_and_release_failure_logs_omit_the_uri(
+        self, caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The replay-failure and release-failure lines must not persist
+        the URI either."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        secret_uri = "https://bucket/object?sig=TOPSECRET"
+        monkeypatch.setattr(
+            backend_mod, "_write_json_line",
+            AsyncMock(side_effect=RuntimeError("pipe gone")),
+        )
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.mcp_gateway.backend"):
+            with pytest.raises(backend_mod.BackendGone):
+                await backend.replay_resource_subscriptions("s1", [secret_uri])
+            await backend._release_upstream_subscriptions([secret_uri])
+        assert "could not replay" in caplog.text
+        assert "could not release" in caplog.text
+        assert "TOPSECRET" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refused_release_joins_replacement_locally(self) -> None:
+        """When the in-flight release is REFUSED the server retained the
+        lease, so a parked replacement joins the still-live entry locally —
+        no second upstream subscribe."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # parks as replacement
+        await _settle_lease(backend, error={"code": -32000, "message": "no"})
+        assert await _drain(inbox2) == {"jsonrpc": "2.0", "id": 3, "result": {}}
+        assert backend._resource_subscriptions == {
+            "file:///watched.txt": {"s1", "s2"}}
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1
+        assert backend._lease_replacement_subscribes == {}
+
+    @pytest.mark.asyncio
+    async def test_detach_never_promotes_the_departing_stubs_own_rider(
+        self,
+    ) -> None:
+        """A departing stub's own parked duplicate must not be promoted into
+        its in-flight subscribe: the grant would record a phantom subscriber
+        that blocks the release and swallows updates. The rider prune runs
+        before the pending scan, so the pending converts to the sentinel and
+        the granted-but-unwanted lease is released."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # s1's own duplicate parks as a rider
+        await backend.detach_stub("s1")
+        p = next(p for p in backend._pending_requests.values() if p.resource_uri)
+        assert p.stub_uuid == backend_mod._RELEASE_STUB_SENTINEL
+        assert backend._lease_pending_riders == {}
+        await _settle_lease(backend)  # grant lands under the sentinel
+        # Nobody wants the lease: routing stays empty and it is released.
+        assert backend._resource_subscriptions == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+
+    @pytest.mark.asyncio
+    async def test_replacement_parks_behind_a_gateway_originated_release(
+        self,
+    ) -> None:
+        """A detach-orphaned release is a release like any other: it must
+        mark the URI in-flight so a replacement subscribe parks behind it
+        instead of forwarding beside it and racing its answer order (the
+        round-11 guard covered only stub-forwarded releases)."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        # Last subscriber departs WITHOUT unsubscribing: the gateway
+        # originates the release itself.
+        await backend.detach_stub("s1")
+        assert "file:///watched.txt" in backend._lease_awaiting_release
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # parks — not forwarded beside the in-flight release
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1
+        await _settle_lease(backend)  # the gateway release confirms
+        assert "file:///watched.txt" not in backend._lease_awaiting_release
+        await _settle_lease(backend)  # the drained fresh subscribe is granted
+        assert (await _drain(inbox2))["id"] == 2
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+
+    @pytest.mark.asyncio
+    async def test_concurrent_replays_coalesce_on_one_lease(self) -> None:
+        """Two identity-less replays of one URI must not put two grants in
+        flight: the server holds ONE subscription, so a later final
+        unsubscribe would release it while the other stub stayed routed.
+        The second replay rides the first's sentinel grant, and a final
+        unsubscribe afterwards only leaves the table (lease intact)."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.replay_resource_subscriptions("s1", ["file:///watched.txt"])
+        await backend.replay_resource_subscriptions("s2", ["file:///watched.txt"])
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1  # second replay rides, never forwards
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {
+            "file:///watched.txt": {"s1", "s2"}}
+        # s1 leaves: with a co-tenant still routed this must NOT release
+        # the server's single subscription.
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        assert (await _drain(inbox1))["id"] == 1
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert releases == []
+
+    @pytest.mark.asyncio
+    async def test_replay_joins_a_held_lease_locally(self) -> None:
+        """A replay for a URI another stub already holds joins the routing
+        table locally — no duplicate upstream subscribe."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.replay_resource_subscriptions("s2", ["file:///watched.txt"])
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1
+        assert backend._resource_subscriptions == {
+            "file:///watched.txt": {"s1", "s2"}}
+
+    @pytest.mark.asyncio
+    async def test_replay_parks_behind_an_inflight_release(self) -> None:
+        """A replay racing an in-flight release parks as a replacement and
+        is granted on the fresh sentinel subscribe after the release
+        settles — never forwarded beside it."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # final release in flight
+        await backend.replay_resource_subscriptions("s2", ["file:///watched.txt"])
+        assert backend._lease_replacement_subscribes == {
+            "file:///watched.txt": [("s2", None)]}
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1
+        await _settle_lease(backend)  # release confirms; drain forwards
+        await _settle_lease(backend)  # fresh sentinel subscribe granted
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+
+    @pytest.mark.asyncio
+    async def test_maintenance_pendings_carry_a_start_time(self) -> None:
+        """Gateway-originated release and replay pendings must carry
+        ``t_start_ms``: the heartbeat wedge scan computes each pending's age
+        from it, and a zero start time reads as host-uptime old — past the
+        hard ceiling it recycles a healthy backend as wedged."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend._release_upstream_subscriptions(["file:///a.txt"])
+        await backend.replay_resource_subscriptions("s1", ["file:///b.txt"])
+        maintenance = [
+            p for p in backend._pending_requests.values() if p.resource_uri
+        ]
+        assert len(maintenance) == 2
+        assert all(p.t_start_ms > 0 for p in maintenance)
+
+    @pytest.mark.asyncio
+    async def test_idless_subscription_frames_are_swallowed(self) -> None:
+        """An id-less subscribe has no response that could ever settle the
+        lease transition it would start: it must neither mutate lease state
+        (later subscribers would park forever) nor be forwarded (a
+        server-side subscription the broker never routes). A later valid
+        subscriber proceeds normally."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # id-less
+        assert backend._lease_awaiting_grant == set()
+        assert _frames(backend) == []
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # id-less unsubscribe swallowed too
+        assert _frames(backend) == []
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        assert (await _drain(inbox2))["id"] == 1
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_release_waiters_count_toward_the_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repeated final unsubscribes under a slow server park as waiters;
+        the per-stub cap bounds that list exactly as it bounds riders."""
+        monkeypatch.setattr(
+            backend_mod, "_RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB", 2)
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        for req_id in (2, 3, 4, 5):
+            await backend.forward_from_stub("s1", {
+                "jsonrpc": "2.0", "id": req_id,
+                "method": "resources/unsubscribe",
+                "params": {"uri": "file:///watched.txt"},
+            })
+        # id 2 forwarded (release in flight), 3 and 4 parked, 5 refused.
+        refusal = await _drain(inbox1)
+        assert refusal["id"] == 5 and "error" in refusal
+        assert len(backend._lease_release_waiters["file:///watched.txt"]) == 2
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(upstream) == 1
+
+    @pytest.mark.asyncio
+    async def test_orphaned_leases_are_bounded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The orphaned-lease set is bounded: past the cap an arbitrary
+        entry is evicted rather than growing the set for the backend's
+        lifetime (suppression is telemetry hygiene, not correctness)."""
+        monkeypatch.setattr(backend_mod, "_ORPHANED_LEASES_MAX", 2)
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        backend._orphaned_leases.update({"file:///old1", "file:///old2"})
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.detach_stub("s1")  # sentinel release forwarded
+        await _settle_lease(backend, error={"code": -32000, "message": "no"})
+        assert "file:///watched.txt" in backend._orphaned_leases
+        assert len(backend._orphaned_leases) == 2
+
+    @pytest.mark.asyncio
+    async def test_backend_death_settles_every_parked_lease_request(
+        self,
+    ) -> None:
+        """A rider, a release waiter, and a parked replacement each hold a
+        client id only a backend response would settle. When the backend
+        dies terminally, each must receive the synthetic backend-gone error
+        instead of hanging in the client's id table forever, and the lease
+        coordination state must clear (the routing table is kept for the
+        respawn replay)."""
+        backend = _make_backend()
+        rider_inbox = await backend.attach_stub("rider")
+        waiter_inbox = await backend.attach_stub("waiter")
+        repl_inbox = await backend.attach_stub("repl")
+        # A rider: parks behind rider's own in-flight grant on uri A.
+        await backend.forward_from_stub("rider", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///a.txt"},
+        })
+        await backend.forward_from_stub("rider", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///a.txt"},
+        })  # rider parking (rider, 2)
+        # A waiter + a replacement: waiter holds uri B, releases it, then
+        # repeats the unsubscribe (waiter parking) while repl subscribes
+        # (replacement parking).
+        await backend.forward_from_stub("waiter", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///b.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(waiter_inbox)
+        await backend.forward_from_stub("waiter", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///b.txt"},
+        })  # final release in flight
+        await backend.forward_from_stub("waiter", {
+            "jsonrpc": "2.0", "id": 5, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///b.txt"},
+        })  # waiter parking (waiter, 5)
+        await backend.forward_from_stub("repl", {
+            "jsonrpc": "2.0", "id": 6, "method": "resources/subscribe",
+            "params": {"uri": "file:///b.txt"},
+        })  # replacement parking (repl, 6)
+        await backend._broadcast_backend_gone("test teardown")
+        # Every parked id answered with the synthetic error.
+        rider_err = await _drain(rider_inbox)
+        assert rider_err["id"] in (1, 2) and "error" in rider_err
+        rider_err2 = await _drain(rider_inbox)
+        assert {rider_err["id"], rider_err2["id"]} == {1, 2}
+        assert "error" in rider_err2
+        waiter_errs = [await _drain(waiter_inbox), await _drain(waiter_inbox)]
+        assert {e["id"] for e in waiter_errs} == {4, 5}
+        assert all("error" in e for e in waiter_errs)
+        repl_err = await _drain(repl_inbox)
+        assert repl_err["id"] == 6 and "error" in repl_err
+        # Coordination state cleared; routing kept for the respawn replay.
+        assert backend._lease_pending_riders == {}
+        assert backend._lease_release_waiters == {}
+        assert backend._lease_replacement_subscribes == {}
+        assert backend._lease_awaiting_grant == set()
+        assert backend._lease_awaiting_release == set()
+        assert backend._resource_subscriptions == {"file:///b.txt": {"waiter"}}
+
+    @pytest.mark.asyncio
+    async def test_replay_write_failure_raises_not_swallows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A replay WRITE failure must surface as BackendGone: the
+        replacement's pipe is broken, and swallowing it would report a
+        successful respawn whose subscriptions are silently dark forever."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        monkeypatch.setattr(
+            backend_mod, "_write_json_line",
+            AsyncMock(side_effect=RuntimeError("pipe gone")),
+        )
+        with pytest.raises(backend_mod.BackendGone):
+            await backend.replay_resource_subscriptions(
+                "s1", ["file:///watched.txt"])
+        assert backend._lease_awaiting_grant == set()
+        assert all(
+            not p.resource_uri for p in backend._pending_requests.values())
+
+    @pytest.mark.asyncio
+    async def test_partial_replay_failure_scopes_earlier_pendings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the second replay write fails, the FIRST URI's already-sent
+        pending is scoped to release-on-grant: the respawn is reported
+        failed, so a late success must release its lease rather than pin it
+        to a stub the caller is tearing down."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        real_write = backend_mod._write_json_line
+        calls = {"n": 0}
+
+        async def write_second_fails(writer: Any, obj: Any) -> None:
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise RuntimeError("pipe gone")
+            await real_write(writer, obj)
+
+        monkeypatch.setattr(backend_mod, "_write_json_line", write_second_fails)
+        with pytest.raises(backend_mod.BackendGone):
+            await backend.replay_resource_subscriptions(
+                "s1", ["file:///a.txt", "file:///b.txt"])
+        # The first URI's pending survives but is scoped: no replay stub.
+        survivors = [
+            p for p in backend._pending_requests.values() if p.resource_uri
+        ]
+        assert len(survivors) == 1
+        assert not survivors[0].replay_stub
+        # Its late grant releases the lease instead of granting s1.
+        monkeypatch.setattr(backend_mod, "_write_json_line", real_write)
+        await _settle_lease(backend)
+        assert backend._resource_subscriptions == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+
+    @pytest.mark.asyncio
+    async def test_identity_detach_releases_as_the_grant_caller(self) -> None:
+        """On an identity-capable server a departing stub's subscription is
+        released AS the caller recorded at grant time — a bare unsubscribe
+        would be adjudicated as the connection, leaving the departed
+        caller's upstream subscription firing forever."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        assert backend._grant_callers == {
+            ("file:///watched.txt", "s1"): caller_a}
+        await backend.detach_stub("s1")
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+        assert backend._grant_callers == {}
+        assert backend._resource_subscriptions == {}
+
+    @pytest.mark.asyncio
+    async def test_identity_detach_skips_release_for_a_shared_caller(
+        self,
+    ) -> None:
+        """Two stubs claimed to one session hold ONE per-caller grant
+        upstream: the first stub's detach must NOT release it (the survivor
+        stays routed); the last sharer's detach releases it."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        for stub, req_id, inbox in (("s1", 1, inbox1), ("s2", 2, inbox2)):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": req_id,
+                "method": "resources/subscribe",
+                "params": {"uri": "file:///watched.txt"},
+            }, caller=caller_a)
+            await _settle_lease(backend)
+            await _drain(inbox)
+        await backend.detach_stub("s1")
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert releases == []  # survivor still consumes the shared grant
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        await backend.detach_stub("s2")
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1  # last sharer departs: released once
+        # ... and released AS the grant caller, not as a bare unsubscribe.
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+
+    @pytest.mark.asyncio
+    async def test_identity_unknown_grant_caller_orphans_not_bare_release(
+        self,
+    ) -> None:
+        """A routed identity grant with no recorded caller cannot be
+        released safely (a bare unsubscribe is the wrong principal): the
+        lease is knowingly retained and orphan-marked so its updates never
+        charge a hazard to a blameless server."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # no caller: grant recorded with no principal
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        assert backend._grant_callers == {}
+        await backend.detach_stub("s1")
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert releases == []
+        assert "file:///watched.txt" in backend._orphaned_leases
+
+    @pytest.mark.asyncio
+    async def test_replayed_identity_grant_records_the_replay_caller(
+        self,
+    ) -> None:
+        """A respawn-replayed identity grant is held by the replay's
+        principal: the grant caller is recorded so the stub's later detach
+        releases it as that caller instead of orphaning the lease."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.replay_resource_subscriptions(
+            "s1", ["file:///watched.txt"], caller=caller_a)
+        await _settle_lease(backend)
+        assert backend._grant_callers == {
+            ("file:///watched.txt", "s1"): caller_a}
+        await backend.detach_stub("s1")
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+        assert "file:///watched.txt" not in backend._orphaned_leases
+
+    @pytest.mark.asyncio
+    async def test_malformed_identity_grant_releases_as_the_caller(
+        self,
+    ) -> None:
+        """An identity subscribe answered with neither result nor error may
+        have taken upstream: recording nothing would strand a live
+        per-caller lease. The unsettled verdict releases it as the caller
+        that took it."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        fid = next(f for f, p in backend._pending_requests.items() if p.resource_uri)
+        await backend._route_backend_line(_line({"id": fid}))  # malformed
+        assert backend._resource_subscriptions == {}
+        assert backend._grant_callers == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+
+    @pytest.mark.asyncio
+    async def test_shared_caller_unsubscribe_settles_locally(self) -> None:
+        """Two stubs sharing one per-caller grant: either stub's explicit
+        unsubscribe must settle locally (drop only that stub) — forwarding
+        it would destroy the survivor's upstream subscription. The last
+        sharer's unsubscribe forwards and releases."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        for stub, req_id, inbox in (("s1", 1, inbox1), ("s2", 2, inbox2)):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": req_id,
+                "method": "resources/subscribe",
+                "params": {"uri": "file:///watched.txt"},
+            }, caller=caller_a)
+            await _settle_lease(backend)
+            await _drain(inbox)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        assert await _drain(inbox1) == {"jsonrpc": "2.0", "id": 3, "result": {}}
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert upstream == []  # settled locally, survivor keeps the lease
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        # Last sharer's unsubscribe forwards normally.
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(upstream) == 1
+        await _settle_lease(backend)
+        assert (await _drain(inbox2))["id"] == 4
+        assert backend._resource_subscriptions == {}
+        assert backend._grant_callers == {}
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_retracts_a_parked_replacement(self) -> None:
+        """A stub that parked a replacement subscribe and then unsubscribes
+        must not be resurrected by the release drain: the parking is
+        retracted (its subscribe id answered with a cancellation error) and
+        the settled release re-subscribes nobody."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # final release in flight
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 3, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # parks as replacement
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 4, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        })  # retracts the parking
+        retracted = await _drain(inbox2)
+        assert retracted["id"] == 3 and "error" in retracted
+        unsub_reply = await _drain(inbox2)
+        assert unsub_reply["id"] == 4 and "result" in unsub_reply
+        assert backend._lease_replacement_subscribes == {}
+        await _settle_lease(backend)  # the release confirms
+        # Nobody is re-subscribed: exactly one upstream subscribe ever.
+        upstream = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/subscribe"
+        ]
+        assert len(upstream) == 1
+        assert backend._resource_subscriptions == {}
+
+    @pytest.mark.asyncio
+    async def test_evict_stub_subscriptions_releases_as_grant_caller(
+        self,
+    ) -> None:
+        """A warm-pool claim rekeys a stub to a new session: the old
+        caller's grants are evicted and released AS the grant-time caller,
+        so the new owner never receives the old owner's resource-update
+        URIs. The stub stays attached (rekey, not detach)."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        evicted = await backend.evict_stub_subscriptions("s1")
+        assert evicted == 1
+        assert backend._resource_subscriptions == {}
+        assert backend._grant_callers == {}
+        assert "s1" in backend._stub_inboxes  # attached: rekey, not detach
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+        # Post-eviction: an update for the old URI routes to nobody.
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///watched.txt"},
+        }))
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_evict_stub_subscriptions_identityless_last_subscriber(
+        self,
+    ) -> None:
+        """Identity-less regime: eviction drops the stub from routing and
+        releases the shared lease only when it was the last subscriber."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        for stub, req_id, inbox in (("s1", 1, inbox1), ("s2", 2, inbox2)):
+            await backend.forward_from_stub(stub, {
+                "jsonrpc": "2.0", "id": req_id,
+                "method": "resources/subscribe",
+                "params": {"uri": "file:///watched.txt"},
+            })
+            if stub == "s1":
+                await _settle_lease(backend)
+            await _drain(inbox)
+        assert await backend.evict_stub_subscriptions("s1") == 1
+        assert backend._resource_subscriptions == {"file:///watched.txt": {"s2"}}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert releases == []  # co-tenant still subscribed: no release
+        assert await backend.evict_stub_subscriptions("s2") == 1
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1  # last subscriber evicted: released
+
+    @pytest.mark.asyncio
+    async def test_eviction_sentinelizes_inflight_unsubscribe(self) -> None:
+        """An unsubscribe sent under the OLD owner whose response arrives
+        AFTER the rekey must not deliver under the old request id into the
+        rekeyed stub's stream — the new owner may have already reused that
+        id for its own request. Eviction sentinelizes the pending (mirror
+        of ``detach_stub``): the response settles silently."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)  # release in flight at the rekey moment
+        pend = [
+            (fid, p) for fid, p in backend._pending_requests.items()
+            if p.method == "resources/unsubscribe" and p.stub_uuid == "s1"
+        ]
+        assert len(pend) == 1
+        fid, p = pend[0]
+        assert p.original_id == 2
+        await backend.evict_stub_subscriptions("s1")
+        assert p.stub_uuid == backend_mod._RELEASE_STUB_SENTINEL
+        assert p.original_id is None
+        # The unsubscribe response settles after the rekey: nothing may
+        # reach the rekeyed stub's stream under the old id.
+        await backend._route_backend_line(_line({
+            "jsonrpc": "2.0", "id": fid, "result": {},
+        }))
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_eviction_retracts_inflight_subscribe(self) -> None:
+        """A subscribe sent under the old owner whose grant arrives AFTER
+        the rekey must not route to the new owner: eviction retracts the
+        pending (id answered with a cancellation error) and the late grant
+        releases the lease as the old principal."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)  # grant in flight
+        assert await backend.evict_stub_subscriptions("s1") == 0
+        retracted = await _drain(inbox1)
+        assert retracted["id"] == 1 and "error" in retracted
+        await _settle_lease(backend)  # the late grant arrives
+        assert backend._resource_subscriptions == {}
+        assert backend._grant_callers == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+
+    @pytest.mark.asyncio
+    async def test_eviction_commits_routing_before_first_await(self) -> None:
+        """The claim path reassigns the owner then awaits the eviction: any
+        frame routed during those awaits must already see the stub gone
+        from the tables, so every removal commits before the first reply
+        or release is awaited."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///granted.txt"},
+        }, caller=caller_a)
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/subscribe",
+            "params": {"uri": "file:///inflight.txt"},
+        }, caller=caller_a)  # in flight: forces a retract-reply await
+        seen_at_first_await: list[dict] = []
+        real_reply = backend._reply_locally
+
+        async def spying_reply(*args: Any, **kwargs: Any) -> None:
+            if not seen_at_first_await:
+                seen_at_first_await.append(
+                    {u: set(s) for u, s in backend._resource_subscriptions.items()}
+                )
+            await real_reply(*args, **kwargs)
+
+        backend._reply_locally = spying_reply  # type: ignore[method-assign]
+        try:
+            await backend.evict_stub_subscriptions("s1")
+        finally:
+            backend._reply_locally = real_reply  # type: ignore[method-assign]
+        assert seen_at_first_await == [{}]  # routing already empty at await
+        assert backend._grant_callers == {}
+
+    @pytest.mark.asyncio
+    async def test_eviction_retracts_inflight_replay(self) -> None:
+        """A REPLAY in flight when the stub is rekeyed targets the stub by
+        its ``replay_stub`` back-reference, which the subscribe retraction
+        cannot see: eviction must scope it to release-on-grant, or the old
+        owner's replayed URI routes to (and its grant-caller record binds
+        to) the new owner."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        await backend.replay_resource_subscriptions("s1", ["file:///old.txt"])
+        assert any(
+            p.replay_stub == "s1" for p in backend._pending_requests.values()
+        )  # replay grant in flight
+        await backend.evict_stub_subscriptions("s1")
+        assert not any(
+            p.replay_stub == "s1" for p in backend._pending_requests.values()
+        )
+        await _settle_lease(backend)  # the late replay grant arrives
+        assert backend._resource_subscriptions == {}
+        assert backend._grant_callers == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1  # released, not routed to the new owner
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///old.txt"},
+        }))
+        assert inbox1.empty()  # nothing delivered to the rekeyed stub
+
+    @pytest.mark.asyncio
+    async def test_respawn_capture_includes_inflight_replay_uris(self) -> None:
+        """Routing commits only on the server's grant, so a replacement that
+        dies before its replay responses arrive holds those URIs in neither
+        the routing table nor anywhere the NEXT respawn's capture looked:
+        ``resource_subscription_uris`` must include in-flight replay URIs or
+        a second respawn goes permanently dark."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.replay_resource_subscriptions(
+            "s1", ["file:///pending.txt"])
+        # No grant yet: the routing table is empty, the replay is in flight.
+        assert backend._resource_subscriptions == {}
+        assert backend.resource_subscription_uris("s1") == [
+            "file:///pending.txt"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_respawn_capture_survives_backend_death(self) -> None:
+        """The backend-gone cleanup clears the pending table — previously
+        erasing an in-flight replay's only record, so a replacement dying
+        before its replay responses arrived left the NEXT respawn's capture
+        empty and the subscription permanently dark. Death now preserves the
+        replay-target URIs for the capture. A rekey-evicted replay
+        (``replay_stub`` scoped to ``""``) is correctly NOT preserved."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.replay_resource_subscriptions("s1", ["file:///live.txt"])
+        await backend.replay_resource_subscriptions("s2", ["file:///evicted.txt"])
+        await backend.evict_stub_subscriptions("s2")  # scopes s2's replay
+        await backend._broadcast_backend_gone("stdout EOF")
+        assert backend._pending_requests == {}
+        assert backend.resource_subscription_uris("s1") == ["file:///live.txt"]
+        assert backend.resource_subscription_uris("s2") == []
+
+    @pytest.mark.asyncio
+    async def test_eviction_clears_grants_without_caller_records(self) -> None:
+        """On an identity server the grant arm commits routing even when the
+        accepted subscribe carried no caller metadata (no ``_grant_callers``
+        record). An eviction keyed on the records alone would leave that
+        entry routed — the new owner would keep receiving the old owner's
+        URI. Eviction must walk the routing table: the callerless grant is
+        removed and orphan-marked (retained upstream, updates dropped), not
+        released as the wrong principal."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        backend.supports_caller_identity = True
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///keyless.txt"},
+        })  # no caller kwarg: grant will carry no _grant_callers record
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        assert backend._resource_subscriptions == {"file:///keyless.txt": {"s1"}}
+        assert backend._grant_callers == {}
+        evicted = await backend.evict_stub_subscriptions("s1")
+        assert evicted == 1
+        assert backend._resource_subscriptions == {}
+        assert "file:///keyless.txt" in backend._orphaned_leases
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert releases == []  # never released as the wrong principal
+        await backend._route_backend_line(_line({
+            "method": "notifications/resources/updated",
+            "params": {"uri": "file:///keyless.txt"},
+        }))
+        assert inbox1.empty()  # nothing routed to the rekeyed stub
+
+    @pytest.mark.asyncio
+    async def test_replay_stops_when_stub_rekeyed_mid_loop(self) -> None:
+        """A multi-URI replay awaits between writes; a claim landing
+        mid-loop evicts the pendings written so far, but the loop would
+        keep writing the REMAINING URIs under the old owner. The replay
+        must notice the rekey between writes and stop."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        real_write = backend_mod._write_json_line
+        calls: list[str] = []
+
+        async def rekeying_write(stdin: Any, msg: dict) -> None:
+            calls.append(msg["params"]["uri"])
+            await real_write(stdin, msg)
+            if len(calls) == 1:
+                # The claim lands while the first write's await is live.
+                await backend.evict_stub_subscriptions("s1")
+
+        backend_mod._write_json_line = rekeying_write
+        try:
+            await backend.replay_resource_subscriptions(
+                "s1", ["file:///a.txt", "file:///b.txt", "file:///c.txt"])
+        finally:
+            backend_mod._write_json_line = real_write
+        assert calls == ["file:///a.txt"]  # loop stopped after the rekey
+
+    @pytest.mark.asyncio
+    async def test_nonholder_unsubscribe_settles_locally(self) -> None:
+        """On an identity server a stub holding NO grant for the URI must
+        have its unsubscribe answered locally: the server adjudicates by
+        CALLER, so forwarding a non-holder's frame would remove a
+        same-caller HOLDER's live lease while the holder stayed locally
+        routed — updates silently stop."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///held.txt"},
+        }, caller=caller_a)
+        await _settle_lease(backend)
+        await _drain(inbox1)
+        # s2 (same caller) never subscribed, nothing outstanding — its
+        # unsubscribe must settle locally, not forward.
+        await backend.forward_from_stub("s2", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///held.txt"},
+        }, caller=caller_a)
+        reply = await _drain(inbox2)
+        assert reply["id"] == 2 and "error" not in reply
+        forwarded = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert forwarded == []  # holder's lease untouched upstream
+        assert backend._resource_subscriptions == {"file:///held.txt": {"s1"}}
+
+    @pytest.mark.asyncio
+    async def test_retracted_pendings_still_count_against_the_cap(self) -> None:
+        """Sentinelizing a retracted subscribe removes it from stub-keyed
+        accounting; without origin accounting a stub cycling
+        subscribe/unsubscribe against an unresponsive server slips every
+        cycle's pending out of its count and grows the table without
+        bound. Retained sentinels must count against the originator."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        before = backend._stub_subscription_count("s1")
+        for i in range(3):
+            await backend.forward_from_stub("s1", {
+                "jsonrpc": "2.0", "id": 100 + i,
+                "method": "resources/subscribe",
+                "params": {"uri": f"file:///cycle-{i}.txt"},
+            }, caller=caller_a)  # server never answers
+            await backend.forward_from_stub("s1", {
+                "jsonrpc": "2.0", "id": 200 + i,
+                "method": "resources/unsubscribe",
+                "params": {"uri": f"file:///cycle-{i}.txt"},
+            }, caller=caller_a)  # retract sentinelizes the pending
+        assert backend._stub_subscription_count("s1") == before + 3
+
+    @pytest.mark.asyncio
+    async def test_identity_detach_sentinelizes_inflight_subscribe(
+        self,
+    ) -> None:
+        """An identity stub detaching with a subscribe in flight must not
+        drop the pending: the late grant would strand the upstream lease
+        with nobody to release it. The pending converts to the sentinel and
+        the grant is released as the pending's caller."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)  # grant in flight
+        await backend.detach_stub("s1")
+        p = next(p for p in backend._pending_requests.values() if p.resource_uri)
+        assert p.stub_uuid == backend_mod._RELEASE_STUB_SENTINEL
+        await _settle_lease(backend)  # the late grant arrives
+        assert backend._resource_subscriptions == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+
+    @pytest.mark.asyncio
+    async def test_identity_unsubscribe_retracts_inflight_subscribe(
+        self,
+    ) -> None:
+        """An identity unsubscribe racing the stub's own in-flight subscribe
+        retracts it: the subscribe id is answered with a cancellation error,
+        the unsubscribe settles locally, and the out-of-order late grant
+        releases instead of recording routing for a stub that left."""
+        backend = _make_backend()
+        backend.supports_caller_identity = True
+        inbox1 = await backend.attach_stub("s1")
+        caller_a = CallerContext(session_key="dashboard:aaa")
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)  # grant in flight
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 2, "method": "resources/unsubscribe",
+            "params": {"uri": "file:///watched.txt"},
+        }, caller=caller_a)
+        cancelled = await _drain(inbox1)
+        assert cancelled["id"] == 1 and "error" in cancelled
+        assert await _drain(inbox1) == {"jsonrpc": "2.0", "id": 2, "result": {}}
+        unsubs = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert unsubs == []  # nothing granted: settled locally
+        await _settle_lease(backend)  # the out-of-order grant arrives late
+        assert backend._resource_subscriptions == {}
+        assert backend._grant_callers == {}
+        releases = [
+            f for f in _frames(backend)
+            if f.get("method") == "resources/unsubscribe"
+        ]
+        assert len(releases) == 1
+        assert CALLER_META_KEY in releases[0]["params"]["_meta"]
+
+    @pytest.mark.asyncio
+    async def test_overlong_uri_refused_before_any_table_stores_it(
+        self,
+    ) -> None:
+        """The per-stub cap bounds subscription COUNT, not bytes: an
+        overlong URI is refused locally before any table retains the key,
+        and the refusal does not echo the URI."""
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        huge = "file:///" + "x" * (backend_mod._RESOURCE_URI_MAX_LEN + 1)
+        await backend.forward_from_stub("s1", {
+            "jsonrpc": "2.0", "id": 1, "method": "resources/subscribe",
+            "params": {"uri": huge},
+        })
+        refusal = await _drain(inbox1)
+        assert refusal["id"] == 1 and "error" in refusal
+        assert huge not in json.dumps(refusal)
+        assert backend._resource_subscriptions == {}
+        assert backend._lease_awaiting_grant == set()
+        assert backend._lease_pending_riders == {}
+        assert all(
+            not p.resource_uri for p in backend._pending_requests.values())
+        assert _frames(backend) == []  # never forwarded either
 
 
 # --- run_stdout_pump --------------------------------------------------------

--- a/test/test_mcp_gateway_claim.py
+++ b/test/test_mcp_gateway_claim.py
@@ -230,7 +230,7 @@ async def test_claim_retargets_live_connection(monkeypatch: pytest.MonkeyPatch) 
     await asyncio.wait_for(fb.forwarded.wait(), timeout=5.0)
     assert fb.callers == [None]
 
-    ack = gw._apply_claim(_claim(_WRAPPER_PID, "dashboard:chat-CP-1"))
+    ack = await gw._apply_claim(_claim(_WRAPPER_PID, "dashboard:chat-CP-1"))
     assert ack["type"] == "claimed" and ack["updated"] == 1
 
     fb.forwarded.clear()
@@ -275,7 +275,7 @@ async def test_claim_matches_host_pid_for_pidns_stub(monkeypatch: pytest.MonkeyP
         assert pid in gw._CONN_INDEX, f"pid {pid} missing from claim index"
 
     # The gateway claims with the HOST launcher pid (top of the host chain).
-    ack = gw._apply_claim(_claim(host_chain[-1], "dashboard:chat-NS-1"))
+    ack = await gw._apply_claim(_claim(host_chain[-1], "dashboard:chat-NS-1"))
     assert ack["type"] == "claimed" and ack["updated"] == 1
 
     fb.forwarded.clear()
@@ -348,7 +348,7 @@ async def test_no_host_indexing_when_peer_pid_unavailable(
 
     assert resolve_calls == []  # never resolved without a kernel-attested pid
     assert 9100 not in gw._CONN_INDEX and 9020 not in gw._CONN_INDEX
-    ack = gw._apply_claim(_claim(9020, "dashboard:chat-NS-2"))
+    ack = await gw._apply_claim(_claim(9020, "dashboard:chat-NS-2"))
     assert ack["updated"] == 0
 
     reader.feed({"type": "unregister"})
@@ -400,7 +400,8 @@ def test_resolve_peer_identity_config_dir_error_returns_empty(
     assert gw._resolve_peer_identity(999) == ("", [])
 
 
-def test_claim_zero_connections_warns_and_audits(
+@pytest.mark.asyncio
+async def test_claim_zero_connections_warns_and_audits(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A claim naming a pid with no indexed connection must leave a loud
@@ -416,7 +417,7 @@ def test_claim_zero_connections_warns_and_audits(
     monkeypatch.setattr(gw, "SecurityEventLog", _FakeSEL)
     gw._CONN_INDEX.clear()
     with caplog.at_level("WARNING", logger="kiro_crew.mcp_gateway.gatewayd"):
-        ack = gw._apply_claim(_claim(777777, "dashboard:chat-GHOST"))
+        ack = await gw._apply_claim(_claim(777777, "dashboard:chat-GHOST"))
     assert ack == {"type": "claim-noop", "updated": 0, "connections": 0}
     assert any("ZERO connections" in r.message for r in caplog.records)
     noop = [
@@ -425,6 +426,191 @@ def test_claim_zero_connections_warns_and_audits(
         and e.get("outcome") == "noop"
     ]
     assert len(noop) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_rekey_evicts_old_callers_subscriptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claim that CHANGES a stub's owner must evict the old caller's
+    resource subscriptions on the hosting backend (the new session must
+    not receive the old session's resource-update URIs); an idempotent
+    re-claim to the same key must not evict."""
+    _patch_env(monkeypatch)
+
+    class _FakeBackend:
+        def __init__(self) -> None:
+            self.evicted: list[str] = []
+
+        async def evict_stub_subscriptions(self, stub_uuid: str) -> int:
+            self.evicted.append(stub_uuid)
+            return 1
+
+    class _FakePool:
+        def __init__(self, backend: "_FakeBackend") -> None:
+            self._backend = backend
+
+        def backends_hosting_stub(self, stub_uuid: str) -> list:
+            return [self._backend]
+
+    fake_backend = _FakeBackend()
+    fake_pool = _FakePool(fake_backend)
+    gw._CONN_INDEX.clear()
+    conn = gw._StubConn(
+        stub_uuid="stub-rk-1", ancestor_pids=[_PID],
+        pool_label="pool", caller=None,
+    )
+    gw._CONN_INDEX[_PID] = {conn}
+    try:
+        ack = await gw._apply_claim(
+            _claim(_PID, "dashboard:owner-A"), fake_pool)
+        assert ack["updated"] == 1
+        assert fake_backend.evicted == ["stub-rk-1"]  # owner change: evict
+        ack = await gw._apply_claim(
+            _claim(_PID, "dashboard:owner-A"), fake_pool)
+        assert ack["updated"] == 0
+        assert fake_backend.evicted == ["stub-rk-1"]  # idempotent: no evict
+        ack = await gw._apply_claim(
+            _claim(_PID, "dashboard:owner-B"), fake_pool)
+        assert ack["updated"] == 1
+        assert fake_backend.evicted == ["stub-rk-1", "stub-rk-1"]
+    finally:
+        gw._CONN_INDEX.clear()
+
+
+@pytest.mark.asyncio
+async def test_claim_retargets_all_connections_before_first_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first eviction's await yields; a sibling connection still
+    carrying the OLD caller during that await would forward its frames as
+    the previous session — wrong-principal execution. Every eligible
+    connection must be retargeted BEFORE the first eviction runs."""
+    _patch_env(monkeypatch)
+    conn_a = gw._StubConn(
+        stub_uuid="stub-2p-a", ancestor_pids=[_PID],
+        pool_label="pool", caller=None,
+    )
+    conn_b = gw._StubConn(
+        stub_uuid="stub-2p-b", ancestor_pids=[_PID],
+        pool_label="pool", caller=None,
+    )
+    callers_at_first_evict: list[str] = []
+
+    class _SpyBackend:
+        async def evict_stub_subscriptions(self, stub_uuid: str) -> int:
+            if not callers_at_first_evict:
+                for c in (conn_a, conn_b):
+                    callers_at_first_evict.append(
+                        c.caller.session_key if c.caller is not None else "")
+            return 1
+
+    class _SpyPool:
+        def __init__(self) -> None:
+            self._backend = _SpyBackend()
+
+        def backends_hosting_stub(self, stub_uuid: str) -> list:
+            return [self._backend]
+
+    gw._CONN_INDEX.clear()
+    gw._CONN_INDEX[_PID] = {conn_a, conn_b}
+    try:
+        ack = await gw._apply_claim(
+            _claim(_PID, "dashboard:owner-2P"), _SpyPool())
+        assert ack["updated"] == 2
+        # At the moment the FIRST eviction ran, BOTH connections already
+        # carried the new owner — no wrong-principal window.
+        assert callers_at_first_evict == [
+            "dashboard:owner-2P", "dashboard:owner-2P",
+        ]
+    finally:
+        gw._CONN_INDEX.clear()
+
+
+@pytest.mark.asyncio
+async def test_claim_survives_disconnect_during_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection disconnecting while another's eviction awaits must not
+    abort the claim mid-iteration: the loop walks a snapshot."""
+    _patch_env(monkeypatch)
+
+    class _MutatingBackend:
+        def __init__(self) -> None:
+            self.evicted: list[str] = []
+
+        async def evict_stub_subscriptions(self, stub_uuid: str) -> int:
+            self.evicted.append(stub_uuid)
+            # Simulate a sibling connection disconnecting mid-await.
+            gw._CONN_INDEX[_PID].discard(
+                next(iter(gw._CONN_INDEX[_PID])))
+            return 1
+
+    class _FakePool:
+        def __init__(self, backend: "_MutatingBackend") -> None:
+            self._backend = backend
+
+        def backends_hosting_stub(self, stub_uuid: str) -> list:
+            return [self._backend]
+
+    fake_backend = _MutatingBackend()
+    gw._CONN_INDEX.clear()
+    conns = {
+        gw._StubConn(
+            stub_uuid=f"stub-mu-{i}", ancestor_pids=[_PID],
+            pool_label="pool", caller=None,
+        )
+        for i in range(3)
+    }
+    gw._CONN_INDEX[_PID] = set(conns)
+    try:
+        ack = await gw._apply_claim(
+            _claim(_PID, "dashboard:owner-X"), _FakePool(fake_backend))
+        assert ack["type"] == "claimed"  # no RuntimeError, claim acked
+        assert len(fake_backend.evicted) == 3  # snapshot walked fully
+    finally:
+        gw._CONN_INDEX.clear()
+
+
+@pytest.mark.asyncio
+async def test_claim_reassigns_owner_before_eviction_awaits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subscribe arriving while the eviction awaits must be authorized as
+    the NEW caller: the owner reassignment happens before the await."""
+    _patch_env(monkeypatch)
+
+    class _SpyBackend:
+        def __init__(self, conn: "gw._StubConn") -> None:
+            self._conn = conn
+            self.owner_at_evict: list[str] = []
+
+        async def evict_stub_subscriptions(self, stub_uuid: str) -> int:
+            self.owner_at_evict.append(
+                self._conn.caller.session_key if self._conn.caller else "")
+            return 0
+
+    class _FakePool:
+        def __init__(self, backend: "_SpyBackend") -> None:
+            self._backend = backend
+
+        def backends_hosting_stub(self, stub_uuid: str) -> list:
+            return [self._backend]
+
+    gw._CONN_INDEX.clear()
+    conn = gw._StubConn(
+        stub_uuid="stub-ord-1", ancestor_pids=[_PID],
+        pool_label="pool", caller=None,
+    )
+    gw._CONN_INDEX[_PID] = {conn}
+    spy = _SpyBackend(conn)
+    try:
+        ack = await gw._apply_claim(
+            _claim(_PID, "dashboard:new-owner"), _FakePool(spy))
+        assert ack["updated"] == 1
+        assert spy.owner_at_evict == ["dashboard:new-owner"]
+    finally:
+        gw._CONN_INDEX.clear()
 
 
 @pytest.mark.asyncio
@@ -438,7 +624,7 @@ async def test_claim_replaces_existing_identity(monkeypatch: pytest.MonkeyPatch)
     task = asyncio.create_task(_handle(reader, _RecordingWriter()))
     await asyncio.wait_for(fb.forwarded.wait(), timeout=5.0)
 
-    ack = gw._apply_claim(_claim(_PID, "dashboard:new-session"))
+    ack = await gw._apply_claim(_claim(_PID, "dashboard:new-session"))
     assert ack["updated"] == 1
 
     fb.forwarded.clear()
@@ -464,7 +650,7 @@ async def test_claim_idempotent_same_key(monkeypatch: pytest.MonkeyPatch) -> Non
     task = asyncio.create_task(_handle(reader, _RecordingWriter()))
     await asyncio.wait_for(fb.forwarded.wait(), timeout=5.0)
 
-    ack = gw._apply_claim(_claim(_PID, "dashboard:same-1"))
+    ack = await gw._apply_claim(_claim(_PID, "dashboard:same-1"))
     assert ack["type"] == "claimed" and ack["updated"] == 0 and ack["connections"] == 1
     reader.feed({"type": "unregister"})
     await task
@@ -481,7 +667,7 @@ async def test_claim_malformed_rejected_and_audited(monkeypatch: pytest.MonkeyPa
         _claim(True, "dashboard:x"),       # bool is not a pid
         _claim(_PID, ""),                  # empty session key
     ):
-        ack = gw._apply_claim(bad)
+        ack = await gw._apply_claim(bad)
         assert ack["type"] == "claim-rejected", bad
     events = _claim_events(sel)
     assert len(events) == 4
@@ -531,7 +717,8 @@ def _claim_with_token(pid: int, session_key: str, token: Optional[str]) -> dict[
     return frame
 
 
-def test_claim_skips_recycled_pid(
+@pytest.mark.asyncio
+async def test_claim_skips_recycled_pid(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """The core defect scenario: the register-time owner of PID P exited, the
@@ -542,7 +729,7 @@ def test_claim_skips_recycled_pid(
     sel = _fake_sel(monkeypatch)
     conn = _indexed_conn(_PID, "111", "dashboard:original-owner")
     with caplog.at_level("WARNING", logger="kiro_crew.mcp_gateway.gatewayd"):
-        ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:new-owner", "222"))
+        ack = await gw._apply_claim(_claim_with_token(_PID, "dashboard:new-owner", "222"))
     assert ack == {"type": "claimed", "updated": 0, "connections": 1, "skipped": 1}
     assert conn.caller is not None
     assert conn.caller.session_key == "dashboard:original-owner"  # unchanged
@@ -552,12 +739,13 @@ def test_claim_skips_recycled_pid(
     assert "recycled" in denied[0]["error"]
 
 
-def test_claim_applies_on_matching_token(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_claim_applies_on_matching_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Same token on both sides — the register-time process is still alive —
     keeps the existing replace behavior."""
     sel = _fake_sel(monkeypatch)
     conn = _indexed_conn(_PID, "111", "dashboard:old-session")
-    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:new-session", "111"))
+    ack = await gw._apply_claim(_claim_with_token(_PID, "dashboard:new-session", "111"))
     assert ack == {"type": "claimed", "updated": 1, "connections": 1, "skipped": 0}
     assert conn.caller is not None and conn.caller.session_key == "dashboard:new-session"
     events = _claim_events(sel)
@@ -573,7 +761,8 @@ def test_claim_applies_on_matching_token(monkeypatch: pytest.MonkeyPatch) -> Non
         ("111", "111"),  # both known and equal
     ],
 )
-def test_claim_unknown_token_is_match(
+@pytest.mark.asyncio
+async def test_claim_unknown_token_is_match(
     monkeypatch: pytest.MonkeyPatch,
     frame_token: Optional[str],
     recorded_token: Optional[str],
@@ -583,13 +772,14 @@ def test_claim_unknown_token_is_match(
     None) and legacy claim frames would reject every claim."""
     _fake_sel(monkeypatch)
     conn = _indexed_conn(_PID, recorded_token)
-    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-TOK-1", frame_token))
+    ack = await gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-TOK-1", frame_token))
     assert ack["updated"] == 1 and ack["skipped"] == 0
     assert conn.caller is not None
     assert conn.caller.session_key == "dashboard:chat-TOK-1"
 
 
-def test_claim_mixed_bucket_retargets_only_matching_conn(
+@pytest.mark.asyncio
+async def test_claim_mixed_bucket_retargets_only_matching_conn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Index buckets stay keyed on the raw int PID, so a bucket may mix a
@@ -598,7 +788,7 @@ def test_claim_mixed_bucket_retargets_only_matching_conn(
     sel = _fake_sel(monkeypatch)
     stale = _indexed_conn(_PID, "111", "dashboard:original-owner")
     live = _indexed_conn(_PID, "222")
-    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:new-owner", "222"))
+    ack = await gw._apply_claim(_claim_with_token(_PID, "dashboard:new-owner", "222"))
     assert ack == {"type": "claimed", "updated": 1, "connections": 2, "skipped": 1}
     assert stale.caller is not None
     assert stale.caller.session_key == "dashboard:original-owner"
@@ -607,7 +797,8 @@ def test_claim_mixed_bucket_retargets_only_matching_conn(
     assert outcomes == ["allowed", "denied"]
 
 
-def test_claim_non_string_token_treated_as_unknown(
+@pytest.mark.asyncio
+async def test_claim_non_string_token_treated_as_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A garbage (non-string) ``pid_start_id`` never becomes a mismatch: it is
@@ -616,12 +807,13 @@ def test_claim_non_string_token_treated_as_unknown(
     conn = _indexed_conn(_PID, "111")
     frame = _claim(_PID, "dashboard:chat-G-1")
     frame["pid_start_id"] = 12345  # wrong type
-    ack = gw._apply_claim(frame)
+    ack = await gw._apply_claim(frame)
     assert ack["updated"] == 1 and ack["skipped"] == 0
     assert conn.caller is not None and conn.caller.session_key == "dashboard:chat-G-1"
 
 
-def test_stubconn_legacy_constructor_defaults_to_empty_tokens(
+@pytest.mark.asyncio
+async def test_stubconn_legacy_constructor_defaults_to_empty_tokens(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The pre-guard constructor shape (no ``pid_start_ids``) keeps working:
@@ -631,7 +823,7 @@ def test_stubconn_legacy_constructor_defaults_to_empty_tokens(
     conn = gw._StubConn("legacy-stub", [_PID], "legacy-pool", None)
     assert conn.pid_start_ids == {}
     gw._conn_index_add(conn)
-    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-L-1", "999"))
+    ack = await gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-L-1", "999"))
     assert ack["updated"] == 1 and ack["skipped"] == 0
     assert conn.caller is not None and conn.caller.session_key == "dashboard:chat-L-1"
 
@@ -653,7 +845,7 @@ async def test_register_records_start_tokens_and_claim_verifies(
     (conn,) = gw._CONN_INDEX[_PID]
     assert conn.pid_start_ids == {p: "111" for p in _ANCESTORS}
 
-    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-W-1", "222"))
+    ack = await gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-W-1", "222"))
     assert ack["updated"] == 0 and ack["skipped"] == 1
 
     fb.forwarded.clear()

--- a/test/test_mcp_gateway_pool_integ.py
+++ b/test/test_mcp_gateway_pool_integ.py
@@ -545,3 +545,24 @@ def test_pool_integ_is_never_silently_skipped_on_windows() -> None:
         assert not offenders, (
             f"pooling assertions were added to the Windows skip list: {offenders}"
         )
+
+
+@pytest.mark.asyncio
+async def test_backends_hosting_stub_covers_exclusive() -> None:
+    """The stub lookup must cover exclusive (private) backends too: a
+    private stub rekeys like a pooled one, and omitting it would leave the
+    previous caller's subscriptions routing to the new owner."""
+    from kiro_crew.mcp_gateway.pool import BackendPool
+
+    class _Stub:
+        def __init__(self, inboxes: dict) -> None:
+            self._stub_inboxes = inboxes
+
+    pool = BackendPool(max_backends=4)
+    pooled = _Stub({"s-pooled": object()})
+    private = _Stub({"s-private": object()})
+    pool._backends["d1"] = pooled  # type: ignore[assignment]
+    pool._exclusive["d2"] = private  # type: ignore[assignment]
+    assert pool.backends_hosting_stub("s-pooled") == [pooled]
+    assert pool.backends_hosting_stub("s-private") == [private]
+    assert pool.backends_hosting_stub("s-none") == []

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -1216,6 +1216,102 @@ class TestRespawnBackendForStub:
         pool.unreserve.assert_called_once_with(key)
         await _drain_task(got_task)
 
+    @pytest.mark.asyncio
+    async def test_replay_skipped_when_owner_rekeyed_mid_respawn(self, monkeypatch):
+        """A ``claim`` frame can retarget this connection's identity during
+        the respawn's acquire/prime awaits. The captured URIs belong to the
+        OLD principal — replaying them would resubscribe the old owner's
+        resources onto the rekeyed stub, the exact leak
+        ``evict_stub_subscriptions`` exists to prevent. The replay gate must
+        recheck the live owner and skip when it changed."""
+        key = _pool_key(server="respawn-rekey-mcp")
+        pool = BackendPool(max_backends=2)
+        pool.unreserve = MagicMock()  # type: ignore[method-assign]
+        old = _fake_backend()
+        old.detach_stub = AsyncMock(return_value=0)  # type: ignore[method-assign]
+        old.resource_subscription_uris = MagicMock(  # type: ignore[method-assign]
+            return_value=["file:///old-owner.txt"]
+        )
+        fresh = _fake_backend(key, pid=7171)
+        fresh.attach_stub = AsyncMock(  # type: ignore[method-assign]
+            return_value=asyncio.Queue()
+        )
+        fresh.replay_resource_subscriptions = AsyncMock()  # type: ignore[method-assign]
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(fresh, True)))
+
+        old_caller = CallerContext(session_key="dashboard:old")
+        conn = gw._StubConn("stub-r6", [], "pool", old_caller)
+        # The claim lands while prime_initialize is awaited: the connection
+        # identity names a NEW principal before the replay gate runs.
+        fresh.prime_initialize = AsyncMock(  # type: ignore[method-assign]
+            side_effect=lambda *_a, **_k: setattr(
+                conn, "caller", CallerContext(session_key="dashboard:new")
+            )
+        )
+
+        out = await gw._respawn_backend_for_stub(
+            pool,
+            key,
+            lambda k: None,
+            "stub-r6",
+            cast(Any, _FakeWriter()),
+            {"id": 0, "method": "initialize"},
+            old,
+            None,
+            None,
+            caller=old_caller,
+            conn=conn,
+        )
+
+        assert out is not None  # the respawn itself still succeeds
+        fresh.replay_resource_subscriptions.assert_not_awaited()
+        _backend, _inbox, task = out
+        await _drain_task(task)
+
+    @pytest.mark.asyncio
+    async def test_replay_proceeds_when_owner_unchanged(self, monkeypatch):
+        """Control for the rekey gate: an unchanged owner still gets its
+        subscriptions replayed onto the fresh backend."""
+        key = _pool_key(server="respawn-stable-mcp")
+        pool = BackendPool(max_backends=2)
+        pool.unreserve = MagicMock()  # type: ignore[method-assign]
+        old = _fake_backend()
+        old.detach_stub = AsyncMock(return_value=0)  # type: ignore[method-assign]
+        old.resource_subscription_uris = MagicMock(  # type: ignore[method-assign]
+            return_value=["file:///same-owner.txt"]
+        )
+        fresh = _fake_backend(key, pid=7272)
+        fresh.prime_initialize = AsyncMock()  # type: ignore[method-assign]
+        fresh.attach_stub = AsyncMock(  # type: ignore[method-assign]
+            return_value=asyncio.Queue()
+        )
+        fresh.replay_resource_subscriptions = AsyncMock()  # type: ignore[method-assign]
+        monkeypatch.setattr(gw, "_acquire_backend", AsyncMock(return_value=(fresh, True)))
+
+        same_caller = CallerContext(session_key="dashboard:same")
+        conn = gw._StubConn("stub-r7", [], "pool", same_caller)
+
+        out = await gw._respawn_backend_for_stub(
+            pool,
+            key,
+            lambda k: None,
+            "stub-r7",
+            cast(Any, _FakeWriter()),
+            {"id": 0, "method": "initialize"},
+            old,
+            None,
+            None,
+            caller=same_caller,
+            conn=conn,
+        )
+
+        assert out is not None
+        fresh.replay_resource_subscriptions.assert_awaited_once_with(
+            "stub-r7", ["file:///same-owner.txt"], caller=same_caller
+        )
+        _backend, _inbox, task = out
+        await _drain_task(task)
+
 
 # --- zombie diagnostic ------------------------------------------------------
 

--- a/test/test_mcp_shareability.py
+++ b/test/test_mcp_shareability.py
@@ -143,9 +143,10 @@ class TestDisqualifiers:
         """The two must not collapse into one rule.
 
         ``rotating_secret_env`` withholds because a live guard declines the work.
-        A broker gap has no such guard -- pooling proceeds and a subscription simply
-        stops firing -- so it must stay pure information. Sharing one flag between
-        them would silently re-introduce the disqualifier this change removed.
+        A broker gap has no such guard -- pooling proceeds and log verbosity simply
+        follows the last caller's level -- so it must stay pure information.
+        Sharing one flag between them would silently re-introduce the disqualifier
+        this change removed.
         """
         verdict = assess(
             ShareEvidence(
@@ -154,7 +155,7 @@ class TestDisqualifiers:
                 has_tools=True,
                 capabilities={
                     "experimental": {shareability.CALLER_IDENTITY_CAPABILITY: {}},
-                    "resources": {"subscribe": True},
+                    "logging": {},
                 },
                 preflight_ran=True,
             )
@@ -228,15 +229,17 @@ class TestDisqualifiers:
         verdict = assess(ShareEvidence(name="x", is_stdio=False, probe_ok=True))
         assert _codes(verdict) == {"not_stdio"}
 
-    def test_resources_subscribe_is_a_note_not_a_disqualifier(self) -> None:
-        """A lost feature is not a hazard.
+    def test_resources_subscribe_no_longer_produces_a_degradation_note(self) -> None:
+        """Subscriptions survive pooling, so there is nothing to warn about.
 
-        ``notifications/resources/updated`` carries no request id, so a shared
-        backend cannot attribute it and DROPS it (deny-by-default in
-        ``backend._notification_owner``). The subscription silently stops working
-        -- nobody receives anybody else's content. That costs the operator a
-        feature, which is worth reporting, and it is not a reason to refuse the
-        stub: a stub keeps the backend 1:1 with the session.
+        The broker keeps a ``uri -> {stub_uuid}`` table
+        (``backend._resource_subscriptions``) and routes each
+        ``notifications/resources/updated`` to exactly the stubs subscribed to
+        its URI. The degradation table's contract is delete-not-relax: an
+        entry leaves the moment the broker learns to attribute the frames it
+        covers, and this test pins ``resources.subscribe``'s absence. A
+        subscribe-capable server is otherwise unremarkable evidence and lands
+        on the ordinary no-objection tier.
         """
         verdict = assess(
             ShareEvidence(
@@ -250,19 +253,7 @@ class TestDisqualifiers:
         assert verdict.recommend_stub is True
         assert verdict.recommend_share is False
         notes = [r for r in verdict.reasons if r.code == "degrades_when_shared"]
-        assert [r.detail for r in notes] == ["resources_subscribe"]
-
-    def test_subscribe_false_is_an_explicit_no_and_does_not_count(self) -> None:
-        """``{"subscribe": false}`` is the server saying it does NOT subscribe."""
-        verdict = assess(
-            ShareEvidence(
-                name="x",
-                probe_ok=True,
-                has_tools=True,
-                capabilities={"resources": {"subscribe": False, "listChanged": True}},
-            )
-        )
-        assert verdict.strength is Strength.NO_OBJECTION
+        assert notes == []
 
     def test_list_changed_alone_is_not_a_disqualifier(self) -> None:
         """Those notifications are global broadcasts, safe to fan out."""
@@ -430,16 +421,19 @@ class TestPositiveDeclaration:
     def test_a_broker_gap_is_reported_but_does_not_withhold_sharing(self) -> None:
         """The note names OUR missing feature, so it cannot be the server's cost.
 
-        ``notifications/resources/updated`` carries no request id, but it does not
-        need one: the broker saw which stub subscribed to which URI, so a
-        ``uri -> {stub_uuid}`` table would route the update exactly. It keeps no
-        such table today -- that is the defect, and it is ours. Withholding
-        pooling here would charge the operator for work we have not done, which is
-        the failure mode of a layer whose whole job is to say yes.
+        ``logging/setLevel`` is process-global, but a proxy can emit at the
+        finest level any tenant asked for and filter DOWN per stub, giving each
+        tenant the verbosity it requested from one process. The broker does not
+        do that today -- that is the defect, and it is ours. Withholding pooling
+        here would charge the operator for work we have not done, which is the
+        failure mode of a layer whose whole job is to say yes.
 
-        The note still ships, because until the broker learns to attribute them a
-        subscription really does stop firing once pooled, and the operator is
-        entitled to know that before pressing a bulk action.
+        The note still ships, because until the broker learns to attribute it,
+        log verbosity really does follow the last caller's level once pooled,
+        and the operator is entitled to know that before pressing a bulk action.
+        The degradation table's contract is delete-not-relax: an entry leaves
+        the moment the broker attributes the frames it covers, as
+        ``resources.subscribe``'s absence demonstrates.
         """
         verdict = assess(
             ShareEvidence(
@@ -448,7 +442,7 @@ class TestPositiveDeclaration:
                 has_tools=True,
                 capabilities={
                     "experimental": {shareability.CALLER_IDENTITY_CAPABILITY: {}},
-                    "resources": {"subscribe": True},
+                    "logging": {},
                 },
                 preflight_ran=True,
             )
@@ -1550,7 +1544,11 @@ class TestBackendRecordsHazards:
         hazards.flush_sink()  # must not raise
 
     def test_both_observation_sites_call_the_recorder(self) -> None:
-        """Ratchet: the two hazard sites must stay wired to the ledger.
+        """Ratchet: the hazard sites must stay wired to the ledger.
+
+        Three sites: the unattributable request-scoped notification drop, the
+        unroutable server->client request recycle, and the terminal
+        resources/updated drop for a URI nobody subscribed to.
 
         Asserted on the source because reproducing either frame end to end
         needs a live shared backend and a misbehaving server; the value here is
@@ -1561,6 +1559,6 @@ class TestBackendRecordsHazards:
         import kiro_crew.mcp_gateway.backend as backend_mod
 
         src = _Path(backend_mod.__file__).read_text(encoding="utf-8")
-        assert src.count("self._record_hazard(") == 2, "expected exactly two hazard sites"
+        assert src.count("self._record_hazard(") == 3, "expected exactly three hazard sites"
         assert "hazards.HAZARD_UNATTRIBUTABLE_NOTIFICATION" in src
         assert "hazards.HAZARD_UNROUTABLE_SERVER_REQUEST" in src


### PR DESCRIPTION
## Problem / Motivation

A pooled backend drops every `notifications/resources/updated` it receives, so a resource subscription silently stops firing the moment a server's backend is shared. The client sees no error -- it just keeps showing data that never updates again.

## Why it matters

Any session that relies on `resources/subscribe` loses live updates as a silent side effect of turning pooling on. Silence is the worst failure shape: nothing goes red, the operator has no signal, and the shareability page could only warn about the gap rather than fix it.

## What changed (motivation -> approach -> change)

The broker attributed request-scoped notifications by routing token in `backend._notification_owner`; `notifications/resources/updated` carries no request id, so the deny-by-default arm dropped it. But a request id is not the only way to attribute it -- the broker saw which stub sent `resources/subscribe` for which URI.

`backend.py` now keeps a `uri -> {stub_uuid}` routing table of the stubs whose subscribe the server ACCEPTED, and delivers each update to exactly those stubs:

- **The URI arm is terminal.** URI is the only permitted attribution for this notification: an update for a URI nobody subscribed to is dropped with a hazard recorded, and it never falls through to request-scoped attribution -- a server-supplied `_meta.relatedRequestId` must not hand one tenant a URI only a co-tenant ever named.
- **Grants land on the server's response, never at forward time**, so every subscriber routes only on an upstream authorization decision. On an identity-capable server every subscribe is forwarded with its own caller block and granted per stub. On an identity-less server (which sees every co-tenant as one principal) only lease transitions reach the one shared subscription: the first subscriber's subscribe takes the lease; a stub arriving mid-grant is parked and answered with the server's actual verdict, never a premature success; a stub joining a confirmed lease is answered locally with the MCP empty result; a non-final unsubscribe is answered locally; the final unsubscribe keeps routing until the server confirms the release (a refused unsubscribe means the server retained the subscription); a final unsubscribe arriving while a release is already in flight parks behind it and settles on that one verdict, so exactly one release is in flight per URI -- the in-flight release may belong to a stub that has since detached, and refusing instead would leave the parked stub routed forever. A server refusal of the forwarded subscribe settles the forwarder and every parked rider on that refusal. A subscribe arriving while a release is in flight PARKS as a replacement: the wire orders the writes but the server may answer out of order, so forwarding it beside the release could leave routing keeping a subscriber whose lease the release then destroyed upstream -- the settled release drains the parking into a fresh forwarded subscribe (confirmed release) or a local join (refused release, lease retained). A MALFORMED response (neither `result` nor `error`) is never a grant: routing fails closed on it, and because it also proves no refusal, a possibly-live lease with nobody routed is released on the spot rather than stranded upstream firing updates that get charged to the server as hazards.
- **Teardown is lease-aware.** Detach prunes the departing stub, hands its in-flight grant to the first parked rider (or converts it to the lease sentinel so a granted-but-unwanted lease is released), and sends a gateway-originated release when the last subscriber departs. Release confirmations remove only the releasing stub, so an out-of-order replacement grant survives.
- **Subscriptions survive transparent respawn.** When a shared backend dies, `_respawn_backend_for_stub` captures the stub's subscribed URIs before detaching the dead backend and replays them onto the replacement (`Backend.replay_resource_subscriptions`); routing returns when the server grants the replay, fail-closed until then. On an identity-capable server the replay carries the connection's authoritative caller block; without one it is skipped entirely rather than adjudicated as the wrong principal. A replay grant is honoured only while its stub is still attached. Without this, a live subscription goes dark on respawn -- the same silent failure shape as #4624 at a different trigger.
- **Failed releases do not poison hazard telemetry.** A lease the server refused to release with nobody left to route to is tracked in `_orphaned_leases`: its updates are dropped WITHOUT recording the unattributable-notification hazard, because the retained subscription is a consequence of the broker's own lease handling and recording it would withdraw the server's pooling recommendation for behaviour that is correct. A later successful release or a new grant clears the mark.
- **Bounded.** A per-stub cap (`_RESOURCE_SUBSCRIPTIONS_MAX_PER_STUB`) counts confirmed grants, in-flight subscribes, and each rider parking individually (duplicates included) and refuses further subscribes locally with a JSON-RPC error -- the same guard class as `_STUB_INBOX_MAXSIZE`. Release-waiter parkings are capped per stub the same way, the orphaned-lease set is bounded at `_ORPHANED_LEASES_MAX` with arbitrary eviction (suppression is telemetry hygiene, not correctness), gateway-originated release/replay pendings carry `t_start_ms` so the heartbeat wedge scan never reads them as host-uptime old, and an id-less subscribe/unsubscribe is swallowed before any lease mutation (no response could ever settle the transition it would start).

The `resources_subscribe` degradation note in `shareability.py` described the broker's missing table; per that table's own delete-not-relax contract the entry is deleted, the matcher's now entry-less truthy mode goes with it, and `docs/system-specs/modules/mcp-shareability.md` is updated in the same commit. The `logging` gap remains and keeps its note.

Eleven pre-push/CI review rounds (GPT, Opus, Design, First Principles) shaped this surface; every finding was fixed with zero overrides.

## Tests

New/updated in `test/test_mcp_gateway_backend_coverage.py` (the guarded behaviors are mutation-verified -- the guarded line was broken and the test went red):

- update reaches only the URI's subscriber; both subscribers of one URI receive it; a non-subscribed co-tenant receives nothing
- **terminal-arm regression**: an update tagged with a live `_meta.relatedRequestId` is still dropped when nobody subscribed -- never routed by request id
- an update racing an unconfirmed grant is dropped, not guessed; an update for an unknown URI records the unattributable-notification hazard
- duplicate subscribe answered locally (one upstream frame); a rider parked mid-grant settles on the server's verdict; a refused subscribe grants nobody (forwarder and riders all receive the refusal)
- identity-capable server: every subscribe forwarded, granted per stub; one stub's refusal does not disturb a co-tenant's accepted subscription
- non-final unsubscribe answered locally keeping the lease; final unsubscribe keeps routing until the server confirms; a refused final unsubscribe keeps routing; a subscribe racing an in-flight release parks and is granted on a fresh subscribe serialized after the settled release (out-of-order answers can no longer destroy the replacement's lease); a stray unsubscribe never tears down a co-tenant's lease
- detach: drops routing and releases the lease as last subscriber; keeps the lease while a subscriber remains; promotes the first parked rider of an in-flight grant; an orphaned grant is released not leaked -- never the departing stub's own parked duplicate (the rider prune runs before the pending scan, so a phantom subscriber cannot be recorded)
- respawn replay: routing restored on grant; caller block carried on identity-capable servers; replay skipped without a caller there; a replay grant for a detached stub releases the lease
- orphaned lease: a refused orphan release suppresses the false hazard while a genuinely unknown URI still records one
- per-stub cap refused locally, counting in-flight and duplicate parkings; malformed subscribe params record nothing; malformed update URI dropped; full-inbox detach mid-fan-out does not break delivery
- **response hardening**: a malformed (neither-result-nor-error) response grants nothing on the normal, replay, and release paths and releases the possibly-live lease (a settled refusal releases nothing); a second final unsubscribe parks behind the in-flight release and settles on its verdict (success and refusal both tested, plus the co-tenant case where the releaser detached); routing/pending-owner transitions commit before replies so a full-inbox detach mid-reply cannot resurrect a detached rider, strand a stale set alias, or overwrite detach's rider promotion; the orphan-drop, replay-failure, and release-failure log lines carry no URI (URIs can carry tokens or presigned params)

`test/test_mcp_shareability.py`: `resources.subscribe` no longer produces a degradation note (pins the delete-not-relax contract); broker-gap tests re-anchored on the remaining `logging` entry; hazard-site ratchet updated to the three sites. `test/test_gatewayd_more_coverage.py`: respawn test double carries the caller parameter.

Gates: isort, flake8, mypy, black gate, docs-lint, brand, harness-parity all green; 363 tests across test_mcp_gateway_backend_coverage.py, test_mcp_shareability.py, and test_gatewayd_more_coverage.py pass; full `python -m pytest` has only known host-environment failures outside the touched area.

## Manual verification

N/A -- the routing, lease, refusal, teardown, respawn-replay, and hazard-suppression paths are all exercised end-to-end against in-memory pipes by the unit suite; no UI surface.

## Related Issues

Closes #4624

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff



