### PR TITLE
fix(ci): restore the two red frontend gates on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1151,7 +1151,7 @@ jobs:
         # The ceiling must EQUAL the measured count, not sit above it: slack is
         # silent admission, and a warning that lands inside it never surfaces
         # again. Re-measure with `cd website && npx eslint src/` when burning down.
-        run: npx eslint src/ --max-warnings 680
+        run: npx eslint src/ --max-warnings 678
 
       - name: Copy/paste detection
         working-directory: website

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1694,6 +1694,7 @@ export default function App() {
           (value) => store.dispatch(updateSlot({ key: activeSlot, reasoning_effort: value })))
       } catch (e) {
         store.dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+        // eslint-disable-next-line no-console -- failure diagnostic; the notice above already told the user
         console.error('onCycleReasoningEffort failed', e)
       }
     },
@@ -1717,6 +1718,7 @@ export default function App() {
           (value) => store.dispatch(updateSlot({ key: activeSlot, reasoning_effort: value })))
       } catch (e) {
         store.dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+        // eslint-disable-next-line no-console -- failure diagnostic; the notice above already told the user
         console.error('onCyclePrevReasoningEffort failed', e)
       }
     },
@@ -1766,6 +1768,7 @@ export default function App() {
           (value) => store.dispatch(updateSlot({ key: activeSlot, model: value })))
       } catch (e) {
         store.dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+        // eslint-disable-next-line no-console -- failure diagnostic; the notice above already told the user
         console.error('onCycleModel failed', e)
       }
     },
@@ -1790,6 +1793,7 @@ export default function App() {
           (value) => store.dispatch(updateSlot({ key: activeSlot, model: value })))
       } catch (e) {
         store.dispatch(setAgentSwitchNotice(agentSwitchFailureMessage(e)))
+        // eslint-disable-next-line no-console -- failure diagnostic; the notice above already told the user
         console.error('onCyclePrevModel failed', e)
       }
     },

--- a/website/src/apps/command-bar/CommandBarOverlay.test.tsx
+++ b/website/src/apps/command-bar/CommandBarOverlay.test.tsx
@@ -8,7 +8,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SETTINGS_REGISTRY } from '../../components/commandPalette/settingsRegistry.gen'
 import { localizedSettingLabel } from '../../components/commandPalette/settingsSearchCore'
 import { settingsSubtitle, settingsTabLabel } from '../../components/commandPalette/settingsTabLabel'
-import { i18nT } from '../../i18n/t'
 import CommandBarOverlay from './CommandBarOverlay'
 
 /**

--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -15,6 +15,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "configKey": "dashboard.use_builtin_browser"
   },
   {
+    "id": "channels.app-client-id-teams",
+    "label": "App (Client) ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.app_client_id",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.app_id"
+  },
+  {
     "id": "channels.enable-imessage-channel-imessage",
     "label": "Enable iMessage channel (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.enable",
@@ -254,6 +267,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.hard-context-threshold-teams",
+    "label": "Hard context threshold % (Teams)",
+    "labelKey": "pages.settings.channels.hard_threshold_label",
+    "labelSuffix": "Teams",
+    "description": "Compact automatically at this percentage, even without a reply, so the context window never overflows.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.hard_threshold_pct"
+  },
+  {
     "id": "channels.messages-database-path-imessage",
     "label": "Messages database path (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.db_path",
@@ -344,6 +371,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.soft-context-threshold-teams",
+    "label": "Soft context threshold % (Teams)",
+    "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.soft_threshold_pct"
+  },
+  {
     "id": "channels.soft-context-threshold-telegram",
     "label": "Soft context threshold % (Telegram)",
     "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
@@ -366,6 +406,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "params": {
       "channel": "wecom"
     }
+  },
+  {
+    "id": "channels.tenant-id-teams",
+    "label": "Tenant ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.tenant_id",
+    "labelSuffix": "Teams",
+    "description": "Optional — only for single-tenant bots.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.tenant_id"
   },
   {
     "id": "chat.auto-compact-threshold",


### PR DESCRIPTION
## Problem / Motivation

Two frontend gates are red on **main itself**, so every open PR inherits both regardless of what it changes. Observed identically on two unrelated PRs whose diffs contain no frontend file at all (#5158, backend/CLI; #5357, one Python test module):

- `Frontend Tests (3)` — `settingsRegistry.gen.ts — anti-stale guard: checked-in registry matches live extraction`
- `Frontend Lint & Type Check` — `npx eslint src/ --max-warnings 680` exits 1 at **683** warnings (0 errors)

## Why it matters

A gate that is red on main cannot distinguish a PR that broke something from a PR that merely exists. Every author now has to diagnose two failures they did not cause before they can read their own results, and the `PR Readiness` rollup is red for all of them — which is also what makes the next real regression easy to wave through.

## What changed (motivation → approach → change)

**Frontend Tests (shard 3).** The guard did exactly its job: the Teams channel panel landed without regenerating the checked-in registry. Regenerated with `npm run gen:settings`; the diff is the missing Teams entries (`teams.app_id`, the Teams context-threshold rows, …). Guard passes, shard 3 goes 369→370 files green locally.

**Frontend Lint.** The ceiling's own comment forbids raising it — "The ceiling must EQUAL the measured count, not sit above it: slack is silent admission" — so the +3 had to be found rather than absorbed. Removing three dead directives elsewhere would also have reached 680 and would have hidden the real regression behind an unrelated burn-down, so instead I measured the warning **set** at `19b799a53` (the commit that pinned 680) using that commit's own lockfile — same eslint 9.39.4, and it measures exactly 680, confirming the baseline — and diffed it against main. The delta is precisely three:

| Warning | File | Base → now |
|---|---|---|
| `no-console` | `website/src/App.tsx` | 2 → 4 |
| `@typescript-eslint/no-unused-vars` (`i18nT`) | `website/src/apps/command-bar/CommandBarOverlay.test.tsx` | 0 → 1 |

The two new `no-console` are in the newly-added `onCycleReasoningEffort` / `onCyclePrevReasoningEffort` handlers. All four cycle handlers log a failure whose cause the user has *already* been told about via the `setAgentSwitchNotice(...)` dispatched immediately above, which is exactly the "intentional diagnostic" case this file (line 1147) and `src/utils/{widgetHeights,slotDraftStore,storageGc}.ts` already express as `// eslint-disable-next-line no-console -- <rationale>`. So all four carry it now, not only the two new ones: siblings that differ arbitrarily are how the next copy-paste reintroduces this. The dead `i18nT` import is removed.

That measures 678, and the ceiling is re-pinned **down** to 678, as the comment directs.

### One note worth passing on

`eslint-disable-next-line` applies to the line *immediately* after it. A rationale wrapped onto a second comment line retargets the directive at that comment and leaves the original warning standing — you get the warning **and** an `Unused eslint-disable directive` warning. I hit this while writing the fix (the count went 683→686 before I put each rationale on one line), and it is the mechanism behind the 13 pre-existing `Unused eslint-disable directive` warnings still inside the baseline, several of which are exactly that shape:

```
// eslint-disable-next-line react-hooks/exhaustive-deps -- the revision is an
// invalidation token: what `surfacePreviewEnabled` reads lives in localStorage
```

Those 13 are left alone here — burning them down is a real change to eight files' rationale prose and does not belong in a gate-restoration PR.

## Tests

No new test. Both failures are gate regressions, and each gate is itself the test:

- `settingsRegistry.test.ts`'s anti-stale guard fails on the stale file and passes on the regenerated one (verified both ways).
- The eslint ceiling fails at 683 and passes at the re-pinned 678 (verified both ways).

Verified locally, at each step, on this branch's base: `npx eslint src/ --max-warnings 678` → 0; `npx tsc -b` → 0; `npx jscpd .` → 0; `npx vitest run --shard=3/4` → 370 files / 5795 tests passed, 0 failed. The baseline measurement was taken in a separate worktree at `19b799a53` with its own `npm ci`, so the 680-vs-683 comparison is not confounded by a tool version.

## Manual verification

N/A — unit coverage sufficient: both gates are mechanical and were run locally in both the failing and fixed states.

## Related Issues

no linked issue: found while driving #5158 and #5357, both of which were red on these two gates without touching frontend code.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** no rendered delta — the App.tsx change adds comment lines only, the registry file is generated non-visual data, and the other two changes are a dead import and a CI flag.
