### PR TITLE
fix(mcp-gateway): keep healthy overlays through transient rewrite faults (#5328)

### DIFF
--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -1415,6 +1415,7 @@ def rewrite_agents(
     # both overlays. Non-poolable / HTTP settings servers stay raw in settings.
     settings_src_spec: dict[str, Any] | None = None
     settings_poolable: dict[str, Any] = {}
+    settings_read_transient = False
     if kiro_settings_json.is_file():
         try:
             loaded = json.loads(kiro_settings_json.read_text())
@@ -1430,12 +1431,24 @@ def rewrite_agents(
         except OSError as exc:
             # Transient read failure: same reasoning as the per-agent site —
             # do not cache a pass that treated an existing settings file as
-            # absent (it would also have pruned the settings overlay).
+            # absent, and keep the previous settings overlay (#5328).
             notes.source_read_failed = True
+            settings_read_transient = True
             logger.warning("failed to read global mcp.json: %s", exc)
         except json.JSONDecodeError as exc:
             # Content problem — cacheable; a fix changes the stat signature.
             logger.warning("failed to read global mcp.json: %s", exc)
+
+    # Names of agents whose overlay could not be refreshed THIS PASS for a
+    # TRANSIENT reason (source read failure, overlay write failure). The prune
+    # keep-set is ``written | transient_keep``: a transient victim keeps its
+    # previous, healthy overlay (stale-but-working beats no overlay at all,
+    # #5328), while a deterministic skip (bad JSON, non-dict spec) prunes
+    # exactly as a deleted source does — those passes are cacheable, and the
+    # cached path's prune would sweep a kept-stale overlay one boot later
+    # anyway, so keeping it here would make two boots over identical inputs
+    # behave differently.
+    transient_keep: set[str] = set()
 
     for path in sorted(source_dir.glob("*.json")):
         try:
@@ -1444,9 +1457,16 @@ def rewrite_agents(
             # Transient: the file stat'ed fine for the fingerprint but could
             # not be read. Readability can return without size/mtime changing,
             # so caching this incomplete pass would serve overlays missing
-            # this agent forever. Mark the pass uncacheable.
+            # this agent forever. Mark the pass uncacheable, and keep the
+            # agent's previous overlay (#5328).
             notes.source_read_failed = True
-            logger.warning("skipping agent %s: %s", path.name, exc)
+            transient_keep.add(path.name)
+            logger.warning(
+                "skipping agent %s: %s (previous overlay, if any, stays in "
+                "effect until a later pass succeeds)",
+                path.name,
+                exc,
+            )
             continue
         except json.JSONDecodeError as exc:
             # Deterministic: the CONTENT is bad, and fixing it changes the
@@ -1499,25 +1519,70 @@ def rewrite_agents(
             # env sidecar and settings overlay.
             atomic_write(target, json.dumps(new_spec, indent=2) + "\n", restrict_to_owner=True)
         except OSError as exc:
-            logger.warning("failed to write overlay %s: %s", target, exc)
+            logger.warning(
+                "failed to write overlay %s: %s (previous overlay, if any, "
+                "stays in effect until a later pass succeeds)",
+                target,
+                exc,
+            )
             overlay_write_failed = True
+            transient_keep.add(path.name)
             continue
         written.add(path.name)
         if wrapped:
             results[path.name] = wrapped
 
-    # Prune stale overlay entries (user deleted or renamed an agent).
+    # Prune stale overlay entries (user deleted or renamed an agent). The
+    # keep-set answers "does this overlay's source still exist and did we
+    # either refresh it or fail TRANSIENTLY?" — never bare write success,
+    # which conflated a transient failure with a deleted source and unlinked
+    # the previous, healthy overlay (#5328). Deterministic skips (bad JSON,
+    # non-dict) stay OUT of the keep-set: their pass is cacheable, and the
+    # cached-path prune keys on the stored outputs, so keeping them here
+    # would let two boots over identical inputs disagree.
     for stale in overlay_dir.glob("*.json"):
-        if stale.name not in written:
+        if stale.name not in written and stale.name not in transient_keep:
             try:
                 stale.unlink()
             except OSError:
                 pass
 
+    # Every overlay that SURVIVES the prune must have its target mappings
+    # published, or a kept overlay's stub resolves through the bare
+    # server-name fallback — which, when two agents declare the same server
+    # name with different args, is another agent's command. Harvest the kept
+    # overlays' wrapped entries into ``target_env`` exactly as the cached
+    # path does (``_cached_rewrite_result`` reconstructs from overlay files),
+    # via ``setdefault`` inside ``_collect_target_env`` so entries from the
+    # freshly-rewritten specs always win and the kept overlay only fills the
+    # hash-keyed slots nothing else claimed. Unreadable/corrupt kept overlays
+    # are skipped — the stub then degrades to the same fallback as before.
+    for name in sorted(transient_keep):
+        kept = overlay_dir / name
+        try:
+            kept_spec = json.loads(kept.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(kept_spec, dict):
+            servers = kept_spec.get("mcpServers", {})
+            if isinstance(servers, dict):
+                _collect_target_env(servers, target_env)
+
     # Prune stale env sidecars (server removed / renamed / flipped
     # non-poolable) so old credential files don't accumulate on disk.
+    # ``written_sidecars`` is enumeration-keyed, not write-success-keyed:
+    # ``_build_stub_entry`` adds the sidecar name BEFORE attempting the write,
+    # so a transient sidecar write failure keeps the previous sidecar on disk
+    # (and ``notes.sidecar_write_failed`` makes the pass uncacheable). But on
+    # any pass that KEPT a previous overlay (source read failure — the
+    # victim's sidecar names are unknowable; overlay write failure — the kept
+    # overlay may reference sidecars of servers the new spec renamed away),
+    # the kept overlay still points ``--env-file`` at old names, and pruning
+    # them would spawn its backends credential-less for the rest of this
+    # gateway's lifetime. Skip the sidecar prune on such a pass: it is
+    # already uncacheable, so the next boot re-enumerates and sweeps.
     env_dir = env_sidecar_dir_for_stubs(stubs_dir)
-    if env_dir.is_dir():
+    if env_dir.is_dir() and not (notes.source_read_failed or overlay_write_failed):
         for stale in env_dir.glob("*.json"):
             if stale.name not in written_sidecars:
                 try:
@@ -1585,10 +1650,26 @@ def rewrite_agents(
             settings_overlay_path = None
             overlay_write_failed = True
     else:
-        # Source settings/mcp.json absent (deleted between runs): prune any
-        # previously-written settings overlay, mirroring the per-agent
-        # stale-prune above so the overlay tree doesn't accumulate cruft.
-        if settings_overlay_file.is_file():
+        # ``settings_src_spec`` is None: the source is absent, was unreadable
+        # this pass, or carried bad content. Only CONFIRMED absence and
+        # deterministic bad content prune the previous overlay (matching the
+        # per-agent rule and the cached path's keying); a transient read
+        # failure keeps it (#5328). Classify with an explicit ``stat()``
+        # rather than ``is_file()``, which folds a stat fault (ACL hiccup,
+        # transient I/O error) into "absent" and would delete a healthy
+        # overlay — treat a stat fault as transient: keep, and mark the pass
+        # uncacheable so the next boot retries.
+        prune_settings = False
+        if not settings_read_transient:
+            try:
+                kiro_settings_json.stat()
+            except FileNotFoundError:
+                prune_settings = True  # confirmed absent: deleted between runs
+            except OSError:
+                notes.source_read_failed = True  # unknown: keep and retry
+            else:
+                prune_settings = True  # present but bad content: deterministic
+        if prune_settings and settings_overlay_file.is_file():
             try:
                 settings_overlay_file.unlink()
             except OSError:

--- a/test/test_mcp_gateway_rewriter_fingerprint.py
+++ b/test/test_mcp_gateway_rewriter_fingerprint.py
@@ -625,6 +625,226 @@ def test_deleted_agent_spec_invalidates_and_prunes(
     assert not overlay.exists()
 
 
+def test_transient_overlay_write_failure_keeps_the_previous_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stale-overlay prune keeps a TRANSIENT failure's previous overlay
+    instead of keying on write success (#5328): a single transient
+    overlay-write failure must leave that agent's previous, healthy overlay
+    on disk — stale-but-working beats no overlay at all — while the other
+    agents still rewrite."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    victim = tmp_path / "mcp-gateway" / "agents" / "agent-1.json"
+    survivor = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert victim.is_file()
+    before_bytes = victim.read_bytes()
+
+    # Change agent-1's CONTENT (not just mtime): a successful write would now
+    # produce different bytes, so surviving-with-old-bytes proves both that
+    # the write failed and that the prune spared the file.
+    spec_path = src / "agent-1.json"
+    spec = json.loads(spec_path.read_text())
+    spec["mcpServers"]["srv"]["args"] = ["changed-args"]
+    spec_path.write_text(json.dumps(spec))
+
+    real_write = rewriter.atomic_write
+    fail = {"on": True}
+
+    def flaky(target: Path, *args: Any, **kwargs: Any) -> None:
+        if fail["on"] and Path(target).name == "agent-1.json":
+            raise OSError("disk full")
+        real_write(target, *args, **kwargs)
+
+    monkeypatch.setattr(rewriter, "atomic_write", flaky)
+    _rewrite(tmp_path)
+    fail["on"] = False
+
+    assert victim.is_file()  # healthy overlay survived the failed pass
+    assert victim.read_bytes() == before_bytes  # ...byte-identical, not rewritten
+    assert survivor.is_file()  # the unaffected agent still rewrote
+    # Degraded pass not cached: the next boot retries the write.
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    assert not fp.exists()
+
+    # Fault cleared: the retry rewrites agent-1 and the stale bytes go away.
+    _rewrite(tmp_path)
+    assert victim.read_bytes() != before_bytes
+    assert fp.is_file()
+
+
+def test_transient_agent_read_failure_keeps_the_previous_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same keying, other transient arm: a source spec that fails to READ this
+    pass keeps its previous overlay (before #5328 the read-failure
+    ``continue`` skipped ``written.add`` and the prune deleted the healthy
+    overlay) — AND its env sidecars: the kept overlay's stub argv still
+    points ``--env-file`` at them, and a read-failure pass cannot enumerate
+    the victim's sidecar names, so the sidecar prune is skipped for the whole
+    (already-uncacheable) pass. Pruning them would spawn the kept overlay's
+    backends credential-less for the rest of the gateway's lifetime."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    victim = tmp_path / "mcp-gateway" / "agents" / "agent-1.json"
+    assert victim.is_file()
+    before_bytes = victim.read_bytes()
+    env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
+    sidecars_before = set(env_dir.glob("*.json"))
+    assert sidecars_before  # _mk_tree declares env, so sidecars exist
+
+    _bump_mtime(src / "agent-1.json")  # invalidate so the next call rewrites
+    real_read = Path.read_text
+    fail = {"on": True}
+    victim_src = src / "agent-1.json"
+
+    def flaky(self: Path, *args: Any, **kwargs: Any) -> str:
+        if fail["on"] and self == victim_src:
+            raise OSError("transient I/O error")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    _rewrite(tmp_path)
+    fail["on"] = False
+
+    assert victim.is_file()  # overlay survived the unreadable-source pass
+    assert victim.read_bytes() == before_bytes
+    # Every sidecar survived too — overlay/sidecar coherence is kept.
+    assert set(env_dir.glob("*.json")) == sidecars_before
+    # Degraded pass not cached: the next boot retries the read.
+    assert not (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).exists()
+
+
+def test_malformed_source_still_prunes_its_overlay(
+    tmp_path: Path,
+) -> None:
+    """Deterministic bad content (JSONDecodeError / non-dict) is NOT a
+    transient keep: the pass is cacheable and the cached-path prune keys on
+    the stored outputs, so sparing the overlay here would let two boots over
+    identical inputs behave differently. Bad content prunes exactly like a
+    deleted source, as before #5328."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-1.json"
+    assert overlay.is_file()
+
+    (src / "agent-1.json").write_text("{not json")
+    _rewrite(tmp_path)
+    assert not overlay.exists()  # deterministic skip -> pruned, and cacheable
+    assert (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).is_file()
+
+
+def test_write_failure_does_not_suppress_the_prune_for_deleted_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The prune keep-set is per-source, never a pass-wide failure switch: in
+    ONE degraded pass, a deleted source still loses its overlay while the
+    write-failure victim keeps its previous one. Guards against 'fixing'
+    #5328 by skipping the prune whenever anything failed, which would leak
+    overlays for genuinely-deleted agents."""
+    src = _mk_tree(tmp_path, n_agents=3)
+    _rewrite(tmp_path)
+    overlay_dir = tmp_path / "mcp-gateway" / "agents"
+    assert (overlay_dir / "agent-0.json").is_file()
+    assert (overlay_dir / "agent-1.json").is_file()
+    assert (overlay_dir / "agent-2.json").is_file()
+
+    (src / "agent-0.json").unlink()  # genuinely deleted -> must be pruned
+    real_write = rewriter.atomic_write
+
+    def flaky(target: Path, *args: Any, **kwargs: Any) -> None:
+        if Path(target).name == "agent-1.json":
+            raise OSError("disk full")
+        real_write(target, *args, **kwargs)
+
+    monkeypatch.setattr(rewriter, "atomic_write", flaky)
+    _rewrite(tmp_path)
+
+    assert not (overlay_dir / "agent-0.json").exists()  # prune still ran
+    assert (overlay_dir / "agent-1.json").is_file()  # victim kept its overlay
+    assert (overlay_dir / "agent-2.json").is_file()  # healthy agent rewrote
+
+
+def test_write_failure_pass_keeps_the_kept_overlays_sidecars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pass that kept a previous overlay must not prune that overlay's env
+    sidecars. With a server RENAME (srv -> srv2) in the failing agent's spec,
+    ``written_sidecars`` holds only the new name — pruning the old ``srv``
+    sidecar would leave the kept overlay's ``--env-file`` dangling and spawn
+    that backend credential-less until the next boot. The sidecar prune is
+    therefore skipped on any transient-keep pass (already uncacheable, so a
+    healthy boot re-sweeps)."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path)
+    env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
+    sidecars_before = set(env_dir.glob("*.json"))
+    assert sidecars_before
+
+    # Rename agent-1's server so the new pass enumerates a DIFFERENT sidecar
+    # name, then fail agent-1's overlay write so the old overlay is kept.
+    spec_path = src / "agent-1.json"
+    spec = json.loads(spec_path.read_text())
+    spec["mcpServers"]["srv2"] = spec["mcpServers"].pop("srv")
+    spec_path.write_text(json.dumps(spec))
+
+    real_write = rewriter.atomic_write
+
+    def flaky(target: Path, *args: Any, **kwargs: Any) -> None:
+        if Path(target).name == "agent-1.json":
+            raise OSError("disk full")
+        real_write(target, *args, **kwargs)
+
+    monkeypatch.setattr(rewriter, "atomic_write", flaky)
+    _rewrite(tmp_path)
+
+    # The old (agent-1, srv) sidecar — still referenced by the kept overlay's
+    # --env-file — survived the pass.
+    assert sidecars_before <= set(env_dir.glob("*.json"))
+    # Degraded pass not cached: the next boot retries and re-sweeps.
+    assert not (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).exists()
+
+
+def test_kept_overlay_target_mappings_stay_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A kept overlay's stub must keep resolving to its OWN backend command.
+    The stub's pool key hashes the OLD args, so if the pass only published
+    ``target_env`` from freshly-rewritten specs, the retained stub would miss
+    its args-hashed entry and fall back to the bare server-name key — which,
+    with two agents declaring the same server name, is ANOTHER agent's
+    command. The pass therefore harvests every kept overlay's wrapped entries
+    into ``target_env`` after the prune (mirroring the cached path)."""
+    src = _mk_tree(tmp_path)
+    _, healthy_env = _rewrite(tmp_path)
+    # The fixture gives agent-0/agent-1 the same server name with different
+    # args, so each contributes its own args-hashed key.
+    hashed_before = {k for k in healthy_env if "__" in k}
+    assert len(hashed_before) >= 2
+
+    # Change agent-1's args and fail its overlay write: its overlay (old
+    # args) is kept, and the fresh pass publishes only the NEW args' hash.
+    spec_path = src / "agent-1.json"
+    spec = json.loads(spec_path.read_text())
+    spec["mcpServers"]["srv"]["args"] = ["changed-args"]
+    spec_path.write_text(json.dumps(spec))
+
+    real_write = rewriter.atomic_write
+
+    def flaky(target: Path, *args: Any, **kwargs: Any) -> None:
+        if Path(target).name == "agent-1.json":
+            raise OSError("disk full")
+        real_write(target, *args, **kwargs)
+
+    monkeypatch.setattr(rewriter, "atomic_write", flaky)
+    _, degraded_env = _rewrite(tmp_path)
+
+    # Every hash-keyed mapping the healthy pass published is still present:
+    # the kept overlay's old-args hash (what its live stub actually sends)
+    # resolves to its own command, not the bare-key fallback.
+    assert hashed_before <= set(degraded_env)
+
+
 def test_missing_overlay_file_forces_full_rewrite(
     tmp_path: Path, rewrite_counter: dict[str, int]
 ) -> None:
@@ -919,12 +1139,16 @@ def test_transient_settings_read_failure_is_not_cached(
 ) -> None:
     """The settings/mcp.json read site has the same transient-failure rule as
     the agent-spec site: a pass that treated an existing settings file as
-    absent (and pruned its overlay) must not be cached, and a fingerprint from
-    an earlier healthy run must be removed."""
+    absent must not be cached, and a fingerprint from an earlier healthy run
+    must be removed. Since #5328 the degraded pass also KEEPS the previous
+    settings overlay (the prune is keyed on source existence, not on whether
+    this pass managed to read the source)."""
     src = _mk_tree(tmp_path)
     _rewrite(tmp_path)  # healthy run: fingerprint exists
     fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
     assert fp.is_file()
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    assert settings_overlay.is_file()
 
     _bump_mtime(src / "agent-0.json")  # invalidate so the next call rewrites
     real_read = Path.read_text
@@ -940,12 +1164,16 @@ def test_transient_settings_read_failure_is_not_cached(
     fail["on"] = False
 
     assert not fp.exists()  # degraded pass not cached, stale fingerprint gone
+    # The previous healthy settings overlay survived the degraded pass —
+    # unlinking it here would strip every session's global MCP servers until
+    # a later pass succeeds (#5328).
+    assert settings_overlay.is_file()
 
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
     assert rewrite_counter["n"] == before + 2  # full retry after fault clears
     assert fp.is_file()
-    # The settings overlay is back (the degraded pass had pruned it).
+    # The settings overlay is (still) present after the healthy retry.
     assert (tmp_path / "mcp-gateway" / "settings" / "mcp.json").is_file()
 
 


### PR DESCRIPTION
# fix(mcp-gateway): keep healthy overlays through transient rewrite faults

Closes #5328

## Problem

In `rewrite_agents`, the stale-overlay prune deletes every file in `overlay_dir` whose name is absent from the `written` set — which is populated only after a **successful** overlay write. A single transient failure (ENOSPC, a Windows ACL/icacls hiccup, an unreadable-but-present source file) therefore unlinked the previous, **healthy** overlay for that agent. The agent was left with no overlay at all rather than a stale-but-working one, and its sessions ran unpooled until a later rewrite pass succeeded.

## Why it matters

One transient I/O fault at gateway startup silently degrades an agent for the whole gateway lifetime: no pooling, and (via the settings-overlay sibling of the same bug) potentially no global MCP servers. The failure is invisible unless the operator correlates a one-line write warning with later session behavior.

## Fix (symptom → root cause → change)

The prune conflated two questions — "did this pass write this overlay?" and "does this overlay's source agent still exist?" — and answered the second with the first. The change re-keys the prunes so only the right evidence deletes a file:

- **Per-agent overlay prune** now keeps `written | transient_keep`, where `transient_keep` collects agents whose source read or overlay write failed with `OSError` this pass. Transient victims keep their previous overlay (the pass is already uncacheable, so the next boot retries); **deterministic** skips (bad JSON, non-dict spec) still prune exactly like deleted sources — keeping them would desynchronize the full path from the cached path's outputs-keyed prune and make two boots over identical inputs behave differently.
- **Env-sidecar prune** is skipped on a pass with a source-read failure: the victim's sidecar names derive from parsing the spec, so they are unknowable, and its kept overlay still references them via `--env-file`. Pruning them would spawn those backends credential-less for the rest of the gateway lifetime (the stub fails soft on a missing env file). A write-only failure does **not** skip this prune.
- **Settings-overlay prune** classifies the source with an explicit `stat()` instead of `is_file()` (which folds stat/ACL faults into "absent"): confirmed `FileNotFoundError` prunes, deterministic bad content prunes, a transient read or stat fault keeps the overlay and marks the pass uncacheable.
- Keep sites log a warning naming the agent and that its previous overlay stays in effect.

Fingerprint/caching contract, on-disk overlay format, and `overlay_ready()` are untouched.

## Prune sites audited (per the issue's checklist)

| Site | Verdict |
| --- | --- |
| Per-agent overlay prune (`written`-keyed) | **Fixed** — keyed on `written \| transient_keep` |
| Env-sidecar prune (`written_sidecars`-keyed) | **Conditionally fixed** — `_build_stub_entry` adds the sidecar name **before** attempting the write, so it was already enumeration-keyed for write failures; the one broken arm (source-read failure makes the expected set unknowable) is handled by skipping the prune on that already-uncacheable pass |
| Settings-overlay prune (`settings_src_spec is None` else-arm) | **Fixed** — explicit stat classification (absence/deterministic prune, transient keep) |
| Earlier cached-path prunes (`overlay_sigs` / `sidecar_sigs` in `_cached_rewrite_result`, ~line 1170) | **Left alone, correct** — reachable only after a fully-successful cacheable pass over unchanged inputs (transient passes never store a fingerprint), so every name absent from its keep-set is a foreign file or a deterministically-skipped source, never a transient-failure victim |

A related **pre-existing** defect surfaced by the verification lane — a transient `settings/mcp.json` read failure drops *injected global poolable servers* from agent overlays (mechanism identical on main; this PR only stops the additional deletion of the settings overlay file) — is out of scope here and filed as #5344.

## Tests

All in `test/test_mcp_gateway_rewriter_fingerprint.py` (the module that drives `rewrite_agents` end-to-end):

- `test_transient_overlay_write_failure_keeps_the_previous_overlay` — one overlay write fails; the victim's overlay survives byte-identical, siblings still rewrite, pass uncacheable, retry rewrites.
- `test_transient_agent_read_failure_keeps_the_previous_overlay` — unreadable source keeps its overlay **and** the full sidecar set (overlay/sidecar coherence).
- `test_write_failure_does_not_suppress_the_prune_for_deleted_sources` — in one degraded pass, a deleted source is still pruned while the failure victim keeps its overlay (guards against a pass-wide failure switch).
- `test_malformed_source_still_prunes_its_overlay` — deterministic bad content prunes and stays cacheable.
- `test_transient_settings_read_failure_is_not_cached` — extended to assert the settings overlay survives the degraded pass.

Mutation-verified in five directions (prune re-keyed to `written`; prune no-op; sidecar guard removed; settings transient flag bypassed; bad-JSON added to keep-set) — each mutant is caught by a named test.

## Manual verification

N/A — unit coverage drives the real `rewrite_agents` end to end against a real tmp overlay tree, including the failure injections; there is no UI surface. Full backend suite: 62164 passed, 39 failures byte-identical to the same-commit baseline on clean main (verified in a throwaway worktree).

## Screenshots

N/A — backend-only change, no user-visible UI delta.

<!-- no-visual-delta -->
