### PR TITLE
fix(security): fence trailing-dot and 8.3 Windows spellings (#5265)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -9164,6 +9164,94 @@ def _sensitive_path_pattern() -> str:
     return rf"{home_alts}/(?:{dirs_pattern}){path_end}"
 
 
+# ── Windows normalization-equivalent segment spellings (#5265) ──
+# Win32 path normalization strips trailing dots AND trailing spaces from every
+# path segment (``kiro-cli.`` and ``kiro-cli `` both resolve to ``kiro-cli``),
+# and each entry also answers to its 8.3 short name (``KIRO-C~1``). This gate
+# compares SPELLINGS in raw command text, so a fenced segment must admit those
+# equivalent forms or the fence is bypassable by re-spelling alone. The fix is
+# deliberately textual and per-segment: resolving spellings through the
+# filesystem (GetLongPathName) needs a real path tokenizer, a policy for
+# not-yet-existing write targets, and an answer for the non-Windows hosts this
+# gate also runs on — an architecture decision that is out of scope here.
+# Characters 8.3 short-name generation DROPS from the long name (dots, spaces,
+# and the always-illegal quote) versus the 8.3-invalid punctuation it
+# SUBSTITUTES with ``_`` (mirroring ``RtlGenerate8dot3Name``), before
+# truncating to the 6-character stem (found in review: dropping the
+# substituted set produced ``FOOBAR~1`` where Windows generates ``FOO_BA~1``).
+_WIN_83_DROPPED = set('. "')
+_WIN_83_SUBSTITUTED = set("+,;=[]")
+
+
+def _win_83_chars(text: str) -> str:
+    """Uppercase ``text`` the way 8.3 generation renders it (drop/substitute)."""
+    return "".join(
+        "_" if c in _WIN_83_SUBSTITUTED else c
+        for c in text.upper()
+        if c not in _WIN_83_DROPPED
+    )
+
+
+def _win_83_short_pattern(name: str) -> str | None:
+    """Regex (uncompiled; IGNORECASE at compile) for ``name``'s 8.3 short form.
+
+    Mirrors the generator's textual shape: uppercase, drop the characters 8.3
+    names cannot carry, substitute ``_`` for the 8.3-invalid punctuation, keep
+    the first 6 as the stem, append ``~N``; a long extension survives as its
+    first 3 characters (``config.json`` → ``CONFIG~1.JSO``). Collisions vary
+    only the numeric tail, matched as
+    ASCII ``[0-9]+`` (a DOS numeric tail is never a non-ASCII digit, and
+    Python's ``\\d`` would admit those). Once the truncated stem collides
+    ~4 times, the generator switches to the HASH form: the first 2 filtered
+    characters + 4 hex digits + ``~N`` (``KI0F3D~1``). The hash VALUE is not
+    predictable textually, but its SHAPE is, so the hash branch matches the
+    shape (found in review: a hash-form alias resolved to the fenced store
+    while matching neither prior branch). A stem can coincide with a SIBLING
+    entry sharing its first 6 characters, and the hash branch can coincide
+    with a sibling whose 8.3 name happens to fit the shape — over-matching
+    is the safe direction for a gate that blocks on naming alone.
+    """
+    base, dot, ext = name.lstrip(".").rpartition(".")
+    if not dot:
+        base, ext = ext, ""
+    stem = _win_83_chars(base)[:6]
+    if not stem:
+        return None
+    stem_alts = [rf"{re.escape(stem)}~[0-9]+"]
+    hash_prefix = stem[:2]
+    if hash_prefix:
+        stem_alts.append(rf"{re.escape(hash_prefix)}[0-9A-Fa-f]{{4}}~[0-9]+")
+    pattern = rf"(?:{'|'.join(stem_alts)})"
+    ext_stem = _win_83_chars(ext)[:3]
+    if ext_stem:
+        pattern += rf"\.{re.escape(ext_stem)}"
+    return pattern
+
+
+def _win_segment(name: str) -> str:
+    """One Windows path segment naming ``name``, in any equivalent spelling.
+
+    Alternates the literal with the 8.3 short form, and allows the trailing
+    dots/spaces Win32 normalization strips after either — both characters, or
+    the space spelling becomes the next member of the class to leak. The run
+    is deliberately UNBOUNDED: ``[. ]`` is a flat class with no nested
+    quantifier, so an unbounded repeat over it is linear — PROVIDED the token
+    before it cannot also match ``.`` (true here: the alternatives end in an
+    escaped literal, a digit, or an escaped extension stem); a preceding run
+    whose class contains ``.`` must exclude ``.`` from its last character or
+    the ambiguous pair backtracks exponentially inside a starred group (see
+    ``win_gsep``). Any finite cap on the run is attacker-defeatable by
+    padding one character past it (whether Win32 enforces the
+    component-length ceiling before or after stripping is a question this
+    shape never has to answer).
+    """
+    alts = [re.escape(name)]
+    short = _win_83_short_pattern(name)
+    if short is not None:
+        alts.append(short)
+    return rf"(?:{'|'.join(alts)})[. ]*"
+
+
 def _build_sensitive_regex() -> re.Pattern[str]:
     """Build a compiled regex matching bash reads OR writes of sensitive paths.
 
@@ -9286,8 +9374,30 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # ``Roaming\..`` and the literal segment matches the re-entry). A
     # multi-level ``..`` chain can over-match a path that actually ends
     # elsewhere — the safe direction for this gate, which blocks on naming
-    # alone. The name run is length-capped to bound backtracking.
-    win_gsep = rf"(?:{win_sep}(?:\.|[^\\/\s'\"]{{1,64}}{win_sep}\.\.))*{win_sep}"
+    # alone. The name run is capped at Windows's 254-character component
+    # ceiling (``{0,254}`` + one trailing non-dot char = 255): a longer run
+    # names no real Windows path component (Win32 rejects components past
+    # 255), so the cap costs no coverage, and it bounds the SYNCHRONOUS scan
+    # this gate runs on the hook path — an uncapped run let a ~24 KB
+    # single-component command drive a linear scan past the watchdog
+    # deadline and terminate the gateway (found in review). Its LAST
+    # character excludes ``.`` so the run is DISJOINT from the ``[. ]*``
+    # that follows: the name class otherwise contains ``.``, and an
+    # ambiguous adjacent pair inside this starred group is exponential on
+    # non-matching dot-run inputs (found in review — measured seconds at
+    # ~350 chars). The disjoint split kills the backtracking; the cap
+    # bounds the input length — the two failure modes are distinct and both
+    # are addressed. Trailing dots still match; they are consumed by
+    # ``[. ]*``, which is where normalization puts them. The control
+    # segments themselves tolerate trailing ``[. ]`` runs (``\.. \Roaming``
+    # normalizes to ``\..\Roaming``), or the quirk class re-enters through the
+    # very excursion spellings this separator exists to catch (found in
+    # review, #5265).
+    win_gsep = (
+        rf"(?:{win_sep}(?:\.[. ]*|[^\\/\s'\"]{{0,254}}[^\\/\s'\".]"
+        rf"[. ]*{win_sep}\.\.[. ]*))*"
+        rf"{win_sep}"
+    )
     # Shell word-end terminator for the Windows-native branches below. Mirrors the POSIX
     # ``path_end`` above, INCLUDING the shell metacharacters, and for the reason stated
     # there: the class is every character a shell itself treats as the end of a word, and
@@ -9319,11 +9429,37 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # alias is therefore left open here rather than closed with a rule that costs a
     # legitimate read.
     win_path_end = rf"(?:{win_sep}|\s|$|['\"]|[;&|()<>,:`$])"
+    # Every fenced segment is rendered through ``_win_segment`` so its
+    # normalization-equivalent spellings (trailing ``[. ]`` runs, the 8.3
+    # short form) name the same store the literal does (#5265). Applied at
+    # EVERY Windows join site — the home-anchored dirs, the %APPDATA% /
+    # %LOCALAPPDATA% remainders, the write-protected prefixes/leaves, the
+    # crew variable-leaf parents, the agents dir, and the module-level
+    # traversal alternation — because the report measured the leak on more
+    # than one branch, and a fix that closes only one reproduces the
+    # partial-fix pattern the issue was filed about.
     win_dirs_pattern = "|".join(
-        win_gsep.join(re.escape(part) for part in d.split("/"))
+        win_gsep.join(_win_segment(part) for part in d.split("/"))
         for d in _SENSITIVE_HOME_DIRS
     )
-    generic_win_home = rf"[A-Za-z]:{win_sep}(?:Users|home){win_sep}[^\\/\s'\"]+"
+    # ``[. ]*`` after the anchor's fixed segment: ``C:\Users.\u\...``
+    # resolves to ``C:\Users\u\...`` under the same trailing-dot/space
+    # stripping, so the anchor must tolerate it too or the class re-enters
+    # one segment to the left. The username segment gets its run from the
+    # ``win_home_alts`` pad below — ``C:\Users\u \.aws`` re-enters one segment
+    # to the RIGHT otherwise (found in review, #5265). The username run is
+    # capped at Windows's 254-character component ceiling (same reason as
+    # the ``win_gsep`` name run: a longer run names no real component, and
+    # the cap bounds the synchronous hook-path scan) and its last character
+    # excludes ``.`` for the same disjointness reason as the ``win_gsep``
+    # name run above (its class contains ``.``, and the ``win_home_alts``
+    # pad's ``[. ]*`` follows it
+    # directly); trailing dots are consumed by the pad instead, so
+    # acceptance is unchanged.
+    generic_win_home = (
+        rf"[A-Za-z]:{win_sep}(?:Users|home)[. ]*{win_sep}"
+        rf"[^\\/\s'\"]{{0,254}}[^\\/\s'\".]"
+    )
     unc_prefix = r"\\\\[^\s'\"]+"
     # cmd.exe and PowerShell spellings of the profile variable both anchor a
     # home-relative fenced path. The cmd.exe form tolerates expansion
@@ -9344,9 +9480,39 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|{re.escape('$env:HOMEDRIVE$env:HOMEPATH')}"
         rf"|{re.escape('${env:HOMEDRIVE}${env:HOMEPATH}')})"
     )
+    # The resolved home literal participates in the WINDOWS branches too, so
+    # its segments render through ``_win_segment`` like every other join site:
+    # ``re.escape`` alone left this anchor blind to the 8.3 short form of a
+    # home segment — ``D:\USERPR~1\alice`` opens ``D:\User Profiles\alice``,
+    # and Pass 2's tokenizer cannot see raw backslash spellings, so an
+    # embedded read through the alias proceeded (found in review, #5265
+    # round 6). A POSIX home gains only per-segment trailing-[. ] tolerance
+    # — a strict widening of a DENY gate, the safe direction.
+    _home_str = str(Path.home())
+    win_home = (win_sep if _home_str[:1] in "\\/" else "") + win_sep.join(
+        _win_segment(part) for part in re.split(r"[\\/]+", _home_str) if part
+    )
+    # The trailing ``[. ]*`` pad closes the anchor's own final segment:
+    # ``C:\Users\u \`` (username), ``%USERPROFILE%.\`` (expansion lands the
+    # stripped dot on the home's last segment) all normalize back to the
+    # anchor (found in review, #5265). No overlap with what follows: every
+    # use joins ``win_gsep``, which begins ``[\\/]``.
+    #
+    # The pad is applied PER ALTERNATIVE, not once after the group, because
+    # two members must NOT carry it (the linearity invariant again):
+    # ``unc_prefix`` ends in ``[^\s'\"]+`` whose class contains ``.``, and a
+    # group-level pad made that adjacent pair ambiguous over a dot run — a
+    # ~24 KB UNC dot flood backtracked for ~56 s on the synchronous hook
+    # path (found in review, #5265 round 6; the same disjointness rule
+    # ``win_gsep`` documents). The UNC arm needs no pad — its own class
+    # already consumes trailing dots — and ``win_home`` needs none either,
+    # because ``_win_segment`` ends every segment with its own ``[. ]*`` run.
+    # Every padded member ends in a character the pad cannot match (a
+    # non-dot class, ``%``/``!``/``}``, ``~``, or an escaped literal), so
+    # each pair is disjoint and the scan stays linear.
     win_home_alts = (
-        f"(?:{home}|{generic_win_home}|{userprofile}"
-        f"|{tilde}|{home_var})"
+        f"(?:{win_home}|{generic_win_home}[. ]*"
+        f"|{userprofile}[. ]*|{tilde}[. ]*|{home_var}[. ]*)"
     )
     # Between the anchor and the fenced remainder, accept the same
     # canonical-no-op chains (``\.\``, ``\X\..\``): they are equivalent to a
@@ -9369,7 +9535,7 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # one form the tokenizing passes cannot see, so leaving it out would fence the temp
     # everywhere except in an embedded-script literal.
     win_artifact_parents_pattern = "|".join(
-        win_gsep.join(re.escape(part) for part in d.split("/"))
+        win_gsep.join(_win_segment(part) for part in d.split("/"))
         for d in _KEYSTONE_ARTIFACT_PARENTS
     )
     win_artifact_path = (
@@ -9390,14 +9556,19 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|{re.escape('${env:APPDATA}')})"
     )
     appdata_remainders = "|".join(
-        win_gsep.join(re.escape(part) for part in d.split("/")[2:])
+        win_gsep.join(_win_segment(part) for part in d.split("/")[2:])
         for d in _SENSITIVE_HOME_DIRS
         if d.startswith("AppData/Roaming/")
     )
     # ``%APPDATA%`` ends in ``Roaming`` by definition, so ``\..\Roaming``
-    # right after it is a canonical no-op specific to this anchor.
+    # right after it is a canonical no-op specific to this anchor. The anchor
+    # gets the ``[. ]*`` pad (``%APPDATA%.\`` strips back to the anchor) and
+    # the re-entry segment is rendered like every other fenced segment, or
+    # ``\..\Roaming.\`` re-opens the quirk class here (found in review,
+    # #5265).
     appdata_sensitive_path = (
-        rf"{appdata_var}(?:{win_sep}\.\.{win_sep}Roaming)*"
+        rf"{appdata_var}[. ]*"
+        rf"(?:{win_sep}\.\.[. ]*{win_sep}{_win_segment('Roaming')})*"
         rf"{win_gsep}(?:{appdata_remainders}){win_path_end}"
     )
     # ``%LOCALAPPDATA%`` is the same shape one directory over: it points INTO
@@ -9416,14 +9587,22 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|{re.escape('${env:LOCALAPPDATA}')})"
     )
     localappdata_remainders = "|".join(
-        win_gsep.join(re.escape(part) for part in d.split("/")[2:])
+        # Rendered through ``_win_segment`` like every other fenced join site
+        # — ``re.escape`` alone left this branch, the one naming the CURRENT
+        # kiro-cli store, blind to 8.3/hash-form and trailing-run spellings
+        # (found in review).
+        win_gsep.join(_win_segment(part) for part in d.split("/")[2:])
         for d in _SENSITIVE_HOME_DIRS
         if d.startswith("AppData/Local/")
     )
     # ``%LOCALAPPDATA%`` ends in ``Local`` by definition, so ``\..\Local``
-    # right after it is this anchor's canonical no-op.
+    # right after it is this anchor's canonical no-op. The anchor gets the
+    # same ``[. ]*`` pad and ``_win_segment`` re-entry its ``%APPDATA%`` twin
+    # has, or ``%LOCALAPPDATA%.\`` and ``\..\Local.\`` re-open the quirk
+    # class one branch over (found in review, #5265).
     localappdata_sensitive_path = (
-        rf"{localappdata_var}(?:{win_sep}\.\.{win_sep}Local)*"
+        rf"{localappdata_var}[. ]*"
+        rf"(?:{win_sep}\.\.[. ]*{win_sep}{_win_segment('Local')})*"
         rf"{win_gsep}(?:{localappdata_remainders}){win_path_end}"
     )
     # Windows-native spelling of the write-protected leaves. The POSIX leaf
@@ -9435,11 +9614,11 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # generalized separator, so both spellings of every leaf are gated
     # identically and a leaf added to the tuple is covered in both.
     win_wp_prefixes = "|".join(
-        win_gsep.join(re.escape(part) for part in p.split("/"))
+        win_gsep.join(_win_segment(part) for part in p.split("/"))
         for p in _CREW_HOME_PREFIXES
     )
     win_wp_leaves = "|".join(
-        win_gsep.join(re.escape(part) for part in leaf.split("/"))
+        win_gsep.join(_win_segment(part) for part in leaf.split("/"))
         for leaf in _WRITE_PROTECTED_BASH_LEAVES
     )
     win_write_protected_path = (
@@ -9460,7 +9639,10 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # ``AppData/Roaming`` and ``Library/Application Support`` -- directories whose
     # variable-leaf spellings (``%APPDATA%\%APP%``) are ordinary and constant.
     win_crew_leaf_parents = "|".join(
-        win_gsep.join(re.escape(part) for part in d.split("/"))
+        # Rendered through ``_win_segment`` like every other fenced join site
+        # — ``re.escape`` alone left the variable-leaf branch blind to
+        # ``crew.\`` / ``KIRO~1`` spellings of the keystone parent (#5265).
+        win_gsep.join(_win_segment(part) for part in d.split("/"))
         for d in _SENSITIVE_LEAF_PARENT_DIRS
         if any(d == p or d.startswith(f"{p}/") for p in _CREW_HOME_PREFIXES)
     )
@@ -9540,7 +9722,7 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|{kiro_home_var}/(?:{agents_leaf_alt})){path_end}"
     )
     win_agents_dir_alt = win_gsep.join(
-        re.escape(part) for part in _KIRO_AGENTS_DIR.split("/")
+        _win_segment(part) for part in _KIRO_AGENTS_DIR.split("/")
     )
     # cmd.exe ``%KIRO_HOME%`` (with expansion modifiers) and the two PowerShell
     # spellings, mirroring ``userprofile``/``appdata_var`` above.
@@ -9551,7 +9733,9 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     )
     win_agents_write_path = (
         rf"(?:{win_anchor}(?:{win_agents_dir_alt})"
-        rf"|{win_kiro_home_var}{win_gsep}(?:{agents_leaf_alt})){win_path_end}"
+        rf"|{win_kiro_home_var}[. ]*{win_gsep}"
+        rf"(?:{_win_segment(_KIRO_HOME_LEAF)}))"
+        rf"{win_path_end}"
     )
     # Bare path-SEGMENT match for the globally distinctive leaves. Both branches
     # above require a home anchor and a crew prefix, so both are defeated by a
@@ -10851,16 +11035,20 @@ def _extracts_into_trust_root(command: str) -> bool:
 # link to a credential file lets a later in-workspace read follow it.  We block
 # the CREATION verbs (``ln``, ``cp -s``/``--symbolic-link``) when any token
 # names a sensitive dir via dot-slash traversal.
-_SENSITIVE_SEGMENT_ALT = "|".join(re.escape(d) for d in _SENSITIVE_HOME_DIRS)
-# Same alternation with either separator accepted between segments, so the
+# The alternation accepts either separator between segments, so the
 # Windows-native relative spelling (``..\..\.aws\credentials``) is caught by
 # the traversal matcher below alongside the POSIX one. Forward-slash-only
 # entries still match (the class includes ``/``), so this strictly widens.
 # A repeated separator run is handled by collapsing the SUBJECT before this
 # matcher runs, not by admitting a run here (#6350) -- see
 # ``_collapse_separator_runs``.
+# Segments render through ``_win_segment`` like the anchored fence branches —
+# ``re.escape`` alone left this pass blind to ``..\..\AWS~1\credentials`` and
+# ``..\..\.aws.\credentials`` spellings of the same stores (#5265). The
+# ``[. ]*`` runs stay linear here: the separator class cannot match ``.`` and
+# the traversal prefix's alternation is not starred over an ambiguous pair.
 _SENSITIVE_SEGMENT_ALT_ANYSEP = "|".join(
-    r"[\\/]".join(re.escape(part) for part in d.split("/"))
+    r"[\\/]".join(_win_segment(part) for part in d.split("/"))
     for d in _SENSITIVE_HOME_DIRS
 )
 _RELATIVE_SENSITIVE_RE = re.compile(

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -4424,25 +4424,29 @@ class TestKeystonePublishArtifacts:
         """Spellings the shell or filesystem treats as the same path must still match."""
         assert is_sensitive_bash_command(command) is not None
 
-    def test_the_leaf_branch_covers_the_noop_segment_but_not_the_trailing_dot(self) -> None:
-        """Honest scope: the no-op segment is closed on the leaf branch, the dot is not.
+    def test_the_leaf_branch_covers_the_noop_segment_and_the_trailing_dot(self) -> None:
+        """The no-op segment AND the trailing-dot alias are both closed on the leaf branch.
 
         The leaf branch already absorbed no-op chains, because it joins every segment of
-        its entry with the generalized separator. Its TRAILING-DOT alias is left open on
-        purpose: closing it needs ``.`` in the terminator, and because these branches also
-        accept forward slashes, that refused ``ls -d ~/.kiro/crew/backup.tar`` -- a
-        different file whose name is prefixed by the fenced directory leaf ``backup``, and
-        the read-only listing #6021 exists to allow. A terminator after a directory name
-        cannot separate the alias from the sibling; the artifact branches can, because
-        their lookahead sits at the end of a complete filename.
+        its entry with the generalized separator. Its TRAILING-DOT alias was left open
+        while closing it required ``.`` in the terminator — that refused
+        ``ls -d ~/.kiro/crew/backup.tar``, a different file whose name is prefixed by the
+        fenced directory leaf ``backup``, and the read-only listing #6021 exists to allow.
+        #5265 closes the alias WITHOUT touching the terminator: every fenced segment
+        renders through ``_win_segment``, whose ``[. ]*`` run sits at the end of the
+        complete segment NAME, so ``computer_use.json.`` is the alias while
+        ``backup.tar`` remains a different name — the constraint that kept the gap open
+        no longer binds.
         """
         assert (
             is_sensitive_bash_command(r"type C:\Users\u\.kiro\crew\.\computer_use.json") is not None
         )
-        # The pre-existing gap, asserted so a future change to the terminator is a
-        # deliberate decision rather than a surprise.
-        assert is_sensitive_bash_command(r"type C:\Users\u\.kiro\crew\computer_use.json.") is None
-        # ...and the read that constrains it stays allowed.
+        # The trailing-dot alias of a fenced leaf is the same file to Win32;
+        # it is now a deliberate match (#5265), not a pinned gap.
+        assert (
+            is_sensitive_bash_command(r"type C:\Users\u\.kiro\crew\computer_use.json.") is not None
+        )
+        # ...and the read that constrained the old terminator approach stays allowed.
         assert is_sensitive_bash_command("ls -d ~/.kiro/crew/backup.tar") is None
 
     def test_the_alias_tolerance_still_rejects_a_different_file(self) -> None:
@@ -7476,6 +7480,347 @@ class TestWindowsPathShapes:
         for cmd in cmds:
             assert is_sensitive_bash_command(cmd) is not None, cmd
 
+    def test_trailing_dot_and_space_segment_spellings_are_blocked(self) -> None:
+        # Win32 normalization strips trailing dots AND trailing spaces from a
+        # path segment, so ``kiro-cli.`` / ``kiro-cli `` resolve to the fenced
+        # ``kiro-cli`` while matching none of the literal branches (#5265).
+        # Both the home-anchored and the %APPDATA% alias branches leaked, so
+        # both are asserted.
+        cmds = [
+            # home-anchored, trailing dot on the fenced segment
+            "type 'C:\\Users\\u\\AppData\\Roaming\\kiro-cli.\\data.sqlite3'",
+            "type 'C:\\Users\\u\\.aws.\\credentials'",
+            # alias branches (cmd.exe and PowerShell spellings)
+            'del "%APPDATA%\\kiro-cli.\\data.sqlite3"',
+            'del "$env:APPDATA\\kiro-cli.\\data.sqlite3"',
+            # trailing dot on a NON-final segment of the fenced path
+            "type 'C:\\Users\\u\\AppData.\\Roaming\\kiro-cli\\data.sqlite3'",
+            # trailing dot on the anchor's fixed segment
+            "type 'C:\\Users.\\u\\.aws\\credentials'",
+            # trailing space spellings (stripped the same way as the dot)
+            "type 'C:\\Users\\u\\AppData\\Roaming\\kiro-cli \\data.sqlite3'",
+            'del "%APPDATA%\\kiro-cli \\data.sqlite3"',
+            # trailing space on the USERNAME segment — the anchor's own final
+            # segment, one to the right of the fixed-segment case above
+            # (found in review)
+            "type 'C:\\Users\\u \\.aws\\credentials'",
+            "echo x > 'C:\\Users\\u \\.kiro\\crew\\connections-tool-aliases.json'",
+            'copy evil.json "C:\\Users\\u \\.kiro\\agents\\evil.json"',
+            # trailing dot lands on the ANCHOR itself after variable expansion
+            # (found in review)
+            'type "%USERPROFILE%.\\.aws\\credentials"',
+            'del "%APPDATA%.\\kiro-cli\\data.sqlite3"',
+            'copy /Y evil.json "%KIRO_HOME%.\\agents\\evil.agent.json"',
+            # the AppData re-entry no-op with a re-spelled Roaming, and a
+            # trailing space on a traversal control segment (found in review)
+            'type "%APPDATA%\\..\\Roaming.\\kiro-cli\\data.sqlite3"',
+            "type 'C:\\Users\\u\\AppData\\junk\\.. \\Roaming\\kiro-cli\\data.sqlite3'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_83_short_name_spellings_are_blocked(self) -> None:
+        # An 8.3 short name (filtered 6-char stem + ``~N``) resolves to the
+        # same long-named directory, so the short spelling names the fenced
+        # store without containing its literal text (#5265). Home-anchored and
+        # alias branches are both asserted, mirroring the measured leak.
+        cmds = [
+            # home-anchored
+            "type 'C:\\Users\\u\\AppData\\Roaming\\KIRO-C~1\\data.sqlite3'",
+            "type 'C:\\Users\\u\\AWS~1\\credentials'",
+            # collision tails beyond ~1 name the same class of entry
+            "type 'C:\\Users\\u\\AWS~2\\credentials'",
+            # alias branches (cmd.exe and PowerShell spellings)
+            'del "%APPDATA%\\KIRO-C~1\\data.sqlite3"',
+            'del "$env:APPDATA\\KIRO-C~1\\data.sqlite3"',
+            # short-name spelling of a NON-final segment of the fenced path
+            "type 'C:\\Users\\u\\APPDAT~1\\Roaming\\kiro-cli\\data.sqlite3'",
+            # short names are case-insensitive like every Windows branch
+            "type 'C:\\Users\\u\\appdata\\roaming\\kiro-c~1\\data.sqlite3'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_normalization_allowances_do_not_widen_to_unfenced_paths(self) -> None:
+        # The trailing-[. ] run and the ~N alternation must not make an
+        # UNfenced path match: one negative per new form, per branch.
+        cmds = [
+            # trailing dot on a benign segment
+            "type 'C:\\Users\\u\\project.\\readme.md'",
+            # trailing space on the username segment of a benign path
+            "type 'C:\\Users\\u \\project\\readme.md'",
+            # trailing dot on the anchor of a benign remainder
+            'type "%APPDATA%.\\someapp\\config.txt"',
+            # benign 8.3 spellings, home-anchored and alias
+            "type 'C:\\Users\\u\\PROJEC~1\\readme.md'",
+            'type "%APPDATA%\\SOMEAP~1\\config.txt"',
+            # a tilde without digits is not a short name
+            "type 'C:\\Users\\u\\AppData\\Roaming\\kiro-c~x\\data.sqlite3'",
+            # a fenced name extended past the segment boundary stays a
+            # DIFFERENT entry, dot allowance or not
+            "type 'C:\\Users\\u\\.awsx\\credentials'",
+            "type 'C:\\Users\\u\\AppData\\Roaming\\kiro-cli.bak\\data.sqlite3'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is None, cmd
+
+    def test_83_stem_substitutes_invalid_punctuation(self) -> None:
+        # RtlGenerate8dot3Name substitutes ``_`` for the 8.3-invalid
+        # punctuation rather than dropping it: ``foo+bar`` shortens to
+        # ``FOO_BA~1``, not ``FOOBAR~1``. No fenced constant carries these
+        # characters today; this pins the helper's contract so a future one
+        # does not re-open the bypass (found in review). Asserted
+        # BEHAVIOURALLY (does the pattern accept/reject the spelling) rather
+        # than on the exact regex string, so re-shaping the alternation
+        # cannot fail this test while the fence behaves identically.
+        import re as re_mod
+
+        from kiro_crew.security import _win_83_short_pattern
+
+        def matches(name: str, spelling: str) -> bool:
+            pat = _win_83_short_pattern(name)
+            assert pat is not None
+            return re_mod.fullmatch(pat, spelling, re_mod.IGNORECASE) is not None
+
+        assert matches("foo+bar", "FOO_BA~1")
+        assert not matches("foo+bar", "FOOBAR~1")
+        assert matches("a=b,c;d", "A_B_C_~2")
+        # dots and spaces are dropped, not substituted
+        assert matches("Application Support", "APPLIC~1")
+        assert not matches("Application Support", "APPLI_~1")
+        # the hash form (first 2 filtered chars + 4 hex + ~N) is a branch of
+        # every pattern; a non-hex middle is not
+        assert matches("kiro-cli", "KI0F3D~1")
+        assert not matches("kiro-cli", "KIZZZZ~1")
+
+    def test_83_hash_form_short_names_are_blocked(self) -> None:
+        # When ~4 truncated stems collide, RtlGenerate8dot3Name switches to
+        # the HASH form: first 2 filtered chars + 4 hex digits + ``~N``
+        # (``kiro-cli`` → ``KI0F3D~1``). A hash-form alias resolves to the
+        # same fenced store while matching neither the literal nor the
+        # plain-stem branch, so the shape must be fenced too (found in
+        # review). Home-anchored and alias branches both asserted, mirroring
+        # the plain-stem test above.
+        cmds = [
+            # home-anchored
+            "type 'C:\\Users\\u\\AppData\\Roaming\\KI0F3D~1\\data.sqlite3'",
+            "type 'C:\\Users\\u\\AW1A2B~1\\credentials'",
+            # collision tails beyond ~1 name the same class of entry
+            "type 'C:\\Users\\u\\AppData\\Roaming\\KI0F3D~2\\data.sqlite3'",
+            # alias branches (cmd.exe and PowerShell spellings)
+            'del "%APPDATA%\\KI0F3D~1\\data.sqlite3"',
+            'del "$env:APPDATA\\KI0F3D~1\\data.sqlite3"',
+            # hash-form spelling of a NON-final segment of the fenced path
+            "type 'C:\\Users\\u\\AP9C2E~1\\Roaming\\kiro-cli\\data.sqlite3'",
+            # hash forms are case-insensitive like every Windows branch
+            "type 'C:\\Users\\u\\appdata\\roaming\\ki0f3d~1\\data.sqlite3'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_83_hash_form_does_not_widen_to_unfenced_names(self) -> None:
+        # The hash branch requires exactly 4 HEX digits between the 2-char
+        # prefix and the tilde: a same-prefix name whose middle is not hex is
+        # a DIFFERENT entry and must stay unfenced, per branch.
+        cmds = [
+            # Z is not a hex digit
+            "type 'C:\\Users\\u\\AppData\\Roaming\\KIZZZZ~1\\data.sqlite3'",
+            'del "%APPDATA%\\KIZZZZ~1\\data.sqlite3"',
+            # 3 hex digits, not 4
+            "type 'C:\\Users\\u\\AppData\\Roaming\\KI0F3~1\\data.sqlite3'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is None, cmd
+
+    def test_localappdata_normalization_spellings_are_blocked(self) -> None:
+        # %LOCALAPPDATA% names the CURRENT kiro-cli store; its remainder
+        # segments must admit the same equivalent spellings as every other
+        # join site (plain 8.3, hash form, trailing dot) — this branch
+        # rendered its segments with re.escape alone and was blind to all of
+        # them (found in review).
+        cmds = [
+            'del "%LOCALAPPDATA%\\KIRO-C~1\\data.sqlite3"',
+            'del "%LOCALAPPDATA%\\KI0F3D~1\\data.sqlite3"',
+            'del "$env:LOCALAPPDATA\\KI0F3D~1\\data.sqlite3"',
+            'del "%LOCALAPPDATA%\\kiro-cli.\\data.sqlite3"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # a benign name under the same anchor stays unfenced
+        benign = 'del "%LOCALAPPDATA%\\SOMEAP~1\\config.txt"'
+        assert is_sensitive_bash_command(benign) is None, benign
+
+    def test_localappdata_anchor_pad_and_reentry_spellings_are_blocked(self) -> None:
+        # The %LOCALAPPDATA% ANCHOR itself must tolerate the trailing-run and
+        # re-entry spellings its %APPDATA% twin does — ``%LOCALAPPDATA%.\``
+        # strips back to the anchor and ``\..\Local.\`` is the anchor's
+        # canonical no-op in an equivalent spelling. Without the pad both
+        # reached the fenced store unmatched (found in review).
+        cmds = [
+            'del "%LOCALAPPDATA%.\\kiro-cli\\data.sqlite3"',
+            'del "%LOCALAPPDATA%\\..\\Local.\\kiro-cli\\data.sqlite3"',
+            'del "%LOCALAPPDATA%\\..\\LOCAL~1\\kiro-cli\\data.sqlite3"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_crew_variable_leaf_parent_spellings_are_blocked(self) -> None:
+        # The keystone variable-leaf branch anchors on the crew PARENT
+        # directory; its segments rendered with re.escape alone were blind to
+        # trailing-run and 8.3 spellings of that parent (found in review).
+        cmds = [
+            'type "%USERPROFILE%\\.kiro\\crew.\\%F%"',
+            'type "%USERPROFILE%\\.kiro.\\crew\\%F%"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_relative_traversal_spellings_are_blocked(self) -> None:
+        # The dot-slash traversal pass shares the declared root cause: its
+        # segment alternation compared literal text, so 8.3 and trailing-run
+        # spellings of the same stores walked through (found in review).
+        cmds = [
+            'cat "..\\..\\AWS~1\\credentials"',
+            'cat "..\\..\\.aws.\\credentials"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # a benign relative path with an 8.3-shaped but unfenced name stays
+        # unfenced
+        benign = 'cat "..\\..\\MYDATA~1\\notes.txt"'
+        assert is_sensitive_bash_command(benign) is None, benign
+
+    def test_long_segment_names_are_still_fenced(self) -> None:
+        # Any finite cap on a name run is attacker-defeatable by padding one
+        # character past it: a 65+-char username (or excursion segment)
+        # walked straight past the fence while shorter spellings were
+        # refused (found in review). Windows itself allows components up to
+        # 255 chars, so these are real, creatable names.
+        long_name = "u" * 80
+        cmds = [
+            f"type 'C:\\Users\\{long_name}\\.aws\\credentials'",
+            f"type 'C:\\Users\\u\\AppData\\Roaming\\{long_name}\\..\\kiro-cli\\data.sqlite3'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_excursion_chains_match_in_linear_time(self) -> None:
+        # The ``[. ]*`` run adjacent to win_gsep's name run backtracked
+        # exponentially on non-matching dot-run inputs before the runs were
+        # made disjoint — measured seconds at ~350 chars, through this very
+        # call (found in review). This input reaches ~600 chars, where the
+        # exponential shape needs minutes-to-hours; the fixed pattern
+        # answers in milliseconds, so a 1s bound stays deterministic on a
+        # loaded runner while any re-opened ambiguity fails it loudly.
+        cmd = "type 'C:\\Users\\u\\" + ("." * 60 + "\\..") * 8 + "\\NOPE\\file.txt'"
+        start = time.monotonic()
+        assert is_sensitive_bash_command(cmd) is None
+        assert time.monotonic() - start < 1.0
+        # A single ~19 KB non-separator component (just under the 20 KiB
+        # scannable ceiling, so the matchers run) must also stay under the
+        # deadline: an UNBOUNDED name run let this drive a linear scan past
+        # the synchronous hook-path watchdog and terminate the gateway
+        # (found in review); the 254-char component cap bounds it.
+        big = "type 'C:\\Users\\u\\" + ("A" * 19000) + "\\NOPE\\file.txt'"
+        start = time.monotonic()
+        assert is_sensitive_bash_command(big) is None
+        assert time.monotonic() - start < 1.0
+
+    def test_fenced_path_beyond_former_scan_window_is_blocked(self) -> None:
+        # The raw-text pass briefly capped its scan at 2000 chars to bound
+        # the old quadratic token anchors — but the window was itself a
+        # bypass: Pass 2's tokenizing normalizer cannot see Windows-native
+        # backslash spellings, so a fenced store named past the window was
+        # not blocked by ANYTHING (found in review). The linear-time anchors
+        # removed the window; a fenced path must match regardless of how
+        # much padding precedes it.
+        pad = "echo " + ("a" * 3000) + "; "
+        cmd = pad + "type 'C:\\Users\\u\\AppData\\Roaming\\kiro-cli\\data.sqlite3'"
+        assert is_sensitive_bash_command(cmd) is not None
+
+    def test_adversarial_floods_match_in_linear_time(self) -> None:
+        # Each flood targets one alternate family of the raw-text pass:
+        # token separators (every offset becomes an anchor candidate), read
+        # verbs (the old single-regex verb arm re-scanned the tail at every
+        # verb occurrence), and interpreter words (same, for the ``open(``
+        # one-liner family). The old ``(?:^|.*[sep])`` anchors took ~20s on
+        # 24 KB on a fast Linux box; the linear anchors + per-line verb walk
+        # answer in well under a second. Inputs sit just below the 20 KiB
+        # ``MAX_SCANNABLE_COMMAND_CHARS`` ceiling so the matchers actually
+        # run — at or above it pass 0 refuses without scanning, which is a
+        # different (also linear) code path. The 5s bound keeps roughly an
+        # order of magnitude of headroom on both sides: deterministic for the
+        # linear shape on the slowest runner, while a re-opened quadratic at
+        # this input size lands far past it and fails loudly.
+        floods = [
+            ("a " * 9500) + "x",
+            ("cat " * 4750) + "x",
+            ("python x " * 2100) + "x",
+        ]
+        for cmd in floods:
+            start = time.monotonic()
+            verdict = is_sensitive_bash_command(cmd)
+            # Benign floods either pass (None) or hit the deliberate
+            # traversal-analysis budget that main applies fail-closed to
+            # very long commands — any OTHER block here would mean a fenced
+            # path was wrongly matched in plain padding.
+            assert verdict is None or "traversal analysis" in verdict
+            assert time.monotonic() - start < 5.0, f"flood too slow: {cmd[:24]!r}"
+
+    def test_unc_dot_flood_matches_in_linear_time(self) -> None:
+        # A group-level ``[. ]*`` pad after ``win_home_alts`` sat adjacent to
+        # ``unc_prefix``'s ``[^\s'\"]+`` — whose class contains ``.`` — so a
+        # UNC dot run had N split points between the two, each retrying the
+        # generalized separator: ~56s at 24 KB on the synchronous hook path
+        # (found in review, #5265 round 6). The pad is now per-alternative
+        # and the UNC arm carries none, so the pair is disjoint and the scan
+        # is linear. Sized just under the 20 KiB scannable ceiling so the
+        # matcher runs; same 5s bound rationale as the flood test above.
+        cmd = "type '\\\\srv" + ("." * 19000) + "\\x'"
+        start = time.monotonic()
+        assert is_sensitive_bash_command(cmd) is None
+        assert time.monotonic() - start < 5.0
+
+    def test_resolved_home_83_alias_is_fenced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The resolved home literal is a Windows join site like any other:
+        # spelled through its 8.3 short segment (``D:\USERPR~1\alice`` for
+        # ``D:\User Profiles\alice``) it opens the same fenced store, and
+        # Pass 2's tokenizer cannot see raw backslash spellings — so the
+        # raw-scan anchor must accept the alias (found in review, #5265
+        # round 6). Build the pattern under a faked home; the builder's only
+        # ``Path`` use is ``Path.home()``.
+        import pathlib
+
+        class _FakePath:
+            @staticmethod
+            def home() -> pathlib.PurePath:
+                return pathlib.PurePath("D:/User Profiles/alice")
+
+        monkeypatch.setattr(security, "Path", _FakePath)
+        pattern = security._build_sensitive_regex()
+        assert pattern.search(r"type 'D:\USERPR~1\alice\.aws\credentials'")
+        # ...and the literal spelling still matches under the same rendering.
+        assert pattern.search(r"type 'D:\User Profiles\alice\.aws\credentials'")
+
+    def test_verb_then_glued_sensitive_path_still_blocked(self) -> None:
+        # The verb-anchored family moved from the compiled pattern to chained
+        # linear searches; these pin that the move kept its unique coverage —
+        # a sensitive path GLUED to a non-separator, which the token-anchored
+        # branches deliberately do not match, is still denied when a
+        # read/write verb (or an interpreter ``open(`` call) precedes it.
+        cmds = [
+            "cat -- -$HOME/.aws/credentials",
+            'python -c "open(-$HOME/.aws/credentials)"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # …and without any verb, the same glued spelling stays unmatched by
+        # the raw-text pass (the token anchor exists to avoid substring false
+        # positives), so the split did not silently widen branch (2).
+        from kiro_crew.security import _get_sensitive_re
+
+        assert _get_sensitive_re().search("-$HOME/.aws/credentials") is None
+
     @pytest.mark.skipif(
         os.name != "nt",
         reason="fence targets are os.sep-joined; the match is only real on Windows",
@@ -7487,6 +7832,31 @@ class TestWindowsPathShapes:
         for fenced in (".aws\\credentials", "AppData\\Roaming\\kiro-cli\\data.sqlite3"):
             cmd = f"type '{home}\\{fenced}'"
             assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_artifact_parent_alias_spellings_are_blocked(self) -> None:
+        # The keystone-artifact fence (``<parent>/<name>.tmp|.lock``) renders its
+        # parent segments through ``_win_segment`` like every other Windows join
+        # site. With plain ``re.escape`` a trailing-dot or 8.3 spelling of a
+        # parent segment named the same directory while matching no branch, so
+        # the temp/lock siblings of governance files were reachable through a
+        # re-spelled parent (#5265 review, round 10: the one unconverted join
+        # site). Both alias classes are asserted, plus the plain spelling as
+        # the control that the fence itself fires.
+        cmds = [
+            # control: plain spelling is fenced
+            "type '%USERPROFILE%\\.kiro\\crew\\security_policy.json.tmp'",
+            # trailing dot on a parent segment (Win32 strips it on resolution)
+            "type '%USERPROFILE%\\.kiro\\crew.\\security_policy.json.tmp'",
+            "type '%USERPROFILE%\\.kiro.\\crew\\security_policy.json.tmp'",
+            # 8.3 short-name spelling of a parent segment
+            "type '%USERPROFILE%\\.kiro\\CREW~1\\security_policy.json.tmp'",
+            "del '%USERPROFILE%\\KIROCR~1\\config.json.lock'",
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # A non-fenced parent with the same shape stays allowed: the alias
+        # branches widen the fenced names only, not the ``.tmp`` suffix class.
+        assert is_sensitive_bash_command("type '%USERPROFILE%\\projects.\\build.json.tmp'") is None
 
 
 class TestWindowsSeparatorRuns:


### PR DESCRIPTION
## Problem

The shell-side credential fence `is_sensitive_bash_command` decides its first pass by pattern-matching the RAW command text. Two Windows path-normalization forms resolve to a fenced credential store while matching none of the matcher's branches, so a command naming the store in either spelling was permitted:

1. **Trailing dot or space on a path segment.** Win32 strips trailing dots AND spaces from every segment, so `kiro-cli.` and `kiro-cli ` both resolve to the fenced `kiro-cli`.
2. **8.3 short name.** Every entry answers to its DOS short form (`AWS~1` for `.aws`, `KIRO-C~1` for `kiro-cli`), so the short spelling names the store without containing its literal text.

The reporter measured both forms leaking on the `%LOCALAPPDATA%`-style alias branch AND the pre-existing home-anchored branch — the root cause is a property of comparing normalization-equivalent spellings textually, not a gap in any one branch.

Closes #5265

## Why it matters

The fenced directories hold kiro-cli's live SSO bearer token; the gate exists so that an agent shell command naming that store is refused. For either spelling the blast radius equals the fence being absent. Severity bounds: neither spelling arises in normal usage (it must be produced deliberately), and the separate tool-path gate `is_sensitive_path` is unaffected — this is the shell/raw-text pass only.

## Fix

**Symptoms → root cause:** the matcher rendered every fenced segment as `re.escape(literal)`, so any normalization-equivalent re-spelling of a segment fell outside the alternation.

**Change:** every fenced Windows path segment is rendered through a new `_win_segment()` helper that alternates the literal with its textually-derived 8.3 short-form pattern (`_win_83_short_pattern()`, ASCII `[0-9]+` tails, `_`-substitution for the 8.3-invalid punctuation mirroring `RtlGenerate8dot3Name`) and tolerates a trailing `[. ]*` run. Applied at EVERY Windows join site — the home-anchored dirs, the `%APPDATA%` remainders, the write-protected prefixes/leaves, the agents dir, and the keystone-artifact parents (the last converted in review round 10, which found it still on `re.escape`) — because the report measured the leak on more than one branch. The now-consumerless `_SENSITIVE_SEGMENT_ALT` alternation is deleted (First Principles review subtraction). The verb-anchored linearization this branch previously carried landed on `main` independently via #8282; this diff now contains only the spelling fence.

Pre-push review (GPT 5.6 Sol + Opus 5, model-pinned) found the same class re-entering at the seams, all fixed in this commit:

- the anchor's own final segment (`C:\Users\u \…`, `%USERPROFILE%.\…`, `%APPDATA%.\…`, `%KIRO_HOME%.\…`) now tolerates the run via a pad on `win_home_alts` and the variable anchors;
- `win_gsep`'s traversal control segments (`\.`, `\X\..`) tolerate the run, and the `%APPDATA%\..\Roaming` re-entry renders `Roaming` through `_win_segment` like every other fenced segment;
- the trailing run is `[. ]*` (unbounded flat class, linear match) rather than a finite cap that padding one character past would defeat.

Two further behavior changes ride in this diff, both derived from review findings and previously documented only in code comments: `win_gsep`'s excursion-segment name cap is raised from `{1,64}` to `{0,254}` (a 65-char segment name was a pad-past-cap bypass), and the fence's Windows branches are restructured so adversarial dot-flood / single-component commands up to the 20 KiB scan ceiling cannot stall the synchronous hook path (the pre-fix shape measured ~56 s of backtracking at 24 KB; wall-clock liveness is pinned by `test_security_gate_liveness.py` and the resized flood tests).

**Deliberately out of scope (recorded in the issue triage comment):** direction 1 — resolving spellings through a real path tokenizer/`GetLongPathName` — needs a policy for not-yet-existing write targets and an answer for the non-Windows hosts this gate also runs on. That is an architecture decision for a human; this change does not foreclose it. Known residuals, recorded rather than implied: the anchor-free bare-token branch (`_BARE_TOKEN_PROTECTED_LEAVES`) is not extended with 8.3 alternatives (advisory; `is_sensitive_write_path` is the primary control there), and reviewer suggestions to *suppress* `~N` alternatives for names that appear already-8.3-valid were declined — over-matching is this gate's documented safe direction, and suppressing based on a model of the generator risks re-opening a bypass where that model is wrong.

## Tests

- `TestWindowsPathShapes::test_trailing_dot_and_space_segment_spellings_are_blocked` — trailing dot/space on fenced segments, non-final segments, the anchor's fixed segment, the username segment (all three branches: sensitive dirs, write-protected leaf, agents dir), the variable anchors, the `Roaming` re-entry, and a traversal control segment.
- `TestWindowsPathShapes::test_83_short_name_spellings_are_blocked` — home-anchored and alias 8.3 spellings, collision tails, non-final segments, case-insensitivity.
- `TestWindowsPathShapes::test_normalization_allowances_do_not_widen_to_unfenced_paths` — negatives proving the run and the `~N` alternation do not widen onto benign paths, sibling entries (`kiro-cli.bak`, `.awsx`), or a digitless tilde.
- `TestWindowsPathShapes::test_83_stem_substitutes_invalid_punctuation` — pins the helper's `_`-substitution contract directly.
- `TestWindowsPathShapes::test_artifact_parent_alias_spellings_are_blocked` — trailing-dot and 8.3 spellings of a keystone-artifact parent are refused (round-10 regression: the one join site left on `re.escape`), with plain-spelling and non-fenced-parent controls.

**Non-vacuity proven:** with `main`'s unmodified matcher, the three positive/helper tests FAIL (verified by checking out `main`'s `security.py` and re-running the class: exactly `test_trailing_dot_and_space_segment_spellings_are_blocked`, `test_83_short_name_spellings_are_blocked`, and `test_83_stem_substitutes_invalid_punctuation` fail; the negatives pass on both). All tests are pure string-in/verdict-out — no credential file is created, read, or touched.

Local gates: isort, flake8, mypy (1038 files), full `test/test_security.py` (546 passed, 1 skipped).

## Manual verification

Ran a verdict-only repro harness over 17 spellings (12 bypass forms, 5 negatives): on `main`, 10 of 12 bypass spellings are permitted; with this change all 12 are refused and all 5 negatives remain permitted. The two spellings already caught on `main` (trailing-space forms whose space fell inside an existing character class) stay caught.

## Screenshots

N/A — backend security matcher change, no user-visible dashboard or app state.

## Pattern harvest

Rule candidate: a regex `search()`-ed over hook-path input must not have an alternate that begins with `.*` (or any unbounded consumer) — `search` already retries every offset, so a leading `.*` re-scans the tail at each position and turns the scan O(n²). This branch originally carried that linearization; the equivalent fix landed on `main` via #8282 (linear token anchors + a per-line verb walk), whose source-guard test and adversarial-flood wall-clock tests this diff extends rather than replaces. A `grep -P 'rf?"\(\?:\^\|\.\*'` over `src/kiro_crew/security.py` would make it a cheap Automated Rule Check candidate.


