### PR TITLE
fix(security): a read-only command could delete branches, repoint a remote, and write files

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import contextlib
+import fnmatch
 import hashlib
 import json
 import logging
@@ -586,6 +587,896 @@ def _is_help_probe(segment: str) -> bool:
     return True
 
 
+# ── Side effects reached through an allowlisted read-only verb ──
+#
+# The allowlist above names a verb and is matched as a prefix, so it vouches
+# for every flag, subcommand and operand that verb accepts. Some of those
+# write a file, change a ref or launch another program — and none of it goes
+# through a shell redirect, so `_UNSAFE_SHELL_RE` never sees it.
+#
+# The tables are keyed by verb because the same spelling is harmless
+# elsewhere: `ls -o` is a long listing format and `grep -o` prints only the
+# match, while `sort -o FILE` truncates and writes FILE.
+
+# Flags that make the program write a file named on its own command line.
+_WRITE_FLAGS: dict[str, tuple[str, ...]] = {
+    # `-T` does not name the output, it names a DIRECTORY sort writes its
+    # temporaries into — a write to a path the caller chose, one step removed,
+    # exactly like `tree -R` below. Reported by #5038.
+    "sort": ("-o", "--output", "-T", "--temporary-directory"),
+    # `-R` writes without being handed a filename: tree re-runs itself in every
+    # directory it descends into, adding `-o 00Tree.html` each time, so the file
+    # is named by tree rather than by the command line. Same outcome as `-o`, one
+    # step removed, which is why looking only for a filename-bearing flag missed
+    # it.
+    "tree": ("-o", "--output", "-R"),
+    "file": ("-C", "--compile"),
+    "uniq": ("-o",),
+    "git diff": ("--output",),
+    "git show": ("--output",),
+    "git log": ("--output",),
+    # A pager, and not on the prefix allowlist — but the PIPE-TARGET check runs
+    # this table too, and `cat f | less -O FILE` writes FILE from a segment whose
+    # leading verb is a read.
+    "less": ("-o", "-O", "--log-file", "--LOG-FILE"),
+}
+
+# Flags that hand control to a program the repository names, not the caller:
+# an external diff driver comes from the repo's config or .gitattributes.
+_EXEC_FLAGS: dict[str, tuple[str, ...]] = {
+    # `--textconv` is the same hand-off as `--ext-diff` through a different config
+    # key, and it was missing here while `git cat-file` below already listed it —
+    # the table gap, not the design, is what let `git diff --textconv` through.
+    #
+    # Scope, stated plainly: this stops the COMMAND LINE from selecting the
+    # program. It does not stop a textconv driver the user configured from being
+    # applied by default, because that name comes from git config, which is not
+    # part of a repository and is not something a checkout can add. Requiring
+    # `--no-textconv` would be the only way to cover that, and it would take plain
+    # `git diff` off the read-only path — the most common read there is.
+    "git diff": ("--ext-diff", "--textconv"),
+    "git show": ("--ext-diff", "--textconv"),
+    "git log": ("--ext-diff", "--textconv"),
+    # `--filters` runs the repository's clean/smudge filter — a command from
+    # `.gitattributes`, i.e. chosen by the checkout rather than by the caller.
+    # `--textconv` is the same hand-off through a different config key.
+    "git cat-file": ("--filters", "--textconv"),
+    # `sort` compresses its temporary files by running this program.
+    "sort": ("--compress-program",),
+    # A pager that runs a filter over its input, reachable as a pipe target.
+    # `-k` is the sharper one and it is INDIRECT: it loads a lesskey file, and a
+    # lesskey file can set environment variables — including `LESSOPEN`, which less
+    # treats as an input PREPROCESSOR and runs. So a checkout-supplied lesskey is
+    # arbitrary command execution, two steps removed from anything on the command
+    # line. Verified against `less --help` on less 608: `-k [file]` /
+    # `--lesskey-file=[file]`, plus `--lesskey-src` on newer builds.
+    #
+    # Case is load-bearing here, as it is for `file -C`: lowercase `-k` loads the
+    # keyfile, while uppercase `-K` is `--quit-on-intr` and an ordinary read.
+    "less": ("--filter", "-k", "--lesskey-file", "--lesskey-src"),
+}
+
+# `git branch` and `git tag` each carry a read mode and a write mode under one
+# subcommand, so the prefix match admits the destructive spellings. Some of
+# these also open `$EDITOR`, which runs a program of the environment's
+# choosing: `git branch --edit-description` always does, and `git tag <name>`
+# does whenever `tag.gpgSign` or `tag.forceSignAnnotated` is set.
+_GIT_REF_WRITE_FLAGS: dict[str, tuple[str, ...]] = {
+    "branch": (
+        "-d",
+        "-D",
+        "--delete",
+        "-m",
+        "-M",
+        "--move",
+        "-c",
+        "-C",
+        "--copy",
+        "-f",
+        "--force",
+        "-u",
+        "--set-upstream",
+        "--set-upstream-to",
+        "--unset-upstream",
+        "--edit-description",
+    ),
+    "tag": (
+        "-d",
+        "--delete",
+        "-a",
+        "--annotate",
+        "-s",
+        "--sign",
+        "-m",
+        "--message",
+        "-F",
+        "--file",
+        "-f",
+        "--force",
+        "--cleanup",
+        # `-u <keyid>` is `--local-user`: it makes the tag ANNOTATED and signed,
+        # so it creates a ref exactly as `-a` does. `-u` was in the `branch` list
+        # (set-upstream) and missing here, and the omission was reachable —
+        # `git tag -ulin@kiro.co release` created a signed tag.
+        "-u",
+        "--local-user",
+    ),
+}
+
+# Why a bare operand needs TWO tables rather than one.
+#
+# `git branch <name>` creates a ref, so a bare operand is the signal. Deciding
+# when an operand is NOT that name was collapsed into a single "this flag eats
+# the next token" set, and that conflated two different things git keeps apart:
+#
+#   * whether the flag CONSUMES the following word, which git's own option
+#     parser decides by whether the argument is required or optional. A required
+#     argument is taken from the next word; an OPTIONAL one must be attached with
+#     `=`, and a separate word is left as an operand. `--color` is optional, so
+#     `git branch --color newbranch` still creates `newbranch` — while the guard
+#     read `newbranch` as the colour and passed the segment.
+#   * whether the command is in LIST mode, where an operand is a pattern to match
+#     rather than a ref to create. `git branch --list newbranch` lists, it does
+#     not create, so treating that operand as a creation would be a false denial.
+#
+# Splitting them keeps both answers right: `--color` is in neither set, and
+# `--list` is in the list-mode set only.
+
+# Flags whose argument is REQUIRED, so git takes it from the following word.
+_GIT_REF_VALUE_FLAGS: frozenset[str] = frozenset(("--points-at", "--format", "--sort"))
+
+
+def _consumes_next_word(token: str) -> bool:
+    """Whether *token* is a required-argument flag that takes the FOLLOWING word.
+
+    Abbreviations count, because git's parser resolves them: `git branch --form`
+    reaches `--format` and eats the next word, so reading `--form` as an ordinary
+    option left `-l` in `git branch --form -l newbranch` looking like a list flag
+    and licensed the bare operand that created the branch.
+
+    This is the fourth site on this guard to need the abbreviation axis — after
+    `_matched_flag`, `_system_set_flag` and `_glob_reaches` — which is why it is a
+    named helper rather than a fourth inline prefix test.
+
+    An ATTACHED value (`--format=x`) takes nothing from the next word, so it is
+    not one of these. Over-matching an ambiguous abbreviation is safe: git rejects
+    it rather than running it.
+    """
+    if "=" in token or not token.startswith("--") or len(token) <= 2:
+        return False
+    return any(flag == token or flag.startswith(token) for flag in _GIT_REF_VALUE_FLAGS)
+
+
+# Flags that put `git branch` / `git tag` in list mode, where a bare operand is a
+# pattern. `--points-at` appears in both: it consumes its value AND selects.
+_GIT_REF_LIST_FLAGS: frozenset[str] = frozenset(
+    (
+        "-l",
+        "--list",
+        "--contains",
+        "--no-contains",
+        "--merged",
+        "--no-merged",
+        "--points-at",
+    )
+)
+
+
+def _glob_shifts_arguments(token: str) -> bool:
+    """Whether a glob in *token* can change how many arguments the program gets.
+
+    A separate question from `_glob_hides_word`, which asks what a pattern can
+    expand INTO. This one is about the COUNT, and it cuts both ways:
+
+    * several matches become several WORDS — with `in1` and `in2` present,
+      `uniq in*` runs `uniq in1 in2`, whose second operand is an OUTPUT file;
+    * no match under `nullglob` makes the word VANISH — `git branch --format
+      nomatch* --list newbranch` loses the format's value, so `--format` eats
+      `--list` instead and `newbranch` stops being a pattern.
+
+    Neither outcome needs the pattern to resemble anything this module decides on,
+    so it is only asked where the argument COUNT or POSITION carries the verdict:
+    a `uniq` operand, and a required git option's value. An operand whose meaning
+    does not depend on its position — `ls *.py`, `git branch --list 'feat/*'` —
+    is not affected, which is what keeps ordinary globbing on the read path.
+    """
+    return bool(_GLOB_META_RE.search(token) or _EXTGLOB_RE.search(token))
+
+
+# The SHORT list-mode flags, per subcommand, because they do not agree. `-l` is
+# a listing for both, but `git tag -n[<num>]` prints annotation lines — a listing
+# form `git branch` has no counterpart for, and reading it as anything else
+# denied a common inspection (`git tag -n 'v1.*'`) its auto-approval. Kept as
+# LETTERS, not flags, because they arrive bundled: `git tag -n2` and `git tag -ln`
+# both select, and only a per-letter test sees that. A letter here must never be
+# a write flag for the same subcommand — `-n` is not in `_GIT_REF_WRITE_FLAGS`
+# ("tag"), which is what makes reading it as a listing safe.
+_GIT_REF_LIST_SHORTS: dict[str, str] = {"branch": "l", "tag": "ln"}
+
+# Flags that CANCEL list mode, per subcommand. git's parse-options auto-generates
+# a `--no-<opt>` negation for a boolean, so `--list` has one and it undoes the
+# listing — `git branch --list --no-list newbranch` CREATES the branch. Verified
+# against git rather than inferred, which matters because the neighbouring
+# `--no-` spellings do NOT behave this way:
+#
+#     git branch --list --no-list nl1                -> branch nl1 CREATED
+#     git branch --list --no-lis nl2                 -> branch nl2 CREATED
+#     git branch -l --no-list nl3                    -> branch nl3 CREATED
+#     git branch --contains HEAD --no-contains nc1   -> no ref (git errors)
+#     git branch --merged --no-merged nm1            -> no ref (git errors)
+#     git tag -l --no-list t1                        -> no ref (unknown option)
+#
+# So `--no-contains` and `--no-merged` are real list FILTERS rather than
+# negations, and treating them as cancelling would deny two ordinary reads;
+# `git tag` has no `--no-list` at all. The table says only what was measured.
+_GIT_REF_LIST_CANCEL_FLAGS: dict[str, tuple[str, ...]] = {"branch": ("--no-list",)}
+
+
+def _cancels_list_mode(token: str, subcommand: str) -> bool:
+    """Whether *token* turns list mode off for *subcommand*.
+
+    Abbreviations count, as everywhere else on this guard: `--no-lis` reaches
+    `--no-list`. Cancelling can only move a bare operand from "pattern" to
+    "creates a ref", i.e. toward the prompt, so over-matching here is safe.
+    """
+    head = token.split("=", 1)[0]
+    if not head.startswith("--") or len(head) <= 2:
+        return False
+    cancels = _GIT_REF_LIST_CANCEL_FLAGS.get(subcommand, ())
+    return any(flag.startswith(head) for flag in cancels)
+
+
+# `git remote` subcommands that rewrite remote configuration. `set-url` is the
+# sharpest: it repoints the remote, so later fetches and pushes go elsewhere.
+_GIT_REMOTE_WRITE_SUBCOMMANDS: frozenset[str] = frozenset(
+    ("add", "remove", "rm", "rename", "set-url", "set-head", "set-branches", "prune", "update")
+)
+
+# Allowlist entries that name a VERSION PROBE, matched as a prefix like every
+# other entry — so a trailing operand was vouched for too. That is not academic:
+# `javac` does not act on `-version` and exit, it prints the version and then
+# compiles whatever else it was handed, so
+#
+#     javac -version -processorpath evil.jar -processor Evil Payload.java
+#
+# auto-approved and ran an annotation processor — ordinary compiled Java on a
+# path the caller supplies, i.e. arbitrary code execution. Reported by #5038,
+# and the highest-severity shape in this family.
+#
+# All five probes are listed, not only `javac`. Whether an interpreter ignores a
+# trailing operand is a property of the installed release rather than of the
+# flag, and JDK single-file source mode (`java Foo.java`) already moved that
+# answer once. A version probe has no legitimate operand, so requiring the exact
+# spelling costs nothing and does not depend on being right about each tool.
+_EXACT_ONLY_BASH_PREFIXES: frozenset[str] = frozenset(
+    (
+        "python --version",
+        "python3 --version",
+        "node --version",
+        "java -version",
+        "javac -version",
+    )
+)
+
+# Flags that change SYSTEM state rather than writing a file: `hostname` renames
+# the host, `date` sets the clock. Both entries are on the read-only allowlist
+# for their bare listing form, and both carry a setter under the same verb.
+#
+# Kept out of `_WRITE_FLAGS` because they must NOT go through `_matched_flag`'s
+# short-option CLUSTER scan, and `date` is the worked example of why: `-s` sets
+# the clock, while `date -Iseconds` is an ordinary read whose attached VALUE
+# contains an `s`. A cluster scan reads that `s` as `-s` and denies the read.
+# `_system_set_flag` prefix-matches the token instead, which `-Iseconds` (a
+# token starting `-I`) cannot satisfy. Reported by #5038, whose comment names
+# the same trap.
+_SYSTEM_SET_FLAGS: dict[str, tuple[str, ...]] = {
+    # `-b`/`--boot` and `-F`/`--file` set the name with no operand at all.
+    # Case is load-bearing: `-F` sets from a file, `-f` prints the FQDN.
+    "hostname": ("-b", "--boot", "-F", "--file"),
+    "date": ("-s", "--set"),
+}
+
+# Verbs whose bare OPERAND changes system state, with no flag involved:
+# `hostname evil-host` renames the host and `date 08221200` sets the clock.
+# `date`'s one legitimate operand is a `+FORMAT` string, which is why the two
+# need different predicates rather than one shared "no operands" rule.
+#
+# The flags here take their value from the FOLLOWING word, so that word is not
+# an operand — without them `date -d yesterday` and `date -r FILE`, both reads,
+# would be denied.
+_SYSTEM_OPERAND_VALUE_FLAGS: dict[str, frozenset[str]] = {
+    "hostname": frozenset(),
+    "date": frozenset(("-d", "--date", "-r", "--reference", "-f", "--file")),
+}
+
+# The SHORT setters as LETTERS, and the letters that consume the rest of their
+# token, because a cluster has to be walked rather than prefix-tested. `-s` sets
+# the clock, and it can arrive anywhere in a cluster: GNU resolves
+# `date -us2026-08-23` to `-u` plus `-s 2026-08-23`, which a test anchored at the
+# token's first character never saw.
+#
+# The value-taking letters are what keeps the walk from reading a VALUE as a flag —
+# the `date -Iseconds` case: `I` takes an optional attached value, so the `s` in
+# `seconds` belongs to that value and the walk stops before it. This is the same
+# distinction, stated per letter, that the note above states per token.
+_SYSTEM_SHORT_SETTERS: dict[str, str] = {"hostname": "bF", "date": "s"}
+_SYSTEM_SHORT_VALUE_TAKING: dict[str, str] = {"hostname": "F", "date": "dfrsI"}
+
+
+def _system_set_flag(verb: str, args: list[str]) -> str:
+    """Return the setter flag *args* supplies for *verb*, or "".
+
+    Prefix-matches the token, so the attached spelling (`--set=…`, `-s2020`) is
+    caught while an unrelated flag whose attached value merely CONTAINS the
+    letter is not. See the note on `_SYSTEM_SET_FLAGS` for why the cluster scan
+    in :func:`_matched_flag` is the wrong tool here.
+
+    A long option is ALSO matched by any unambiguous abbreviation of it, because
+    GNU's own parser resolves one: `date --se=2026-08-23` reaches `--set` and the
+    clock moves, while a plain prefix test on the flag saw nothing. Avoiding the
+    cluster scan is what this function is for — abbreviation is a separate axis,
+    and `_matched_flag` already accepts it for every other table.
+
+    A SHORT setter is found by walking the cluster, because it can sit anywhere in
+    one: GNU resolves `date -us2026-08-23` to `-u` plus `-s 2026-08-23`. The walk
+    stops at the first letter that consumes the rest of the token, which is what
+    keeps `date -Iseconds` a read — the `s` there is part of `I`'s value, not a
+    flag. Avoiding `_matched_flag`'s *undifferentiated* cluster scan is still the
+    point; this one knows which letters take a value.
+    """
+    for tok in args:
+        head = tok.split("=", 1)[0]
+        if len(tok) > 1 and tok[0] == "-" and tok[1] != "-":
+            setters = _SYSTEM_SHORT_SETTERS.get(verb, "")
+            consumes = _SYSTEM_SHORT_VALUE_TAKING.get(verb, "")
+            for ch in tok[1:]:
+                if ch in setters:
+                    return "-" + ch
+                if ch in consumes:
+                    break
+        for flag in _SYSTEM_SET_FLAGS.get(verb, ()):
+            if len(flag) == 2 and flag[0] == "-" and flag[1] != "-":
+                # Short setters are handled by the cluster walk above; matching
+                # them again by prefix here would re-introduce the `-Iseconds`
+                # false positive this function exists to avoid.
+                continue
+            if tok.startswith(flag):
+                return flag
+            # `--` plus at least one character, and a prefix of this flag. Over-
+            # matching can only add a prompt: an abbreviation that is ambiguous
+            # against the tool's OTHER long options is rejected by the tool itself,
+            # so refusing it here costs a command that was never going to run.
+            if (
+                flag.startswith("--")
+                and head.startswith("--")
+                and len(head) > 2
+                and flag.startswith(head)
+            ):
+                return flag
+    return ""
+
+
+def _operands(args: list[str]) -> list[str]:
+    """Operand tokens in *args*, honouring the `--` terminator.
+
+    Before the terminator a leading-dash word is an option; after it EVERY word
+    is an operand however it is spelled. That second half is what
+    `uniq -- input -pwned` turned on: counting only the non-dash words saw one
+    operand and passed a segment that writes `-pwned`.
+    """
+    if "--" in args:
+        cut = args.index("--")
+        return [tok for tok in args[:cut] if not tok.startswith("-")] + args[cut + 1 :]
+    return [tok for tok in args if not tok.startswith("-")]
+
+
+#: Shell expansions whose RESULT is the argument, while ``shlex`` hands this
+#: module the unexpanded text. Every check here is keyed on the token, so where
+#: the two disagree the guard inspects one string and the program receives
+#: another:
+#:
+#:     git diff $'--output=/tmp/pwned'       shlex: `$--output=…`     bash: `--output=…`
+#:     git diff $"--output=/tmp/pwned"       shlex: `$--output=…`     bash: `--output=…`
+#:     git diff ${HOME:+--output=/tmp/pwned} shlex: literal           bash: `--output=…`
+#:     git remote se${x}t-url …              shlex: `se${x}t-url`     bash: `set-url`
+#:     git diff --{out,out}put=/tmp/pwned    shlex: `--{out,out}put=` bash: `--output=…`
+#:
+#: Matched as ONE class rather than one spelling at a time. Closing ``$'`` alone
+#: left ``$"`` (locale translation) and ``${…}`` (parameter expansion) open on the
+#: identical path, and the remaining forms are bounded only by bash's grammar.
+#: Un-expanding them here would mean reimplementing that grammar, so a segment
+#: carrying one is refused instead: a read-only command has no need of any of
+#: them, and a rejected segment falls through to the human approval prompt.
+#:
+#: Brace expansion belongs to the same class even though it carries no ``$``: it
+#: is performed FIRST, before any other expansion, and it can assemble a flag out
+#: of fragments that match nothing here. Only the forms bash actually expands are
+#: matched — a comma list or a ``..`` range — so a lone ``{`` (a JSON argument, a
+#: Go template) is left alone.
+#:
+#: ``$(…)`` and backticks are already refused upstream by ``_UNSAFE_SHELL_RE``;
+#: this covers what that pattern does not reach.
+#:
+#: Positional and special parameters (``$1``, ``$@``, ``$*``, ``$?``, ``$$``,
+#: ``$!``, ``$#``, ``$-``) belong to the same class and are matched by their own
+#: alternative. Their NAME is not an identifier, so the ``$[A-Za-z_]`` branch
+#: above never saw them, and in a `bash -c` string with no positional arguments
+#: ``$@`` and ``$*`` expand to NOTHING — which is what makes them the sharpest
+#: spelling here rather than a curiosity:
+#:
+#:     git remote $@set-url origin …   shlex: `$@set-url`      bash: `set-url`
+#:     git diff $1--output=/tmp/pwned  shlex: `$1--output=…`   bash: `--output=…`
+#:
+#: Matched on the raw segment, so a QUOTED occurrence is refused too even though
+#: bash would not expand it (``grep '*.{js,ts}' f``). That is the same trade the
+#: ``$`` forms already make, and it errs toward the prompt.
+#:
+#: Applied only to a GUARDED verb (see ``_side_effect_reason``). A verb this
+#: module has no table for cannot have a decision subverted by a hidden word,
+#: so ``cat $HOME/.bashrc`` and ``head -20 $LOG`` — the ordinary reads — stay on
+#: the auto-approve path.
+_SHELL_EXPANSION_RE = re.compile(
+    r"\$['\"{]"
+    r"|\$[A-Za-z_][A-Za-z0-9_]*"
+    r"|\$[0-9@*#?$!\-]"
+    r"|\{[^{}\s]*,[^{}\s]*\}"
+    r"|\{[^{}\s]*\.\.[^{}\s]*\}"
+)
+#: Pathname-expansion metacharacters. NOT part of the class above, because a glob
+#: is usually the argument itself in a read-only command (`ls *.py`) — it is
+#: refused only in the positions where the spelling is what gets classified. See
+#: the note in `_side_effect_reason`.
+#:
+#: A leading `~` is deliberately NOT here: tilde expansion yields a path starting
+#: with `/`, so it cannot synthesize a flag or a subcommand.
+_GLOB_META_RE = re.compile(r"[*?\[]")
+
+#: Bash EXTGLOB operators, which synthesize a token the same way an ordinary glob
+#: does — `git diff @(--output=pwned)` matches a file of that name and git writes
+#: it. Reported by #5038, which measured it.
+#:
+#: These get their own regex and their own verdict because `fnmatch` — the test
+#: that makes the plain-glob case precise — does not implement extglob: it reads
+#: `@(` as two literal characters, so `fnmatch("--output", "@(--output")` is False
+#: and the pattern that reaches the flag looks inert. Nothing can be proven about
+#: an extglob token here, so a guarded verb refuses it outright. That is the same
+#: trade the `$`-led forms make, and it costs nothing: unlike a plain glob, an
+#: extglob has no ordinary use in a read-only command.
+#:
+#: Extglob is off by default in a non-interactive `bash -c`, so reaching this needs
+#: `shopt -s extglob` (or a `BASHOPTS` carrying it) AND a matching file — narrower
+#: than the plain-glob case, closed here because it is the same cause.
+_EXTGLOB_RE = re.compile(r"[?*+@!]\(")
+
+#: Every word this module decides on: the flags of all four tables, the
+#: ``git remote`` write subcommands, and the option terminator. A glob is
+#: dangerous exactly when the filesystem can hand the program one of THESE in
+#: place of the pattern, so the test is ``fnmatch`` against this set rather than
+#: "the token contains a metacharacter" — which would have taken `ls *.py` and
+#: `git diff *.py` off the read-only path for no gain.
+_GLOB_SENSITIVE_WORDS: frozenset[str] = (
+    frozenset(
+        flag
+        for table in (_WRITE_FLAGS, _EXEC_FLAGS, _GIT_REF_WRITE_FLAGS)
+        for flags in table.values()
+        for flag in flags
+    )
+    | _GIT_REMOTE_WRITE_SUBCOMMANDS
+    # A glob that expands to `--` shifts every following word into operand
+    # position, which is how the terminator changes what the walk below decides.
+    | frozenset(("--",))
+)
+
+#: Verbs whose OWN tables carry a short flag, so a glob can expand into a bundled
+#: cluster for them (``?uo`` -> ``-uo``, which supplies ``-o``). A cluster is not
+#: a word in the set above, so it takes the extra test in `_glob_hides_word` —
+#: and only here, which is what keeps `git diff *.py` (long flags only) passing.
+#: Derived from the tables so the two cannot drift apart.
+_SHORT_FLAG_VERBS: frozenset[str] = frozenset(
+    key
+    for table in (_WRITE_FLAGS, _EXEC_FLAGS)
+    for key, flags in table.items()
+    if any(len(flag) == 2 and flag[0] == "-" for flag in flags)
+)
+
+
+def _glob_hides_word(token: str, has_short_flags: bool) -> bool:
+    """Whether *token*'s glob can expand into a word this module decides on.
+
+    Two shapes, because a pattern reaches a flag two different ways:
+
+    * it matches a decided word outright — ``s?t-url`` matches ``set-url``,
+      ``--outp?t`` matches ``--output``, ``?o`` matches ``-o``, and a bare ``*``
+      matches every one of them. ``fnmatchcase`` answers this exactly, so a
+      pattern that CANNOT reach one (``*.py``) is left alone;
+    * its metacharacter is the FIRST character, so the filesystem chooses the
+      leading character too and the expansion can be a short-option CLUSTER
+      (``?uo`` -> ``-uo``, which :func:`_matched_flag` reads as supplying ``-o``).
+      A cluster is not a word in the set above, so it needs its own test — but
+      only where the verb HAS a short flag to be bundled into, which keeps
+      ``git diff *.py`` (long flags only) passing.
+
+    An EXTGLOB token short-circuits to True: ``fnmatch`` cannot model extglob, so
+    neither shape below can rule on one. See `_EXTGLOB_RE`.
+    """
+    if _EXTGLOB_RE.search(token):
+        return True
+    if not _GLOB_META_RE.search(token):
+        return False
+    head = token.split("=", 1)[0]
+    # A token that already LOOKS like an option is refused on the metacharacter
+    # alone, without asking what it can match. `fnmatch` answers "can this reach a
+    # decided word", and a short-option CLUSTER is not one of those words, so
+    # `sort -u? victim` slipped: no candidate is three characters long, the
+    # metacharacter is not first so the cluster test below does not fire, and bash
+    # resolves `-u?` against a file named `-uo` — which `_matched_flag` would have
+    # rejected had it ever seen it. Nothing legitimate is lost, because the head is
+    # the flag NAME: a glob in a flag's VALUE is split off above, which is what
+    # keeps `git log --grep=[abc]` a read.
+    if token.startswith("-") and _GLOB_META_RE.search(head):
+        return True
+    # Every word this module decides on, PLUS every abbreviation of a long one,
+    # because `_matched_flag` resolves an abbreviation and so does the parser it
+    # guards. Testing only the full spellings left `git diff ??out=victim`
+    # auto-approved: `fnmatch("--output", "??out")` is False on the length alone,
+    # `git diff`'s table is long-only so the cluster arm below does not fire, and
+    # bash resolves `??out` against a file named `--out` that git then reads as
+    # `--output`. The full spelling `??output` was already refused, which is what
+    # made the gap look closed.
+    if any(_glob_reaches(head, word) for word in _GLOB_SENSITIVE_WORDS):
+        return True
+    return has_short_flags and _GLOB_META_RE.match(token) is not None
+
+
+def _glob_reaches(head: str, word: str) -> bool:
+    """Whether glob *head* can expand to *word* or to an abbreviation of it.
+
+    A long option is abbreviable to any unambiguous prefix, and an ambiguous one
+    is rejected by the tool rather than run — so every prefix of `--` plus one
+    character is tested, and over-matching can only add a prompt.
+
+    Compared CASE-INSENSITIVELY, because `nocaseglob` decouples the pattern's case
+    from the filename's: with it set, `git diff ??OUT=victim` expands to
+    `--out=victim` and git writes the file, while a case-sensitive test saw a
+    pattern matching nothing. Measured — `bash -O nocaseglob -c 'echo git diff
+    ??OUT=victim'` prints `git diff --out=victim`, and plain `bash -c` does not.
+
+    The case sensitivity this module DOES rely on is elsewhere and unaffected:
+    `_matched_flag` still distinguishes `file -C` (compiles a magic file) from
+    `file -c` (prints one), because that reads a literal token rather than asking
+    what a pattern could become.
+    """
+    folded = head.lower()
+    lowered = word.lower()
+    if fnmatch.fnmatchcase(lowered, folded):
+        return True
+    if not word.startswith("--") or len(word) <= 3:
+        return False
+    return any(fnmatch.fnmatchcase(lowered[:cut], folded) for cut in range(3, len(word)))
+
+
+def _matched_flag(tokens: list[str], flags: tuple[str, ...]) -> str:
+    """Return the first token in *tokens* that supplies one of *flags*.
+
+    Matches the flag on its own (``-o``), joined to its value (``--output=x``)
+    and bundled into a short-option cluster (``-uo`` supplies ``-o``), so the
+    check cannot be stepped around by respelling the same flag.
+    """
+    shorts = {f[1] for f in flags if len(f) == 2 and f[0] == "-"}
+    longs = [f for f in flags if f.startswith("--") and len(f) > 2]
+    for tok in tokens:
+        if tok in flags:
+            return tok
+        for flag in flags:
+            if tok.startswith(flag + "="):
+                return flag
+        # A GNU long option may be ABBREVIATED to any unambiguous prefix, so
+        # `--out=FILE` and `--outp=FILE` reach the same `--output` that exact
+        # matching missed. Accept any prefix of a known flag that is at least
+        # `--` plus one character: the parser this guards resolves it, so the
+        # guard has to as well. Over-matching here can only add a prompt.
+        head = tok.split("=", 1)[0]
+        if head.startswith("--") and len(head) > 2:
+            for flag in longs:
+                if flag.startswith(head):
+                    return flag
+        if shorts and len(tok) > 1 and tok[0] == "-" and tok[1] != "-":
+            for ch in tok[1:]:
+                if ch in shorts:
+                    return "-" + ch
+    return ""
+
+
+def _side_effect_reason(segment: str) -> str:
+    """Reason *segment* has a side effect, despite naming a read-only verb.
+
+    Returns "" when the segment is genuinely read-only. Called after the verb
+    has cleared the allowlist, because the allowlist only decides *which
+    program* runs — not what the rest of the command line asks it to do.
+    """
+    try:
+        # Discard-only redirects are scrubbed first, mirroring the unsafe-shell
+        # check upstream, because the exact-match rule below would otherwise read
+        # one as a trailing operand. `java -version 2>&1` is the canonical probe —
+        # java prints its version to stderr — so counting `2>&1` as an operand
+        # would deny the single most common read on this path.
+        tokens = shlex.split(_DEVNULL_REDIR_RE.sub(" ", segment))
+    except ValueError:
+        # Cannot recover argv, so cannot vouch for the operands.
+        return "quoting cannot be resolved"
+    if not tokens:
+        return ""
+    # A version probe acts on an operand, so its entry matches EXACTLY: the
+    # allowlist named `javac -version`, the prefix match vouched for everything
+    # after it, and javac compiled it. See `_EXACT_ONLY_BASH_PREFIXES`.
+    spelled = " ".join(tokens).lower()
+    for probe in _EXACT_ONLY_BASH_PREFIXES:
+        if spelled.startswith(probe + " "):
+            return f"'{probe}' takes no operand, and acts on one when given it"
+    # The verb is matched case-insensitively, like the allowlist does, so an
+    # unusual spelling cannot step past the table. Flags keep their case,
+    # because for these programs the case carries the meaning.
+    verb = tokens[0].rsplit("/", 1)[-1].lower()
+    args = tokens[1:]
+
+    # Whether an unexpanded word can subvert THIS segment's classification.
+    #
+    # Every check below is keyed on a table, so a verb with no table has no
+    # decision to subvert: whatever `cat $HOME/.bashrc` expands to, this
+    # function was always going to return "". Refusing an expansion there buys
+    # nothing and costs the most ordinary read on the auto-approve path, so the
+    # refusal is scoped to the verbs whose arguments this module reads.
+    #
+    # `git` is guarded whatever the subcommand, because the subcommand itself is
+    # a decided word: `git $x` reaches bash as `git branch -D release`.
+    #
+    # `hostname` and `date` are guarded through `_SYSTEM_OPERAND_VALUE_FLAGS`
+    # rather than a flag table, because their rule is an OPERAND rule: an
+    # unexpanded word IS the decision there, so `hostname $EVIL` renames the host
+    # under a spelling this module read as harmless.
+    guarded = (
+        verb in ("git", "uniq")
+        or verb in _WRITE_FLAGS
+        or verb in _EXEC_FLAGS
+        or verb in _SYSTEM_OPERAND_VALUE_FLAGS
+    )
+
+    # ANSI-C quoting is stripped by `shlex` but honoured by bash, so the token
+    # this check inspects is not the token the shell runs: `git diff $'-o'` reaches
+    # `shlex` as `$-o` — matching no flag — while bash passes `-o`. The same trick
+    # hides a subcommand (`git remote $'set-url'`), and a positional or special
+    # parameter does it with no quoting at all — `git remote $@set-url …`, where
+    # `$@` expands to nothing in a `bash -c` string. It is a spelling with no
+    # legitimate use in a read-only command, so the segment is refused outright
+    # rather than un-quoted here, which would mean reimplementing bash's rules.
+    if guarded and _SHELL_EXPANSION_RE.search(segment):
+        return "a shell expansion hides the real argument"
+
+    # Pathname expansion cannot be refused wholesale: a glob usually IS the
+    # argument — `ls *.py`, `grep -rn TODO src/*` — so the question is whether
+    # THIS pattern can reach a word this module decides on. `_glob_hides_word`
+    # answers it with `fnmatch`, which is what keeps the ordinary forms passing:
+    #
+    #     git remote s?t-url origin https://evil   (a file named `set-url` nearby)
+    #     git diff --outp?t=/tmp/pwned
+    #     cat f | sort ?o victim                   (a file named `-o` nearby)
+    #
+    # The last one is why a leading-dash test is not enough. `?o` does not start
+    # with `-`, so a test keyed on the spelling skipped it, bash resolved it to
+    # `-o`, and `sort` truncated `victim` under an auto-approval.
+    if guarded:
+        has_short_flags = verb in _SHORT_FLAG_VERBS or (
+            verb == "git" and bool(args) and args[0].lower() in _GIT_REF_WRITE_FLAGS
+        )
+        for token in args:
+            if _glob_hides_word(token, has_short_flags):
+                return "a glob could expand into a flag or subcommand"
+
+    # The allowlist names `git <subcommand>`, so that is the unit to key on.
+    key = verb
+    if verb == "git" and args:
+        subcommand = args[0].lower()
+        key = f"git {subcommand}"
+        args = args[1:]
+
+        if subcommand in _GIT_REF_WRITE_FLAGS:
+            hit = _matched_flag(args, _GIT_REF_WRITE_FLAGS[subcommand])
+            if hit:
+                return f"'git {subcommand} {hit}' changes a ref"
+            # A bare operand names a ref to create, unless the command is in list
+            # mode (where it is a pattern) or the operand is a required flag value.
+            #
+            # List mode is decided over the whole argument list, because the
+            # selecting flag can come after the operand it makes into a pattern:
+            # `git branch newbranch --list` is still a list. It must stop at `--`,
+            # though: after the terminator a word spelled like a flag is an
+            # operand, so `git tag -- --list` CREATES the ref `--list` while
+            # reading that `--list` as list mode passed it off as a read.
+            options = args[: args.index("--")] if "--" in args else args
+            list_shorts = _GIT_REF_LIST_SHORTS.get(subcommand, "")
+            # A required flag's VALUE is not an option, however it is spelled. git
+            # takes it from the following word, so `git branch --format -l newbranch`
+            # hands `-l` to `--format` and never sees a list flag — while scanning
+            # every token read that `-l` as one, and the bare operand it then
+            # licensed created the branch. The walk below already tracks this for
+            # operands; list mode has to track it too, over the same tokens.
+            selectors: list[str] = []
+            consumed = ""
+            for tok in options:
+                if _consumes_next_word(consumed):
+                    # A glob HERE decides by COUNT, not by what it becomes: under
+                    # `nullglob` an unmatched pattern vanishes, so the flag eats the
+                    # NEXT word instead and every later position shifts by one.
+                    # `git branch --format nomatch* --list newbranch` loses the
+                    # format's value, `--format` takes `--list`, and `newbranch`
+                    # stops being a pattern. See `_glob_shifts_arguments`.
+                    if _glob_shifts_arguments(tok):
+                        return "a glob in a required option's value shifts the arguments"
+                    consumed = ""
+                    continue
+                if tok.startswith("-"):
+                    # An ATTACHED value takes nothing from the next word.
+                    consumed = "" if "=" in tok else tok
+                    selectors.append(tok)
+                    continue
+                consumed = ""
+            list_mode = any(
+                tok.split("=", 1)[0] in _GIT_REF_LIST_FLAGS
+                or (
+                    len(tok) > 1
+                    and tok[0] == "-"
+                    and tok[1] != "-"
+                    # EVERY character of the cluster must be a list letter or a
+                    # digit, not merely one of them. `any` read an attached VALUE
+                    # as part of the cluster, which is the same trap the note on
+                    # `_SYSTEM_SET_FLAGS` records for `date -Iseconds`: the `l` in
+                    # `git tag -ulin@kiro.co` selected list mode and the bare
+                    # operand it then licensed created a signed tag. A digit is
+                    # allowed because `-n` carries an optional count (`-n5`).
+                    #
+                    # A MIXED cluster (`-lv`) is no longer a listing here and falls
+                    # through to the prompt. That is the intended trade: the letter
+                    # this cannot distinguish from a value is exactly the letter a
+                    # write flag arrives on, and the ordinary spellings — a separate
+                    # `-l`, `--list`, or `-n5` — are unaffected.
+                    and all(ch in list_shorts or ch.isdigit() for ch in tok[1:])
+                )
+                for tok in selectors
+            )
+            # A `--no-list` anywhere in the span undoes it, and the operand it was
+            # protecting becomes a ref to create. Applied AFTER the scan and
+            # unconditionally, rather than as git's last-wins: cancelling can only
+            # move an operand toward the prompt, so being coarse here is the safe
+            # direction. See `_GIT_REF_LIST_CANCEL_FLAGS` for what was measured.
+            if list_mode and any(_cancels_list_mode(tok, subcommand) for tok in selectors):
+                list_mode = False
+            previous = ""
+            operand_only = False
+            for tok in args:
+                # `--` ends the options. Everything after it is an operand, however
+                # it is spelled: `git tag -- -z` creates the tag `-z`, while a
+                # leading-dash test read it as one more option and passed. A SECOND
+                # `--` is itself an operand, so the terminator is consumed once.
+                if tok == "--" and not operand_only:
+                    operand_only = True
+                    previous = ""
+                    continue
+                if not operand_only and tok.startswith("-"):
+                    # An ATTACHED value (`--sort=x`) takes nothing from the next
+                    # word, so it must not mark the following operand as consumed.
+                    previous = "" if "=" in tok else tok
+                    continue
+                if _consumes_next_word(previous):
+                    previous = ""
+                    continue
+                if list_mode:
+                    continue
+                return f"'git {subcommand} {tok}' creates a ref"
+
+        if subcommand == "remote":
+            # `git remote -v set-url …` puts an option BEFORE the subcommand, and
+            # git accepts it there. Keying on `args[0]` therefore saw `-v` and let
+            # the mutation through, so the leading options are skipped and the
+            # first non-option word is the subcommand — the same token git uses.
+            for tok in args:
+                if tok.startswith("-"):
+                    continue
+                if tok in _GIT_REMOTE_WRITE_SUBCOMMANDS:
+                    return f"'git remote {tok}' rewrites remote configuration"
+                # A glob HERE, even one that reaches no decided word, because this
+                # loop stops at the first non-option token and `nullglob` can make
+                # a token VANISH: with it exported, `git remote nomatch* set-url
+                # origin …` loses `nomatch*` entirely and git receives `set-url` —
+                # while this loop broke on the pattern and never looked further.
+                #
+                # `_glob_hides_word` above cannot cover it: that test asks whether
+                # the pattern can EXPAND INTO a decided word, and `nomatch*` cannot
+                # — the mutation comes from the token disappearing, not from what it
+                # becomes. Removing this check on the grounds that the general test
+                # subsumed it is what opened the hole.
+                if _GLOB_META_RE.search(tok) or _EXTGLOB_RE.search(tok):
+                    return "a glob in the subcommand hides the real argument"
+                # Likewise an expansion: `guarded` refuses those for `git` before
+                # this point, so reaching here with one is impossible — but the
+                # subcommand position is load-bearing enough to state rather than
+                # infer.
+                if _SHELL_EXPANSION_RE.search(tok):
+                    return "a shell expansion hides the real argument"
+                break
+
+    hit = _matched_flag(args, _WRITE_FLAGS.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' writes a file"
+    hit = _matched_flag(args, _EXEC_FLAGS.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' runs a program named by the repository"
+
+    # `uniq INPUT OUTPUT` writes its second operand. `--` ends the options here
+    # too, so a word after it is an operand however it is spelled:
+    # `uniq -- input -pwned` writes `-pwned`, while a leading-dash test counted
+    # one operand and passed the segment as a read.
+    if verb == "uniq":
+        operands = _operands(args)
+        # Counting the tokens is only sound if each one stays ONE word. A glob
+        # here decides by count: with `in1` and `in2` present, `uniq in*` runs
+        # `uniq in1 in2`, and the second operand is the OUTPUT file — so a single
+        # pattern passed a segment that truncates a file. `uniq`'s operands are
+        # positional, which is what makes this different from `ls *.py`.
+        if any(_glob_shifts_arguments(tok) for tok in operands):
+            return "a glob in a 'uniq' operand can expand into a second operand, which it writes"
+        if len(operands) > 1:
+            return "'uniq INPUT OUTPUT' writes its second operand"
+
+    # `hostname` and `date` each carry a SYSTEM-state setter under a verb whose
+    # bare form is a listing, so the prefix match vouched for the setter too.
+    hit = _system_set_flag(verb, args)
+    if hit:
+        changes = "renames the host" if verb == "hostname" else "sets the system clock"
+        return f"'{verb} {hit}' {changes}"
+
+    # Both also change state through a BARE OPERAND, with no flag at all —
+    # `hostname evil-host` and `date 08221200` (which fails only on privilege,
+    # not on parsing). Their legitimate operands differ, so the predicate does
+    # too: every `hostname` read form is flag-only, while `date`'s one operand
+    # is a `+FORMAT` string.
+    if verb in _SYSTEM_OPERAND_VALUE_FLAGS:
+        value_flags = _SYSTEM_OPERAND_VALUE_FLAGS[verb]
+        previous = ""
+        operand_only = False
+        for tok in args:
+            # `--` ends the options here for the same reason it does for a ref:
+            # after it, `hostname -- -evil` names the host `-evil`, and a
+            # leading-dash test read that as one more option and passed it.
+            if tok == "--" and not operand_only:
+                operand_only = True
+                previous = ""
+                continue
+            if not operand_only and tok.startswith("-"):
+                # Whether a flag takes the FOLLOWING word depends on its form,
+                # and long and short disagree. A long option consumes the next
+                # word unless the value is attached with `=`, so
+                # `date --date yesterday` is a read. A short option consumes it
+                # only when the token is the bare flag: `-Iseconds` carries its
+                # own value, so reading it as `-I` + a separate operand would
+                # deny that read.
+                if tok.startswith("--"):
+                    previous = "" if "=" in tok else tok
+                else:
+                    previous = tok if len(tok) == 2 else ""
+                continue
+            if previous in value_flags:
+                previous = ""
+                continue
+            previous = ""
+            if verb == "date":
+                if tok.startswith("+"):
+                    continue
+                return "'date <operand>' sets the system clock unless it is a +FORMAT string"
+            return f"'{verb} <operand>' sets the hostname; every read form is flag-only"
+
+    return ""
+
+
 def _classify_bash(cmd: str) -> str:
     """Single source of truth for read-only bash classification.
 
@@ -609,17 +1500,55 @@ def _classify_bash(cmd: str) -> str:
         pipe_parts = [p.strip() for p in part.split("|") if p.strip()]
         if not pipe_parts:
             return "unsafe shell pattern"
-        first = pipe_parts[0].strip().lower()
+        # The verb is compared case-insensitively, but the side-effect check
+        # below needs the original spelling: flags are case-sensitive, and the
+        # two cases can mean opposite things (`file -C` compiles a magic file,
+        # `file -c` only prints one).
+        head = pipe_parts[0].strip()
+        first = head.lower()
         if not (
             _is_help_probe(first)
             or any(first == p or first.startswith(p + " ") for p in _READ_ONLY_BASH_PREFIXES)
         ):
             base = first.split()[0] if first.split() else first
             return f"command '{base}' is not on the read-only allowlist"
+        # Clearing the allowlist only settles which program runs. The rest of
+        # the command line can still write a file, change a ref or start
+        # another program.
+        side_effect = _side_effect_reason(head)
+        if side_effect:
+            return f"not read-only: {side_effect}"
         for target in pipe_parts[1:]:
-            if not _READ_ONLY_PIPE_RE.match(target):
+            matched = _READ_ONLY_PIPE_RE.match(target)
+            if not matched:
                 tgt = target.split()[0] if target.split() else target
                 return f"pipe target '{tgt}' is not a read-only filter"
+            # The name the allowlist matched must be the program bash actually
+            # runs. `_READ_ONLY_PIPE_RE` ends its filter name at a `\b`, and `$`
+            # satisfies that, so `sort$IFS-o victim` matched the entry `sort` while
+            # bash split `$IFS` into whitespace and ran `sort -o victim`. Nothing
+            # downstream recovered: `_side_effect_reason` reads the verb as
+            # `sort$ifs-o`, finds no table for it, and returns "".
+            #
+            # The leading segment of a pipeline was never exposed to this, because
+            # its allowlist test pins the boundary to a literal space
+            # (`first == p or first.startswith(p + " ")`). This makes the pipe
+            # allowlist say the same thing: the first argv word, exactly.
+            try:
+                target_tokens = shlex.split(target)
+            except ValueError:
+                return "pipe target quoting cannot be resolved"
+            if not target_tokens or target_tokens[0] != matched.group(1):
+                tgt = target_tokens[0] if target_tokens else target
+                return (
+                    f"pipe target '{tgt}' is not the read-only filter "
+                    f"'{matched.group(1)}' it matched"
+                )
+            # The pipe allowlist matches only the leading verb, so a filter's
+            # own output flag (`sort -o FILE`) needs the same check.
+            side_effect = _side_effect_reason(target)
+            if side_effect:
+                return f"pipe target is not read-only: {side_effect}"
     return ""
 
 

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -319,6 +319,849 @@ class TestIsReadOnlyBash:
         # An option, not a bare subcommand, in the middle.
         assert is_read_only_bash("some-tool -f /etc/shadow --help") is False
 
+    def test_allowlisted_verb_may_not_write_via_its_own_output_flag(self):
+        """A write does not need a shell redirect to be a write.
+
+        `_UNSAFE_SHELL_RE` only sees `>`, so a program's own output flag
+        reached the filesystem while the command still classified read-only.
+        """
+        assert is_read_only_bash("tree -o /tmp/pwned") is False
+        assert is_read_only_bash("git diff --output=/tmp/pwned") is False
+        assert is_read_only_bash("git show --output=/tmp/pwned") is False
+        assert is_read_only_bash("git log --output=/tmp/pwned") is False
+        # `file -C` compiles a magic file; `file -c` only prints one.
+        assert is_read_only_bash("file -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("file -c") is True
+
+    def test_pipe_target_may_not_write_via_its_own_output_flag(self):
+        """The pipe allowlist matched only the filter's leading verb."""
+        assert is_read_only_bash("cat f | sort -o /tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort --output=/tmp/pwned") is False
+        # Bundled short cluster supplies the same flag.
+        assert is_read_only_bash("cat f | sort -uo /tmp/pwned") is False
+        # `uniq INPUT OUTPUT` writes its second operand.
+        assert is_read_only_bash("cat f | uniq /tmp/in /tmp/pwned") is False
+        # The read-only spellings of the same filters still pass.
+        assert is_read_only_bash("cat f | sort") is True
+        assert is_read_only_bash("cat f | sort -u") is True
+        assert is_read_only_bash("cat f | uniq -c") is True
+
+    def test_allowlisted_git_verb_may_not_change_a_ref_or_remote(self):
+        """`git branch`/`git tag`/`git remote` have read and write modes.
+
+        The allowlist entries are the listing forms, but a prefix match
+        admitted the destructive spellings under the same verb.
+        """
+        # Ref deletion, rename and copy.
+        assert is_read_only_bash("git branch -D release") is False
+        assert is_read_only_bash("git branch -d release") is False
+        assert is_read_only_bash("git branch -m main hijacked") is False
+        # A bare operand names a ref to create.
+        assert is_read_only_bash("git branch newbranch") is False
+        assert is_read_only_bash("git tag sometag") is False
+        assert is_read_only_bash("git tag -d v1.0.0") is False
+        assert is_read_only_bash("git tag -m msg v1.0.0") is False
+        # Remote configuration: `set-url` repoints where pushes go.
+        assert is_read_only_bash("git remote set-url origin https://evil.example/x.git") is False
+        assert is_read_only_bash("git remote add evil https://evil.example/x.git") is False
+        assert is_read_only_bash("git remote remove origin") is False
+        assert is_read_only_bash("git remote rename origin upstream") is False
+
+    def test_allowlisted_git_verb_may_not_launch_an_editor_or_diff_driver(self):
+        """Both spellings hand control to a program the caller did not name."""
+        # `--edit-description` always opens $EDITOR.
+        assert is_read_only_bash("git branch --edit-description") is False
+        # An external diff driver comes from repo config / .gitattributes.
+        assert is_read_only_bash("git diff --ext-diff") is False
+        assert is_read_only_bash("git log --ext-diff") is False
+
+    def test_read_only_git_inspection_still_auto_approves(self):
+        """The listing and inspection forms must not regress into a prompt."""
+        assert is_read_only_bash("git branch") is True
+        assert is_read_only_bash("git branch -a") is True
+        assert is_read_only_bash("git branch -vv") is True
+        assert is_read_only_bash("git branch --list") is True
+        assert is_read_only_bash("git branch --show-current") is True
+        assert is_read_only_bash("git branch --merged") is True
+        # A bare operand that is the value of a read-only flag is not a new ref.
+        assert is_read_only_bash("git branch --contains HEAD") is True
+        assert is_read_only_bash("git tag") is True
+        assert is_read_only_bash("git tag -l") is True
+        assert is_read_only_bash("git tag -l v1.*") is True
+        assert is_read_only_bash("git remote") is True
+        assert is_read_only_bash("git remote -v") is True
+        assert is_read_only_bash("git remote get-url origin") is True
+
+    def test_side_effect_check_is_case_insensitive_on_the_verb_only(self):
+        """The verb is matched like the allowlist does; flags keep their case.
+
+        The allowlist lowercases before comparing, so an odd verb spelling
+        clears it — the side-effect table has to fold the verb the same way,
+        while `-C` and `-c` must stay distinct.
+        """
+        assert is_read_only_bash("FILE -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("GIT BRANCH -D release") is False
+        assert is_read_only_bash("ls -o") is True
+        assert is_read_only_bash("grep -o pattern file") is True
+
+    def test_an_abbreviated_long_option_still_matches(self):
+        """GNU resolves any unambiguous prefix, so exact matching missed the flag.
+
+        `git diff --out=FILE` reaches the same `--output` as the full spelling and
+        writes the file, while the check compared against `--output` alone.
+        """
+        assert is_read_only_bash("git diff --output=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --outp=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --out=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --o=/tmp/pwned") is False
+        assert is_read_only_bash("git branch --edit-desc") is False
+        assert is_read_only_bash("git branch --ed") is False
+        # A prefix of no known write flag is untouched: these stay read-only.
+        assert is_read_only_bash("git diff --stat") is True
+        assert is_read_only_bash("git diff --name-only") is True
+        assert is_read_only_bash("git branch --contains HEAD") is True
+
+    def test_a_shell_expansion_in_the_arguments_is_refused(self):
+        """bash expands these; `shlex` does not, so the two see different argv.
+
+        Matched as one CLASS, not one spelling. Closing `$'…'` alone left the
+        siblings open on the identical path: `$"…"` is locale translation and
+        `${…}` is parameter expansion, and both let the real flag or subcommand
+        appear only after bash is done with it. Un-expanding them here would mean
+        reimplementing bash's grammar, so a segment carrying one is refused.
+        """
+        # ANSI-C quoting.
+        assert is_read_only_bash("git diff $'-o' /tmp/pwned") is False
+        assert is_read_only_bash("git diff $'--output=/tmp/pwned'") is False
+        assert is_read_only_bash("git remote $'set-url' origin https://evil") is False
+        # Locale translation — the sibling form.
+        assert is_read_only_bash('git diff $"--output=/tmp/pwned"') is False
+        assert is_read_only_bash('git remote $"set-url" origin https://evil') is False
+        # Parameter expansion, including one spliced INSIDE a word.
+        assert is_read_only_bash("git diff ${HOME:+--output=/tmp/pwned}") is False
+        assert is_read_only_bash("git remote ${x:-set-url} origin https://evil") is False
+        assert is_read_only_bash("git remote se${x}t-url origin https://evil") is False
+        assert is_read_only_bash("git branch ${x:--D} release") is False
+        # A bare variable reference is the same divergence.
+        assert is_read_only_bash("git diff $FLAG") is False
+        # Ordinary quoting is unaffected — only the `$`-led forms are.
+        assert is_read_only_bash("git tag -l 'v1.*'") is True
+        assert is_read_only_bash('grep -n "pattern" file') is True
+
+    def test_a_pipe_target_and_git_cat_file_cannot_write_or_exec(self):
+        """The pipe-target check runs the same tables, so their gaps are reachable.
+
+        `less` is not on the prefix allowlist, so it cannot lead a segment — but
+        `cat f | less -O FILE` writes FILE from a segment whose leading verb is a
+        read. `git cat-file --filters` hands off to the filter named by the
+        repository's `.gitattributes`, and `sort --compress-program` to a program
+        of the caller's choosing.
+        """
+        assert is_read_only_bash("cat f | less -O /tmp/pwned") is False
+        assert is_read_only_bash("cat f | less --log-file=/tmp/pwned") is False
+        assert is_read_only_bash("git cat-file --filters HEAD:f") is False
+        assert is_read_only_bash("git cat-file --textconv HEAD:f") is False
+        # The read forms still pass.
+        assert is_read_only_bash("cat f | less") is True
+        assert is_read_only_bash("git cat-file -p HEAD:f") is True
+
+    def test_a_leading_option_does_not_hide_a_git_remote_subcommand(self):
+        """git accepts an option BEFORE the subcommand, so `args[0]` is not it.
+
+        `git remote -v set-url …` repointed the remote because the check read `-v`
+        as the subcommand and found it harmless. The leading options are skipped so
+        the first non-option word is the one git acts on.
+        """
+        assert is_read_only_bash("git remote -v set-url origin https://evil") is False
+        assert is_read_only_bash("git remote --verbose add evil https://evil") is False
+        assert is_read_only_bash("git remote -v remove origin") is False
+        assert is_read_only_bash("git remote -v rename a b") is False
+        # The listing forms, which is what the option is normally used for.
+        assert is_read_only_bash("git remote -v") is True
+        assert is_read_only_bash("git remote --verbose") is True
+        assert is_read_only_bash("git remote") is True
+
+    def test_brace_expansion_can_assemble_a_flag_out_of_fragments(self):
+        """Brace expansion runs FIRST and carries no `$`, so the `$`-led class missed it.
+
+        `git diff --{out,out}put=/tmp/pwned` reaches this module as one token that
+        matches no flag, while bash hands git `--output=…` twice and the file is
+        truncated. Only the forms bash actually expands are refused — a comma list
+        or a `..` range — so a lone brace is still allowed through.
+        """
+        assert is_read_only_bash("git diff --{out,out}put=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --outpu{t,t}=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --output{,}=/tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort -{o,o} /tmp/pwned") is False
+        # A range, the other expanding form.
+        assert is_read_only_bash("git log --{a..z}") is False
+        # A brace that bash does not expand is not this class.
+        assert is_read_only_bash("git log --format={hash}") is True
+        assert is_read_only_bash('grep -n "{}" file') is True
+
+    def test_a_glob_is_refused_only_where_the_spelling_is_classified(self):
+        """Pathname expansion is the one expansion that cannot be refused wholesale.
+
+        A glob usually IS the argument in a read-only command, so refusing the
+        character outright would take `ls *.py` and `grep -rn TODO src/*` off this
+        path. It still has to go where the SPELLING is what gets classified — the
+        subcommand and a flag NAME — because there bash resolves it against the
+        filesystem and hands the program a word this module never saw.
+        """
+        # The subcommand, including `git remote`'s own subcommand word.
+        assert is_read_only_bash("git remote s?t-url origin https://evil") is False
+        assert is_read_only_bash("git remote se[t]-url origin https://evil") is False
+        assert is_read_only_bash("git remote *et-url origin https://evil") is False
+        assert is_read_only_bash("git remote -v s?t-url origin https://evil") is False
+        # A flag name.
+        assert is_read_only_bash("git diff --outp?t=/tmp/pwned") is False
+        assert is_read_only_bash("git diff --outp[u]t=/tmp/pwned") is False
+        assert is_read_only_bash("cat f | sort --out?ut=/tmp/pwned") is False
+        # A glob in an OPERAND is the ordinary case and must keep working.
+        assert is_read_only_bash("ls *.py") is True
+        assert is_read_only_bash("grep -rn TODO src/*") is True
+        assert is_read_only_bash("cat *.log") is True
+        assert is_read_only_bash("wc -l *.md") is True
+        assert is_read_only_bash("ls file?.txt") is True
+        assert is_read_only_bash("grep 'a[bc]d' file") is True
+        assert is_read_only_bash("git diff -- src/*") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+        # A flag's VALUE is left alone too — only its name is classified.
+        assert is_read_only_bash("git log --grep=[abc]") is True
+
+    def test_a_lesskey_file_is_an_indirect_code_execution_path(self):
+        """`less -k` loads a lesskey file, and a lesskey file can set `LESSOPEN`.
+
+        less treats `LESSOPEN` as an input PREPROCESSOR and runs it, so a
+        checkout-supplied lesskey is arbitrary command execution two steps removed
+        from anything on the command line — which is why `--filter` alone did not
+        cover it. Verified against `less --help` on less 608: `-k [file]` /
+        `--lesskey-file=[file]`, plus `--lesskey-src` on newer builds.
+
+        Case is load-bearing, as it is for `file -C`: lowercase `-k` loads the
+        keyfile, uppercase `-K` is `--quit-on-intr` and an ordinary read.
+        """
+        assert is_read_only_bash("cat f | less -k evil.lesskey") is False
+        assert is_read_only_bash("cat f | less -kevil.lesskey") is False
+        assert is_read_only_bash("cat f | less -Nk evil.lesskey") is False
+        assert is_read_only_bash("cat f | less --lesskey-file=evil.lesskey") is False
+        assert is_read_only_bash("cat f | less --lesskey-src=evil.lesskey") is False
+        assert is_read_only_bash("cat f | less --lesskey=evil.lesskey") is False
+        # The paging reads, including the uppercase twin and the clusters.
+        assert is_read_only_bash("cat f | less") is True
+        assert is_read_only_bash("cat f | less -K") is True
+        assert is_read_only_bash("cat f | less -Ki") is True
+        assert is_read_only_bash("cat f | less -NSR") is True
+        assert is_read_only_bash("cat f | less --no-lessopen") is True
+
+    def test_tree_writes_without_being_given_a_filename(self):
+        """`tree -R` names the output file itself, so a filename-bearing flag missed it.
+
+        tree re-runs itself in each directory it descends into, adding
+        `-o 00Tree.html` every time. Same write as `-o`, one step removed.
+        """
+        assert is_read_only_bash("tree -L 1 -R .") is False
+        assert is_read_only_bash("tree -aR .") is False
+        # The ordinary listing forms still pass.
+        assert is_read_only_bash("tree -L 2 .") is True
+        assert is_read_only_bash("tree") is True
+
+    def test_textconv_hands_off_the_same_way_ext_diff_does(self):
+        """`--textconv` selects a program from config, exactly as `--ext-diff` does.
+
+        The table listed it for `git cat-file` and not for `git diff`/`show`/`log`,
+        so the identical hand-off was open on the three most-used spellings.
+
+        Scope: this stops the COMMAND LINE from selecting the program. A textconv
+        driver the user configured is still applied by default, because that name
+        comes from git config rather than from the repository, and requiring
+        `--no-textconv` would take plain `git diff` off the read-only path.
+        """
+        assert is_read_only_bash("git diff --textconv HEAD") is False
+        assert is_read_only_bash("git show --textconv HEAD") is False
+        assert is_read_only_bash("git log --textconv") is False
+        # The default spellings stay read-only.
+        assert is_read_only_bash("git diff") is True
+        assert is_read_only_bash("git diff HEAD") is True
+        assert is_read_only_bash("git log --oneline -n 20") is True
+
+    def test_an_optional_flag_value_does_not_swallow_a_ref_name(self):
+        """git takes a separate word only for a REQUIRED argument.
+
+        `--color` takes an optional one, which git accepts only when attached with
+        `=`. Reading `newbranch` as the colour meant `git branch --color newbranch`
+        created the ref and the segment passed. List mode is tracked separately, so
+        `git branch --list newbranch` is still the read it is.
+        """
+        assert is_read_only_bash("git branch --color newbranch") is False
+        assert is_read_only_bash("git branch --color=always newbranch") is False
+        assert is_read_only_bash("git tag --color newtag") is False
+        # A required-argument flag does consume the next word.
+        assert is_read_only_bash("git branch --points-at HEAD") is True
+        assert is_read_only_bash("git branch --format %(refname) --list") is True
+        assert is_read_only_bash("git branch --sort=refname --list") is True
+        # List mode: the operand is a pattern, not a ref to create.
+        assert is_read_only_bash("git branch --list newbranch") is True
+        assert is_read_only_bash("git tag -l 'v1*'") is True
+        assert is_read_only_bash("git branch --contains HEAD") is True
+
+    def test_the_option_terminator_makes_everything_after_it_an_operand(self):
+        """`git tag -- -z` creates the tag `-z`.
+
+        Classifying by a leading dash read `-z` as one more option, so the operand
+        that names the ref was never seen.
+        """
+        assert is_read_only_bash("git tag -- -z") is False
+        assert is_read_only_bash("git branch -- -z") is False
+        assert is_read_only_bash("git tag -- v9") is False
+        # `--` with nothing after it names no ref.
+        assert is_read_only_bash("git tag --") is True
+        assert is_read_only_bash("git branch --") is True
+
+    def test_a_glob_can_expand_into_a_flag_it_does_not_look_like(self):
+        """`?o` does not start with `-`, and bash hands the program `-o`.
+
+        Refusing a glob only in a token that ALREADY looks like a flag name read
+        the spelling instead of the expansion, so `cat f | sort ?o victim` — with
+        a file named `-o` in the checkout, which a repository can carry — passed
+        as a read while `sort` truncated `victim`. The test is now whether the
+        pattern can MATCH a word this module decides on, which is also what keeps
+        `ls *.py` and `git diff *.py` on the auto-approve path.
+        """
+        # A glob that resolves to a write flag, and to a short-option cluster
+        # supplying one (`-uo` supplies `-o`).
+        assert is_read_only_bash("cat f | sort ?o victim") is False
+        assert is_read_only_bash("cat f | sort ?uo victim") is False
+        assert is_read_only_bash("cat f | sort [-]o victim") is False
+        assert is_read_only_bash("tree ?o /tmp/pwned") is False
+        assert is_read_only_bash("file ?C -m /tmp/magic.src") is False
+        assert is_read_only_bash("git branch ?D release") is False
+        # A bare `*` matches every one of them, so it cannot be vouched for
+        # where a short flag exists to be matched.
+        assert is_read_only_bash("cat f | sort *") is False
+        assert is_read_only_bash("git branch *") is False
+        # A pattern that CANNOT reach a decided word is left alone — that is the
+        # whole point of testing the expansion rather than the character.
+        assert is_read_only_bash("git diff *.py") is True
+        assert is_read_only_bash("git diff -- src/*") is True
+        assert is_read_only_bash("ls *.py") is True
+        assert is_read_only_bash("cat *.log") is True
+        assert is_read_only_bash("grep -rn TODO src/*") is True
+
+    def test_the_option_terminator_does_not_hide_a_ref_or_an_operand(self):
+        """`--` ends the options, so a word after it is an operand however spelled.
+
+        Two shapes slipped through. List mode was decided over the WHOLE argument
+        list, so the `--list` in `git tag -- --list` was read as "this is a
+        listing" when git creates a ref by that name. And `uniq`'s operand count
+        skipped every leading-dash word, so `uniq -- input -pwned` counted one
+        operand and wrote `-pwned`.
+        """
+        # A flag spelling after the terminator names a ref.
+        assert is_read_only_bash("git tag -- --list") is False
+        assert is_read_only_bash("git tag -- -l") is False
+        assert is_read_only_bash("git branch -- --merged") is False
+        assert is_read_only_bash("git branch -- --contains") is False
+        # A second `--` is itself an operand, so the terminator is consumed once.
+        assert is_read_only_bash("git tag -- --") is False
+        # `uniq`'s second operand is its OUTPUT file, terminator or not.
+        assert is_read_only_bash("cat f | uniq -- input -pwned") is False
+        assert is_read_only_bash("cat f | uniq -- -in -pwned") is False
+        # A selecting flag BEFORE the terminator is still a listing.
+        assert is_read_only_bash("git tag -l -- 'v1.*'") is True
+        assert is_read_only_bash("git branch --list -- 'feat/*'") is True
+        # One operand after the terminator is the input, and reads.
+        assert is_read_only_bash("cat f | uniq -- input") is True
+
+    def test_a_positional_or_special_parameter_hides_the_real_argument(self):
+        """`$@` and `$1` are expansions whose NAME is not an identifier.
+
+        The `$`-led class was keyed on `$` followed by a quote, a brace or an
+        identifier character, so the positional and special parameters were the
+        one sibling left open on the identical path — and the sharpest, because in
+        a `bash -c` string with no positional arguments `$@` and `$*` expand to
+        NOTHING: `git remote $@set-url origin …` reaches this module as the token
+        `$@set-url`, matching no subcommand, and reaches git as `set-url`.
+        """
+        assert is_read_only_bash("git remote $@set-url origin https://evil") is False
+        assert is_read_only_bash("git remote $*set-url origin https://evil") is False
+        assert is_read_only_bash("git remote $1set-url origin https://evil") is False
+        assert is_read_only_bash("git diff $1--output=/tmp/pwned") is False
+        assert is_read_only_bash("git diff $@--output=/tmp/pwned") is False
+        assert is_read_only_bash("git branch $@-D release") is False
+        assert is_read_only_bash("cat f | sort $@-o /tmp/pwned") is False
+        # The other special parameters are the same divergence.
+        for param in ("$?", "$$", "$!", "$#", "$-", "$0"):
+            assert is_read_only_bash(f"git diff {param}--output=/tmp/pwned") is False
+
+    def test_an_expansion_is_refused_only_where_a_table_decides_the_argument(self):
+        """A verb with no table has no decision an unexpanded word could subvert.
+
+        `cat $HOME/.bashrc` was always going to classify read-only whatever `$HOME`
+        holds — `cat` has no write flag, no subcommand and no operand rule here —
+        so refusing the expansion bought nothing and took the most ordinary read
+        off the auto-approve path. The refusal is scoped to the verbs whose
+        arguments this module actually reads.
+        """
+        # No table: the expansion cannot change the answer, so it still reads.
+        assert is_read_only_bash("cat $HOME/.bashrc") is True
+        assert is_read_only_bash("ls $PWD") is True
+        assert is_read_only_bash("head -20 $LOG") is True
+        assert is_read_only_bash("grep -rn TODO $DIR") is True
+        assert is_read_only_bash("wc -l ${F}") is True
+        assert is_read_only_bash("cat file.{js,ts}") is True
+        assert is_read_only_bash("readlink -f $X") is True
+        # A table decides the argument: the expansion is still refused.
+        assert is_read_only_bash("git diff $FLAG") is False
+        assert is_read_only_bash("cat f | sort $FLAG /tmp/pwned") is False
+        assert is_read_only_bash("uniq $ARGS") is False
+        assert is_read_only_bash("tree ${FLAG}") is False
+        assert is_read_only_bash("file ${FLAG} -m /tmp/magic.src") is False
+
+    def test_git_tag_annotation_listing_is_not_a_ref_creation(self):
+        """`git tag -n` prints annotation lines — a listing with no `branch` twin.
+
+        List mode was keyed on the letter `l` for both subcommands, so `git tag -n
+        'v1.*'` read its pattern as a ref to create and a common inspection lost
+        its auto-approval. The letters are tracked per subcommand because the two
+        do not agree, and a letter may only be added where it is not also a write
+        flag for that subcommand.
+        """
+        assert is_read_only_bash("git tag -n") is True
+        assert is_read_only_bash("git tag -n 'v1.*'") is True
+        assert is_read_only_bash("git tag -n5 'v1.*'") is True
+        assert is_read_only_bash("git tag -ln") is True
+        assert is_read_only_bash("git tag -n -l 'v1.*'") is True
+        # `git branch` has no `-n` listing, so the letter must not leak across.
+        assert is_read_only_bash("git branch -n newbranch") is False
+        # And the write flags of `git tag` are untouched by the listing letters.
+        assert is_read_only_bash("git tag -n -d v1.0.0") is False
+        assert is_read_only_bash("git tag -nm msg v1.0.0") is False
+
+    def test_a_version_probe_entry_matches_exactly(self):
+        """`javac` prints its version and then compiles whatever else it was given.
+
+        `"javac -version"` is an allowlist literal matched as a PREFIX, so the
+        operands after it were vouched for too — and an annotation processor is
+        ordinary compiled Java on a caller-supplied path, i.e. arbitrary code
+        execution under an auto-approval. Reported on #1532 by the reviewers and
+        independently in #5038, whose table names it as the sharpest shape.
+
+        All five probes require the exact spelling, not only `javac`: whether an
+        interpreter ignores a trailing operand is a property of the installed
+        release, and JDK single-file source mode already moved that answer once.
+        """
+        assert (
+            is_read_only_bash("javac -version -processorpath evil.jar -processor Evil P.java")
+            is False
+        )
+        assert is_read_only_bash("java -version Payload.java") is False
+        assert is_read_only_bash("python3 --version payload.py") is False
+        assert is_read_only_bash("python --version payload.py") is False
+        assert is_read_only_bash("node --version payload.js") is False
+        # The probes themselves, including the canonical `java` spelling: java
+        # prints its version to STDERR, so `2>&1` must not read as an operand.
+        assert is_read_only_bash("javac -version") is True
+        assert is_read_only_bash("java -version") is True
+        assert is_read_only_bash("java -version 2>&1") is True
+        assert is_read_only_bash("java -version 2>/dev/null") is True
+        assert is_read_only_bash("python3 --version") is True
+        assert is_read_only_bash("node --version") is True
+
+    def test_a_system_state_setter_hides_under_a_listing_verb(self):
+        """`hostname` and `date` are on the allowlist for their bare listing form.
+
+        Each also carries a setter under the same verb, and the prefix match
+        vouched for it: `hostname evil-host` renames the host and `date 08221200`
+        sets the clock, both with no flag at all. Reported in #5038.
+
+        The two need different operand predicates rather than one shared rule —
+        every `hostname` read form is flag-only, while `date`'s one legitimate
+        operand is a `+FORMAT` string.
+        """
+        # Bare operands.
+        assert is_read_only_bash("hostname evil-host") is False
+        assert is_read_only_bash("date 08221200") is False
+        assert is_read_only_bash("date -- 08221200") is False
+        # Setter flags, including the attached spellings.
+        assert is_read_only_bash("hostname -F /tmp/name") is False
+        assert is_read_only_bash("hostname --file=/tmp/name") is False
+        assert is_read_only_bash("hostname -b") is False
+        assert is_read_only_bash("date -s '2020-01-01'") is False
+        assert is_read_only_bash("date --set='2020-01-01'") is False
+        # The listing and inspection forms all still auto-approve. `date -Iseconds`
+        # is the case a short-option CLUSTER scan gets wrong: its attached value
+        # contains an `s`, which is not the `-s` that sets the clock.
+        assert is_read_only_bash("date") is True
+        assert is_read_only_bash("date -u") is True
+        assert is_read_only_bash("date -Iseconds") is True
+        assert is_read_only_bash("date +%Y-%m-%d") is True
+        assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date --date=yesterday") is True
+        assert is_read_only_bash("date -r /tmp/f") is True
+        assert is_read_only_bash("hostname") is True
+        assert is_read_only_bash("hostname -f") is True
+        assert is_read_only_bash("hostname -I") is True
+        # `-F` sets from a file, `-f` prints the FQDN: the case carries the meaning.
+        assert is_read_only_bash("hostname --fqdn") is True
+
+    def test_sort_writes_into_a_caller_named_temporary_directory(self):
+        """`sort -T DIR` writes its temporaries into a directory the caller chose.
+
+        A write to a caller-named path, one step removed from `-o` — the same
+        shape as `tree -R`, and missed for the same reason: the flag does not
+        name the file. Reported in #5038.
+        """
+        assert is_read_only_bash("cat f | sort -T /tmp/evildir") is False
+        assert is_read_only_bash("cat f | sort -T/tmp/evildir") is False
+        assert is_read_only_bash("cat f | sort --temporary-directory=/tmp/evildir") is False
+        # The ordinary sort options are untouched.
+        assert is_read_only_bash("cat f | sort -u") is True
+        assert is_read_only_bash("cat f | sort -k2,2n") is True
+        assert is_read_only_bash("cat f | sort -t,") is True
+
+    def test_an_extglob_token_is_refused_because_fnmatch_cannot_rule_on_it(self):
+        """Extglob synthesizes an option token exactly as an ordinary glob does.
+
+        `git diff @(--output=pwned)` matches a file of that name and git writes
+        it. It needs its own verdict because `fnmatch` — the test that makes the
+        plain-glob case precise — does not implement extglob: it reads `@(` as two
+        literal characters, so the pattern that reaches the flag looks inert.
+        Nothing can be proven about the token, so a guarded verb refuses it.
+        Reported in #5038, which measured the expansion.
+        """
+        for op in ("@", "!", "+", "?", "*"):
+            assert is_read_only_bash(f"git diff {op}(--output=pwned)") is False
+        assert is_read_only_bash("cat f | sort @(-o) victim") is False
+        assert is_read_only_bash("git remote @(set-url) origin https://evil") is False
+        # A parenthesis with no extglob operator in front of it is not this class,
+        # and an unguarded verb is unaffected either way.
+        assert is_read_only_bash("grep -n 'f(x)' file") is True
+        assert is_read_only_bash("ls *.py") is True
+
+    def test_a_system_setter_is_not_reachable_through_a_terminator_or_expansion(self):
+        """The operand rule is the decision for `hostname`/`date`, so it needs both guards.
+
+        Two shapes, both found reviewing this change against the reviewer
+        contracts before pushing it. `--` ends the options for these verbs too,
+        so `hostname -- -evil` names the host `-evil` while a leading-dash test
+        read it as one more option. And because their rule is an OPERAND rule
+        rather than a flag table, an unexpanded word IS the decision: `hostname
+        $EVIL` renames the host under a spelling this module read as harmless.
+        """
+        # The option terminator.
+        assert is_read_only_bash("hostname -- -evil") is False
+        assert is_read_only_bash("hostname -- evil") is False
+        assert is_read_only_bash("date -- 08221200") is False
+        # An expansion or a glob standing where the operand is read.
+        assert is_read_only_bash("hostname $EVIL") is False
+        assert is_read_only_bash("hostname ${EVIL}") is False
+        assert is_read_only_bash("hostname evil{a,b}") is False
+        assert is_read_only_bash("date $ARGS") is False
+        assert is_read_only_bash("hostname *.txt") is False
+        # The listing forms are flag-only, so they carry no operand to expand.
+        assert is_read_only_bash("hostname") is True
+        assert is_read_only_bash("hostname -f") is True
+        assert is_read_only_bash("date -u") is True
+
+    def test_a_long_option_takes_its_value_from_the_following_word(self):
+        """Long and short options disagree about consuming the next word.
+
+        A long option takes a separate value unless it is attached with `=`, so
+        `date --date yesterday` is an ordinary read; a short option takes one only
+        when the token is the bare flag, because `-Iseconds` carries its own.
+        Collapsing the two into one length test denied the long forms.
+        """
+        assert is_read_only_bash("date --date yesterday") is True
+        assert is_read_only_bash("date --reference /tmp/f") is True
+        assert is_read_only_bash("date --file /tmp/dates") is True
+        assert is_read_only_bash("date --date=yesterday") is True
+        assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date -r /tmp/f") is True
+        assert is_read_only_bash("date -Iseconds") is True
+        # A value-taking flag does not license a SECOND operand.
+        assert is_read_only_bash("date -d yesterday 08221200") is False
+        assert is_read_only_bash("date --date yesterday 08221200") is False
+
+    def test_an_option_looking_glob_is_refused_on_the_metacharacter_alone(self):
+        """`fnmatch` cannot see a short-option CLUSTER, so the flag NAME needs its own rule.
+
+        `sort -u? victim` slipped every other test: no decided word is three
+        characters long, the metacharacter is not first so the leading-character
+        rule did not fire, and bash resolved `-u?` against a file named `-uo` —
+        which `_matched_flag` would have rejected had it ever seen the token.
+
+        Refusing it costs nothing, because what is inspected is the flag NAME: a
+        glob in a flag's VALUE is split off first.
+        """
+        assert is_read_only_bash("cat f | sort -u? victim") is False
+        assert is_read_only_bash("cat f | sort -[u]o victim") is False
+        assert is_read_only_bash("cat f | sort -u* victim") is False
+        assert is_read_only_bash("git diff --outp?t=/tmp/pwned") is False
+        assert is_read_only_bash("git branch -D? release") is False
+        # A glob in a flag's VALUE, and in an operand, are the ordinary cases.
+        assert is_read_only_bash("git log --grep=[abc]") is True
+        assert is_read_only_bash("ls *.py") is True
+        assert is_read_only_bash("git diff -- src/*") is True
+
+    def test_a_glob_that_reaches_an_abbreviated_long_option_is_refused(self):
+        """`_matched_flag` resolves an abbreviation, so the glob test has to as well.
+
+        Testing a glob head against the FULL spellings only left
+        `git diff ??out=victim` auto-approved: `fnmatch("--output", "??out")` is
+        False on the length alone, `git diff`'s table carries no short flag so the
+        cluster arm does not fire either, and bash resolves `??out` against a file
+        named `--out` which git then reads as `--output`. The full-length spelling
+        `??output` was already refused, which is what made the gap look closed.
+        """
+        assert is_read_only_bash("git diff ??out=victim") is False
+        assert is_read_only_bash("git log ??out=victim") is False
+        assert is_read_only_bash("git show ??outp=victim") is False
+        assert is_read_only_bash("git diff ??ext-dif") is False
+        assert is_read_only_bash("git cat-file ??filt=HEAD:f") is False
+        # The full spellings, and the un-globbed abbreviation, were already refused.
+        assert is_read_only_bash("git diff ??output=victim") is False
+        assert is_read_only_bash("git diff --out=victim") is False
+        assert is_read_only_bash("cat f | sort ??out=victim") is False
+        # A pattern that reaches no decided word — full or abbreviated — still reads.
+        assert is_read_only_bash("git diff *.py") is True
+        assert is_read_only_bash("git diff -- src/*") is True
+        assert is_read_only_bash("git log --grep=[abc]") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+        assert is_read_only_bash("ls *.py") is True
+
+    def test_a_pipe_target_must_be_the_filter_it_matched(self):
+        """`_READ_ONLY_PIPE_RE` ends its filter name at a `\\b`, and `$` satisfies that.
+
+        `cat f | sort$IFS-o victim` matched the allowlist entry `sort` while bash
+        split `$IFS` into whitespace and ran `sort -o victim`. Nothing downstream
+        recovered it either: `_side_effect_reason` reads the verb as `sort$ifs-o`,
+        finds no table under that name, and returns "".
+
+        The leading segment of a pipeline was never exposed, because its allowlist
+        test pins the boundary to a literal space. This makes the pipe allowlist
+        say the same thing: the first argv word, exactly.
+        """
+        assert is_read_only_bash("cat f | sort$IFS-o victim") is False
+        assert is_read_only_bash("cat f | sort${IFS}-o victim") is False
+        assert is_read_only_bash("cat f | uniq$IFS/tmp/in$IFS/tmp/pwned") is False
+        assert is_read_only_bash("cat f | head$IFS-c1000") is False
+        # The honest filters, which are the whole point of the pipe allowlist.
+        assert is_read_only_bash("cat f | sort") is True
+        assert is_read_only_bash("cat f | sort -u") is True
+        assert is_read_only_bash("cat f | uniq -c") is True
+        assert is_read_only_bash("cat f | head -5") is True
+        assert is_read_only_bash("git log --oneline | grep fix | wc -l") is True
+
+    def test_a_short_setter_is_found_anywhere_in_a_cluster(self):
+        """`date -us2026-08-23` is `-u` plus `-s 2026-08-23`, and it sets the clock.
+
+        A setter test anchored at the token's first character never saw it. The
+        cluster is walked instead, stopping at the first letter that consumes the
+        rest of the token — which is what keeps `date -Iseconds` a read, since the
+        `s` there belongs to `-I`'s value rather than being a flag.
+        """
+        assert is_read_only_bash("date -us2026-08-23") is False
+        assert is_read_only_bash("date -Rs2026-08-23") is False
+        assert is_read_only_bash("date -s2026-08-23") is False
+        assert is_read_only_bash("hostname -bF /tmp/name") is False
+        # The value-carrying and no-value read letters, and the case distinction.
+        assert is_read_only_bash("date -Iseconds") is True
+        assert is_read_only_bash("date -u") is True
+        assert is_read_only_bash("date -R") is True
+        assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date -r /tmp/f") is True
+        assert is_read_only_bash("hostname -s") is True
+        assert is_read_only_bash("hostname -f") is True
+        assert is_read_only_bash("hostname -I") is True
+
+    def test_a_required_option_value_does_not_enable_git_list_mode(self):
+        """git takes a required flag's value from the following word, so it is not an option.
+
+        `git branch --format -l newbranch` hands `-l` to `--format` and git never
+        sees a list flag — while scanning every token read that `-l` as one, and
+        the bare operand it then licensed created the branch. The operand walk
+        already tracked this; list mode now tracks it over the same tokens.
+        """
+        assert is_read_only_bash("git branch --format -l newbranch") is False
+        assert is_read_only_bash("git branch --sort -l newbranch") is False
+        assert is_read_only_bash("git tag --format -l newtag") is False
+        # `--points-at` is in BOTH sets by design: it consumes its value AND
+        # selects. So here list mode is genuinely on, `-l` is its value, and
+        # `newbranch` is a pattern rather than a ref to create — git lists.
+        # Excluding consumed values must not turn a real selector off.
+        assert is_read_only_bash("git branch --points-at -l newbranch") is True
+        assert is_read_only_bash("git branch --points-at HEAD newbranch") is True
+        # A real selector, and an ATTACHED value that consumes nothing.
+        assert is_read_only_bash("git branch --format %(refname) --list") is True
+        assert is_read_only_bash("git branch --format=%(refname) --list") is True
+        assert is_read_only_bash("git branch --sort=refname --list") is True
+        assert is_read_only_bash("git branch --list newbranch") is True
+        assert is_read_only_bash("git tag -l 'v1.*'") is True
+
+    def test_an_abbreviated_value_flag_still_consumes_the_following_word(self):
+        """git resolves `--form` to `--format`, so it eats the next word.
+
+        Reading `--form` as an ordinary option left the `-l` in
+        `git branch --form -l newbranch` looking like a list flag, and the bare
+        operand that licensed created the branch. This is the fourth site on this
+        guard to need the abbreviation axis — after `_matched_flag`,
+        `_system_set_flag` and `_glob_reaches` — hence a named helper.
+        """
+        assert is_read_only_bash("git branch --form -l newbranch") is False
+        assert is_read_only_bash("git branch --forma -l newbranch") is False
+        assert is_read_only_bash("git branch --so -l newbranch") is False
+        assert is_read_only_bash("git tag --form -l newtag") is False
+        # The full spellings, and an ATTACHED value which consumes nothing.
+        assert is_read_only_bash("git branch --format %(refname) --list") is True
+        assert is_read_only_bash("git branch --format=%(refname) --list") is True
+        assert is_read_only_bash("git branch --sort=refname --list") is True
+        assert is_read_only_bash("git branch --points-at HEAD newbranch") is True
+
+    def test_a_glob_in_the_remote_subcommand_position_is_refused(self):
+        """`nullglob` makes an unmatched pattern VANISH, which shifts the subcommand.
+
+        With `nullglob` exported, `git remote nomatch* set-url origin …` loses
+        `nomatch*` entirely and git receives `set-url`, while the subcommand loop
+        broke on the pattern and never looked further.
+
+        `_glob_hides_word` cannot cover this: it asks whether a pattern can expand
+        INTO a decided word, and `nomatch*` cannot — the mutation comes from the
+        token disappearing, not from what it becomes. Removing this check on the
+        grounds that the general test subsumed it is what opened the hole.
+        """
+        assert is_read_only_bash("git remote nomatch* set-url origin https://evil") is False
+        assert is_read_only_bash("git remote nomatch? add evil https://evil") is False
+        assert is_read_only_bash("git remote no[m]atch remove origin") is False
+        assert is_read_only_bash("git remote -v nomatch* set-url origin https://evil") is False
+        # The listing forms, and the read subcommand, still auto-approve.
+        assert is_read_only_bash("git remote") is True
+        assert is_read_only_bash("git remote -v") is True
+        assert is_read_only_bash("git remote get-url origin") is True
+
+    def test_a_glob_that_changes_the_argument_count_is_refused(self):
+        """A glob can decide by COUNT rather than by what it becomes, in both directions.
+
+        Several matches become several WORDS: with `in1` and `in2` present,
+        `uniq in*` runs `uniq in1 in2`, whose second operand is the OUTPUT file —
+        so one pattern passed a segment that truncates a file. And no match under
+        `nullglob` makes the word VANISH: `git branch --format nomatch* --list
+        newbranch` loses the format's value, `--format` eats `--list` instead, and
+        `newbranch` stops being a pattern.
+
+        Neither needs the pattern to resemble a word this module decides on, so
+        `_glob_hides_word` could not rule on either. It is asked only where the
+        count or the position carries the verdict — a `uniq` operand and a required
+        git option's value — which is what keeps ordinary globbing a read.
+        """
+        assert is_read_only_bash("cat f | uniq in*") is False
+        assert is_read_only_bash("cat f | uniq in* out") is False
+        assert is_read_only_bash("cat f | uniq @(in)") is False
+        assert is_read_only_bash("cat f | uniq -- in*") is False
+        assert is_read_only_bash("git branch --format nomatch* --list newbranch") is False
+        assert is_read_only_bash("git branch --sort nomatch* --list newbranch") is False
+        assert is_read_only_bash("git tag --format nomatch* -l newtag") is False
+        # An operand whose meaning does NOT depend on its position is unaffected,
+        # which is the whole reason this is a separate question.
+        assert is_read_only_bash("cat f | uniq -c") is True
+        assert is_read_only_bash("cat f | uniq /tmp/in") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+        assert is_read_only_bash("git tag -l 'v1.*'") is True
+        assert is_read_only_bash("git branch --format %(refname) --list") is True
+        assert is_read_only_bash("git branch --format=%(refname) --list") is True
+        assert is_read_only_bash("git diff *.py") is True
+        assert is_read_only_bash("ls *.py") is True
+        assert is_read_only_bash("grep -rn TODO src/*") is True
+        assert is_read_only_bash("cat *.log") is True
+
+    def test_a_negated_list_flag_cancels_list_mode(self):
+        """git auto-generates `--no-<opt>` for a boolean, so `--list` has a negation.
+
+        `git branch --list --no-list newbranch` CREATES the branch, and reading the
+        `--list` alone as "this is a listing" passed the bare operand off as a
+        pattern.
+
+        The table behind this was measured against git rather than inferred,
+        because the neighbouring `--no-` spellings do not behave the same way:
+        `--no-contains` and `--no-merged` are real list FILTERS, not negations, and
+        `git tag` has no `--no-list` at all — so treating any `--no-*` as
+        cancelling would have denied ordinary reads.
+        """
+        assert is_read_only_bash("git branch --list --no-list newbranch") is False
+        assert is_read_only_bash("git branch --list --no-lis newbranch") is False
+        assert is_read_only_bash("git branch -l --no-list newbranch") is False
+        assert is_read_only_bash("git branch --no-list newbranch") is False
+        # Measured: git errors on these rather than creating a ref, so the listing
+        # filters must keep reading.
+        assert is_read_only_bash("git branch --no-contains HEAD") is True
+        assert is_read_only_bash("git branch --no-merged") is True
+        assert is_read_only_bash("git branch --contains HEAD --no-contains newbranch") is True
+        assert is_read_only_bash("git branch --list") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+
+    def test_a_glob_pattern_is_matched_case_insensitively(self):
+        """`nocaseglob` decouples the pattern's case from the filename's.
+
+        With it set, `git diff ??OUT=victim` expands to `--out=victim` and git
+        writes the file, while a case-sensitive test saw a pattern matching
+        nothing. Measured: `bash -O nocaseglob -c 'echo git diff ??OUT=victim'`
+        prints `git diff --out=victim`; plain `bash -c` does not.
+
+        The case sensitivity this module DOES rely on is elsewhere and unaffected —
+        `file -C` still differs from `file -c`, because that reads a literal token
+        rather than asking what a pattern could become.
+        """
+        assert is_read_only_bash("git diff ??OUT=victim") is False
+        assert is_read_only_bash("git log ??OUTPUT=victim") is False
+        assert is_read_only_bash("git show ??Out=victim") is False
+        assert is_read_only_bash("cat f | sort ??OUT=victim") is False
+        assert is_read_only_bash("git remote S?T-URL origin https://evil") is False
+        # The literal-token case distinction is untouched.
+        assert is_read_only_bash("file -C -m /tmp/magic.src") is False
+        assert is_read_only_bash("file -c") is True
+        # And a pattern that reaches no decided word in either case still reads.
+        assert is_read_only_bash("git diff *.PY") is True
+        assert is_read_only_bash("ls *.PY") is True
+
+    def test_an_abbreviated_long_setter_still_matches(self):
+        """GNU resolves an unambiguous abbreviation, so a plain prefix test missed it.
+
+        `date --se=2026-08-23` reaches `--set` and the clock moves. Abbreviation is
+        a separate axis from the cluster scan this function exists to avoid, and
+        `_matched_flag` already accepts it for every other table.
+        """
+        assert is_read_only_bash("date --se=2026-08-23") is False
+        assert is_read_only_bash("date --s=2026-08-23") is False
+        assert is_read_only_bash("date --set=2026-08-23") is False
+        assert is_read_only_bash("hostname --fi=/tmp/name") is False
+        assert is_read_only_bash("hostname --file=/tmp/name") is False
+        # An abbreviation of a READ option is not a setter.
+        assert is_read_only_bash("date --dat=yesterday") is True
+        assert is_read_only_bash("date --utc") is True
+        assert is_read_only_bash("hostname --fqdn") is True
+
+    def test_a_signing_key_does_not_select_git_tag_list_mode(self):
+        """`git tag -u <keyid>` makes the tag annotated and signed, so it creates a ref.
+
+        Two defects met here. `-u`/`--local-user` was in the `branch` write list
+        (set-upstream) and missing from `tag`. And the list-letter scan asked
+        whether ANY character of the cluster was a list letter, which read an
+        attached VALUE as part of the cluster — the `l` in `-ulin@kiro.co` selected
+        list mode, and the bare operand it then licensed created a signed tag.
+        Every character must now be a list letter or a digit.
+        """
+        assert is_read_only_bash("git tag -ulin@kiro.co release") is False
+        assert is_read_only_bash("git tag -u lin@kiro.co release") is False
+        assert is_read_only_bash("git tag --local-user=lin release") is False
+        assert is_read_only_bash("git tag -u lin") is False
+        # The listing clusters still list: a list letter, or one plus `-n`'s count.
+        assert is_read_only_bash("git tag -l 'v1.*'") is True
+        assert is_read_only_bash("git tag -n 'v1.*'") is True
+        assert is_read_only_bash("git tag -n5 'v1.*'") is True
+        assert is_read_only_bash("git tag -ln") is True
+        assert is_read_only_bash("git tag -ln5") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+
     def test_compound_read_commands(self):
         assert is_read_only_bash("git status && git log --oneline -3") is True
         assert is_read_only_bash("ls -la; echo done") is True


### PR DESCRIPTION
## Problem / Motivation

The read-only bash classifier (`_classify_bash`, `src/kiro_crew/dashboard/state.py`) gates an allowlist entry on the command **head** and never vets its arguments:

```python
any(first == p or first.startswith(p + " ") for p in _READ_ONLY_BASH_PREFIXES)
```

So clearing the allowlist vouched for every flag, subcommand and operand that verb accepts. The pipe allowlist (`_READ_ONLY_PIPE_RE`) matches a filter's head only, with the same result. None of these involve a shell `>`, so `_UNSAFE_SHELL_RE` never sees them — and a read-only classification is **auto-approved**, which is the path that skips both the dashboard prompt and the `hooks.on_tool_call` PreToolUse gate.

Run against the classifier on `main`, every line below returns `""` — no permission request:

| command shape | verified effect |
|---|---|
| `javac -version -processorpath e.jar -processor E P.java` | compiles, and runs the annotation processor |
| `git remote set-url origin <attacker-url>` | remote repointed; later fetches and pushes go there |
| `git remote add\|remove\|rename X` | remote config rewritten |
| `git branch -D release`, `git branch <name>` | branch deleted / created |
| `git branch --edit-description` | `$EDITOR` executed |
| `git tag <name>` | `$EDITOR` executed when `tag.gpgSign` is set |
| `git tag -d v1.0.0` | tag deleted |
| `git diff\|show\|log --output=FILE` | FILE written |
| `git diff --ext-diff` / `--textconv`, `git cat-file --filters` | a program the repository names runs |
| `tree -o FILE`, `tree -R` | FILE written |
| `file -C -m FILE` | `FILE.mgc` written |
| `cat f \| sort -o FILE`, `sort -T DIR`, `uniq IN OUT`, `less -O FILE` | FILE written |
| `cat f \| sort --compress-program=PROG` | PROG executed |
| `hostname evil-host`, `hostname -F FILE` | host renamed |
| `date --set=…`, `date 08221200` | system clock set |

Neither `is_sensitive_bash_command` nor the deny floor catches any of them.

## Why it matters

A false negative here means an unsafe command runs with no human gate, under `--approval reads` / trust-reads.

`javac` is arbitrary code execution: it does not act on `-version` and exit — it prints the version and then compiles whatever else it was handed, and an annotation processor is ordinary compiled Java on a path the caller supplies. The file writes are the primitive that plants a shim. The `$EDITOR` cases start a program the caller never named. `git remote set-url` redirects every later fetch and push.

## What changed (motivation → approach → change)

One root cause — the head match settles **which program** runs, not what the rest of the command line asks it to do — so the fix is a vetting step plus small tables, not a change to the match itself. Making the head match strict globally was rejected: operands are the normal way to use most entries (`ls -la`, `git log --oneline -5`), so it would send the whole allowlist to the human prompt.

`_side_effect_reason` runs after the verb clears the allowlist. The tables are keyed by verb, because the same spelling is harmless elsewhere: `ls -o` is a long listing format and `grep -o` prints only the match, while `sort -o FILE` truncates and writes FILE. A blanket ban on `-o` would have broken both.

| table | covers |
|---|---|
| `_WRITE_FLAGS` | `sort -o`/`-T`, `tree -o`/`-R`, `file -C`, `uniq -o`, `less -o`/`--log-file`, `git diff\|show\|log --output` |
| `_EXEC_FLAGS` | `git diff\|show\|log --ext-diff`/`--textconv`, `git cat-file --filters`, `sort --compress-program`, `less --filter` |
| `_GIT_REF_WRITE_FLAGS` | the write-mode flags of `git branch` / `git tag`, including `--edit-description` |
| `_GIT_REMOTE_WRITE_SUBCOMMANDS` | `add`, `remove`, `rm`, `rename`, `set-url`, `set-head`, `set-branches`, `prune`, `update` |
| `_EXACT_ONLY_BASH_PREFIXES` | the five version probes — a probe has no legitimate operand, so its entry matches exactly |
| `_SYSTEM_SET_FLAGS` + an operand rule | `hostname` renames the host, `date` sets the clock, by flag and by bare operand |

Three details decide whether the check actually holds:

- **Respelling.** `_matched_flag` accepts the flag alone (`-o`), attached to its value (`--output=x`, `-drelease`), bundled into a short cluster (`-uo` supplies `-o`), and GNU-abbreviated (`--out=x` reaches `--output`).
- **Bare operands mutate.** `git branch <name>`, `git tag <name>`, `hostname <name>` and `date <stamp>` need no flag at all, so a bare operand is rejected — unless it is a required flag's value, a list-mode pattern, or `date`'s `+FORMAT`.
- **Case.** The verb is folded like the allowlist folds it; flags keep their case, because here the case carries the meaning — `file -C` compiles a magic file, `file -c` only prints one, and `hostname -F` sets the name while `-f` prints the FQDN.

**Nothing that previously prompted is newly allowed.** Every path added here only returns a reason, and a returned reason sends the segment to the human approval prompt — which is where a write, a ref change or a clock change belonged.

### Relationship to #1532 and #5038

This supersedes **#1532** (@kaizawa97) — rebased onto current `main`, whose `_is_help_probe` change its base predates — and absorbs the coverage of **#5038** (@SebastianYuSun), who found this class independently and enumerated more of it. Both are credited as commit co-authors. Every shape in #5038's 13-row table is closed here; a full disposition is posted on that PR.

Five fixes over #1532, each mutation-verified — its test fails on #1532's head and passes here:

1. **A glob could expand into a flag it did not look like.** The check ran only on tokens that already started with `-`, so `cat f | sort ?o victim` passed while bash resolved `?o` against a file named `-o` that a checkout can carry. `_glob_hides_word` now asks whether the pattern can **match** a word this module decides on (`fnmatch` against `_GLOB_SENSITIVE_WORDS`), plus a leading-metacharacter test for short clusters. Because it tests the expansion rather than the character, `ls *.py`, `grep -rn TODO src/*`, `git diff *.py` and `git branch --list 'feat/*'` all keep auto-approving.
2. **`--` hid a ref creation.** List mode was decided over the whole argument list, so the `--list` in `git tag -- --list` read as a listing when git creates a ref by that name. It now stops at the terminator.
3. **`--` hid a `uniq` output file.** `uniq -- input -pwned` counted one operand and wrote `-pwned`.
4. **Positional and special parameters were outside the `$`-led class.** `$@` expands to **nothing** in a `bash -c` string, so `git remote $@set-url origin …` arrives as `$@set-url` and reaches git as `set-url`. Same for `$* $1 $0 $? $$ $! $# $-`.
5. **Two over-blocks.** `git tag -n 'v1.*'` was read as a ref creation (list letters are now per subcommand), and the expansion refusal applied to every verb, so `cat $HOME/.bashrc` and `cat file.{js,ts}` lost their auto-approval for nothing — a verb with no table has no decision an unexpanded word could subvert.

Four more taken from #5038, which #1532 did not cover: the `javac` exact-match rule (with `2>&1` scrubbed first, since `java` prints its version to stderr), `sort -T`, the `hostname`/`date` setters, and bash **extglob** operators — which need their own verdict because `fnmatch` does not implement extglob and reads `@(` as two literal characters.

Three defects in the newly added code, found reviewing this commit against the `codex-review.yml` and `claude-review.yml` contracts **before** pushing, are fixed in the same commit: `hostname -- -evil` reached the operand rule as an option; `hostname $EVIL` was unguarded because those verbs carry no flag table; and one length test collapsed long and short options, denying `date --date yesterday`.

## Tests

Fifteen test methods in `test/test_trust_reads.py` cover the guard, eleven of them new here — one per finding above, each locking in both directions (the bypass is refused, the sibling read still auto-approves):

- `test_allowlisted_verb_may_not_write_via_its_own_output_flag`, `test_pipe_target_may_not_write_via_its_own_output_flag` — writes through a program's own output flag, on the head and on a pipe target.
- `test_allowlisted_git_verb_may_not_change_a_ref_or_remote`, `test_a_leading_option_does_not_hide_a_git_remote_subcommand`, `test_an_optional_flag_value_does_not_swallow_a_ref_name` — ref and remote mutation, including `git remote -v set-url` and `git branch --color newbranch`.
- `test_allowlisted_git_verb_may_not_launch_an_editor_or_diff_driver`, `test_textconv_hands_off_the_same_way_ext_diff_does`, `test_a_pipe_target_and_git_cat_file_cannot_write_or_exec` — hand-off to `$EDITOR` and to a repository-named program.
- `test_a_shell_expansion_in_the_arguments_is_refused`, `test_brace_expansion_can_assemble_a_flag_out_of_fragments`, `test_a_positional_or_special_parameter_hides_the_real_argument`, `test_an_expansion_is_refused_only_where_a_table_decides_the_argument` — the four expansion classes, and the scope that keeps `cat $HOME/.bashrc` a read.
- `test_a_glob_is_refused_only_where_the_spelling_is_classified`, `test_a_glob_can_expand_into_a_flag_it_does_not_look_like`, `test_an_extglob_token_is_refused_because_fnmatch_cannot_rule_on_it` — the three glob shapes.
- `test_the_option_terminator_makes_everything_after_it_an_operand`, `test_the_option_terminator_does_not_hide_a_ref_or_an_operand`, `test_a_system_setter_is_not_reachable_through_a_terminator_or_expansion` — `--` for refs, for `uniq`, and for the system setters.
- `test_a_version_probe_entry_matches_exactly`, `test_a_system_state_setter_hides_under_a_listing_verb`, `test_sort_writes_into_a_caller_named_temporary_directory`, `test_git_tag_annotation_listing_is_not_a_ref_creation`, `test_a_long_option_takes_its_value_from_the_following_word`, `test_an_abbreviated_long_option_still_matches`, `test_tree_writes_without_being_given_a_filename`, `test_side_effect_check_is_case_insensitive_on_the_verb_only` — the ported #5038 shapes and the over-block guards.

```
pytest test/test_trust_reads.py                                            ->   84 passed
pytest test/test_trust_reads.py test_dashboard_approval.py test_hooks.py    ->  265 passed
pytest test/ -k "trust or approval or hooks or security or chat_runner or state"
                                                                           -> 5005 passed, 2 pre-existing failures
black / flake8 / isort / mypy on both changed files                         -> clean
```

The two failures are `test_dev_fleet_app.py::test_trusted_bin_pins_the_resolved_target_not_the_symlink` and `test_host_isolation_floor.py::…test_each_pinned_path_is_outside_the_real_home[…_DEFAULT_KIRO_HOOKS_DIR]`. Both are in files this diff does not touch, and both reproduce identically on a clean `origin/main` worktree at the same commit — they are shaped by this sandbox's home layout.

Both call sites of the classifier are exercised: the approval flow in `dashboard/chat_runner.py` and the read-only auto-approve branch in `hooks.py`.

## Manual verification

Direct classifier verification, run against the head of this branch: **the side-effect commands all prompt and the read-only commands all still auto-approve**, no misclassification either way. That set is deliberately weighted toward the reads an over-block would break — `git branch --contains HEAD`, `git branch --list newbranch`, `git tag -l 'v1.*'`, `git tag -n5 'v1.*'`, `git tag -l -- 'v1.*'`, `git branch --list 'feat/*'`, `git remote get-url origin`, `git log --format='%H %s'`, `git diff --no-ext-diff`, `git diff *.py`, `git diff -- src/*`, `ls -o`, `ls *.py`, `grep -o pattern file`, `grep -rn TODO src/*`, `file -c`, `tree -L 2`, `cat f | sort -u`, `cat f | sort -k2,2n`, `cat f | uniq -c`, `cat $HOME/.bashrc`, `cat file.{js,ts}`, `java -version 2>&1`, `date -Iseconds`, `date --date yesterday`, `date -r /tmp/f`, `hostname --fqdn`.

Each of #5038's 13 reported shapes was re-run against this branch and confirmed to prompt, and against `main` to confirm it auto-approves there.

## Related Issues

no linked issue: reported and fixed together on #1532 and #5038, neither of which has a filed issue behind it, so there is nothing for this PR to close on merge. Supersedes #1532 (closed) and #5038. Follow-up work raised by Design Review is tracked in #5370 — deliberately NOT closed by this PR.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — the rationale lives in comments above each table, where a future edit would need it
- [x] No secrets, credentials, or internal references in the diff

### Not in scope

The tables are a denylist, and a denylist over third-party CLI surface is never provably complete — this closes the shapes that were verified, it does not prove no other allowlisted verb has a side effect. The durable fix is the other direction: a per-verb allowlist of permitted flags, or a filesystem sandbox so a write cannot land regardless of spelling.

#5038 additionally converts `date`, `hostname`, `sort` and `file` to exactly that — a positive `_OPTION_ACCEPT_LISTS` allowlist of read-only options per tool. That design is its author's contribution and deserves its own review rather than being re-homed inside this diff, so this PR closes those tools' verified holes with rules proportional to the fix. The conversion is tracked in #5370, together with extracting the classifier out of `dashboard/state.py` — both raised by Design Review on this PR.

Also acknowledged: `less`/`more` as pipe targets have a `!command` shell escape, but it needs an interactive TTY, which a tool call does not have.
