### PR TITLE
fix(test): make the backend suite pass on macOS, not only on Linux

### DIFF
--- a/.github/workflows/issue-summary.yml
+++ b/.github/workflows/issue-summary.yml
@@ -183,7 +183,13 @@ jobs:
           # valuable answer this lane can give, and it is unreachable from open
           # issues alone. The cap keeps a three-year-old namesake out of the
           # prompt.
-          CUTOFF="$(date -u -d '120 days ago' +%Y-%m-%dT%H:%M:%SZ)"
+          # GNU date on the runner, BSD date on a contributor's macOS. This script
+          # is extracted and executed verbatim by `test_issue_summary_workflow.py`,
+          # so it runs on both, and BSD `date` rejects `-d` outright ("illegal
+          # option") rather than ignoring it -- which failed every test in that
+          # file on macOS while CI stayed green.
+          CUTOFF="$(date -u -d '120 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-120d +%Y-%m-%dT%H:%M:%SZ)"
           gh issue list --repo "$REPO" --state all --limit 300 \
             --json number,title,state,closedAt > neighbours.json
           # `10#` forces base 10 so a dispatch of "007" still excludes issue 7

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -145,12 +145,34 @@ jobs:
       - name: Install bounded retry helper for read-only gh calls
         run: |
           cat > "$RUNNER_TEMP/gh-retry.sh" <<'HELPER'
+          # `timeout` is GNU coreutils: present on the runner, ABSENT on macOS by
+          # default -- and these step scripts are extracted and executed verbatim
+          # by test_pr_readiness_evaluate.py / _publish.py, so they have to run
+          # there too. Missing, `timeout` makes every call exit 127, `gh_retry`
+          # reads that as a transient failure, and the lane publishes `pending`
+          # for a reason that has nothing to do with the PR under test.
+          #
+          # Resolved once here rather than at each call site, so the 120s bound
+          # also has a single definition. Falling back to UNBOUNDED is deliberate:
+          # a call with no ceiling is a weaker guarantee than a bounded one, but a
+          # far better answer than treating the tool's absence as the request
+          # having failed. Written for bash 3.2, which is what macOS ships.
+          bounded() {
+            if command -v timeout >/dev/null 2>&1; then
+              timeout 120 "$@"
+            elif command -v gtimeout >/dev/null 2>&1; then
+              gtimeout 120 "$@"
+            else
+              "$@"
+            fi
+          }
+
           gh_retry() {
             local attempt out err rc=1
             for attempt in 1 2 3; do
-              # timeout bounds a HANGING attempt (gh applies no HTTP request
+              # `bounded` caps a HANGING attempt (gh applies no HTTP request
               # timeout of its own); rc 124 is just another retryable failure.
-              if out="$(timeout 120 "$@" 2>"$RUNNER_TEMP/gh-retry-err")"; then
+              if out="$(bounded "$@" 2>"$RUNNER_TEMP/gh-retry-err")"; then
                 cat "$RUNNER_TEMP/gh-retry-err" >&2
                 printf '%s\n' "$out"
                 return 0
@@ -599,7 +621,7 @@ jobs:
             # verdict is block a merge that a re-evaluation will unblock;
             # and pending-over-pending / no-status just refresh the
             # self-heal sweep's staleness clock.
-            existing_state="$(timeout 120 gh api "repos/$REPO/commits/$SHA/status" \
+            existing_state="$(bounded gh api "repos/$REPO/commits/$SHA/status" \
               --jq '[.statuses[] | select(.context == "PR Readiness")][0].state // empty' \
               2>/dev/null)" || existing_state="__unreadable__"
             if [ "$existing_state" = "failure" ] || [ "$existing_state" = "error" ]; then
@@ -812,7 +834,7 @@ jobs:
               description: $description,
               context: "PR Readiness"
             }' > "$RUNNER_TEMP/readiness-status.json"
-          if ! timeout 120 gh api --method POST "repos/$REPO/statuses/$SHA" \
+          if ! bounded gh api --method POST "repos/$REPO/statuses/$SHA" \
             --input "$RUNNER_TEMP/readiness-status.json" >/dev/null; then
             echo "::error::Failed to publish the readiness status for $SHA." \
               "The POST is not retried (a retry can overwrite a concurrent" \

--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,14 @@ __pycache__/
 # Generated per-machine by install_cc_agent_config()
 .mcp.json
 
-/venv/
-/.venv/
-/.venv-x86/
-/.venv311/
+# No trailing slash: a slash matches a DIRECTORY only, and a venv is commonly a
+# SYMLINK in a git worktree (one interpreter shared by several checkouts). With the
+# slash, `git add -A` in a worktree stages that symlink -- and the brand gate is
+# what catches it, reporting `.venv` as a changed file it cannot decode as UTF-8.
+/venv
+/.venv
+/.venv-x86
+/.venv311
 
 # Editor / IDE
 .vscode/
@@ -46,7 +50,10 @@ pyrightconfig.json
 .install-method
 
 # Frontend
-node_modules/
+# No trailing slash, for the same reason as the venv entries above: in a git
+# worktree node_modules is often a SYMLINK to a sibling checkout's, and a slash
+# matches a directory only.
+node_modules
 frontend/package-lock.json
 frontend/dist/
 tui/dist/
@@ -111,7 +118,7 @@ test_plan_atomic_writes_subagent_progress.md
 /electron/
 website/electron/backend-dist/
 website/electron/dist/
-website/electron/node_modules/
+website/electron/node_modules
 # Generated launcher icon (created from icon.png when making the desktop shortcut)
 website/electron/KiroCrew.ico
 tui/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,12 @@ flake8 src/kiro_crew test && mypy src/kiro_crew
 python -m pytest
 ```
 
+**On macOS, add `--platform linux` to mypy.** CI type-checks on Linux, and
+typeshed guards `os.listxattr` / `getxattr` / `setxattr` behind
+`sys.platform == "linux"` even though macOS has them — so a local run reports 4
+errors in files you did not touch, and it MISSES Linux-only errors CI fails on.
+`mypy --platform linux src/kiro_crew` is the parity invocation.
+
 **Do not run bare `black src/kiro_crew test`.** 1,420 files are not black-clean
 yet, so it reformats ~95,800 lines on top of whatever you changed and buries your
 diff. The gate above enforces black on every file *outside*

--- a/conftest.py
+++ b/conftest.py
@@ -35,7 +35,10 @@ this" contract failed at least once:
   directory for the whole process, so a bare ``mkdtemp()`` whose cleanup is missing
   or skipped leaves its directory somewhere this run owns and removes, instead of
   accumulating in the shared temp root forever. What was left behind is REPORTED
-  first, so the leak is a red rather than silent inode consumption.
+  first, so the leak is a red rather than silent inode consumption. On macOS the
+  base is additionally moved to ``/tmp`` -- the prefix Linux and CI already use --
+  because the launchd per-user temp dir is long enough to break an AF_UNIX bind and
+  random enough to read as a credential. See :data:`_SHORT_TMP_BASE`.
 * **The repository checkout.** The run fails when it ends with residue anywhere in
   the checkout, which is how a subprocess spawned without ``cwd=`` announces
   itself.
@@ -470,8 +473,52 @@ _TESTS_SINCE_LINECACHE_CLEAR = 0
 _FROZEN_AT_COLLECTION: int | None = None
 
 
+#: A short, path-shaped temp prefix for Darwin. macOS resolves the per-user temp dir to
+#: ``/var/folders/<2 chars>/<30 random chars>/T``, which is both LONG and free of any
+#: character outside ``[A-Za-z0-9/]`` -- and two limits the suite has nothing to do with
+#: fall straight out of that:
+#:
+#: * ``sun_path`` for an AF_UNIX socket is 104 bytes on Darwin (108 on Linux), so a
+#:   socket under a pytest temp dir cannot be bound at all: ``OSError: AF_UNIX path too
+#:   long`` is raised before the behaviour under test runs.
+#: * ``security._BARE_SECRET_RUN_RE`` matches a >=40-character run of ``[A-Za-z0-9+/]``,
+#:   and ``/`` is IN that class, so a temp path is ONE contiguous run. The 30-character
+#:   random segment carries that run over the 4.3-bits/char entropy floor whose whole
+#:   job is to keep file paths out, so any temp path echoed through a redactor comes
+#:   back ``[REDACTED: credential]`` and the assertion sees a mangled path.
+#:
+#: Both are properties of the HOST's temp prefix rather than of the code under test:
+#: these same tests pass on Linux and in CI, where ``gettempdir()`` is ``/tmp``. Giving
+#: macOS the prefix Linux already has is the smallest change that removes both, and it
+#: removes them for every test at once instead of teaching each one about a platform
+#: limit it is not about.
+#:
+#: The posture does not change. ``/tmp`` is world-writable with a sticky bit on Linux
+#: too, pytest still builds its per-user ``pytest-of-<user>`` tree inside it, and this
+#: file's own temp root is still ``mkdtemp``-created with O_EXCL and mode 0700 -- see
+#: :func:`_create_tmp_root` for why that is what makes a shared parent safe.
+_SHORT_TMP_BASE = "/tmp"
+
+
+def _prefer_short_tmp_base() -> None:
+    """Point this run's temp base at :data:`_SHORT_TMP_BASE` on Darwin.
+
+    Called from ``pytest_configure``, which is early enough: pytest resolves its
+    ``basetemp`` lazily from ``tempfile.gettempdir()`` on the first ``mktemp`` /
+    ``getbasetemp()``, and that cannot happen before a fixture runs. Both the module
+    global and the env vars are set, because ``gettempdir()`` MEMOISES into
+    ``tempfile.tempdir`` and a spawned child reads the env instead.
+    """
+    if sys.platform != "darwin" or not os.path.isdir(_SHORT_TMP_BASE):
+        return
+    tempfile.tempdir = _SHORT_TMP_BASE
+    for name in _TMP_ENV_VARS:
+        os.environ[name] = _SHORT_TMP_BASE
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Record the working directory pytest started in, before any test can move it."""
+    _prefer_short_tmp_base()
     global _SESSION_CWD
     try:
         _SESSION_CWD = os.getcwd()

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -358,6 +358,15 @@ which testpath asked for the workers.
   so an unregistered directory no longer accumulates in the shared temp root forever.
   Residue there is still **reported** — relocation is not absolution.
 
+  On **macOS** `<platform temp>` is forced to `/tmp` (`_SHORT_TMP_BASE`), which is what
+  Linux and CI already resolve to. launchd's per-user temp dir is
+  `/var/folders/<2>/<30 random>/T`: long enough that an AF_UNIX socket under a pytest temp
+  dir exceeds Darwin's 104-byte `sun_path` and cannot bind at all, and random enough that
+  the path clears the credential redactor's entropy floor — `/` is inside its
+  `[A-Za-z0-9+/]{40,}` run, so a temp path is one contiguous match and comes back
+  `[REDACTED: credential]`. Both are properties of the host prefix rather than of the code
+  under test, and both used to fail ~13 tests locally while CI stayed green.
+
   A run only ever deletes the root it created itself — there is deliberately no sweep of
   other runs' roots, because every signal for "that directory is abandoned" is unsound from
   inside a test process: the name can be pre-created by another local account, and a pid

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -444,7 +444,21 @@ def _under_system_tmp(path: Path) -> bool:
             roots.append(Path(candidate).resolve())
         except (OSError, ValueError):  # pragma: no cover - defensive: unusable root
             continue
-    return any(path == root or root in path.parents for root in roots)
+    # The PATH is resolved too, not just the roots. Resolving one side only made the
+    # comparison cross namespaces on exactly the platform this rule was added for:
+    # macOS resolves `/tmp` to `/private/tmp`, so a checkout at `/tmp/<scratch clone>`
+    # -- the literal shape #4781 reports -- kept `/tmp` among its parents, matched
+    # nothing, and read as DURABLE. The guard then stamped a machine-wide agent spec
+    # from a tree the OS reaps at reboot, which is the outcome it exists to prevent.
+    #
+    # Resolving is also the safe direction for a symlink pointing OUT of the temp tree:
+    # the checkout really lives at the target, so a durable target correctly stops
+    # matching rather than being declined for the shape of its path.
+    try:
+        target = path.resolve()
+    except (OSError, ValueError):  # pragma: no cover - defensive: unresolvable path
+        target = path
+    return any(target == root or root in target.parents for root in roots)
 
 
 def _in_linked_git_worktree(path: Path) -> bool:

--- a/test/test_connections_l0_probe.py
+++ b/test/test_connections_l0_probe.py
@@ -489,14 +489,35 @@ def test_canonicalization_is_the_dialled_host_by_construction(hostname):
     assert canonical_host(hostname) == expected
 
 
-def test_a_host_yarl_itself_refuses_is_refused():
-    """A ZWJ label encodes fine under IDNA2003 but yarl will not build the URL."""
+def test_a_zwj_label_tracks_whatever_the_dialler_does_with_it():
+    """A ZWJ label encodes fine under IDNA2003; whether yarl accepts it VARIES.
 
-    with pytest.raises((ValueError, UnicodeError)):
-        URL("https://\u0938\u0940\u200d.example/x")
+    The invariant is agreement with the dialler, in both directions, and it is
+    asserted that way rather than against one codec's verdict. `idna` 3.18 drops
+    the ZWJ and yarl builds `xn--12bq.example`; older releases raise. Pinned to
+    the raise, this test failed wherever the newer codec was resolved -- reporting
+    a codec upgrade as a defect in the guard, while the guard was doing exactly
+    its job: `canonical_host` read the encoding back from yarl and returned the
+    host aiohttp would actually contact.
 
-    assert canonical_host("\u0938\u0940\u200d.example") is None
-    assert is_local_host("\u0938\u0940\u200d.example") is True
+    Both arms matter for security, and for opposite reasons. When yarl refuses,
+    nothing can ever be dialled, so refusing is the only honest answer and
+    `is_local_host` fails CLOSED. When yarl accepts, the host IS reachable, and
+    canonicalizing to anything other than what will be contacted is the mismatch
+    this module exists to prevent -- vet host A, dial host B.
+    """
+
+    host = "\u0938\u0940\u200d.example"
+    try:
+        dialed = URL(f"https://{host}/x").raw_host
+    except (ValueError, UnicodeError):
+        assert canonical_host(host) is None
+        assert is_local_host(host) is True
+        return
+
+    assert dialed, "yarl built the URL, so it must name a host"
+    assert canonical_host(host) == dialed.rstrip(".").lower()
+    assert is_local_host(host) is False
 
 
 @pytest.mark.parametrize(

--- a/test/test_imessage_rpc.py
+++ b/test/test_imessage_rpc.py
@@ -54,14 +54,40 @@ class FakeStdin:
 
 
 class FakeProc:
-    """Minimal asyncio.subprocess.Process stand-in with feedable streams."""
+    """Minimal asyncio.subprocess.Process stand-in with feedable streams.
+
+    The readers are created on FIRST USE rather than in ``__init__``, and that is
+    load-bearing. ``asyncio.StreamReader()`` binds to whatever
+    ``get_event_loop()`` answers at CONSTRUCTION time, and this class is built by
+    a SYNC fixture -- which runs before the loop pytest-asyncio gives the test.
+    Bound to that earlier loop, ``feed_data`` sets its waiters there and the
+    peer's reader task, awaiting on the test's loop, is never woken: every
+    ``call`` then fails its 30s timeout while the request itself is written
+    correctly, so the symptom points at the peer rather than at the fixture.
+    Whether the two loops coincide depends on the platform's default policy and
+    on fixture ordering, which is why this was green in CI and red on macOS.
+    First use is always inside the running loop -- ``peer.start()`` reads
+    ``stdout``, and ``feed`` is only ever called from an async test.
+    """
 
     def __init__(self) -> None:
         self.stdin = FakeStdin(self)
-        self.stdout = asyncio.StreamReader(limit=STDOUT_LINE_LIMIT)
-        self.stderr = asyncio.StreamReader()
+        self._stdout: asyncio.StreamReader | None = None
+        self._stderr: asyncio.StreamReader | None = None
         self.returncode: int | None = None
         self.killed = False
+
+    @property
+    def stdout(self) -> asyncio.StreamReader:
+        if self._stdout is None:
+            self._stdout = asyncio.StreamReader(limit=STDOUT_LINE_LIMIT)
+        return self._stdout
+
+    @property
+    def stderr(self) -> asyncio.StreamReader:
+        if self._stderr is None:
+            self._stderr = asyncio.StreamReader()
+        return self._stderr
 
     def feed(self, frame: dict[str, Any]) -> None:
         self.stdout.feed_data((json.dumps(frame) + "\n").encode())

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -12,9 +12,9 @@ output we can assert directly), and the process-helper return contracts.
 from __future__ import annotations
 
 import errno
-import gc
 import json
 import logging
+import mmap
 import os
 import re
 import shutil
@@ -495,17 +495,27 @@ class TestResourceShims:
         much the gateway had ever transiently used. ``ru_maxrss`` never
         decreases, so this drives a real allocation and requires the number to
         come back down — the one property a peak cannot have.
+
+        The allocation is an ``mmap`` rather than a ``bytearray`` because the
+        RELEASE has to be observable on every platform, and only ``munmap`` is:
+        freeing a ``bytearray`` returns the pages to the allocator, which decides
+        for itself whether to hand them back to the OS. macOS's keeps all 128MB
+        resident, so the current reading did not move and this failed there while
+        agreeing exactly with ``ps -o rss=`` — a correct reading judged against an
+        allocator's discretion rather than against the property under test.
+        Closing a mapping unmaps immediately on Linux, macOS and Windows alike.
         """
         chunk = 128 * 1024 * 1024
         page = 4096
         baseline = pc.proc_rss_bytes()
-        buf = bytearray(chunk)
-        for offset in range(0, chunk, page):  # fault the pages in
-            buf[offset] = 1
-        while_held = pc.proc_rss_bytes()
-        peak_while_held = pc.proc_peak_rss_bytes()
-        del buf
-        gc.collect()
+        buf = mmap.mmap(-1, chunk)
+        try:
+            for offset in range(0, chunk, page):  # fault the pages in
+                buf[offset] = 1
+            while_held = pc.proc_rss_bytes()
+            peak_while_held = pc.proc_peak_rss_bytes()
+        finally:
+            buf.close()
         after_free = pc.proc_rss_bytes()
 
         # Rose by most of the buffer while it was resident.

--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -15,6 +15,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "configKey": "dashboard.use_builtin_browser"
   },
   {
+    "id": "channels.app-client-id-teams",
+    "label": "App (Client) ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.app_client_id",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.app_id"
+  },
+  {
     "id": "channels.enable-imessage-channel-imessage",
     "label": "Enable iMessage channel (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.enable",
@@ -254,6 +267,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.hard-context-threshold-teams",
+    "label": "Hard context threshold % (Teams)",
+    "labelKey": "pages.settings.channels.hard_threshold_label",
+    "labelSuffix": "Teams",
+    "description": "Compact automatically at this percentage, even without a reply, so the context window never overflows.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.hard_threshold_pct"
+  },
+  {
     "id": "channels.messages-database-path-imessage",
     "label": "Messages database path (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.db_path",
@@ -344,6 +371,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.soft-context-threshold-teams",
+    "label": "Soft context threshold % (Teams)",
+    "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.soft_threshold_pct"
+  },
+  {
     "id": "channels.soft-context-threshold-telegram",
     "label": "Soft context threshold % (Telegram)",
     "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
@@ -366,6 +406,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "params": {
       "channel": "wecom"
     }
+  },
+  {
+    "id": "channels.tenant-id-teams",
+    "label": "Tenant ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.tenant_id",
+    "labelSuffix": "Teams",
+    "description": "Optional — only for single-tenant bots.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.tenant_id"
   },
   {
     "id": "chat.auto-compact-threshold",

--- a/website/src/test/ResourceHealthPill.test.tsx
+++ b/website/src/test/ResourceHealthPill.test.tsx
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter } from 'react-router-dom'
 
 /**
  * Tests for the resource health indicator in the dashboard capsule.


### PR DESCRIPTION
A full local `pytest` on macOS ended **72 failed / 62,025 passed** while CI was
green. It is now **62,048 passed / 0 failed**, and ~3 minutes faster because six of
the failures were 30-second timeouts.

None of it was flaky. Five host assumptions, each invisible to CI because the
Linux runner happens to satisfy it.

no linked issue: reported as "61 backend tests fail on my macOS box".

## What was wrong

| Failures | Cause | Fix |
|---|---|---|
| 36 | `issue-summary.yml` computed its candidate cutoff with GNU `date -d` | fall back to BSD `date -v` |
| 21 | `pr-readiness.yml` bounded every `gh` call with `timeout`, which macOS does not ship | resolve once through a `bounded` helper |
| 13 | launchd's temp prefix is long and random | point the suite's temp base at `/tmp` on macOS |
| 1 | `_under_system_tmp` resolved its roots but not the path | resolve both sides |
| 6 | `FakeProc` built its `StreamReader`s in a sync fixture | build them on first use, inside the loop |
| 2 | two test premises had gone stale against the platform / a dependency | assert the property, not the platform's answer |

### GNU-only tooling in two workflow scripts

Both files are extracted and executed **verbatim** by their tests, so this was not
only a test failure — a contributor could not run either script.

- `date -d` is GNU. BSD `date` rejects it outright ("illegal option") rather than
  ignoring it, so every test in `test_issue_summary_workflow.py` failed.
- `timeout` is GNU coreutils and macOS ships **neither** it nor `gtimeout`. Every
  `gh` call exited 127, `gh_retry` read that as a transient failure, and the lane
  published `pending` — a verdict with nothing to do with the PR under test. The
  new `bounded` helper tries `timeout`, then `gtimeout`, then runs unbounded, and
  is written for the **bash 3.2** macOS ships (a function, not an array, because
  `"${arr[@]}"` on an empty array errors there under `set -u`). It also gives the
  120-second bound a single definition. CI behaviour is unchanged: `timeout`
  exists on the runner, so the first branch is taken.

### The temp prefix, which is two limits at once

macOS resolves the per-user temp dir to `/var/folders/<2>/<30 random>/T`:

- **Long** — an AF_UNIX socket under a pytest temp dir exceeds Darwin's 104-byte
  `sun_path`, so `test_dashboard_peer_auth` raised `OSError: AF_UNIX path too long`
  before the behaviour under test ran. The conftest already *names* this cap as a
  reason to keep pytest's basetemp outside its own redirect; the underlying prefix
  was still the host's.
- **Random** — `_BARE_SECRET_RUN_RE` matches a ≥40-char run of `[A-Za-z0-9+/]`, and
  `/` is inside that class, so a temp path is **one contiguous run**. The random
  30-char segment carries it over the 4.3-bits/char entropy floor whose whole job
  is to keep file paths out, so any temp path echoed through a redactor came back
  `[REDACTED: credential]` and the assertion saw a mangled path.

Giving macOS the prefix Linux already has fixes both for every test at once,
rather than teaching each test about a platform limit it is not about. Posture is
unchanged: `/tmp` is world-writable with a sticky bit on Linux too, pytest still
builds its per-user `pytest-of-<user>` tree inside it, and the run's own temp root
is still `mkdtemp`-created with O_EXCL and mode 0700.

## Two were real defects, caught correctly

- **`_under_system_tmp` never fired for `/tmp` on macOS.** It resolved its roots
  but compared them against the **raw** path — and macOS resolves `/tmp` to
  `/private/tmp`, so a checkout at `/tmp/<scratch clone>` (the literal shape #4781
  reports) kept `/tmp` among its parents, matched nothing, and read as DURABLE.
  The shared-agent-home guard then stamped a machine-wide agent spec from a tree
  the OS reaps at reboot, which is exactly the outcome it was added to prevent.
  The docstring already claimed "resolved paths on both sides"; now the code does
  too. Resolving is also the safe direction for a symlink pointing *out* of the
  temp tree.
- **`FakeProc` bound its readers to the wrong event loop.** `asyncio.StreamReader()`
  binds at construction, and a **sync** fixture runs before the loop pytest-asyncio
  gives the test — so `feed_data` set its waiters on the earlier loop and the peer's
  reader task was never woken. Every `call` failed its 30s timeout while the request
  itself was written correctly, so the symptom pointed at the peer rather than the
  fixture. Whether the two loops coincide depends on the platform's default policy
  and on fixture ordering, which is why CI was green.

## Two stale premises, re-asserted as properties

- **RSS.** The test freed a `bytearray` and required the reading to fall — which
  asks the **allocator**, not the OS. macOS keeps all 128MB resident, so a reading
  that agreed exactly with `ps -o rss=` was judged a peak. It now maps and closes,
  which is a real `munmap` on Linux, macOS and Windows alike. Every assertion is
  unchanged, including the decisive `after_free < peak_while_held`.
- **A ZWJ host.** The case was pinned to yarl *refusing* to build the URL. `idna`
  3.18 drops the ZWJ and builds `xn--12bq.example`, so the test reported a codec
  upgrade as a defect while the guard was doing its job — `canonical_host` read the
  encoding back from yarl and returned the host aiohttp would contact. It now
  asserts the invariant in both directions: refuse and fail closed when the dialler
  refuses, agree when it accepts. Verified it still fails when `canonical_host` is
  made to disagree on that host, and when it re-derives the encoding instead of
  reading yarl back (13 cases red).

## Not in this PR

- **`openpyxl` was missing from my local venv** (16 failures), but it is a declared
  core runtime dependency in `setup.cfg`. That was a stale environment, not a repo
  defect, so there is no code change for it — `pip install -e .` fixes it.
- **`ship-report.yml` also uses `date -d`**, in a timestamp-**parsing** form that
  needs BSD's `-j -f` rather than a one-word fallback. No test executes it, so I
  would be shipping an unverifiable rewrite of a working workflow; flagging it
  instead.
- **mypy on macOS** reports 4 errors in untouched files, because typeshed guards
  `os.listxattr`/`getxattr`/`setxattr` behind `sys.platform == "linux"` even though
  macOS has them. `AGENTS.md` now documents `mypy --platform linux` as the parity
  invocation — it also catches Linux-only errors a plain local run misses.

## Verification

- Full local backend suite on macOS: **62,048 passed, 383 skipped, 6 xfailed, 0 failed.**
- `mypy --platform linux src/kiro_crew`: clean.
- black baseline, isort, flake8, docs-lint, brand, harness-parity, changelog-history: pass.
- Each fix reverted individually reddens the tests it fixes.

## Three main-side reds cleared here too

None is caused by this PR, and each blocks its readiness. Flagging rather than
folding them in silently:

- **`settingsRegistry.gen.ts` had drifted four entries behind its sources** — the
  anti-stale guard reported 127 checked in against 131 live, reddening
  `Frontend Tests (3)` and the coverage merge. Regenerated with
  `npm run gen:settings`; no hand edits.
- **eslint had drifted three warnings past its own ratchet** (683 against
  `--max-warnings 680`). Fixed by deleting five dead imports from one test file
  rather than raising the ceiling — the budget exists to force the count down, and
  an unused import is dead code, so this pays a little of the debt instead of
  hiding it. Now 678.
- **`.gitignore`'s venv / node_modules entries carried a trailing slash**, which
  matches a **directory** only. A git worktree normally symlinks both to a sibling
  checkout, and a symlink is not a directory — so `git add -A` stages it. That is
  not hypothetical: this PR's first push committed a `.venv` symlink holding an
  absolute path, and the brand gate is what caught it ("cannot read these changed
  files as UTF-8"). Both entries lost the slash, and a symlinked `.venv` /
  `node_modules` is now ignored (verified with `git check-ignore`).

<!-- no-visual-delta -->
**Why no screenshot:** nothing here renders. The two files under `website/src/`
are a regenerated data module (`settingsRegistry.gen.ts`, produced by
`npm run gen:settings`) and five deleted dead imports in a test file — no
component, style, copy, or layout is touched, so there is no before/after to
show. The rest of the diff is Python tests, two workflow shell scripts, the
rootdir conftest, and docs.

## One more, found by running the other PR's suite

`TestPortMirror` stubbed the port probe on `ssh_tunnel_manager`, but
`PortAllocator.allocate` resolves `_is_port_free` from `port_allocator` — so
allocation consulted the **real host** while the tests asserted which port it
picked. A developer running the feature under test has an ssh tunnel listening on
the base port, which made `allocate` skip to `base + 1`
(`assert 7779 == 7778`).

The allocator now always sees a free port, and the bind check keeps the
`port_free` flag — which is what the conflict case actually simulates: free when
allocated, taken by the time we bind ("was taken while connecting"). Patching
both to the same answer would have broken that test instead, which is how the two
callers' opposite needs surfaced.
