### PR TITLE
fix: route remaining Enter-submit sites through the IME guard

### DIFF
--- a/website/src/app-sdk/ChatEmbed.tsx
+++ b/website/src/app-sdk/ChatEmbed.tsx
@@ -196,9 +196,8 @@ function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSe
           {...ime.bindComposition()}
           onKeyDown={e => {
             if (e.key !== 'Enter' || e.shiftKey) return
-            // Rule 1: single-line input; the emptiness test stays outside the guard.
-            if (ime.isComposing(e)) return
-            if (input.trim()) { e.preventDefault(); send() }
+            // The emptiness test stays outside the guard.
+            if (input.trim() && ime.claimEnter(e)) send()
           }}
           placeholder={running ? i18nT('appSdk.chatEmbed.agent_is_working') : (placeholder || i18nT('appSdk.chatEmbed.message'))}
           disabled={sendMutation.isPending}

--- a/website/src/apps/auto-improvement/SetupPanel.tsx
+++ b/website/src/apps/auto-improvement/SetupPanel.tsx
@@ -22,6 +22,7 @@ import SimpleSelect from '../../components/SimpleSelect'
 import { Badge, Btn, Card, CardTitle, Input } from '../../components/ui'
 import { fmtDateFields } from '../../i18n/format'
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 const API = '/api/apps/auto-improvement'
 
@@ -110,6 +111,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
 }
 
 export default function SetupPanel({ config }: { config?: Record<string, unknown> }) {
+  const ime = useImeGuard()
   const qc = useQueryClient()
   const configured = Boolean(config?.clone)
   const display = String(config?.target_display || config?.target_url || '')
@@ -194,9 +196,7 @@ export default function SetupPanel({ config }: { config?: Record<string, unknown
             placeholder={i18nT('apps.autoImprovement.setupPanel.https_github_com_owner_repo')}
             className="flex-1"
             aria-label={i18nT('autoImprovement.repoLabel')}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && url.trim()) clone.mutate(url.trim())
-            }}
+            {...ime.bindEnter({ onEnter: () => { if (url.trim()) clone.mutate(url.trim()) } })}
           />
           <Btn
             primary

--- a/website/src/apps/auto-research/GrillTree.tsx
+++ b/website/src/apps/auto-research/GrillTree.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Check, Circle, Search, Plus, Trash2, HelpCir
 import { GrillNode, GrillAction, nodeDepth } from './grillTreeModel'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 const MAX_DEPTH = 4        // mirrors backend _MAX_GRILL_DEPTH
 const SOFT_LIMIT = 25      // soft "tree getting large" advisory (no hard cap)
 
@@ -26,6 +27,7 @@ function AutoGrow({ value, onChange, onSubmit, placeholder, className = '', aria
   ariaLabel?: string
 }) {
   const ref = useRef<HTMLTextAreaElement>(null)
+  const ime = useImeGuard()
   useEffect(() => {
     const el = ref.current
     if (el) { el.style.height = 'auto'; el.style.height = `${el.scrollHeight}px` }
@@ -34,7 +36,8 @@ function AutoGrow({ value, onChange, onSubmit, placeholder, className = '', aria
     <textarea ref={ref} rows={1} aria-label={ariaLabel} placeholder={placeholder}
               className={`resize-none overflow-hidden ${className}`}
               value={value} onChange={e => onChange(e.target.value)}
-              onKeyDown={e => { if (onSubmit && e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSubmit(value) } }} />
+              {...ime.bindComposition<HTMLTextAreaElement>()}
+              onKeyDown={e => { if (onSubmit && e.key === 'Enter' && !e.shiftKey && ime.claimEnter(e)) onSubmit(value) }} />
   )
 }
 

--- a/website/src/apps/auto-research/ResearchLabPage.tsx
+++ b/website/src/apps/auto-research/ResearchLabPage.tsx
@@ -12,6 +12,7 @@ import GrillTree from './GrillTree'
 import { grillReducer, promotedResearch, answeredClarifiers, suggestedMaxCycles, GrillNode } from './grillTreeModel'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 const ACTIVE_STATUSES = ['running', 'paused', 'stagnant', 'needs_input']
 
 interface Campaign { id: string; name: string; question: string; sub_questions: string; sources: string; max_cycles: number; idle_secs: number; status: string; total_cycles: number; findings?: Finding[]; error_message?: string; pending_question?: string; parent_id?: string; parallel_workers?: number }
@@ -29,6 +30,7 @@ function GrowTextarea({ value, onChange, onSubmit, placeholder, className = '', 
   className?: string
   ariaLabel?: string
 }) {
+  const ime = useImeGuard()
   const ref = useRef<HTMLTextAreaElement>(null)
   useEffect(() => {
     const el = ref.current
@@ -46,9 +48,9 @@ function GrowTextarea({ value, onChange, onSubmit, placeholder, className = '', 
       value={value}
       placeholder={placeholder}
       onChange={e => onChange(e.target.value)}
+      {...ime.bindComposition<HTMLTextAreaElement>()}
       onKeyDown={e => {
-        if (onSubmit && e.key === 'Enter' && !e.shiftKey) {
-          e.preventDefault()
+        if (onSubmit && e.key === 'Enter' && !e.shiftKey && ime.claimEnter(e)) {
           onSubmit()
         }
       }}

--- a/website/src/apps/code-review-sage/components/AddReposModal.tsx
+++ b/website/src/apps/code-review-sage/components/AddReposModal.tsx
@@ -30,6 +30,7 @@ import { relativeAge } from '../lib/format'
 
 import { useDialogFocusTrap } from '../../../hooks/useDialogFocusTrap'
 import { i18nT } from '../../../i18n/t'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 /** One selectable repo row, shared by both lists. */
 function RepoRow({
@@ -111,6 +112,7 @@ function GhNotice({ message }: { message?: string }) {
 }
 
 export default function AddReposModal({ onClose }: { onClose: () => void }) {
+  const ime = useImeGuard()
   const {
     pinnedRepos, pinRepo, pinRepoUrl, pinError, unpinRepo,
     recent, recentLoading, recentError,
@@ -211,7 +213,7 @@ export default function AddReposModal({ onClose }: { onClose: () => void }) {
                 <input
                   value={manual}
                   onChange={(e) => setManual(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter') submitManual() }}
+                  {...ime.bindEnter({ onEnter: submitManual })}
                   aria-label={i18nT('apps.codeReviewSage.components.addReposModal.repository_or_pull_request_url_or_owner_repo')}
                   placeholder={i18nT('apps.codeReviewSage.components.addReposModal.owner_repo_a_repo_url_or_paste_a_pull_request_li')}
                   className="flex-1 min-w-0 bg-transparent border-0 py-2 text-[13px] font-mono text-text outline-none"

--- a/website/src/apps/code-review-sage/components/LearningRail.tsx
+++ b/website/src/apps/code-review-sage/components/LearningRail.tsx
@@ -12,7 +12,9 @@ import { sageApi } from '../api'
 import { useSage } from '../context'
 
 import { i18nT } from '../../../i18n/t'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 export default function LearningRail() {
+  const ime = useImeGuard()
   const { selectedNamespace, selectNamespace } = useSage()
   const qc = useQueryClient()
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
@@ -197,10 +199,10 @@ export default function LearningRail() {
               value={newName}
               autoFocus
               onChange={(e) => setNewName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && newName.trim()) createMut.mutate(newName.trim())
-                if (e.key === 'Escape') { setAdding(false); setNewName('') }
-              }}
+              {...ime.bindEnter({
+                onEnter: () => { if (newName.trim()) createMut.mutate(newName.trim()) },
+                onEscape: () => { setAdding(false); setNewName('') },
+              })}
               aria-label={i18nT('apps.codeReviewSage.components.learningRail.new_namespace_name')}
               placeholder={i18nT('apps.codeReviewSage.components.learningRail.new_namespace_2')}
               className="flex-1 min-w-0 rounded-md border border-border bg-bg-elevated px-2 py-1 font-mono text-[12px] text-text outline-none focus-visible:border-accent"

--- a/website/src/apps/command-bar/CommandBarOverlay.tsx
+++ b/website/src/apps/command-bar/CommandBarOverlay.tsx
@@ -22,6 +22,7 @@ import { useLanguage } from '../../i18n/LanguageProvider'
 
 import { loadUsage, recordUse, type UsageMap } from './frecency'
 import { rankRootRows, type RankedRow, type RootGroup, type RootRow, type RootRowKind } from './rootIndex'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 /**
  * Command Bar — the ⌘K launcher.
@@ -93,6 +94,7 @@ export default function CommandBarOverlay({
   open: boolean
   onClose: () => void
 }) {
+  const ime = useImeGuard()
   const vv = useVisualViewport()
   const inputRef = useRef<HTMLInputElement | null>(null)
   const dialogRef = useRef<HTMLDivElement | null>(null)
@@ -351,7 +353,8 @@ export default function CommandBarOverlay({
         e.preventDefault()
         setSelected(i => (rowCount === 0 ? 0 : (i - 1 + rowCount) % rowCount))
       } else if (e.key === 'Enter') {
-        e.preventDefault()
+        // Only the Enter branch is claimed — arrow navigation stays untouched.
+        if (!ime.claimEnter(e)) return
         activateIndex(selected)
       } else if (e.key === 'Backspace' && query === '' && scope) {
         // Leaving a scope is Backspace on an empty input — the same gesture that
@@ -437,6 +440,7 @@ export default function CommandBarOverlay({
               setQuery(e.target.value)
               setSelected(0)
             }}
+            {...ime.bindComposition()}
             onKeyDown={onKeyDown}
             placeholder={
               scope

--- a/website/src/apps/crew-companion/ColorCustomizerPanel.tsx
+++ b/website/src/apps/crew-companion/ColorCustomizerPanel.tsx
@@ -12,6 +12,7 @@ import { BUILT_IN_CAT_PRESETS } from './builtInCatPresets'
 import { toDataUri } from './animationResolver'
 import { i18nT } from '../../i18n/t'
 import { petBridge } from './petBridge'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 /**
  * The built-in pack's id, canonical in the backend (appearances.py `DEFAULT_PACK`).
@@ -114,6 +115,7 @@ function ColorEditorCard({ sourceColor, targetColor, bodyPart, svgContent, allCo
 interface Props { idleSvgContent: string; }
 
 export const ColorCustomizerPanel: React.FC<Props> = ({ idleSvgContent }) => {
+  const ime = useImeGuard()
   const [colorMap, setColorMap] = useState<ColorMap>({})
   const [registry, setRegistry] = useState<PresetRegistry>(() => new PresetRegistry(BUILT_IN_CAT_PRESETS))
   const [activePresetId, setActivePresetId] = useState<string | null>(null)
@@ -215,7 +217,7 @@ export const ColorCustomizerPanel: React.FC<Props> = ({ idleSvgContent }) => {
               type="text"
               value={saveNameInput}
               onChange={e => setSaveNameInput(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') handleSaveAsPreset(); if (e.key === 'Escape') setShowSaveForm(false) }}
+              {...ime.bindEnter({ onEnter: handleSaveAsPreset, onEscape: () => setShowSaveForm(false) })}
               placeholder={i18nT('apps.crewCompanion.color.promptName')}
               aria-label={i18nT('apps.crewCompanion.color.promptName')}
               autoFocus

--- a/website/src/apps/crew-companion/GalleryPanel.tsx
+++ b/website/src/apps/crew-companion/GalleryPanel.tsx
@@ -88,6 +88,7 @@ import { errorText } from './errorText'
 import type { SpriteImportResult } from './spriteImportTypes'
 import './gallery.css'
 import { splitOnPlaceholder } from './splitOnPlaceholder'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 
 // ── Styles ─────────────────────────────────────────────────────────────────
@@ -597,6 +598,7 @@ function ImportPetDialog({ input, onInput, resolving, resolved, importing, error
   onClose: () => void
   onBrowse: () => void
 }) {
+  const ime = useImeGuard()
   // Esc closes, like any dialog
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
@@ -652,7 +654,7 @@ function ImportPetDialog({ input, onInput, resolving, resolved, importing, error
           <input
             value={input}
             onChange={(e) => onInput(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && resolved) onConfirm() }}
+            {...ime.bindEnter({ onEnter: () => { if (resolved) onConfirm() } })}
             placeholder={i18nT('apps.crewCompanion.gallery.petdexPlaceholder')}
             aria-label={i18nT('apps.crewCompanion.gallery.petdexPlaceholder')}
             autoFocus

--- a/website/src/apps/crew-companion/PanelViews.tsx
+++ b/website/src/apps/crew-companion/PanelViews.tsx
@@ -21,6 +21,7 @@ import { BREAK_MIN_MINS, BREAK_MAX_MINS } from './constants'
 import type { Reminder } from './types'
 import { ReminderInput } from './ReminderInput'
 import { petBridge } from './petBridge'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 const api = petBridge
 
@@ -268,6 +269,7 @@ const Toggle: React.FC<{
 }
 
 export const SettingsView: React.FC = () => {
+  const ime = useImeGuard()
   // The interval picker below styles itself from the skin. Omitting this threw
   // `ReferenceError: skin is not defined` on render, which unmounted the whole card.
   const skin = useSkin()
@@ -367,17 +369,24 @@ export const SettingsView: React.FC = () => {
               placeholder={i18nT('apps.crewCompanion.view.everyMinShort')}
               value={customDraft !== null ? customDraft
                 : BREAK_PRESETS.includes(breakMins) ? '' : String(breakMins)}
-              onFocus={() => setCustomDraft(
-                BREAK_PRESETS.includes(breakMins) ? '' : String(breakMins),
-              )}
+              {...ime.bindComposition({
+                onFocus: () => setCustomDraft(
+                  BREAK_PRESETS.includes(breakMins) ? '' : String(breakMins),
+                ),
+                onBlur: () => {
+                  const next = clampBreakMins(customDraft ?? '')
+                  setCustomDraft(null)
+                  if (next === null) return
+                  setBreakMins(next)
+                  api?.updateConfig?.({ breakReminderMins: next })
+                },
+              })}
               onChange={(e) => setCustomDraft(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
-              onBlur={() => {
-                const next = clampBreakMins(customDraft ?? '')
-                setCustomDraft(null)
-                if (next === null) return
-                setBreakMins(next)
-                api?.updateConfig?.({ breakReminderMins: next })
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter') return
+                // Early-return BEFORE the blur: a committing IME Enter must not commit.
+                if (ime.isComposing(e)) return
+                ;(e.target as HTMLInputElement).blur()
               }}
               style={{
                 width: 42, height: 24, borderRadius: 999, textAlign: 'center',

--- a/website/src/apps/crew-companion/SettingsSection.tsx
+++ b/website/src/apps/crew-companion/SettingsSection.tsx
@@ -5,6 +5,7 @@ import ToggleRow from './ToggleRow'
 import { BREAK_PRESETS, BREAK_MIN_MINS, BREAK_MAX_MINS, BREAK_DEFAULT_MINS } from './constants'
 import { clampBreakMins } from './reminders'
 import type { ReminderConfigPatch, RemindersPayload } from './types'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 
 export default function SettingsSection({ rem, remError, onCfg, customMins, setCustomMins }: {
@@ -21,6 +22,7 @@ export default function SettingsSection({ rem, remError, onCfg, customMins, setC
   customMins: string | null
   setCustomMins: (v: string | null) => void
 }) {
+  const ime = useImeGuard()
   const mins = rem?.breakReminderMins ?? BREAK_DEFAULT_MINS
   const isPreset = BREAK_PRESETS.includes(mins)
 
@@ -63,13 +65,20 @@ export default function SettingsSection({ rem, remError, onCfg, customMins, setC
             aria-label={i18nT('apps.crewCompanion.settings.custom_minutes')}
             placeholder={i18nT('apps.crewCompanion.settings.custom_placeholder')}
             value={customMins !== null ? customMins : (isPreset ? '' : String(mins))}
-            onFocus={() => setCustomMins(isPreset ? '' : String(mins))}
+            {...ime.bindComposition({
+              onFocus: () => setCustomMins(isPreset ? '' : String(mins)),
+              onBlur: () => {
+                const next = clampBreakMins(customMins ?? '')
+                setCustomMins(null)
+                if (next !== null) onCfg({ breakReminderMins: next })
+              },
+            })}
             onChange={(e) => setCustomMins(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
-            onBlur={() => {
-              const next = clampBreakMins(customMins ?? '')
-              setCustomMins(null)
-              if (next !== null) onCfg({ breakReminderMins: next })
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter') return
+              // Early-return BEFORE the blur: a committing IME Enter must not commit.
+              if (ime.isComposing(e)) return
+              ;(e.target as HTMLInputElement).blur()
             }}
           />
         </div>

--- a/website/src/apps/design-critique/AskLayer.tsx
+++ b/website/src/apps/design-critique/AskLayer.tsx
@@ -5,6 +5,7 @@ import { S } from './styles'
 import type { Ask, Sel } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 interface Props {
   sel: Sel | null
   asks: Ask[]
@@ -24,6 +25,7 @@ interface Props {
 }
 
 export default function AskLayer(p: Props) {
+  const ime = useImeGuard()
   const { sel, asks, openAskId, askDraft, reduceMotion } = p
 
   // Floating "Ask about this" chip for the current selection.
@@ -79,13 +81,14 @@ export default function AskLayer(p: Props) {
           disabled={p.pending}
           placeholder={activeAsk && activeAsk.turns.length ? 'Ask a follow-up…' : 'What don’t you understand about this?'}
           onChange={(e) => p.setAskDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !p.pending) {
+          {...ime.bindEnter({
+            onEnter: () => {
+              if (p.pending) return
               if (composing) p.askAbout(sel!.quote, askDraft)
               else p.askFollowUp(activeAsk!.id, askDraft)
-            }
-            if (e.key === 'Escape') { p.setOpenAskId(null); p.setSel(null) }
-          }}
+            },
+            onEscape: () => { p.setOpenAskId(null); p.setSel(null) },
+          })}
         />
         <button
           style={{ ...S.askIcon, ...S.askSend, ...(p.pending ? { opacity: 0.6, cursor: 'default' } : {}) }}

--- a/website/src/apps/design-critique/Composer.tsx
+++ b/website/src/apps/design-critique/Composer.tsx
@@ -6,6 +6,7 @@ import { S } from './styles'
 import type { Blocked, StagedItem } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 interface Props {
   staged: StagedItem[]
   refText: string
@@ -31,6 +32,7 @@ interface Props {
 }
 
 export default function Composer(p: Props) {
+  const ime = useImeGuard()
   const { staged, refText, dragging, blocked, showAuth, busy, err, inputRef } = p
 
   const canStart = !busy && (staged.length > 0 || !!refText.trim())
@@ -130,7 +132,7 @@ export default function Composer(p: Props) {
           value={refText} disabled={staged.length > 0 || busy}
           placeholder={staged.length ? 'Using your screenshots — clear them to critique a link instead' : 'Figma link · git repo · a folder on this machine · a running URL (localhost or a deployed preview)'}
           onChange={(e) => p.setRefText(e.target.value)}
-          onKeyDown={(e) => { if (e.key === 'Enter') p.start() }}
+          {...ime.bindEnter({ onEnter: () => p.start() })}
         />
         <button
           style={{ ...S.bigStart, ...(canStart ? {} : S.startOff) }} disabled={!canStart} onClick={p.start}

--- a/website/src/apps/design-critique/ScopingPicker.tsx
+++ b/website/src/apps/design-critique/ScopingPicker.tsx
@@ -4,6 +4,7 @@ import { S } from './styles'
 import type { Scope, Flow, DiscoveryScreen } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 interface Props {
   scope: Scope
   picked: string[]
@@ -24,6 +25,7 @@ const sameSet = (a: string[], b: string[]) => a.length === b.length && a.every((
 // Discovery found candidate screens. Routes are knowable; flows are a guess —
 // so flows are offered as suggestions the user confirms and can reorder.
 export default function ScopingPicker(p: Props) {
+  const ime = useImeGuard()
   const { scope, picked, refBrief, dragId } = p
   const groups = new Map<string, DiscoveryScreen[]>()
   scope.screens.forEach(s => {
@@ -128,7 +130,7 @@ export default function ScopingPicker(p: Props) {
             aria-label={i18nT('apps.designCritique.scopingPicker.optional_brief_who_is_it_for_and_what_is_the_mai')}
             placeholder={i18nT('apps.designCritique.scopingPicker.optional_who_is_it_for_and_what_s_the_main_task')}
             onChange={(e) => p.setRefBrief(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && picked.length) p.runScoped() }}
+            {...ime.bindEnter({ onEnter: () => { if (picked.length) p.runScoped() } })}
           />
           <button style={{ ...S.bigStart, ...(picked.length ? {} : S.startOff) }} disabled={!picked.length} onClick={p.runScoped}>
             <PencilRuler size={16} />

--- a/website/src/apps/design-tweak/DesignTweakPage.tsx
+++ b/website/src/apps/design-tweak/DesignTweakPage.tsx
@@ -41,6 +41,7 @@ import {
   stopDevServer as apiStopDevServer,
 } from './api'
 import { deliveryVerdict, needsDeliveryRetry } from './delivery'
+import { useImeGuard } from '../../hooks/useImeGuard'
 import type {
   Project, Request, Comment, ThreadEntry, EditSelection,
   PreviewScoped, OverlayMessage,
@@ -484,6 +485,8 @@ function RequestGroup({
 
 
 export default function DesignTweak() {
+  // One instance covers both inputs; the binding's focus/blur reset makes sharing safe.
+  const ime = useImeGuard()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
@@ -1650,7 +1653,7 @@ export default function DesignTweak() {
                           value={newPath}
                           autoFocus
                           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewPath(e.target.value)}
-                          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && addProject()}
+                          {...ime.bindEnter({ onEnter: () => addProject() })}
                           placeholder={i18nT('apps.designTweak.projects.path_placeholder')}
                           className="flex-1 h-8 px-2 rounded-md bg-bg-elevated border border-border text-[12px] text-text"
                         />
@@ -2050,10 +2053,7 @@ export default function DesignTweak() {
                           value={devDraft}
                           autoFocus
                           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDevDraft(e.target.value)}
-                          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                            if (e.key === 'Enter') setDevServer(devDraft.trim())
-                            if (e.key === 'Escape') { setDevOpen(false); setDevDraft('') }
-                          }}
+                          {...ime.bindEnter({ onEnter: () => setDevServer(devDraft.trim()), onEscape: () => { setDevOpen(false); setDevDraft('') } })}
                           placeholder={i18nT('apps.designTweak.devServer.url_placeholder')}
                           className="h-8 px-2 rounded-md bg-bg-elevated border border-border text-[12px] text-text"
                           style={{ width: '190px' }}

--- a/website/src/apps/file-explorer/PathBar.tsx
+++ b/website/src/apps/file-explorer/PathBar.tsx
@@ -8,6 +8,7 @@ import { useDebouncedValue } from './hooks'
 import type { GitInfo, TreeEntry } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 interface PathBarProps {
   rootPath: string
   gitInfo: GitInfo | null
@@ -16,6 +17,7 @@ interface PathBarProps {
 }
 
 export default function PathBar({ rootPath, gitInfo, onChangeRoot, onNavigate }: PathBarProps) {
+  const ime = useImeGuard()
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(rootPath)
   const [open, setOpen] = useState(false)
@@ -62,8 +64,9 @@ export default function PathBar({ rootPath, gitInfo, onChangeRoot, onNavigate }:
     if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) { setOpen(true); return }
     if (open && e.key === 'ArrowDown') { e.preventDefault(); setActiveIdx((i) => suggestions.length === 0 ? -1 : (i + 1) % suggestions.length) }
     else if (open && e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx((i) => suggestions.length === 0 ? -1 : (i - 1 + suggestions.length) % suggestions.length) }
-    else if (open && e.key === 'Enter') { e.preventDefault(); if (activeIdx >= 0 && suggestions[activeIdx]) accept(suggestions[activeIdx]); else commit() }
-    else if (!open && e.key === 'Enter') { e.preventDefault(); commit() }
+    // Only the Enter branches are claimed — arrow/Tab navigation stays untouched.
+    else if (open && e.key === 'Enter') { if (!ime.claimEnter(e)) return; if (activeIdx >= 0 && suggestions[activeIdx]) accept(suggestions[activeIdx]); else commit() }
+    else if (!open && e.key === 'Enter') { if (ime.claimEnter(e)) commit() }
     else if (e.key === 'Escape') { setDraft(rootPath); setEditing(false); setOpen(false) }
     else if (e.key === 'Tab' && open && suggestions.length > 0) { e.preventDefault(); setDraft(suggestions[activeIdx >= 0 ? activeIdx : 0].path) }
   }
@@ -83,7 +86,7 @@ export default function PathBar({ rootPath, gitInfo, onChangeRoot, onNavigate }:
               aria-label={i18nT('apps.fileExplorer.pathBar.folder_path')}
               value={draft}
               onChange={(e) => { setDraft(e.target.value); setOpen(true) }}
-              onFocus={() => setOpen(true)}
+              {...ime.bindComposition({ onFocus: () => setOpen(true) })}
               onKeyDown={onKeyDown}
               placeholder={i18nT('apps.fileExplorer.pathBar.path_to_folder')}
               spellCheck={false}

--- a/website/src/apps/file-explorer/TabStrip.tsx
+++ b/website/src/apps/file-explorer/TabStrip.tsx
@@ -7,6 +7,7 @@ import { extOf, basename } from './utils'
 import type { FolderTab, FileTab } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 interface TabStripProps {
   folderTabs: FolderTab[]
   fileTabs: FileTab[]
@@ -21,6 +22,8 @@ interface TabStripProps {
 }
 
 export default function TabStrip({ folderTabs, fileTabs, activeFolderId, activeFileId, onActivateFolder, onActivateFile, onCloseFolder, onCloseFile, onNewFolder, onRenameFolder }: TabStripProps) {
+  // Only one rename input renders at a time, so a single instance is safe.
+  const ime = useImeGuard()
   const [renameId, setRenameId] = useState<string | null>(null)
   const [renameDraft, setRenameDraft] = useState('')
   const [attachScroller, fades, remeasure] = useScrollEdges<HTMLDivElement>()
@@ -55,11 +58,11 @@ export default function TabStrip({ folderTabs, fileTabs, activeFolderId, activeF
                 value={renameDraft}
                 onChange={(e) => setRenameDraft(e.target.value)}
                 onClick={(e) => e.stopPropagation()}
-                onBlur={() => { onRenameFolder(t.id, renameDraft.trim()); setRenameId(null) }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') { onRenameFolder(t.id, renameDraft.trim()); setRenameId(null) }
-                  if (e.key === 'Escape') setRenameId(null)
-                }}
+                {...ime.bindEnter({
+                  onEnter: () => { onRenameFolder(t.id, renameDraft.trim()); setRenameId(null) },
+                  onEscape: () => setRenameId(null),
+                  onBlur: () => { onRenameFolder(t.id, renameDraft.trim()); setRenameId(null) },
+                })}
               />
             ) : (
               <span className="mc-fe-tab-label">{t.label || basename(t.rootPath) || '/'}</span>

--- a/website/src/apps/issue-radar/ConnectPanel.tsx
+++ b/website/src/apps/issue-radar/ConnectPanel.tsx
@@ -38,6 +38,7 @@ import GitlabLogo from '../../components/icons/GitlabLogo'
 
 import { i18nT } from '../../i18n/t'
 import { fmtDateTimeNumeric } from '../../i18n/format'
+import { useImeGuard } from '../../hooks/useImeGuard'
 /** The provider a connect flow is pointed at.
  *
  * An ALIAS of `api.ts`'s `SourceProvider`, not a second union: this used to be its
@@ -474,6 +475,7 @@ function urlPlaceholderFor(provider: SourceProvider): string {
  * would just fail the same way) and the whole right column becomes the setup
  * notice. */
 export default function ConnectPanel({ flow }: { flow: ConnectFlow }) {
+  const ime = useImeGuard()
   // Every wired provider expands into the two-column body. Jira/Linear stay
   // collapsed because they are still placeholders.
   const expanded = expandsCard(flow.provider)
@@ -630,7 +632,7 @@ export default function ConnectPanel({ flow }: { flow: ConnectFlow }) {
                   aria-label={i18nT('apps.issueRadar.connectPanel.repository_url')}
                   value={flow.url}
                   onChange={(e) => flow.setUrl(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter') flow.submit() }}
+                  {...ime.bindEnter({ onEnter: () => flow.submit() })}
                   disabled={flow.pending}
                   placeholder={urlPlaceholder}
                   className="w-full box-border text-[12.5px] px-3 py-2 rounded-md bg-bg text-text border border-border font-mono disabled:opacity-50"

--- a/website/src/apps/issue-radar/components/CrewEditor.tsx
+++ b/website/src/apps/issue-radar/components/CrewEditor.tsx
@@ -57,6 +57,7 @@ import CrewGhost, { djb2, ghostVariantCount } from './CrewGhost'
 import { issueRadarApi, type Crew, type CrewPatch, type CrewSpec } from '../api'
 import { repoScopeKey } from '../lib/links'
 import { useIssueRadar } from '../context'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 /** Backstop wake, in seconds. A CONSTANT, not state: see the file header. */
 const BACKSTOP_WAKE_SECONDS = 120
@@ -272,6 +273,7 @@ export interface CrewEditorProps {
 }
 
 export default function CrewEditor({ open, onClose, crew }: CrewEditorProps) {
+  const ime = useImeGuard()
   const { t } = useTranslation()
   const { active } = useIssueRadar()
   const scopeKey = repoScopeKey(active)
@@ -811,18 +813,11 @@ export default function CrewEditor({ open, onClose, crew }: CrewEditorProps) {
                     className="w-40 py-1 font-mono text-[12px]"
                     value={newLabel}
                     onChange={e => setNewLabel(e.target.value)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        commitNewLabel()
-                      }
-                      // Escape is NOT handled here: Radix's DismissableLayer
-                      // listens on `document` with `{ capture: true }`, so it has
-                      // already decided to dismiss by the time a bubble-phase
-                      // handler on this input runs — `stopPropagation` here would
-                      // read like a guard and close the whole form anyway. The
-                      // interception lives on `DialogContent`'s `onEscapeKeyDown`.
-                    }}
+                    // Escape is NOT handled by us beyond the binding's latch
+                    // reset: Radix's DismissableLayer listens on `document` with
+                    // `{ capture: true }`, so it has already decided to dismiss
+                    // by the time a bubble-phase handler on this input runs.
+                    {...ime.bindEnter({ onEnter: commitNewLabel })}
                   />
                   <IconButton
                     aria-label={t('apps.issueRadar.views.crews.editor.labels_add_commit')}

--- a/website/src/apps/issue-radar/components/PrActionsBar.tsx
+++ b/website/src/apps/issue-radar/components/PrActionsBar.tsx
@@ -29,6 +29,7 @@ import { providerTerms, isGitlab } from '../lib/links'
 import type { PrDetailData, PullRequest, RepoRef } from '../api'
 
 import { i18nT } from '../../../i18n/t'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 /** Which composer is open, if any. `null` means the bar is showing its buttons. */
 type Composer = 'approve' | 'request_changes' | 'comment' | null
@@ -86,6 +87,7 @@ export default function PrActionsBar({
    * says why instead of offering buttons that fail. */
   canWrite: boolean
 }) {
+  const ime = useImeGuard()
   const terms = providerTerms(repoRef)
   const actions = usePrActions(repoRef, pull.number)
   const [composer, setComposer] = useState<Composer>(null)
@@ -255,11 +257,12 @@ export default function PrActionsBar({
           ref={textRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
+          {...ime.bindComposition<HTMLTextAreaElement>()}
           onKeyDown={(e) => {
             if (e.key === 'Escape') { e.preventDefault(); closeComposer() }
             // Cmd/Ctrl+Enter submits, matching the chat composer. A bare Enter
             // stays a newline: these bodies are prose, often multi-line.
-            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); submitComposer() }
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { if (ime.claimEnter(e)) submitComposer() }
           }}
           placeholder={copy.placeholder}
           aria-label={copy.title}

--- a/website/src/apps/issue-radar/components/PrBulkBar.tsx
+++ b/website/src/apps/issue-radar/components/PrBulkBar.tsx
@@ -42,6 +42,7 @@ import { providerTerms, isGitlab, repoScopeKey } from '../lib/links'
 import type { BulkPrAction } from '../api'
 
 import { i18nT } from '../../../i18n/t'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 // The confirmation TOKENS and the merge pseudo-action are protocol values, not copy:
 // a translated token makes the action impossible to complete. They live in
@@ -64,6 +65,7 @@ const NEEDS_CONFIRM = new Set<BulkPrAction>(['close'])
 
 
 export default function PrBulkBar() {
+  const ime = useImeGuard()
   const {
     active, canWrite, checkedPulls, clearCheckedPulls, toggleAllPullsChecked, sortedPulls,
     togglePullChecked, prBulkMax,
@@ -569,6 +571,7 @@ export default function PrBulkBar() {
               <input
                 value={confirmText}
                 onChange={(e) => setConfirmText(e.target.value)}
+                {...ime.bindComposition()}
                 onKeyDown={(e) => {
                   if (e.key === 'Escape') {
                     e.preventDefault()
@@ -580,7 +583,7 @@ export default function PrBulkBar() {
                   // Enter mid-run started a concurrent loop that merged a row twice and
                   // defeated stop-on-first-failure.
                   if (e.key === 'Enter' && confirmArmed && !seq.busy && !bulk.busy) {
-                    e.preventDefault()
+                    if (!ime.claimEnter(e)) return
                     if (isMergePending) runSequentialMerge()
                     else apply(pending)
                   }

--- a/website/src/apps/issue-radar/views/settings/CrewProtocolSettings.tsx
+++ b/website/src/apps/issue-radar/views/settings/CrewProtocolSettings.tsx
@@ -55,6 +55,7 @@ import {
   type CrewSettings, type CrewSettingsPatch, type CrewSettingsResponse, type RepoRef,
 } from '../../api'
 import { repoScopeKey } from '../../lib/links'
+import { useImeGuard } from '../../../../hooks/useImeGuard'
 
 /** The free-text fields. Both commit the same way — trim, refuse a blank, send
  *  one key — so they share one renderer and one branch in `commit`. */
@@ -84,6 +85,8 @@ export default function CrewProtocolSettings({
    *  tell a real edit from a no-op. */
   settings: CrewSettings | undefined
 }) {
+  // One instance covers every field render; the binding's focus/blur reset makes sharing safe.
+  const ime = useImeGuard()
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const scope = repoScopeKey(repoRef)
@@ -327,8 +330,7 @@ export default function CrewProtocolSettings({
             aria-invalid={message ? true : undefined}
             aria-describedby={message ? errorId : undefined}
             onChange={(e) => edit(field, e.target.value)}
-            onBlur={() => commit(field)}
-            onKeyDown={(e) => { if (e.key === 'Enter') commit(field) }}
+            {...ime.bindEnter({ onEnter: () => commit(field), onBlur: () => commit(field) })}
             disabled={!settings}
             className="max-w-[140px] flex-none"
             data-testid={testId}
@@ -364,8 +366,7 @@ export default function CrewProtocolSettings({
           aria-invalid={message ? true : undefined}
           aria-describedby={message ? errorId : undefined}
           onChange={(e) => edit(field, e.target.value)}
-          onBlur={() => commit(field)}
-          onKeyDown={(e) => { if (e.key === 'Enter') commit(field) }}
+          {...ime.bindEnter({ onEnter: () => commit(field), onBlur: () => commit(field) })}
           disabled={!settings}
           className={`w-full${mono ? ' font-mono' : ''}`}
           data-testid={testId}

--- a/website/src/apps/md-notebook/BlockEditor.tsx
+++ b/website/src/apps/md-notebook/BlockEditor.tsx
@@ -12,6 +12,7 @@ import {
   FONT_BODY,
 } from './constants'
 import { carriedMarker, isEmptyListItem, shiftListItem } from './utils'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 export interface BlockEditorProps {
   initial: string
@@ -44,6 +45,7 @@ export function BlockEditor({
   textStyle,
   caret,
 }: BlockEditorProps) {
+  const ime = useImeGuard()
   const [text, setText] = useState(initial)
   const ref = useRef<HTMLTextAreaElement>(null)
   // Set once we hand off to a new block, so the blur that follows unmounting
@@ -97,14 +99,20 @@ export function BlockEditor({
         onDirty?.()
         autoSize()
       }}
-      onBlur={() => {
-        if (!handedOff.current) onCommit(text)
-      }}
+      {...ime.bindComposition<HTMLTextAreaElement>({
+        onBlur: () => {
+          if (!handedOff.current) onCommit(text)
+        },
+      })}
       onKeyDown={e => {
         if (e.key === 'Escape') {
           e.stopPropagation()
           onCancel()
         } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          // Claim BEFORE the blur: a committing IME Enter must not commit the
+          // block, and on a textarea the declined key must ALSO be consumed or
+          // the browser inserts a literal newline into the draft (R3).
+          if (!ime.claimEnter(e)) return
           e.currentTarget.blur()
         } else if (e.key === 'Tab') {
           // Tab nests a list item, Shift+Tab lifts it out. On anything that is
@@ -117,7 +125,7 @@ export function BlockEditor({
           rewrite(ta, next.text, next.pos)
         } else if (e.key === 'Enter' && !e.shiftKey && onSplit) {
           // Shift+Enter falls through to the browser: a soft break in this block.
-          e.preventDefault()
+          if (!ime.claimEnter(e)) return
           const ta = e.currentTarget
           const before = text.slice(0, ta.selectionStart)
           const after = text.slice(ta.selectionEnd)
@@ -173,6 +181,7 @@ export function InlineTitle({
   onRename: (next: string) => void
   mb?: string
 }) {
+  const ime = useImeGuard()
   const name = (path.split('/').pop() ?? path).replace(/\.md$/i, '')
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(name)
@@ -244,17 +253,19 @@ export function InlineTitle({
         setValue(e.target.value.replace(/\n/g, ''))
         autoSize()
       }}
-      onBlur={() => {
-        setEditing(false)
-        if (value.trim() && value.trim() !== name) onRename(value)
-      }}
+      {...ime.bindComposition<HTMLTextAreaElement>({
+        onBlur: () => {
+          setEditing(false)
+          if (value.trim() && value.trim() !== name) onRename(value)
+        },
+      })}
       onKeyDown={e => {
         if (e.key === 'Escape') {
           e.stopPropagation()
           setValue(name)
           setEditing(false)
         } else if (e.key === 'Enter') {
-          e.preventDefault()
+          if (!ime.claimEnter(e)) return
           e.currentTarget.blur()
         }
       }}

--- a/website/src/apps/md-notebook/NoteRow.tsx
+++ b/website/src/apps/md-notebook/NoteRow.tsx
@@ -16,6 +16,7 @@ import Clickable from '../../components/Clickable'
 import { relTime, rowBadge } from './utils'
 import type { Note, NoteActions, TreeNode } from './types'
 import { compareText } from '../../i18n/format'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 /** Sync badge, matching the Sessions list tag-chip recipe. */
 function badgeStyle(status: string): CSSProperties {
@@ -83,6 +84,7 @@ export function NoteRow({
   /** Omitted in contexts with no row affordances (e.g. a preview list). */
   actions?: NoteActions
 }) {
+  const ime = useImeGuard()
   // In flat-list view the folder tree is gone, so surface the note's parent
   // folder in the meta line to disambiguate same-named notes.
   const folder =
@@ -169,11 +171,11 @@ export function NoteRow({
           aria-label={i18nT('apps.mdNotebook.row.renameField')}
           onChange={e => setDraft(e.target.value)}
           onClick={e => e.stopPropagation()}
-          onBlur={commitRename}
+          {...ime.bindComposition({ onBlur: commitRename })}
           onKeyDown={e => {
             e.stopPropagation()
             if (e.key === 'Enter') {
-              e.preventDefault()
+              if (!ime.claimEnter(e)) return
               commitRename()
             } else if (e.key === 'Escape') {
               e.preventDefault()

--- a/website/src/apps/meetings/SettingsView.tsx
+++ b/website/src/apps/meetings/SettingsView.tsx
@@ -29,6 +29,7 @@ import {
   type ConfigResponse,
   type MeetingsConfig,
 } from './api'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 interface Props {
   onBack: () => void
@@ -36,6 +37,7 @@ interface Props {
 }
 
 export default function SettingsView({ onBack, notify }: Props) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   // `patch()` builds a full-replace PUT from this cache, so a backgrounded tab
   // with stale cache would silently revert settings changed from another tab.
@@ -317,9 +319,7 @@ export default function SettingsView({ onBack, notify }: Props) {
               className="w-48"
               placeholder={i18nT('apps.meetings.settings.correctPlaceholder')}
               aria-label={i18nT('apps.meetings.settings.correctLabel')}
-              onKeyDown={e => {
-                if (e.key === 'Enter') submitTerm()
-              }}
+              {...ime.bindEnter({ onEnter: submitTerm })}
             />
             <SendBtn onClick={submitTerm} aria-label={i18nT('apps.meetings.settings.addTerm')}>
               <Plus className="lucide-inline" />

--- a/website/src/apps/meetings/components/AgentPanel.tsx
+++ b/website/src/apps/meetings/components/AgentPanel.tsx
@@ -40,6 +40,7 @@ import MarkdownRenderer from '../../../components/MarkdownRenderer'
 import { Btn, Card, CardTitle, Input, SendBtn } from '../../../components/ui'
 import type { AgentDef } from '../api'
 import { buildSketchSrcdoc } from '../lib/sketchSrcdoc'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 interface Props {
   agent: AgentDef
@@ -60,6 +61,7 @@ export default function AgentPanel({
   onToggleChatView,
   onSendMessage,
 }: Props) {
+  const ime = useImeGuard()
   const inputRef = useRef<HTMLInputElement>(null)
   const [sent, setSent] = useState<string[]>([])
   const isChatAgent = agent.widget_type === 'chat'
@@ -152,9 +154,7 @@ export default function AgentPanel({
             aria-label={i18nT('apps.meetings.agentPanel.messagePlaceholder', {
               name: agent.name,
             })}
-            onKeyDown={e => {
-              if (e.key === 'Enter') send()
-            }}
+            {...ime.bindEnter({ onEnter: send })}
           />
           <SendBtn onClick={send} aria-label={i18nT('apps.meetings.agentPanel.send')}>
             {i18nT('apps.meetings.agentPanel.send')}

--- a/website/src/apps/meetings/components/BroadcastBar.tsx
+++ b/website/src/apps/meetings/components/BroadcastBar.tsx
@@ -9,6 +9,7 @@ import { Send } from 'lucide-react'
 
 import { i18nT } from '../../../i18n/t'
 import { Input, SendBtn } from '../../../components/ui'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 interface Props {
   onSend: (text: string) => void
@@ -17,6 +18,7 @@ interface Props {
 }
 
 export default function BroadcastBar({ onSend, caption, disabled }: Props) {
+  const ime = useImeGuard()
   const inputRef = useRef<HTMLInputElement>(null)
 
   const send = () => {
@@ -52,9 +54,7 @@ export default function BroadcastBar({ onSend, caption, disabled }: Props) {
           aria-label={i18nT('apps.meetings.broadcastBar.placeholder')}
           disabled={disabled}
           className="flex-1"
-          onKeyDown={e => {
-            if (e.key === 'Enter') send()
-          }}
+          {...ime.bindEnter({ onEnter: send })}
         />
         <SendBtn
           onClick={send}

--- a/website/src/apps/meetings/components/TaskSidebar.tsx
+++ b/website/src/apps/meetings/components/TaskSidebar.tsx
@@ -12,6 +12,7 @@ import { i18nT } from '../../../i18n/t'
 import SimpleSelect from '../../../components/SimpleSelect'
 import { Badge, Btn, Input, SendBtn } from '../../../components/ui'
 import { PRIORITY_LABEL_KEY, type Task, type TaskPriority } from '../api'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 
 const PRIORITIES: TaskPriority[] = ['high', 'medium', 'low']
 
@@ -30,6 +31,7 @@ interface Props {
 }
 
 export default function TaskSidebar({ tasks, onClose, onAdd, onUpdate, onDelete }: Props) {
+  const ime = useImeGuard()
   const quickAddRef = useRef<HTMLInputElement>(null)
 
   const quickAdd = () => {
@@ -145,9 +147,7 @@ export default function TaskSidebar({ tasks, onClose, onAdd, onUpdate, onDelete 
           className="flex-1"
           placeholder={i18nT('apps.meetings.taskSidebar.quickAddPlaceholder')}
           aria-label={i18nT('apps.meetings.taskSidebar.quickAddPlaceholder')}
-          onKeyDown={e => {
-            if (e.key === 'Enter') quickAdd()
-          }}
+          {...ime.bindEnter({ onEnter: quickAdd })}
         />
         <SendBtn onClick={quickAdd} aria-label={i18nT('apps.meetings.taskSidebar.add')}>
           <Plus className="lucide-inline" />

--- a/website/src/apps/mochi/src/renderer/ChatPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/ChatPanel.tsx
@@ -1496,6 +1496,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
         <textarea
           ref={inputRef}
           {...ime.bindComposition<HTMLTextAreaElement>({
+            onFocus: (e) => {
+              e.currentTarget.style.borderColor = editingTs ? 'var(--accent)' : 'var(--border-focus)'
+              e.currentTarget.style.boxShadow = '0 0 0 3px var(--accent-glow)'
+            },
             onBlur: (e) => {
               e.currentTarget.style.borderColor = editingTs ? 'var(--accent)' : 'var(--border)'
               e.currentTarget.style.boxShadow = editingTs ? '0 0 0 2px var(--accent-glow)' : 'none'
@@ -1549,10 +1553,6 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
             lineHeight: '1.4',
             maxHeight: 120, overflowY: 'auto',
             boxShadow: editingTs ? '0 0 0 2px var(--accent-glow)' : undefined,
-          }}
-          onFocus={(e) => {
-            e.currentTarget.style.borderColor = editingTs ? 'var(--accent)' : 'var(--border-focus)'
-            e.currentTarget.style.boxShadow = '0 0 0 3px var(--accent-glow)'
           }}
         />
         <button onClick={handleSend} title={i18nT('apps.mochi.chat.send')} aria-label={i18nT('apps.mochi.chat.send')} style={{

--- a/website/src/apps/mochi/src/renderer/ColorCustomizer.tsx
+++ b/website/src/apps/mochi/src/renderer/ColorCustomizer.tsx
@@ -12,6 +12,7 @@ import { BUILT_IN_CAT_PRESETS, presetDisplayName } from '../shared/builtInCatPre
 import { toDataUri } from './animationResolver'
 import { api } from '../mochiApi'
 import { i18nT } from '../../../../i18n/t'
+import { useImeGuard } from '../../../../hooks/useImeGuard'
 
 /** i18n key for each source color's body part label */
 const BODY_PART_KEYS: Record<string, string> = {
@@ -102,6 +103,7 @@ function ColorEditorCard({ sourceColor, targetColor, bodyPart, svgContent, allCo
 interface Props { idleSvgContent: string }
 
 export const ColorCustomizerPanel: React.FC<Props> = ({ idleSvgContent }) => {
+  const ime = useImeGuard()
   const [colorMap, setColorMap] = useState<ColorMap>({})
   const [registry, setRegistry] = useState<PresetRegistry>(() => new PresetRegistry(BUILT_IN_CAT_PRESETS))
   const [activePresetId, setActivePresetId] = useState<string | null>(null)
@@ -199,7 +201,7 @@ export const ColorCustomizerPanel: React.FC<Props> = ({ idleSvgContent }) => {
               type="text"
               value={saveNameInput}
               onChange={e => setSaveNameInput(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') handleSaveAsPreset(); if (e.key === 'Escape') setShowSaveForm(false) }}
+              {...ime.bindEnter({ onEnter: handleSaveAsPreset, onEscape: () => setShowSaveForm(false) })}
               placeholder={i18nT('apps.mochi.color.prompt_name')}
               autoFocus
               style={{

--- a/website/src/apps/mochi/src/renderer/PetdexImporter.tsx
+++ b/website/src/apps/mochi/src/renderer/PetdexImporter.tsx
@@ -22,6 +22,7 @@ import {
 import { api } from '../mochiApi'
 import type { SpritePrefillInput } from './SpriteImporter'
 import { i18nT } from '../../../../i18n/t'
+import { useImeGuard } from '../../../../hooks/useImeGuard'
 
 interface Props {
   /** A pet was obtained and measured; take over with the mapping step. */
@@ -79,6 +80,7 @@ function measure(uri: string): Promise<{ width: number; height: number }> {
 }
 
 export const PetdexImporter: React.FC<Props> = ({ onReady, onUseFile, onCancel }) => {
+  const ime = useImeGuard()
   const [slug, setSlug] = useState('')
   const [installed, setInstalled] = useState<PetdexInstalled[]>([])
   const [busy, setBusy] = useState<string | null>(null)
@@ -137,7 +139,7 @@ export const PetdexImporter: React.FC<Props> = ({ onReady, onUseFile, onCancel }
               value={slug}
               placeholder={i18nT('apps.mochi.petdex.name_placeholder')}
               onChange={(e) => setSlug(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') submitSlug() }}
+              {...ime.bindEnter({ onEnter: submitSlug })}
               disabled={busy !== null}
             />
             <button

--- a/website/src/apps/ops-mission-control/SettingsPanel.tsx
+++ b/website/src/apps/ops-mission-control/SettingsPanel.tsx
@@ -73,6 +73,7 @@ import {
   type SlackOutStatus,
   type SweepWindows,
 } from './api'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 /** Module-level frozen empty so the render-time fallback is referentially stable. */
 const EMPTY_COMPANIONS: readonly CompanionInfo[] = Object.freeze([])
@@ -98,6 +99,7 @@ function ProviderRow({
    */
   fencedIdentity?: { label: string; settingsKey: string; value: string; help: string }
 }) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [secretDrafts, setSecretDrafts] = useState<Record<string, string>>({})
   const [configDrafts, setConfigDrafts] = useState<Record<string, string>>({})
@@ -206,9 +208,7 @@ function ProviderRow({
               value={identityDraft ?? fencedIdentity.value}
               placeholder="—"
               onChange={(e) => setIdentityDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') commitIdentity()
-              }}
+              {...ime.bindEnter({ onEnter: commitIdentity })}
             />
             <SendBtn
               disabled={
@@ -631,6 +631,7 @@ function SharedMemoryCard({
   onSave: (updates: Record<string, unknown>) => void
   saving: boolean
 }) {
+  const ime = useImeGuard()
   // Local drafts, seeded from the server and re-seeded while untouched — the same shape
   // as the Slack channel field, so a background /state refresh cannot clobber typing.
   const serverRemote = status?.remote ?? ''
@@ -749,9 +750,7 @@ function SharedMemoryCard({
               setRemoteTouched(true)
               setRemote(e.target.value)
             }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') saveRemote()
-            }}
+            {...ime.bindEnter({ onEnter: saveRemote })}
           />
           {/* An explicit Save, not a commit on blur. Tabbing out of a half-pasted URL
               would repoint the whole team's repo, and the backend's branch/length
@@ -773,9 +772,7 @@ function SharedMemoryCard({
               setBranchTouched(true)
               setBranch(e.target.value)
             }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') saveBranch()
-            }}
+            {...ime.bindEnter({ onEnter: saveBranch })}
           />
           <SendBtn disabled={!branchDirty || saving} onClick={saveBranch}>
             {i18nT('apps.opsMissionControl.settingsPanel.save')}
@@ -876,6 +873,7 @@ function OnCallScheduleCard({
   roster?: RotationRoster
   syncReady: boolean
 }) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   // From the ROSTER, not from provider config. The login moved onto the keystone floor
   // (`policy_store.OPERATOR_ONLY_KEYS`) because it is an input to the authorization decision —
@@ -968,9 +966,7 @@ shifts:
                 setTouched(true)
                 setLogin(e.target.value)
               }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') commit()
-              }}
+              {...ime.bindEnter({ onEnter: commit })}
             />
             <SendBtn disabled={!dirty || loginMutation.isPending} onClick={commit}>
               {i18nT('apps.opsMissionControl.settingsPanel.save')}
@@ -1102,6 +1098,7 @@ function HeartbeatCard({
   onSave: (updates: Record<string, unknown>) => void
   saving: boolean
 }) {
+  const ime = useImeGuard()
   // Drafts in MINUTES, because the backend's seconds are a storage unit and nobody tunes a
   // 12-hour window by typing 43200. Re-seeded from the server while untouched, the same
   // shape as every other field here, so a background /state refresh cannot clobber typing.
@@ -1175,11 +1172,7 @@ function HeartbeatCard({
               setStaleTouched(true)
               setStale(e.target.value)
             }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                save('stale_after_secs', staleSecs, () => setStaleTouched(false))
-              }
-            }}
+            {...ime.bindEnter({ onEnter: () => save('stale_after_secs', staleSecs, () => setStaleTouched(false)) })}
           />
           <span className="text-muted shrink-0">{i18nT('apps.opsMissionControl.settingsPanel.min')}</span>
           <SendBtn
@@ -1201,13 +1194,11 @@ function HeartbeatCard({
               setNeedsHumanTouched(true)
               setNeedsHuman(e.target.value)
             }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                save('needs_human_stale_after_secs', needsHumanSecs, () =>
-                  setNeedsHumanTouched(false),
-                )
-              }
-            }}
+            {...ime.bindEnter({
+              onEnter: () => save('needs_human_stale_after_secs', needsHumanSecs, () =>
+                setNeedsHumanTouched(false),
+              ),
+            })}
           />
           <span className="text-muted shrink-0">{i18nT('apps.opsMissionControl.settingsPanel.min')}</span>
           <SendBtn

--- a/website/src/apps/papyrus/ProjectList.tsx
+++ b/website/src/apps/papyrus/ProjectList.tsx
@@ -18,6 +18,7 @@ import { papyrusApi, type Project } from './api'
 import { pruneSlots } from './lib'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 export interface ProjectListProps {
   onOpenProject: (name: string) => void
@@ -38,6 +39,8 @@ function formatModified(epochSeconds: number): string {
 }
 
 export default function ProjectList({ onOpenProject }: ProjectListProps) {
+  // One instance covers both inputs; the binding's focus/blur reset makes sharing safe.
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [newName, setNewName] = useState('')
   const [cloneUrl, setCloneUrl] = useState('')
@@ -253,7 +256,7 @@ export default function ProjectList({ onOpenProject }: ProjectListProps) {
               placeholder={i18nT('apps.papyrus.page.new_paper_name_placeholder')}
               value={newName}
               onChange={e => setNewName(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') submitCreate() }}
+              {...ime.bindEnter({ onEnter: submitCreate })}
             />
             <SendBtn onClick={submitCreate} disabled={!newName.trim() || createMutation.isPending}>
               {createMutation.isPending
@@ -269,7 +272,7 @@ export default function ProjectList({ onOpenProject }: ProjectListProps) {
               placeholder={i18nT('apps.papyrus.page.clone_url_placeholder')}
               value={cloneUrl}
               onChange={e => setCloneUrl(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') submitClone() }}
+              {...ime.bindEnter({ onEnter: submitClone })}
             />
             <Btn onClick={submitClone} disabled={!cloneUrl.trim() || cloneMutation.isPending}>
               {cloneMutation.isPending

--- a/website/src/apps/personal-shopper/SitesTab.tsx
+++ b/website/src/apps/personal-shopper/SitesTab.tsx
@@ -12,6 +12,7 @@ import * as shopApi from './api'
 import { Btn, EmptyState, Input } from '../../components/ui'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 // ── Types ──
 
 interface Site {
@@ -41,6 +42,7 @@ async function saveSites(data: SitesData): Promise<void> {
 // ── Component ──
 
 export function SitesTab() {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [showAddForm, setShowAddForm] = useState(false)
   const [newName, setNewName] = useState('')
@@ -195,7 +197,7 @@ export function SitesTab() {
             value={newUrl}
             onChange={(e) => setNewUrl(e.target.value)}
             placeholder={i18nT('apps.personalShopper.sitesTab.url_e_g_store_example_com')}
-            onKeyDown={(e) => { if (e.key === 'Enter') addSite() }}
+            {...ime.bindEnter({ onEnter: addSite })}
           />
           <div className="flex gap-2">
             <Btn onClick={addSite} disabled={!newName.trim() || !newUrl.trim()}>

--- a/website/src/apps/pptx-maker/LibraryPanel.tsx
+++ b/website/src/apps/pptx-maker/LibraryPanel.tsx
@@ -21,6 +21,7 @@ import { pptxMakerApi, type StyleEntry, type TemplateEntry } from './api'
 import { BoardThumb } from './BoardFrame'
 import BoardFrame from './BoardFrame'
 import { nameFromFilename, templateAccents } from './lib'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 /**
  * Font specimen for the template's theme preview.
@@ -72,6 +73,7 @@ function RenameRow({
   onCancel: () => void
 }) {
   const [value, setValue] = useState(initial)
+  const ime = useImeGuard()
   return (
     <div className="flex items-center gap-2 mb-3 flex-wrap">
       <Input
@@ -79,10 +81,7 @@ function RenameRow({
         value={value}
         aria-label={i18nT('apps.pptxMaker.libraryPanel.new_name')}
         onChange={(event) => setValue(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter') onSubmit(value.trim())
-          if (event.key === 'Escape') onCancel()
-        }}
+        {...ime.bindEnter({ onEnter: () => onSubmit(value.trim()), onEscape: onCancel })}
         className="flex-1 min-w-[160px]"
       />
       <SendBtn onClick={() => onSubmit(value.trim())}>

--- a/website/src/apps/spec-builder/components/DocView.tsx
+++ b/website/src/apps/spec-builder/components/DocView.tsx
@@ -12,6 +12,7 @@ import { ACCENT, SEL_BG, Btn } from './shared'
 import { DocSkeleton } from './Shimmer'
 
 import { i18nT } from '../../../i18n/t'
+import { useImeGuard } from '../../../hooks/useImeGuard'
 interface Selection {
   text: string
   x: number
@@ -42,6 +43,7 @@ export interface DocViewProps {
 }
 
 export default function DocView({ detail, tab, addComment, running = false }: DocViewProps) {
+  const ime = useImeGuard()
   const content = detail?.files?.[tab + '.md']
   const boxRef = useRef<HTMLDivElement>(null)
   const [sel, setSel] = useState<Selection | null>(null)
@@ -138,7 +140,7 @@ export default function DocView({ detail, tab, addComment, running = false }: Do
               autoFocus
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') submit(); if (e.key === 'Escape') { setNote(null); setDraft('') } }}
+              {...ime.bindEnter({ onEnter: submit, onEscape: () => { setNote(null); setDraft('') } })}
               placeholder={i18nT('apps.specBuilder.components.docView.your_feedback_on_this_passage_enter_adds_it_to_t')}
               aria-label={i18nT('apps.specBuilder.components.docView.your_feedback_on_the_passage_in', { document: note.tab }) + '.md'}
               className="flex-1"

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -2537,14 +2537,14 @@ function ChatInput({
           onKeyDown={handleKeyDown}
           {...ime.bindComposition<HTMLTextAreaElement>({
             // The paste-hover preview dismisses on blur; the guard's latch reset rides
-            // in the binding itself, so this handler only carries what is local here.
+            // in the binding itself, so these handlers only carry what is local here.
+            onFocus: prefetchSkills,
             onBlur: () => { if (hoverRef.current) hoverRef.current.handleMouseLeave() },
           })}
           onPaste={handlePaste}
           onCopy={handleCopy}
           onCut={handleCut}
           onClick={handleTextareaClick}
-          onFocus={prefetchSkills}
           onMouseUp={handleSelectSnap}
           onSelect={handleSelectSnap}
           onInput={handleInput}

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -70,6 +70,7 @@ export default function ChatPane({
    *  anchors the destination near the pane's oldest message, not the newest. */
   onOpenFull?: (slot: string, anchorTs?: string, anchorMid?: string) => void
 }) {
+  // One instance covers both dropdown filter inputs (never open at once).
   const dispatch = useAppDispatch()
   const provider = useProvider()
   // Same gate the main chat uses: hide a Connections-owned OAuth banner only
@@ -632,7 +633,10 @@ export default function ChatPane({
                 placeholder={i18nT('components.chatPane.type_to_filter')}
                 value={agentDD.filter}
                 onChange={(e) => agentDD.setFilter(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Escape') agentDD.setOpen(false); if (e.key === 'Enter' && agentDD.filtered.length === 1) { switchAgent(agentDD.filtered[0].name); agentDD.setOpen(false) } }}
+                /* Enter/Escape live on the portal container's onListKeyDown
+                   (useListboxKeyboard), which claims Enter against IME
+                   composition internally — a second handler here would give
+                   the same keys two dispatch paths. */
                 className={ddInputCls}
               />
             </div>
@@ -661,7 +665,10 @@ export default function ChatPane({
                 placeholder={i18nT('components.chatPane.type_to_filter')}
                 value={modelDD.filter}
                 onChange={(e) => modelDD.setFilter(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Escape') modelDD.setOpen(false); if (e.key === 'Enter' && modelDD.filtered.length === 1) { switchModel(modelDD.filtered[0].name); modelDD.setOpen(false) } }}
+                /* Enter/Escape live on the portal container's onListKeyDown
+                   (useListboxKeyboard), which claims Enter against IME
+                   composition internally — a second handler here would give
+                   the same keys two dispatch paths. */
                 className={ddInputCls}
               />
             </div>

--- a/website/src/components/CommentThreads.tsx
+++ b/website/src/components/CommentThreads.tsx
@@ -22,6 +22,7 @@ import { platformShortcut } from '../utils/platform'
 import { timeAgo } from '../utils/timeAgo'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 /** One review conversation: the comment that opened it plus its replies. */
 export interface CommentThread {
   /** Provider thread id — absent for standalone comments and review summaries. */
@@ -149,6 +150,7 @@ function ReplyBox({
   error: string | null
   label?: string
 }) {
+  const ime = useImeGuard()
   const [open, setOpen] = useState(false)
   const [text, setText] = useState('')
   const trimmed = text.trim()
@@ -183,12 +185,12 @@ function ReplyBox({
       <textarea
         value={text}
         onChange={(e) => setText(e.target.value)}
+        {...ime.bindComposition<HTMLTextAreaElement>()}
         // Enter inserts a newline (comments are markdown and often multi-line);
         // Cmd/Ctrl+Enter sends, matching the rest of the dashboard's composers.
         onKeyDown={(e) => {
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault()
-            void send()
+            if (ime.claimEnter(e)) void send()
           }
           if (e.key === 'Escape') setOpen(false)
         }}

--- a/website/src/components/CronFolderHeader.tsx
+++ b/website/src/components/CronFolderHeader.tsx
@@ -7,6 +7,7 @@ import {
 import type { CronFolder } from '../utils/cronFolders'
 import { TableCell, TableRow } from './ui/table'
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 
 interface Props {
   folder: CronFolder
@@ -19,6 +20,7 @@ interface Props {
 }
 
 export default function CronFolderHeader({ folder, jobCount, collapsed, onToggleCollapse, onRename, onDelete, colSpan }: Props) {
+  const ime = useImeGuard()
   const [editing, setEditing] = useState(false)
   const [editName, setEditName] = useState(folder.name)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
@@ -43,11 +45,7 @@ export default function CronFolderHeader({ folder, jobCount, collapsed, onToggle
                   className="bg-bg rounded px-2 py-0.5 flex-none min-w-[120px]"
                   value={editName}
                   onChange={e => setEditName(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter') commitRename()
-                    if (e.key === 'Escape') setEditing(false)
-                  }}
-                  onBlur={commitRename}
+                  {...ime.bindEnter({ onEnter: commitRename, onEscape: () => setEditing(false), onBlur: commitRename })}
                 />
               </>
             ) : (

--- a/website/src/components/DiscoverySearchBar.tsx
+++ b/website/src/components/DiscoverySearchBar.tsx
@@ -26,11 +26,18 @@ interface SearchBarProps {
   onQueryChange: (value: string) => void
   onKeyDown: (e: React.KeyboardEvent) => void
   onClear: () => void
+  /** Extra props spread onto the input — the modals pass `ime.bindComposition()`
+   *  from `useImeGuard` so their Enter-to-install guard can track composition.
+   *  Deliberately narrowed to the binding's own keys: a wider type would let a
+   *  future caller pass `onKeyDown` (e.g. a stray `bindEnter`) and silently
+   *  shadow this component's arrow/Enter logic by JSX last-one-wins — a
+   *  cross-component hazard the source ratchet cannot see. */
+  inputProps?: Pick<React.InputHTMLAttributes<HTMLInputElement>, 'onFocus' | 'onBlur' | 'onCompositionStart' | 'onCompositionEnd'>
 }
 
 export const DiscoverySearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
   function DiscoverySearchBar(
-    { idPrefix, subject, query, debouncedQuery, providers, resultCount, isLoading, hasResults, activeDescendant, onQueryChange, onKeyDown, onClear },
+    { idPrefix, subject, query, debouncedQuery, providers, resultCount, isLoading, hasResults, activeDescendant, onQueryChange, onKeyDown, onClear, inputProps },
     inputRef
   ) {
     return (
@@ -48,6 +55,7 @@ export const DiscoverySearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
             value={query}
             onChange={e => onQueryChange(e.target.value)}
             onKeyDown={onKeyDown}
+            {...inputProps}
             placeholder={i18nT('components.discoverySearchBar.search_across_providers', { subject })}
             className="w-full pl-9 pr-9 py-2 rounded-md border border-border bg-bg text-text text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             autoFocus

--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -217,6 +217,7 @@ interface Props {
 
 import { PierreFilePair, type PierreEditorHandle, type RevealTarget } from '../pierre'
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 
 /**
  * File types that render through a dedicated viewer instead of a text editor.
@@ -818,6 +819,7 @@ export interface MarkdownPanelHandle {
 }
 
 export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPanel({ filePath, content, onContentChange, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, initialDiffMode, onDiffModeChange, embedded, savedBaseline, revealLine, onRevealConsumed, browserRail, railOpen, onRailToggle }: Props, ref) {
+  const ime = useImeGuard()
   const qc = useQueryClient()
   // Code files (non-rich, non-markdown) have no meaningful preview — their
   // "preview" was just a read-only render of the same text. They open
@@ -1101,8 +1103,9 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
         type="text"
         value={findTerm}
         onChange={(e) => setFindTerm(e.target.value)}
+        {...ime.bindComposition()}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') { e.preventDefault(); stepFind(e.shiftKey ? -1 : 1) }
+          if (e.key === 'Enter') { if (!ime.claimEnter(e)) return; stepFind(e.shiftKey ? -1 : 1) }
           if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); closeFind() }
         }}
         placeholder={i18nT('components.markdownPanel.find_in_document')}

--- a/website/src/components/McpBrowserModal.tsx
+++ b/website/src/components/McpBrowserModal.tsx
@@ -21,6 +21,7 @@ import { safeHttpUrl } from '../lib/safeUrl'
 import type { DiscoveredMcpServer, McpDiscoverDetail, McpInstallPlan } from '../types'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 interface Props {
   open: boolean
   onClose: () => void
@@ -46,6 +47,7 @@ function installReadyFor(
 }
 
 export default function McpBrowserModal({ open, onClose }: Props) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
@@ -183,7 +185,8 @@ export default function McpBrowserModal({ open, onClose }: Props) {
     if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1) }
     else if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1) }
     else if (e.key === 'Enter' && selectedServer && !(selectedServer.installed || installedOverride.has(serverKey(selectedServer)))) {
-      e.preventDefault()
+      // Only the Enter branch is claimed — arrow navigation stays untouched.
+      if (!ime.claimEnter(e)) return
       // Consent gate: only install once the detail query for the selected
       // server has resolved — i.e. the pane showing the install plan and
       // required env is actually rendered, not still loading.
@@ -217,6 +220,7 @@ export default function McpBrowserModal({ open, onClose }: Props) {
           onQueryChange={handleQueryChange}
           onKeyDown={handleKeyDown}
           onClear={clearQuery}
+          inputProps={ime.bindComposition()}
         />
 
         <DiscoveryStates debouncedQuery={debouncedQuery} isLoading={isLoading} resultCount={results.length} noun="servers" />

--- a/website/src/components/OnboardingFlow.tsx
+++ b/website/src/components/OnboardingFlow.tsx
@@ -12,6 +12,7 @@ import { capRoleOther, clampRoleOther } from '../lib/userProfile'
 import { ROLE_SLUGS, TECH_SLUGS } from '../lib/profileOptions'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 /**
  * First-run onboarding flow (5 steps) — the Customize chapter plus the feature
  * tour. It is the LAST of the three first-run chapters: Import setup runs first,
@@ -137,6 +138,7 @@ export default function OnboardingFlow({
   // onComplete when the host does not distinguish the two.
   onSkipAll?: () => void
 }) {
+  const ime = useImeGuard()
   const navigate = useNavigate()
   const {
     colorTheme,
@@ -629,14 +631,9 @@ export default function OnboardingFlow({
               // truncates mid-surrogate-pair.
               setRoleOther(capRoleOther(e.target.value))
             }}
-            onKeyDown={e => {
-              // Enter in a single-field reveal should advance, not submit the
-              // dialog's first button.
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                if (!savingProfile) void next()
-              }
-            }}
+            // Enter in a single-field reveal should advance, not submit the
+            // dialog's first button (claimEnter consumes the accepted key).
+            {...ime.bindEnter({ onEnter: () => { if (!savingProfile) void next() } })}
             placeholder={i18nT('components.onboardingFlow.e_g_solutions_architect_sre_founder')}
             aria-label={i18nT('components.onboardingFlow.describe_your_role')}
             className="mt-2 w-full rounded-lg border border-border bg-transparent px-3 py-2 text-[13px] text-text placeholder:text-muted focus-visible:border-accent focus:outline-none disabled:opacity-60"

--- a/website/src/components/ProjectPicker.tsx
+++ b/website/src/components/ProjectPicker.tsx
@@ -240,7 +240,6 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
               value={input}
               onChange={e => setInput(e.target.value)}
               {...ime.bindComposition()}
-              onFocus={() => ime.reset()}
               onKeyDown={e => {
                 const n = filteredBrowse.length
                 const commit = () => { const p = input.trim() || browsePath; if (p) select(p) }
@@ -248,9 +247,8 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
                 else if (e.key === 'ArrowUp') { e.preventDefault(); setBrowseSel(s => Math.max(s - 1, 0)) }
                 else if (e.key === 'Enter') {
                   // Rule 2: the handler also carries the arrow keys, so only the
-                  // Enter path is gated — claiming would break list navigation.
-                  if (ime.isComposing(e)) return
-                  e.preventDefault()
+                  // Enter path is claimed — arrow navigation stays untouched.
+                  if (!ime.claimEnter(e)) return
                   if (e.metaKey || e.ctrlKey) commit()                               // ⌘/Ctrl+Enter commits the current dir
                   else if (n > 0 && filteredBrowse[browseSel]) browse(filteredBrowse[browseSel].path)  // Enter drills into the highlighted folder
                   else commit()                                                       // nothing to drill into -> commit typed path

--- a/website/src/components/QuestionCard.tsx
+++ b/website/src/components/QuestionCard.tsx
@@ -236,7 +236,6 @@ function QuestionCard({ questions, onSubmit, onDismiss, busy = false, onDraftCha
                     setSelections(prev => ({ ...prev, [qIdx]: new Set() }))
                   }}
                   {...ime.bindComposition()}
-                  onFocus={() => ime.reset()}
                   onKeyDown={e => {
                     if (e.key !== 'Enter') return
                     // Rule 1: single-line input; the readiness test stays outside.

--- a/website/src/components/QueueStack.tsx
+++ b/website/src/components/QueueStack.tsx
@@ -126,10 +126,8 @@ function EditInput({ initial, onCommit, onCancel }: {
         onKeyDown={e => {
           e.stopPropagation()
           if (e.key === 'Enter' && !e.shiftKey) {
-            // Rule 1: single-line input — decline the IME's committing Enter,
-            // nothing else. The commit's own emptiness check stays in commit().
-            if (ime.isComposing(e)) return
-            e.preventDefault(); commit()
+            // The commit's own emptiness check stays in commit().
+            if (ime.claimEnter(e)) commit()
           } else if (e.key === 'Escape') { e.preventDefault(); ime.reset(); cancel() }
         }}
         {...ime.bindComposition({ onBlur: commit })}

--- a/website/src/components/SearchBar.tsx
+++ b/website/src/components/SearchBar.tsx
@@ -5,6 +5,7 @@ import { platformShortcut } from '../utils/platform'
 import { SEARCH_LISTBOX_ID, searchOptionId } from './SearchResultsList'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 interface SearchBarProps {
   term: string
   setTerm: (t: string) => void
@@ -23,6 +24,7 @@ interface SearchBarProps {
 }
 
 export default function SearchBar({ term, setTerm, matches, currentIdx, next, prev, close, caseSensitive, toggleCaseSensitive, focusNonce, goTo, docked }: SearchBarProps) {
+  const ime = useImeGuard()
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => { inputRef.current?.focus() }, [])
@@ -38,7 +40,8 @@ export default function SearchBar({ term, setTerm, matches, currentIdx, next, pr
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      e.preventDefault()
+      // Only the Enter path is claimed — arrow/Home/End navigation stays untouched.
+      if (!ime.claimEnter(e)) return
       if (e.shiftKey) prev()
       else next()
     }
@@ -93,9 +96,18 @@ export default function SearchBar({ term, setTerm, matches, currentIdx, next, pr
         aria-activedescendant={matches.length > 0 ? searchOptionId(currentIdx) : undefined}
         value={term}
         onChange={e => setTerm(e.target.value)}
+        {...ime.bindComposition()}
         onKeyDown={handleKeyDown}
         aria-label={i18nT('components.searchBar.find_in_chat')}
         placeholder={i18nT('components.searchBar.find_in_chat_2')}
+        /* focus-cue-ok: undocked, the cue is on the WRAPPER — the pill above
+           carries `focus-within:border-accent` (same structure as IssueList's
+           search box), and a ring on the bare input would nest two outlines.
+           Docked, the bar is the search panel's title, summoned by the user and
+           autofocused, with the caret as the in-place cue; it has carried no
+           outline since it shipped, and this change only rewired the
+           composition/Enter handling, so restyling the docked header is out of
+           its scope. */
         className={`bg-transparent border-none outline-none text-text placeholder:text-muted text-[13px] ${docked ? 'flex-1 min-w-0' : 'w-[180px]'}`}
       />
       <button

--- a/website/src/components/SessionColorSwatches.tsx
+++ b/website/src/components/SessionColorSwatches.tsx
@@ -7,6 +7,7 @@ import { useSessionPalette } from '../hooks/useSessionPalette'
 import { colorName } from '../utils/sessionColors'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 
 /** Mirrors the backend contract in chat_persistence.COLOR_HEX_RE. */
 const HEX_RE = /^#[0-9a-fA-F]{6}$/
@@ -38,6 +39,7 @@ export default function SessionColorSwatches({ slotKey, colorIndex, colorHex, on
   colorHex?: string | null
   onPicked?: () => void
 }) {
+  const ime = useImeGuard()
   const dispatch = useAppDispatch()
   const { paletteColors } = useSessionPalette()
   const [customOpen, setCustomOpen] = useState(false)
@@ -176,9 +178,9 @@ export default function SessionColorSwatches({ slotKey, colorIndex, colorHex, on
             }}
             onKeyDown={e => {
               e.stopPropagation()
-              if (e.key === 'Enter') { e.preventDefault(); commitHex(draft) }
+              if (e.key === 'Enter') { if (ime.claimEnter(e)) commitHex(draft) }
             }}
-            onBlur={() => { if (dirtyRef.current) commitHex(draft) }}
+            {...ime.bindComposition({ onBlur: () => { if (dirtyRef.current) commitHex(draft) } })}
             aria-label={i18nT('components.sessionColorSwatches.hex_color_code')}
             placeholder="#4f8ef7"
             className="w-[76px] bg-bg-accent border border-border rounded px-1.5 py-0.5 text-[11px] font-mono text-text outline-none focus-visible:border-accent"

--- a/website/src/components/SkillBrowserModal.tsx
+++ b/website/src/components/SkillBrowserModal.tsx
@@ -21,6 +21,7 @@ import type { DiscoveredSkill } from '../types'
 
 import { i18nT } from '../i18n/t'
 import { fmtCompact } from '../i18n/format'
+import { useImeGuard } from '../hooks/useImeGuard'
 interface Props {
   open: boolean
   onClose: () => void
@@ -40,6 +41,7 @@ type InstallPhase =
   | { step: 'error'; message: string }
 
 export default function SkillBrowserModal({ open, onClose }: Props) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
@@ -166,7 +168,8 @@ export default function SkillBrowserModal({ open, onClose }: Props) {
     if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1) }
     else if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1) }
     else if (e.key === 'Enter' && selectedSkill && !(selectedSkill.installed || installedOverride.has(skillKey(selectedSkill)))) {
-      e.preventDefault()
+      // Only the Enter branch is claimed — arrow navigation stays untouched.
+      if (!ime.claimEnter(e)) return
       const phase = installPhases[skillKey(selectedSkill)]
       if (!phase || phase.step === 'error') handleInstall(selectedSkill)
     }
@@ -193,6 +196,7 @@ export default function SkillBrowserModal({ open, onClose }: Props) {
           onQueryChange={handleQueryChange}
           onKeyDown={handleKeyDown}
           onClear={clearQuery}
+          inputProps={ime.bindComposition()}
         />
 
         <DiscoveryStates debouncedQuery={debouncedQuery} isLoading={isLoading} resultCount={results.length} noun="skills" />

--- a/website/src/components/WorkspacePicker.tsx
+++ b/website/src/components/WorkspacePicker.tsx
@@ -4,6 +4,7 @@ import { FolderOpen, ChevronRight, ChevronLeft } from 'lucide-react'
 import { api } from '../api/client'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -12,6 +13,8 @@ interface Props {
 }
 
 export default function WorkspacePicker({ open, onOpenChange, anchorRef, onCreated }: Props) {
+  // One instance covers both inputs; the binding's focus/blur reset makes sharing safe.
+  const ime = useImeGuard()
   const [input, setInput] = useState('')
   const [browsePath, setBrowsePath] = useState('')
   const [browseParent, setBrowseParent] = useState('')
@@ -89,7 +92,7 @@ export default function WorkspacePicker({ open, onOpenChange, anchorRef, onCreat
             <div className="p-3 flex flex-col gap-2">
               <div className="text-[12px] text-muted font-medium uppercase tracking-wider">{i18nT('components.workspacePicker.create_workspace')}</div>
               <div className="text-[13px] font-mono text-text truncate bg-bg-elevated rounded px-2 py-1.5 border border-border">{selectedDir}</div>
-              <input autoFocus type="text" aria-label={i18nT('components.workspacePicker.workspace_name')} placeholder={i18nT('components.workspacePicker.workspace_name_2')} value={wsName} onChange={e => { setWsName(e.target.value); setError('') }} onKeyDown={e => { if (e.key === 'Enter') create(); if (e.key === 'Escape') { setSelectedDir(''); setWsName('') } }} className="bg-bg-elevated border border-border rounded px-2 py-1.5 text-[13px] font-mono text-text placeholder:text-muted focus:outline-none focus-visible:border-accent" />
+              <input autoFocus type="text" aria-label={i18nT('components.workspacePicker.workspace_name')} placeholder={i18nT('components.workspacePicker.workspace_name_2')} value={wsName} onChange={e => { setWsName(e.target.value); setError('') }} {...ime.bindEnter({ onEnter: create, onEscape: () => { setSelectedDir(''); setWsName('') } })} className="bg-bg-elevated border border-border rounded px-2 py-1.5 text-[13px] font-mono text-text placeholder:text-muted focus:outline-none focus-visible:border-accent" />
               {error && <div className="text-[11px] text-red-400">{error}</div>}
               <div className="flex gap-2 justify-end">
                 <button onClick={() => { setSelectedDir(''); setWsName('') }} className="px-3 py-1.5 text-[12px] text-muted hover:text-text rounded">{i18nT('components.workspacePicker.back')}</button>
@@ -102,7 +105,7 @@ export default function WorkspacePicker({ open, onOpenChange, anchorRef, onCreat
                 {browseParent && browseParent !== browsePath && (
                   <button onClick={() => browse(browseParent)} className="p-1 text-muted hover:text-text rounded hover:bg-bg-hover shrink-0" title={i18nT('components.workspacePicker.back')} aria-label={i18nT('components.workspacePicker.back')}><ChevronLeft size={16} /></button>
                 )}
-                <input autoFocus type="text" aria-label={i18nT('components.workspacePicker.project_directory_path')} placeholder={i18nT('components.workspacePicker.path_to_project')} value={input} onChange={e => setInput(e.target.value)} onKeyDown={e => { if (e.key === 'Enter' && input.trim()) selectDir(input.trim()); if (e.key === 'Escape') onOpenChange(false) }} className="flex-1 bg-bg-elevated border border-border rounded px-2 py-1.5 text-[13px] font-mono text-text placeholder:text-muted focus:outline-none focus-visible:border-accent" />
+                <input autoFocus type="text" aria-label={i18nT('components.workspacePicker.project_directory_path')} placeholder={i18nT('components.workspacePicker.path_to_project')} value={input} onChange={e => setInput(e.target.value)} {...ime.bindEnter({ onEnter: () => { if (input.trim()) selectDir(input.trim()) }, onEscape: () => onOpenChange(false) })} className="flex-1 bg-bg-elevated border border-border rounded px-2 py-1.5 text-[13px] font-mono text-text placeholder:text-muted focus:outline-none focus-visible:border-accent" />
                 <button onClick={() => selectDir(input.trim() || browsePath)} className="px-2 py-1 text-[11px] bg-accent/20 text-accent rounded hover:bg-accent/30 shrink-0">{i18nT('components.workspacePicker.select')}</button>
               </div>
               <div className="overflow-y-auto flex-1 min-h-0">

--- a/website/src/components/appstore/SourcesPopover.tsx
+++ b/website/src/components/appstore/SourcesPopover.tsx
@@ -15,6 +15,7 @@ import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover'
 import RegistryManager from '../RegistryManager'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 export default function SourcesPopover({ open, onOpenChange, onError, onInstalled }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -24,6 +25,7 @@ export default function SourcesPopover({ open, onOpenChange, onError, onInstalle
   // closes and a freshly-installed (disabled) app is invisible in the sidebar.
   onInstalled?: (name: string) => void
 }) {
+  const ime = useImeGuard()
   const [installPath, setInstallPath] = useState('')
   const [installing, setInstalling] = useState(false)
 
@@ -67,7 +69,7 @@ export default function SourcesPopover({ open, onOpenChange, onError, onInstalle
               placeholder={i18nT('components.appstore.sourcesPopover.path_to_app_directory')}
               value={installPath}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInstallPath(e.target.value)}
-              onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && handleInstall()}
+              {...ime.bindEnter({ onEnter: () => handleInstall() })}
               className="flex-1"
             />
             <Btn onClick={handleInstall} disabled={installing || !installPath.trim()}>

--- a/website/src/components/settings.tsx
+++ b/website/src/components/settings.tsx
@@ -176,12 +176,17 @@ interface SettingsInputProps {
   hint?: string
   value: string
   onChange: (value: string) => void
-  onBlur?: () => void
+  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>
   /** Key handler on the control itself. Needed by panels that commit on blur and
    *  have no Save button (WeChat), where Enter must commit the value the way it
    *  would in a form — a `<div>` wrapper cannot carry that without becoming an
    *  interactive static element. */
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>
+  /** Composition/focus pass-throughs so callers can spread `ime.bindComposition()`
+   *  from `useImeGuard` onto the control; see the WeChat folder-name field. */
+  onFocus?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>
+  onCompositionStart?: React.CompositionEventHandler<HTMLInputElement | HTMLTextAreaElement>
+  onCompositionEnd?: React.CompositionEventHandler<HTMLInputElement | HTMLTextAreaElement>
   placeholder?: string
   type?: 'text' | 'number'
   min?: number
@@ -194,7 +199,7 @@ interface SettingsInputProps {
   configKey?: string
 }
 
-export function SettingsInput({ label, description, hint, value, onChange, onBlur, onKeyDown, placeholder, type = 'text', min, max, step, disabled, multiline, 'aria-label': ariaLabel, configKey }: SettingsInputProps) {
+export function SettingsInput({ label, description, hint, value, onChange, onBlur, onKeyDown, onFocus, onCompositionStart, onCompositionEnd, placeholder, type = 'text', min, max, step, disabled, multiline, 'aria-label': ariaLabel, configKey }: SettingsInputProps) {
   // Per-instance id pairing the caption's htmlFor with the control. This is
   // what gives the single-line branch an accessible name by DEFAULT: it used
   // to render aria-label={ariaLabel} with ariaLabel undefined unless a caller
@@ -211,6 +216,9 @@ export function SettingsInput({ label, description, hint, value, onChange, onBlu
           onChange={e => onChange(e.target.value)}
           onBlur={onBlur}
           onKeyDown={onKeyDown}
+          onFocus={onFocus}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
           placeholder={placeholder}
           disabled={disabled}
           rows={3}
@@ -225,6 +233,9 @@ export function SettingsInput({ label, description, hint, value, onChange, onBlu
           onChange={e => onChange(e.target.value)}
           onBlur={onBlur}
           onKeyDown={onKeyDown}
+          onFocus={onFocus}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
           placeholder={placeholder}
           min={min}
           max={max}

--- a/website/src/hooks/useImeGuard.ts
+++ b/website/src/hooks/useImeGuard.ts
@@ -112,12 +112,21 @@ export function useImeGuard() {
    * `claimEnter` also consumes those keypresses, a latched guard is SILENT: the
    * surface simply stops sending. So the recovery ships with the tracking, and a
    * caller's own blur handler is composed rather than replacing it.
+   *
+   * The focus reset is the other half of the same recovery: when one hook
+   * instance is shared across sibling inputs (or an input remounts), a latch
+   * stranded by the previous element must not decline the first Enter on the
+   * next one. Sites used to spell `onFocus={() => ime.reset()}` by hand; the
+   * binding now carries it so a consumer cannot opt out by omission, and a
+   * caller's own focus handler is composed rather than replacing it.
    */
   const bindComposition = <T extends HTMLElement>(opts: {
+    onFocus?: (e: FocusEvent<T>) => void
     onBlur?: (e: FocusEvent<T>) => void
   } = {}) => ({
     onCompositionStart,
     onCompositionEnd,
+    onFocus: (e: FocusEvent<T>) => { reset(); opts.onFocus?.(e) },
     onBlur: (e: FocusEvent<T>) => { reset(); opts.onBlur?.(e) },
   })
 
@@ -125,13 +134,19 @@ export function useImeGuard() {
    * Spread onto simple Enter-to-submit / Escape-to-cancel inputs. Auto-resets
    * stale composition state on blur & Escape so sharing one hook instance
    * across sibling inputs is safe.
+   *
+   * CONTRACT: single-line inputs only, and modifier keys do not participate —
+   * Shift/Cmd/Ctrl+Enter all submit. A textarea (where Shift+Enter must stay a
+   * soft break) or any handler that branches on modifiers keeps its own
+   * `onKeyDown` with `claimEnter` in the Enter branch instead.
    */
   const bindEnter = <T extends HTMLElement>(opts: {
     onEnter?: () => void
     onEscape?: () => void
+    onFocus?: (e: FocusEvent<T>) => void
     onBlur?: (e: FocusEvent<T>) => void
   }) => ({
-    ...bindComposition<T>({ onBlur: opts.onBlur }),
+    ...bindComposition<T>({ onFocus: opts.onFocus, onBlur: opts.onBlur }),
     onKeyDown: (e: KeyboardEvent<T>) => {
       if (e.key === 'Enter' && claimEnter(e)) opts.onEnter?.()
       if (e.key === 'Escape') { reset(); opts.onEscape?.() }

--- a/website/src/hooks/useListboxKeyboard.cov80.test.tsx
+++ b/website/src/hooks/useListboxKeyboard.cov80.test.tsx
@@ -222,3 +222,59 @@ describe('Enter', () => {
     expect(closeToTrigger).not.toHaveBeenCalled()
   })
 })
+
+describe('IME guard on Enter-selects-sole-match', () => {
+  // The committing Enter of a WebKit composition arrives AFTER compositionend
+  // with the native flag already false; the hook's internal latch (tracked via
+  // native listeners on the filter input) is the only signal left. Unguarded,
+  // the dispatch below selected the sole match — switching agent/model — with
+  // half-composed filter text (#4292).
+  it('declines the committing Enter in the post-composition window AND consumes it', () => {
+    const onEnterSingleMatch = vi.fn()
+    render(<Harness hasFilterInput filteredCount={1} onEnterSingleMatch={onEnterSingleMatch} />)
+    const input = screen.getByTestId('zzq-input')
+    input.focus()
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    const notPrevented = fireEvent.keyDown(list(), { key: 'Enter' })
+    expect(onEnterSingleMatch).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(false)
+  })
+
+  it('leaves a mid-composition Enter to the IME (native flag set)', () => {
+    const onEnterSingleMatch = vi.fn()
+    render(<Harness hasFilterInput filteredCount={1} onEnterSingleMatch={onEnterSingleMatch} />)
+    screen.getByTestId('zzq-input').focus()
+    const notPrevented = fireEvent.keyDown(list(), { key: 'Enter', isComposing: true })
+    expect(onEnterSingleMatch).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(true)
+  })
+
+  it('recovers from an abandoned composition on blur/refocus', () => {
+    const onEnterSingleMatch = vi.fn()
+    render(<Harness hasFilterInput filteredCount={1} onEnterSingleMatch={onEnterSingleMatch} />)
+    const input = screen.getByTestId('zzq-input')
+    input.focus()
+    fireEvent.compositionStart(input) // abandoned: no compositionEnd follows
+    input.blur()
+    input.focus()
+    fireEvent.keyDown(list(), { key: 'Enter' })
+    expect(onEnterSingleMatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not inherit a stale latch across a close/reopen', () => {
+    const onEnterSingleMatch = vi.fn()
+    const { rerender } = render(
+      <Harness hasFilterInput filteredCount={1} onEnterSingleMatch={onEnterSingleMatch} />,
+    )
+    const input = screen.getByTestId('zzq-input')
+    input.focus()
+    fireEvent.compositionStart(input) // abandoned mid-composition
+    rerender(<Harness open={false} hasFilterInput filteredCount={1} onEnterSingleMatch={onEnterSingleMatch} />)
+    rerender(<Harness hasFilterInput filteredCount={1} onEnterSingleMatch={onEnterSingleMatch} />)
+    const reopened = screen.getByTestId('zzq-input')
+    reopened.focus()
+    fireEvent.keyDown(list(), { key: 'Enter' })
+    expect(onEnterSingleMatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/website/src/hooks/useListboxKeyboard.ts
+++ b/website/src/hooks/useListboxKeyboard.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { isTouchDevice } from '../utils/isTouchDevice'
+import { useImeGuard } from './useImeGuard'
 
 /**
  * Roving-focus keyboard navigation for a portal listbox that pairs with
@@ -16,6 +17,9 @@ import { isTouchDevice } from '../utils/isTouchDevice'
  *  - put `onKeyDown={onListKeyDown}` on the `role="listbox"` container
  *  - mark each focusable option with `data-option` or `role="option"`, plus `tabIndex={-1}`
  *  - render the filter input with `ref={inputRef}` (when present)
+ *  - IME composition on the filter input is tracked internally (native
+ *    listeners via `inputRef`), so the Enter-selects-sole-match path is
+ *    IME-safe without any consumer wiring
  */
 export function useListboxKeyboard(opts: {
   open: boolean
@@ -31,6 +35,44 @@ export function useListboxKeyboard(opts: {
   closeToTrigger: () => void
 }) {
   const { open, dropdownRef, inputRef, hasFilterInput, filteredCount, onEnterSingleMatch, closeToTrigger } = opts
+
+  // IME guard for the Enter-selects-sole-match path. The committing Enter of a
+  // WebKit composition arrives AFTER `compositionend` with the native flag
+  // already false, so unguarded it would select the sole match with
+  // half-composed filter text (#4292). Tracking lives HERE, not in consumers:
+  // the hook owns the Enter dispatch, so it owns the guard — native listeners
+  // on the filter input need no consumer wiring and cannot collide with any
+  // binding a consumer spreads on the same element. `useImeGuard`'s handlers
+  // close over refs only, so calling the latest render's copy through a ref
+  // keeps the effect's dependency list to stable values (no re-attach churn,
+  // and no reset() firing mid-composition on unrelated re-renders).
+  const ime = useImeGuard()
+  const imeRef = useRef(ime)
+  imeRef.current = ime
+  useEffect(() => {
+    if (!open || !hasFilterInput) return
+    // A reopened menu must not inherit a latch stranded by a composition the
+    // previous open abandoned.
+    imeRef.current.reset()
+    const el = inputRef.current
+    if (!el) return
+    const onStart = () => imeRef.current.onCompositionStart()
+    const onEnd = () => imeRef.current.onCompositionEnd()
+    // Focus/blur recovery, mirroring bindComposition's: a composition abandoned
+    // without `compositionend` must not latch the guard for the input's (or a
+    // sibling's) whole lifetime.
+    const onRecover = () => imeRef.current.reset()
+    el.addEventListener('compositionstart', onStart)
+    el.addEventListener('compositionend', onEnd)
+    el.addEventListener('focus', onRecover)
+    el.addEventListener('blur', onRecover)
+    return () => {
+      el.removeEventListener('compositionstart', onStart)
+      el.removeEventListener('compositionend', onEnd)
+      el.removeEventListener('focus', onRecover)
+      el.removeEventListener('blur', onRecover)
+    }
+  }, [open, hasFilterInput, inputRef])
 
   const optionEls = useCallback(
     // AgentSelector marks options (and action rows) with `data-option`;
@@ -97,15 +139,18 @@ export function useListboxKeyboard(opts: {
       }
       case 'Enter':
         // Enter on a focused option is handled natively (button click). Here we
-        // only cover the filter input when it has narrowed to a single match.
+        // only cover the filter input when it has narrowed to a single match —
+        // and only after claiming the key, so an IME's committing Enter cannot
+        // select a match with half-composed filter text.
         if (inInput && filteredCount === 1) {
+          if (!ime.claimEnter(e)) break
           e.preventDefault()
           e.stopPropagation()
           onEnterSingleMatch()
         }
         break
     }
-  }, [optionEls, inputRef, filteredCount, onEnterSingleMatch, closeToTrigger])
+  }, [optionEls, inputRef, filteredCount, onEnterSingleMatch, closeToTrigger, ime])
 
   return { onListKeyDown }
 }

--- a/website/src/hooks/useSceneInteraction.tsx
+++ b/website/src/hooks/useSceneInteraction.tsx
@@ -527,12 +527,9 @@ export function useSceneInteraction(
           value={draft}
           onChange={e => setDraft(e.target.value)}
           {...ime.bindComposition()}
-          onFocus={() => ime.reset()}
           onKeyDown={e => {
             if (e.key !== 'Enter' || e.shiftKey) return
-            // Rule 1: single-line input — the guard alone is enough here.
-            if (ime.isComposing(e)) return
-            e.preventDefault(); sendToAgent(threadView.agent, draft)
+            if (ime.claimEnter(e)) sendToAgent(threadView.agent, draft)
           }}
           placeholder={sourceFor(threadView.agent)?.running ? i18nT('hooks.useSceneInteraction.steer_this_agent') : i18nT('hooks.useSceneInteraction.message_this_agent')}
           aria-label={i18nT('hooks.useSceneInteraction.message', { name: threadView.agent.name })}

--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -1467,11 +1467,11 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
               value={nameDraft}
               aria-label={i18nT('pages.artifactDetailPage.artifact_name')}
               onChange={(e) => setNameDraft(e.target.value)}
-              onBlur={commitRename}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') { e.preventDefault(); void commitRename() }
-                else if (e.key === 'Escape') { e.preventDefault(); setRenaming(false) }
-              }}
+              {...ime.bindEnter({
+                onEnter: () => void commitRename(),
+                onEscape: () => setRenaming(false),
+                onBlur: () => void commitRename(),
+              })}
               className="px-2 py-0.5 text-2xl font-bold tracking-tight text-text-strong w-full max-w-[36rem]"
             />
           ) : (
@@ -1573,9 +1573,9 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
                 if (e.key === ',' || e.key === ' ') {
                   // Space cycles IME candidates mid-composition; committing here
                   // would post the composing buffer and kill candidate selection.
-                  if (ime.isComposing(e)) return
-                  e.preventDefault()
-                  if (newTag.trim()) addTag(newTag)
+                  // The claim is key-agnostic: it consumes the separator only
+                  // when the IME is not itself using the keypress.
+                  if (ime.claimEnter(e) && newTag.trim()) addTag(newTag)
                 }
                 if (e.key === 'Escape') { ime.reset(); setNewTag(''); setAddingTag(false) }
               }}

--- a/website/src/pages/ArtifactsPage.tsx
+++ b/website/src/pages/ArtifactsPage.tsx
@@ -663,12 +663,12 @@ function FolderNameInput({ initial = '', placeholder = 'Folder name', onCommit, 
       placeholder={placeholder}
       aria-label={placeholder}
       onChange={(e) => setValue(e.target.value)}
-      onFocus={(e) => e.target.select()}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
       className="w-full bg-transparent border border-accent rounded px-1.5 py-0.5 text-text-strong outline-none text-sm select-text focus-ring"
       {...ime.bindEnter<HTMLInputElement>({
+        onFocus: (e) => (e.target as HTMLInputElement).select(),
         onEnter: () => { (document.activeElement as HTMLInputElement)?.blur() },
         onEscape: () => { cancelledRef.current = true; onCancel() },
         onBlur: () => {

--- a/website/src/pages/ProjectsPage.tsx
+++ b/website/src/pages/ProjectsPage.tsx
@@ -18,6 +18,7 @@ import {
 } from './projectsLayout'
 
 import { i18nT } from '../i18n/t'
+import { useImeGuard } from '../hooks/useImeGuard'
 type Mode = 'compose' | 'spec' | 'yaml'
 
 // Module-level so the resize hook's memoised resolver isn't invalidated every render.
@@ -51,6 +52,7 @@ function TextInputPanel({ text, setText, rows, placeholder, accept, onUpload, on
 }
 
 export default function ProjectsPage() {
+  const ime = useImeGuard()
   const refreshTrigger = useAppSelector(s => s.dashboard.refreshTrigger)
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -557,7 +559,13 @@ export default function ProjectsPage() {
           <>
             <div className="px-4 py-2 flex items-center gap-2 border-b border-border shrink-0">
               {editingName ? (
-                <input aria-label={i18nT('pages.projectsPage.project_name')} className="text-[13px] font-semibold bg-transparent border border-accent rounded px-1 py-0 text-text-strong outline-none min-w-[120px] focus-ring" autoFocus maxLength={200} value={editNameValue} onChange={e => setEditNameValue(e.target.value)} onBlur={() => { const v = editNameValue.trim(); if (v && v !== (selectedRun.name || selectedRun.spec_name || '')) { api.renameTaskRun(selectedRun.task_id, v).then(load).catch(() => {}) }; setEditingName(false) }} onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); else if (e.key === 'Escape') setEditingName(false) }} />
+                <input aria-label={i18nT('pages.projectsPage.project_name')} className="text-[13px] font-semibold bg-transparent border border-accent rounded px-1 py-0 text-text-strong outline-none min-w-[120px] focus-ring" autoFocus maxLength={200} value={editNameValue} onChange={e => setEditNameValue(e.target.value)} {...ime.bindComposition({ onBlur: () => { const v = editNameValue.trim(); if (v && v !== (selectedRun.name || selectedRun.spec_name || '')) { api.renameTaskRun(selectedRun.task_id, v).then(load).catch(() => {}) }; setEditingName(false) } })} onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    // Early-return BEFORE the blur: a committing IME Enter must not commit.
+                    if (ime.isComposing(e)) return
+                    ;(e.target as HTMLInputElement).blur()
+                  } else if (e.key === 'Escape') setEditingName(false)
+                }} />
               ) : (
                 <span
                   role="button"

--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -137,6 +137,7 @@ function EmptyFolderChip({ folder, onRename, onDelete, error }: { folder: CronFo
   const [confirming, setConfirming] = useState(false)
   const [editing, setEditing] = useState(false)
   const [editName, setEditName] = useState(folder.name)
+  const ime = useImeGuard()
 
   const commitRename = () => {
     const trimmed = editName.trim()
@@ -155,11 +156,11 @@ function EmptyFolderChip({ folder, onRename, onDelete, error }: { folder: CronFo
             className="bg-bg rounded px-2 py-0.5 flex-none min-w-[120px]"
             value={editName}
             onChange={e => setEditName(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') commitRename()
-              if (e.key === 'Escape') setEditing(false)
-            }}
-            onBlur={commitRename}
+            {...ime.bindEnter({
+              onEnter: commitRename,
+              onEscape: () => setEditing(false),
+              onBlur: commitRename,
+            })}
           />
         ) : (
           <span className="text-sm font-medium text-text">{folder.name}</span>
@@ -273,6 +274,7 @@ export default function SchedulePage() {
   const [folderModal, setFolderModal] = useState<{ mode: 'create'; resolve?: (id: string | undefined) => void } | null>(null)
   const [folderModalName, setFolderModalName] = useState('')
   const folderNameIme = useImeGuard()
+  const batchConfirmIme = useImeGuard()
   const [folderModalError, setFolderModalError] = useState<string | null>(null)
   const toggleFolderCollapse = useCallback((folderId: string) => {
     setCollapsedFolders(prev => {
@@ -928,7 +930,6 @@ export default function SchedulePage() {
               value={folderModalName}
               onChange={e => setFolderModalName(e.target.value)}
               {...folderNameIme.bindComposition()}
-              onFocus={() => folderNameIme.reset()}
               onKeyDown={e => {
                 if (e.key !== 'Enter') return
                 // Rule 1: single-line input; emptiness stays outside the guard.
@@ -994,7 +995,9 @@ export default function SchedulePage() {
               autoFocus
               value={confirmText}
               onChange={e => setConfirmText(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter' && confirmArmed && !batchDeleting) runBatchDelete() }}
+              {...batchConfirmIme.bindEnter({
+                onEnter: () => { if (confirmArmed && !batchDeleting) runBatchDelete() },
+              })}
               placeholder={BULK_DELETE_TOKEN}
               className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm text-text outline-none focus-visible:border-accent"
             />

--- a/website/src/pages/chat/McpOAuthBanner.tsx
+++ b/website/src/pages/chat/McpOAuthBanner.tsx
@@ -7,6 +7,7 @@ import { queryClient } from '../../api/queryClient'
 import { parseErrorCode } from '../../utils/errorReport'
 import { isValidLoopbackReturnAddress } from '../../utils/loopbackReturnAddress'
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 /**
  * Inline banner for kiro-cli MCP OAuth flow. `meta.completed` flips it to the
  * authenticated state; `meta.failed` flips it to the error state.
@@ -123,6 +124,7 @@ export default function McpOAuthBanner({
  * never mints one (parked decision #4286, untouched).
  */
 function RelayAffordance({ serverName }: { serverName: string }) {
+  const ime = useImeGuard()
   const [open, setOpen] = useState(false)
   const [returnAddress, setReturnAddress] = useState('')
   const [busy, setBusy] = useState(false)
@@ -221,9 +223,7 @@ function RelayAffordance({ serverName }: { serverName: string }) {
               spellCheck={false}
               value={returnAddress}
               onChange={e => setReturnAddress(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') void runRelay()
-              }}
+              {...ime.bindEnter({ onEnter: () => void runRelay() })}
               placeholder={i18nT('pages.connectionsPage.return_address_placeholder')}
               aria-label={i18nT('pages.connectionsPage.return_address')}
               disabled={busy}

--- a/website/src/pages/connections/ConnectionsPage.tsx
+++ b/website/src/pages/connections/ConnectionsPage.tsx
@@ -80,6 +80,7 @@ function safeApprovalUrl(value: string): string {
 // The loopback pre-check lives in `utils/loopbackReturnAddress` (shared with
 // the chat banner's relay affordance).
 import { isValidLoopbackReturnAddress } from '../../utils/loopbackReturnAddress'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 export interface PendingConnect {
   kind: 'new' | 'reconnect'
@@ -363,6 +364,7 @@ function ConnectionCard({
   onTest,
   onRelay,
 }: ConnectionCardProps) {
+  const ime = useImeGuard()
   const { t } = useTranslation()
   const [returnAddress, setReturnAddress] = useState('')
   const [invalidReturnAddress, setInvalidReturnAddress] = useState(false)
@@ -502,12 +504,7 @@ function ConnectionCard({
                     setReturnAddress(event.target.value)
                     if (invalidReturnAddress) setInvalidReturnAddress(false)
                   }}
-                  onKeyDown={event => {
-                    if (event.key === 'Enter') {
-                      event.preventDefault()
-                      void runRelay()
-                    }
-                  }}
+                  {...ime.bindEnter({ onEnter: () => void runRelay() })}
                   placeholder={t('pages.connectionsPage.return_address_placeholder')}
                   autoComplete="off"
                   spellCheck={false}

--- a/website/src/pages/knowledge/DetailView.tsx
+++ b/website/src/pages/knowledge/DetailView.tsx
@@ -9,6 +9,7 @@ import { typeBadgeVariant, formatDate, useCopy } from './helpers'
 import type { KnowledgeItem, Entity } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 function highlightEntities(text: string, entities: Entity[], onEntityClick?: (name: string) => void) {
   if (!entities?.length) return text
   const names = [...entities].sort((a, b) => b.name.length - a.name.length).map(e => e.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
@@ -47,6 +48,7 @@ function RelatedItems({ itemId, entities }: { itemId: string; entities: Entity[]
 }
 
 function TagEditor({ itemId, currentTags }: { itemId: string; currentTags: string }) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(currentTags)
@@ -82,7 +84,7 @@ function TagEditor({ itemId, currentTags }: { itemId: string; currentTags: strin
       <Tag size={11} className="text-muted shrink-0" />
       <input aria-label={i18nT('pages.knowledge.detailView.comma_separated_tags')} value={value} onChange={e => setValue(e.target.value)} placeholder={i18nT('pages.knowledge.detailView.tag1_tag2_tag3')}
         className="flex-1 px-2 py-1 text-[12px] bg-bg-elevated border border-border rounded outline-none focus-ring"
-        onKeyDown={e => { if (e.key === 'Enter') saveMutation.mutate(value); if (e.key === 'Escape') setEditing(false) }}
+        {...ime.bindEnter({ onEnter: () => saveMutation.mutate(value), onEscape: () => setEditing(false) })}
         autoFocus />
       <button onClick={() => saveMutation.mutate(value)} disabled={saveMutation.isPending}
         className="text-[11px] text-accent bg-transparent border-none cursor-pointer">{i18nT('pages.knowledge.detailView.save')}</button>

--- a/website/src/pages/knowledge/SourcesList.tsx
+++ b/website/src/pages/knowledge/SourcesList.tsx
@@ -10,6 +10,7 @@ import { fmtCompact, fmtNumber } from '../../i18n/format'
 import type { Source, SourceSpend, NamespaceInfo, IngestionJob, SourceFilesResponse } from './types'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 
 /**
  * Indexing progress and the Kiro requests a source still owes.
@@ -268,6 +269,7 @@ export default function SourcesList({ onIngest, uploadNamespace, setUploadNamesp
   supportedFormatsDisplay: string
   uploadAccept?: string; acceptsNoExtension?: boolean
 }) {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [showAdd, setShowAdd] = useState(false)
   const [addType, setAddType] = useState<'local_file' | 'local_folder'>('local_file')
@@ -534,7 +536,7 @@ export default function SourcesList({ onIngest, uploadNamespace, setUploadNamesp
                 {editingId === s.id ? (
                   <div className="flex items-center gap-1">
                     <input autoFocus value={editDraft} onChange={e => setEditDraft(e.target.value)}
-                      onKeyDown={e => { if (e.key === 'Enter' && !renameMutation.isPending) submitRename(); else if (e.key === 'Escape') setEditingId(null) }}
+                      {...ime.bindEnter({ onEnter: () => { if (!renameMutation.isPending) submitRename() }, onEscape: () => setEditingId(null) })}
                       maxLength={200} aria-label={i18nT('pages.knowledge.sourcesList.source_name')}
                       className="bg-bg-elevated border border-border rounded-md px-2 py-1 text-[13px] text-text outline-none w-full max-w-xs focus-ring" />
                     <button aria-label={i18nT('pages.knowledge.sourcesList.save_name')} onClick={submitRename} disabled={renameMutation.isPending}

--- a/website/src/pages/knowledge/index.tsx
+++ b/website/src/pages/knowledge/index.tsx
@@ -30,6 +30,7 @@ const STATUS_LABEL_KEY = {
 } as const
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 const KnowledgeGraph = lazy(() => import('./KnowledgeGraph'))
 
 const TABS = ['list', 'graph', 'sources', 'settings'] as const
@@ -173,6 +174,7 @@ function BulkActions({ selectedIds, items, onDone }: { selectedIds: Set<string>;
 }
 
 export default function KnowledgePage() {
+  const ime = useImeGuard()
   const queryClient = useQueryClient()
   const [tab, setTab] = useState<Tab>('list')
   const [query, setQuery] = useState('')
@@ -463,9 +465,11 @@ export default function KnowledgePage() {
       <div className="relative flex-1 min-w-[200px]">
         <SearchInput placeholder={i18nT('pages.knowledge.index.search_knowledge_press_enter_to_search')} value={searchInput}
           onChange={e => { setSearchInput((e.target as HTMLInputElement).value); setShowAutocomplete(true) }}
-          onKeyDown={e => { if ((e as React.KeyboardEvent).key === 'Enter') { setQuery(searchInput); setPage(1) } }}
-          onFocus={() => setShowAutocomplete(true)}
-          onBlur={() => setTimeout(() => setShowAutocomplete(false), 200)}
+          {...ime.bindEnter({
+            onEnter: () => { setQuery(searchInput); setPage(1) },
+            onFocus: () => setShowAutocomplete(true),
+            onBlur: () => setTimeout(() => setShowAutocomplete(false), 200),
+          })}
         />
         {showAutocomplete && searchInput.length >= 2 && (
           <EntityAutocomplete query={searchInput} onSelect={handleEntitySelect} />

--- a/website/src/pages/overview/KiroCrewCfgTab.tsx
+++ b/website/src/pages/overview/KiroCrewCfgTab.tsx
@@ -11,6 +11,7 @@ import { useProvider } from '../../providers'
 import type { KiroCrewAgent } from '../../components/AgentSelector'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 type KiroCrewAgentCfg = Omit<KiroCrewAgent, 'name'>
 interface WorkspaceCfg { dir: string }
 interface MemoryStoreCfg { description: string; embedding_provider: string }
@@ -84,6 +85,7 @@ function CfgSelect({ label, path, value, options, hint, labels, onSave }: { labe
 }
 
 function CfgNumber({ label, path, value, suffix, min, max, hint, onSave }: { label: string; path: string; value: number; suffix?: string; min?: number; max?: number; hint?: string; onSave: (p: string, v: number) => void }) {
+  const ime = useImeGuard()
   const [local, setLocal] = useState(String(value))
   const { ok, markDirty } = useDirtyTrack(value)
   const [err, setErr] = useState('')
@@ -101,8 +103,7 @@ function CfgNumber({ label, path, value, suffix, min, max, hint, onSave }: { lab
         className={`${inputCls} text-right ${err ? 'border-danger' : ''}`}
         value={local}
         onChange={e => { setLocal(e.target.value); setErr('') }}
-        onBlur={commit}
-        onKeyDown={e => { if (e.key === 'Enter') commit() }}
+        {...ime.bindEnter({ onEnter: commit, onBlur: commit })}
       />
       {suffix && <span className="text-muted text-[12px]">{suffix}</span>}
       {err && <span className="text-danger text-[11px]">{err}</span>}

--- a/website/src/pages/overview/VectorMemoryCard.tsx
+++ b/website/src/pages/overview/VectorMemoryCard.tsx
@@ -6,6 +6,7 @@ import InfoTip from '../../components/InfoTip'
 import { esc } from '../../api/helpers'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 import { fmtDateNumeric, fmtDateTimeNumeric } from '../../i18n/format'
 const extractError = (err: unknown): string => {
   if (err != null && typeof err === 'object' && !(err instanceof Error)) {
@@ -140,6 +141,8 @@ export function embedModelDisclosure(status?: EmbeddingStatus | null): { label: 
 }
 
 export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: { onActiveChange?: (active: boolean) => void; onMigratedChange?: (migrated: boolean) => void }) {
+  // One instance covers every input in this card; the binding's focus/blur reset makes sharing safe.
+  const ime = useImeGuard()
   const [stats, setStats] = useState<VectorStats | null>(null)
   const [embStatus, setEmbStatus] = useState<EmbeddingStatus | null>(null)
   const [semantic, setSemantic] = useState<SemanticEntry[]>([])
@@ -408,7 +411,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
             <datalist id="key-suggestions">{filteredKeys.map(k => <option key={k} value={k}>{k}</option>)}</datalist>
           </div>
           <Input placeholder={i18nT('pages.overview.vectorMemoryCard.value')} style={{ flex: 2 }} value={newVal} onChange={e => { setNewVal(e.target.value); setWriteError('') }}
-            onKeyDown={async e => { if (e.key === 'Enter' && newKey && newVal) { try { await api.vectorSemanticWrite(newKey, newVal); setNewKey(''); setNewVal(''); setWriteError(''); load() } catch (err: unknown) { setWriteError(extractError(err)) } } }} />
+            {...ime.bindEnter({ onEnter: async () => { if (!newKey || !newVal) return; try { await api.vectorSemanticWrite(newKey, newVal); setNewKey(''); setNewVal(''); setWriteError(''); load() } catch (err: unknown) { setWriteError(extractError(err)) } } })} />
           <SendBtn onClick={async () => { if (!newKey || !newVal) return; try { await api.vectorSemanticWrite(newKey, newVal); setNewKey(''); setNewVal(''); setWriteError(''); load() } catch (e: unknown) { setWriteError(extractError(e)) } }}>{i18nT('pages.overview.vectorMemoryCard.set')}</SendBtn>
         </div>
         {writeError && <p className="text-danger text-[13px] mb-2"><AlertTriangle className="lucide-inline" /> {writeError}</p>}
@@ -433,7 +436,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
                     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                     <div className="flex gap-1 items-center" onClick={ev => ev.stopPropagation()}>
                       <Input value={editVal} onChange={ev => setEditVal(ev.target.value)} className="!py-1 !px-2 !text-sm"
-                        onKeyDown={async ev => { if (ev.key === 'Enter') { try { await api.vectorSemanticWrite(e.key, editVal); setEditKey(null); setWriteError(''); load() } catch (err: unknown) { setWriteError(extractError(err)) } } if (ev.key === 'Escape') setEditKey(null) }}
+                        {...ime.bindEnter({ onEnter: async () => { try { await api.vectorSemanticWrite(e.key, editVal); setEditKey(null); setWriteError(''); load() } catch (err: unknown) { setWriteError(extractError(err)) } }, onEscape: () => setEditKey(null) })}
                         autoFocus />
                       <Btn onClick={async () => { try { await api.vectorSemanticWrite(e.key, editVal); setEditKey(null); setWriteError(''); load() } catch (err: unknown) { setWriteError(extractError(err)) } }}><Check className="lucide-inline" /></Btn>
                       <Btn onClick={() => setEditKey(null)}><X className="lucide-inline" /></Btn>
@@ -463,7 +466,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
         <CardTitle>{i18nT('pages.overview.vectorMemoryCard.episodic_memory')} <InfoTip text={i18nT('pages.overview.vectorMemoryCard.conversation_fragments_with_vector_search_import')} /></CardTitle>
         <div className="flex gap-2 items-center flex-wrap mb-3">
           <Input placeholder={i18nT('pages.overview.vectorMemoryCard.search_episodic_memories')} style={{ flex: 1 }} value={epQuery} onChange={e => setEpQuery(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') loadEpisodic() }} />
+            {...ime.bindEnter({ onEnter: () => loadEpisodic() })} />
           <SendBtn onClick={() => loadEpisodic()}>{i18nT('pages.overview.vectorMemoryCard.search')}</SendBtn>
           {epQuery && <Btn onClick={() => { setEpQuery(''); setEpTagFilter(null); loadEpisodic('', false, null) }}>{i18nT('pages.overview.vectorMemoryCard.clear')}</Btn>}
           {!epQuery && epTagFilter && <Btn onClick={() => { setEpTagFilter(null); loadEpisodic('', false, null) }}>{i18nT('pages.overview.vectorMemoryCard.clear')}</Btn>}
@@ -539,7 +542,7 @@ export default function VectorMemoryCard({ onActiveChange, onMigratedChange }: {
         <CardTitle><Search className="lucide-inline" /> {i18nT('pages.overview.vectorMemoryCard.memory_inspector')} <InfoTip text={i18nT('pages.overview.vectorMemoryCard.preview_what_gets_injected_into_prompts_enter_a')} /></CardTitle>
         <div className="flex gap-2 items-center flex-wrap mb-3">
           <Input placeholder={i18nT('pages.overview.vectorMemoryCard.test_query_e_g_what_database_should_i_use')} style={{ flex: 1 }} value={inspectorQuery} onChange={e => setInspectorQuery(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') loadPreview(inspectorQuery) }} />
+            {...ime.bindEnter({ onEnter: () => loadPreview(inspectorQuery) })} />
           <SendBtn onClick={() => loadPreview(inspectorQuery)}>{i18nT('pages.overview.vectorMemoryCard.preview')}</SendBtn>
         </div>
         {preview && (

--- a/website/src/pages/settings/DisplayPanel.tsx
+++ b/website/src/pages/settings/DisplayPanel.tsx
@@ -35,6 +35,7 @@ import { isFontInstalled, monospaceFontStack } from '../../utils/fontDetect'
 import { i18nT } from '../../i18n/t'
 import { ThemeDroppedRulesNotice } from './ThemeDroppedRulesNotice'
 import ErrorNotice from '../../components/ErrorNotice'
+import { useImeGuard } from '../../hooks/useImeGuard'
 /**
  * Lightweight inline spinner (no modal / progress bar — matches the "status,
  * not ceremony" preference). Colors come from theme CSS vars via Tailwind
@@ -69,6 +70,7 @@ function StatusIndicator({ label }: { label: string }) {
 }
 
 export function DisplayPanel() {
+  const ime = useImeGuard()
   const { language, detected: detectedLanguage, setLanguage, syncFailed: langSyncFailed } = useLanguage()
   const { zoom, zoomSupported, zoomIn, zoomOut, reset, family, setFontFamily } = useZoomCtx()
   // Shortcut label for the zoom hint/description: ⌘ on macOS, Ctrl elsewhere.
@@ -460,7 +462,7 @@ export function DisplayPanel() {
                   and sat visibly shorter and darker than the picker. */}
               <Input aria-label={i18nT('pages.settings.displayPanel.theme_source_location')} value={installValue}
                 onChange={e => setInstallValue(e.target.value)}
-                onKeyDown={e => { if (e.key === 'Enter') handleInstall() }}
+                {...ime.bindEnter({ onEnter: () => handleInstall() })}
                 placeholder={installType === 'github' ? 'https://github.com/user/theme' : '/path/to/theme'}
                 className="min-w-0" />
               <button onClick={handleInstall} disabled={installBusy || !installValue.trim()}

--- a/website/src/pages/settings/SecurityPanel.tsx
+++ b/website/src/pages/settings/SecurityPanel.tsx
@@ -405,13 +405,7 @@ function AddDenyInput({ value, onChange, note, onNoteChange, onAdd, busy, submit
         <Input
           value={value}
           onChange={e => { onChange(e.target.value); if (error) setError('') }}
-          {...ime.bindComposition()}
-          onKeyDown={e => {
-            if (e.key !== 'Enter') return
-            // Rule 1: single-line input — decline the IME's committing Enter only.
-            if (ime.isComposing(e)) return
-            e.preventDefault(); submit()
-          }}
+          {...ime.bindEnter({ onEnter: submit })}
           placeholder={i18nT('pages.settings.securityPanel.add_a_custom_deny_pattern_regex_e_g_rm_rf_tmp_mi')}
           aria-label={i18nT('pages.settings.securityPanel.custom_deny_pattern')}
         />
@@ -428,14 +422,7 @@ function AddDenyInput({ value, onChange, note, onNoteChange, onAdd, busy, submit
         <Input
           value={note}
           onChange={e => onNoteChange(e.target.value)}
-          {...ime.bindComposition()}
-          onKeyDown={e => {
-            if (e.key !== 'Enter') return
-            // Rule 1: single-line input — one shared instance covers both fields;
-            // the binding's blur reset makes that safe.
-            if (ime.isComposing(e)) return
-            e.preventDefault(); submit()
-          }}
+          {...ime.bindEnter({ onEnter: submit })}
           placeholder={i18nT('pages.settings.securityPanel.optional_why_shown_to_the_agent_when_this_rule_fir')}
           aria-label={i18nT('pages.settings.securityPanel.custom_deny_note')}
           maxLength={200}

--- a/website/src/pages/settings/SlackPanel.tsx
+++ b/website/src/pages/settings/SlackPanel.tsx
@@ -113,13 +113,7 @@ export function TagListEditor({ label, description, values, placeholder, onChang
         <div className="flex items-center gap-2">
           <Input value={draft} placeholder={placeholder} className="flex-none font-mono"
             onChange={e => { setDraft(e.target.value); setErr('') }}
-            {...ime.bindComposition()}
-            onKeyDown={e => {
-              if (e.key !== 'Enter') return
-              // Rule 1: single-line input — decline the IME's committing Enter only.
-              if (ime.isComposing(e)) return
-              e.preventDefault(); add()
-            }} />
+            {...ime.bindEnter({ onEnter: add })} />
           <Btn onClick={add} disabled={!draft.trim()}><Plus size={13} /> {i18nT('pages.settings.slackPanel.add')}</Btn>
         </div>
       )}

--- a/website/src/pages/settings/WeixinPanel.tsx
+++ b/website/src/pages/settings/WeixinPanel.tsx
@@ -8,6 +8,7 @@ import { SettingsInput, SettingsToggle } from '../../components/settings'
 import { TagListEditor } from './SlackPanel'
 
 import { i18nT } from '../../i18n/t'
+import { useImeGuard } from '../../hooks/useImeGuard'
 /** Brand name — do-not-translate, so it lives here rather than in the catalog. */
 const CHANNEL_NAME = "WeChat"
 const SETUP_GUIDE =
@@ -33,6 +34,7 @@ type Phase = 'idle' | 'starting' | 'waiting' | 'scanned' | 'confirmed' | 'expire
  * the bot credential itself.
  */
 export function WeixinPanel() {
+  const ime = useImeGuard()
   const qc = useQueryClient()
   const { data, isError } = useQuery({
     queryKey: ['weixin-config'],
@@ -471,15 +473,19 @@ export function WeixinPanel() {
               disabled={readOnly}
               placeholder={CHANNEL_NAME}
               onChange={setFolderName}
-              onBlur={() =>
-                save({ session_folder: folderName.trim() || CHANNEL_NAME }, undefined, () => {
-                  clearTimeout(folderSavedTimer.current)
-                  setFolderSaved(true)
-                  folderSavedTimer.current = setTimeout(() => setFolderSaved(false), SAVED_MS)
-                })
-              }
+              {...ime.bindComposition({
+                onBlur: () =>
+                  save({ session_folder: folderName.trim() || CHANNEL_NAME }, undefined, () => {
+                    clearTimeout(folderSavedTimer.current)
+                    setFolderSaved(true)
+                    folderSavedTimer.current = setTimeout(() => setFolderSaved(false), SAVED_MS)
+                  }),
+              })}
               onKeyDown={e => {
-                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key !== 'Enter') return
+                // Early-return BEFORE the blur: a committing IME Enter must not commit.
+                if (ime.isComposing(e)) return
+                e.currentTarget.blur()
               }}
             />
             {folderSaved && (

--- a/website/src/test/ImeEnterClaimRatchet.test.ts
+++ b/website/src/test/ImeEnterClaimRatchet.test.ts
@@ -33,11 +33,107 @@ const SRC = join(__dirname, '..')
 /** An Enter branch that reads a composition signal directly instead of claiming the key. */
 const HAND_ROLLED = /key === 'Enter'[^\n]*(?:ime\.isComposing\(|nativeEvent\.isComposing)/
 
+/**
+ * The same defect split across two lines: a guard that DECLINES the key without
+ * consuming it, then consumes manually on the accepted path. `claimEnter` owns
+ * both halves precisely so the two cannot disagree — a copy of this spelling
+ * pasted onto a textarea re-opens the newline defect the one-line rule pins.
+ * A decline WITHOUT a following manual `preventDefault` stays legal ONLY on
+ * single-line inputs: there nothing is inserted and consuming would suppress a
+ * wanted implicit form submit. On a textarea the browser answers the unconsumed
+ * key with a literal newline, so a separate rule below rejects the decline
+ * by element tag.
+ */
+const GUARD_RETURN = /\bisComposing\([^)]*\)\)?\s*return\b/
+const MANUAL_CONSUME = /^\s*(?:if \([^)]*\) *\{? *)?\w+\.preventDefault\(\)/
+
 function sourceFiles(): string[] {
   return readdirSync(SRC, { recursive: true, encoding: 'utf8' })
     .map(p => p.split('\\').join('/'))
     .filter(p => /\.tsx?$/.test(p))
     .filter(p => !p.startsWith('test/') && !p.includes('__tests__'))
+}
+
+/*
+ * The scan bodies live in named functions rather than inline in each `it` so
+ * the fixture suite at the bottom can exercise the exact predicate the tree
+ * scan runs — a regex tightened against the live tree alone can silently stop
+ * matching the defect shape it was written for, and no offender would tell us.
+ */
+
+/** True when one of the next two CODE lines after `i` manually consumes the key. */
+function consumesWithinWindow(lines: string[], i: number): boolean {
+  let seen = 0
+  for (let j = i + 1; j < lines.length && seen < 2; j++) {
+    const l = lines[j].trim()
+    if (l === '' || l.startsWith('//') || l.startsWith('/*') || l.startsWith('*')) continue
+    seen++
+    if (MANUAL_CONSUME.test(lines[j])) return true
+  }
+  return false
+}
+
+/** Decline-then-consume pairs: the two-line re-implementation of claimEnter. */
+function scanDeclineConsumePairs(lines: string[]): number[] {
+  const hits: number[] = []
+  lines.forEach((line, i) => {
+    if (GUARD_RETURN.test(line) && consumesWithinWindow(lines, i)) hits.push(i + 1)
+  })
+  return hits
+}
+
+/**
+ * Unconsumed declines on a textarea. The single-line-input exemption above
+ * does not transfer: a textarea answers the unclaimed Enter with a literal
+ * newline into the draft — the exact corruption the guard exists to prevent —
+ * and an `Enter→blur` commit does not change that. The element is found by the
+ * same backtrack the shadowing rule uses; a spread's own generic annotation
+ * (`bindComposition<HTMLTextAreaElement>`) also names the tag, so the shape
+ * that motivated this rule is caught either way. Unrecognized formatting fails
+ * open, consistent with the rest of this file.
+ */
+function scanUnconsumedTextareaDeclines(lines: string[]): number[] {
+  const hits: number[] = []
+  lines.forEach((line, i) => {
+    if (!GUARD_RETURN.test(line) || consumesWithinWindow(lines, i)) return
+    let start = i
+    while (start > 0 && !/<[A-Za-z]/.test(lines[start])) start--
+    if (/<\w*[Tt]ext[Aa]rea/.test(lines[start])) hits.push(i + 1)
+  })
+  return hits
+}
+
+/**
+ * Props each binding carries; a standalone copy of one beside the spread
+ * shadows that half of the guard by JSX last-one-wins. `bindEnter` also owns
+ * the whole keydown, so a standalone `onKeyDown` beside it replaces the Enter
+ * guard itself. `bindComposition` deliberately does NOT list `onKeyDown`: the
+ * claim-in-own-handler pattern (rule 2) spreads the composition binding next
+ * to a site-owned `onKeyDown` by design.
+ */
+const SHADOWABLE: Record<string, RegExp> = {
+  bindComposition: /^\s*(?:onBlur|onFocus|onCompositionStart|onCompositionEnd)=/,
+  bindEnter: /^\s*(?:onBlur|onFocus|onCompositionStart|onCompositionEnd|onKeyDown)=/,
+}
+
+/** The lines of the JSX element enclosing line `i` (this tree's formatting). */
+function elementSpan(lines: string[], i: number): string[] {
+  let start = i
+  while (start > 0 && !/<[A-Za-z]/.test(lines[start])) start--
+  let end = i
+  while (end < lines.length - 1 && !lines[end].includes('/>')) end++
+  return lines.slice(start, end + 1)
+}
+
+/** Binding spreads with a standalone copy of a prop the binding already carries. */
+function scanShadowedBindings(lines: string[]): number[] {
+  const hits: number[] = []
+  lines.forEach((line, i) => {
+    const m = /\.\.\.\w+\.(bindComposition|bindEnter)/.exec(line)
+    if (!m) return
+    if (elementSpan(lines, i).some(l => SHADOWABLE[m[1]].test(l))) hits.push(i + 1)
+  })
+  return hits
 }
 
 describe('IME Enter claim ratchet', () => {
@@ -53,13 +149,52 @@ describe('IME Enter claim ratchet', () => {
     expect(offenders).toEqual([])
   })
 
-  it('never lets a standalone onBlur sit on an element that spreads the binding', () => {
+  it('never re-implements claimEnter as a decline-then-consume pair', () => {
+    // The two-line spelling of the same defect the one-line rule pins: decline
+    // via `isComposing(...) return`, then `preventDefault()` on the accepted
+    // path. Comment-only lines between the two do not launder the pair. The
+    // scan window is deliberately short (the next two code lines): a guard
+    // whose consumption sits further away is a different structure, and this
+    // check fails open rather than mis-flagging it.
+    const offenders: string[] = []
+    for (const rel of sourceFiles()) {
+      if (rel === 'hooks/useImeGuard.ts') continue
+      const lines = readFileSync(join(SRC, rel), 'utf8').split('\n')
+      for (const n of scanDeclineConsumePairs(lines)) offenders.push(`${rel}:${n}`)
+    }
+    // An entry here declines the Enter without consuming it and then consumes
+    // manually when accepted. Replace the pair with `ime.claimEnter(e)`.
+    expect(offenders).toEqual([])
+  })
+
+  it('never leaves a declined Enter unconsumed on a textarea', () => {
+    // BlockEditor shipped exactly this in the sweep that added the rule above:
+    // `if (ime.isComposing(e)) return` before an Enter→blur commit on a
+    // textarea. Inside the post-composition latch window the decline hands the
+    // key back to the browser, which inserts a literal newline into the note
+    // draft — neither committed nor intact. Textarea declines must claim.
+    const offenders: string[] = []
+    for (const rel of sourceFiles()) {
+      if (rel === 'hooks/useImeGuard.ts') continue
+      const lines = readFileSync(join(SRC, rel), 'utf8').split('\n')
+      for (const n of scanUnconsumedTextareaDeclines(lines)) offenders.push(`${rel}:${n}`)
+    }
+    // An entry here declines an Enter on a textarea and lets the browser act
+    // on it. Replace the decline with `if (!ime.claimEnter(e)) return`.
+    expect(offenders).toEqual([])
+  })
+
+  it('never lets a standalone copy of a bound prop sit on an element that spreads a binding', () => {
     // JSX resolves duplicate props by last-one-wins, so a standalone `onBlur` after the
     // spread drops the latch reset and a standalone one before it drops the caller's own
     // handler. Both are silent. This is not hypothetical: the pet composer shipped the
     // first form in the very commit that made the binding mandatory, and only a blind
     // reviewer caught it — the hook can make the correct spelling AVAILABLE but only a
     // reader of the whole element can see the shadowing, so the check belongs here.
+    // The guarded set is per binding (see SHADOWABLE): `onFocus` joined when the
+    // stale-latch reset moved into the binding, the composition handlers because a
+    // standalone copy severs the tracking itself, and `onKeyDown` beside `bindEnter`
+    // because there the binding carries the Enter guard in that very prop.
     //
     // Elements are bracketed by this tree's formatting (one attribute per line, the tag
     // closing on its own line). A file that formats differently is not flagged rather
@@ -68,17 +203,11 @@ describe('IME Enter claim ratchet', () => {
     const offenders: string[] = []
     for (const rel of sourceFiles()) {
       const lines = readFileSync(join(SRC, rel), 'utf8').split('\n')
-      lines.forEach((line, i) => {
-        if (!/\.\.\.\w+\.bindComposition/.test(line)) return
-        let start = i
-        while (start > 0 && !/<[A-Za-z]/.test(lines[start])) start--
-        let end = i
-        while (end < lines.length - 1 && !lines[end].includes('/>')) end++
-        const span = lines.slice(start, end + 1)
-        if (span.some(l => /^\s*onBlur=/.test(l))) offenders.push(`${rel}:${i + 1}`)
-      })
+      for (const n of scanShadowedBindings(lines)) offenders.push(`${rel}:${n}`)
     }
-    // Pass the handler INTO bindComposition({ onBlur }) so both run.
+    // Pass the handler INTO bindComposition/bindEnter({ onFocus, onBlur, … }) so both
+    // run — or, for an `onKeyDown` beside bindEnter, keep the site's own handler and
+    // claim the Enter branch instead of spreading bindEnter.
     expect(offenders).toEqual([])
   })
 
@@ -120,5 +249,102 @@ describe('IME Enter claim ratchet', () => {
     expect(returned.split(',').map(s => s.trim())).not.toContain('composition')
     // Every binding the hook returns carries onBlur.
     expect(hook).toMatch(/bindComposition[\s\S]{0,600}?onBlur/)
+  })
+})
+
+describe('ratchet rule fixtures', () => {
+  // The tree scans above can only prove "no offender today". These fixtures
+  // prove the predicates still MATCH the defect shapes they were written for —
+  // without them, a regex edit could silently stop matching and every scan
+  // would keep passing vacuously.
+  const jsx = (s: string) => s.split('\n')
+
+  it('flags a standalone onKeyDown beside bindEnter but not beside bindComposition', () => {
+    expect(scanShadowedBindings(jsx(`
+      <input
+        {...ime.bindEnter({ onEnter: send })}
+        onKeyDown={e => step(e)}
+      />`))).toHaveLength(1)
+    // Rule 2's sanctioned shape: composition binding NEXT TO a site-owned
+    // keydown that claims its own Enter branch.
+    expect(scanShadowedBindings(jsx(`
+      <input
+        onKeyDown={e => { if (e.key === 'Enter' && !ime.claimEnter(e)) return }}
+        {...ime.bindComposition()}
+      />`))).toHaveLength(0)
+  })
+
+  it('flags standalone composition handlers beside either binding', () => {
+    expect(scanShadowedBindings(jsx(`
+      <input
+        {...ime.bindComposition()}
+        onCompositionStart={track}
+      />`))).toHaveLength(1)
+    expect(scanShadowedBindings(jsx(`
+      <input
+        {...ime.bindEnter({ onEnter: send })}
+        onCompositionEnd={track}
+      />`))).toHaveLength(1)
+  })
+
+  it('still flags the original onBlur/onFocus shadowing', () => {
+    expect(scanShadowedBindings(jsx(`
+      <input
+        {...ime.bindComposition()}
+        onBlur={commit}
+      />`))).toHaveLength(1)
+    expect(scanShadowedBindings(jsx(`
+      <input
+        onFocus={e => e.target.select()}
+        {...ime.bindEnter({ onEnter: send })}
+      />`))).toHaveLength(1)
+  })
+
+  it('flags an unconsumed decline on a textarea but not on a single-line input', () => {
+    const textareaDecline = jsx(`
+      <textarea
+        value={text}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            if (ime.isComposing(e)) return
+            e.currentTarget.blur()
+          }
+        }}
+      />`)
+    expect(scanUnconsumedTextareaDeclines(textareaDecline)).toHaveLength(1)
+    // The same decline on a single-line input is the sanctioned non-consuming
+    // remedy — nothing is inserted there.
+    expect(scanUnconsumedTextareaDeclines(
+      textareaDecline.map(l => l.replace('<textarea', '<input')),
+    )).toHaveLength(0)
+  })
+
+  it('routes a consumed decline to the pair rule, not the textarea rule', () => {
+    const consumedPair = jsx(`
+      <textarea
+        onKeyDown={e => {
+          if (ime.isComposing(e)) return
+          e.preventDefault()
+        }}
+      />`)
+    expect(scanUnconsumedTextareaDeclines(consumedPair)).toHaveLength(0)
+    expect(scanDeclineConsumePairs(consumedPair)).toHaveLength(1)
+  })
+
+  it('catches the generic-annotated spread shape BlockEditor actually shipped', () => {
+    // The backtrack from the decline stops at the spread's own generic
+    // annotation, which still names the tag (<HTMLTextAreaElement>): the exact
+    // pre-fix BlockEditor shape is caught even though the `<textarea` opener
+    // sits further up.
+    expect(scanUnconsumedTextareaDeclines(jsx(`
+      {...ime.bindComposition<HTMLTextAreaElement>({
+        onBlur: () => onCommit(text),
+      })}
+      onKeyDown={e => {
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          if (ime.isComposing(e)) return
+          e.currentTarget.blur()
+        }
+      }}`))).toHaveLength(1)
   })
 })

--- a/website/src/test/ImeEnterGuardSites.test.tsx
+++ b/website/src/test/ImeEnterGuardSites.test.tsx
@@ -47,6 +47,9 @@ vi.mock('../api/client', async (importOriginal) => {
 import { api } from '../api/client'
 import TagManagerList from '../components/TagManagerList'
 import ProjectPicker from '../components/ProjectPicker'
+import SearchBar from '../components/SearchBar'
+import BroadcastBar from '../apps/meetings/components/BroadcastBar'
+import { BlockEditor } from '../apps/md-notebook/BlockEditor'
 
 /** Arm the hook's post-composition latch: the WebKit commit-Enter window. */
 function armLatch(el: Element) {
@@ -208,5 +211,135 @@ describe('ProjectPicker path input — rule 2: gate the Enter path only', () => 
     fireEvent.keyDown(input, { key: 'Enter' })
     await act(async () => { await vi.advanceTimersByTimeAsync(0) })
     expect(vi.mocked(api.browseDirs)).toHaveBeenCalledWith('/home/u/alpha')
+  })
+})
+
+describe('BroadcastBar input — rule 1 single-line Enter-only site: bindEnter', () => {
+  // Representative of the #4292 sweep's bindEnter migrations: the handler is
+  // Enter-only, so the whole binding (composition tracking + claim + focus/blur
+  // recovery) comes from one spread and no hand-rolled spelling exists to copy.
+  it('does NOT send on the committing Enter in the post-composition window', () => {
+    const onSend = vi.fn()
+    render(<BroadcastBar onSend={onSend} />)
+    const input = screen.getByLabelText(/./, { selector: 'input' }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '你好' } })
+    armLatch(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('leaves a mid-composition Enter to the IME (native flag set)', () => {
+    const onSend = vi.fn()
+    render(<BroadcastBar onSend={onSend} />)
+    const input = screen.getByLabelText(/./, { selector: 'input' }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '你好' } })
+    fireEvent.compositionStart(input)
+    const defaultNotPrevented = fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+    expect(onSend).not.toHaveBeenCalled()
+    // The guard must not touch a key the IME is consuming.
+    expect(defaultNotPrevented).toBe(true)
+  })
+
+  it('sends on a plain Enter (positive control)', () => {
+    const onSend = vi.fn()
+    render(<BroadcastBar onSend={onSend} />)
+    const input = screen.getByLabelText(/./, { selector: 'input' }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSend).toHaveBeenCalledWith('hello')
+  })
+
+  it('a stale latch from an abandoned composition clears on the next focus', () => {
+    // The C2 recovery: the reset now rides in the binding's onFocus, replacing
+    // the site-level `onFocus={() => ime.reset()}` copies. Abandon a composition
+    // (no compositionend), refocus, and the next Enter must send.
+    const onSend = vi.fn()
+    render(<BroadcastBar onSend={onSend} />)
+    const input = screen.getByLabelText(/./, { selector: 'input' }) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.compositionStart(input)   // abandoned: no compositionEnd follows
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSend).toHaveBeenCalledWith('hello')
+  })
+})
+
+describe('SearchBar find input — rule 2 mixed handler: claim the Enter branch only', () => {
+  // Representative of the sweep's claim-in-mixed-handler sites: Enter steps the
+  // find while arrows/Home/End navigate, so only the Enter branch is claimed.
+  const renderBar = () => {
+    const next = vi.fn()
+    const prev = vi.fn()
+    render(
+      <SearchBar
+        term="查询" setTerm={vi.fn()} matches={[]} currentIdx={0}
+        next={next} prev={prev} close={vi.fn()}
+        caseSensitive={false} toggleCaseSensitive={vi.fn()}
+      />,
+    )
+    const input = screen.getByLabelText(/./, { selector: 'input' }) as HTMLInputElement
+    return { input, next, prev }
+  }
+
+  it('does NOT step the find on the committing Enter, and consumes it', () => {
+    const { input, next } = renderBar()
+    armLatch(input)
+    const defaultNotPrevented = fireEvent.keyDown(input, { key: 'Enter' })
+    expect(next).not.toHaveBeenCalled()
+    // claimEnter consumed the declined key (both native signals clear).
+    expect(defaultNotPrevented).toBe(false)
+  })
+
+  it('keeps arrow-key navigation working while the latch is armed', () => {
+    const { input, next } = renderBar()
+    armLatch(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('steps the find on a plain Enter (positive control)', () => {
+    const { input, next, prev } = renderBar()
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(next).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(prev).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('md-notebook BlockEditor — rule 3 textarea: claim before the Enter→blur commit', () => {
+  // The sweep's review caught this site declining WITHOUT claiming: inside the
+  // post-composition window the unclaimed Cmd/Ctrl+Enter neither committed nor
+  // stayed inert — the browser answered it with a literal newline into the
+  // note draft. The textarea rule of the source ratchet now pins the shape;
+  // this pins the behaviour.
+  function renderEditor() {
+    const onCommit = vi.fn()
+    render(<BlockEditor initial="草稿" onCommit={onCommit} onCancel={vi.fn()} />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    return { ta, onCommit }
+  }
+
+  it('declines the committing Ctrl+Enter in the post-composition window AND consumes it', () => {
+    const { ta, onCommit } = renderEditor()
+    armLatch(ta)
+    const defaultNotPrevented = fireEvent.keyDown(ta, { key: 'Enter', ctrlKey: true })
+    expect(onCommit).not.toHaveBeenCalled()
+    // Consumption is the half the pre-fix decline dropped: unclaimed, the
+    // browser inserts a newline into the draft the user is still composing.
+    expect(defaultNotPrevented).toBe(false)
+  })
+
+  it('leaves a mid-composition Ctrl+Enter to the IME (native flag set)', () => {
+    const { ta, onCommit } = renderEditor()
+    fireEvent.compositionStart(ta)
+    const defaultNotPrevented = fireEvent.keyDown(ta, { key: 'Enter', ctrlKey: true, isComposing: true })
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(defaultNotPrevented).toBe(true)
+  })
+
+  it('commits on a plain Ctrl+Enter via the blur it triggers (positive control)', () => {
+    const { ta, onCommit } = renderEditor()
+    fireEvent.keyDown(ta, { key: 'Enter', ctrlKey: true })
+    expect(onCommit).toHaveBeenCalledWith('草稿')
   })
 })

--- a/website/src/test/useImeGuard.test.ts
+++ b/website/src/test/useImeGuard.test.ts
@@ -69,17 +69,17 @@ describe('useImeGuard', () => {
     expect(result.current.isComposing(key())).toBe(false)
   })
 
-  it('the composition binding carries the latch recovery, and composes a caller onBlur', () => {
+  it('the composition binding carries the latch recovery, and composes caller handlers', () => {
     // There is no recovery-less binding to pick. A composition abandoned without a
     // `compositionend` latches the guard, and since claimEnter consumes what it
     // declines, a surface missing the reset stops sending SILENTLY. Shipping the reset
     // with the tracking is what makes that unreachable rather than merely documented.
-    // A caller's own blur handler is composed, never replaced — the earlier shape,
+    // A caller's own blur/focus handler is composed, never replaced — the earlier shape,
     // where a consumer spread the binding and then declared its own `onBlur`, dropped
     // the reset without a word.
     const { result } = renderHook(() => useImeGuard())
     expect(Object.keys(result.current.bindComposition()).sort())
-      .toEqual(['onBlur', 'onCompositionEnd', 'onCompositionStart'])
+      .toEqual(['onBlur', 'onCompositionEnd', 'onCompositionStart', 'onFocus'])
 
     const onBlur = vi.fn()
     const bound = result.current.bindComposition<HTMLTextAreaElement>({ onBlur })
@@ -88,6 +88,22 @@ describe('useImeGuard', () => {
     act(() => bound.onBlur({} as React.FocusEvent<HTMLTextAreaElement>))
     expect(result.current.isComposing(key())).toBe(false)
     expect(onBlur).toHaveBeenCalledTimes(1)
+  })
+
+  it('the composition binding resets a stale latch on focus, and composes a caller onFocus', () => {
+    // One hook instance is routinely shared across sibling inputs. A latch stranded
+    // by the previous element (composition abandoned mid-flight) must not decline
+    // the first Enter on the next one, so the reset rides in the binding's onFocus
+    // — the site-level `onFocus={() => ime.reset()}` copies this replaces could be
+    // dropped by omission on a new consumer.
+    const { result } = renderHook(() => useImeGuard())
+    const onFocus = vi.fn()
+    const bound = result.current.bindComposition<HTMLInputElement>({ onFocus })
+    act(() => result.current.onCompositionStart())
+    expect(result.current.isComposing(key())).toBe(true)
+    act(() => bound.onFocus({} as React.FocusEvent<HTMLInputElement>))
+    expect(result.current.isComposing(key())).toBe(false)
+    expect(onFocus).toHaveBeenCalledTimes(1)
   })
 
   it('clears pending timer on unmount (no stale timer callbacks after teardown)', () => {
@@ -124,6 +140,19 @@ describe('useImeGuard', () => {
       expect(result.current.isComposing(key())).toBe(false)
       // user callback still invoked
       expect(onBlur).toHaveBeenCalledTimes(1)
+    })
+
+    it('onFocus resets a stale latch AND forwards user callback', () => {
+      const onFocus = vi.fn()
+      const { result } = renderHook(() => useImeGuard())
+      act(() => result.current.onCompositionStart())
+      expect(result.current.isComposing(key())).toBe(true)
+
+      const props = result.current.bindEnter<HTMLInputElement>({ onFocus })
+      act(() => props.onFocus({} as React.FocusEvent<HTMLInputElement>))
+
+      expect(result.current.isComposing(key())).toBe(false)
+      expect(onFocus).toHaveBeenCalledTimes(1)
     })
 
     it('Escape resets composingRef BEFORE invoking onEscape (order matters)', () => {


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** behavior-only sweep — every change rewires keyboard/composition event handling (`onKeyDown`/`onCompositionStart`/`onCompositionEnd`/`onFocus`/`onBlur`); no markup, class, or style renders differently. The one style-adjacent edit is a `focus-cue-ok` comment on `SearchBar`'s input documenting where the pre-existing focus cue lives (wrapper `focus-within:border-accent`), which paints nothing.

Closes #4292 — the follow-up sweep of #4305: route every remaining Enter-submit site through the `useImeGuard` IME guard, so the WebKit post-composition committing Enter (delivered after `compositionend`, native `isComposing` already false) can no longer submit half-composed text.

## What changed

**~45 newly guarded sites + 8 old two-line spellings migrated**, each by the settled rule for its shape:

- **R1 — single-line, Enter-only handler** → spread `ime.bindEnter({ onEnter, onEscape?, onBlur?, onFocus? })`; the binding carries composition tracking, the Enter claim, and latch recovery in one spread.
- **R2 — mixed-key handler** (arrows/Tab/mod-combos share the keydown) → keep the site's own `onKeyDown`, gate only the Enter branch with `claimEnter`/`isComposing`, spread `bindComposition()` alongside.
- **R3 — textarea** → `claimEnter` always: a declined-but-unconsumed Enter becomes a literal newline in the draft.

**C1 — ratchet widened** (`ImeEnterClaimRatchet.test.ts`): now also catches the two-line decline-then-consume spelling, standalone `onKeyDown` beside a `bindEnter` spread, standalone composition handlers beside either binding, and (new rule) an unconsumed decline on a textarea. Scan predicates are extracted to named functions with a fixture suite pinning each defect shape, so a regex edit cannot silently stop matching.

**C2 — stale-latch reset folded into the bindings**: `bindComposition`/`bindEnter` now reset on focus, replacing 4 site-level `onFocus={() => ime.reset()}` copies (`bindEnter` forwards `onFocus`, so select-on-focus sites keep their behavior without shadowing).

**Pass-throughs added**: `SettingsInput` and `DiscoverySearchBar` forward composition props; `DiscoverySearchBar.inputProps` is deliberately narrowed to the binding's own keys so a future caller cannot shadow its arrow/Enter logic cross-component.

## Pre-push dual-model review (both applied in full)

GPT 5.6 Sol: PASS + 1 Low. Opus 5: BLOCKING — 2 High, 1 Medium, 3 Low. All fixed before opening this PR:

- **High**: two same-shape rename inputs missed by the sweep, both in files this commit touched — `ArtifactDetailPage` title rename and `SchedulePage`'s `EmptyFolderChip` (whose comment says "same inline-edit pattern as CronFolderHeader", the very component the sweep migrated). Both now `bindEnter`.
- **High**: `BlockEditor` (md-notebook) declined Cmd/Ctrl+Enter on a textarea WITHOUT consuming it — inside the latch window the browser inserted a literal newline into the note draft, the exact R3 corruption. Now `claimEnter`, matching the same commit's `CommentThreads` handling.
- **Medium**: the ratchet's decline-without-consume exemption was stated per-shape but is only sound on single-line inputs — a new tree rule now rejects it on textareas by element tag (and catches the generic-annotation shape `bindComposition<HTMLTextAreaElement>` that `BlockEditor` actually shipped; fixture-pinned).
- **Low ×4**: shadowing ratchet widened to `onKeyDown`-beside-`bindEnter` + composition handlers (GPT + Opus), `SchedulePage` batch-delete confirm input guarded (destructive action, narrow but real window), `DiscoverySearchBar.inputProps` type narrowed, `bindEnter` doc now states the single-line / modifier-agnostic contract (Shift/Cmd/Ctrl+Enter all submit; textareas keep their own handler).

## Deliberately not migrated

39 residual `key === 'Enter'` sites were inventoried: activation/navigation handlers (buttons, list options) where composed text cannot be submitted, plus native-DOM listeners that `useImeGuard` structurally cannot serve (its `claimEnter`/`isComposing` read `e.nativeEvent.isComposing`, synthetic-only — the boundary the ratchet documents). One of those native listeners DOES carry the hazard: `useListKeyboardNav`'s document-capture Enter dispatches over 5 picker surfaces whose filter is composed text (First Principles round 2). Guarding it needs a native-event latch — a new mechanism, not a consumer of this PR's hook — so it is filed as follow-up #5340 rather than expanding this sweep. `GrillTree`/`ResearchLabPage` textareas keep their own handlers (they branch on `shiftKey`, which `bindEnter` deliberately does not).

Note: issue discussion mentions 4 site-level `onFocus` reset copies; the tree at base had 3 — the 4th (`ChatInput`) already routed through a different recovery path.

## Verification

- Backend pytest 62,011 passed; frontend vitest full suite 22,965 passed at base revision; post-review delta re-verified with tsc clean + 31 IME tests (ratchet 12, sites 19) + 356 tests across all touched-component suites; eslint 0 errors.
- New site-level behavior tests: BroadcastBar (R1 representative incl. C2 focus-recovery), SearchBar (R2 representative), BlockEditor (R3, pins the review-caught defect: window Ctrl+Enter declined AND consumed, positive control commits).
- Electron suite: 1218 pass, 0 fail; 26 `gateway-stop.test.js` cancellations reproduce identically on pristine base (host-env, zero overlap with this diff).

## CI review round 1 (GPT 5.6 BLOCKING — fixed at the chokepoint)

GPT flagged ChatPane's two dropdown filter inputs: the child guard declines the IME committing Enter, but the event still bubbles to the portal container's `onListKeyDown`, whose Enter-selects-sole-match path (`useListboxKeyboard`) had NO composition guard — so the parent switched agent/model anyway. Verified real, and bigger than the two flagged lines: the same unguarded hook path also serves `ChatPage`'s and `AgentsPage`'s filter inputs, which carry no input-level guard at all (the `case 'Enter':` spelling evaded the sweep's `key === 'Enter'` enumeration).

Fixed where the dispatch lives instead of per site: `useListboxKeyboard` now claims the Enter itself (internal `useImeGuard`; composition tracked via native listeners on the consumer-supplied `inputRef`, with focus/blur + reopen latch recovery — zero consumer wiring, no JSX prop collision with any binding a consumer spreads). All 10 consumers inherit the guard. ChatPane's two inputs then revert to bare inputs — their `bindEnter` copies had duplicated the container's Enter/Escape dispatch (a pre-existing double-fire, idempotent only by luck) and are now a single guarded path. 4 new hook tests pin the window decline, mid-composition pass-through, and both latch recoveries.
