### PR TITLE
refactor(cloud): let a provisioned crew take the stock port

### DIFF
--- a/src/kiro_crew/cloud/launch_engine.py
+++ b/src/kiro_crew/cloud/launch_engine.py
@@ -16,8 +16,6 @@ import threading
 from kiro_crew.cloud import connect as connect_mod
 from kiro_crew.cloud import ec2, iam, login, sizes
 from kiro_crew.cloud.aws import AWSError
-from kiro_crew.instances.port_allocator import PortAllocator
-from kiro_crew.instances.registry import InstancesRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -105,44 +103,6 @@ class _RealSigninHandle:
 class RealLaunchEngine:
     """Drives a launch against the user's AWS account via the ``cloud/`` engine."""
 
-    def __init__(self) -> None:
-        # Settled once per launch, then reused for BOTH ends: the crew's gateway
-        # starts on it (KIROCREW_PORT via the stack) and the registry records it as
-        # remote_port. See _allocate_port.
-        self._port = 0
-
-    def _allocate_port(self) -> int:
-        """Pick a gateway port this crew can actually be reached on.
-
-        NOTE: the constraint this was written for is gone. The tunnel used to force
-        ``local_port == remote_port`` and hard-fail when that port was busy, so
-        registering every crew on the default 5476 produced a crew that could never
-        be connected -- the operator's own gateway usually owns 5476, and a second
-        crew collided with the first. The hub now allocates its local forward port
-        independently, so crews sharing a remote port connect fine and this could
-        simply pass the registry default.
-
-        It survives here only because deleting it changes which port a provisioned
-        EC2 gateway BINDS, and verifying that means exercising the cloud launch
-        suites -- a provisioning behaviour change does not belong in the instances
-        change that removed the mirror. Tracked as #5253; delete it there rather
-        than growing new callers here. Allocates deterministically upward from the
-        tunnel base, skipping every port the registry already hands out.
-        """
-        if self._port:
-            return self._port
-        used: set[int] = set()
-        try:
-            for inst in InstancesRegistry().list():
-                used.add(inst.remote_port)
-                if inst.local_port:
-                    used.add(inst.local_port)
-        except Exception as exc:  # pragma: no cover - registry absent is not fatal
-            logger.info("could not read the instances registry for port reuse: %s", exc)
-        self._port = PortAllocator().allocate(exclude=used)
-        logger.info("allocated gateway port %d for this crew", self._port)
-        return self._port
-
     def preflight(self, profile: str, region: str) -> None:
         reach = iam.reachability_check(profile, region)
         if not reach.get("reachable"):
@@ -151,12 +111,16 @@ class RealLaunchEngine:
 
     def provision(self, *, tag: str, size_key: str, profile: str, region: str) -> str:
         tier = sizes.get_tier(size_key)
+        # No dashboard_port override: the stack binds its own DashboardPort
+        # default. A crew once needed a bespoke port here because the tunnel
+        # forced local_port == remote_port and hard-failed on a busy one; the
+        # hub now picks its local forward port independently, so crews can
+        # share the stock remote port instead of each consuming a fresh one.
         result = ec2.deploy(
             tag=tag,
             tier=tier,
             profile=profile,
             region=region,
-            dashboard_port=self._allocate_port(),
         )
         return result.instance_id
 
@@ -164,11 +128,11 @@ class RealLaunchEngine:
         return _RealSigninHandle(instance_id, profile, region)
 
     def register(self, *, instance_id: str, tag: str, profile: str, region: str) -> None:
+        # remote_port stays at register_instance's own default, which matches
+        # the stack's DashboardPort default bound above — the two ends of one
+        # crew must name the same port or the tunnel forwards to nothing.
         registered = connect_mod.register_instance(
             instance_id, name=f"Kiro Crew Cloud ({tag})", profile=profile, region=region,
-            # Must match the port the stack started the gateway on, or the tunnel
-            # would forward to a port nothing is listening on.
-            remote_port=self._allocate_port(),
         )
         if registered is None:
             # register_instance is best-effort BY CONTRACT: it returns None both when the

--- a/test/test_cloud_launch_job.py
+++ b/test/test_cloud_launch_job.py
@@ -369,11 +369,18 @@ class TestRealSigninHandleFailures:
 
 
 class TestRealEngineGatewayPort:
-    """The tunnel forces local_port == remote_port and hard-fails when that port is
-    busy, so registering every crew on the default 5476 produced a crew that could
-    never be connected — the operator's own gateway usually owns 5476."""
+    """A provisioned crew takes the stock port on BOTH ends.
 
-    def _engine(self, monkeypatch, used_ports):
+    The launch engine once allocated a bespoke gateway port because the tunnel
+    forced local_port == remote_port and hard-failed when that port was busy —
+    the operator's own gateway usually owns the default, so a crew registered on
+    it could never be connected. The hub now picks its local forward port
+    independently, so crews share the stock remote port: the stack binds its
+    DashboardPort default, the registry records its matching default, and no
+    allocation step exists to reintroduce.
+    """
+
+    def _engine(self, monkeypatch):
         from kiro_crew.cloud import launch_engine as le
 
         seen = {}
@@ -384,58 +391,20 @@ class TestRealEngineGatewayPort:
             le.connect_mod, "register_instance",
             lambda iid, **kw: seen.update({"reg": kw}) or "inst-1",
         )
-        # Deterministic allocation: the first free port at/after the base, minus
-        # whatever the registry already hands out.
-        monkeypatch.setattr(
-            le, "PortAllocator",
-            lambda *a, **k: SimpleNamespace(
-                allocate=lambda exclude=None: next(
-                    p for p in range(5600, 5700) if p not in set(exclude or ())
-                )
-            ),
-        )
         return le, seen
 
-    def test_the_same_allocated_port_reaches_the_stack_and_the_registry(self, monkeypatch):
-        le, seen = self._engine(monkeypatch, set())
+    def test_provision_and_register_leave_both_ports_at_their_defaults(self, monkeypatch):
+        le, seen = self._engine(monkeypatch)
         eng = le.RealLaunchEngine()
 
         eng.provision(tag="kc-1", size_key="balanced", profile="", region="us-east-1")
         eng.register(instance_id="i-0abc", tag="kc-1", profile="", region="us-east-1")
 
-        # One port, both ends — a mismatch would forward the tunnel at nothing.
-        assert seen["dashboard_port"] == 5600
-        assert seen["reg"]["remote_port"] == 5600
-
-    def test_it_skips_ports_the_registry_already_uses(self, monkeypatch):
-        le, seen = self._engine(monkeypatch, set())
-
-        class _Reg:
-            def list(self):
-                return [SimpleNamespace(remote_port=5600, local_port=5601)]
-
-        # The import is module-scope now, so the name must be patched WHERE IT IS
-        # LOOKED UP — patching sys.modules would be a no-op.
-        monkeypatch.setattr(le, "InstancesRegistry", _Reg)
-        le.RealLaunchEngine().provision(
-            tag="kc-2", size_key="balanced", profile="", region="us-east-1"
-        )
-
-        assert seen["dashboard_port"] == 5602
-
-    def test_a_registry_read_failure_does_not_block_the_launch(self, monkeypatch):
-        le, seen = self._engine(monkeypatch, set())
-
-        class _Boom:
-            def __init__(self):
-                raise RuntimeError("registry unreadable")
-
-        monkeypatch.setattr(le, "InstancesRegistry", _Boom)
-        le.RealLaunchEngine().provision(
-            tag="kc-3", size_key="balanced", profile="", region="us-east-1"
-        )
-
-        assert seen["dashboard_port"] == 5600
+        # Neither end may pass an override: the stack's DashboardPort default
+        # and register_instance's remote_port default name the SAME port (the
+        # stock dashboard port), which is what lets one crew reach the other.
+        assert "dashboard_port" not in seen
+        assert "remote_port" not in seen["reg"]
 
 
 class TestRealEnginePreflight:


### PR DESCRIPTION
﻿## Problem / Motivation

`RealLaunchEngine._allocate_port` exists only to work around a constraint that no longer exists. It was written because the instance tunnel forced `local_port == remote_port` and hard-failed when that port was busy, so a cloud crew registered on the default dashboard port could never be connected. #5189 removed that constraint — the hub now allocates its local forward port independently — and the helper's own docstring conceded it "could simply pass the registry default". The deletion was asked for three times in #5189's First Principles review and deferred there only on blast-radius grounds (fixes #5253).

## Why it matters

Leaving it costs every future launch a fresh, pointless port allocation on both ends of one crew, keeps an instances-registry read on the cloud provisioning path for information the registry no longer needs, and forces every reader to reconstruct the dead local==remote rule to understand two lines of kwargs. The hedge "still mildly useful" is not a requirement; this makes the removal owned.

## What changed (motivation → approach → change)

With the tunnel's local port independent, a crew no longer needs a unique remote port: EC2 hosts are isolated per crew, so sharing the stock remote port cannot collide across crews, and within one host there is exactly one gateway. Both ends therefore take their own defaults, which already agree:

- `provision()` calls `ec2.deploy(...)` with **no** `dashboard_port` override → the CloudFormation stack binds its `DashboardPort` default (`5476`, per `cloud/templates/kirocrew-ec2.yaml`).
- `register()` calls `register_instance(...)` with **no** `remote_port` → its signature default `DEFAULT_REMOTE_DASHBOARD_PORT = 5476` (`cloud/connect.py`), the same number.
- `_allocate_port`, the memoised `self._port`, and the now-unused `PortAllocator` / `InstancesRegistry` imports are deleted.

Alternatives: keeping the helper "just in case" was the exact state being corrected; making the default explicit by passing constants at both call sites would duplicate two spellings of one fact instead of deleting them.

## Tests

`TestRealEngineGatewayPort` in `test/test_cloud_launch_job.py` is rewritten to pin the new contract: after provision + register, `ec2.deploy` received **no** `dashboard_port` key and `register_instance` received **no** `remote_port` key — so any reintroduced allocation step turns the suite red. The three tests that existed to pin the old allocation behaviour (same port both ends, skip registry ports, survive an unreadable registry) are deleted along with the behaviour they described.

## Manual verification

Full local run of the touched surface, Windows 11 / Python 3.12:

```
pytest test/test_cloud_launch_job.py test/test_cloud_cli.py test/test_cloud_wizard.py \
       test/test_cloud_login.py test/test_cloud_connect.py
→ 142 passed, 3 skipped
```

Plus flake8, isort, mypy clean on the changed module. Both changed files sit in `.github/black-baseline.txt`; their pre-existing formatting state is untouched and the diff adds no new black findings.

## Related Issues

Fixes #5253

## Checklist

- [x] Single commit with a Conventional Commits title (`refactor: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented behaviour changes; the helper's docstring left with it
- [x] No secrets, credentials, or internal references in the diff
