### PR TITLE
test: stub DNS resolution in push-destination validation tests (#5229)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
@@ -1235,6 +1235,33 @@ class TestTheStoredPushDestinationIsValidated:
     destination rather than trusting persisted input. Raised by the GPT review of this branch.
     """
 
+    @pytest.fixture(autouse=True)
+    def _public_dns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Resolve every hostname to a fixed public address.
+
+        ``resolve_origin_url``'s identity-pinning step re-runs ``validate_target_url``,
+        whose ``_host_is_blocked`` SSRF check does a LIVE ``socket.getaddrinfo`` resolve
+        and fails CLOSED on any resolver error. On a transient runner DNS hiccup
+        ``github.com`` read as blocked and a legitimate remote resolved to ``""``,
+        flaking the legitimate-remote cases in CI (#5229); the foreign-remote cases
+        short-circuit on the allowlist before DNS and cannot flake, but the pin covers
+        the whole class so no case here ever reaches a resolver. These tests are about
+        URL/identity validation, not address screening — the address decision has its
+        own tests below — so resolution is stubbed, same shape as the ``public_dns``
+        fixture in ``test/test_meetings_providers.py``. The patch swaps the shared
+        ``socket`` module's ``getaddrinfo`` for the whole process while a test runs
+        (``clone_setup.socket`` IS that module; monkeypatch restores it at teardown);
+        these tests do no other network I/O, so do not copy this fixture into ones
+        that do. The fail-closed production behaviour is deliberately untouched: it is
+        correct for a real DNS failure; the defect was a unit test exercising the real
+        resolver.
+        """
+        monkeypatch.setattr(
+            clone_setup.socket,
+            "getaddrinfo",
+            lambda *_a, **_kw: [(2, 1, 6, "", ("93.184.216.34", 443))],
+        )
+
     @pytest.mark.parametrize(
         "url",
         [
@@ -1280,6 +1307,60 @@ class TestTheStoredPushDestinationIsValidated:
         if clone_setup._remote_slug(url):
             cfg["target_url"] = "https://github.com/owner/repo"
         assert clone_setup.resolve_origin_url(cfg) == url
+
+
+class TestTheAddressDecisionItself:
+    """The SSRF screen the class above stubs out gets its own direct coverage.
+
+    ``TestTheStoredPushDestinationIsValidated`` pins ``getaddrinfo`` so it no longer
+    exercises ``_host_is_blocked`` incidentally (#5229) — which was the helper's ONLY
+    coverage in the repo. Losing the pinned-away coverage without an equivalent is how
+    a later edit to the screen (say, dropping the ``is_private`` predicate, or turning
+    the fail-closed ``except`` into fail-open) would land silently. Same split as the
+    ``public_dns`` precedent in ``test/test_meetings_providers.py``: the scheme tests
+    stub resolution, and the address decision is tested on its own.
+    """
+
+    def _pin(self, monkeypatch: pytest.MonkeyPatch, result) -> None:
+        if isinstance(result, Exception):
+
+            def _resolve(*_a, **_kw):
+                raise result
+
+        else:
+
+            def _resolve(*_a, **_kw):
+                return [(2, 1, 6, "", (result, 443))]
+
+        monkeypatch.setattr(clone_setup.socket, "getaddrinfo", _resolve)
+
+    def test_a_public_address_is_allowed(self, monkeypatch) -> None:
+        self._pin(monkeypatch, "93.184.216.34")
+        assert clone_setup._host_is_blocked("github.com") is False
+
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.7",  # private
+            "169.254.169.254",  # link-local (the cloud metadata range)
+            "0.0.0.0",  # unspecified
+        ],
+    )
+    def test_an_internal_address_is_blocked(self, monkeypatch, address) -> None:
+        """An allowlisted NAME pointed at an internal ADDRESS is the rebinding case."""
+        self._pin(monkeypatch, address)
+        assert clone_setup._host_is_blocked("github.com") is True
+
+    def test_a_resolver_error_fails_closed(self, monkeypatch) -> None:
+        """The contract the fixture above leans on: a DNS error means BLOCKED.
+
+        This is exactly the behaviour that made #5229 a test-hermeticity defect and
+        not a production one — pin it so the fail-closed ``except`` cannot quietly
+        become fail-open.
+        """
+        self._pin(monkeypatch, OSError("resolver down"))
+        assert clone_setup._host_is_blocked("github.com") is True
 
 
 class TestApprovalIsOneShotNotPersistent:


### PR DESCRIPTION
## Problem

`TestTheStoredPushDestinationIsValidated::test_a_legitimate_remote_still_resolves` flakes in CI (#5229), asserting `'' == 'https://github.com/owner/repo.git'`.

The mechanism is not CWD/git-fixture pollution and not a race: `resolve_origin_url` is pure string parsing EXCEPT its identity-pinning step, which re-runs `validate_target_url` → `_host_is_blocked` → a **live** `socket.getaddrinfo` resolve that fails **closed** on any `OSError`/`ValueError`. On a transient runner DNS failure, `github.com` reads as blocked, `validate_target_url` returns `None`, and `resolve_origin_url` returns `""` — exactly the reported assertion. A unit test was carrying a live-network dependency, which is why it only flakes where DNS can hiccup and never reproduces locally.

## Fix (test-only, production code untouched)

- Class-level autouse fixture pins `clone_setup.socket.getaddrinfo` to a fixed public address, following the existing `public_dns` precedent in `test/test_meetings_providers.py`. The production fail-closed behaviour is deliberately untouched — failing closed on a real DNS error is correct for an SSRF check; the defect was exercising it against the real resolver from a unit test.
- The pinned class was `_host_is_blocked`'s only (incidental) coverage in the repo, so the address decision now gets its own direct tests (`TestTheAddressDecisionItself`): public address allowed; loopback/private/link-local(metadata)/unspecified blocked; **resolver error fails closed** — pinning the exact contract this fix leans on, mirroring how the precedent splits scheme tests from address tests.
- The foreign-remote cases short-circuit on the allowlist before DNS (verified: `_is_allowed_remote`/`_remote_slug` are pure string parsing), so the class-wide pin makes them stricter, not weaker — the rejection reason tightens from "resolver error" to "allowlist refusal".

## Fail-before / fail-after reproduction

With `socket.getaddrinfo` patched to raise `OSError` (simulating the runner DNS failure) on **pre-fix** code, all 4 network-remote params fail with exactly the reported assertion:

```
AssertionError: assert '' == 'https://gith...wner/repo.git'
AssertionError: assert '' == 'git@github.c...wner/repo.git'
AssertionError: assert '' == 'ssh://git@gi...wner/repo.git'
AssertionError: assert '' == 'https://x-ac...wner/repo.git'
```

**Post-fix** under the identical fault injection: 20 passed (14 original + 6 new). Local/foreign params are unaffected in both runs (they never reach DNS).

## Verification

- `isort` / `flake8` / `mypy` / black gate: clean
- Full backend pytest: 62728 passed; 54 failures reproduced identically on clean main (host bus-permission environment issue, `Failed to connect to bus: Permission denied`, zero in `auto_improvement`) — stash-control verified
- Pre-push dual model review: GPT 5.6 PASS (zero findings); Opus 5 PASS (0 blocking, 5 advisories: A2 addressed in-branch with the dedicated address-decision tests, A3/A4 docstring precision adopted, A1+A5 same-class residual in `test_pr_recipe.py` filed as #5364 per the task-spec scoping rule to keep this PR to one file)

Closes #5229
