### PR TITLE
docs: add Teams Git installation options

### DIFF
--- a/src/kiro_crew/docs/teams-integration.md
+++ b/src/kiro_crew/docs/teams-integration.md
@@ -47,6 +47,33 @@ Framework **pushes** activities to a messaging endpoint you host. Kiro Crew:
   If the channel is enabled without this extra, Kiro Crew logs an actionable
   error and skips Teams (the rest of the gateway still starts).
 
+ > [!NOTE]
+ > The error `invalid-egg-fragment` occurs because modern `pip` (v22+) deprecated and removed support for using `#egg=package_name[extra]` in direct Git URLs.
+ >
+ > Use PIP's **Direct URL requirement syntax** (`package[extra] @ git+https://...`) to install the package along with extras:
+ >
+ > ```bash
+ > pip install "kirocrew[teams] @ git+https://github.com/kirodotdev/KiroCrew.git"
+ > ```
+ > ### Alternative Solutions
+ >
+ > #### Option 1: Install Subdirectory / Local Clone (Editable Mode)
+ >
+ > If you have cloned the [Kiro Crew GitHub repository](https://github.com/kirodotdev/KiroCrew) locally, navigate to the repo root and run:
+ >
+ > ```bash
+ > pip install -e ".[teams]"
+ > ```
+ >
+ > #### Option 2: Fallback to Two Steps
+ >
+ > If you run into issues with Git dependency syntax, you can install the repository root first and then install the required `teams` dependencies directly (such as `pyjwt` and `cryptography` required for Azure Bot Framework JWT validation):
+ >
+ > ```bash
+ > pip install "git+https://github.com/kirodotdev/KiroCrew.git"
+ > pip install pyjwt cryptography
+ > ```
+
 ## 1. Register an Azure Bot
 
 1. In the [Azure Portal](https://portal.azure.com), create an **Azure Bot**


### PR DESCRIPTION
## Problem / Motivation

Installing Kiro Crew directly from Git with Teams extras using the legacy
`#egg=package[extra]` fragment fails on modern pip (22+) with
`invalid-egg-fragment`. The existing Teams guide did not show a valid Git
installation path.

## Why it matters

Users testing or installing the repository version cannot reliably install the
Teams dependencies. If Teams is enabled without them, Kiro Crew logs an
actionable error and skips Teams while the rest of the gateway starts.

## What changed (motivation → approach → change)

Modern pip requires PEP 508 direct URL syntax for extras, so the Teams guide now
documents:

- `kirocrew[teams] @ git+https://github.com/kirodotdev/KiroCrew.git`
- editable installation from a local clone at the repository root
- a two-step fallback that installs the repository, then `pyjwt cryptography`

This is a documentation-only change. Technical identifiers such as `kirocrew`
and the `/KiroCrew` repository URL remain unchanged.

## Tests

No tests were added because this changes documentation only. The current
automated PR checks passed, including `Brand Name Gate`, `Docs Lint`, and
`PR Readiness`.

## Manual verification

Reviewed the documented command syntax and the rendered Markdown structure and
code blocks. Also ran `scripts/check_brand_name.py` and `scripts/docs-lint.sh`
locally; no installation command was executed.

## Related Issues

N/A — no linked issue.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
