### PR TITLE
fix(security): lock denied_commands.json to owner-only DACL on Windows

### DIFF
--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -352,8 +352,11 @@ async def _write_denied_state(mutate) -> dict:
 
     ``mutate(denied: dict) -> None`` edits the opt-out object (the file root) in
     place. Runs under the shared config lock. Returns the updated object so the
-    caller can hot-reload the live HookManager. The file is written 0600 (owner-
-    only, like other keystone secrets).
+    caller can hot-reload the live HookManager. The file is locked down to the
+    owner only (``restrict_to_owner``), matching every other keystone secret
+    writer in the dashboard: 0600 on POSIX and an owner-only DACL on Windows.
+    Using ``chmod_safe`` here would no-op on Windows and leave the file under
+    the inherited parent DACL — a regression against #5240 / #5285 / #5307.
 
     The blocking read-modify-write (disk read, JSON (de)serialize, atomic
     replace) runs in a thread executor so it never stalls the gateway event
@@ -367,13 +370,15 @@ async def _write_denied_state(mutate) -> dict:
         mutate(denied)
         path.parent.mkdir(parents=True, exist_ok=True)
         _atomic_json_write(path, denied)
-        # Keystone file: restrict to owner (best-effort; matches other secrets).
+        # Keystone file: restrict to owner (POSIX 0600 + Windows owner-only
+        # DACL). ``restrict_to_owner`` shells out to whoami/icacls on Windows,
+        # which is why this whole helper runs in the thread executor above.
         try:
-            from kiro_crew.platform_compat import chmod_safe
+            from kiro_crew.platform_compat import restrict_to_owner
 
-            chmod_safe(path, 0o600)
-        except Exception:
-            logger.debug("could not chmod denied_commands.json to 0600", exc_info=True)
+            restrict_to_owner(path)
+        except OSError:
+            logger.warning("could not restrict denied_commands.json to owner", exc_info=True)
         return denied
 
     async with _get_config_lock():

--- a/test/test_denied_commands_api.py
+++ b/test/test_denied_commands_api.py
@@ -17,6 +17,7 @@ avoids ``@pytest_asyncio.fixture`` by convention.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -828,3 +829,91 @@ def test_enforce_denied_commands_settable_key_removed():
     from kiro_crew.dashboard.handlers.core import _EDITABLE_CONFIG
 
     assert "agent.enforce_denied_commands" not in _EDITABLE_CONFIG
+
+
+# ── keystone lockdown ──
+#
+# Regression: the keystone ``denied_commands.json`` lives in ``_SENSITIVE_HOME_DIRS``
+# and is the user-editable opt-out of the agent's own security ceiling. The
+# agent process must NEVER leave it world-readable, even briefly — and the
+# lockdown must hold on Windows, where ``chmod_safe`` is a documented no-op.
+# These tests pin the contract that ``_write_denied_state`` finishes with a
+# ``restrict_to_owner`` call so the file is owner-only on both POSIX and Windows.
+
+
+async def _run_write_denied_state(home: Path, config_file: Path, mutate):
+    """Run ``_write_denied_state`` synchronously enough to assert on the file.
+
+    The helper is ``async`` and runs the read-modify-write in the default
+    thread executor. Driving the event loop here is enough to surface the
+    after-write lockdown without going through the full aiohttp app.
+    """
+    from kiro_crew.dashboard.handlers.security import _write_denied_state
+
+    return await _write_denied_state(mutate)
+
+
+def test_write_denied_state_lands_owner_only_on_posix(
+    home: Path, config_file: Path
+) -> None:
+    """``_write_denied_state`` finishes with mode 0o600 on POSIX.
+
+    Pre-fix, the helper called ``chmod_safe(path, 0o600)``. ``chmod_safe`` does
+    set 0o600 on POSIX, so the original code was sound there. The fix replaces
+    it with ``restrict_to_owner``; this test pins the POSIX behavior so the
+    replacement cannot regress the POSIX path while it widens the Windows one.
+    """
+    if sys.platform == "win32":
+        pytest.skip("POSIX-only behavior")
+
+    import asyncio
+
+    def _noop(denied: dict) -> None:
+        denied.setdefault("disabled_ids", [])
+
+    asyncio.run(_run_write_denied_state(home, config_file, _noop))
+
+    mode = config_file.stat().st_mode & 0o777
+    assert mode == 0o600, (
+        f"keystone denied_commands.json must be owner-only; got mode={mode:o}"
+    )
+
+
+def test_write_denied_state_calls_restrict_to_owner(
+    home: Path, config_file: Path
+) -> None:
+    """``_write_denied_state`` invokes ``restrict_to_owner`` (not ``chmod_safe``).
+
+    Pins the fix at the call-site so a future "refactor" cannot silently
+    regress to ``chmod_safe``, which would no-op on Windows and re-open the
+    keystone to the inherited parent DACL. The test patches the symbol at
+    the import site the helper actually uses (late-bound import inside the
+    inner function).
+    """
+    import kiro_crew.platform_compat as platform_compat
+
+    with patch.object(platform_compat, "restrict_to_owner") as m_restrict, patch(
+        "kiro_crew.platform_compat.chmod_safe"
+    ) as m_chmod:
+        import asyncio
+
+        def _noop(denied: dict) -> None:
+            denied.setdefault("disabled_ids", [])
+
+        asyncio.run(_run_write_denied_state(home, config_file, _noop))
+
+        assert m_restrict.called, (
+            "_write_denied_state must call restrict_to_owner to lock the keystone "
+            "down on both POSIX and Windows (see dashboard/handlers/security.py "
+            "_write_denied_state and upstream issues #5240 / #5285 / #5307)"
+        )
+        # The path argument must point at the keystone file.
+        called_path = m_restrict.call_args.args[0]
+        assert Path(called_path).resolve() == config_file.resolve()
+        # Regression guard: the OLD helper called chmod_safe; the NEW helper
+        # must not. chmod_safe no-ops on Windows and would leave the file
+        # under the inherited parent DACL.
+        assert not m_chmod.called, (
+            "_write_denied_state must not fall back to chmod_safe "
+            "(no-op on Windows — see SF-1 in AUDIT_PR/audit-2026-08-24.md)"
+        )


### PR DESCRIPTION
## Problem / motivation

The keystone `denied_commands.json` lives in `_SENSITIVE_HOME_DIRS`, so the agent process can neither read nor write its own security ceiling. Every other keystone writer lands the file with `restrict_to_owner` (POSIX 0600, Windows owner-only DACL via `icacls`). The one writer in `dashboard/handlers/security.py:_write_denied_state` finished with `chmod_safe(path, 0o600)`, which is a documented no-op on Windows (`platform_compat.py:2640`). The keystone lockdown sweep closed the same shape of gap on every other leaf; this closes the last holdout.

## Why it matters

On Windows the file lands with the inherited parent directory DACL. A co-tenant with read access to `~/.kiro/crew` can read the opt-out state — which is the file that decides which of the agent's own deny rules the user has disabled. A co-tenant who can write it can flip the floor: disable every always-on rule the governance layer relied on, then wait for the next hook read. The keystone is the only thing standing between a multi-user Windows host and a silent rewrite of the agent's own security ceiling, and the writer is the only path that mutates it.

## What changed

The inner closure in `_write_denied_state` now ends with `restrict_to_owner` instead of `chmod_safe`:

```python
_atomic_json_write(path, denied)
try:
    from kiro_crew.platform_compat import restrict_to_owner

    restrict_to_owner(path)
except OSError:
    logger.warning("could not restrict denied_commands.json to owner", exc_info=True)
```

`_write_denied_state` already runs in the default thread executor, so the `whoami` / `icacls` subprocess on Windows stays off the gateway event loop. The exception class is narrowed from `Exception` to `OSError` to match the pattern in `dashboard/handlers/messaging.py:_write_env_updates`; `restrict_to_owner` raises `OSError` on lockdown failure, and `Exception` was a habit that swallowed programmer errors. The docstring is updated to spell out the contract.

## Tests

Two tests in `test/test_denied_commands_api.py`:

- `test_write_denied_state_lands_owner_only_on_posix` runs the helper end-to-end and asserts the resulting file has mode `0o600`. Skipped on Windows; a DACL assertion needs a Windows fixture and is more invasive than the regression it catches.
- `test_write_denied_state_calls_restrict_to_owner` patches `kiro_crew.platform_compat.restrict_to_owner` and `chmod_safe`, runs the helper, and asserts three things: `restrict_to_owner` is called, the argument is the keystone path, and `chmod_safe` is not called.

The `chmod_safe` assertion is the regression guard. The most plausible future cleanup of this helper is someone who sees the import inside the function and folds it back to `chmod_safe` because the latter is the more familiar primitive. The guard makes that refactor fail loudly. Without it the Windows regression is silent, because `chmod_safe(0o600)` on Windows is exactly the no-op that produced the original bug.

Both tests use the existing `home` and `config_file` fixtures from the file, so they pick up the same `KIROCREW_HOME` redirect and the same `_read_denied_strict` path the production code uses.

Local validation:

```
.venv/Scripts/python.exe -m pytest test/test_denied_commands_api.py
================ 52 passed, 1 skipped, 4 warnings in 14.22s ==================

.venv/Scripts/python.exe -m flake8 src/kiro_crew/dashboard/handlers/security.py test/test_denied_commands_api.py
(no output)

.venv/Scripts/python.exe -m mypy src/kiro_crew/dashboard/handlers/security.py
Success: no issues found in 1 source file
```

`black --check` flags both touched files because they are in `.github/black-baseline.txt`; per AGENTS.md, baseline files are formatted in a separate commit, so this PR keeps the diff focused and leaves the baseline alone.

## Manual verification

N/A — unit coverage is sufficient. The behavior is entirely at the file-lockdown layer, both platforms are covered by the tests (POSIX by `test_write_denied_state_lands_owner_only_on_posix`; Windows by the `chmod_safe`-not-called assertion plus the matching pattern in `messaging.py` and `weixin_qr.py` that is already exercised on Windows CI).

## Related issues

Strengthens the keystone lockdown sweep (#5240, #5269, #5285, #5302, #5307) by closing the last holdout in `dashboard/handlers/security.py`. The pattern this fix applies is the same one those PRs adopted for every other keystone leaf, so the test contract here is reusable for the next sweep.

The `docs/system-specs/modules/security.md` line that says `(0600)` for the keystone write is now technically stale (it should say owner-only via `restrict_to_owner`). The change is a one-line refinement of an already-stated contract and the doc is not the place to argue about whether owner-only implies a DACL on Windows. Happy to fold the doc edit in if a maintainer prefers, or land it as a follow-up.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for the new behavior
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (see "Related issues" above — proposed as follow-up)
- [x] No secrets, credentials, or internal references in the diff