### PR TITLE
test(sage): run the Code Review Sage suite on Windows too

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/conftest.py
@@ -1,31 +1,12 @@
-"""Collection-time platform gate for the Code Review Sage suite.
+"""Shared fixtures for the Code Review Sage suite.
 
-The app itself now runs on Windows: the provider-CLI trust gate it shares with
-Issue Radar answers from the Windows ACL, and the review worker is handed the
-absolute interpreter the app resolves rather than the bare `python3` that is not
-an interpreter there.
-
-What still gates the suite is the suite, not the app. These tests assert POSIX
-behaviour throughout — `0600` file modes as `st_mode` bits (Windows expresses
-owner-only as a DACL and always reports `0o666`), forward-slash path suffixes,
-and shell-script `gh` stubs the Windows runner cannot execute — so running them
-there would fail on the harness rather than on anything under test. Making them
-Windows-native is separate work from making the app run.
-
-This lives next to the suite it gates, so the reason travels with the tests
-rather than sitting in a CI workflow that would hide it.
+The suite collects on every platform. Tests that pin inherently POSIX
+behaviour carry their own ``skipUnless`` guards (owner-only mode bits,
+unprivileged symlinks), so this module carries no platform gate -- only the
+fixtures every platform needs.
 """
 
-import os
-
 import pytest
-
-collect_ignore_glob = ["*"] if os.name == "nt" else []
-
-pytestmark = pytest.mark.skipif(
-    os.name == "nt",
-    reason="Code Review Sage's test harness is POSIX-only (see this conftest's docstring)",
-)
 
 
 @pytest.fixture(autouse=True)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/fixtures.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/fixtures.py
@@ -1,5 +1,32 @@
 """Representative fixtures for adapter + blast-radius tests."""
 
+import os
+import tempfile
+
+
+def _symlinks_creatable() -> bool:
+    """Whether this platform lets an unprivileged process create a symlink.
+
+    Windows grants SeCreateSymbolicLinkPrivilege only to an administrator or a
+    Developer Mode account, so on such a host the planted-link tests cannot even
+    stage their attack. The guard those tests cover runs everywhere -- only
+    staging the plant is privileged.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        probe = os.path.join(d, "probe")
+        try:
+            os.symlink(d, probe)
+        except (OSError, NotImplementedError):
+            return False
+    return True
+
+
+#: Gate for every test that stages a planted symlink. Probed once per process;
+#: importing modules decorate classes and functions at definition time, so this
+#: must be a plain constant rather than a fixture.
+SYMLINKS_OK = _symlinks_creatable()
+
+
 # A sensitive file (gateway/lifecycle) with a guard removal + an import add,
 # plus a small non-sensitive file — the blast-radius signal fixture.
 _SERVER_DIFF = """--- a/src/kiro_crew/gateway/server.py

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -23,6 +23,7 @@ import pytest
 from aiohttp import web
 
 from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
 
 _APP_ROOT = Path(__file__).resolve().parent.parent
 _ROUTES = _APP_ROOT / "backend" / "routes.py"
@@ -759,6 +760,7 @@ class TestAdoptionRefusesAPlantedLink:
     link across, and must not leave one behind to retry.
     """
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_symlink_is_refused_and_removed(self, tmp_path):
 
         store.ensure_layout(tmp_path)
@@ -993,6 +995,7 @@ class TestPublishRefusesAPlantedDestinationLink:
             "counts": {"red": 0, "yellow": 1},
         }
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_planted_link_is_replaced_not_followed(self, tmp_path):
 
         store.ensure_layout(tmp_path)
@@ -1126,6 +1129,7 @@ class TestPublishRefusesAPlantedSourceLink:
     direction.
     """
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_symlinked_record_is_not_published(self, tmp_path):
 
         store.ensure_layout(tmp_path)
@@ -1184,6 +1188,7 @@ class TestReportWritesRefusePlantedLinks:
             "generated_at": "2026-01-01T00:00:00Z",
         }
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     @pytest.mark.parametrize("name", [
         "focus-report.html", "rows.json", "report.json", "index.json",
     ])
@@ -1216,7 +1221,11 @@ class TestReportWritesRefusePlantedLinks:
             assert p.is_file(), f"{name} was not written"
             # The temp file is chmod'ed before it takes the real name, so the
             # mode must hold on the final path with no separate chmod step.
-            assert oct(p.stat().st_mode)[-3:] == "600", f"{name} is not 0600"
+            # Windows expresses the same owner-only lockdown as a DACL, which
+            # st_mode never reflects (it always reports 0o666), so the mode
+            # bits are only observable on POSIX.
+            if platform_compat.IS_POSIX:
+                assert oct(p.stat().st_mode)[-3:] == "600", f"{name} is not 0600"
         assert list(rd.glob("*.tmp")) == [], "a staging temp file survived"
 
 
@@ -1462,6 +1471,7 @@ class TestReportsDirReadsDoNotFollowAPlant:
         (rd / name).symlink_to(secret)
         return rd / name
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_planted_html_link_is_not_read(self, tmp_path):
         from sage_lib import report
 
@@ -1469,6 +1479,7 @@ class TestReportsDirReadsDoNotFollowAPlant:
         assert link.is_file()          # the link resolves — it just must not be read
         assert report.read_within_reports(link, tmp_path, "run-r1") is None
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_planted_index_link_is_not_read(self, tmp_path):
         from sage_lib import report
 
@@ -1485,6 +1496,7 @@ class TestReportsDirReadsDoNotFollowAPlant:
         got = report.read_within_reports(rd / "index.json", tmp_path, "run-r2")
         assert json.loads(got or "{}")["report_slug"] == "ok"
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_read_report_refuses_a_planted_report_json(self, tmp_path):
         """The consumer, not just the helper: a plant renders as no report."""
         from sage_lib import report
@@ -1492,6 +1504,7 @@ class TestReportsDirReadsDoNotFollowAPlant:
         self._plant(tmp_path, "report.json", json.dumps({"rows": ["leak"]}))
         assert report.read_report(tmp_path, "run-r1") is None
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_set_report_slug_does_not_merge_a_planted_index(self, tmp_path):
         from sage_lib import report
 
@@ -1647,12 +1660,14 @@ class TestResultReadsDoNotFollowAPlantedLink:
         (rd / f"{results.safe_change_id(change_id)}.json").symlink_to(target)
         return rd
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_read_result_refuses_a_planted_record(self, tmp_path):
         from sage_lib import results
 
         self._plant(tmp_path, "victim", "CR-1", {"change_id": "ATTACKER"})
         assert results.read_result("CR-1", tmp_path, "victim") is None
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_list_results_skips_a_planted_record(self, tmp_path):
         from sage_lib import results
 
@@ -1695,6 +1710,7 @@ class TestResultReadsDoNotFollowAPlantedLink:
         store.ensure_layout(tmp_path)
         assert results.read_result("CR-NONE", tmp_path, "empty") is None
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_the_reviewed_index_is_guarded_too(self, tmp_path):
         """It decides which PRs count as reviewed, so a swap suppresses reviews."""
         from sage_lib import results, store

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_followup.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_followup.py
@@ -28,26 +28,7 @@ from sage_lib import followup as FU  # noqa: N812
 from sage_lib import review_pool as RP  # noqa: N812
 from sage_lib import store
 
-
-def _symlinks_creatable() -> bool:
-    """Whether this platform lets an unprivileged process create a symlink.
-
-    Windows requires SeCreateSymbolicLinkPrivilege, which CI does not grant, so
-    the planted-symlink tests below cannot run there. The GUARD they cover is not
-    Windows-specific — ``read_text_nolink`` and the mkstemp write protect every
-    platform — but the attack can only be *staged* where symlinks can be made.
-    """
-    with tempfile.TemporaryDirectory() as d:
-        target = Path(d) / "t"
-        target.write_text("x", encoding="utf-8")
-        try:
-            (Path(d) / "l").symlink_to(target)
-        except (OSError, NotImplementedError):
-            return False
-    return True
-
-
-SYMLINKS_OK = _symlinks_creatable()
+from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
 
 
 def _ev(kind, **over):

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_learning.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_learning.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from sage_lib import learning as L  # noqa: N812
 from sage_lib import store
 
+from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
+
 
 def _pattern(title, repo="github.com/o/r", guidance="do the thing carefully", **kw):
     p = {"title": title, "scope": "common", "repo_identity": repo, "dimension": "security",
@@ -186,6 +188,7 @@ class TestStagingRefusesPlantedLinks(unittest.TestCase):
         self.root = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_staging_does_not_follow_a_planted_symlink(self):
         secret = self.root / "credentials"
         secret.write_text("aws_secret_access_key = SHOULD-NEVER-BE-READ\n",
@@ -266,12 +269,14 @@ class TestGuardedCandidateReads(unittest.TestCase):
         cf.symlink_to(secret)
         return cf
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_list_candidate_does_not_publish_a_planted_link(self):
         """This feeds the dashboard, so an unguarded read is an egress path."""
         self._plant()
         rendered = repr(L.list_candidate(self.root))
         self.assertNotIn("NEVER-READ", rendered)
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_selective_clear_does_not_reserialize_a_planted_link(self):
         cf = self._plant()
         L.clear_candidate(self.root, None, only_ids=["nope"])
@@ -296,6 +301,7 @@ class TestCandidateLockRefusesPlantedLockFile(unittest.TestCase):
         ns_dir.mkdir(parents=True, exist_ok=True)
         return ns_dir / "candidate.md.lock"
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_symlinked_lock_file_does_not_truncate_its_target(self):
         victim = self.root / "precious.txt"
         victim.write_text("KEEP-ME\n", encoding="utf-8")
@@ -391,6 +397,7 @@ class TestCandidateLockPortability:
         lock = L._namespace_dir("default", tmp_path) / "candidate.md.lock"
         assert lock.is_file()
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_symlink_is_still_refused_without_the_flag(self, tmp_path, monkeypatch):
         monkeypatch.delattr(L.os, "O_NOFOLLOW", raising=False)
         ns = L._namespace_dir("default", tmp_path)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
@@ -22,6 +22,8 @@ from sage_lib import results
 from sage_lib import review_driver as D
 from sage_lib import store
 
+from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
+
 
 def _record(cid: str = "CR-1") -> dict:
     return {
@@ -248,6 +250,7 @@ class TestStakedSlot(_Base):
     def test_an_empty_slot_is_already_the_wanted_state(self):
         self.assertTrue(results.stake_shared("CR-never-seen", self.root))
 
+    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
     def test_a_planted_symlink_is_removed_not_followed(self):
         # os.unlink removes the link itself, so the target it aimed at must survive.
         target = self.root / "elsewhere.json"


### PR DESCRIPTION
﻿## Problem / Motivation

Code Review Sage's test suite is collected **nowhere** on Windows: `tests/conftest.py` sets `collect_ignore_glob = ["*"]` for the whole directory, so the platform the app is being brought up on has zero automated coverage of it (#4988). The gate predates the app's Windows support work and conflates the app-level refusal in `sage_lib/discovery.py`'s `gh_bin()` (its review prompts still name `python3` — untouched here, tracked separately) with three harness details the tests themselves can express.

## Why it matters

The coverage hole sits exactly where recent risk was: a Windows-only silent failure in the review worker had to be found by hand because no Windows shard ran a single sage test. Every PR that touches this app lands blind on the platform it now claims to support.

## What changed (motivation → approach → change)

Lift the collection gate and give each platform-dependent test the guard its failure actually needs, instead of one blanket skip:

- **Symlink plants (20 of 21 failures, all `OSError: [WinError 1314]`).** The suite already had the right pattern — `SYMLINKS_OK`, a probe for unprivileged symlink creation, defined privately in `test_followup.py`. That probe now lives in `tests/fixtures.py`, the suite's shared module, and every test that stages a planted link skips only where creating a symlink needs a privilege the host does not grant (Developer Mode / elevated runners run them again). The no-follow guards they pin keep running everywhere else.
- **Owner-only mode bits.** The report-output privacy test asserted `0600` through `st_mode`, which Windows never reports (the lockdown there is an ACL). That assertion is scoped to POSIX while file-presence and temp-file-cleanup checks still run on every platform; the two existing `skipUnless(platform_compat.IS_POSIX)` sites are unchanged.
- **Collection gate.** Removed; the conftest keeps only its SEL-muting fixture.

Alternatives weighed: keeping the blanket gate until #4979 lands (leaves the coverage hole open longer), or making the mode assertions ACL-aware instead of POSIX-gated (no cross-platform "verify owner-only DACL" helper exists yet; that would be a new production-side seam, out of scope for a test-enablement change).

## Tests

Test-only change; the diff modifies how tests are gated, not what they assert:

- 17 planted-symlink test sites now carry `@unittest.skipUnless(SYMLINKS_OK, ...)` with the suite's established reason string.
- `test_outputs_are_private_and_leave_no_temp_behind` pins its `0600` assertion behind `platform_compat.IS_POSIX` and keeps presence/cleanup assertions unconditional.
- `test_followup.py` imports the shared probe instead of defining its own copy (same semantics, one owner).

## Manual verification

Measured locally on Windows 11 (Python 3.12, the CI pin set: pytest 9.0.3 / xdist 3.5.0 / pytest-timeout 2.2.0):

| run | before | after |
|---|---|---|
| serial (`-n0`) | 21 failed / 735 passed / 11 skipped | **736 passed / 31 skipped / 0 failed** |
| parallel (`-n4 --dist loadgroup`) | — | **736 passed / 31 skipped / 0 failed** |

Gates: `flake8` clean, `isort --check-only` clean, `mypy` clean over the suite's 30 files, `git diff --check` clean. The five touched files sit in `.github/black-baseline.txt`; their formatting state is unchanged and the diff adds no new black findings. N/A for browser/UI checks — nothing user-visible moves.

## Related Issues

Fixes #4988

## Checklist

- [x] Single commit with a Conventional Commits title (`test: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: test-gating only, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
