### PR TITLE
test(instances): stub the port probe in the allocator's namespace too

### DIFF
--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -1029,6 +1029,30 @@ class TestRegistry:
 # ── SshTunnelManager (mocked) ─────────────────────────────────────────────────
 
 
+def _patch_port_probe(monkeypatch, *, manager_free: bool = True, allocator_free: bool = True):
+    """Make loopback port probing deterministic in BOTH namespaces that probe.
+
+    The connect path probes twice, and each site resolves ``_is_port_free`` from
+    its own module, so patching one leaves the other binding real sockets:
+
+    * ``PortAllocator.allocate`` resolves the name in ``port_allocator``. Left
+      real, allocation walks upward past whatever the host happens to be
+      holding, so which port an instance is handed depends on host state — and
+      a test asserting an exact port passes only where the base port is free.
+    * ``ssh_tunnel_manager`` holds its own re-bound reference for the advisory
+      re-probe it runs on the port it just allocated.
+
+    The two knobs are separate because the answers legitimately differ: the
+    conflict case models a TOCTOU loss, where allocation succeeds and the
+    re-probe then finds that port taken.
+    """
+    import kiro_crew.instances.port_allocator as pa
+    import kiro_crew.instances.ssh_tunnel_manager as stm
+
+    monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": manager_free)
+    monkeypatch.setattr(pa, "_is_port_free", lambda port, host="127.0.0.1": allocator_free)
+
+
 class _FakeTunnel:
     def __init__(
         self,
@@ -1076,9 +1100,7 @@ class _FakeTunnel:
 class TestSshTunnelArgvCompression:
     @pytest.fixture(autouse=True)
     def _free_ports(self, monkeypatch):
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def test_compression_flag_present_by_default(self):
         from kiro_crew.instances.ssh_tunnel_manager import _build_ssh_tunnel_argv
@@ -1307,9 +1329,7 @@ class TestSshTunnelManager:
     def _free_ports(self, monkeypatch):
         # Connect now probes _is_port_free (CSE SEC-016 mirror conflict check).
         # Keep these unit tests hermetic / independent of the host's real ports.
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def _mgr(self, tmp_path, *, mint=None, factory=_FakeTunnel):
         from kiro_crew.instances.registry import InstancesRegistry
@@ -3072,9 +3092,7 @@ class TestTunnelStatus:
 class TestSelfHealRefreshRestart:
     @pytest.fixture(autouse=True)
     def _free_ports(self, monkeypatch):
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def _mgr(self, tmp_path, *, mint=None, factory=_ResilTunnel):
         from kiro_crew.instances.registry import InstancesRegistry
@@ -3599,10 +3617,12 @@ class TestPortMirror:
 
     @staticmethod
     def _mgr(reg, factory, monkeypatch, *, port_free=True):
-        import kiro_crew.instances.ssh_tunnel_manager as stm
         from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
 
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": port_free)
+        # Allocation must still succeed when ``port_free`` is False: that case
+        # models the TOCTOU loss where the port is taken between allocating it
+        # and the manager's re-probe.
+        _patch_port_probe(monkeypatch, manager_free=port_free)
 
         async def ok_mint(
             host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
@@ -3724,9 +3744,7 @@ class TestLastError:
 
     @pytest.fixture(autouse=True)
     def _free_ports(self, monkeypatch):
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def _mgr(self, tmp_path, *, mint=None, factory=_FakeTunnel):
         from kiro_crew.instances.registry import InstancesRegistry
@@ -3826,9 +3844,7 @@ class TestStatusForRetainedError:
 
     @pytest.fixture(autouse=True)
     def _free_ports(self, monkeypatch):
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def _mgr(self, tmp_path, *, mint=None, factory=_FakeTunnel):
         from kiro_crew.instances.registry import InstancesRegistry
@@ -3900,9 +3916,7 @@ class TestStartupRevive:
 
     @pytest.fixture(autouse=True)
     def _free_ports(self, monkeypatch):
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def _mgr(self, tmp_path, *, mint=None, factory=_FakeTunnel):
         from kiro_crew.instances.registry import InstancesRegistry
@@ -4409,9 +4423,7 @@ class TestSsmTransportSelection:
         # tunnel, so `mgr._tunnels[id]` raises KeyError and the test flakes. Stub
         # the probe to always-free, exactly as the other SshTunnelManager test
         # classes do, so transport selection is tested deterministically.
-        import kiro_crew.instances.ssh_tunnel_manager as stm
-
-        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+        _patch_port_probe(monkeypatch)
 
     def _mgr(self, tmp_path, *, mint=None, connect_timeout_secs=None):
         from kiro_crew.instances.registry import InstancesRegistry


### PR DESCRIPTION
## Problem / Motivation

`test/test_instances.py::TestPortMirror::test_reconnect_does_not_reclaim_its_own_recorded_port` fails on any host that happens to hold the tunnel base port:

```
FAILED test/test_instances.py::TestPortMirror::test_reconnect_does_not_reclaim_its_own_recorded_port - assert 7779 == 7778
```

The test asserts the allocated local port equals `base_port`, and gets `base_port + 1` — because the allocator did a **real** loopback bind probe, found 7778 occupied on the runner, and walked upward.

## Why it matters

The test is a genuine assertion about allocation policy (a recorded port must never be preferred), but its verdict currently depends on what the host is listening on. It reports a policy regression when the only thing that changed is which ports the machine holds — and it is red today.

Seven sibling patch sites carry the same latent defect: they perform real loopback binds during a unit test. They stay green only because their assertions do not name an exact port, so they are one assertion-tightening away from the same failure.

## What changed (motivation → approach → change)

Symptom: an exact-port assertion returns `base + 1`. Root cause: **two** probes run on the connect path and each resolves `_is_port_free` from its own module:

- `PortAllocator.allocate` resolves it in `port_allocator`.
- `ssh_tunnel_manager` holds its own re-bound reference (`from … import _is_port_free`) for the advisory re-probe it runs on the port it just allocated.

All eight test sites patched only the `ssh_tunnel_manager` name, so the allocator kept binding real sockets. Two of those sites state in a comment that they exist precisely to "keep these unit tests hermetic / independent of the host's real ports" — that stopped being true once allocation joined the connect path, and the patch was never widened to match.

Rather than patch the one red assertion, all eight sites now route through a single `_patch_port_probe(monkeypatch, *, manager_free=True, allocator_free=True)` helper that patches **both** namespaces.

The two knobs are not redundant: the conflict case (`TestPortMirror::test_port_conflict_hard_fails`) needs them to differ. It models a TOCTOU loss where allocation **succeeds** and the manager's re-probe then finds that port taken — asserting on the `"was taken while connecting"` error. Collapsing them into one flag would make `allocate` raise "no free loopback port" instead and the case would no longer test what it names.

## Tests

No new test: the behavioural test that should have caught this already exists (`test_reconnect_does_not_reclaim_its_own_recorded_port`) — it was simply unable to render an honest verdict on a host holding the base port. This change makes its verdict depend on allocation policy rather than host state.

Verified the fix actually bites by mutation rather than by the suite turning green: with the helper's allocator-namespace line replaced by a no-op, `test/test_instances.py` reproduces exactly the original failure (`assert 7779 == 7778`); with it restored, 215/215 pass. Confirmed on a host where `_is_port_free(7778)` is `False`, i.e. the failing condition is actually present locally.

## Manual verification

N/A — unit coverage sufficient: the change is confined to test-side probe stubbing, and its effect is pinned by the mutation check above.

## Related Issues

no linked issue: found while driving #5158, whose shard-2 CI was red on this; filing the fix directly rather than an issue first.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** test-only change; no frontend file touched and no rendered UI delta.
