### PR TITLE
feat(overview): Add a single-owner panel slot below the summary cards

### DIFF
--- a/website/docs/extension-seams.md
+++ b/website/docs/extension-seams.md
@@ -9,10 +9,10 @@ The backend has the sibling mechanism, Composed Platform Providers: see
 [`docs/system-specs/modules/platform-context.md`](../../docs/system-specs/modules/platform-context.md).
 The two are independent. Nothing here reads `CONTRACT_VERSION`.
 
-## The nine registry seams
+## The ten registry seams
 
 Each entry is one registrar the edition may call, paired with the reader the core
-already calls. `src/extensions.ts` names exactly these nine in its header, and
+already calls. `src/extensions.ts` names exactly these ten in its header, and
 `src/test/extensionSeams.test.tsx` exercises each one.
 
 | Seam | Module | Registrar to reader |
@@ -24,6 +24,7 @@ already calls. `src/extensions.ts` names exactly these nine in its header, and
 | Top-bar widgets | `apps/topBarWidgets.tsx` | `registerTopBarWidgets()` to `getTopBarWidgets()` |
 | Readout-capsule segments | `apps/capsuleSegments.tsx` | `registerCapsuleSegment()` to `getCapsuleSegments()` |
 | Overview status cards | `pages/overviewStatCards.tsx` | `registerOverviewStatCards()` to `getOverviewStatCards()` |
+| Overview lower panel (single owner) | `pages/overviewPanel.tsx` | `registerOverviewPanel()` to `getOverviewPanel()` |
 | Panel-navigation chords | `hooks/useKeyboardShortcuts.ts` | `registerPanelShortcut()`, read by the shortcut handler and `DEFAULT_SHORTCUTS` |
 | Non-app route prefixes | `components/MigrationCheck.tsx` | `registerNonAppPrefix()`, read by `MigrationCheck` |
 
@@ -32,7 +33,7 @@ registry; see "API methods" below.
 
 Other `register*()` functions in `src/` (built-in surfaces, command-palette
 providers, tool pills, terminal sockets, highlight.js languages) are core-internal
-wiring, not edition seams. Only the nine above are called from the composition
+wiring, not edition seams. Only the ten above are called from the composition
 root.
 
 ## Composition root
@@ -361,6 +362,18 @@ which hides registered segments along with the core readouts.
 adds a self-contained `StatCard` (owning its own query and state, like the core
 `TunnelStatus`) to the Settings Overview grid, after the core cards, in ascending
 `order`. Each receives a `delay` prop for the grid's stagger animation.
+
+**Overview lower panel.** `registerOverviewPanel({ id, component })` claims the
+region below the Usage/Memory summary grid, which the stock build leaves empty.
+Unlike every other registry here this slot holds **at most one** entry: the first
+registration owns the region, and a second is a collision (throws in dev/test,
+warns and is ignored in production) rather than appending or replacing. That is
+the point — the region has one owner who renders whatever internal layout it
+wants and owns all of it, so there is no layout negotiation between parties who
+cannot see each other. Reach for `registerOverviewStatCards` instead when the
+contribution really is one more tile in the status grid; use this slot when the
+content does not fit a 150px tile. The component receives no props and is wrapped
+in an `ErrorBoundary`, so a throwing panel disables only itself.
 
 **Non-app route prefixes.** `registerNonAppPrefix(prefix)` tells `MigrationCheck`
 that a route can never host a migratable app, so the migration banner does not

--- a/website/src/extensions.ts
+++ b/website/src/extensions.ts
@@ -17,6 +17,7 @@
  *   import { registerTheme }             from '@/hooks/useTheme'
  *   import { registerCapsuleSegment }    from '@/apps/capsuleSegments'
  *   import { registerOverviewStatCards } from '@/pages/overviewStatCards'
+ *   import { registerOverviewPanel }     from '@/pages/overviewPanel'
  *
  * For edition-owned API methods there is no registrar — the edition imports the
  * blessed `apiTransport` (`@/api/apiTransport`) and builds its own typed API

--- a/website/src/pages/OverviewPage.tsx
+++ b/website/src/pages/OverviewPage.tsx
@@ -9,6 +9,7 @@ import { Card, CardTitle, StatCard } from '../components/ui'
 import { TunnelStatus } from '../components/TunnelStatus'
 import ErrorBoundary from '../components/ErrorBoundary'
 import { getOverviewStatCards } from './overviewStatCards'
+import { getOverviewPanel } from './overviewPanel'
 import { MemoryTab, UsageTab } from './overview'
 import { useProvider } from '../providers'
 import type { NormalizedUsage } from '../providers'
@@ -170,6 +171,11 @@ export default function OverviewPage() {
     return <DrillIn title={i18nT('pages.overviewPage.usage')} onBack={() => setView(null)}><UsageTab /></DrillIn>
   }
 
+  // Resolved once per render, and bound to a capitalized local so JSX treats it
+  // as a component rather than an intrinsic element.
+  const overviewPanel = getOverviewPanel()
+  const OverviewPanelComp = overviewPanel?.component
+
   return (
     <>
       {/* Health hero. Status only — Overview edits no config, so it hosts no
@@ -220,6 +226,19 @@ export default function OverviewPage() {
         <UsageSummaryCard onOpen={() => setView('usage')} />
         <MemorySummaryCard onOpen={() => setView('memory')} />
       </div>
+
+      {/* Extension slot: the single downstream-owned panel for the region below
+          the summary cards. One surface, one owner — a second registration
+          fails loud at the seam rather than negotiating layout here. Absent in
+          the stock build, and isolated so a throwing panel takes only itself
+          down, not the whole Overview. */}
+      {overviewPanel && OverviewPanelComp ? (
+        <ErrorBoundary scope={`overview-panel:${overviewPanel.id}`} fallback={null}>
+          <div className="mt-6">
+            <OverviewPanelComp />
+          </div>
+        </ErrorBoundary>
+      ) : null}
     </>
   )
 }

--- a/website/src/pages/overviewPanel.tsx
+++ b/website/src/pages/overviewPanel.tsx
@@ -1,0 +1,60 @@
+/**
+ * Overview lower-region panel slot.
+ *
+ * Overview ends at the deep-surface summary grid (Usage + Memory), leaving the
+ * rest of the page empty. A downstream edition that needs real estate there —
+ * something too big for a 150px stat tile, e.g. a scannable code or a compact
+ * live chart — has nowhere to put it, and the only alternative is editing
+ * OverviewPage.tsx on every upstream sync.
+ *
+ * This slot is deliberately SINGULAR, which is the whole design:
+ *
+ * - One surface, one owner, one default. A second registration does not append
+ *   and does not re-order; it is a collision, and `reportSeamCollision` fails
+ *   loud in dev/test. So there is never layout negotiation between parties who
+ *   cannot see each other, and the region always has exactly one owner.
+ * - It is NOT a second card grid. `overviewStatCards` is the card-composition
+ *   shape and covers the tile strip; adding another one here would multiply that
+ *   shape rather than give this region an owner. The registrant renders whatever
+ *   internal layout it wants inside the slot, and owns all of it.
+ *
+ * Registration is expected at module-load time (edition composition), before the
+ * page renders — this registry is not reactive. The core registers nothing, so
+ * the region stays empty in the stock build.
+ */
+import type { ComponentType } from 'react'
+import { reportSeamCollision } from '../apps/seamCollision'
+
+export interface OverviewPanel {
+  /** Stable key, used for the ErrorBoundary scope and the collision message. */
+  id: string
+  /**
+   * The panel. Rendered full-width below the summary grid, with no props: a
+   * slot owner reads whatever it needs itself, exactly as the built-in
+   * summary cards do.
+   */
+  component: ComponentType
+}
+
+let OVERVIEW_PANEL: OverviewPanel | null = null
+
+/**
+ * Claim the overview panel slot. First registration wins; a second one is a
+ * collision (throws in dev/test, warns and is ignored in production) rather
+ * than silently replacing an owner or stacking beneath it.
+ */
+export function registerOverviewPanel(panel: OverviewPanel): void {
+  if (OVERVIEW_PANEL) {
+    reportSeamCollision(
+      'overviewPanel',
+      `panel ${OVERVIEW_PANEL.id} already owns the overview panel slot; ignoring ${panel.id}`,
+    )
+    return
+  }
+  OVERVIEW_PANEL = panel
+}
+
+/** The registered panel, or `null` in the stock build. */
+export function getOverviewPanel(): OverviewPanel | null {
+  return OVERVIEW_PANEL
+}

--- a/website/src/test/OverviewPage.test.tsx
+++ b/website/src/test/OverviewPage.test.tsx
@@ -114,4 +114,22 @@ describe('OverviewPage — mission control', () => {
     renderWithProviders(<OverviewPage />, { store: statusStore() })
     expect(screen.queryByRole('button', { name: /Restart/i })).not.toBeInTheDocument()
   })
+
+  // The region below the summary cards is empty in the stock build, and the
+  // panel seam is only worth anything if the page actually READS it — a
+  // registry nothing renders is the failure this asserts against.
+  it('renders nothing in the lower panel region until a panel is registered', () => {
+    renderWithProviders(<OverviewPage />, { store: statusStore() })
+    expect(screen.queryByTestId('edition-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders a registered lower panel', async () => {
+    const { registerOverviewPanel } = await import('../pages/overviewPanel')
+    registerOverviewPanel({
+      id: 'test:lower-panel',
+      component: () => <div data-testid="edition-panel">registered</div>,
+    })
+    renderWithProviders(<OverviewPage />, { store: statusStore() })
+    expect(screen.getByTestId('edition-panel')).toBeInTheDocument()
+  })
 })

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -34,6 +34,7 @@ import {
 import { registerTheme, getRegisteredThemes } from '../hooks/useTheme'
 import { registerCapsuleSegment, getCapsuleSegments } from '../apps/capsuleSegments'
 import { registerOverviewStatCards, getOverviewStatCards } from '../pages/overviewStatCards'
+import { registerOverviewPanel, getOverviewPanel } from '../pages/overviewPanel'
 import { apiTransport } from '../api/apiTransport'
 // Importing the client installs the blessed transport (installApiTransport runs
 // at client module load), so `apiTransport` is populated for the test below.
@@ -314,6 +315,27 @@ describe('overviewStatCards — settings status-card seam', () => {
   })
 })
 
+describe('overviewPanel — lower-region single-owner slot', () => {
+  it('is empty in the stock build until something claims it', () => {
+    expect(getOverviewPanel()).toBeNull()
+  })
+
+  it('registers a panel and returns it', () => {
+    const Comp = () => null
+    registerOverviewPanel({ id: 'testpanel:a', component: Comp })
+    expect(getOverviewPanel()).toEqual({ id: 'testpanel:a', component: Comp })
+  })
+
+  it('throws on a second claim in dev/test; the first owner keeps the slot', () => {
+    // The slot is deliberately singular: a second registrant is a collision,
+    // not an append, so the region never has two owners negotiating layout.
+    expect(() =>
+      registerOverviewPanel({ id: 'testpanel:b', component: () => null }),
+    ).toThrow(/already owns the overview panel slot/)
+    expect(getOverviewPanel()?.id).toBe('testpanel:a')
+  })
+})
+
 describe('builtinRegistry — route-shape guard', () => {
   // BuiltinAppRoute resolves /:builtinApp from ONE pathname segment and never
   // the query/hash — so anything that isn't a bare plain segment registers but
@@ -402,6 +424,7 @@ describe('composition root — stock extensions.ts is empty', () => {
   it('capsule-segment + overview-stat-card seams are empty in the stock build', () => {
     expect(getCapsuleSegments().every(s => !s.id.startsWith('edition:'))).toBe(true)
     expect(getOverviewStatCards().every(c => !c.id.startsWith('edition:'))).toBe(true)
+    expect(getOverviewPanel()?.id.startsWith('edition:') ?? false).toBe(false)
   })
 
   it('importing it adds no registrations beyond the seeded core state', async () => {


### PR DESCRIPTION
## Problem

`OverviewPage` ends at the Usage/Memory summary grid, so everything below it is
empty page. A downstream edition whose contribution does not fit a 150px stat
tile (a scannable code, a compact live chart) has nowhere to put it. The only
alternative today is editing `OverviewPage.tsx`, which every downstream sync then
has to re-apply.

## What this adds

`registerOverviewPanel({ id, component })`, claiming the region below the summary
cards. The core registers nothing, so **the stock build renders identically**:
the region stays empty and the Overview DOM is unchanged.

The slot is deliberately **singular**, and that is the design rather than a
shortcut:

- **One surface, one owner, one default.** A second registration does not append
  and does not re-order. It is a collision, so `reportSeamCollision` throws in
  dev/test and warns in production. The region therefore never needs layout
  negotiation between parties who cannot see each other, which is the known
  failure mode of card composition.
- **It is not a second card grid.** `overviewStatCards` already covers the tile
  strip and is the card-composition shape. Adding another one here would
  multiply that shape instead of giving this region an owner. The registrant
  renders whatever internal layout it wants inside the slot and owns all of it.

The seam inventory is kept self-consistent, since adding a table row alone would
have left the docs contradicting themselves: `extension-seams.md` now says ten
seams rather than nine in all three places that count them, and the
`extensions.ts` header lists `registerOverviewPanel` alongside the other
registrars, so the seam is discoverable from the composition root's own
inventory.

## Alternative considered and rejected

Adding a `region?: 'tiles' | 'panels'` field to the existing `OverviewStatCard`
looked cheaper, and is wrong. A registered component renders its own `StatCard`,
and the two grids have different geometry: `repeat(auto-fit,minmax(150px,1fr))`
for the tile strip against a fixed `grid-cols-2` for the summary row. One
component cannot look correct in both, so a placement flag would claim an
interchangeability that does not exist, and would make the type name wrong for
half of its entries.

## Relationship to the "Everything is an App" RFC

`docs/request-for-change/rfc-everything-is-an-app.md` (draft) proposes in Phase 2
to delete `registerOverviewStatCards` rather than promote it, on the §5.2
argument that whole-surface replacement beats card composition: *"Several apps
each contributing a card into one page requires layout negotiation between
parties who cannot see each other, and produces a page nobody owns."*

This slot is shaped to agree with that argument rather than cut against it. It is
one surface with one owner and one default, which is the shape §5.2 asks for, and
it adds no new card-composition surface. If Phase 2 lands, this becomes a named
surface with an owning app rather than something to unwind.

One factual note for that RFC, offered as data rather than an objection: §5.2
observes that `registerOverviewStatCards` "after being built it has no
registrants in the stock build." That is true of the stock build by construction,
since the seam exists for downstream editions, and there is at least one
downstream registrant today. The premise reads as weaker evidence than it looks.

## Tests

- Registry seam (`extensionSeams.test.tsx`): empty before any claim; registers
  and returns; a second claim throws and the first owner keeps the slot. The
  stock-build-empty invariant already asserted for the capsule-segment and
  stat-card seams is extended to cover this one.
- Page render (`OverviewPage.test.tsx`): nothing renders in the region until a
  panel is registered, and a registered panel does render.

The render pair is the group that matters. A registry the page never reads is the
failure this seam could silently have, and only a render assertion catches it.

## Gate

`npx tsc -b` clean, `npm run lint` 0 errors. `extensionSeams.test.tsx` 46 passed,
`OverviewPage.test.tsx` 9 passed (7 before, +2). No user-facing string is added,
so no i18n catalog change is required.

## Visual evidence

<!-- no-visual-delta -->

**Why no screenshot:** the stock build renders identically. The core registers
no panel, so `getOverviewPanel()` returns `null` and the new branch renders
`null`, leaving the Overview DOM unchanged. This is not an assertion of intent:
`OverviewPage.test.tsx` pins it with "renders nothing in the lower panel region
until a panel is registered", alongside a second case proving the slot does
render once claimed. A screenshot here could only show a panel that no shipped
build contains.
