### PR TITLE
fix: offload standalone vector-store init off the event loop (#5221)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -200,6 +200,9 @@ def _get_vector_store(state: DashboardState):
     if mem.vector_store:
         return mem.vector_store
     # Fallback: create standalone
+    # COUPLING: ``_get_vector_store_async``'s fast-path predicate mirrors the
+    # resolution above. A new ``init()``-bearing branch added here must be
+    # reflected there, or async handlers may run it on the event loop again.
     if not hasattr(state, "_standalone_vector"):
         # Both imports resolve their target at CALL time, which is what lets a test
         # substitute the attribute on the source module and have this function
@@ -220,6 +223,56 @@ def _get_vector_store(state: DashboardState):
     return state._standalone_vector  # type: ignore[attr-defined]
 
 
+async def _get_vector_store_async(state: DashboardState):
+    """Async facade over ``_get_vector_store`` honouring init's caller contract.
+
+    ``VectorMemoryStore.init()`` documents that async callers must offload it
+    (the Windows path shells out to icacls, freezing the loop for seconds), so
+    the standalone fallback inside ``_get_vector_store`` must not run inline in
+    a handler (#5221). Fast path: when a store is already resolvable without
+    running ``init()`` — the context_builder supplied one, or a prior call
+    cached the standalone fallback on ``state`` — delegate synchronously, so
+    the common request path pays no thread hop. In both fast-path cases
+    ``_get_vector_store`` returns before reaching its fallback, so ``init()``
+    stays unreachable on the loop.
+    """
+    # Resolve the memory store ON the loop: ``_get_memory``'s
+    # check-create-publish of ``state._standalone_memory`` is atomic here (no
+    # await), exactly as it is for every synchronous caller. Resolving it only
+    # inside the worker would race a concurrent loop-side ``_get_memory`` into
+    # publishing a second MemoryStore, detaching ``vector_store`` from the
+    # object every other handler reads. MemoryStore's own ``init()`` is a
+    # cheap mkdir+seed (not the icacls-bearing one this wrapper offloads) and
+    # ran on the loop for every request before #5221.
+    mem = _get_memory(state)
+    if mem.vector_store or hasattr(state, "_standalone_vector"):
+        return _get_vector_store(state)
+    # Slow path: at most the first standalone request per process constructs
+    # and ``init()``s the store — offload it. All concurrent misses await ONE
+    # shared task, restoring the serialization the synchronous call sites used
+    # to get for free from the event loop: without it, two concurrent first
+    # requests would both miss the cache and both run ``init()``, leaking one
+    # of the two sqlite connections. ``asyncio.shield`` keeps the task (and
+    # its worker thread) alive when a caller is cancelled — e.g. an aiohttp
+    # client disconnect — so a request landing in that window awaits the same
+    # init instead of arming a second one. The slot is armed with no await
+    # between the read and the write (cannot race on one loop) and cleared on
+    # completion: after success the fast path serves from the cache
+    # (``_get_vector_store`` publishes it before the task resolves), and after
+    # failure the next request retries with a fresh task — matching the
+    # pre-#5221 per-request retry semantics.
+    task = getattr(state, "_standalone_vector_init_task", None)
+    if task is None:
+        task = asyncio.get_running_loop().create_task(
+            asyncio.to_thread(_get_vector_store, state)
+        )
+        state._standalone_vector_init_task = task  # type: ignore[attr-defined]
+        task.add_done_callback(
+            lambda _t: setattr(state, "_standalone_vector_init_task", None)
+        )
+    return await asyncio.shield(task)
+
+
 async def api_memory_semantic(request: web.Request) -> web.Response:
     """GET /api/memory/semantic — list semantic memory entries (paginated).
 
@@ -229,7 +282,7 @@ async def api_memory_semantic(request: web.Request) -> web.Response:
     dashboard memory card's client-side filter keeps full coverage for typical
     single-user stores; a store larger than this needs server-side search.
     """
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     try:
         limit = min(int(request.query.get("limit", "1000")), 1000)
         offset = int(request.query.get("offset", "0"))
@@ -267,7 +320,7 @@ async def api_memory_semantic_write(request: web.Request) -> web.Response:
             source="dashboard", resources="restricted_session_block",
         )
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     try:
         body = await request.json()
     except Exception:
@@ -332,7 +385,7 @@ async def api_memory_semantic_delete(request: web.Request) -> web.Response:
             source="dashboard", resources="restricted_session_block",
         )
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     key = request.match_info["key"]
     # Offload: acquires _db_lock internally (#1947) — see api_memory_semantic.
     ok = await asyncio.to_thread(store.delete_semantic, key, source="user_explicit")
@@ -343,7 +396,7 @@ async def api_memory_semantic_delete(request: web.Request) -> web.Response:
 
 async def api_memory_events(request: web.Request) -> web.Response:
     """GET /api/memory/events — paginated audit trail."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     try:
         limit = min(int(request.query.get("limit", "50")), 200)
         offset = int(request.query.get("offset", "0"))
@@ -667,17 +720,9 @@ async def api_memory_embedding_model(request: web.Request) -> web.Response:
         )
 
     prog = reembed_progress()
-    if prog.is_active():
-        # Single-flight: a second apply mid-re-embed would race the first over
-        # the same rows and the same FAISS file.
-        return web.json_response(
-            {"error": "a model change is already being applied",
-             "code": "model_change_in_progress"},
-            status=409
-        )
 
     try:
-        store = _get_vector_store(state)
+        store = await _get_vector_store_async(state)
     except Exception as exc:  # noqa: BLE001 - surfaced to the caller, not swallowed
         # Acquire the store BEFORE begin_apply(). If this raised after the
         # progress tracker was armed, is_active() would stay true for the rest of
@@ -688,6 +733,20 @@ async def api_memory_embedding_model(request: web.Request) -> web.Response:
             {"ok": False, "error": f"vector memory is unavailable: {exc}",
              "code": "vector_store_unavailable"},
             status=503,
+        )
+
+    if prog.is_active():
+        # Single-flight: a second apply mid-re-embed would race the first over
+        # the same rows and the same FAISS file. Checked once, AFTER the
+        # awaited store acquisition — the acquisition can yield to the loop
+        # (#5221), so a pre-await check could go stale before begin_apply();
+        # and whenever an apply is active, a prior apply already resolved the
+        # store, so the acquisition above was the free sync fast path. Checked
+        # BEFORE the SEL audit so a refused apply is not logged as allowed.
+        return web.json_response(
+            {"error": "a model change is already being applied",
+             "code": "model_change_in_progress"},
+            status=409
         )
 
     # Audit the ALLOWED decision too, not just the restricted-session denial
@@ -996,7 +1055,7 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                             pass
 
     # Wire embed_fn now that the model file is confirmed present.
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     store.embed_fn = make_sync_embed_fn()
 
     # Build FAISS index for any existing episodic memories with embeddings.
@@ -1058,7 +1117,7 @@ async def api_memory_disable_embeddings(request: web.Request) -> web.Response:
 
 async def api_memory_episodic_search(request: web.Request) -> web.Response:
     """GET /api/memory/episodic/search?q=...&tags=t1,t2 — search episodic memories."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     query = request.query.get("q", "")[:500]
     try:
         limit = min(int(request.query.get("limit", "20")), 50)
@@ -1090,7 +1149,7 @@ async def api_memory_episodic_search(request: web.Request) -> web.Response:
 
 async def api_memory_episodic_list(request: web.Request) -> web.Response:
     """GET /api/memory/episodic?tags=t1,t2 — paginated list of episodic memories."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     try:
         limit = min(int(request.query.get("limit", "50")), 100)
         offset = int(request.query.get("offset", "0"))
@@ -1132,7 +1191,7 @@ async def api_memory_episodic_delete(request: web.Request) -> web.Response:
             },
             status=403,
         )
-    store = _get_vector_store(state)
+    store = await _get_vector_store_async(state)
     mem_id = request.match_info["id"]
     # Offload: acquires _db_lock internally (#1947) — see api_memory_semantic.
     ok = await asyncio.to_thread(store.delete_episodic, mem_id)
@@ -1143,7 +1202,7 @@ async def api_memory_episodic_delete(request: web.Request) -> web.Response:
 
 async def api_memory_stats(request: web.Request) -> web.Response:
     """GET /api/memory/stats — memory system statistics."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     # Offload: serializes on _db_lock — see api_memory_semantic.
     stats = await asyncio.to_thread(store.memory_stats)
     # Add embedding status. The shadowing import is deliberate: resolving
@@ -1163,7 +1222,7 @@ async def api_memory_stats(request: web.Request) -> web.Response:
 
 async def api_memory_migrate(request: web.Request) -> web.Response:
     """POST /api/memory/migrate — migrate legacy markdown memory to vector store."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
 
     global _migrate_lock
     if _migrate_lock is None:
@@ -1197,7 +1256,7 @@ async def api_memory_import(request: web.Request) -> web.Response:
             source="dashboard", resources="restricted_session_block",
         )
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     try:
         data = await request.json()
     except Exception:
@@ -1211,7 +1270,7 @@ async def api_memory_import(request: web.Request) -> web.Response:
 
 async def api_memory_context_preview(request: web.Request) -> web.Response:
     """GET /api/memory/context-preview?q=... — preview what gets injected into prompts."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     query = request.query.get("q", "")[:500]
     # Offload: the fetch serializes on _db_lock (#1947) — see api_memory_semantic.
     # (No query_text is passed, so this is the recency path — no embed calls.)
@@ -1312,7 +1371,7 @@ async def api_memory_consolidate(request: web.Request) -> web.Response:
 
 async def api_memory_observability(request: web.Request) -> web.Response:
     """GET /api/memory/observability — memory health metrics and context preview."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     query = request.query.get("q", "")[:500]
     # Offload: both serialize on _db_lock (#1947) — see api_memory_semantic.
     stats = await asyncio.to_thread(store.memory_stats)
@@ -1332,7 +1391,7 @@ async def api_memory_observability(request: web.Request) -> web.Response:
 
 async def api_memory_promote(request: web.Request) -> web.Response:
     """POST /api/memory/promote — promote repeated episodic patterns to semantic facts."""
-    store = _get_vector_store(request.app["state"])
+    store = await _get_vector_store_async(request.app["state"])
     try:
         body = await request.json()
     except Exception:

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -973,12 +973,13 @@ class VectorMemoryStore:
         #
         # CALLER CONTRACT: an async caller must offload this. The Windows path shells
         # out to icacls, so calling ``init()`` directly on an event loop freezes it
-        # for seconds. ``eval.runner`` offloads via ``asyncio.to_thread``. ONE known
-        # violator remains: ``dashboard/handlers/memory.py::_get_vector_store``'s
-        # standalone fallback inits on the loop. It is cached, so it costs at most one
-        # first-request stall per process and only when no context_builder supplied a
-        # store -- not fixed here because offloading it means making that sync helper
-        # async across ~15 handlers. Tracked in #5221.
+        # for seconds. ``eval.runner`` and ``slack.gateway`` offload via
+        # ``asyncio.to_thread``; ``dashboard/handlers/memory.py``'s standalone
+        # fallback routes through ``_get_vector_store_async``, which offloads the
+        # init-bearing path (#5221). ONE inline async caller remains:
+        # ``cli_server._run_task`` inits at one-shot CLI startup, before the loop
+        # serves anything concurrent, so the freeze has nothing to stall — tracked
+        # in #5389.
         self._restrict_memory_files()
 
         # Load persisted FAISS index (or rebuild from SQLite embeddings)

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -14,8 +14,11 @@ GGUF, or a sandbox.
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -420,6 +423,151 @@ class TestRedactAndStoreResolution:
         ctor.assert_called_once()
         created.init.assert_called_once()
         assert mem.vector_store is created
+
+
+# ---------------------------------------------------------------------------
+# _get_vector_store_async (#5221) — the standalone fallback's ``init()`` must
+# never run on the event loop (VectorMemoryStore's caller contract: the
+# Windows path shells out to icacls and would freeze the loop for seconds).
+# ---------------------------------------------------------------------------
+
+
+class TestGetVectorStoreAsync:
+    @staticmethod
+    def _fallback_state() -> Any:
+        """A state whose only resolution path is the standalone fallback."""
+        mem = SimpleNamespace(vector_store=None)
+        return SimpleNamespace(context_builder=SimpleNamespace(memory=mem))
+
+    @pytest.mark.asyncio
+    async def test_standalone_fallback_init_runs_off_event_loop(self, monkeypatch) -> None:
+        """Fail-before: with the sync call reinstated, init runs on this thread."""
+        import kiro_crew.vector_memory as vm_mod
+
+        init_threads: list[threading.Thread] = []
+
+        class RecordingStore:
+            def __init__(self, **kwargs: Any) -> None:
+                pass
+
+            def init(self) -> None:
+                init_threads.append(threading.current_thread())
+
+        monkeypatch.setattr(vm_mod, "VectorMemoryStore", RecordingStore)
+        state = self._fallback_state()
+        with patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()):
+            store = await mem_mod._get_vector_store_async(state)
+
+            assert isinstance(store, RecordingStore)
+            assert len(init_threads) == 1
+            assert init_threads[0] is not threading.current_thread()
+
+            # Cached: the second call takes the sync fast path — same store,
+            # no second ``init()``, and no thread hop at all.
+            with patch(f"{_MOD}.asyncio.to_thread", new_callable=AsyncMock) as hop:
+                assert await mem_mod._get_vector_store_async(state) is store
+            hop.assert_not_awaited()
+        assert len(init_threads) == 1
+
+    @pytest.mark.asyncio
+    async def test_cancelled_first_caller_does_not_double_init(self, monkeypatch) -> None:
+        """Cancelling the first caller (e.g. an aiohttp client disconnect)
+        must not let a racing request arm a second ``init()``: the shared
+        shielded task keeps the in-flight init as the single flight."""
+        import kiro_crew.vector_memory as vm_mod
+
+        init_calls: list[threading.Thread] = []
+        started = threading.Event()
+        release = threading.Event()
+
+        class SlowStore:
+            def __init__(self, **kwargs: Any) -> None:
+                pass
+
+            def init(self) -> None:
+                init_calls.append(threading.current_thread())
+                started.set()
+                release.wait(timeout=5)
+
+        monkeypatch.setattr(vm_mod, "VectorMemoryStore", SlowStore)
+        state = self._fallback_state()
+        with patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()):
+            first = asyncio.ensure_future(mem_mod._get_vector_store_async(state))
+            # Wait until init() is genuinely running in the worker thread,
+            # then cancel the caller mid-init.
+            await asyncio.to_thread(started.wait, 5)
+            first.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+            # A request landing in the cancellation window must join the
+            # orphaned-but-alive init, not start a second one.
+            second = asyncio.ensure_future(mem_mod._get_vector_store_async(state))
+            await asyncio.sleep(0.05)
+            release.set()
+            store = await second
+        assert isinstance(store, SlowStore)
+        assert len(init_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_calls_init_once(self, monkeypatch) -> None:
+        """Single-flight: the lock restores the serialization the sync call
+        sites used to get for free from the event loop."""
+        import kiro_crew.vector_memory as vm_mod
+
+        init_calls: list[threading.Thread] = []
+        release = threading.Event()
+
+        class SlowStore:
+            def __init__(self, **kwargs: Any) -> None:
+                pass
+
+            def init(self) -> None:
+                init_calls.append(threading.current_thread())
+                release.wait(timeout=5)
+
+        monkeypatch.setattr(vm_mod, "VectorMemoryStore", SlowStore)
+        state = self._fallback_state()
+        with patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()):
+            t1 = asyncio.ensure_future(mem_mod._get_vector_store_async(state))
+            t2 = asyncio.ensure_future(mem_mod._get_vector_store_async(state))
+            # Let both tasks pass the fast-path check and reach the lock while
+            # the first ``init()`` is still blocked in its worker thread.
+            await asyncio.sleep(0.05)
+            release.set()
+            first, second = await asyncio.gather(t1, t2)
+        assert first is second
+        assert len(init_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_supplied_store_fast_path_pays_no_thread_hop(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        with patch(f"{_MOD}.asyncio.to_thread", new_callable=AsyncMock) as hop:
+            assert await mem_mod._get_vector_store_async(state) is store
+        hop.assert_not_awaited()
+
+    def test_no_async_handler_calls_sync_get_vector_store(self) -> None:
+        """Tripwire: every ``async def`` in the handler module must route
+        through ``_get_vector_store_async`` (the one place allowed to call the
+        sync helper, because it offloads the init-bearing path)."""
+        tree = ast.parse(inspect.getsource(mem_mod))
+        offenders: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+            if node.name == "_get_vector_store_async":
+                continue
+            for call in ast.walk(node):
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "_get_vector_store"
+                ):
+                    offenders.append(f"{node.name}:{call.lineno}")
+        assert not offenders, (
+            "async handlers must await _get_vector_store_async(...) instead of "
+            f"calling the sync helper on the event loop (#5221): {offenders}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1046,6 +1194,28 @@ class TestEmbeddingModelEndpoint:
             resp = await mem_mod.api_memory_embedding_model(req)
         assert resp.status == 503
         assert _body(resp)["code"] == "vector_store_unavailable"
+        prog.begin_apply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_apply_armed_during_store_await_is_409_and_arms_nothing(self) -> None:
+        """The awaited store acquisition can yield to the loop (#5221), so a
+        concurrent apply may arm between the single-flight gate and
+        ``begin_apply()`` — the post-await re-check must refuse it."""
+        state = _make_state()
+        prog = _prog()
+        req = _make_request(state, method="POST", json_body={"path": ""})
+
+        async def _arm_mid_await(_state: Any) -> Any:
+            prog.is_active.return_value = True
+            return _store()
+
+        with (
+            patch(f"{_MOD}.reembed_progress", return_value=prog),
+            patch(f"{_MOD}._get_vector_store_async", side_effect=_arm_mid_await),
+        ):
+            resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 409
+        assert _body(resp)["code"] == "model_change_in_progress"
         prog.begin_apply.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What broke

In standalone dashboard mode, `dashboard/handlers/memory.py::_get_vector_store`'s fallback branch runs `VectorMemoryStore.init()` inline on the gateway event loop. Since #5206, `init()` tightens file permissions — shelling out to `icacls` on Windows — and `vector_memory.py` documents a CALLER CONTRACT that async callers must offload it. The two other call sites (`eval/runner.py`, `slack/gateway.py`) already comply; the ~15 async handlers in this file did not, so the first memory request per process could freeze the loop for seconds.

## What changed

- **`_get_vector_store_async`** (new): fast path returns synchronously whenever a store is already resolvable without `init()` — context_builder-supplied, or the cached standalone fallback — so the common request path pays no thread hop. The init-bearing cache-miss path is offloaded via `asyncio.to_thread` wrapped in **one shared shielded task per state**: concurrent first requests, including one landing after an earlier caller was cancelled mid-init (aiohttp client disconnect), await the same flight instead of arming a second `init()`. On failure the slot clears, preserving per-request retry semantics.
- **All 15 async handler call sites** converted to `await _get_vector_store_async(...)`; the sync helper remains for synchronous callers.
- **`api_memory_embedding_model`** re-checks the re-embed single-flight gate after the awaited store acquisition: the new yield point otherwise lets two concurrent applies both pass the 409 gate and race over the same rows and FAISS file. Re-checked before the SEL audit so a refused apply is not logged as allowed.
- **Stale contract comment** in `vector_memory.py` ("ONE known violator remains… Tracked in #5221") updated to match reality; a COUPLING note in `_get_vector_store`'s fallback points future init-bearing branches at the wrapper's fast-path predicate.

## Tests

- Fallback `init()` asserted to run **off** the loop thread (fail-before verified by reverting the wrapper to a sync call).
- Single-flight concurrency test (two concurrent misses → one `init()`).
- Cancelled-first-caller regression (fail-before verified: the earlier lock-based shape double-inits, `assert 2 == 1`).
- No-thread-hop assertions for both fast-path branches (supplied store, cached fallback).
- Post-await 409 re-check on the apply path.
- AST tripwire: no `async def` in the module may call the sync `_get_vector_store` directly.

## Verification

Local gates green: isort, flake8, mypy (1050 files), baselined black gate, full backend pytest (62733 passed; 55 failures reproduced identically on pristine main via stash control — host-environment `/run/user` bus ownership, `Failed to connect to bus: Permission denied`, unrelated to this change).

Pre-push dual model-pinned review: GPT 5.6 Sol found the cancellation window bypassing the original lock-based single-flight (fixed via the shared shielded task above); Opus 5 PASS with advisories (post-await 409 re-check, cached-fallback no-hop assertion, coupling note — adopted; cross-module tripwire scope declined as no consumer exists outside this module. An initially-adopted facade export was subtracted on First Principles review: zero consumers).

## Known limits

- The shared task is bound to the loop that created it; a state object reused across event loops mid-init would error on await. No production path does this (one DashboardState per app/loop).
- If the sole caller is cancelled and the orphaned init then fails, the failure surfaces only as an unretrieved-task log warning — the next request retries with a fresh flight.

Closes #5221

