### PR TITLE
fix(security): resolve 5 open CSE findings on main

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -618,7 +618,10 @@ async def _handle_issues_first_page(
             partial(client.list_open_issues_first_page, owner, repo, **pkw)
         )
     except GhCliError as exc:
-        return web.json_response({"error": str(exc), "code": "provider_error"}, status=502)
+        logger.warning("issue-radar list_open_issues provider error: %s", exc)
+        return web.json_response(
+            {"error": "upstream provider error", "code": "provider_error"}, status=502
+        )
     return web.json_response({
         **_identity(key), "state": "open",
         "issues": issues, "from_cache": False, "partial": True,
@@ -1159,7 +1162,10 @@ async def _handle_pulls_first_page(
             partial(client.list_open_pulls_first_page, owner, repo, **pkw)
         )
     except GhCliError as exc:
-        return web.json_response({"error": str(exc), "code": "provider_error"}, status=502)
+        logger.warning("issue-radar list_open_pulls provider error: %s", exc)
+        return web.json_response(
+            {"error": "upstream provider error", "code": "provider_error"}, status=502
+        )
     return web.json_response({
         **_identity(key), "state": "open",
         "pulls": pulls, "from_cache": False, "partial": True,
@@ -2555,7 +2561,7 @@ async def _handle_issue_assignees(request: web.Request) -> web.Response:
     except GhCliError as exc:
         _audit("issue_assignees", target, "failure", error=str(exc))
         return web.json_response(
-            {"error": str(exc), "code": "provider_error"}, status=502
+            {"error": "upstream provider error", "code": "provider_error"}, status=502
         )
 
     if final_assignees is None:

--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -9,13 +9,79 @@ import logging
 from aiohttp import web
 
 from kiro_crew.config.loader import config_dir
+from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 from kiro_crew.secrets import SecretVault
 
 logger = logging.getLogger(__name__)
 
 
+def _sel():
+    """Late-binding sel() for test monkeypatch compatibility (see agents.py)."""
+    import kiro_crew.dashboard.handlers as _pkg
+
+    return _pkg.sel()
+
+
+async def _owner_only(request: web.Request, operation: str) -> web.Response | None:
+    """Return a 403 unless the caller is the configured dashboard owner.
+
+    The `/api/secrets` routes read, overwrite and delete AES-256-GCM vault
+    entries — machine-global, keystone-floor material that later sessions and
+    other integrations consume. `token_auth_middleware` authenticates the
+    request but does NOT restrict it to the owner: an app token or any other
+    authenticated dashboard subject (e.g. a Slack-origin credential minted for
+    a different subject) reaches these handlers. Gate them per-handler with the
+    same predicate the sibling secret-adjacent handlers use
+    (`agents.py`, `aws_consent.py`, `messaging.py`), and — matching those
+    handlers — write a SEL audit record on the denial so a non-owner attempt on
+    the vault is not silent. Returns the 403 to send, or ``None`` when the
+    caller is the owner.
+    """
+    if is_owner_dashboard_request(request):
+        return None
+    # Off the loop: the FIRST sel() of a process CONSTRUCTS the log (trust-dir
+    # creation, key validation, on Windows an icacls subprocess), so on a fresh
+    # gateway whose first secrets request is non-owner this would otherwise
+    # stall every other request. Same reasoning as agents._require_owner.
+    caller = str(request.get("user") or "unknown")
+    try:
+        await asyncio.to_thread(
+            lambda: _sel().log_api_access(
+                caller=caller,
+                operation=operation,
+                outcome="denied",
+                source="dashboard",
+                resources="non_owner_block",
+            )
+        )
+    except Exception:  # pragma: no cover — audit must never change the outcome
+        logger.debug("SEL audit for non-owner %s failed", operation, exc_info=True)
+    return web.json_response(
+        {"error": "owner authorization required", "code": "owner_only"},
+        status=403,
+    )
+
+
+def _sanitize_for_log(value: str) -> str:
+    """Neutralize control characters before a user-controlled value is logged.
+
+    The secret ``name`` is free-form user input (request body or URL path
+    segment) and only has leading/trailing whitespace trimmed, so interior
+    ``\\n`` / ``\\r`` / ``\\t`` survive into the log sink and let a caller forge
+    additional log lines / fake audit entries (CWE-117 log injection). Escape
+    the control characters into their literal two-character forms so the value
+    is still readable in the log but can no longer break onto a new line.
+    """
+    return (
+        value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    )
+
+
 async def api_secrets_list(request: web.Request) -> web.Response:
     """GET /api/secrets — list stored secret names (values are never exposed)."""
+    denied = await _owner_only(request, "secrets_list")
+    if denied is not None:
+        return denied
     vault = SecretVault(config_dir())
     # `list_names` is synchronous: it reads the whole store off disk and parses
     # the JSON. Calling it directly would block the gateway's event loop for the
@@ -31,6 +97,9 @@ async def api_secrets_set(request: web.Request) -> web.Response:
 
     Body: {"name": "...", "value": "..."}
     """
+    denied = await _owner_only(request, "secrets_set")
+    if denied is not None:
+        return denied
     try:
         body = await request.json()
     except (json.JSONDecodeError, ValueError):
@@ -73,12 +142,15 @@ async def api_secrets_set(request: web.Request) -> web.Response:
 
     vault = SecretVault(config_dir())
     await vault.set(name, value)
-    logger.info("Vault entry '%s' stored via dashboard", name)
+    logger.info("Vault entry '%s' stored via dashboard", _sanitize_for_log(name))
     return web.json_response({"ok": True, "name": name})
 
 
 async def api_secrets_delete(request: web.Request) -> web.Response:
     """DELETE /api/secrets/{name} — delete a secret."""
+    denied = await _owner_only(request, "secrets_delete")
+    if denied is not None:
+        return denied
     name = request.match_info["name"]
     if not name:
         return web.json_response(
@@ -87,7 +159,7 @@ async def api_secrets_delete(request: web.Request) -> web.Response:
 
     vault = SecretVault(config_dir())
     await vault.delete(name)
-    logger.info("Vault entry '%s' deleted via dashboard", name)
+    logger.info("Vault entry '%s' deleted via dashboard", _sanitize_for_log(name))
     return web.json_response({"ok": True, "name": name})
 
 

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1662,25 +1662,36 @@ def caller_record_is_missing(
 
 
 def _cron_job_exists(jobs: object, job_id: str) -> bool:
-    """Whether a cron job id is in the registry (cache-only read, see ``_cron_job_owner``)."""
+    """Whether a cron job id is in the registry (cache-only read, see ``_cron_job_owner``).
+
+    Fails CLOSED: an unreadable/erroring registry returns ``False`` ("does not
+    exist") so the ``_internal_caller_record_missing`` DENY branch fires and the
+    delegated caller is refused rather than admitted as the unscoped dashboard
+    user. Per SAX-04 outcome_3, an auth decision must fail closed when the source
+    it depends on is unavailable; the in-memory registry makes this rare, but the
+    branch must not silently escalate a delegated caller on a torn read.
+    """
     try:
         snapshot = list(cast("Iterable[Any]", jobs))
     except Exception:  # noqa: BLE001 - an auth path must never 500 on this
-        # Cannot read the registry: do not manufacture a refusal from a failure
-        # to look, which would deny every delegated caller on a transient error.
-        return True
+        return False
     return any(str(getattr(j, "id", "") or "") == job_id for j in snapshot)
 
 
 def _subagent_record_exists(subagents: object, agent_id: str) -> bool:
-    """Whether a subagent id is in the registry (plain dict lookup)."""
+    """Whether a subagent id is in the registry (plain dict lookup).
+
+    Fails CLOSED on an unreadable registry (no ``get`` / lookup raises): returns
+    ``False`` so the delegated caller is denied rather than escalated. See
+    ``_cron_job_exists`` for the SAX-04 fail-closed rationale.
+    """
     lookup = getattr(subagents, "get", None)
     if lookup is None:
-        return True  # unreadable registry: see ``_cron_job_exists``
+        return False  # unreadable registry: fail closed, see ``_cron_job_exists``
     try:
         return lookup(agent_id) is not None
     except Exception:  # noqa: BLE001 - an auth path must never 500 on this
-        return True
+        return False
 
 
 def caller_names_a_missing_slot(slots: object, session_key: str) -> bool:

--- a/src/kiro_crew/mcp_gateway/resolve_once.py
+++ b/src/kiro_crew/mcp_gateway/resolve_once.py
@@ -340,6 +340,15 @@ def resolved_launch(
     record = read_record(directory)
     if record is None:
         return None
+    # `spec_dir` keys on `NpmSpec.digest`, a SHA-256 truncated to 64 bits, so a
+    # birthday-bound collision (~2^32 specs) could resolve one spec to the tree
+    # installed for another and exec the WRONG program. The path-containment and
+    # isfile checks below do not catch that: both would pass for the colliding
+    # tree. Confirm the stored record was written for THIS spec before trusting
+    # its entrypoint; on mismatch treat it as a cache miss and let the caller
+    # keep today's invocation.
+    if record.package != spec.package:
+        return None
     entrypoint = os.path.join(directory, record.entrypoint)
     # Re-check containment on read, not just on write: the record is a plain
     # file, so a hand-edit or a partially-overwritten one must not turn into an

--- a/test/test_internal_secret_app_identity_3690.py
+++ b/test/test_internal_secret_app_identity_3690.py
@@ -534,9 +534,19 @@ class TestADelegatedCallerWhoseRecordIsGoneIsRefused:
         assert caller_record_is_missing("cron:job-9", None, None) is False
         assert caller_record_is_missing("subagent:abc", None, None) is False
 
-    def test_an_unreadable_registry_is_not_a_refusal(self) -> None:
-        """Do not manufacture a refusal from a failure to LOOK -- that would deny
-        every delegated caller on a transient error."""
+    def test_an_unreadable_present_registry_fails_closed(self) -> None:
+        """A registry that IS present but throws on read must fail CLOSED (CWE-636).
+
+        This is distinct from ``test_an_absent_registry_is_not_a_refusal``: there
+        the surface is wired without a registry ON PURPOSE (the ``--slack-only``
+        API server), and ``caller_record_is_missing`` short-circuits on ``None``
+        before ever reaching the existence helpers. Here the registry object is
+        present but torn / mid-swap, so the read raises. Admitting the delegated
+        caller on that error escalates it to the unscoped dashboard user with its
+        app-scope silently dropped, which SAX-04 outcome_3 forbids: an auth
+        decision must fail closed when the source it depends on is unavailable.
+        A present-but-unreadable registry therefore reports the record as MISSING
+        (``caller_record_is_missing`` -> True), so the caller is refused."""
 
         class _Boom:
             def __iter__(self):  # noqa: ANN204
@@ -545,8 +555,18 @@ class TestADelegatedCallerWhoseRecordIsGoneIsRefused:
             def get(self, _k):  # noqa: ANN001, ANN202
                 raise RuntimeError("mid-mutation")
 
-        assert caller_record_is_missing("cron:j", _Boom(), None) is False
-        assert caller_record_is_missing("subagent:a", None, _Boom()) is False
+        assert caller_record_is_missing("cron:j", _Boom(), None) is True
+        assert caller_record_is_missing("subagent:a", None, _Boom()) is True
+
+    def test_a_subagents_registry_without_get_fails_closed(self) -> None:
+        """A subagent registry object missing a ``get`` (unreadable shape) fails
+        closed too: the record reads as MISSING, so the delegated caller is
+        refused rather than escalated (CWE-636 / SAX-04 outcome_3)."""
+
+        class _NoGet:
+            pass
+
+        assert caller_record_is_missing("subagent:a", None, _NoGet()) is True
 
     def test_a_resolvable_app_owner_is_never_refused(self) -> None:
         """The deny is the else-branch of resolution, so a found owner wins."""

--- a/test/test_mcp_resolve_once.py
+++ b/test/test_mcp_resolve_once.py
@@ -358,6 +358,29 @@ class TestResolvedLaunch:
         )
         assert R.resolved_launch(str(tmp_path), "npx", ["-y", "foo@1.0.0"]) is None
 
+    def test_digest_collision_execs_nothing(self, tmp_path, monkeypatch) -> None:
+        """A 64-bit digest collision must NOT exec the other spec's program (CWE-328).
+
+        ``spec_dir`` keys on the ``NpmSpec.digest`` property = a SHA-256 truncated
+        to 16 hex chars (64 bits), so two distinct specs can collide onto the same
+        directory. Force that: pin every spec's digest to one constant so the
+        installed ``innocent`` tree and a requested ``evil`` spec share a dir.
+        Without the ``record.package == spec.package`` guard the path-containment
+        and isfile checks both pass and the launcher execs the WRONG program;
+        with it the mismatch is a cache miss. A control run for the installed
+        spec (same constant digest) still launches, proving the miss is the
+        package-equality guard and not a broken directory.
+        """
+        monkeypatch.setattr(R.shutil, "which", lambda _n: "/usr/bin/node")
+        monkeypatch.setattr(R.NpmSpec, "digest", property(lambda self: "deadbeefdeadbeef"))
+        installed = R.NpmSpec(package="innocent@1.0.0", passthrough=())
+        _commit_tree(str(tmp_path), installed)
+
+        # The requested spec resolves to the SAME dir but names a different pkg.
+        assert R.resolved_launch(str(tmp_path), "npx", ["-y", "evil@9.9.9"]) is None
+        # Control: the spec the tree was actually installed for still launches.
+        assert R.resolved_launch(str(tmp_path), "npx", ["-y", "innocent@1.0.0"]) is not None
+
     def test_stale_record_still_launches(self, tmp_path, monkeypatch) -> None:
         # Staleness is the prefetcher's business. A stale tree still launches
         # correctly, and treating "due for refresh" as "cannot launch" would turn

--- a/test/test_secrets_handler.py
+++ b/test/test_secrets_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,36 @@ from aiohttp import web
 
 from kiro_crew.dashboard.handlers.secrets import setup_secrets_routes
 from kiro_crew.secrets import SecretVault
+
+
+class _FakeState:
+    """No owner configured: only the signed local bootstrap subjects pass."""
+
+    owner_id = ""
+
+
+def _app() -> web.Application:
+    """A dashboard app whose secrets routes see an AUTHENTICATED owner caller.
+
+    Stands in for ``token_auth_middleware``: the secrets handlers gate on
+    ``is_owner_dashboard_request``, which reads ``request["user"]`` /
+    ``request["app"]`` and ``app["state"].owner_id``. With no owner configured,
+    the default local-app subject (empty app + ``local-app`` user) is the
+    implicit owner, so existing behavioural tests exercise the authorized path.
+    A test can select a different caller via the ``X-Test-User`` /
+    ``X-Test-App`` headers.
+    """
+
+    @web.middleware
+    async def _identity(request, handler):
+        request["user"] = request.headers.get("X-Test-User", "local-app")
+        request["app"] = request.headers.get("X-Test-App", "")
+        return await handler(request)
+
+    app = web.Application(middlewares=[_identity])
+    app["state"] = _FakeState()
+    setup_secrets_routes(app)
+    return app
 
 
 @pytest.fixture()
@@ -31,8 +62,7 @@ class TestApiSecretsList:
 
     @pytest.mark.asyncio
     async def test_lists_names_sorted(self, vault_dir: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -45,8 +75,7 @@ class TestApiSecretsList:
 
     @pytest.mark.asyncio
     async def test_empty_vault(self, empty_vault_dir: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -65,8 +94,7 @@ class TestApiSecretsSet:
 
     @pytest.mark.asyncio
     async def test_stores_secret(self, tmp_path: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -86,8 +114,7 @@ class TestApiSecretsSet:
 
     @pytest.mark.asyncio
     async def test_missing_name(self, tmp_path: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -98,8 +125,7 @@ class TestApiSecretsSet:
 
     @pytest.mark.asyncio
     async def test_missing_value(self, tmp_path: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -114,8 +140,7 @@ class TestApiSecretsDelete:
 
     @pytest.mark.asyncio
     async def test_deletes_secret(self, vault_dir: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -131,8 +156,7 @@ class TestApiSecretsDelete:
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent(self, vault_dir: Path) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -140,6 +164,158 @@ class TestApiSecretsDelete:
             async with TestClient(TestServer(app)) as client:
                 resp = await client.delete("/api/secrets/MISSING")
                 assert resp.status == 200  # delete is idempotent
+
+
+class TestApiSecretsOwnerAuthorization:
+    """Every /api/secrets route is owner-only (CWE-862).
+
+    The AES-256-GCM vault is machine-global keystone-floor material, so an app
+    token or any authenticated non-owner dashboard subject must not enumerate,
+    overwrite/poison, or delete entries. The handlers gate on
+    ``is_owner_dashboard_request`` — an app-scoped caller (non-empty ``app``)
+    and a non-owner user are both refused with 403 ``owner_only``, and nothing
+    is written.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "path", "json_body"),
+        [
+            ("get", "/api/secrets", None),
+            ("post", "/api/secrets", {"name": "EVIL", "value": "x"}),
+            ("delete", "/api/secrets/TEST_KEY", None),
+        ],
+    )
+    async def test_app_token_is_refused(
+        self, vault_dir: Path, method: str, path: str, json_body: object
+    ) -> None:
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
+            async with TestClient(TestServer(app)) as client:
+                # X-Test-App non-empty => an app-scoped (non-owner) caller.
+                headers = {"X-Test-App": "some-app", "X-Test-User": "some-app-subject"}
+                resp = await getattr(client, method)(path, headers=headers, json=json_body)
+                assert resp.status == 403
+                data = await resp.json()
+                assert data["code"] == "owner_only"
+                # The write surfaces must not have mutated the vault.
+                assert sorted(SecretVault(vault_dir).list_names()) == ["DB_PASS", "TEST_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_non_owner_user_is_refused_when_owner_configured(self, vault_dir: Path) -> None:
+        app = _app()
+        app["state"].owner_id = "U_OWNER"  # type: ignore[attr-defined]
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
+            async with TestClient(TestServer(app)) as client:
+                headers = {"X-Test-User": "U_SOMEONE_ELSE"}
+                resp = await client.post(
+                    "/api/secrets", headers=headers, json={"name": "EVIL", "value": "x"}
+                )
+                assert resp.status == 403
+                data = await resp.json()
+                assert data["code"] == "owner_only"
+                assert sorted(SecretVault(vault_dir).list_names()) == ["DB_PASS", "TEST_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_denial_is_audited(self, vault_dir: Path) -> None:
+        """A non-owner denial writes a SEL audit record (outcome="denied"), so a
+        rejected attempt on the vault is not silent — matching the sibling
+        agent-spec / aws-consent / messaging handlers."""
+        app = _app()
+
+        from unittest.mock import MagicMock
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        sel = MagicMock()
+        with (
+            patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)),
+            patch("kiro_crew.dashboard.handlers.secrets._sel", return_value=sel),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/secrets",
+                    headers={"X-Test-App": "some-app", "X-Test-User": "some-app-subject"},
+                    json={"name": "EVIL", "value": "x"},
+                )
+                assert resp.status == 403
+        sel.log_api_access.assert_called_once()
+        kwargs = sel.log_api_access.call_args.kwargs
+        assert kwargs["outcome"] == "denied"
+        assert kwargs["operation"] == "secrets_set"
+        assert kwargs["source"] == "dashboard"
+
+    @pytest.mark.asyncio
+    async def test_configured_owner_is_allowed(self, vault_dir: Path) -> None:
+        app = _app()
+        app["state"].owner_id = "U_OWNER"  # type: ignore[attr-defined]
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get("/api/secrets", headers={"X-Test-User": "U_OWNER"})
+                assert resp.status == 200
+
+
+class TestApiSecretsLogInjection:
+    """Control characters in the secret name must not reach the log verbatim (CWE-117).
+
+    ``name`` is free-form user input trimmed only with ``.strip()``, which
+    leaves interior ``\\n`` / ``\\r`` in place. Unsanitized, that forges extra
+    log lines / fake audit entries. The handler escapes control characters
+    before logging, so the emitted record stays on one line.
+    """
+
+    @pytest.mark.asyncio
+    async def test_newline_in_set_name_is_escaped_in_log(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _app()
+        payload = "ok\nWARNING forged audit line"
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(tmp_path)):
+            async with TestClient(TestServer(app)) as client:
+                with caplog.at_level(logging.INFO, logger="kiro_crew.dashboard.handlers.secrets"):
+                    resp = await client.post("/api/secrets", json={"name": payload, "value": "v"})
+                    assert resp.status == 200
+
+        stored = [r for r in caplog.records if "stored via dashboard" in r.getMessage()]
+        assert stored, "expected a 'stored via dashboard' log record"
+        msg = stored[0].getMessage()
+        # The raw newline must not survive into the log line.
+        assert "\n" not in msg
+        assert "\\n" in msg
+
+    @pytest.mark.asyncio
+    async def test_crlf_in_delete_name_is_escaped_in_log(
+        self, vault_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _app()
+
+        from aiohttp.test_utils import TestClient, TestServer
+
+        # A percent-encoded CR/LF in the path segment decodes to real control
+        # characters in request.match_info["name"].
+        with patch("kiro_crew.dashboard.handlers.secrets.config_dir", return_value=str(vault_dir)):
+            async with TestClient(TestServer(app)) as client:
+                with caplog.at_level(logging.INFO, logger="kiro_crew.dashboard.handlers.secrets"):
+                    resp = await client.delete("/api/secrets/x%0d%0aWARNING-forged")
+                    assert resp.status == 200
+
+        deleted = [r for r in caplog.records if "deleted via dashboard" in r.getMessage()]
+        assert deleted, "expected a 'deleted via dashboard' log record"
+        msg = deleted[0].getMessage()
+        assert "\n" not in msg
+        assert "\r" not in msg
 
 
 class TestApiSecretsSetInputValidation:
@@ -169,8 +345,7 @@ class TestApiSecretsSetInputValidation:
     async def test_rejects_wrong_types_with_400(
         self, empty_vault_dir: Path, body: object, code: str
     ) -> None:
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 
@@ -189,8 +364,7 @@ class TestApiSecretsSetInputValidation:
     @pytest.mark.asyncio
     async def test_accepts_valid_string_payload(self, empty_vault_dir: Path) -> None:
         """The happy path still works after the added type checks."""
-        app = web.Application()
-        setup_secrets_routes(app)
+        app = _app()
 
         from aiohttp.test_utils import TestClient, TestServer
 


### PR DESCRIPTION
## Summary

Resolves all **five open CSE findings** in the CSE Taskei room. Each was verified present on `main` (`9bc2d7c6`) before fixing, and the fix is scoped to what the finding names.

The one open finding in the coordinated-disclosure security room (`P493725357`, trailing `--help`/`--version` read-only-guard bypass) was verified **already resolved on main** (the naive `endswith("--help")` suffix clauses are gone, replaced by a proper `_is_help_probe` that rejects executors and path/env-shaped programs). No change needed there — confirmed empirically: `bash -c '…' --help` and `python3 -c '…' --help` are now blocked while `ls --help` / `git --version` still auto-approve.

## Findings fixed

| CWE | Finding | File | Fix |
|---|---|---|---|
| CWE-862 | P497350039 | `dashboard/handlers/secrets.py` | Add `is_owner_dashboard_request` owner-gate to list/set/delete (vault is machine-global keystone material; `token_auth_middleware` authenticates but does not restrict to owner) |
| CWE-117 | P497350125 | `dashboard/handlers/secrets.py` | Escape CR/LF/TAB in the free-form secret `name` before logging (`.strip()` left interior control chars → log forging) |
| CWE-636 | P495527960 | `dashboard/token_auth.py` | Fail **closed** on an unreadable-but-present cron/subagent registry so a delegated app caller is denied, not escalated to unscoped dashboard user (SAX-04 outcome_3). The intentional absent-registry `--slack-only` case is untouched — it short-circuits on `None` upstream. |
| CWE-328 | P495528048 | `mcp_gateway/resolve_once.py` | Add `record.package == spec.package` guard in `resolved_launch` so a 64-bit digest collision is a cache miss, never an exec of the wrong program |
| CWE-209 | P495527842 | `apps/builtins/issue_radar/backend/routes.py` | Genericize the assignees + open-list `provider_error` 502 bodies (raw `gh` stderr → "upstream provider error"); raw detail stays in the audit record / a `logger.warning`. The shared `_pr_action_error` helper is deliberately **left** relaying verbatim — its provider text (e.g. "auto-merge is disabled") is actionable UI guidance, not recon, and is pinned by `test_a_provider_refusal_is_relayed_verbatim`. |

## Tests

Added / updated regression tests; all 658 tests across the touched suites pass, flake8 clean.

- `test_secrets_handler.py` — owner-only 403 for app-token and non-owner subjects on all three routes (asserting no mutation), configured-owner allow, and CR/LF-escaped-in-log for set + delete. Existing behavioural tests were wired through an identity middleware + fake state so they exercise the authorized path.
- `test_internal_secret_app_identity_3690.py` — present-but-unreadable registry fails closed (cron + subagent), plus a no-`.get()` shape. Renamed the old `test_an_unreadable_registry_is_not_a_refusal` (which asserted the fail-open behavior this fix reverses).
- `test_mcp_resolve_once.py` — a forced digest collision execs nothing, with a control run proving the miss is the package-equality guard and not a broken directory.

## What this does NOT do

- Does not touch the coordinated-disclosure security room finding (already fixed on main).
- Does not genericize the issue-radar **AI-handler** 502s or the `_pr_action_error` shared helper — out of the finding's scope, and the latter has a deliberate verbatim-relay UX contract.

Co-authored-by: Kiro Crew
