### PR TITLE
fix(apps): guard non-object agent-spec JSON at three json.loads consumers (#5319)

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -896,10 +896,19 @@ def _register_agents(app_name: str, manifest: AppManifest, app_root: Path) -> li
         # Read agent JSON to get the agent name
         try:
             agent_data = json.loads(agent_path.read_text(encoding="utf-8"))
-            agent_name = agent_data.get("name", agent_path.stem)
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("App %s: unreadable agent %s: %s", app_name, agent_path, exc)
             continue
+        if not isinstance(agent_data, dict):
+            # Valid JSON that is not an object (a list, a scalar, null) parses
+            # fine, but every `.get` below would raise. Same disposition as the
+            # unreadable case: skip this agent rather than register a config
+            # the spec never described.
+            logger.warning(
+                "App %s: agent spec %s is not a JSON object; skipping", app_name, agent_path
+            )
+            continue
+        agent_name = agent_data.get("name", agent_path.stem)
 
         # The agent name is app-controlled (read from the agent JSON) and is
         # about to become a filesystem path component. Reject any path separator
@@ -2273,7 +2282,6 @@ def _prune_stale_app_resources(app_name: str, manifest: AppManifest, app_root: P
             if not agent_path.resolve().is_relative_to(app_root.resolve()):
                 continue
             data = json.loads(agent_path.read_text(encoding="utf-8"))
-            agent_name = data.get("name", agent_path.stem)
         except (json.JSONDecodeError, OSError) as exc:
             # A declared agent we CANNOT read is not the same as a removed one. If
             # we skipped it, its name would be absent from `current_links` and the
@@ -2289,6 +2297,20 @@ def _prune_stale_app_resources(app_name: str, manifest: AppManifest, app_root: P
             )
             current_links = None  # type: ignore[assignment]  # sentinel: do not prune agents
             break
+        if not isinstance(data, dict):
+            # Valid JSON that is not an object (a list, a scalar, null) parses
+            # fine, but it carries no readable `name` — the same cannot-read !=
+            # removed situation as above. Abort the agent prune so this agent
+            # does not fall out of `current_links` and lose its last-good
+            # materialized config.
+            logger.warning(
+                "Skipping agent prune for %s: declared agent %s is not a JSON object",
+                app_name,
+                agent_path_str,
+            )
+            current_links = None  # type: ignore[assignment]  # sentinel: do not prune agents
+            break
+        agent_name = data.get("name", agent_path.stem)
         current_links.add(_safe_link_name(_namespace(app_name, agent_name)) + ".json")
     agents_dir = _kiro_agents_dir()
     if current_links is not None and agents_dir.is_dir():

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1697,6 +1697,11 @@ def _read_managed_tool_policy_sync(agent_path: Path) -> dict[str, Any] | None:
         config = json.loads(agent_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(config, dict):
+        # Valid JSON that is not an object (a list, a scalar, null) parses
+        # fine, but `.get` on it would raise. It is a malformed spec, so it
+        # takes the same disposition as the unparseable case above.
+        return None
     policy = config.get("managedToolPolicy", {})
     return policy if isinstance(policy, dict) else None
 

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -323,6 +323,30 @@ class TestAgentRegistration:
         assert link.is_file(), "the working config must survive a failed rewrite"
         assert link.read_text(encoding="utf-8") == good, "…with its old contents intact"
 
+    @pytest.mark.parametrize("content", ["[1, 2, 3]", "42", "null", "true", '"a string"'])
+    def test_a_valid_json_non_object_agent_spec_is_skipped(
+        self, tmp_path, app_env, content
+    ):
+        """A spec that is valid JSON but not an object parses fine, so the
+        JSONDecodeError guard never fires — but ``.get`` on the parsed value
+        would raise AttributeError and take down the whole registration pass.
+        Same disposition as the unreadable case: skip that agent, register
+        nothing for it, and do not crash.
+        """
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        app_root = app_env["home"] / "apps" / "test-app"
+        (app_root / "agents" / "my-agent.json").write_text(content, encoding="utf-8")
+
+        registered = _register_agents("test-app", manifest, app_root)
+
+        assert registered == []
+        link = app_env["kiro_agents"] / "test-app--my-agent.json"
+        assert not link.exists(), "a spec that was never understood must not be materialized"
+
     def test_a_legacy_symlink_is_still_replaced(self, tmp_path, app_env):
         """A symlink from an older KiroCrew is dropped and replaced with a real file."""
         src = _make_app_source(tmp_path)
@@ -3334,6 +3358,33 @@ class TestPruneAbortsOnUnreadableAgent:
 
         bridges_mod._prune_stale_app_resources("test-app", manifest, app_root)
         assert keep.is_file(), "prune must abort — not delete a config over an unreadable source"
+
+    @pytest.mark.parametrize("content", ["[1, 2, 3]", "42", "null", "true", '"a string"'])
+    def test_a_valid_json_non_object_agent_spec_aborts_the_agent_prune(
+        self, tmp_path, app_env, monkeypatch, content
+    ):
+        """Valid JSON that is not an object parses fine, so the JSONDecodeError
+        guard never fires — but ``.get`` on the parsed value would raise
+        AttributeError. A spec that cannot be read as an object is the same
+        cannot-read != removed situation: the agent must be RETAINED (treated
+        as present), never pruned out of its last-good materialized config.
+        """
+        from kiro_crew.apps import bridges as bridges_mod
+
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        app_root = app_env["home"] / "apps" / "test-app"
+        # A materialized config that MUST survive if the prune aborts.
+        keep = app_env["kiro_agents"] / "test-app--my-agent.json"
+        keep.write_text('{"name": "my-agent"}', encoding="utf-8")
+        # Make the declared agent source valid JSON but not an object.
+        (app_root / "agents" / "my-agent.json").write_text(content, encoding="utf-8")
+
+        bridges_mod._prune_stale_app_resources("test-app", manifest, app_root)
+        assert keep.is_file(), "prune must retain the agent — a non-object spec is unreadable, not removed"
 
 
 class TestMalformedConfigIsNotClobbered:

--- a/test/test_session_tool_policy_off_loop.py
+++ b/test/test_session_tool_policy_off_loop.py
@@ -115,6 +115,29 @@ async def test_an_unparseable_agent_config_is_an_empty_policy(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("content", ["[1, 2, 3]", "42", "null", "true", '"a string"'])
+async def test_a_valid_json_non_object_agent_config_is_an_empty_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, content: str
+) -> None:
+    """A spec that is valid JSON but not an object parses fine, so the
+    JSONDecodeError guard never fires — but ``.get`` on the parsed value would
+    raise AttributeError out of the handler. It is a malformed spec: answer the
+    same empty policy as the unparseable case, and do not log it as a success
+    (only a config that was read AND understood earns the SEL ``ok`` record).
+    """
+    (tmp_path / f"{AGENT}.json").write_text(content, encoding="utf-8")
+
+    sel = MagicMock()
+    monkeypatch.setattr(sessions_mod, "kiro_agents_dir", lambda: tmp_path)
+    monkeypatch.setattr(sessions_mod, "_sel", lambda: sel)
+    response = await sessions_mod.api_session_tool_policy(_request(_state()))
+
+    assert response.status == 200
+    assert _body(response) == {}
+    assert not sel.log_api_access.called, "a config that was never understood must not report ok"
+
+
+@pytest.mark.asyncio
 async def test_a_non_dict_policy_is_an_empty_policy(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem / Motivation

An agent spec file that is valid JSON but NOT a JSON object (`[1,2,3]`, `42`, `null`) parses cleanly, so guards that only catch parse FAILURE (`json.JSONDecodeError` / `OSError`) let it through, and the subsequent `.get(...)` on the parsed value raises `AttributeError`. Three sites on main have this shape:

- `src/kiro_crew/dashboard/handlers/sessions.py` `_read_managed_tool_policy_sync` — `config.get("managedToolPolicy", {})` sits outside the except, so the `AttributeError` escapes into the `/api/session-tool-policy` handler path.
- `src/kiro_crew/apps/bridges.py` `_register_agents` — `agent_data.get("name", ...)` is inside the `try`, but the except does not catch `AttributeError`, so one bad spec takes down the whole app registration pass.
- `src/kiro_crew/apps/bridges.py` `_prune_stale_app_resources` — same shape in the unlink/prune pass, where the documented semantic is that an agent we cannot read must be treated as PRESENT, never removed.

Follow-up to #5309 / PR #5316 (which guarded the `cli_doctor.py` MCP section); these three sites were counted by that PR's review and verified by execution-path reading.

## Why it matters

A single malformed agent spec on disk crashes a request handler that managed MCP servers call on ordinary traffic, aborts registration of every remaining healthy agent in an app, and — worst — could interact with the prune pass whose whole design contract is "cannot read != removed": an uncaught `AttributeError` there aborts app reconciliation entirely.

## What changed (motivation → approach → change)

Symptom: `AttributeError: 'list'/'int'/'NoneType' object has no attribute 'get'` from agent-spec readers. Root cause: `json.loads` accepts any JSON value, but the guards only covered parse failure, not a parse SUCCESS of the wrong shape. The fix mirrors PR #5316's shape — an explicit `isinstance(…, dict)` check right after the parse — while preserving each site's own documented semantic:

- `_read_managed_tool_policy_sync`: a non-dict parse result returns `None` (malformed, not "an agent with no policy"), so the handler answers the same empty policy as the unparseable case and, as before, does not log a SEL `ok` for a config it never understood.
- `_register_agents`: a non-dict spec is skipped with a warning, the same disposition as the unreadable case — nothing is registered for a spec that described nothing.
- `_prune_stale_app_resources`: a non-dict spec routes to the same abort branch as `JSONDecodeError`/`OSError` — the agent counts as UNREADABLE (present), so it never falls out of `current_links` and its last-good materialized config is never pruned.

Per-site guards were preferred over a shared read helper because the three sites' failure dispositions genuinely diverge (return-None vs skip-and-continue vs abort-the-prune).

## Tests

Parametrized regression tests per site over the non-object family (`[1, 2, 3]`, `42`, `null`, `true`, `"a string"`):

- `test_session_tool_policy_off_loop.py::test_a_valid_json_non_object_agent_config_is_an_empty_policy` — answers `{}` with status 200 and does not log SEL `ok`.
- `test_app_bridges.py::TestAgentRegistration::test_a_valid_json_non_object_agent_spec_is_skipped` — registers nothing, materializes no link, does not crash.
- `test_app_bridges.py::TestPruneAbortsOnUnreadableAgent::test_a_valid_json_non_object_agent_spec_aborts_the_agent_prune` — the agent is RETAINED (materialized config survives), not pruned.

All 15 parametrized cases were verified to fail with `AttributeError` against unfixed production code before the fix was applied.

## Manual verification

N/A — unit coverage sufficient: all three consumers are exercised directly by the new tests through their real read paths against on-disk spec files.

## Related Issues

Closes #5319

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend files touched, no rendered UI delta.
