### PR TITLE
fix(deploy): resolve the aws CLI absolutely at sibling spawn sites

### DIFF
--- a/src/kiro_crew/aws_consent.py
+++ b/src/kiro_crew/aws_consent.py
@@ -554,11 +554,11 @@ async def probe_identity(profile: str, region: str, *, use_cache: bool = True) -
 
     if not _inputs_are_safe(profile, region):
         return Identity(ok=False, detail="The configured AWS profile or region is not valid.")
-    if await asyncio.to_thread(shutil.which, "aws") is None:
+    if not await asyncio.to_thread(_aws_cli_resolvable):
         return Identity(
             ok=False,
             detail=(
-                "The AWS CLI is not on PATH, so the account cannot be shown. "
+                "The AWS CLI could not be found, so the account cannot be shown. "
                 "Install it, or choose a local provider that needs no AWS account."
             ),
         )
@@ -595,6 +595,21 @@ async def probe_identity(profile: str, region: str, *, use_cache: bool = True) -
 
     _probe_cache[key] = (now, identity)
     return identity
+
+
+def _aws_cli_resolvable() -> bool:
+    """Thread-side probe: is the ``aws`` CLI invocable from where we spawn?
+
+    Routes through the deploy engine's shared well-known-dirs resolver (#4770)
+    so a GUI-launched gateway's minimal PATH does not fail the consent gate
+    closed before the voice sites' own resolved spawns ever run — the spawn
+    below already resolves absolutely via ``cloud.aws.run_aws``, so the probe
+    must agree with it. Imported at call time for the same reason as
+    ``_run_aws``.
+    """
+    from kiro_crew.deploy.engine import resolve_aws_bin
+
+    return shutil.which(resolve_aws_bin()) is not None
 
 
 def _run_aws(args: list[str], profile: str, region: str) -> tuple[int, str, str]:

--- a/src/kiro_crew/cloud/aws.py
+++ b/src/kiro_crew/cloud/aws.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 from typing import Any, Optional
 
+from kiro_crew.deploy.engine import resolve_aws_bin
 from kiro_crew.sandbox import cgroup_scope_argv, popen_limited, wrap_argv
 
 logger = logging.getLogger(__name__)
@@ -180,8 +181,11 @@ def _build_argv(args: list[str], profile: str, region: str) -> list[str]:
     Never appends a raw credential — only the profile *name* and region, both of
     which the caller has already charset-validated (see ``cloud.iam`` /
     ``cloud.ec2``).
+
+    The CLI is resolved absolutely through the deploy engine's shared resolver
+    so a GUI-launched gateway's minimal PATH still finds it (#4770).
     """
-    cmd = ["aws", *args]
+    cmd = [resolve_aws_bin(), *args]
     if profile:
         cmd += ["--profile", profile]
     if region:

--- a/src/kiro_crew/cloud/ssm.py
+++ b/src/kiro_crew/cloud/ssm.py
@@ -8,7 +8,8 @@ Two kinds of SSM interaction:
 2. **Open a long-lived port-forward tunnel** — ``start-session`` with the
    ``AWS-StartPortForwardingSession`` document. This is a streaming child
    process, so it is spawned directly with ``subprocess.Popen`` (not through the
-   capture-only chokepoint). The argv builders are pure and testable.
+   capture-only chokepoint). The argv builders are testable (the CLI head is
+   resolved via the deploy engine's shared resolver, #4770).
 
 Requires the ``session-manager-plugin`` on the client for #2 (bundled by the
 launcher prerequisites); #1 needs only the ``aws`` CLI.
@@ -29,6 +30,7 @@ from typing import Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.cloud import aws
+from kiro_crew.deploy.engine import resolve_aws_bin
 
 logger = logging.getLogger(__name__)
 
@@ -166,9 +168,13 @@ def build_port_forward_argv(
     profile: str = "",
     region: str = "",
 ) -> list[str]:
-    """Build the ``aws ssm start-session`` port-forward argv (pure/testable)."""
+    """Build the ``aws ssm start-session`` port-forward argv (testable).
+
+    The CLI head is resolved absolutely through the deploy engine's shared
+    resolver so a GUI-launched gateway's minimal PATH still finds it (#4770).
+    """
     argv = [
-        "aws",
+        resolve_aws_bin(),
         "ssm",
         "start-session",
         "--target",
@@ -188,8 +194,11 @@ def build_port_forward_argv(
 def build_interactive_session_argv(
     instance_id: str, profile: str = "", region: str = ""
 ) -> list[str]:
-    """Build the plain ``aws ssm start-session`` argv (interactive shell)."""
-    argv = ["aws", "ssm", "start-session", "--target", instance_id]
+    """Build the plain ``aws ssm start-session`` argv (interactive shell).
+
+    Same absolute CLI resolution as :func:`build_port_forward_argv` (#4770).
+    """
+    argv = [resolve_aws_bin(), "ssm", "start-session", "--target", instance_id]
     if region:
         argv += ["--region", region]
     if profile:

--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -14,7 +14,6 @@ import contextlib
 import json
 import logging
 import os
-import shutil
 import tempfile
 import time
 
@@ -30,6 +29,7 @@ from kiro_crew.voice_reply import (
     PROVIDER_POLLY,
     VALID_ENGINES,
     VALID_PROVIDERS,
+    resolve_polly_cli,
     stitch_mp3s,
     streaming_voice_reply,
     synthesize_speech,
@@ -330,18 +330,21 @@ async def api_voice_voices(request: web.Request) -> web.Response:
     ):
         return web.json_response({"voices": []})
 
-    if await asyncio.to_thread(shutil.which, "aws") is None:
+    aws_bin = await asyncio.to_thread(resolve_polly_cli)
+    if aws_bin is None:
         # Polly voice listing needs the AWS CLI, which is optional (the
-        # default Piper provider works without it). When the gateway runs
-        # under launchd, its PATH may also lack the dirs where `aws` is
-        # installed (e.g. /usr/local/bin). Degrade to an empty list instead
-        # of a 500 + traceback. Not cached, so the list recovers as soon as
-        # `aws` becomes resolvable. The probe runs in a thread so a wedged
-        # network mount on PATH cannot stall the event loop.
-        logger.info("aws CLI not found on PATH — returning empty voices list")
+        # default Piper provider works without it). Resolution goes through
+        # the deploy engine's shared well-known-dirs resolver, so a gateway
+        # running under launchd with a minimal PATH still finds a Homebrew /
+        # official-pkg install (#4770). When the CLI genuinely is not
+        # installed, degrade to an empty list instead of a 500 + traceback.
+        # Not cached, so the list recovers as soon as `aws` becomes
+        # resolvable. The probe runs in a thread so a wedged network mount
+        # on PATH cannot stall the event loop.
+        logger.info("aws CLI not resolvable — returning empty voices list")
         return web.json_response({"voices": []})
 
-    cmd = ["aws", "polly", "describe-voices", "--output", "json"]
+    cmd = [aws_bin, "polly", "describe-voices", "--output", "json"]
     if _vc.aws_profile:
         cmd += ["--profile", _vc.aws_profile]
     if _vc.region:

--- a/src/kiro_crew/deploy/engine.py
+++ b/src/kiro_crew/deploy/engine.py
@@ -98,7 +98,7 @@ _AWS_BIN_DIRS = (
 )
 
 
-def _resolve_aws_bin() -> str:
+def resolve_aws_bin() -> str:
     """Resolve ``aws`` to an absolute path, falling back to the bare name.
 
     Searches the inherited ``PATH`` first, then the well-known install dirs in
@@ -106,6 +106,11 @@ def _resolve_aws_bin() -> str:
     how it was launched (Finder/Dock give a minimal PATH; a terminal launch does
     not). Falling back to the bare ``"aws"`` preserves the prior behaviour — and
     its "not found" error — when the CLI genuinely is not installed anywhere.
+
+    Public: this is the repo's single ``aws``-CLI resolution chokepoint, reused
+    by every sibling spawn site (``cloud.aws``, ``cloud.ssm``, ``voice_reply``,
+    ``dashboard.chat_voice``, the artifact-deploy skill scripts) so each one
+    survives a GUI-launched gateway's minimal PATH the same way (#4770).
 
     A hit found only through the fallback dirs (i.e. NOT reachable via the
     inherited ``PATH``, which the pre-existing bare-argv behaviour already
@@ -137,7 +142,7 @@ def _resolve_aws_bin() -> str:
 
 def _aws(args: list[str], profile: str) -> list[str]:
     """Build an ``aws`` CLI argv with an optional ``--profile`` (never a raw key)."""
-    cmd = [_resolve_aws_bin()] + list(args)
+    cmd = [resolve_aws_bin()] + list(args)
     if profile:
         cmd += ["--profile", profile]
     return cmd

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -334,6 +334,14 @@ def create_aws_profile(name: str, region: str, *, account: str = "",
                 "or environment variables."
             )
         python_bin = sys.executable or "python3"
+        # Deliberately a bare "aws" (NOT the deploy engine's absolute resolver,
+        # #4770): this command is persisted into ~/.aws/config and later run by
+        # whichever AWS CLI/SDK reads that profile — possibly a different user
+        # shell, possibly long after the CLI was reinstalled elsewhere. An
+        # absolute path resolved in the gateway's environment today can be
+        # wrong or stale in that consumer's environment, and would turn a
+        # PATH-configurable lookup into a frozen location. The consumer
+        # resolves "aws" against its own PATH.
         script = (
             "import json,subprocess;"
             'r=subprocess.run(["aws","sts","assume-role","--role-arn",'

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
@@ -12,6 +12,7 @@ Host). Two origin flavors:
 Append-only: preserves the existing config (default S3 behavior, other apps).
 CloudFront is global; region is only for CLI profile plumbing.
 """
+
 import argparse
 import json
 import os
@@ -27,7 +28,6 @@ OAC_NAME = "kirocrew-deploy-lambda-oac"
 
 
 def aws(profile, region, *args):
-    cmd = ["aws"] + (["--profile", profile] if profile else []) + ["--region", region, *args]
     # Every AWS spawn from these LLM-facing helpers MUST route through
     # the sandbox chokepoint. Failing open when kiro_crew is not importable
     # would run completely unsandboxed, which is exactly the environment an
@@ -35,6 +35,7 @@ def aws(profile, region, *args):
     # run via the package venv (pip install -e / the skill's documented
     # invocation), never bare python3 without kiro_crew on sys.path.
     try:
+        from kiro_crew.deploy.engine import resolve_aws_bin
         from kiro_crew.sandbox import run_limited, sandboxed_spawn_argv
     except ImportError:
         sys.stderr.write(
@@ -43,6 +44,13 @@ def aws(profile, region, *args):
             "python (see skills/artifact-deploy/SKILL.md).\n"
         )
         sys.exit(1)
+    # Resolved absolutely (shared deploy-engine resolver) so a GUI-launched
+    # gateway's minimal PATH still finds the CLI (#4770).
+    cmd = (
+        [resolve_aws_bin()]
+        + (["--profile", profile] if profile else [])
+        + ["--region", region, *args]
+    )
     wrapped_argv, env, cleanup = sandboxed_spawn_argv(cmd)
     # Kernel RLIMIT ceiling on the child (fork bomb / FD / mem / CPU) — the
     # spawn-audit rule requires this on every sandbox-routed spawn; run_limited

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
@@ -15,7 +15,6 @@ import tempfile
 
 
 def aws(profile, region, *args):
-    cmd = ["aws"] + (["--profile", profile] if profile else []) + ["--region", region, *args]
     # Every AWS spawn from these LLM-facing helpers MUST route through the
     # sandbox chokepoint. An ImportError fallback that ran unsandboxed when
     # kiro_crew wasn't importable is exactly the environment an attacker would
@@ -23,6 +22,7 @@ def aws(profile, region, *args):
     # package venv (pip install -e / the skill's documented invocation), never
     # bare python3 without kiro_crew on sys.path.
     try:
+        from kiro_crew.deploy.engine import resolve_aws_bin
         from kiro_crew.sandbox import run_limited, sandboxed_spawn_argv
     except ImportError:
         sys.stderr.write(
@@ -31,6 +31,13 @@ def aws(profile, region, *args):
             "python (see skills/artifact-deploy/SKILL.md).\n"
         )
         sys.exit(1)
+    # Resolved absolutely (shared deploy-engine resolver) so a GUI-launched
+    # gateway's minimal PATH still finds the CLI (#4770).
+    cmd = (
+        [resolve_aws_bin()]
+        + (["--profile", profile] if profile else [])
+        + ["--region", region, *args]
+    )
     wrapped_argv, env, cleanup = sandboxed_spawn_argv(cmd)
     # Kernel RLIMIT ceiling on the child (fork bomb / FD / mem / CPU) — the
     # spawn-audit rule requires this on every sandbox-routed spawn; run_limited

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -362,7 +362,12 @@ class _SshTunnel:
         self._stopping = False
         self.status.state = TunnelState.CONNECTING
         self.status.error = ""
-        argv = self._build_argv()
+        # Built in a worker thread: the SSM branch resolves the aws CLI
+        # absolutely (#4770), which probes the filesystem (PATH scan +
+        # well-known install dirs) — synchronous work that must not run on the
+        # gateway event loop, where a stalled network mount on PATH would
+        # freeze every request and heartbeat.
+        argv = await asyncio.to_thread(self._build_argv)
         target = self._ssm_target if self._transport == "ssm" else self._ssh_host
         logger.info(
             "Opening %s tunnel for %s: 127.0.0.1:%d -> %s:%d",

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -29,6 +29,7 @@ import tempfile
 from typing import TYPE_CHECKING
 
 from kiro_crew import aws_consent
+from kiro_crew.deploy.engine import resolve_aws_bin
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
     cgroup_scope_argv,
@@ -41,6 +42,21 @@ if TYPE_CHECKING:
     from kiro_crew.slack.client import SlackClientOps
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_polly_cli() -> str | None:
+    """Resolve the ``aws`` CLI for Polly spawn sites; ``None`` when not invocable.
+
+    Routes through the deploy engine's shared well-known-dirs resolver so a
+    GUI-launched gateway's minimal PATH still finds the CLI instead of silently
+    skipping TTS / degrading to an empty voice list (#4770). The trailing
+    ``shutil.which`` turns the resolver's bare-name fallback into the ``None``
+    these probe sites already treat as "unavailable", and confirms an absolute
+    hit is still actually executable.
+    """
+    aws_bin = resolve_aws_bin()
+    return aws_bin if shutil.which(aws_bin) else None
+
 
 # ── Provider constants ──
 PROVIDER_POLLY = "polly"
@@ -69,7 +85,7 @@ def is_available(
     when voice output was requested but cannot be produced.
     """
     if provider == PROVIDER_POLLY:
-        return shutil.which("aws") is not None
+        return resolve_polly_cli() is not None
     if provider == PROVIDER_PIPER:
         bin_path = _resolve_piper_binary(piper_binary)
         if not bin_path:
@@ -447,9 +463,13 @@ async def _synthesize_polly(
         return None
     # Polly is OPTIONAL and driven via the ``aws`` CLI (no boto3 dependency).
     # On a vanilla machine without the CLI installed, degrade gracefully here
-    # instead of raising FileNotFoundError from create_subprocess_exec.
-    if shutil.which("aws") is None:
-        logger.info("voice_reply: Polly unavailable (aws CLI not on PATH); skipping TTS")
+    # instead of raising FileNotFoundError from create_subprocess_exec. Resolved
+    # absolutely (shared deploy-engine resolver) so a GUI-launched gateway's
+    # minimal PATH does not silently skip TTS (#4770); resolution probes the
+    # filesystem, so it runs in a thread rather than on the event loop.
+    aws_bin = await asyncio.to_thread(resolve_polly_cli)
+    if aws_bin is None:
+        logger.info("voice_reply: Polly unavailable (aws CLI not resolvable); skipping TTS")
         return None
     if not aws_profile:
         # The reporter's core case: with no profile the argv below carries no
@@ -468,7 +488,7 @@ async def _synthesize_polly(
     sandbox_cleanup: str | None = None
     try:
         try:
-            cmd: list[str] = ["aws", "polly", "synthesize-speech"]
+            cmd: list[str] = [aws_bin, "polly", "synthesize-speech"]
             if aws_profile:
                 cmd += ["--profile", aws_profile]
             if region:

--- a/test/test_aws_consent.py
+++ b/test/test_aws_consent.py
@@ -1181,7 +1181,33 @@ class TestIdentityProbeInputs:
         with patch("shutil.which", return_value=None):
             identity = asyncio.run(aws_consent.probe_identity("", "", use_cache=False))
         assert identity.ok is False
-        assert "not on PATH" in identity.detail
+        assert "could not be found" in identity.detail
+
+    def test_cli_probe_resolves_under_minimal_path(self, home, monkeypatch, tmp_path):
+        """A GUI-launched gateway's minimal PATH must not fail the consent gate
+        closed: the probe routes through the deploy engine's well-known-dirs
+        resolver (#4770), agreeing with the resolved spawn below it."""
+        import os as _os
+
+        if _os.name == "nt":
+            pytest.skip("fallback install dirs are POSIX literals; dead on Windows by design")
+        from kiro_crew import github_runner
+        from kiro_crew.deploy import engine
+
+        fake_aws = tmp_path / "aws"
+        fake_aws.write_text("#!/bin/sh\n")
+        fake_aws.chmod(0o755)
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+        monkeypatch.setattr(github_runner, "validate_provider_executable", lambda c: c)
+
+        payload = '{"Account": "111122223333", "Arn": "arn:aws:iam::1:user/x"}'
+        with patch.object(aws_consent, "_run_aws", return_value=(0, payload, "")) as run:
+            identity = asyncio.run(aws_consent.probe_identity("", "", use_cache=False))
+        assert identity.ok is True
+        assert run.call_count == 1  # the gate passed; the probe reached the spawn
 
     def test_the_local_half_of_the_gate_never_probes(self, home):
         """``is_granted`` stays local; only ``authorize`` may probe.

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -381,8 +381,8 @@ class TestVoiceVoices:
         config_dir().mkdir(parents=True, exist_ok=True)
         _consent_to_polly(profile="", region="")
         # The gate also verifies the LIVE account, which would spawn the AWS CLI
-        # and collide with this class's single-argument `shutil.which` stub.
-        # These cases are about the catalogue, so return a matching identity.
+        # behind this class's `resolve_polly_cli` stub. These cases are about
+        # the catalogue, so return a matching identity.
         from kiro_crew import aws_consent
 
         async def _probe(_profile, _region, *, use_cache=True):
@@ -420,7 +420,9 @@ class TestVoiceVoices:
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
-        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_voice.resolve_polly_cli", lambda: "/usr/local/bin/aws"
+        )
 
         from kiro_crew.dashboard.chat_voice import api_voice_voices
         app = web.Application()
@@ -479,7 +481,9 @@ class TestVoiceVoices:
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
-        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_voice.resolve_polly_cli", lambda: "/usr/local/bin/aws"
+        )
 
         from kiro_crew.dashboard.chat_voice import api_voice_voices
         app = web.Application()
@@ -514,7 +518,9 @@ class TestVoiceVoices:
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
-        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_voice.resolve_polly_cli", lambda: "/usr/local/bin/aws"
+        )
 
         from kiro_crew.dashboard.chat_voice import api_voice_voices
         app = web.Application()
@@ -534,7 +540,7 @@ class TestVoiceVoices:
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache", None)
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache_ts", 0)
 
-        monkeypatch.setattr("shutil.which", lambda cmd: None)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice.resolve_polly_cli", lambda: None)
         spawn = AsyncMock()
         monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
 
@@ -565,7 +571,9 @@ class TestVoiceVoices:
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache", None)
         monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache_ts", 0)
 
-        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_voice.resolve_polly_cli", lambda: "/usr/local/bin/aws"
+        )
 
         async def mock_exec(*args, **kwargs):
             raise FileNotFoundError(2, "No such file or directory", "aws")

--- a/test/test_cloud_aws.py
+++ b/test/test_cloud_aws.py
@@ -10,6 +10,12 @@ from kiro_crew.cloud import aws
 
 
 class TestBuildArgv:
+    @pytest.fixture(autouse=True)
+    def _bare_resolver(self, monkeypatch):
+        """Pin the shared resolver to the bare name so argv-shape assertions
+        stay deterministic across hosts (with/without an installed CLI)."""
+        monkeypatch.setattr(aws, "resolve_aws_bin", lambda: "aws")
+
     def test_bare(self):
         assert aws._build_argv(["sts", "get-caller-identity"], "", "") == [
             "aws",
@@ -24,6 +30,32 @@ class TestBuildArgv:
     def test_profile_only(self):
         argv = aws._build_argv(["s3", "ls"], "prod", "")
         assert argv == ["aws", "s3", "ls", "--profile", "prod"]
+
+    def test_argv_head_resolved_absolutely_under_minimal_path(self, monkeypatch, tmp_path):
+        """A GUI-launched gateway's minimal PATH must not yield a bare 'aws'
+        head that fails execvp: the builder routes through the deploy engine's
+        well-known-dirs resolver (#4770)."""
+        import os as _os
+
+        if _os.name == "nt":
+            pytest.skip("fallback install dirs are POSIX literals; dead on Windows by design")
+        from kiro_crew import github_runner
+        from kiro_crew.deploy import engine
+
+        fake_aws = tmp_path / "aws"
+        fake_aws.write_text("#!/bin/sh\n")
+        fake_aws.chmod(0o755)
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+        monkeypatch.setattr(github_runner, "validate_provider_executable", lambda c: c)
+        # Undo this class's bare-name pin: this test exercises the real resolver.
+        monkeypatch.setattr(aws, "resolve_aws_bin", engine.resolve_aws_bin)
+
+        argv = aws._build_argv(["sts", "get-caller-identity"], "dev", "")
+        assert argv[0] == str(fake_aws)
+        assert argv[1:] == ["sts", "get-caller-identity", "--profile", "dev"]
 
 
 class TestRunAws:

--- a/test/test_cloud_ssm.py
+++ b/test/test_cloud_ssm.py
@@ -12,6 +12,12 @@ from kiro_crew.cloud import aws, ssm
 
 
 class TestArgvBuilders:
+    @pytest.fixture(autouse=True)
+    def _bare_resolver(self, monkeypatch):
+        """Pin the shared resolver to the bare name so argv-shape assertions
+        stay deterministic across hosts (with/without an installed CLI)."""
+        monkeypatch.setattr(ssm, "resolve_aws_bin", lambda: "aws")
+
     def test_port_forward_argv(self):
         argv = ssm.build_port_forward_argv("i-0abc", 5476, 5599, "dev", "us-east-1")
         assert argv[:3] == ["aws", "ssm", "start-session"]
@@ -39,6 +45,36 @@ class TestArgvBuilders:
             "--profile",
             "dev",
         ]
+
+    def test_argv_heads_resolved_absolutely_under_minimal_path(self, monkeypatch, tmp_path):
+        """Both start-session builders must resolve the CLI absolutely under a
+        GUI-launched gateway's minimal PATH via the deploy engine's shared
+        well-known-dirs resolver (#4770)."""
+        import os as _os
+
+        if _os.name == "nt":
+            pytest.skip("fallback install dirs are POSIX literals; dead on Windows by design")
+        from kiro_crew import github_runner
+        from kiro_crew.deploy import engine
+
+        fake_aws = tmp_path / "aws"
+        fake_aws.write_text("#!/bin/sh\n")
+        fake_aws.chmod(0o755)
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+        monkeypatch.setattr(github_runner, "validate_provider_executable", lambda c: c)
+        # Undo this class's bare-name pin: this test exercises the real resolver.
+        monkeypatch.setattr(ssm, "resolve_aws_bin", engine.resolve_aws_bin)
+
+        pf = ssm.build_port_forward_argv("i-0abc", 5476, 5599, "dev", "us-east-1")
+        assert pf[0] == str(fake_aws)
+        assert pf[1:3] == ["ssm", "start-session"]
+
+        it = ssm.build_interactive_session_argv("i-0abc")
+        assert it[0] == str(fake_aws)
+        assert it[1:3] == ["ssm", "start-session"]
 
 
 class TestOpenPortForward:

--- a/test/test_deploy_script_validation.py
+++ b/test/test_deploy_script_validation.py
@@ -1,6 +1,7 @@
 """Unit tests for argument validation in attach_backend.py and detach_backend.py."""
 
 import importlib.util
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -167,3 +168,56 @@ class TestAwsSpawnFlow:
         assert exc.value.code == 7
         assert "AccessDenied" in capsys.readouterr().err
         assert not profile_file.exists(), "temp sandbox profile must be unlinked on CLI failure"
+
+
+class TestAwsHelperResolvesAbsolutely:
+    """The scripts' aws() spawn helper must resolve the CLI absolutely under a
+    GUI-launched gateway's minimal PATH via the deploy engine's shared
+    well-known-dirs resolver (#4770)."""
+
+    @pytest.fixture(params=["attach_backend.py", "detach_backend.py"])
+    def mod(self, request):
+        return _load_script(request.param)
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="fallback install dirs are POSIX literals; dead on Windows by design",
+    )
+    def test_cmd_head_absolute_under_minimal_path(self, mod, monkeypatch, tmp_path):
+        from kiro_crew import github_runner, sandbox
+        from kiro_crew.deploy import engine
+
+        fake_aws = tmp_path / "aws"
+        fake_aws.write_text("#!/bin/sh\n")
+        fake_aws.chmod(0o755)
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+        monkeypatch.setattr(github_runner, "validate_provider_executable", lambda c: c)
+
+        seen: dict = {}
+
+        def fake_spawn_argv(cmd):
+            seen["cmd"] = list(cmd)
+            return list(cmd), {}, None
+
+        def fake_run_limited(argv, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+        # The helper imports these lazily from kiro_crew.sandbox at call time,
+        # so patching the sandbox module attributes intercepts the spawn.
+        monkeypatch.setattr(sandbox, "sandboxed_spawn_argv", fake_spawn_argv)
+        monkeypatch.setattr(sandbox, "run_limited", fake_run_limited)
+
+        out = mod.aws("dev", "us-west-2", "sts", "get-caller-identity")
+        assert out == "{}"
+        assert seen["cmd"][0] == str(fake_aws)  # absolute, not a bare "aws"
+        assert seen["cmd"][1:] == [
+            "--profile",
+            "dev",
+            "--region",
+            "us-west-2",
+            "sts",
+            "get-caller-identity",
+        ]

--- a/test/test_deploy_web_engine.py
+++ b/test/test_deploy_web_engine.py
@@ -116,7 +116,7 @@ def test_aws_bin_path_hit_wins_without_fallback(monkeypatch, tmp_path):
     monkeypatch.setenv("PATH", str(tmp_path))
     monkeypatch.setattr(engine, "_AWS_BIN_DIRS", ())
 
-    assert engine._resolve_aws_bin() == str(fake_aws)
+    assert engine.resolve_aws_bin() == str(fake_aws)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="fallback branch is dead on Windows")
@@ -139,7 +139,7 @@ def test_aws_bin_fallback_hit_failing_provenance_returns_bare_name(monkeypatch, 
 
     monkeypatch.setattr(github_runner, "validate_provider_executable", _refuse)
 
-    assert engine._resolve_aws_bin() == "aws"
+    assert engine.resolve_aws_bin() == "aws"
 
 
 def test_aws_bin_prefers_path_then_falls_back_to_bare_name(monkeypatch):
@@ -148,7 +148,7 @@ def test_aws_bin_prefers_path_then_falls_back_to_bare_name(monkeypatch):
     monkeypatch.setenv("PATH", "")
     monkeypatch.setattr(engine, "_AWS_BIN_DIRS", ())
 
-    assert engine._resolve_aws_bin() == "aws"
+    assert engine.resolve_aws_bin() == "aws"
     assert engine._aws(["s3", "ls"], "")[0] == "aws"
 
 

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -4271,6 +4271,74 @@ class TestSsmRegistry:
 class TestSsmTunnelArgv:
     """The SSM port-forward argv (loopback-bound, no shell, no injected opts)."""
 
+    @pytest.fixture(autouse=True)
+    def _bare_resolver(self, monkeypatch):
+        """Pin the shared aws-CLI resolver (#4770) to the bare name so the
+        argv-shape assertions stay deterministic across hosts."""
+        from kiro_crew.cloud import ssm
+
+        monkeypatch.setattr(ssm, "resolve_aws_bin", lambda: "aws")
+
+    def test_start_builds_argv_off_the_event_loop(self, monkeypatch):
+        """The SSM branch's argv build resolves the aws CLI (#4770), which
+        probes the filesystem — start() must run it in a worker thread, never
+        on the gateway event loop (a stalled network mount on PATH would
+        otherwise freeze every request)."""
+        from kiro_crew.instances import ssh_tunnel_manager as stm
+        from kiro_crew.instances.ssh_tunnel_manager import _SshTunnel
+
+        seen: dict = {}
+
+        def probe_builder(*a, **k):
+            try:
+                asyncio.get_running_loop()
+                seen["on_loop"] = True
+            except RuntimeError:
+                seen["on_loop"] = False
+            return ["aws", "ssm", "start-session"]
+
+        monkeypatch.setattr(stm, "_build_ssm_tunnel_argv", probe_builder)
+
+        class FakeProc:
+            returncode = None
+            stderr = None
+            pid = 4242
+
+            def terminate(self):
+                self.returncode = -15
+
+            def kill(self):
+                self.returncode = -9
+
+            async def wait(self):
+                return self.returncode
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        async def main():
+            t = _SshTunnel(
+                "cd-1",
+                "",
+                7778,
+                7777,
+                transport="ssm",
+                ssm_target="i-0123456789abcdef0",
+            )
+
+            async def _reachable():
+                return True
+
+            t._port_reachable = _reachable
+            ok = await t.start()
+            assert ok
+            await t.stop()
+
+        asyncio.run(main())
+        assert seen["on_loop"] is False  # built in a worker thread, not on the loop
+
     def test_argv_shape(self):
         from kiro_crew.instances.ssh_tunnel_manager import _build_ssm_tunnel_argv
 

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -247,6 +247,11 @@ def _patch_aws_on_path(monkeypatch) -> None:
         "kiro_crew.voice_reply.shutil.which",
         lambda name, *a, **k: _FAKE_AWS_CLI if name == "aws" else None,
     )
+    # The which stub above is name-sensitive ("aws" only), but the shared
+    # deploy-engine resolver (#4770) would feed it a PATH-hit absolute path.
+    # Pin the resolver to the bare name so this fixture keeps meaning exactly
+    # "the aws CLI is present" regardless of the host.
+    monkeypatch.setattr("kiro_crew.voice_reply.resolve_aws_bin", lambda: "aws")
 
 
 @pytest.fixture(autouse=True)
@@ -343,6 +348,49 @@ class TestIsAvailable:
 
     def test_unknown_provider_returns_false(self, caplog) -> None:
         assert is_available("bogus") is False
+
+
+# ── resolve_polly_cli() (#4770) ─────────────────────────────────────────
+
+
+class TestResolvePollyCli:
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="fallback install dirs are POSIX literals; dead on Windows by design",
+    )
+    def test_resolved_absolutely_under_minimal_path(self, monkeypatch, tmp_path) -> None:
+        """A GUI-launched gateway's minimal PATH must still resolve the CLI
+        absolutely via the deploy engine's well-known-dirs resolver instead of
+        silently skipping TTS (#4770)."""
+        from kiro_crew import github_runner, voice_reply
+        from kiro_crew.deploy import engine
+
+        fake_aws = tmp_path / "aws"
+        fake_aws.write_text("#!/bin/sh\n")
+        fake_aws.chmod(0o755)
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+        monkeypatch.setattr(github_runner, "validate_provider_executable", lambda c: c)
+
+        assert voice_reply.resolve_polly_cli() == str(fake_aws)
+        # The converted is_available() probe site sees the same resolution.
+        assert is_available(PROVIDER_POLLY) is True
+
+    def test_none_when_cli_absent_everywhere(self, monkeypatch, tmp_path) -> None:
+        """Bare-name fallback that is not invocable maps to None — the value
+        every probe site already treats as 'unavailable'."""
+        from kiro_crew import voice_reply
+        from kiro_crew.deploy import engine
+
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", ())
+
+        assert voice_reply.resolve_polly_cli() is None
+        assert is_available(PROVIDER_POLLY) is False
 
 
 # ── _resolve_piper_binary() ─────────────────────────────────────────────


### PR DESCRIPTION
## Problem / Motivation

PR #3709 fixed the GUI-launch minimal-PATH gap for exactly one `aws` spawn site (`deploy/engine.py`). A Finder/Dock-launched macOS gateway inherits the minimal launchd PATH, which contains neither Homebrew nor the official-pkg symlink dir, so the sibling sites that spawn a bare `"aws"` still fail `execvp` the same way: `cloud/aws.py`, both `cloud/ssm.py` start-session builders, `dashboard/chat_voice.py` (degrades to an empty voice list), `voice_reply.py` (silently skips TTS), and the artifact-deploy `attach_backend.py` / `detach_backend.py` scripts.

## Why it matters

On a desktop-app gateway with the CLI installed via Homebrew, cloud connect / SSM tunnels / Polly voice listing / voice replies / backend attach-detach all fail or silently degrade until the user relaunches the gateway from a shell -- the exact failure class #3709 already diagnosed and fixed for the deploy Verify step.

## What changed (motivation -> approach -> change)

Reuse the #3709 mechanism instead of re-implementing it: `deploy/engine.py::_resolve_aws_bin` is promoted to public `resolve_aws_bin()` (PATH first, then well-known install dirs, with fallback-dir hits routed through `validate_provider_executable`, bare-name fallback preserving the prior not-found error), and every sibling spawn site routes through it:

- `cloud/aws.py::_build_argv` -- resolved argv head.
- `cloud/ssm.py` -- both `start-session` argv builders resolved (also covers `instances/ssh_tunnel_manager.py`, which consumes them; the tunnel builder is now invoked in a worker thread since resolution probes the filesystem). Note: the argv head is necessary but not sufficient for the tunnel OUTCOME under a minimal PATH -- `session-manager-plugin` discovery is a separate env-injection question tracked in #5392.
- `voice_reply.py` -- new `resolve_polly_cli()` probe helper (resolver + `shutil.which` invocability check, `None` = unavailable) used by `is_available()` and `_synthesize_polly`.
- `dashboard/chat_voice.py` -- `describe-voices` probe/argv use `resolve_polly_cli` via `asyncio.to_thread` (same threading class as the prior `to_thread(shutil.which, ...)`).
- `attach_backend.py` / `detach_backend.py` -- resolver imported inside the existing fail-closed `kiro_crew` import block, so the sandbox chokepoint contract is unchanged.
- `aws_consent.py` -- the consent gate's CLI pre-probe (`probe_identity`) now routes through the same resolver via a thread-side `_aws_cli_resolvable()` helper. Without this the gate failed closed under a minimal PATH BEFORE the voice sites' resolved spawns could run (found by the First Principles review); the spawn below it already resolves via `cloud.aws.run_aws`, so probe and spawn now agree.
- `deploy/profiles.py` -- the generated `credential_process` deliberately keeps the bare `"aws"` with a note: that command is persisted into `~/.aws/config` and executed later in a different consumer's environment, where a gateway-resolved absolute path could be wrong or stale.

The gateway-wide consolidation of `_AWS_BIN_DIRS` into a single resolver (a deliberate PATH-first/bare-name ordering decision) is out of scope per the issue triage.

## Tests

- New minimal-PATH tests for each converted site (`test_cloud_aws.py`, `test_cloud_ssm.py`, `test_voice_reply.py::TestResolvePollyCli`, `test_deploy_script_validation.py::TestAwsHelperResolvesAbsolutely`, `test_aws_consent.py::test_cli_probe_resolves_under_minimal_path`): empty PATH + fake well-known dir must yield an absolute argv head, not a bare `"aws"`. Mutation-verified: reverting a site to the bare name reddens exactly the new test.
- Existing argv-shape tests pinned to a bare-name resolver so they stay deterministic across hosts with/without an installed CLI (`test_cloud_aws.py`, `test_cloud_ssm.py`, `test_instances.py::TestSsmTunnelArgv`, `test_voice_reply.py::_patch_aws_on_path`); `test_chat_voice.py` stubs repointed from a global `shutil.which` patch to the `resolve_polly_cli` seam.
- Local gates green: 1868 passed / 2 skipped (deploy|cloud|voice|ssm|tunnel|spawn_audit|instances keyword suite), flake8, isort, mypy, black ratchet.

## Manual verification

Not applicable beyond the test suite -- the change is argv-head resolution only; degraded-path semantics (empty voice list, silent TTS skip, fail-closed script imports) are preserved and covered by existing tests.

## Related Issues

Closes #4770

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project license.
