### PR TITLE
ci(security): gate lockdown-before-publish so a new secret writer cannot regress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,6 +436,16 @@ jobs:
           python3 scripts/check_subprocess_encoding.py --test
           python3 scripts/check_subprocess_encoding.py
 
+      # A secret-bearing file must be locked down BEFORE any content reaches it:
+      # a post-publish lockdown leaves the payload at its final path under the
+      # inherited DACL, which on Windows is not covered by atomic_write's POSIX
+      # mode at all. #5307 converted the last seven such writers; this keeps a
+      # new one from reintroducing the shape. Known-unconverted sites live in
+      # KNOWN_UNCONVERTED in the script, keyed to an open issue, and that list is
+      # shrink-only -- a paid-off entry fails the gate until it is deleted.
+      - name: Check lockdown-before-publish (secret writers)
+        run: python3 scripts/check_lockdown_before_publish.py
+
       # isort/flake8/mypy below are BLOCKING (config in pyproject.toml + setup.cfg).
       #
       # The two repo-root modules are named explicitly: `src/kiro_crew test` misses

--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""Refuse an owner-only lockdown applied to a published path AFTER content.
+
+A secret-bearing file must be locked down BEFORE any content reaches it.
+Applying the lockdown once the payload is already at its final path leaves a
+window in which the file exists under whatever permissions it inherited -- on
+Windows that is the parent directory's DACL, and POSIX mode bits are not
+enforced there at all, so ``atomic_write(mode=0o600)`` does not close it.
+
+Issue #5307 converted seven such writers to
+``atomic_write(..., restrict_to_owner=True)``, which locks the temp file down
+before the first content byte and before the rename. Nothing prevented a NEW
+writer from reintroducing the shape; this checker does.
+
+A violation is, within ONE function body, an owner-only lockdown applied to a
+path expression that an EARLIER statement in that same function already wrote
+content to, where that path is the PUBLISHED one.
+
+Deliberately NOT violations -- flagging these would make the gate worse than no
+gate:
+
+* a lockdown on a temp path the same function LATER renames into place, in any
+  spelling (``os.replace(tmp, final)``, ``tmp.rename(final)``, or
+  ``tmp.replace(target=final)``): the published file is never exposed, and this
+  is the shape ``atomic_write`` uses. The rename must come AFTER the lockdown
+  and in the same scope -- an EARLIER rename means the path was rotated aside
+  and the payload written to it afterwards, which is the defect, not the fix;
+* the delegated form ``atomic_write(..., restrict_to_owner=True)``, which is
+  the fix this checker exists to protect;
+* ``chmod``/``chmod_safe``/``fchmod_safe`` with a mode that grants anything to
+  group or other
+  -- making a launcher executable (``0o755``) is not a lockdown. Owner-only is
+  tested as a property, so the symbolic spellings (``stat.S_IRWXU``,
+  ``stat.S_IRUSR | stat.S_IWUSR``) count the same as ``0o700``/``0o600``;
+* ``fd = os.open(p, O_CREAT...)`` then ``restrict_to_owner(p)`` then writing
+  through the descriptor: ``os.open`` creates an EMPTY file, so the lockdown
+  lands before any content. The content-write moment for that idiom is
+  ``os.fdopen(fd, ...)``, and only a lockdown after THAT is a violation;
+A path reached through a single-assignment local alias (``target = secret_path``)
+counts as the same path; anything less tractable -- a name rebound in a branch, an
+attribute, a write and lockdown split across two functions -- is outside the rule
+by construction, so a green run is not proof the shape is absent.
+
+Deliberately NOT violations (continued):
+
+* a site carrying ``# lockdown-ok: <reason>`` on the lockdown line. The reason
+  is mandatory, and there are three legitimate kinds: a load-time re-assert; a
+  file that holds no data; or a call site where a REVIEWED decision says the
+  helper must not be used here at all -- ``workflows/store.py::save`` runs on
+  the event loop and ``restrict_to_owner`` spawns ``icacls``, so #5228 settled
+  it on POSIX ``chmod`` with a ``_redact``-ed payload.
+
+  The marker and ``KNOWN_UNCONVERTED`` are not interchangeable, and picking the
+  wrong one misreports the site. ``KNOWN_UNCONVERTED`` means "this SHOULD be
+  converted and has not been yet", so it is watched: the shrink-only rule fails
+  once the debt is paid. The marker means "converting this would be wrong", so
+  there is nothing to watch -- filing such a site as debt would instead tell the
+  next contributor to make the change the decision rejected.
+
+Usage:
+    python scripts/check_lockdown_before_publish.py [PATH ...]
+
+Exits non-zero and prints ``file:line`` per violation. With no arguments it
+scans ``src/kiro_crew``. Sites tracked by an open conversion issue live in
+``KNOWN_UNCONVERTED``; that list is shrink-only.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import re
+import stat
+import sys
+from pathlib import Path
+
+#: Unambiguous lockdown helper: always means "owner-only, and nobody else".
+RESTRICT_CALL = "restrict_to_owner"
+
+#: ``chmod``-family calls are a lockdown only with an owner-only mode. The same
+#: helpers set directory modes and executable bits.
+CHMOD_CALLS = frozenset({"chmod_safe", "chmod"})
+
+#: Descriptor-addressed lockdowns: ``fchmod_safe(fd, 0o600)`` / ``os.fchmod``.
+#: The path is recovered through the fd map, exactly as the content-write side
+#: already does for ``os.fdopen``/``os.write``. Without these, a writer that
+#: hardened through the descriptor recorded NO lockdown at all -- and
+#: ``fchmod_safe`` is the tree's own helper (platform_compat.py), not a
+#: hypothetical spelling.
+FCHMOD_CALLS = frozenset({"fchmod_safe", "fchmod"})
+
+#: A mode is a lockdown when it grants nothing to group or other. Expressed as a
+#: property rather than a list so 0o600/0o700/0o400 and their symbolic spellings
+#: (``stat.S_IRWXU``, ``stat.S_IRUSR | stat.S_IWUSR``) are all covered, while
+#: 0o755 and 0o644 -- an executable launcher, a world-readable file -- are not.
+GROUP_OTHER_BITS = 0o077
+
+#: Calls whose Nth positional argument is a path that RECEIVES content.
+#: ``replace``/``rename`` are included because the rename is how the published
+#: path gets its content in the temp-file idiom -- a lockdown after it is the
+#: exact defect (see ``workflows/store.py`` before this checker landed).
+WRITE_DESTINATION_ARG = {
+    "atomic_write": 0,
+    # This repo's private JSON writer (agent.py): mkstemp + write + rename, so
+    # the payload lands at the FINAL path when it returns. It is not
+    # ``atomic_write`` and takes no ``restrict_to_owner``, so a lockdown after it
+    # is the #5307 shape -- and it is the single most widely used writer in the
+    # dashboard handlers, which is why leaving it out made the gate quiet about a
+    # real keystone site.
+    "_atomic_json_write": 0,
+    "copy2": 1,  # shutil.copy2(src, dst)
+    "copyfile": 1,
+    "copy": 1,
+    "replace": 1,  # os.replace(tmp, final)
+    "rename": 1,  # os.rename(tmp, final)
+    "move": 1,  # shutil.move(tmp, final)
+}
+
+#: The same destinations by KEYWORD name. Reading positionally alone let the
+#: keyword form (``atomic_write(path=...)``) register no write at all, so a
+#: lockdown after it went unflagged.
+WRITE_DESTINATION_KWARG = {
+    "atomic_write": "path",
+    "_atomic_json_write": "path",
+    "copy2": "dst",
+    "copyfile": "dst",
+    "copy": "dst",
+    "replace": "dst",
+    "rename": "dst",
+    "move": "dst",
+}
+
+#: Keyword name of a publish call's SOURCE (the temp being renamed away).
+PUBLISH_SOURCE_KWARG = "src"
+
+#: Keyword name of the DESTINATION in the pathlib publish spelling:
+#: ``tmp.replace(target=final)``. The os spelling uses ``src``/``dst``, so
+#: reading only those left the pathlib keyword form recording no write at all.
+PUBLISH_TARGET_KWARG = "target"
+
+#: Keyword name of the builtin ``open`` path: ``open(file=final, mode="w")``.
+#: Read positionally alone, the keyword form registered no content write.
+OPEN_PATH_KWARG = "file"
+
+#: ``<path>.write_text(...)`` / ``.write_bytes(...)`` -- receiver is the path.
+WRITE_METHODS = frozenset({"write_text", "write_bytes"})
+
+#: Calls that publish a path UNDER ANOTHER NAME, so a lockdown on the source is
+#: a lockdown on a temp. ``shutil.move`` was absent, which failed BOTH ways: a
+#: ``move`` to the final path recorded no publication (so a lockdown after it was
+#: not flagged) AND the source got no temp exemption (so locking a temp and then
+#: moving it -- correct code -- was flagged).
+PUBLISH_CALLS = frozenset({"replace", "rename", "move"})
+
+#: The subset with a pathlib METHOD spelling where the receiver is the temp:
+#: ``<tmp>.rename(final)`` / ``<tmp>.replace(final)``. ``shutil.move`` is a
+#: module function only, and treating an arbitrary one-argument ``x.move(y)`` as
+#: a publication would read unrelated receivers as temp paths.
+PUBLISH_METHOD_CALLS = frozenset({"replace", "rename"})
+
+WRITE_MODE_CHARS = ("w", "a", "x", "+")
+
+#: ``os.fdopen(fd, ...)`` is where content starts flowing for the
+#: os.open-then-lock-then-write idiom; the fd is mapped back to its path.
+FDOPEN_CALL = "fdopen"
+
+#: ``os.write(fd, data)`` writes content through the descriptor directly, without
+#: ever wrapping it in a file object. Matched only with ``os`` as the literal
+#: receiver -- a bare ``.write(...)`` is the commonest method call in the tree.
+OS_WRITE_CALL = "write"
+
+#: ``# lockdown-ok: <reason>`` -- reason is mandatory and must be non-empty.
+SUPPRESS_RE = re.compile(r"#\s*lockdown-ok\s*:\s*(?P<reason>\S.*)$")
+
+#: Sites carrying the shape under an OPEN conversion issue. Shrink-only: when a
+#: site is converted, delete its entry -- the checker fails if an entry here no
+#: longer violates, so the list cannot outlive the debt it tracks.
+#: ``file::function`` -> ``(issue, path expression)``. The path expression is
+#: load-bearing: keyed by function alone, a SECOND unrelated violating writer
+#: added to an allowlisted function would be suppressed along with the tracked
+#: one, so an allowlist entry would quietly widen into a whole-function waiver.
+KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
+    # Classified by #5346 -- the sites #5307's third acceptance criterion left
+    # untriaged. The two snapshot ones are a shutil.copy2 into a final
+    # destination, so they need copy-to-temp + restrict + replace rather than a
+    # one-line atomic_write swap.
+    #
+    # #5285's six sites were here until main converted them mid-review; the
+    # shrink-only rule below is what forced this list to follow.
+    "src/kiro_crew/snapshot.py::_backup_and_copy": ("#5346", "mc / f"),
+    "src/kiro_crew/snapshot.py::_do_merge": ("#5346", "d"),
+    "src/kiro_crew/sel.py::_append_lines_locked": ("#5346", "self._path"),
+    # Surfaced once _mode_of learned the symbolic spelling: writes a config that
+    # "can carry provider tokens / API keys" (its own docstring), then chmods.
+    # Path expressions are recorded after alias resolution, so this entry names
+    # `home_dir / "config.json"` rather than the local `dst_cfg` the line spells.
+    # That is the more durable key: renaming the local no longer stales the entry.
+    "src/kiro_crew/pod/runtime.py::write_pod_config": ("#5346", 'home_dir / "config.json"'),
+    # Surfaced once _atomic_json_write was recognised as a writer. The most
+    # security-relevant of these five: denied_commands.json is the command
+    # opt-out keystone, and its own docstring says it is written "0600
+    # (owner-only, like other keystone secrets)" -- but the 0600 lands AFTER the
+    # helper has already published the payload at the final path.
+    #
+    # Deliberately tracked rather than converted here. _atomic_json_write takes
+    # no restrict_to_owner, and its rename goes through replace_with_retry for
+    # Windows PermissionError, which its docstring calls load-bearing for spawn
+    # correctness -- so the conversion is either a new parameter threaded through
+    # ~20 callers or a swap that drops that retry. Either is its own change with
+    # its own review, not a rider on a gate.
+    "src/kiro_crew/dashboard/handlers/security.py::_read_modify_write": ("#5346", "path"),
+}
+
+
+def _norm(expr: str | None) -> str:
+    """Normalise a path expression so spellings of one path compare equal."""
+    if not expr:
+        return ""
+    text = " ".join(expr.split())
+    changed = True
+    while changed:
+        changed = False
+        for wrapper in ("str(", "Path(", "os.fspath("):
+            if text.startswith(wrapper) and text.endswith(")"):
+                text = text[len(wrapper) : -1].strip()
+                changed = True
+    return text
+
+
+def _callee(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+@functools.lru_cache(maxsize=8)
+def _source_lines(source: str) -> tuple[str, ...]:
+    """Line split, cached per file.
+
+    ``ast.get_source_segment`` re-splits the entire file on EVERY call, which is
+    fine for a handful of lookups and quadratic once the alias map asks for one
+    per assignment: the whole-tree scan went from ~15s to ~117s before this.
+    Python caches a str's hash after the first use, so keying the cache on the
+    source itself is O(1) per call after the first.
+    """
+    return tuple(source.splitlines(True))
+
+
+def _seg(source: str, node: ast.AST) -> str:
+    """The source text of ``node``.
+
+    Byte offsets, not character offsets: CPython reports ``col_offset`` as a
+    UTF-8 byte index, so each edge line is encoded before slicing -- exactly what
+    ``ast.get_source_segment`` does. This tree has non-ASCII string literals, so
+    slicing the str directly would cut them in the wrong place. A test asserts
+    this agrees with the stdlib on every node in the scanned tree.
+    """
+    lines = _source_lines(source)
+    try:
+        start = node.lineno - 1  # type: ignore[attr-defined]
+        end = node.end_lineno - 1  # type: ignore[attr-defined]
+        col = node.col_offset  # type: ignore[attr-defined]
+        end_col = node.end_col_offset  # type: ignore[attr-defined]
+        if start == end:
+            return lines[start].encode()[col:end_col].decode()
+        first = lines[start].encode()[col:].decode()
+        last = lines[end].encode()[:end_col].decode()
+        return "".join([first, *lines[start + 1 : end], last])
+    except Exception:  # pragma: no cover - mirrors get_source_segment's leniency
+        return ""
+
+
+def _arg(node: ast.Call, index: int | None, keyword: str | None, source: str) -> str | None:
+    """Read an argument positionally or by keyword, normalised."""
+    if index is not None and len(node.args) > index:
+        return _norm(_seg(source, node.args[index]))
+    if keyword:
+        for kw in node.keywords:
+            if kw.arg == keyword:
+                return _norm(_seg(source, kw.value))
+    return None
+
+
+def _exempted_by_restrict_kwarg(node: ast.Call) -> bool:
+    """Only a LITERAL ``restrict_to_owner=True`` is the fix.
+
+    Testing mere presence exempted ``restrict_to_owner=False`` -- a real write
+    followed by a real lockdown, waved through as though already protected.
+    Anything that is not a literal True (False, a name, an expression) reads as
+    a plain write, which fails closed.
+    """
+    for kw in node.keywords:
+        if kw.arg != "restrict_to_owner":
+            continue
+        return isinstance(kw.value, ast.Constant) and kw.value.value is True
+    return False
+
+
+def _module_constants(tree: ast.AST) -> dict[str, object]:
+    """``NAME -> value`` for module-level assignments of a resolvable mode.
+
+    Naming the mode is this tree's prevailing style (``_LAUNCHER_MODE``,
+    ``_DIR_MODE``, ``_SHOT_DIR_MODE``), and an unresolved mode is not owner-only,
+    so ``chmod_safe(path, _SECRET_MODE)`` recorded no lockdown and the writer
+    passed. Module level only: a name assigned inside a function can be rebound
+    per call, and guessing there would trade a false negative for a false
+    positive.
+    """
+    out: dict[str, object] = {}
+    for node in ast.iter_child_nodes(tree):
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        if not targets or getattr(node, "value", None) is None:
+            continue
+        value = _resolve_mode(node.value)
+        if value is None:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                out[target.id] = value
+    return out
+
+
+def _resolve_mode(node: ast.AST, consts: dict[str, object] | None = None) -> object:
+    """An int/str literal, a ``stat.S_*`` constant, a ``|`` chain, or a named one.
+
+    Deliberately NOT general expression evaluation: the ``stat`` names are a
+    closed set with fixed values, so resolving them is exact, and ``consts`` only
+    ever holds module-level names that themselves resolved. Anything else returns
+    None and the caller treats the mode as unknown.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name) and consts:
+        return consts.get(node.id)
+    if isinstance(node, ast.Attribute) and node.attr.startswith("S_I"):
+        value = getattr(stat, node.attr, None)
+        return value if isinstance(value, int) else None
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _resolve_mode(node.left, consts)
+        right = _resolve_mode(node.right, consts)
+        if isinstance(left, int) and isinstance(right, int):
+            return left | right
+        return None
+    return None
+
+
+def _mode_of(node: ast.Call, consts: dict[str, object] | None = None) -> object:
+    if len(node.args) >= 2:
+        resolved = _resolve_mode(node.args[1], consts)
+        if resolved is not None:
+            return resolved
+    for kw in node.keywords:
+        if kw.arg == "mode":
+            return _resolve_mode(kw.value, consts)
+    return None
+
+
+def _is_owner_only_mode(mode: object) -> bool:
+    """Owner-only: something for the owner, nothing for group or other."""
+    return isinstance(mode, int) and mode != 0 and not (mode & GROUP_OTHER_BITS)
+
+
+def _resolve_mode_kwarg(node: ast.Call, consts: dict[str, object] | None = None) -> object:
+    """``mode=`` for a call whose positional slot carries no mode."""
+    for kw in node.keywords:
+        if kw.arg == "mode":
+            return _resolve_mode(kw.value, consts)
+    return None
+
+
+def _is_publish_method_form(node: ast.Call) -> bool:
+    """``tmp.rename(final)`` / ``tmp.replace(target=final)`` -- receiver is the TEMP.
+
+    Told apart from the os-function spelling by ARITY, not node type: ``os.replace``
+    is an attribute access too (``replace`` on ``os``), so keying on
+    ``ast.Attribute`` alone would break ``os.replace(tmp, final)``. The os
+    spelling names its arguments ``src``/``dst``; pathlib takes a single
+    ``target``, so the presence of an os keyword settles the ambiguous arities.
+    """
+    if not isinstance(node.func, ast.Attribute):
+        return False
+    if _callee(node) not in PUBLISH_METHOD_CALLS:
+        return False
+    if any(kw.arg in (PUBLISH_SOURCE_KWARG, "dst") for kw in node.keywords):
+        return False
+    return len(node.args) <= 1
+
+
+def _is_pathlib_chmod_form(node: ast.Call) -> bool:
+    """``final.chmod(0o600)`` -- receiver is the path, argument 0 is the MODE.
+
+    The os/helper spelling puts the path first (``os.chmod(p, 0o600)``,
+    ``platform_compat.chmod_safe(p, 0o600)``), so the two are told apart by
+    ARITY, as with the publish forms above. That is sound rather than merely
+    convenient: ``mode`` is a REQUIRED parameter of both ``os.chmod`` and
+    ``chmod_safe`` (see platform_compat.py), so a one-argument attribute-form
+    chmod cannot be either of them.
+    """
+    if not isinstance(node.func, ast.Attribute):
+        return False
+    if any(kw.arg == "path" for kw in node.keywords):
+        return False
+    if any(kw.arg == "mode" for kw in node.keywords):
+        return not node.args  # `final.chmod(mode=0o600)`
+    return len(node.args) == 1  # `final.chmod(0o600)`
+
+
+def _opens_for_write(node: ast.Call, consts: dict[str, object] | None = None) -> bool:
+    """``open(p, "w")`` -- a builtin open in a writable text/binary mode.
+
+    ``os.open`` is deliberately NOT a content write: it creates an empty file
+    and the payload arrives through the descriptor, which is why the correct
+    idiom locks the empty file down between the two.
+    """
+    mode = _mode_of(node, consts)
+    if not isinstance(mode, str):
+        return False
+    return any(ch in mode for ch in WRITE_MODE_CHARS)
+
+
+def _own_nodes(func: ast.AST):
+    """Every node in this function EXCEPT the bodies of functions nested in it.
+
+    ``ast.walk`` descends into nested ``def``/``lambda``, which pooled an inner
+    function's writes, lockdowns and publishes into the outer one. A rename
+    inside an unrelated nested helper therefore entered the outer function's
+    temp set and exempted a real violation there. Nested functions are still
+    scanned in their own right -- ``scan_source`` visits every FunctionDef in
+    the module -- so nothing stops being checked, it only stops leaking.
+    """
+    stack = [func]
+    while stack:
+        node = stack.pop()
+        yield node
+        for child in ast.iter_child_nodes(node):
+            if child is not func and isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+            ):
+                continue
+            stack.append(child)
+
+
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _binds(func: ast.AST) -> dict[str, int]:
+    """How many times each bare name is bound in this scope.
+
+    Every binding form counts, not just ``=``: a ``for`` target, ``with ... as``,
+    a walrus or an augmented assignment all rebind the name, and a name bound
+    more than once has no single value to alias to.
+    """
+    counts: dict[str, int] = {}
+
+    def bump(node):
+        if isinstance(node, ast.Name):
+            counts[node.id] = counts.get(node.id, 0) + 1
+        elif isinstance(node, (ast.Tuple, ast.List)):
+            for element in node.elts:
+                bump(element)
+
+    for node in _own_nodes(func):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                bump(target)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+            bump(node.target)
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            bump(node.target)
+        elif isinstance(node, ast.withitem):
+            if node.optional_vars is not None:
+                bump(node.optional_vars)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node is not func:
+                counts[node.name] = counts.get(node.name, 0) + 1
+    return counts
+
+
+def _alias_map(func: ast.AST, source: str) -> dict[str, str]:
+    """``local name -> the normalised expression it was assigned``.
+
+    Closes an alias hole that ran in BOTH directions. The rule compares path
+    EXPRESSIONS, so ``target = secret_path`` split a single path into two names:
+
+        target = secret_path
+        target.write_text(secret)      # write recorded against `target`
+        os.chmod(secret_path, 0o600)   # lockdown recorded against `secret_path`
+
+    -- no match, so a real post-content lockdown went unflagged. The same split
+    also FALSELY flagged correct code, because a temp aliased under a second name
+    no longer matched the publish that exempted it.
+
+    Deliberately narrow, and the narrowness is the point:
+
+    * only names bound EXACTLY ONCE in this scope (see ``_binds``) -- a rebound
+      name has no single value, and guessing one would invent findings;
+    * only a bare identifier resolves, so ``self._path`` and ``cfg["p"]`` are
+      left alone -- an attribute or subscript can change under us between the
+      two statements;
+    * same scope only, so nothing is inferred across a function boundary.
+
+    Aliasing beyond that (rebound in a branch, carried through a helper, stored
+    on an object) stays out of reach by construction, which is what makes this a
+    ratchet rather than a dataflow analysis.
+    """
+    binds = _binds(func)
+    out: dict[str, str] = {}
+    for node in _own_nodes(func):  # noqa: SIM118
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name) or binds.get(target.id, 0) != 1:
+            continue
+        value = _norm(_seg(source, node.value))
+        if value and value != target.id:
+            out[target.id] = value
+    return out
+
+
+def _resolve_alias(expr: str, aliases: dict[str, str]) -> str:
+    """Follow a bare-name alias chain to the expression it ultimately names."""
+    seen: set[str] = set()
+    while _IDENT_RE.match(expr) and expr in aliases and expr not in seen:
+        seen.add(expr)
+        expr = aliases[expr]
+    return expr
+
+
+def _fd_paths(func: ast.AST, source: str) -> dict[str, str]:
+    """``fd variable -> path`` for each ``fd = os.open(path, ...)``."""
+    out: dict[str, str] = {}
+    for node in _own_nodes(func):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        value = node.value
+        if not isinstance(target, ast.Name) or not isinstance(value, ast.Call):
+            continue
+        if _callee(value) == "open" and isinstance(value.func, ast.Attribute) and value.args:
+            out[target.id] = _norm(_seg(source, value.args[0]))
+    return out
+
+
+def _write_target(
+    node: ast.Call,
+    source: str,
+    fd_paths: dict[str, str] | None = None,
+    consts: dict[str, object] | None = None,
+) -> str | None:
+    """The path this call writes content to, if any."""
+    name = _callee(node)
+    if name is None:
+        return None
+
+    # `open(p, "w")` -- but NOT `os.open`, which only creates the file.
+    # The path is read positionally OR as `file=`: `open(file=final, mode="w")`
+    # is a valid builtin call that recorded no write at all, so a lockdown after
+    # it found no preceding write and the writer escaped the gate.
+    if name == "open" and isinstance(node.func, ast.Name):
+        if _opens_for_write(node, consts):
+            return _arg(node, 0, OPEN_PATH_KWARG, source)
+        return None
+
+    # Method-form `.open()` is two different calls, told apart by whether the
+    # first positional argument is a string literal (a mode) or not (a path):
+    #   `path.open("w")`             -> receiver is the path, arg 0 is the mode
+    #   `tarfile.open(name, "w:gz")` -> receiver is a module, arg 0 is the path
+    if name == "open" and isinstance(node.func, ast.Attribute):
+        first_is_mode = (
+            bool(node.args)
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        )
+        if first_is_mode or not node.args:
+            # pathlib spelling: the mode sits where the builtin's path would be.
+            mode = node.args[0].value if first_is_mode else _resolve_mode_kwarg(node, consts)
+            if isinstance(mode, str) and any(ch in mode for ch in WRITE_MODE_CHARS):
+                return _norm(_seg(source, node.func.value))
+            return None
+        # module spelling (tarfile/gzip/io): path at 0, mode at 1.
+        if _opens_for_write(node, consts):
+            return _norm(_seg(source, node.args[0]))
+        return None
+
+    # `os.fdopen(fd, ...)` / `os.write(fd, data)` -- content flows into the fd's
+    # path here. os.write goes straight to the descriptor with no file object, so
+    # without it a write to a descriptor opened on the FINAL path went unrecorded
+    # and a lockdown after it was not flagged.
+    if name == FDOPEN_CALL or (
+        name == OS_WRITE_CALL
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "os"
+    ):
+        if node.args and fd_paths:
+            first = node.args[0]
+            if isinstance(first, ast.Name):
+                return fd_paths.get(first.id)
+        return None
+
+    if name in WRITE_METHODS and isinstance(node.func, ast.Attribute):
+        return _norm(_seg(source, node.func.value))
+
+    index = WRITE_DESTINATION_ARG.get(name)
+    if index is None:
+        return None
+    if name == "atomic_write" and _exempted_by_restrict_kwarg(node):
+        # Locks the temp down before content -- the fix, not the defect.
+        return None
+    if name in PUBLISH_CALLS and _is_publish_method_form(node):
+        # Method form: `tmp.rename(final)` / `tmp.replace(target=final)` -- the
+        # destination is the SOLE positional arg, or pathlib's `target=`, never
+        # index 1. The indices above are for the os-function spelling
+        # `os.replace(tmp, final)`; reading index 1 here recorded no write at
+        # all, so a later lockdown on `final` found no preceding write and the
+        # pathlib idiom escaped the gate in BOTH its spellings.
+        return _arg(node, 0, PUBLISH_TARGET_KWARG, source)
+    return _arg(node, index, WRITE_DESTINATION_KWARG.get(name), source)
+
+
+def _lockdown_target(
+    node: ast.Call,
+    source: str,
+    fd_paths: dict[str, str] | None = None,
+    consts: dict[str, object] | None = None,
+) -> str | None:
+    name = _callee(node)
+    if name == RESTRICT_CALL:
+        return _arg(node, 0, "path", source)
+    if name in FCHMOD_CALLS:
+        # `fchmod_safe(fd, 0o600)`: addressed by DESCRIPTOR, so the path comes
+        # from the fd map -- the same recovery the content-write side already
+        # does for `os.fdopen(fd)`/`os.write(fd, ...)`. Unmapped fd -> unknown
+        # path -> no lockdown recorded, which is the pre-existing behaviour for
+        # any path this rule cannot name.
+        if _is_owner_only_mode(_mode_of(node, consts)) and node.args and fd_paths:
+            first = node.args[0]
+            if isinstance(first, ast.Name):
+                return fd_paths.get(first.id)
+        return None
+    if name in CHMOD_CALLS:
+        if _is_pathlib_chmod_form(node):
+            # `final.chmod(0o600)`: the mode sits where the os spelling's path
+            # would be, so _mode_of read no mode, NO lockdown was recorded at
+            # all, and a post-write chmod in this spelling escaped the gate --
+            # the rule needs to see the lockdown before it can flag it.
+            mode = _resolve_mode(node.args[0], consts) if node.args else _mode_of(node, consts)
+            if _is_owner_only_mode(mode):
+                return _norm(_seg(source, node.func.value))
+            return None
+        if _is_owner_only_mode(_mode_of(node, consts)):
+            return _arg(node, 0, "path", source)
+    return None
+
+
+def _temp_sources(node: ast.Call, source: str) -> list[str]:
+    """Paths this call publishes UNDER ANOTHER NAME, in either spelling.
+
+    ``os.replace(tmp, final)``   -- the temp is the first argument.
+    ``tmp.rename(final)``        -- the temp is the receiver.
+    ``tmp.replace(target=final)`` -- likewise, and missing this spelling made the
+    exemption fail OPEN in the other direction: a CORRECT writer that locked its
+    temp down and then published with the keyword form recorded no temp at all,
+    so its temp lockdown was reported as a violation.
+    """
+    if _callee(node) not in PUBLISH_CALLS:
+        return []
+    found = []
+    if _is_publish_method_form(node):
+        found.append(_norm(_seg(source, node.func.value)))
+    else:
+        # `os.replace(tmp, final)` / `os.replace(src=tmp, dst=final)`.
+        found.append(_arg(node, 0, PUBLISH_SOURCE_KWARG, source))
+    return [f for f in found if f]
+
+
+def _suppressions(source: str) -> dict[int, str]:
+    """``lineno -> reason`` for every ``# lockdown-ok:`` marker."""
+    out: dict[int, str] = {}
+    for i, line in enumerate(source.splitlines(), 1):
+        match = SUPPRESS_RE.search(line)
+        if match:
+            out[i] = match.group("reason").strip()
+    return out
+
+
+def scan_source(source: str) -> list[tuple[int, str, str]]:
+    """Return ``(lineno, function, path_expression)`` per violation."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    suppressed = _suppressions(source)
+    consts = _module_constants(tree)
+    violations: list[tuple[int, str, str]] = []
+
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        writes: list[tuple[int, str]] = []
+        lockdowns: list[tuple[int, str]] = []
+        # (line, path): the LINE is load-bearing -- see the exemption below.
+        temps: list[tuple[int, str]] = []
+        fd_paths = _fd_paths(func, source)
+        # Every recorded path goes through the alias map, so the three sides of
+        # the rule name a path the same way even when the code does not.
+        aliases = _alias_map(func, source)
+
+        for node in _own_nodes(func):
+            if not isinstance(node, ast.Call):
+                continue
+            target = _write_target(node, source, fd_paths, consts)
+            if target:
+                writes.append((node.lineno, _resolve_alias(target, aliases)))
+            locked = _lockdown_target(node, source, fd_paths, consts)
+            if locked:
+                lockdowns.append((node.lineno, _resolve_alias(locked, aliases)))
+            temps.extend(
+                (node.lineno, _resolve_alias(t, aliases)) for t in _temp_sources(node, source)
+            )
+
+        for line, path in lockdowns:
+            # Exempt only a publish that comes AFTER this lockdown: that is what
+            # "locked down before it was published" means, and it is the whole
+            # basis of the exemption. Keyed on the path alone, an EARLIER publish
+            # exempted it too -- so rotating an existing secret aside and then
+            # writing a new one to the freed path passed the gate:
+            #
+            #     path.rename(backup)        # `path` published away FIRST
+            #     path.write_text(secret)    # new payload at the PUBLISHED path
+            #     os.chmod(path, 0o600)      # locked only after content
+            #
+            # This is #5307's own invariant, not the stricter temp-path one: the
+            # correct idiom (write temp, lock temp, THEN rename) still exempts,
+            # because there the publish follows the lockdown.
+            if any(t_path == path and t_line > line for t_line, t_path in temps):
+                continue  # published under another name, after being locked
+            if line in suppressed:
+                continue  # reasoned re-assert / dataless file
+            if any(w_path == path and w_line < line for w_line, w_path in writes):
+                violations.append((line, func.name, path))
+
+    return sorted(set(violations))
+
+
+def scan_path(path: Path, root: Path) -> list[tuple[str, int, str, str]]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    # POSIX form on every platform: str() yields backslashes on Windows, which
+    # would make every KNOWN_UNCONVERTED key look stale AND every real site look
+    # new -- the Windows shard caught exactly that.
+    rel = path.relative_to(root).as_posix() if path.is_relative_to(root) else path.as_posix()
+    return [(rel, line, fn, expr) for line, fn, expr in scan_source(source)]
+
+
+def main(argv: list[str]) -> int:
+    root = Path(__file__).resolve().parent.parent
+    targets = [Path(a) for a in argv[1:]] or [root / "src" / "kiro_crew"]
+
+    found: list[tuple[str, int, str, str]] = []
+    for target in targets:
+        files = sorted(target.rglob("*.py")) if target.is_dir() else [target]
+        for py in files:
+            found.extend(scan_path(py, root))
+
+    new: list[tuple[str, int, str, str]] = []
+    seen_known: set[str] = set()
+    for rel, line, fn, expr in found:
+        key = "%s::%s" % (rel, fn)
+        entry = KNOWN_UNCONVERTED.get(key)
+        # Only the exact tracked path is waived. A different path in the same
+        # function is a NEW violation and reports.
+        if entry is not None and entry[1] == expr:
+            seen_known.add(key)
+        else:
+            new.append((rel, line, fn, expr))
+
+    stale = sorted(set(KNOWN_UNCONVERTED) - seen_known)
+
+    if new:
+        print("Lockdown-before-publish check FAILED:\n")
+        for rel, line, fn, expr in new:
+            print(
+                "  %s:%d: `%s` is locked down only AFTER content was written to "
+                "it in %s().\n      Use atomic_write(..., restrict_to_owner=True) "
+                "so the temp file is locked down before the payload and before "
+                "the rename (issue #5307). If this is a load-time re-assert or a "
+                "file that holds no data, annotate the lockdown line with "
+                "`# lockdown-ok: <reason>`." % (rel, line, expr, fn)
+            )
+        print("\n%d new violation(s)." % len(new))
+
+    if stale:
+        print(
+            "\nLockdown-before-publish check FAILED: %d KNOWN_UNCONVERTED entry(ies) "
+            "no longer violate -- the debt was paid, so delete the entry.\n"
+            "Edit KNOWN_UNCONVERTED in scripts/%s and remove:\n" % (len(stale), Path(__file__).name)
+        )
+        for key in stale:
+            issue, expr = KNOWN_UNCONVERTED[key]
+            print("  %s   (`%s`, was tracked by %s)" % (key, expr, issue))
+
+    if new or stale:
+        return 1
+
+    if seen_known:
+        print(
+            "Lockdown-before-publish check passed "
+            "(%d known unconverted site(s) tracked by an open issue)." % len(seen_known)
+        )
+    else:
+        print("Lockdown-before-publish check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pollute.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pollute.py
@@ -287,7 +287,9 @@ class TestTheGateFailsLoudlyRatherThanSilently:
             after = pollute.snapshot([watched])
             assert pollute.diff(before, after) == [str(watched)]
         finally:
-            secret.chmod(0o600)  # so tmp_path cleanup can remove it
+            # lockdown-ok: not a lockdown -- WIDENS 0o000 back so tmp_path cleanup can
+            # unlink it, and the payload is a fake b"leaked" literal, not a secret.
+            secret.chmod(0o600)  # lockdown-ok: widens for cleanup; see above
 
     def test_diff_is_order_independent_and_reports_both_directions(self) -> None:
         """Keyed by path, so a reordered path list cannot change the verdict; and a key

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/preview_tools.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/preview_tools.py
@@ -196,7 +196,10 @@ def install_pdftoppm() -> tuple[bool, str]:
             # chmod AFTER the write and before any caller can resolve it, so the
             # launcher is never observable without its exec bit.
             if not platform_compat.IS_WINDOWS:
-                platform_compat.chmod_safe(launcher, _LAUNCHER_MODE)
+                # 0o700 here is the EXEC bit, not secrecy: the body is generated
+                # launcher text with no payload, so nothing is exposed in the
+                # window before the chmod. The marker must sit on the call line.
+                platform_compat.chmod_safe(launcher, _LAUNCHER_MODE)  # lockdown-ok: exec bit
         except OSError as exc:
             return False, f"cannot write {launcher.name}: {exc}"
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -8,6 +8,7 @@
     "python3 scripts/check_black_formatting.py",
     "python3 scripts/check_subprocess_encoding.py --test",
     "python3 scripts/check_subprocess_encoding.py",
+    "python3 scripts/check_lockdown_before_publish.py",
     "isort --check-only src/kiro_crew test",
     "flake8 src/kiro_crew test",
     "mypy src/kiro_crew/",

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -946,7 +946,7 @@ class SecurityEventLog:
             # at the call site (warn, don't crash): a read-only FS / chmod
             # failure must not take down SecurityEventLog init.
             try:
-                platform_compat.restrict_to_owner(key_path)
+                platform_compat.restrict_to_owner(key_path)  # lockdown-ok: load-time re-assert; the only preceding write to key_path is the legacy-key migration rename in a mutually exclusive branch
             except OSError:
                 # Logs the key file PATH, never the key bytes.
                 logger.warning(  # nosemgrep: python-logger-credential-disclosure
@@ -1086,7 +1086,7 @@ class SecurityEventLog:
                 lock_fh.write(b"\0")
                 lock_fh.flush()
             try:
-                os.chmod(lock_path, 0o600)
+                os.chmod(lock_path, 0o600)  # lockdown-ok: the rotation lock holds no data (a single NUL byte), so there is no payload to expose
             except OSError:
                 pass  # perms are hygiene here; the file holds no data
         except OSError:

--- a/src/kiro_crew/workflows/store.py
+++ b/src/kiro_crew/workflows/store.py
@@ -134,7 +134,7 @@ class WorkflowRunStore:
                 # payload is already passed through ``_redact`` above, so
                 # what a wider Windows DACL could expose is the redacted
                 # run record, not credentials.
-                os.chmod(path, 0o600)
+                os.chmod(path, 0o600)  # lockdown-ok: #5228 -- icacls would block the event loop
             except OSError:
                 pass
         except Exception:  # noqa: BLE001 - persistence must never break a run

--- a/test/test_lockdown_before_publish.py
+++ b/test/test_lockdown_before_publish.py
@@ -1,0 +1,816 @@
+"""A secret-bearing file must be locked down BEFORE it is published.
+
+Applying the owner-only lockdown after the payload is already at its final path
+leaves a window in which the file exists under whatever permissions it
+inherited. On Windows that is the parent directory's DACL, and POSIX mode bits
+are not enforced there at all, so ``atomic_write(mode=0o600)`` does not close
+it. Issue #5307 converted the last seven such writers to
+``atomic_write(..., restrict_to_owner=True)``, which locks the temp file down
+before the first content byte and before the rename.
+
+Nothing prevented a NEW writer from reintroducing the shape. Two layers here:
+
+* ``scripts/check_lockdown_before_publish.py`` is an AST rule over
+  ``src/kiro_crew``, exercised below against fixtures for every shape it must
+  catch and every correct shape it must not. Validated against real history:
+  run against the tree before #5329 it flags 6/6 of #5307's sites; against
+  ``main`` after it, 0/6.
+* behavioural probes assert the ORDER at the live writers, rather than the
+  final mode -- a final-mode assertion passes just as happily when the payload
+  was exposed for the whole write window, and on NTFS reports ``0o666``
+  regardless of the DACL. The technique (record whether the FINAL path exists
+  at the moment lockdown runs) is from PR #5314 by @leonlaiyc, whose
+  production change landed via #5329.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from test_live_target import _make_valid_checkout
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHECKER_PATH = REPO_ROOT / "scripts" / "check_lockdown_before_publish.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("_lockdown_checker", CHECKER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_lockdown_checker"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def _functions(source: str) -> set[str]:
+    return {fn for _line, fn, _expr in checker.scan_source(source)}
+
+
+# ─── shapes the rule MUST catch ─────────────────────────────────────────────
+
+
+VIOLATIONS = {
+    "atomic_write then restrict the final path (#5307 tier 2)": """
+def write_overlay(target, spec):
+    atomic_write(target, spec, mode=0o600)
+    platform_compat.restrict_to_owner(target)
+""",
+    "temp write, publish, then chmod the published path": """
+def save(path, payload):
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, path)
+    os.chmod(path, 0o600)
+""",
+    "open(file=...) keyword path, then chmod the published path": """
+def persist(final, secret):
+    with open(file=final, mode="w", encoding="utf-8") as handle:
+        handle.write(secret)
+    os.chmod(final, 0o600)
+""",
+    "Path.replace(target=...) keyword publish, then chmod the published path": """
+def save(tmp, final, payload):
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.replace(target=final)
+    os.chmod(final, 0o600)
+""",
+    "method-form final.chmod(0o600) after content": """
+def persist(final, secret):
+    final.write_text(secret, encoding="utf-8")
+    final.chmod(0o600)
+""",
+    "method-form final.chmod(mode=0o600) after content": """
+def persist(final, secret):
+    final.write_text(secret, encoding="utf-8")
+    final.chmod(mode=0o600)
+""",
+    "the two-argument helper spelling still records a lockdown": """
+def persist(final, secret):
+    final.write_text(secret, encoding="utf-8")
+    platform_compat.chmod_safe(final, 0o600)
+""",
+    "rotate the old secret aside FIRST, then write and lock the freed path": """
+def rotate(path, backup, secret):
+    path.rename(backup)
+    path.write_text(secret)
+    os.chmod(path, 0o600)
+""",
+    "the same rotation in the os.replace spelling": """
+def rotate(path, backup, secret):
+    os.replace(path, backup)
+    path.write_text(secret)
+    platform_compat.restrict_to_owner(path)
+""",
+    "a rename inside a NESTED function does not exempt the outer lockdown": """
+def outer(path, final, secret):
+    def unrelated():
+        path.rename(final)
+
+    path.write_text(secret)
+    os.chmod(path, 0o600)
+""",
+    "a conditional rotation branch does not exempt the lockdown": """
+def save(path, secret, rotate):
+    if rotate:
+        path.rename(path.with_suffix(".bak"))
+    path.write_text(secret)
+    os.chmod(path, 0o600)
+""",
+    "shutil.move into place, then chmod the published path": """
+def save(tmp, final, secret):
+    tmp.write_text(secret)
+    shutil.move(tmp, final)
+    os.chmod(final, 0o600)
+""",
+    "fchmod_safe on the descriptor AFTER content": """
+def save(final, secret):
+    fd = os.open(final, os.O_WRONLY | os.O_CREAT, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(secret)
+    platform_compat.fchmod_safe(fd, 0o600)
+""",
+    "a named module-level owner-only mode is still a lockdown": """
+_SECRET_MODE = 0o600
+
+
+def save(final, secret):
+    final.write_text(secret)
+    platform_compat.chmod_safe(final, _SECRET_MODE)
+""",
+    "a named mode built from stat symbols is still a lockdown": """
+_OWNER_ONLY = stat.S_IRUSR | stat.S_IWUSR
+
+
+def save(final, secret):
+    final.write_text(secret)
+    os.chmod(final, _OWNER_ONLY)
+""",
+    "the private _atomic_json_write publishes, then chmod the published path": """
+def _read_modify_write(path, denied):
+    _atomic_json_write(path, denied)
+    chmod_safe(path, 0o600)
+""",
+    "a single-assignment local alias is the same path": """
+def save(secret_path, secret):
+    target = secret_path
+    with open(target, "w", encoding="utf-8") as handle:
+        handle.write(secret)
+    os.chmod(secret_path, 0o600)
+""",
+    "an alias chain of two hops is still the same path": """
+def save(secret_path, secret):
+    mid = secret_path
+    target = mid
+    target.write_text(secret)
+    os.chmod(secret_path, 0o600)
+""",
+    "write_bytes then restrict": """
+def persist(path, blob):
+    path.write_bytes(blob)
+    platform_compat.restrict_to_owner(path)
+""",
+    "open for write then restrict": """
+def persist(path, secret):
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(secret)
+    platform_compat.restrict_to_owner(path)
+""",
+    "copy2 into place then restrict (#5346 snapshot shape)": """
+def restore(src, dst):
+    shutil.copy2(str(src), str(dst))
+    platform_compat.restrict_to_owner(str(dst))
+""",
+    "content through the fd, then chmod (pre-#5329 spool shape)": """
+def write_spool(path, data):
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+    os.chmod(path, 0o600)
+""",
+    "restrict_to_owner=False must not exempt the write": """
+def persist(secret_path, token):
+    atomic_write(secret_path, token, restrict_to_owner=False)
+    platform_compat.restrict_to_owner(secret_path)
+""",
+    "the path= keyword form is still a write": """
+def persist(secret_path, token):
+    atomic_write(path=secret_path, content=token, mode=0o600)
+    platform_compat.restrict_to_owner(secret_path)
+""",
+    "the pathlib open method form is a write": """
+def persist(secret_path, secret):
+    with secret_path.open("w", encoding="utf-8") as handle:
+        handle.write(secret)
+    platform_compat.restrict_to_owner(secret_path)
+""",
+    "os.write through a descriptor on the final path is a write": """
+def persist(secret_path, secret):
+    fd = os.open(str(secret_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.write(fd, secret)
+    os.close(fd)
+    platform_compat.restrict_to_owner(secret_path)
+""",
+    "the method-form publish records a write to its destination": """
+def save(path, payload):
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.rename(path)
+    os.chmod(path, 0o600)
+""",
+    "a symbolic owner-only mode is still a lockdown": """
+def write_pod_config(dst_cfg, cfg_data):
+    dst_cfg.write_text(json.dumps(cfg_data))
+    os.chmod(dst_cfg, stat.S_IRUSR | stat.S_IWUSR)
+""",
+    "a symbolic 0o700 is still a lockdown": """
+def persist(path, blob):
+    path.write_bytes(blob)
+    os.chmod(path, stat.S_IRWXU)
+""",
+    "a lockdown addressed by keyword is still a lockdown": """
+def persist(secret_path, token):
+    secret_path.write_bytes(token)
+    platform_compat.restrict_to_owner(path=secret_path)
+""",
+    "str() wrapper must not hide the match": """
+def persist(outfile, blob):
+    outfile.write_bytes(blob)
+    platform_compat.restrict_to_owner(str(outfile))
+""",
+}
+
+
+# ─── shapes the rule MUST NOT catch ─────────────────────────────────────────
+
+
+CORRECT = {
+    "the fix: atomic_write locks the temp before content": """
+def write_overlay(target, spec):
+    atomic_write(target, spec, restrict_to_owner=True)
+""",
+    "restrict the temp, then os.replace it into place": """
+def save(path, payload):
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    platform_compat.restrict_to_owner(tmp)
+    os.replace(tmp, path)
+""",
+    "restrict the temp, then Path.rename it into place (#5317 shape)": """
+def snapshot(outfile, stage):
+    tmp_tar = outfile.with_suffix(".tar.gz.tmp")
+    with tarfile.open(str(tmp_tar), "w:gz") as tar:
+        tar.add(str(stage))
+    platform_compat.restrict_to_owner(str(tmp_tar))
+    tmp_tar.rename(outfile)
+""",
+    "os.open an EMPTY file, restrict it, then write through the fd": """
+def write_secret_file(secret_path, secret):
+    fd = os.open(str(secret_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    platform_compat.restrict_to_owner(secret_path)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(secret)
+""",
+    "the fix written in keyword form": """
+def persist(secret_path, token):
+    atomic_write(path=secret_path, content=token, restrict_to_owner=True)
+""",
+    "restrict the temp, then os.replace it by keyword": """
+def save(path, payload):
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    platform_compat.restrict_to_owner(tmp)
+    os.replace(src=tmp, dst=path)
+""",
+    "mkstemp then os.write then lock then link -- the published path is never bare": """
+def install_id(path, fresh):
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(path.parent))
+    os.write(tmp_fd, fresh.encode("utf-8"))
+    os.close(tmp_fd)
+    platform_compat.restrict_to_owner(tmp_path)
+    os.link(tmp_path, str(path))
+""",
+    "the pathlib open method form in READ mode is not a write": """
+def load(path):
+    with path.open("r", encoding="utf-8") as handle:
+        data = handle.read()
+    platform_compat.restrict_to_owner(path)
+    return data
+""",
+    "a module-form open still reads its path from arg 0, restricted then renamed": """
+def snapshot(outfile, stage):
+    tmp_tar = outfile.with_suffix(".tar.gz.tmp")
+    with tarfile.open(str(tmp_tar), "w:gz") as tar:
+        tar.add(str(stage))
+    platform_compat.restrict_to_owner(str(tmp_tar))
+    tmp_tar.rename(outfile)
+""",
+    "read-side re-assert on a path this function never wrote": """
+def load(path):
+    data = path.read_bytes()
+    platform_compat.restrict_to_owner(path)
+    return data
+""",
+    "a symbolic mode that grants group/other is not a lockdown": """
+def install_launcher(launcher, body):
+    launcher.write_text(body, encoding="utf-8")
+    os.chmod(launcher, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP)
+""",
+    "chmod with an executable mode is not a lockdown": """
+def install_launcher(launcher, body):
+    launcher.write_text(body, encoding="utf-8")
+    platform_compat.chmod_safe(launcher, 0o755)
+""",
+    "a directory mode set before anything is written into it": """
+def ensure_dir(directory):
+    directory.mkdir(parents=True, exist_ok=True)
+    platform_compat.chmod_safe(directory, 0o700)
+""",
+    "restrict the temp, then Path.replace(target=...) it into place": """
+def save(tmp, final, payload):
+    tmp.write_text(payload, encoding="utf-8")
+    platform_compat.restrict_to_owner(tmp)
+    tmp.replace(target=final)
+""",
+    "a method-form chmod that grants group/other is not a lockdown": """
+def install(launcher, body):
+    launcher.write_text(body, encoding="utf-8")
+    launcher.chmod(0o755)
+""",
+    "open(file=...) in READ mode is not a content write": """
+def load(final):
+    with open(file=final, mode="r", encoding="utf-8") as handle:
+        blob = handle.read()
+    os.chmod(final, 0o600)
+    return blob
+""",
+    "chmod_safe the temp after content, then publish it": """
+def save(path, payload):
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    platform_compat.chmod_safe(tmp, 0o600)
+    tmp.replace(path)
+""",
+    "lock then publish inside a loop, once per item": """
+def save_all(files, payload):
+    for f in files:
+        tmp = f.with_suffix(".tmp")
+        tmp.write_text(payload)
+        platform_compat.restrict_to_owner(tmp)
+        tmp.replace(f)
+""",
+    "lock the temp, then shutil.move it into place": """
+def save(tmp, final, secret):
+    tmp.write_text(secret)
+    platform_compat.restrict_to_owner(tmp)
+    shutil.move(tmp, final)
+""",
+    "fchmod_safe on the descriptor BEFORE content": """
+def save(final, secret):
+    fd = os.open(final, os.O_WRONLY | os.O_CREAT, 0o600)
+    platform_compat.fchmod_safe(fd, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(secret)
+""",
+    "a named module-level EXECUTABLE mode is not a lockdown": """
+_LAUNCHER_MODE = 0o755
+
+
+def install(launcher, body):
+    launcher.write_text(body)
+    platform_compat.chmod_safe(launcher, _LAUNCHER_MODE)
+""",
+    "an unresolvable imported mode leaves the mode unknown": """
+def save(final, secret):
+    final.write_text(secret)
+    os.chmod(final, some_module.WHATEVER)
+""",
+    "a mode named inside the function body is not resolved": """
+def save(final, secret, hardened):
+    mode = 0o600 if hardened else 0o644
+    final.write_text(secret)
+    os.chmod(final, mode)
+""",
+    "an aliased temp still matches the publish that exempts it": """
+def save(path, payload):
+    tmp = path.with_suffix(".tmp")
+    p = tmp
+    p.write_text(payload)
+    platform_compat.restrict_to_owner(p)
+    os.replace(tmp, path)
+""",
+    "a REBOUND name is too ambiguous to alias": """
+def save(a, b, secret):
+    target = a
+    target = b
+    target.write_text(secret)
+    os.chmod(a, 0o600)
+""",
+    "two unrelated locals are not conflated": """
+def save(a, b, secret):
+    target = a
+    target.write_text(secret)
+    os.chmod(b, 0o600)
+""",
+    "an explicit reasoned suppression": """
+def append(path, lines):
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(lines)
+    os.chmod(path, 0o600)  # lockdown-ok: re-assert on an existing audit log
+""",
+}
+
+
+class TestTheRuleCatchesTheDefect:
+    @pytest.mark.parametrize("label", sorted(VIOLATIONS))
+    def test_a_write_then_restrict_shape_is_reported(self, label: str) -> None:
+        found = checker.scan_source(VIOLATIONS[label])
+        assert found, f"the rule missed a real violation: {label}"
+
+
+class TestTheRuleLeavesCorrectCodeAlone:
+    @pytest.mark.parametrize("label", sorted(CORRECT))
+    def test_a_correct_shape_is_not_reported(self, label: str) -> None:
+        found = checker.scan_source(CORRECT[label])
+        assert not found, f"false positive on a correct shape: {label} -> {found}"
+
+    def test_the_publish_must_follow_the_lockdown_to_exempt_it(self) -> None:
+        """The temp exemption is about ORDER, not about the path appearing somewhere.
+
+        Same two statements, swapped: locking a path the function LATER renames
+        away is the fix; locking a path it renamed away EARLIER means the payload
+        was written to the freed final path and locked afterwards. Keyed on the
+        path alone these were indistinguishable, and the second one passed.
+        """
+        exempt = """
+def save(tmp, final, payload):
+    tmp.write_text(payload)
+    platform_compat.restrict_to_owner(tmp)
+    tmp.rename(final)
+"""
+        violation = """
+def save(path, backup, payload):
+    path.rename(backup)
+    path.write_text(payload)
+    platform_compat.restrict_to_owner(path)
+"""
+        assert not checker.scan_source(exempt), "the correct idiom stopped being exempt"
+        assert checker.scan_source(violation), "an earlier publish still exempts a lockdown"
+
+    def test_a_nested_function_does_not_pool_into_its_parent(self) -> None:
+        """Scope, not just order: ``ast.walk`` descends into nested ``def``s.
+
+        A rename in an unrelated nested helper entered the outer function's temp
+        set and exempted a real violation there. The nested function is still
+        scanned in its own right, so this narrows nothing.
+        """
+        source = """
+def outer(path, final, secret):
+    def unrelated():
+        path.rename(final)
+
+    path.write_text(secret)
+    os.chmod(path, 0o600)
+"""
+        assert _functions(source) == {"outer"}
+
+    def test_resolving_named_modes_does_not_invent_lockdowns(self) -> None:
+        """The constant map must not turn every named mode into a lockdown.
+
+        Resolving ``_SECRET_MODE = 0o600`` is only safe if ``_LAUNCHER_MODE = 0o755``
+        still reads as "not owner-only". Same shape, same spelling, opposite
+        verdict -- decided by the mode's value, which is the property the rule
+        has always used.
+        """
+        template = """
+_MODE = %s
+
+
+def install(path, body):
+    path.write_text(body)
+    platform_compat.chmod_safe(path, _MODE)
+"""
+        assert checker.scan_source(template % "0o600"), "a named owner-only mode was missed"
+        assert not checker.scan_source(
+            template % "0o755"
+        ), "a named group/other-readable mode was treated as a lockdown"
+
+    def test_only_a_bare_local_name_is_aliased(self) -> None:
+        """Attributes and subscripts are left alone on purpose.
+
+        ``self._path`` or ``cfg["p"]`` can change between the write and the
+        lockdown, so resolving them would be a guess. Pinned because the natural
+        way to write the alias map -- textual substitution on any assignment --
+        would happily rewrite both.
+        """
+        source = """
+def save(cfg, secret):
+    cfg.target = cfg.secret_path
+    cfg.target.write_text(secret)
+    os.chmod(cfg.secret_path, 0o600)
+"""
+        assert not checker.scan_source(source), "an attribute alias was resolved"
+
+    def test_a_suppression_without_a_reason_does_not_suppress(self) -> None:
+        """`# lockdown-ok:` with nothing after the colon must not silence it."""
+        source = """
+def persist(path, blob):
+    path.write_bytes(blob)
+    platform_compat.restrict_to_owner(path)  # lockdown-ok:
+"""
+        assert checker.scan_source(source), "a reasonless marker suppressed the finding"
+
+
+class TestTheRuleAttributesToTheRightFunction:
+    def test_the_reported_function_is_the_enclosing_one(self) -> None:
+        source = """
+def innocent(path):
+    return path.read_text(encoding="utf-8")
+
+
+def guilty(path, blob):
+    path.write_bytes(blob)
+    platform_compat.restrict_to_owner(path)
+"""
+        assert _functions(source) == {"guilty"}
+
+    def test_a_write_in_a_sibling_function_does_not_implicate_a_reassert(self) -> None:
+        source = """
+def writer(path, blob):
+    atomic_write(path, blob, restrict_to_owner=True)
+
+
+def reasserter(path):
+    platform_compat.restrict_to_owner(path)
+"""
+        assert not checker.scan_source(source)
+
+
+class TestTheRealTree:
+    """The gate the CI job runs."""
+
+    def test_src_has_no_unclassified_violation(self) -> None:
+        exit_code = checker.main(["check", str(REPO_ROOT / "src" / "kiro_crew")])
+        assert exit_code == 0, (
+            "a lockdown-before-publish violation is unclassified. Convert it to "
+            "atomic_write(..., restrict_to_owner=True), or annotate a genuine "
+            "re-assert with `# lockdown-ok: <reason>`."
+        )
+
+    def test_every_known_unconverted_entry_still_violates(self) -> None:
+        """KNOWN_UNCONVERTED is shrink-only: a paid-off entry must be deleted.
+
+        Without this the list would quietly outlive the debt it tracks, and a
+        future regression at one of those very sites would land unnoticed
+        because its entry was already there.
+        """
+        src = REPO_ROOT / "src" / "kiro_crew"
+        live: set[str] = set()
+        for py in sorted(src.rglob("*.py")):
+            for rel, _line, fn, _expr in checker.scan_path(py, REPO_ROOT):
+                live.add(f"{rel}::{fn}")
+
+        stale = sorted(set(checker.KNOWN_UNCONVERTED) - live)
+        assert not stale, (
+            "these KNOWN_UNCONVERTED entries no longer violate -- delete them "
+            f"from scripts/{CHECKER_PATH.name}: {stale}"
+        )
+
+    # Source text deliberately built to break a NAIVE segment reader. Every line
+    # that matters puts a node AFTER non-ASCII text, so a reader slicing
+    # CHARACTERS where CPython reports BYTES lands in the wrong place -- and one
+    # emoji is 4 UTF-8 bytes, so the error is not a fixed offset either.
+    _UNICODE_FIXTURE = (
+        "def load(base):\n"
+        '    label = "\u914d\u7f6e\u6587\u4ef6"\n'
+        '    status = {"\u540d\u79f0": label, "\u72b6\u6001 \u2705": base / "x.json"}\n'
+        "    payload = helper(\n"
+        '        "\u53c2\u6570\u4e00",\n'
+        '        "\u53c2\u6570\u4e8c",\n'
+        "    )\n"
+        '    os.chmod(status["\u72b6\u6001 \u2705"], 0o600)  # \u5c3e\u90e8\u6ce8\u91ca\n'
+        "    return payload\n"
+    )
+
+    def test_the_cached_segment_reader_agrees_with_the_stdlib(self) -> None:
+        """`_seg` replaces `ast.get_source_segment` for speed, not for behaviour.
+
+        The stdlib helper re-splits the whole file on every call, which turned the
+        alias map's per-assignment lookups into a ~117s whole-tree scan. The
+        replacement caches the split and slices BYTES, because CPython reports
+        `col_offset` as a UTF-8 byte index.
+
+        Asserted against the stdlib on a fixture built for the failure mode
+        rather than on a large sample of the tree. An earlier version of this
+        test walked ~10,000 nodes across four real files including the 142KB
+        `sel.py`, and reintroduced on the REFERENCE side exactly the quadratic
+        cost `_seg` exists to remove: it passed locally and timed out at 120s in
+        CI. Node count was never the property -- byte offsets and multi-line
+        spans are, and those are exhausted here in a few dozen nodes.
+        """
+        import ast
+
+        source = self._UNICODE_FIXTURE
+        tree = ast.parse(source)
+        checked = 0
+        multiline = 0
+        for node in ast.walk(tree):
+            if not hasattr(node, "lineno") or not hasattr(node, "end_col_offset"):
+                continue
+            assert checker._seg(source, node) == (
+                ast.get_source_segment(source, node) or ""
+            ), f"line {node.lineno} disagrees with ast.get_source_segment"
+            checked += 1
+            if node.end_lineno != node.lineno:
+                multiline += 1
+
+        # Floors, so a future edit to the fixture cannot quietly make this vacuous
+        # or drop the branch that joins several lines.
+        assert checked > 25, f"the fixture stopped exercising the reader: {checked}"
+        assert multiline >= 2, f"the multi-line branch went uncovered: {multiline}"
+
+    def test_the_segment_reader_agrees_on_a_real_file(self) -> None:
+        """The fixture is synthetic; this keeps one real file in the comparison.
+
+        Bounded on both axes -- the checker's own source (~37KB) rather than the
+        tree's large modules, and a node cap -- because the stdlib reference is
+        O(file size) per call and this test must not become the slow thing again.
+        """
+        import ast
+
+        source = CHECKER_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        nodes = [
+            node
+            for node in ast.walk(tree)
+            if hasattr(node, "lineno") and hasattr(node, "end_col_offset")
+        ]
+        assert len(nodes) > 500, f"the checker source stopped being a real sample: {len(nodes)}"
+        for node in nodes[:1200]:
+            assert checker._seg(source, node) == (
+                ast.get_source_segment(source, node) or ""
+            ), f"{CHECKER_PATH.name}:{node.lineno} disagrees with ast.get_source_segment"
+
+    def test_every_known_unconverted_key_is_a_posix_path(self) -> None:
+        """A backslash key matches nothing, so the entry would read as stale.
+
+        `scan_path` normalises with `.as_posix()` for the same reason. On Linux
+        `str()` and `as_posix()` agree, so no assertion here can distinguish
+        them -- the Windows shard is the real verification, and it caught this
+        exact bug: every allowlist entry reported "no longer violates" while
+        every real site reported as new.
+        """
+        bad = [key for key in checker.KNOWN_UNCONVERTED if "\\" in key]
+        assert not bad, f"KNOWN_UNCONVERTED keys must use forward slashes: {bad}"
+
+    def test_every_known_unconverted_entry_names_an_issue(self) -> None:
+        bad = {
+            key: entry
+            for key, entry in checker.KNOWN_UNCONVERTED.items()
+            if not entry[0].startswith("#") or not entry[0][1:].isdigit()
+        }
+        assert not bad, f"KNOWN_UNCONVERTED entries must cite an issue: {bad}"
+
+    def test_every_known_unconverted_entry_names_its_path(self) -> None:
+        """Each entry waives ONE path, not the whole function.
+
+        Keyed by function alone, a second unrelated violating writer added to an
+        allowlisted function would be suppressed with the tracked one.
+        """
+        bad = {
+            key: entry
+            for key, entry in checker.KNOWN_UNCONVERTED.items()
+            if not isinstance(entry, tuple) or len(entry) != 2 or not entry[1].strip()
+        }
+        assert not bad, f"KNOWN_UNCONVERTED entries need (issue, path): {bad}"
+
+    def test_a_second_writer_in_an_allowlisted_function_is_not_waived(
+        self, tmp_path: Path, capsys, monkeypatch
+    ) -> None:
+        """The waiver covers the tracked path only -- driven through ``main()``.
+
+        The enforcement lives in ``main()`` (``entry[1] == expr``), so this runs a
+        real file through it: one function, the tracked violation plus a second
+        unrelated one. An earlier version of this test only compared two dict
+        entries and never invoked the scanner at all, so it asserted nothing
+        about the property it claimed to pin (First Principles review, #5348).
+        """
+        fixture = tmp_path / "writer.py"
+        fixture.write_text(
+            "def save(tracked, other, payload):\n"
+            "    tracked.write_text(payload)\n"
+            "    tracked.chmod(0o600)\n"
+            "    other.write_text(payload)\n"
+            "    other.chmod(0o600)\n",
+            encoding="utf-8",
+        )
+        # `scan_path` keys a file outside the repo by its absolute posix path.
+        monkeypatch.setattr(
+            checker,
+            "KNOWN_UNCONVERTED",
+            {f"{fixture.as_posix()}::save": ("#9999", "tracked")},
+        )
+
+        exit_code = checker.main(["check", str(fixture)])
+
+        out = capsys.readouterr().out
+        assert exit_code == 1, f"the untracked second writer was waived too:\n{out}"
+        assert "`other`" in out, f"the new violation was not reported:\n{out}"
+        assert (
+            "no longer violate" not in out
+        ), f"the tracked entry was reported stale, so the waiver never matched:\n{out}"
+
+    def test_the_tracked_path_alone_is_waived(self, tmp_path: Path, monkeypatch) -> None:
+        """Mirror of the above: with only the tracked writer present, main() passes.
+
+        Without this, the assertion above would also hold if the waiver were
+        broken outright and every entry reported as a new violation.
+        """
+        fixture = tmp_path / "writer.py"
+        fixture.write_text(
+            "def save(tracked, payload):\n"
+            "    tracked.write_text(payload)\n"
+            "    tracked.chmod(0o600)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            checker,
+            "KNOWN_UNCONVERTED",
+            {f"{fixture.as_posix()}::save": ("#9999", "tracked")},
+        )
+
+        assert checker.main(["check", str(fixture)]) == 0
+
+
+# ─── behavioural probes: ORDER at the live writers ──────────────────────────
+#
+# Technique from PR #5314 (@leonlaiyc): patch the lockdown helper and record
+# whether the FINAL path already exists when it runs. That is a property both
+# platforms must satisfy, unlike a final-mode assertion.
+
+
+@pytest.fixture()
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _record_final_path_presence(final_path_of):
+    """Patch restrict_to_owner, returning the list it records into."""
+    from kiro_crew import platform_compat
+
+    seen: list[bool] = []
+    real = platform_compat.restrict_to_owner
+
+    def _recording(path, *args, **kwargs):
+        seen.append(Path(final_path_of()).exists())
+        return real(path, *args, **kwargs)
+
+    return seen, _recording
+
+
+class TestTheLiveTargetPointerIsLockedDownBeforePublication:
+    """The PUBLISHED-path invariant at the live writers: the final path must not
+    exist yet when the lockdown runs.
+
+    Not a duplicate of ``test_live_target.py``'s ``test_lockdown_precedes_content``
+    / ``test_restore_reapplies_the_owner_only_dacl``, which measure SIZE == 0 at
+    lockdown time -- that is the TEMP-path invariant, and neither implies the
+    other. ``os.open(final)`` then lock then write satisfies size == 0 while the
+    final path already exists; writing a temp, locking it, then renaming
+    satisfies final-absent with a non-zero size. This gate enforces the
+    published-path invariant, so these probes pin the property it enforces.
+    """
+
+    def test_write_target_never_publishes_an_unprotected_pointer(self, _home) -> None:
+        from kiro_crew.service import live_target
+
+        seen, recording = _record_final_path_presence(live_target.pointer_path)
+        with patch("kiro_crew.platform_compat.restrict_to_owner", side_effect=recording):
+            live_target.write_target(_make_valid_checkout(_home))
+
+        assert seen, "the pointer was written with no owner-only lockdown at all"
+        assert not any(seen), (
+            "the lockdown ran while the pointer already existed at its final "
+            "path -- the payload was published before it was protected"
+        )
+
+    def test_restore_never_publishes_an_unprotected_pointer(self, _home) -> None:
+        from kiro_crew.service import live_target
+
+        live_target.write_target(_make_valid_checkout(_home))
+        prior = live_target.pointer_path().read_text(encoding="utf-8")
+        live_target.pointer_path().unlink()
+
+        seen, recording = _record_final_path_presence(live_target.pointer_path)
+        with patch("kiro_crew.platform_compat.restrict_to_owner", side_effect=recording):
+            live_target.restore(prior)
+
+        assert seen, "restore rewrote the pointer with no lockdown at all"
+        assert not any(seen), "restore locked the pointer down only after republishing it"


### PR DESCRIPTION
## Problem / Motivation

`#5240` → `#5269` → `#5285` → `#5307` progressively converted secret writers to `atomic_write(..., restrict_to_owner=True)`, which locks the temp file down before the first content byte and before the rename. All four are now closed.

Nothing prevents a **new** writer from reintroducing the shape. That chain of four issues exists because the same defect kept being found by hand, one review lane at a time, and there is no gate behind any of it.

## Why it matters

The defect is not a POSIX permission nit. A lockdown applied after publication leaves the payload at its **final, predictable path** under whatever DACL it inherited, and on Windows POSIX mode bits are not enforced at all — so `atomic_write(mode=0o600)` does not close the window there. The files involved are provider tokens, MCP `env` blocks, the app secret, and the live-target pointer (a code-execution input read at every startup).

It is also invisible to the obvious test. A final-mode assertion passes just as happily when the payload was exposed for the whole write window, and NTFS reports `0o666` for any file regardless of its DACL — which is why `#4534` said "no test could have caught it".

## What changed (motivation → approach → change)

**`scripts/check_lockdown_before_publish.py`** — an AST rule reporting, within one function body, an owner-only lockdown applied to a path expression an **earlier** statement already wrote content to. Wired into the Backend Lint job beside the other `scripts/check_*.py` gates, and registered in the prepare-pr gate floor so an installed copy runs the same check locally.

I first tried an inventory ratchet (enumerate every lockdown call, require each to be classified) and rejected it: the tree has **98** such calls, mostly `chmod_safe(tmp)` and directory modes with nothing to do with this defect. A 98-entry list needing human classification rots, and fails for bookkeeping reasons rather than for the defect — the failure mode `scripts/check_black_formatting.py` already has when files in its baseline get *cleaner*.

Precision was the whole design problem, since a gate with false positives is worse than no gate. Three shapes were false positives during development and each now has a negative fixture pinning it:

| correct shape | why the rule must stay quiet |
|---|---|
| `restrict_to_owner(tmp)` then `os.replace(tmp, final)` **or** `tmp.rename(final)` | the published file is never exposed; this is what `atomic_write` does internally, and what `#5317` landed in `snapshot_main` |
| `fd = os.open(p, O_CREAT…)` → `restrict_to_owner(p)` → write through the fd | `os.open` creates an **empty** file, so the lockdown precedes all content. `#5307` names `secrets/vault.py:171` as exactly this; `dashboard/server.py` and `token_auth.py` use it too |
| a read-side re-assert on a path the function never wrote | no payload to expose |
| `chmod_safe(launcher, 0o755)` | making a launcher executable is not a lockdown |

**Behavioural probes** assert the ORDER at the live writers: patch `platform_compat.restrict_to_owner` and record whether the **final** path already exists at the moment it runs. That is a property both platforms must satisfy, where a mode assertion is silent. Technique from **PR #5314 by @leonlaiyc**, whose production change landed via `#5329`; its test file did not land with it.

**Three sites carry `# lockdown-ok: <reason>` rather than an allowlist entry**, because they are not debt. The marker requires a non-empty reason and a test proves a reasonless one does not suppress:

- `sel.py::_load_or_create_hmac_key` — a load-time re-assert whose only preceding write is a legacy-key migration in a mutually exclusive branch.
- `sel.py::_open_rotation_lock` — the file holds no data (a single NUL byte); the existing code already said so.
- `workflows/store.py::save` — see below.

**`KNOWN_UNCONVERTED`** keys `file::function` to an open issue — `#5346`'s three: the two `snapshot.py` `copy2` restore sites (which need copy-to-temp → restrict → replace, not a one-line swap) and the SEL log's first-append creation. **Shrink-only**: the gate fails when an entry no longer violates, naming the entry to delete.

## The gate changed my own mind twice, which is the useful part

**It found a site four hand enumerations had missed** — `workflows/store.py::save`, a temp-file atomic write that `chmod`-ed the **final** path after `os.replace`. I wrote and tested the one-line conversion for it. Then `#5228` landed, having converted it **deliberately differently**:

> POSIX tightening only, deliberately NOT `platform_compat.restrict_to_owner`: that helper spawns `icacls` on Windows (a blocking subprocess), and `save` runs on the event loop via the registry's persist hooks, where a blocking call freezes every gateway task. The payload is already passed through `_redact` above.

That is the better answer, and my conversion would have put a blocking subprocess on the event loop. Dropped it; the site now carries `# lockdown-ok: icacls would block the event loop` with `#5228`'s argument directly above. The gate's job there was to force the tradeoff to be stated at the call site, not to overturn it.

**The shrink-only rule paid for itself during this PR's own review.** `main` converted all six `#5285` sites while this was open (`aws_consent.py:213`/`:272`, `tips.py:369`, and three more, spot-verified). The gate refused to pass while the allowlist still claimed debt that had been paid, so the list followed — 10 entries down to 3. That is exactly the drift it exists to prevent.

## Tests

`test/test_lockdown_before_publish.py`:

- **7 positive fixtures**, one per shape the rule must catch, including the pre-`#5329` spool shape (content through the fd, then `chmod`) and the `#5346` `copy2` shape
- **8 negative fixtures**, one per correct shape above, plus function-attribution tests proving a write in a sibling function does not implicate a re-assert
- a reasonless `# lockdown-ok:` does **not** suppress; every allowlist key is a POSIX path and cites an issue
- whole-tree test: zero unclassified violations across `src/kiro_crew`
- shrink-only test: every `KNOWN_UNCONVERTED` entry still violates
- two behavioural probes: `live_target.write_target` and `restore` never publish an unprotected pointer

**Validated against real history**, not only against today's tree — before `#5329` the rule flags **6/6** of `#5307`'s sites; after it, **0/6**. It also independently rediscovered three sites `#5307` had parked as "not yet triaged" (`dashboard/server.py:1502`, `token_auth.py:1000`, `kiro_prerequisite.py:757`) before those were confirmed correct-shape and excluded.

**Revert-verified.** Reverting `write_target` to the post-publish shape fails 2 probes; injecting a write-then-restrict site into `src/` fails the whole-tree test. Asserted pytest exit 1 **with** a non-zero failure count rather than merely a non-zero exit — an earlier attempt returned exit 4 (usage error) and would otherwise have read as success. Tree restored byte-for-byte after each.

Local: `flake8`, `isort`, `black`, `check_black_formatting.py`, the new checker, and `test_lockdown_before_publish.py` + `test_prepare_pr_profiles.py` + `test_workflows_store.py` + `test_workflows_store_cov80.py` + `test_sel.py` (329 passed) all green on the rebased tree.

## Manual verification

N/A — unit coverage sufficient. The gate's behaviour is pinned by fixtures in both directions, its calibration by the two-tree historical replay, and its non-vacuity by the revert-verify above.

## Related Issues

no linked issue: this PR adds a gate and closes nothing. #5346 stays open — it still tracks three unconverted sites, and this PR's `KNOWN_UNCONVERTED` points at it. #5285 and #5307 were already resolved by other people's work.

Follow-up tracker: #5346 (updated — two of its four items are already resolved). Prior art: #5285, #5307, #5329, #5228. Origin of the probe technique: #5314.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the checker's docstring is the reference and the CI step carries the rationale inline
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** CI/lint and test-only change; no frontend file touched and no rendered UI delta.
