### PR TITLE
fix(slack): route org-wide calls by the channel's home workspace

### DIFF
--- a/src/kiro_crew/slack/client.py
+++ b/src/kiro_crew/slack/client.py
@@ -234,19 +234,29 @@ class RealSlackClient(SlackClientOps):
 
     def __init__(self, bot_token: str):
         self._web = AsyncWebClient(token=bot_token)
-        # Channel→workspace team_id cache.  Populated from inbound events
-        # by record_channel_team() and used to auto-inject team_id into
+        # Channel→workspace team_id cache. Populated ONLY from
+        # conversations_info()'s home-workspace answer by
+        # ensure_channel_team(), and used to auto-inject team_id into
         # outbound chat.* / reactions.* calls so org-wide (Enterprise Grid)
-        # installs route to the correct workspace.  Empty for non-org-wide
-        # installs — _inject_team becomes a no-op in that case.
+        # installs route to the correct workspace. The team on an inbound
+        # event is the AUTHOR's workspace, which on a Slack Connect shared
+        # channel is not the workspace the channel lives in, so it must
+        # never feed this cache. Empty for non-org-wide installs —
+        # _inject_team becomes a no-op in that case.
         self._channel_team: dict[str, str] = {}
+        # Channels whose home team could not be resolved this process. One
+        # failed lookup must not become one extra API call per inbound
+        # message for the rest of the run; a gateway restart clears the set
+        # and lets resolution try again.
+        self._channel_team_unresolvable: set[str] = set()
 
     def record_channel_team(self, channel: str, team_id: str) -> None:
         """Cache the workspace team_id for a channel.  Idempotent.
 
-        Called from inbound event handlers so subsequent outbound API
-        calls on the same channel can include team_id, which org-wide
-        installs require to avoid ``team_access_not_granted``.
+        Only a CANONICAL home-team answer may enter here: outbound calls
+        route by the workspace the channel lives in, so this method must be
+        fed from :meth:`ensure_channel_team` (conversations_info), never
+        from an inbound event's author-side ``team`` field.
         """
         if not (channel and team_id):
             return
@@ -257,6 +267,53 @@ class RealSlackClient(SlackClientOps):
             cache = {}
             self._channel_team = cache
         cache[channel] = team_id
+
+    async def ensure_channel_team(self, channel: str) -> None:
+        """Resolve a channel's HOME workspace into the routing cache.
+
+        Inbound handlers call this once per message. conversations_info
+        answers with the caller's own ``context_team_id`` for the channel,
+        which is the workspace the channel lives in — the value every
+        outbound ``team_id`` has to carry on an org-wide install. Recording
+        the author's team instead is what flipped shared-channel caches to
+        a participant's workspace and demoted replies off streaming with
+        ``team_access_not_granted``.
+
+        Best-effort: a channel that cannot be resolved simply stays out of
+        the cache, which leaves outbound calls without team_id — the same
+        routing Slack does for a cache miss — and lands in
+        ``_channel_team_unresolvable`` so the failure costs one lookup per
+        process rather than one per message.
+        """
+        if not channel:
+            return
+        cache = getattr(self, "_channel_team", None) or {}
+        if channel in cache:
+            return
+        unresolvable = getattr(self, "_channel_team_unresolvable", None)
+        if unresolvable is None:
+            unresolvable = set()
+            self._channel_team_unresolvable = unresolvable
+        if channel in unresolvable:
+            return
+        try:
+            resp = await self._web.conversations_info(channel=channel)
+            ch = (
+                resp.data.get("channel", {})  # type: ignore[union-attr]
+                if hasattr(resp, "data")
+                else {}
+            )
+            home = str(ch.get("context_team_id") or "")
+        except Exception:
+            logger.info(
+                "could not resolve the home workspace of channel %s", channel,
+                exc_info=True,
+            )
+            home = ""
+        if home:
+            self.record_channel_team(channel, home)
+        else:
+            unresolvable.add(channel)
 
     def _inject_team(self, channel: str, kwargs: dict[str, Any]) -> None:
         """Add team_id to kwargs from cache, if known and not already set.
@@ -482,10 +539,10 @@ class RealSlackClient(SlackClientOps):
                 "task_display_mode": "plan",
             }
             # Workspace routing for org-wide installs.  Prefer the cached
-            # team for this channel — that's the workspace the channel lives
-            # in, which is what ``body["team_id"]`` must route to.  Fall
-            # back to the recipient's team_id only when the cache hasn't
-            # been populated yet (first message into a never-seen channel).
+            # home team for this channel — that's the workspace the channel
+            # lives in, which is what ``body["team_id"]`` must route to.
+            # Fall back to the caller-supplied recipient's team_id only when
+            # the home team hasn't been resolved yet.
             cache = getattr(self, "_channel_team", None)
             cached_team = cache.get(channel) if cache else None
             workspace_team = cached_team or team_id

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -16,6 +16,7 @@ processing the same Slack event twice.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -1960,12 +1961,20 @@ async def _route_message(
 
     # ── Workspace routing cache for org-wide installs ──
     # Slack Web API calls (chat.postMessage, chat.startStream, etc.) need
-    # team_id when the bot is org-wide installed; record the channel→team
-    # mapping so outbound posts on this channel route to the correct
-    # workspace and avoid ``team_access_not_granted``.
-    record_team = getattr(orch.slack, "record_channel_team", None)
-    if record_team and team_id:
-        record_team(channel, team_id)
+    # team_id when the bot is org-wide installed, and the value must be the
+    # workspace the CHANNEL lives in. ``event.team`` is the AUTHOR's
+    # workspace — a participant's, not the channel's, on a Slack Connect
+    # shared channel — so it must never seed this cache; resolve the home
+    # workspace from conversations_info instead (cached per process).
+    ensure_home_team = getattr(orch.slack, "ensure_channel_team", None)
+    if ensure_home_team is not None:
+        # The seam is duck-typed on purpose: orch.slack may be the real
+        # client, a test double, or a wrapper that implements this hook
+        # synchronously or as a coroutine. Accept either; only an awaitable
+        # is awaited.
+        outcome = ensure_home_team(channel)
+        if inspect.isawaitable(outcome):
+            await outcome
 
     # ── Access control: record authorization decision early for SEL audit ──
     # The ephemeral rejection is deferred until after activation checks so

--- a/test/test_review_mode.py
+++ b/test/test_review_mode.py
@@ -318,6 +318,59 @@ class TestTeamIdInjection:
         assert result is True
         assert c._web.conversations_info.await_args.kwargs["team_id"] == "TWORK"
 
+    # ── ensure_channel_team: the cache's only production feeder ──────
+
+    @pytest.mark.asyncio
+    async def test_ensure_resolves_the_home_workspace_not_the_author(self) -> None:
+        """The value that enters the routing cache is the channel's HOME
+        workspace (conversations_info's ``context_team_id``). An inbound
+        event's ``team`` is the author's workspace — a participant's, on a
+        shared channel — and must never reach this cache; the inbound
+        handler therefore never passes it here."""
+        c = self._client()
+        resp = MagicMock()
+        resp.data = {"channel": {"id": "C1", "context_team_id": "THOME"}}
+        c._web.conversations_info = AsyncMock(return_value=resp)
+        await c.ensure_channel_team("C1")
+        assert c._channel_team == {"C1": "THOME"}
+
+    @pytest.mark.asyncio
+    async def test_ensure_skips_a_channel_already_resolved(self) -> None:
+        c = self._client()
+        c.record_channel_team("C1", "TKNOWN")
+        c._web.conversations_info = AsyncMock()
+        await c.ensure_channel_team("C1")
+        c._web.conversations_info.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_lookup_is_retried_once_per_process_not_per_message(self) -> None:
+        """A channel whose home team cannot be resolved must not cost one
+        conversations_info call per inbound message for the rest of the run."""
+        c = self._client()
+        c._web.conversations_info = AsyncMock(side_effect=RuntimeError("missing scope"))
+        await c.ensure_channel_team("C1")
+        await c.ensure_channel_team("C1")
+        await c.ensure_channel_team("C1")
+        assert c._web.conversations_info.await_count == 1
+        assert c._channel_team == {}
+        # And the outbound routing answer for it is a no-op, exactly as for
+        # a channel the cache has never seen.
+        kw: dict = {"channel": "C1"}
+        c._inject_team("C1", kw)
+        assert "team_id" not in kw
+
+    @pytest.mark.asyncio
+    async def test_an_answer_without_context_team_id_counts_as_unresolved(self) -> None:
+        c = self._client()
+        resp = MagicMock()
+        resp.data = {"channel": {"id": "C1"}}
+        c._web.conversations_info = AsyncMock(return_value=resp)
+        await c.ensure_channel_team("C1")
+        assert c._channel_team == {}
+        # Same per-process bound as an erroring lookup.
+        await c.ensure_channel_team("C1")
+        assert c._web.conversations_info.await_count == 1
+
     # ── start_stream workspace_team priority ─────────────────────────
 
     @pytest.mark.asyncio

--- a/test/test_slack_events_coverage.py
+++ b/test/test_slack_events_coverage.py
@@ -83,6 +83,8 @@ def _make_orch(
     orch.slack = AsyncMock()
     # Sync accessor on an AsyncMock would return an un-awaited coroutine.
     orch.slack.record_channel_team = MagicMock()
+    # Same for the home-team resolver the inbound path awaits.
+    orch.slack.ensure_channel_team = AsyncMock()
     # A bare AsyncMock's return_value is itself an AsyncMock, so `info.get(...)`
     # in the display-name lookup would hand back a coroutine. Return a real dict.
     orch.slack.get_user_info = AsyncMock(return_value={})


### PR DESCRIPTION
﻿## Problem / Motivation

On a Slack Connect / shared-channel install, the channel-to-workspace cache records the **message author's** team rather than the **channel's home team**, so a single message from an external participant flips the cache for that channel — and every later outbound Web API call on it routes to the wrong workspace. The visible effect today is a streaming demotion, not a misdelivery: `chat.startStream` is rejected (`team_access_not_granted` / `missing_recipient_team_id`), the client logs a traceback, and the reply falls back to the non-streaming `chat.update` cursor surface. It stays flipped until someone from the channel's own workspace posts again (fixes #4268).

## Why it matters

Shared channels are the normal way to work with external partners, and the failure is silent: the install keeps replying (so nothing looks broken enough to investigate), while every reply loses streaming, approvals render as plain text, and the log fills with tracebacks. Because the cache is last-writer-wins per channel, one external message poisons routing indefinitely.

## What changed (motivation → approach → change)

The root cause is that the canonical value is not on the inbound event at all — `event.team` names whoever spoke. So the cache's production feeder changes from "whoever spoke last" to the API that actually knows:

- New `RealSlackClient.ensure_channel_team(channel)` resolves the channel's HOME workspace from `conversations_info`'s `context_team_id` — the caller's own view of where the channel lives — and caches it via the existing `record_channel_team`.
- `_route_message` now awaits that resolver instead of recording `event.team`. The author-side team is no longer recorded anywhere: nothing consumed it, and keeping it in a parallel field would preserve two spellings of a value only one of which is safe.
- A failed or answer-less lookup leaves the channel out of the cache (outbound then omits `team_id`, exactly today's cold-cache behaviour) and remembers the miss per process, so one broken scope costs one lookup — not one per inbound message. A gateway restart retries.
- `start_stream`'s priority order is untouched; its cached source simply becomes correct.

Alternatives considered: keeping author-team seeding as a fallback beneath the canonical value was rejected because the fallback re-arms the same misrouting whenever resolution fails once; resolving lazily on first outbound instead of inbound was rejected because every outbound method would need an await inserted ahead of `_inject_team`.

## Tests

New cases in `TestTeamIdInjection` (`test/test_review_mode.py`):

- `ensure_channel_team` caches `context_team_id` — never an author team.
- An already-resolved channel triggers no `conversations_info` call.
- A failing lookup costs exactly **one** API call across repeated messages, leaves the cache empty, and `_inject_team` stays a no-op for that channel.
- An answer without `context_team_id` counts as unresolved with the same one-shot bound.

`_make_orch` in `test_slack_events_coverage.py` gains an `ensure_channel_team` async stub so the inbound path's new await has a mockable seam.

Existing tests are unchanged and still pass: they exercise the cache mechanics through `record_channel_team`, which remains the single cache writer — now fed only by the resolver.

## Manual verification

Windows 11 / Python 3.12:

```
pytest test/test_review_mode.py test/test_slack_events_coverage.py   → 234 passed
pytest test/test_slack_client.py test/test_slack_handler.py test/test_slack_gateway.py \
       test/test_slack_transport.py test/test_slack_thread_session_binding.py
                                                                     → 452 passed, 8 skipped
```

flake8 / isort clean on all four touched files; mypy clean on both modules; black clean on the non-baselined file (the other three sit in `.github/black-baseline.txt`, formatting state untouched).

## Related Issues

Fixes #4268

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented behaviour changes; the docstring contract travels with the code
- [x] No secrets, credentials, or internal references in the diff


## CI note

`Backend Tests (…, 3)`, `Coverage Gate`, and `PR Readiness` on this PR are red on a failure that reproduces on **pristine `origin/main`** with none of this diff applied: `test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` — "channels neither using messaging.pre_turn nor listed exempt: ['whatsapp']" — verified locally against `origin/main` checked out verbatim (same assertion, same single failure). This PR touches only `src/kiro_crew/slack/client.py`, `src/kiro_crew/slack/events.py`, and two of their test files; nothing in it can alter the channel roster. The Coverage Gate failure is downstream of the red shard. Every other gate — including all other backend shards on three platforms, lint/typecheck, and the AI review lanes — is green here.
