### PR TITLE
fix: lock secret files down before content, not after publish (#5307)

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
@@ -122,10 +122,6 @@ OPERATOR_ONLY_KEYS: tuple[str, ...] = (
     PRIMARY_KEY,
 )
 
-#: Owner-only, matching the secret file. The value is not a credential, but it IS a control
-#: whose confidentiality and integrity both matter, so it gets the same lockdown.
-_POLICY_FILE_MODE = 0o600
-
 
 def policy_path() -> Path:
     """Absolute path to the keystone policy file (honors ``KIROCREW_HOME``)."""
@@ -182,18 +178,22 @@ class _PolicyLock:
 
 def _write(data: dict[str, Any]) -> None:
     payload = json.dumps(data, indent=2, sort_keys=True)
-    atomic_write(policy_path(), payload, mode=_POLICY_FILE_MODE)
-    # Fail-loud lockdown, same as the secret store: ``atomic_write``'s mode covers POSIX,
-    # and this applies the owner-only DACL on Windows. A lockdown failure must not leave the
-    # ceiling world-readable, so unlink and re-raise rather than continue.
-    try:
-        platform_compat.restrict_to_owner(policy_path())
-    except OSError:
-        try:
-            policy_path().unlink()
-        except OSError:
-            logger.exception("failed to remove ops policy file after lockdown failure")
-        raise
+    # Fail-loud lockdown BEFORE any content lands, same as the secret store:
+    # ``restrict_to_owner=True`` applies the owner-only DACL to the temp file
+    # before the payload reaches it (a post-rename lockdown left the ceiling
+    # readable under the inherited DACL on Windows for the write window, issue
+    # #5285) and implies the owner-only POSIX mode. The default
+    # ``restrict_on_error="raise"`` refuses to publish a ceiling it cannot
+    # protect.
+    #
+    # No cleanup on failure: every failure inside ``atomic_write`` happens
+    # BEFORE the final path is touched, so an unprotectable file never exists
+    # at ``policy_path()`` at all. The unlink the old code ran on lockdown
+    # failure existed to remove a NEW file already PUBLISHED at a wide DACL;
+    # that state is unreachable now, and keeping the unlink would instead
+    # delete the PREVIOUS, healthy governance ceiling on one transient icacls
+    # failure — silently resetting the operator's autonomy policy.
+    atomic_write(policy_path(), payload, restrict_to_owner=True)
 
 
 def read_mode(default: str) -> str:

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
@@ -54,10 +54,6 @@ logger = logging.getLogger(__name__)
 #: rename cannot silently drop the keystone protection.
 SECRETS_FILENAME = "ops_mission_control_secrets.json"
 
-#: Owner-only mode for the secret file (POSIX). Windows gets an owner-only DACL
-#: via ``platform_compat.restrict_to_owner``.
-_SECRET_FILE_MODE = 0o600
-
 #: Value returned to callers in place of a stored secret. Secrets are write-only
 #: over the API: the UI shows whether a field is set, never what it is.
 REDACTED_PLACEHOLDER = "••••••••"
@@ -219,19 +215,23 @@ class KeystoneFileBackend:
 
     def _write(self, data: dict[str, dict[str, str]]) -> None:
         payload = json.dumps(data, indent=2, sort_keys=True)
-        atomic_write(self._path, payload, mode=_SECRET_FILE_MODE)
-        # Fail-loud lockdown. ``atomic_write``'s mode covers POSIX; this also
-        # applies an owner-only DACL on Windows, where POSIX mode bits are not
-        # enforced. A lockdown failure must not leave a world-readable token on
-        # disk, so we unlink and re-raise rather than continue.
-        try:
-            platform_compat.restrict_to_owner(self._path)
-        except OSError:
-            try:
-                self._path.unlink()
-            except OSError:
-                logger.exception("failed to remove secret file after lockdown failure")
-            raise
+        # Fail-loud lockdown BEFORE any content lands: ``restrict_to_owner=True``
+        # applies the owner-only DACL to the temp file before the payload
+        # reaches it (a post-rename lockdown left every stored provider token
+        # readable under the inherited DACL on Windows for the write window,
+        # issue #5285) and implies the owner-only POSIX mode. The default
+        # ``restrict_on_error="raise"`` refuses to publish a token file it
+        # cannot protect.
+        #
+        # No cleanup on failure: every failure inside ``atomic_write`` —
+        # lockdown, payload write (ENOSPC), rename — happens BEFORE the final
+        # path is touched, so an unprotectable file never exists at
+        # ``self._path`` at all. The unlink the old code ran on lockdown
+        # failure existed to remove a NEW store already PUBLISHED at a wide
+        # DACL; that state is unreachable now, and keeping the unlink would
+        # instead delete the PREVIOUS, healthy, already-locked-down store —
+        # every stored provider token — on one transient icacls failure.
+        atomic_write(self._path, payload, restrict_to_owner=True)
 
     # -- SecretBackend -----------------------------------------------------
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
@@ -14,6 +14,7 @@ import json
 import os
 import shutil
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -24,6 +25,10 @@ from kiro_crew import platform_compat
 class _HomeIsolated(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp())
+        # addCleanup on the line after mkdtemp: unittest skips tearDown when
+        # setUp raises, so an rmtree there leaks the directory on every setUp
+        # failure.
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._prev = os.environ.get("KIROCREW_HOME")
         os.environ["KIROCREW_HOME"] = str(self.tmp)
 
@@ -32,7 +37,6 @@ class _HomeIsolated(unittest.TestCase):
             os.environ.pop("KIROCREW_HOME", None)
         else:
             os.environ["KIROCREW_HOME"] = self._prev
-        shutil.rmtree(self.tmp, ignore_errors=True)
 
 
 class TestTheCeilingIsOnTheKeystoneFloor(_HomeIsolated):
@@ -647,3 +651,98 @@ class TestConcurrentWritesCannotRestoreAStaleCeiling(unittest.TestCase):
                         source,
                         f"{writer.__name__} delegates but also touches the file directly",
                     )
+
+
+class TestPolicyLockdownOrdering(_HomeIsolated):
+    """The ceiling's write must never publish a file it has not protected.
+
+    Ports the previous-store-survival recipe from
+    ``test/test_aws_consent.py::TestGrantIsOnTheKeystoneFloor``: every failure
+    inside ``atomic_write`` happens BEFORE the rename, so a transient lockdown
+    or write failure can no longer reach — let alone delete — the previous,
+    healthy ceiling (the old post-publish ``restrict_to_owner`` + unlink-on-
+    OSError shape silently reset the operator's autonomy policy on one icacls
+    failure).
+    """
+
+    def test_write_lockdown_precedes_content(self):
+        """Measured by the file's SIZE at lockdown time — zero means no policy
+        byte existed yet. A post-write stat passes on the buggy ordering too,
+        so it would not be a regression test."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import (
+            models,
+            policy_store,
+        )
+
+        sizes: list[int] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            sizes.append(os.stat(target).st_size)
+            return real_restrict(target)
+
+        with mock.patch("kiro_crew.platform_compat.restrict_to_owner", _measuring):
+            policy_store.set_mode(models.MODE_OBSERVE)
+
+        self.assertTrue(sizes, "premise: the lockdown ran at all")
+        self.assertEqual(
+            sizes[0], 0,
+            f"the file already held payload bytes when it was locked down: {sizes[0]} bytes",
+        )
+
+    def test_a_failed_lockdown_preserves_the_previous_ceiling(self):
+        from kiro_crew.apps.builtins.ops_mission_control.backend import (
+            models,
+            policy_store,
+        )
+
+        policy_store.set_mode(models.MODE_OBSERVE)
+        before = policy_store.policy_path().read_bytes()
+
+        def _refuse(_target):
+            raise OSError("cannot resolve the invoking user's SID")
+
+        with mock.patch("kiro_crew.platform_compat.restrict_to_owner", _refuse):
+            with self.assertRaises(OSError):
+                policy_store.set_mode(models.MODE_ACT)
+
+        self.assertEqual(
+            policy_store.policy_path().read_bytes(), before,
+            "the previous ceiling was altered",
+        )
+        self.assertEqual(
+            policy_store.read_mode("unset"), models.MODE_OBSERVE,
+            "a failed new write destroyed the previously recorded ceiling",
+        )
+
+    def test_a_failed_payload_write_preserves_the_previous_ceiling(self):
+        """Same property for an ordinary write failure (disk full creating the
+        temp file), which never even reaches the lockdown."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import (
+            models,
+            policy_store,
+        )
+
+        policy_store.set_mode(models.MODE_OBSERVE)
+        before = policy_store.policy_path().read_bytes()
+
+        def _no_space(*_a, **_kw):
+            raise OSError("no space left on device")
+
+        # Scope the failure to atomic_write's own tempfile binding — patching
+        # the shared stdlib module attribute would hand a spurious ENOSPC to
+        # every other mkstemp caller alive in this worker.
+        with mock.patch(
+            "kiro_crew.atomic_write.tempfile", types.SimpleNamespace(mkstemp=_no_space)
+        ):
+            with self.assertRaises(OSError):
+                policy_store.set_mode(models.MODE_ACT)
+
+        self.assertEqual(
+            policy_store.policy_path().read_bytes(), before,
+            "the previous ceiling was altered",
+        )
+        self.assertEqual(
+            policy_store.read_mode("unset"), models.MODE_OBSERVE,
+            "a transient write failure destroyed the previously recorded ceiling",
+        )

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -299,6 +299,100 @@ class TestSecretBackend(unittest.TestCase):
         self.assertEqual(self.backend.get("pagerduty", "api_token"), "")
 
 
+class TestSecretStoreLockdownOrdering(unittest.TestCase):
+    """The store's write must never publish a token file it has not protected.
+
+    Ports the previous-store-survival recipe from
+    ``test/test_aws_consent.py::TestGrantIsOnTheKeystoneFloor``: every failure
+    inside ``atomic_write`` happens BEFORE the rename, so a transient lockdown
+    or write failure can no longer reach — let alone delete — the previous,
+    healthy store (the old post-publish ``restrict_to_owner`` + unlink-on-
+    OSError shape destroyed every stored provider token on one icacls failure).
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.backend = secrets.KeystoneFileBackend(self.tmp / "secrets.json")
+
+    def test_write_lockdown_precedes_content(self):
+        """Measured by the file's SIZE at lockdown time — zero means no token
+        byte existed yet. A post-write stat passes on the buggy ordering too,
+        so it would not be a regression test."""
+        from unittest import mock
+
+        from kiro_crew import platform_compat
+
+        sizes: list[int] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            sizes.append(os.stat(target).st_size)
+            return real_restrict(target)
+
+        with mock.patch("kiro_crew.platform_compat.restrict_to_owner", _measuring):
+            self.backend.put("pagerduty", "api_token", "u+secretvalue")
+
+        self.assertTrue(sizes, "premise: the lockdown ran at all")
+        self.assertEqual(
+            sizes[0], 0,
+            f"the file already held payload bytes when it was locked down: {sizes[0]} bytes",
+        )
+
+    def test_a_failed_lockdown_preserves_the_previous_store(self):
+        """One transient icacls failure must not delete every stored token."""
+        from unittest import mock
+
+        self.backend.put("pagerduty", "api_token", "u+secretvalue")
+        before = (self.tmp / "secrets.json").read_bytes()
+
+        def _refuse(_target):
+            raise OSError("cannot resolve the invoking user's SID")
+
+        with mock.patch("kiro_crew.platform_compat.restrict_to_owner", _refuse):
+            with self.assertRaises(OSError):
+                self.backend.put("datadog", "api_key", "x" * 32)
+
+        self.assertEqual(
+            (self.tmp / "secrets.json").read_bytes(), before,
+            "the previous store was altered",
+        )
+        self.assertEqual(
+            self.backend.get("pagerduty", "api_token"), "u+secretvalue",
+            "a failed new write destroyed the previously stored token",
+        )
+
+    def test_a_failed_payload_write_preserves_the_previous_store(self):
+        """Same property for an ordinary write failure (disk full creating the
+        temp file), which never even reaches the lockdown."""
+        import types
+        from unittest import mock
+
+        self.backend.put("pagerduty", "api_token", "u+secretvalue")
+        before = (self.tmp / "secrets.json").read_bytes()
+
+        def _no_space(*_a, **_kw):
+            raise OSError("no space left on device")
+
+        # Scope the failure to atomic_write's own tempfile binding — patching
+        # the shared stdlib module attribute would hand a spurious ENOSPC to
+        # every other mkstemp caller alive in this worker.
+        with mock.patch(
+            "kiro_crew.atomic_write.tempfile", types.SimpleNamespace(mkstemp=_no_space)
+        ):
+            with self.assertRaises(OSError):
+                self.backend.put("datadog", "api_key", "x" * 32)
+
+        self.assertEqual(
+            (self.tmp / "secrets.json").read_bytes(), before,
+            "the previous store was altered",
+        )
+        self.assertEqual(
+            self.backend.get("pagerduty", "api_token"), "u+secretvalue",
+            "a transient write failure destroyed the previously stored token",
+        )
+
+
 class TestDescribeSecrets(unittest.TestCase):
     def test_never_returns_a_value(self):
         import tempfile

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -776,25 +776,18 @@ def _project_identity_database(source: Path, destination: Path) -> bool:
 
 
 def _atomic_write_secret_bytes(path: Path, content: bytes) -> None:
-    """Atomically stage one bounded Kiro identity file with owner-only mode."""
+    """Atomically stage one bounded Kiro identity file, owner-only from birth.
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, temporary = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-    try:
-        with os.fdopen(fd, "wb") as stream:
-            fd = -1
-            platform_compat.fchmod_safe(stream.fileno(), 0o600)
-            stream.write(content)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary, path)
-        platform_compat.restrict_to_owner(str(path))
-    except Exception:
-        if fd >= 0:
-            os.close(fd)
-        with contextlib.suppress(OSError):
-            os.unlink(temporary)
-        raise
+    ``restrict_to_owner=True`` locks the temp file down BEFORE the identity
+    bytes reach it — the previous post-rename lockdown left them readable
+    under the inherited DACL on Windows for the write window, and a lockdown
+    failure after the rename left the published file unprotected (issue
+    #5285). The default ``restrict_on_error="raise"`` keeps this fail-loud:
+    every failure now happens before the final path is touched, so an
+    unprotectable identity file never exists there at all.
+    """
+
+    atomic_write(path, content, fsync=True, restrict_to_owner=True)
 
 
 def kiro_identity_store_path(
@@ -2914,13 +2907,17 @@ class KiroPrerequisiteService:
     def _mark_setup_complete(self) -> None:
         if self._initial_setup_complete:
             return
+        # restrict_to_owner=True locks the temp file down before the content
+        # reaches it and implies 0o600, replacing the previous mode= plus
+        # post-rename restrict_to_owner pair, whose lockdown landed only after
+        # the marker was already published under the inherited DACL on Windows
+        # (issue #5285).
         atomic_write(
             self._setup_marker,
             "complete\n",
             fsync=True,
-            mode=0o600,
+            restrict_to_owner=True,
         )
-        platform_compat.restrict_to_owner(str(self._setup_marker))
         self._initial_setup_complete = True
 
     async def _set_terminal_audit(

--- a/src/kiro_crew/mcp_gateway/apps.py
+++ b/src/kiro_crew/mcp_gateway/apps.py
@@ -26,7 +26,6 @@ its own and is a pure, side-effect-light helper library.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 import os
@@ -38,6 +37,7 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.mcp_apps_render import MAX_SPOOL_BYTES, SPOOL_SCHEMA_VERSION
 
 logger = logging.getLogger(__name__)
@@ -165,28 +165,20 @@ def write_spool(payload: dict) -> str:
             f"mcp-apps spool record {len(data)} bytes exceeds cap {MAX_SPOOL_BYTES}"
         )
     path = directory / f"{spool_id}.json"
-    # O_CREAT|O_EXCL would be ideal, but uuid4 collision is negligible and
-    # O_TRUNC keeps this idempotent on the (impossible) reuse. Mode honours
-    # umask so chmod after to guarantee 0600.
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "wb") as fh:
-        fh.write(data)
-    try:
-        os.chmod(path, 0o600)
-    except OSError:  # pragma: no cover
-        logger.debug("could not chmod spool file %s to 0600", path, exc_info=True)
-    if not platform_compat.IS_POSIX:  # pragma: no cover — exercised on Windows CI
-        # POSIX mode bits above are meaningless on Windows — apply the
-        # owner-only DACL (repo rule for secret-bearing files). Fail closed:
-        # if the lockdown cannot be established, remove the record rather
-        # than leave a readable capability token behind, then propagate so
-        # the interception failure-safe path delivers the original result.
-        try:
-            platform_compat.restrict_to_owner(path)
-        except OSError:
-            with contextlib.suppress(OSError):
-                path.unlink()
-            raise
+    # Lockdown-before-content + atomic publish: ``restrict_to_owner=True``
+    # applies the owner-only DACL (and 0o600 on POSIX) to the temp file BEFORE
+    # any byte of the record — whose filename and callback_secret are live
+    # capability tokens — reaches it. The previous hand-rolled ``os.open`` at
+    # the final path published the content first and applied the Windows DACL
+    # only afterwards, leaving it readable under the inherited ACL for the
+    # write window (issue #5285). Fail closed is now structural: every failure
+    # (lockdown, write, rename) happens before the final path is touched, so
+    # an unprotected record never exists there and no unlink is needed; the
+    # raised OSError propagates so the interception caller's failure-safe path
+    # delivers the original tool result with no app render. uuid4 collision is
+    # negligible, and the atomic replace keeps this idempotent on the
+    # (impossible) reuse.
+    atomic_write(path, data, restrict_to_owner=True)
     return spool_id
 
 
@@ -486,6 +478,16 @@ def sweep_spool(max_age_hours: float = 24.0) -> int:
         try:
             if not sidecar.with_suffix(".json").exists() and sidecar.stat().st_mtime < cutoff:
                 sidecar.unlink()
+        except OSError:
+            continue
+    # Orphaned atomic_write temps. write_spool's atomic_write cleans its temp
+    # up on every exception, so one can only survive a hard kill (SIGKILL,
+    # power loss) mid-write — but this directory's whole point is bounded
+    # lifetime and nothing else reaps it, so age them out with the records.
+    for temp in directory.glob("*.tmp"):
+        try:
+            if temp.stat().st_mtime < cutoff:
+                temp.unlink()
         except OSError:
             continue
     return removed

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -1485,15 +1485,19 @@ def rewrite_agents(
         _collect_target_env(new_spec.get("mcpServers", {}), target_env)
         target = overlay_dir / path.name
         try:
-            # Atomic + 0600: temp-file + os.replace (via atomic_write) so a
+            # Atomic + owner-only: temp-file + os.replace (via atomic_write) so a
             # live session reading this overlay through the bind-mount never
             # sees a truncated spec (which would make the agent's MCP servers
-            # vanish mid-run), and the passed-through non-poolable / HTTP-SSE
-            # env blocks (tokens / API keys) are never world-readable. Matches
-            # the env sidecar and settings overlay.
-            atomic_write(target, json.dumps(new_spec, indent=2) + "\n", mode=0o600)
-            if not platform_compat.IS_POSIX:
-                platform_compat.restrict_to_owner(target)
+            # vanish mid-run). ``restrict_to_owner=True`` locks the temp file
+            # down BEFORE the passed-through non-poolable / HTTP-SSE env blocks
+            # (tokens / API keys) reach it — POSIX mode bits are a no-op against
+            # NTFS ACLs, and the previous Windows-only post-rename lockdown left
+            # them readable under the inherited DACL for the write window
+            # (issue #5285). It implies 0o600 on POSIX. A lockdown failure now
+            # happens before the rename, so the OSError handler below skips the
+            # overlay without ever publishing an unprotected copy. Matches the
+            # env sidecar and settings overlay.
+            atomic_write(target, json.dumps(new_spec, indent=2) + "\n", restrict_to_owner=True)
         except OSError as exc:
             logger.warning("failed to write overlay %s: %s", target, exc)
             overlay_write_failed = True
@@ -1557,19 +1561,20 @@ def rewrite_agents(
                 # Malformed source (mcpServers not a dict): normalize rather
                 # than propagate the broken shape into a freshly-written overlay.
                 new_settings["mcpServers"] = {}
-            # Atomic + 0600: temp-file + os.replace (via atomic_write) so a
+            # Atomic + owner-only: temp-file + os.replace (via atomic_write) so a
             # live session reading this overlay through the bind-mount never
             # sees a truncated mcp.json (which would make its MCP servers
-            # vanish mid-run), and the passed-through non-poolable / HTTP-SSE
-            # env blocks (tokens / API keys) are never world-readable. Matches
-            # the env sidecar and per-agent overlay.
+            # vanish mid-run). ``restrict_to_owner=True`` locks the temp file
+            # down BEFORE the passed-through non-poolable / HTTP-SSE env blocks
+            # (tokens / API keys) reach it — the previous Windows-only
+            # post-rename lockdown left them readable under the inherited DACL
+            # for the write window (issue #5285). It implies 0o600 on POSIX.
+            # Matches the env sidecar and per-agent overlay.
             atomic_write(
                 settings_overlay_path,
                 json.dumps(new_settings, indent=2) + "\n",
-                mode=0o600,
+                restrict_to_owner=True,
             )
-            if not platform_compat.IS_POSIX:
-                platform_compat.restrict_to_owner(settings_overlay_path)
             logger.info(
                 "mcp-gateway rewriter: global mcp.json overlay written, "
                 "%d poolable server(s) relocated to per-agent overlays (overlay=%s)",

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import IO, Literal, NamedTuple, overload
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 
 logger = logging.getLogger(__name__)
@@ -800,60 +801,26 @@ class SecurityEventLog:
                 )
             return existing
         key = os.urandom(32)
-        # Create the key ATOMICALLY: write the full 32 bytes to a temp file in
-        # the same dir (0o600 from birth, so never briefly world-readable) and
-        # os.replace() it into place — the same pattern prune() uses. A plain
-        # os.open()+os.write() is NOT atomic: a crash or full-disk partial
-        # write between the two calls leaves a 0-byte/short key on disk, which
-        # the load-time length check above would then reject with a hard
-        # RuntimeError on the NEXT boot — bricking every SecurityEventLog()
+        # Create the key ATOMICALLY (temp file + rename via ``atomic_write``,
+        # whose short-write loop was modelled on the hand-rolled one this call
+        # replaces): a plain os.open()+os.write() is NOT atomic — a crash or
+        # full-disk partial write leaves a 0-byte/short key on disk, which the
+        # load-time length check above would then reject with a hard
+        # RuntimeError on the NEXT boot, bricking every SecurityEventLog()
         # init until an operator manually removes the file. os.replace() makes
-        # the key file visible only once it is complete, so KiroCrew itself can
-        # never manufacture the hard-fail state; it fires solely on genuine
-        # external corruption/tampering (which is what the error message is
-        # written for).
-        tmp_fd, tmp_path = tempfile.mkstemp(
-            dir=str(key_path.parent), prefix=".sel_hmac_", suffix=".tmp"
-        )
-        try:
-            # os.write() may return a SHORT count (fewer bytes than len(key)),
-            # notably when storage is nearly full. Ignoring it would publish a
-            # truncated key while the running process keeps signing with the
-            # full in-memory key — the next boot then hard-fails on the short
-            # on-disk key and the existing records can't be verified. Loop
-            # until every byte is written; treat a 0-byte write as an error.
-            mv = memoryview(key)
-            while mv:
-                n = os.write(tmp_fd, mv)
-                if n == 0:
-                    raise OSError("short write persisting SEL HMAC key (wrote 0 bytes)")
-                mv = mv[n:]
-            os.close(tmp_fd)
-            tmp_fd = -1
-            os.replace(tmp_path, str(key_path))
-        except BaseException:
-            if tmp_fd != -1:
-                os.close(tmp_fd)
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
-        # Re-enforce owner-only perms (POSIX 0o600 / Windows owner-only DACL).
-        # Fail-SOFT by design: a read-only FS must not crash SecurityEventLog
-        # init (see test_chmod_failure_is_swallowed). Unlike token_secret.py,
-        # which treats the same failure as merely a warning too, the SEL key
-        # tolerates chmod failure at startup.
-        try:
-            platform_compat.restrict_to_owner(key_path)
-        except OSError:
-            # Logs the key file PATH, never the key bytes.
-            logger.warning(  # nosemgrep: python-logger-credential-disclosure
-                "failed to set owner-only permissions on SEL HMAC key %s; "
-                "file may be readable by other users",
-                key_path,
-                exc_info=True,
-            )
+        # the key file visible only once it is complete.
+        #
+        # ``restrict_to_owner=True`` locks the temp file down BEFORE the key
+        # bytes reach it — the previous post-rename lockdown left a brand-new
+        # key readable under the inherited DACL on Windows for the write
+        # window (issue #5285) — and implies 0o600 on POSIX.
+        # ``restrict_on_error="warn"`` keeps this site's fail-SOFT policy: a
+        # read-only FS / chmod failure must not crash SecurityEventLog init
+        # (see test_chmod_failure_is_swallowed). The linked-parent refusal
+        # implied by ``restrict_to_owner=True`` raises unconditionally, which
+        # is the right behavior for the key that signs the audit chain: a
+        # pre-planted link under the trust dir is hostile (#4381).
+        atomic_write(key_path, key, restrict_to_owner=True, restrict_on_error="warn")
         return key
 
     @contextmanager

--- a/src/kiro_crew/service/live_target.py
+++ b/src/kiro_crew/service/live_target.py
@@ -45,7 +45,6 @@ import os
 import sys
 from pathlib import Path
 
-from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config import loader
 
@@ -54,11 +53,6 @@ from kiro_crew.config import loader
 #: if the pointer is somehow still satisfiable — the loop guard that does not
 #: depend on path comparison being correct.
 EXEC_MARKER = "KIROCREW_LIVE_EXECED"
-
-#: Owner-only: the pointer is a code-execution input, and mode does not isolate
-#: another process running as the same UID, but a world-writable one would be
-#: strictly worse.
-_MODE = 0o600
 
 _FILENAME = "live_target.json"
 
@@ -190,13 +184,16 @@ def write_target(checkout: Path | str) -> Path:
     resolved = validate(str(checkout))
     payload = json.dumps({"checkout": str(resolved)}, indent=2) + "\n"
     path = pointer_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write(path, payload, mode=_MODE)
-    # atomic_write's mode is a POSIX permission bit and a no-op on Windows, which
-    # would leave a code-execution input inheriting the directory's ACL there.
-    # restrict_to_owner applies the owner-only DACL instead, so the pointer is
-    # owner-only on every platform.
-    platform_compat.restrict_to_owner(path)
+    # ``restrict_to_owner=True`` locks the temp file down BEFORE the payload
+    # reaches it: the pointer is a code-execution input read at every startup,
+    # and the previous post-rename lockdown left it inheriting the directory's
+    # ACL on Windows for the whole write window (issue #5285). It implies the
+    # owner-only POSIX mode, so the pointer is owner-only on every platform,
+    # and a lockdown failure refuses the write before the final path is
+    # touched. ``atomic_write`` also creates the parent directory itself,
+    # AFTER its planted-link check — a caller-side mkdir would walk through a
+    # pre-planted link before that check could see it.
+    atomic_write(path, payload, restrict_to_owner=True)
     return resolved
 
 
@@ -226,14 +223,18 @@ def restore(prior: str | None) -> bool:
         if prior is None:
             path.unlink(missing_ok=True)
         else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write(path, prior, mode=_MODE)
             # Harden the restored file for the same reason write_target does:
-            # atomic_write's mode is a POSIX permission bit and a no-op on
-            # Windows, so without this the pointer — a code-execution input read
-            # at every startup — would come back inheriting the directory's ACL.
-            # A rollback must not be the step that widens access to it.
-            platform_compat.restrict_to_owner(path)
+            # the pointer is a code-execution input read at every startup, and
+            # a rollback must not be the step that widens access to it.
+            # ``restrict_to_owner=True`` locks the temp file down before the
+            # content reaches it (the previous post-rename lockdown left the
+            # restored pointer inheriting the directory's ACL on Windows for
+            # the write window, issue #5285), and a lockdown failure surfaces
+            # as the OSError this except already maps to ``False`` — before
+            # the final path is touched, so a failed rollback never publishes
+            # an unprotected pointer. The parent mkdir lives inside
+            # ``atomic_write``, after its planted-link check.
+            atomic_write(path, prior, restrict_to_owner=True)
         return True
     except OSError:
         return False

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -136,6 +136,38 @@ async def _wait_for_operation(service: KiroPrerequisiteService) -> None:
 
 
 class TestKiroPrerequisiteHelpers:
+    def test_identity_file_lockdown_precedes_content(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A staged identity file must never exist with content in it before
+        it is locked down.
+
+        ``_atomic_write_secret_bytes`` routes through
+        ``atomic_write(restrict_to_owner=True)``, which applies the lockdown
+        to the TEMP file before the identity bytes reach it (the previous
+        post-rename lockdown left them readable under the inherited DACL on
+        Windows for the write window, issue #5285). Asserted by measuring the
+        file's SIZE at lockdown time — zero means no payload byte existed yet.
+        """
+        sizes: list[int] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            sizes.append(os.stat(target).st_size)
+            return real_restrict(target)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _measuring)
+        target = tmp_path / "staged" / "kiro-token.json"
+        prerequisite_module._atomic_write_secret_bytes(target, b"identity-bytes")
+
+        assert target.read_bytes() == b"identity-bytes"
+        if platform_compat.IS_POSIX:
+            assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert sizes, "premise: the lockdown ran at all"
+        assert sizes[0] == 0, (
+            f"the file already held {sizes[0]} payload bytes at lockdown time"
+        )
+
     @pytest.mark.parametrize("windows", [True, False], ids=["windows", "posix"])
     def test_identity_env_forwards_proxy_configuration_and_refuses_secrets(
         self,

--- a/test/test_live_target.py
+++ b/test/test_live_target.py
@@ -24,7 +24,6 @@ import pytest
 
 from kiro_crew.service.live_target import (
     _FILENAME,
-    _MODE,
     EXEC_MARKER,
     InvalidTarget,
     maybe_reexec,
@@ -287,26 +286,40 @@ class TestWriteTarget:
         checkout = _make_valid_checkout(tmp_path)
         write_target(checkout)
         if os.name != "posix":
-            # Windows has no POSIX bits: write_target applies an owner-only DACL
-            # through restrict_to_owner, which the next test pins directly.
+            # Windows has no POSIX bits: atomic_write(restrict_to_owner=True)
+            # applies an owner-only DACL, which the next test pins directly.
             pytest.skip("POSIX permission bits are not meaningful here")
-        assert pointer_path().stat().st_mode & 0o777 == _MODE
+        assert pointer_path().stat().st_mode & 0o777 == 0o600
 
-    def test_applies_owner_only_lockdown(self, tmp_path, monkeypatch):
-        """restrict_to_owner is called on the written pointer.
+    def test_lockdown_precedes_content(self, tmp_path, monkeypatch):
+        """The pointer — a code-execution input read at startup — must never
+        exist in a file that has not been locked down yet.
 
-        This is the only owner-only mechanism on Windows, where atomic_write's
-        mode argument is a no-op, so it must be asserted independently of the
-        POSIX bit check above.
+        atomic_write(restrict_to_owner=True) locks the TEMP file down before
+        any content reaches it (the previous post-rename lockdown left the
+        pointer inheriting the directory ACL on Windows for the write window,
+        issue #5285). Asserted by measuring the file's SIZE at lockdown time —
+        zero means no payload byte existed yet. A post-write stat passes on
+        the buggy ordering too, so it would not be a regression test.
         """
-        seen: list = []
-        monkeypatch.setattr(
-            "kiro_crew.service.live_target.platform_compat.restrict_to_owner",
-            lambda path: seen.append(Path(path)),
-        )
+        from kiro_crew import platform_compat
+
+        calls: list[tuple[Path, int]] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            calls.append((Path(target), os.stat(target).st_size))
+            return real_restrict(target)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _measuring)
         checkout = _make_valid_checkout(tmp_path)
         write_target(checkout)
-        assert seen == [pointer_path()]
+        # Filter to the pointer's directory: the hook is patched process-wide,
+        # so an unrelated secret write must not shift the indexing.
+        pointer_calls = [(p, s) for p, s in calls if p.parent == pointer_path().parent]
+        assert pointer_calls, f"the pointer lockdown never ran: {calls}"
+        _, size = pointer_calls[0]
+        assert size == 0, f"the file already held {size} payload bytes at lockdown time"
 
     def test_round_trips_through_read_target(self, tmp_path):
         checkout = _make_valid_checkout(tmp_path)
@@ -361,26 +374,38 @@ class TestSnapshotRestore:
     def test_restore_reapplies_the_owner_only_dacl(self, tmp_path, monkeypatch):
         """A rollback must not be the step that widens access to the pointer.
 
-        atomic_write's mode is a POSIX bit and a no-op on Windows, so without an
-        explicit restrict_to_owner the restored pointer -- a code-execution input
-        read at every startup -- comes back inheriting the directory ACL, and on
-        a shared data home another local account could redirect it.
+        atomic_write(restrict_to_owner=True) locks the temp file down BEFORE
+        the restored content reaches it — the pointer is a code-execution
+        input read at every startup, and on a shared data home another local
+        account could otherwise redirect it during the write window.
         """
-        hardened: list = []
-        monkeypatch.setattr(
-            "kiro_crew.service.live_target.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
+        from kiro_crew import platform_compat
+
+        calls: list[tuple[Path, int]] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            calls.append((Path(target), os.stat(target).st_size))
+            return real_restrict(target)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _measuring)
         path = pointer_path()
         path.parent.mkdir(parents=True, exist_ok=True)
 
         assert restore('{"checkout": "/old/path"}\n') is True
 
-        assert hardened == [path], "restore must harden the file it wrote"
+        # Filter to the pointer's directory: the hook is patched process-wide,
+        # so an unrelated secret write must not shift the indexing.
+        pointer_calls = [(p, s) for p, s in calls if p.parent == path.parent]
+        assert pointer_calls, f"restore must harden the file it writes: {calls}"
+        _, size = pointer_calls[0]
+        assert size == 0, f"the file already held {size} payload bytes at lockdown time"
 
     def test_restore_none_does_not_harden_a_deleted_pointer(self, tmp_path, monkeypatch):
         """Deleting leaves no file, so there is nothing to apply a DACL to."""
         hardened: list = []
         monkeypatch.setattr(
-            "kiro_crew.service.live_target.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
+            "kiro_crew.platform_compat.restrict_to_owner", lambda path: hardened.append(path))
         path = pointer_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("anything")
@@ -391,15 +416,20 @@ class TestSnapshotRestore:
         assert hardened == []
 
     def test_restore_returns_false_when_hardening_fails(self, tmp_path, monkeypatch):
-        """A partial rollback reports False so the caller can warn the operator."""
+        """A partial rollback reports False so the caller can warn the operator.
+
+        The lockdown failure now happens BEFORE the rename, so a rollback that
+        could not be hardened also never publishes an unprotected pointer.
+        """
         def boom(_path):
             raise OSError(5, "icacls failed")
 
-        monkeypatch.setattr("kiro_crew.service.live_target.platform_compat.restrict_to_owner", boom)
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", boom)
         path = pointer_path()
         path.parent.mkdir(parents=True, exist_ok=True)
 
         assert restore('{"checkout": "/old/path"}\n') is False
+        assert not path.exists(), "a failed rollback published an unprotected pointer"
 
     def test_restore_returns_false_on_oserror(self, tmp_path, monkeypatch):
         """Best-effort: returns False rather than raising."""

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -25,6 +25,7 @@ import os
 import stat
 import sys
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -208,6 +209,63 @@ class TestWriteSpool:
         record = json.loads((spool_tmp / f"{sid}.json").read_text())
         assert record["created_at"] == "2020-01-01T00:00:00+00:00"
 
+    def test_lockdown_precedes_content(self, spool_tmp, monkeypatch):
+        """The record's filename and callback_secret are live capability
+        tokens, so the file must never exist unprotected with content in it.
+
+        atomic_write(restrict_to_owner=True) locks the TEMP file down before
+        any byte reaches it (the previous hand-rolled os.open at the final
+        path published the content first and applied the Windows DACL only
+        afterwards, issue #5285). Asserted by measuring the file's SIZE at
+        lockdown time — zero means no payload byte existed yet.
+        """
+        from kiro_crew import platform_compat
+
+        calls: list[tuple[str, int]] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            # is_file() guard: the spool DIRECTORY also routes through owner-
+            # only lockdown on some platforms, and a directory's st_size would
+            # fail the zero check with a misleading message.
+            p = Path(str(target))
+            if p.is_file():
+                calls.append((str(p), os.stat(p).st_size))
+            return real_restrict(target)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _measuring)
+        sid = write_spool({"html": "x"})
+
+        assert (spool_tmp / f"{sid}.json").exists()
+        file_calls = [(p, s) for p, s in calls if str(spool_tmp) in p]
+        assert len(file_calls) == 1, f"expected exactly one record-file lockdown: {calls}"
+        _, size = file_calls[0]
+        assert size == 0, f"the record already held {size} payload bytes at lockdown time"
+
+    def test_failed_lockdown_publishes_no_record(self, spool_tmp, monkeypatch):
+        """Fail closed is structural now: an unprotectable record never exists
+        at the final path (no unlink needed), and the raised OSError lets the
+        interception caller's failure-safe path deliver the original result."""
+        from kiro_crew import platform_compat
+
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _refuse(target):
+            # Only refuse the record file itself; the spool DIRECTORY lockdown
+            # (restrict_dir_to_owner routes elsewhere) and unrelated callers
+            # keep working.
+            if str(spool_tmp) in str(target):
+                raise OSError("cannot resolve the invoking user's SID")
+            return real_restrict(target)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _refuse)
+        with pytest.raises(OSError):
+            write_spool({"html": "x"})
+
+        assert not list(spool_tmp.glob("*")), (
+            "an unprotectable record (or its temp file) was left in the spool"
+        )
+
     def test_tool_input_and_result_content_persisted(self, spool_tmp):
         """Additive v1 fields: the originating tools/call arguments and result
         content ride in the record so the app initializes from real state."""
@@ -275,6 +333,23 @@ class TestSweepSpool:
         os.utime(orphan, (old, old))
         sweep_spool(max_age_hours=24.0)
         assert not orphan.exists()
+
+    def test_reaps_orphaned_stale_atomic_write_temp(self, spool_tmp):
+        """A temp file can only survive a hard kill mid-write (atomic_write
+        cleans up on every exception), but nothing else reaps this bounded-
+        lifetime directory, so the sweep must age orphaned temps out too."""
+        spool_tmp.mkdir(parents=True, exist_ok=True)
+        stale_tmp = spool_tmp / "tmpabc12345.tmp"
+        stale_tmp.write_bytes(b"partial")
+        fresh_tmp = spool_tmp / "tmpdef67890.tmp"
+        fresh_tmp.write_bytes(b"in-flight")
+        old = time.time() - 48 * 3600
+        os.utime(stale_tmp, (old, old))
+
+        sweep_spool(max_age_hours=24.0)
+
+        assert not stale_tmp.exists(), "an orphaned stale temp was not reaped"
+        assert fresh_tmp.exists(), "an in-flight fresh temp must not be reaped"
 
     def test_write_spool_sweeps_opportunistically(self, spool_tmp):
         """Every write reaps expired records so a long-running flag-on

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -609,16 +609,22 @@ def test_rewriter_calls_restrict_to_owner_on_windows(
     assert "overlay" in made_dir_names, f"overlay_dir not via make_owner_only_dir: {made_owner_dirs}"
     assert "stubs" in made_dir_names, f"stubs_dir not via make_owner_only_dir: {made_owner_dirs}"
 
-    # Files (env sidecar, overlay spec) still use restrict_to_owner directly
-    # because the non-POSIX guard in the write path fires.
+    # Files (env sidecar, overlay spec) are locked down on their TEMP name
+    # BEFORE any content reaches them (atomic_write's restrict_to_owner=True
+    # for the overlay, the hand-rolled temp-first order for the sidecar), so
+    # the recorded paths are mkstemp names inside the target directory, not
+    # the final published names.
     env_sidecars = [p for p in restricted_paths if "stubs" in str(p.parent)]
     assert env_sidecars, f"env sidecar file not restricted: {restricted_paths}"
-    # The overlay agent spec lives in overlay/ directory
+    # The overlay agent spec's temp file lives in overlay/ directory. The
+    # ".tmp" suffix pins atomic_write's mkstemp suffix — the only externally
+    # observable trace of the temp-first ordering — so a suffix change there
+    # is what breaks this line, not the rewriter.
     overlay_specs = [
         p for p in restricted_paths
-        if p.suffix == ".json" and p.parent.name == "overlay"
+        if p.suffix == ".tmp" and p.parent.name == "overlay"
     ]
-    assert overlay_specs, f"overlay spec file not restricted: {restricted_paths}"
+    assert overlay_specs, f"overlay spec temp file not restricted: {restricted_paths}"
 
 
 def test_rewriter_overlay_dirs_are_traversable_on_posix(tmp_path: Path) -> None:
@@ -672,6 +678,52 @@ def test_rewriter_overlay_dirs_are_traversable_on_posix(tmp_path: Path) -> None:
             f"{d.name} has mode {oct(mode)}, expected 0o700 (owner rwx). "
             f"0o600 would break directory traversal."
         )
+
+
+def test_overlay_lockdown_precedes_content(tmp_path: Path, monkeypatch) -> None:
+    """The per-agent overlay writer locks the temp file down BEFORE content
+    reaches it (the settings overlay shares the same atomic_write call shape).
+
+    Overlays carry passed-through env blocks (tokens / API keys); the previous
+    Windows-only post-rename restrict_to_owner left them readable under the
+    inherited DACL for the whole write window (issue #5285). Asserted by
+    measuring the file's SIZE at lockdown time — zero means no payload byte
+    existed yet. A post-write stat passes on the buggy ordering too, so it
+    would not be a regression test.
+    """
+    from kiro_crew import platform_compat
+    from kiro_crew.mcp_gateway.rewriter import rewrite_agents
+
+    source_dir = tmp_path / "agents"
+    _spec_with_env(source_dir)
+
+    overlay_dir = tmp_path / "overlay" / "agents"
+    sizes_by_dir: dict[str, list[int]] = {}
+    real_restrict = platform_compat.restrict_to_owner
+
+    def _measuring(target):
+        p = Path(str(target))
+        if p.is_file():
+            sizes_by_dir.setdefault(p.parent.name, []).append(os.stat(p).st_size)
+        return real_restrict(target)
+
+    monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _measuring)
+    rewrite_agents(
+        source_dir=source_dir,
+        overlay_dir=overlay_dir,
+        socket_path=tmp_path / "gw.sock",
+        work_dir=tmp_path / "wd",
+        sandbox_mode="auto",
+        approval_mode="interactive",
+        stub_servers=frozenset(["myserver"]),
+    )
+
+    assert (overlay_dir / "test-agent.json").exists(), "premise: overlay written"
+    agent_sizes = sizes_by_dir.get("agents", [])
+    assert agent_sizes, f"per-agent overlay lockdown never ran: {sizes_by_dir}"
+    assert all(s == 0 for s in agent_sizes), (
+        f"an overlay file already held payload bytes at lockdown time: {agent_sizes}"
+    )
 
 
 def _spec_with_env(source_dir: Path) -> None:

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -535,6 +535,57 @@ class TestHmacKeyManagementExtras:
         assert (tmp_path / "trust" / "sel_hmac.key").exists()
         assert log._hmac_key
 
+    def test_lockdown_failure_is_fail_soft(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A restrict_to_owner failure must not crash SecurityEventLog init.
+
+        The chmod test above only exercises the POSIX arm of
+        ``restrict_to_owner``; on Windows it runs icacls instead, so this
+        variant injects the failure at ``restrict_to_owner`` itself — the seam
+        ``atomic_write`` calls on every platform — pinning that
+        ``restrict_on_error="warn"`` keeps key creation fail-soft.
+        """
+        def _refuse(_target):
+            raise OSError("icacls failed")
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _refuse)
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert (tmp_path / "trust" / "sel_hmac.key").exists()
+        assert log._hmac_key
+
+    def test_key_lockdown_precedes_content(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh HMAC key must never exist in a file that has not been
+        locked down yet.
+
+        atomic_write(restrict_to_owner=True) applies the lockdown to the TEMP
+        file before the key bytes reach it (the previous post-rename lockdown
+        left a brand-new key readable under the inherited DACL on Windows for
+        the write window, issue #5285). Asserted by measuring the file's SIZE
+        at lockdown time — zero means no key byte existed yet.
+        """
+        from kiro_crew import platform_compat
+
+        trust_dir = tmp_path / "trust"
+        calls: list[tuple[Path, int]] = []
+        real_restrict = platform_compat.restrict_to_owner
+
+        def _measuring(target):
+            p = Path(str(target))
+            if p.is_file() and p.parent == trust_dir:
+                calls.append((p, os.stat(p).st_size))
+            return real_restrict(target)
+
+        monkeypatch.setattr("kiro_crew.platform_compat.restrict_to_owner", _measuring)
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+
+        assert log._hmac_key
+        assert calls, "premise: the key lockdown ran at all"
+        _, size = calls[0]
+        assert size == 0, f"the key file already held {size} bytes at lockdown time"
+
     def test_singleton_init_is_idempotent(self, tmp_path: Path) -> None:
         a = SecurityEventLog(base_dir=tmp_path, sync=True)
         # Second call must reuse the original instance and ignore base_dir.


### PR DESCRIPTION
Closes #5307

## What

Seven sites applied `restrict_to_owner` to a file's FINAL path only after the payload was already published there, leaving the content readable under the inherited DACL on Windows for the whole write window. The two ops_mission_control stores additionally unlinked the just-published store on a lockdown OSError — so one transient icacls failure deleted every stored provider token, or silently reset the governance ceiling.

Each site is converted to `atomic_write(restrict_to_owner=True)` (PR #5302's recipe): the temp file is locked down before any content byte reaches it, and every failure happens before the rename, so an unprotectable file never exists at the final path and the previous healthy store always survives.

## Converted sites

**Tier 1 (post-publish window + previous-store data loss):**
- `ops_mission_control/backend/secrets.py` `_SecretStore._write` — try/except unlink+raise deleted; `_SECRET_FILE_MODE` lost its last consumer and is removed
- `ops_mission_control/backend/policy_store.py` `_write` — same; `_POLICY_FILE_MODE` removed

**Tier 2 (post-publish ACL window on Windows):**
- `mcp_gateway/rewriter.py` per-agent overlay + settings overlay writes (the other two restrict calls at the cache-hit re-assert already lock the temp first and are untouched)
- `service/live_target.py` `write_target` + `restore` — `restore` keeps its return-False-not-raise contract (the lockdown OSError now surfaces pre-rename into the existing except); the caller-side `mkdir` is removed because `atomic_write` creates the parent itself after its planted-link check; `_MODE` removed
- `mcp_gateway/apps.py` spool write — replaces the hand-rolled `os.open(O_CREAT|O_TRUNC)` at the final path; `MAX_SPOOL_BYTES` still rejects before any filesystem touch, failures still propagate into the interception failure-safe path, and fail-closed is now structural (no unlink needed). `sweep_spool` gains a `*.tmp` age-out branch so a hard-kill orphan cannot grow the bounded spool.

**Triage list — converted (identical mechanical shape):**
- `sel.py` HMAC key create — `restrict_on_error="warn"` keeps its fail-soft policy (pinned by a new lockdown-failure test)
- `kiro_prerequisite.py` `_atomic_write_secret_bytes` (hand-rolled temp+replace+post-restrict collapses to one call)
- `kiro_prerequisite.py` setup marker (`atomic_write(mode=)` + post-publish restrict pair)

## Triage list — classified, not converted

| Site | Classification | Reason |
|---|---|---|
| `snapshot.py:365` | out of scope | tarfile streams directly to a uniquely-named archive; the unlink removes only the new artifact (no previous data at that path); lockdown-before-content needs a stream-restructure recipe, not this PR's mechanical one |
| `snapshot.py:602,702` | out of scope | restore paths using `shutil.copy2`; the source survives in the snapshot archive so the unlink loses nothing; not the `atomic_write` shape |
| `sel.py:792` | correct shape | load-time re-assert on an existing key, no write |
| `kiro_prerequisite.py:757` | correct shape | `O_EXCL` empty create → restrict → sqlite fills it (lockdown precedes content) |
| `dashboard/token_secret.py:59` | correct shape | load-time re-assert, no write |
| `dashboard/token_auth.py:1000` | correct shape | restrict runs on the empty `O_TRUNC` fd before content is written |
| `dashboard/server.py:1502` | correct shape | same restrict-before-content-into-fd shape |
| `cron_script.py:668` | correct shape | restrict precedes the secret `os.write` (its own comment states the ordering) |
| `computer_use/service.py:393` | out of scope | `mkstemp` names the final file (0600 at birth on POSIX); screenshot frames in a per-user temp dir; converting would double-write large frames for a defence-in-depth re-assert |
| `computer_use/capture_windows.py:423`, `capture_macos.py:247` | correct shape / out of scope | files are born under `make_owner_only_dir`'s inheritable `(OI)(CI)` owner-only DACL, so no window exists; the restrict is a re-assert |
| `cli_commands.py:2514` | out of scope per #5240 | a `write_config_atomically` (`update_config_locked`) caller |

## Behavior notes

- `restrict_to_owner=True` implies `atomic_write`'s linked-parent refusal at every converted site, which raises unconditionally (not covered by `restrict_on_error`). For `sel.py` this means a symlink-loop/vanishing-component in the trust dir's parent chain now refuses key creation at `SecurityEventLog` init where the old code wrote through it — deliberate #4381-class hardening, stated here so the support signature is searchable. sel's own linked-trust-dir migration guard runs first and already handles the common layouts.
- A pre-existing rewriter defect surfaced by review (transient overlay write failure → the prune loop deletes the previous healthy overlay) is NOT addressed here; it is identical before and after this patch and is filed as #5328.

## Tests

- Both ops stores: lockdown-precedes-content (file size measured at lockdown time — zero means no payload byte existed), previous-store-survival on lockdown failure, and previous-store-survival on `mkstemp` ENOSPC (ported from `test_aws_consent.py::TestGrantIsOnTheKeystoneFloor`, mocks scoped to `atomic_write`'s own `tempfile` binding)
- live_target: lockdown-precedes-content for `write_target` and `restore`; a failed rollback is pinned to publish nothing
- spool: lockdown-precedes-content; a failed lockdown leaves the spool dir completely empty (`*` glob, temp included); orphaned `*.tmp` age-out
- rewriter: the simulated-Windows restrict test re-anchored to the temp-file lockdown; a new POSIX lockdown-precedes-content test
- sel: new lockdown-failure fail-soft test injecting at `restrict_to_owner` itself (the chmod-mock sibling only exercises the POSIX arm)
- kiro_prerequisite: lockdown-precedes-content for `_atomic_write_secret_bytes`

## Verification

- isort / flake8 / mypy (1039 files) / black baseline gate / brand gate / harness-parity gate: clean
- Full backend suite: 62,000 passed; 20 failures are host-environment artifacts reproduced byte-identically on unmodified origin/main in the same environment (explicit `-n` vs the xdist worker-budget tests, a /tmp-rooted checkout vs artifact-source classification, iMessage RPC timeouts)
- Pre-push reviews: GPT lane (gpt-5.6-sol) PASS; Opus lane (claude-opus-5) BLOCK on a committed `.lock` residue file, removed; all other findings (spool `*.tmp` sweep, mock scoping, `addCleanup` shape, test-strength nits) folded in

No UI changes (backend-only), so no screenshots.
