### PR TITLE
fix(lint): re-aim eslint suppressions that target their own comment

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1411,9 +1411,13 @@ export default function App() {
   // shown up while only the Main branch was gated.
   const advertisedNavItems = useMemo(
     () => NAV_ITEMS.filter(surfacePreviewEnabled),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- the revision is an
-    // invalidation token: what `surfacePreviewEnabled` reads lives in
-    // localStorage, not in React state, so nothing else here can express the dep.
+    // The revision is an invalidation token: what `surfacePreviewEnabled` reads
+    // lives in localStorage, not in React state, so nothing else here can
+    // express the dep. The directive stays on ONE line directly above the deps
+    // array -- `eslint-disable-next-line` targets the literal next line, so a
+    // rationale wrapped after it aims the directive at its own continuation and
+    // suppresses nothing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [previewFlagRevision],
   )
   // Apps nav reorder is dnd-kit sortable (mirrors QueueStack): rows reflow to

--- a/website/src/components/notifications/NotificationFeed.tsx
+++ b/website/src/components/notifications/NotificationFeed.tsx
@@ -208,8 +208,9 @@ export default function NotificationFeed({ selectedTs, onSelect, variant = 'pane
   const resolveApprovalNote = useCallback((n: Notification, action: 'approve' | 'reject') => {
     api.resolveApproval(n.approval_id || n.ts, action)
       .then(() => { dispatch(deleteNotification(n.ts)) })
-      // eslint-disable-next-line no-console -- intentional failure diagnostic;
-      // the row stays in the feed and remains retryable (detail panel too).
+      // Intentional failure diagnostic; the row stays in the feed and remains
+      // retryable (detail panel too).
+      // eslint-disable-next-line no-console
       .catch(err => { console.error(`Inline ${action} failed`, err) })
   }, [dispatch])
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1738,8 +1738,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       setFileDraft(fileDrafts.current, s, pendingFiles)
       saveDraftsDebounced()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- draft key is
-    // composerSlotRef; slot-change effect handles that transition
+    // Draft key is composerSlotRef; the slot-change effect handles that
+    // transition.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingFiles, saveDraftsDebounced])
   // Collapsed paste blocks backing the `[ Paste #N · M lines ]` tokens in
   // `input`. Persisted per-slot via chatPasteDrafts (localStorage, 30-day TTL)


### PR DESCRIPTION
> **Two corrections to earlier revisions of this description.** It opened claiming the Frontend Lint gate was red on `main` (683 vs a ceiling of 680) and that six PRs were blocked by it — true then, not now: unrelated work has since removed warnings elsewhere, `main` measures **678**, and the gate passes. This PR unblocks nothing. A later revision then quoted "675 on this branch, down from main's 678", which was arithmetic across two different bases and simply wrong. The measured figures are **680 at this branch's base → 678 on the branch**.
>
> What stands is the substance: two suppressions in `main` today are silently not in effect.

## The defect

`eslint-disable-next-line` applies to the **literal next line**. Writing the `-- rationale` after the rule name lets it wrap onto a continuation comment, and that comment becomes the "next line" — so the directive suppresses a comment while the warning it was written for fires unsuppressed.

eslint reports both halves, and they read as unrelated findings:

```
1414:5  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')
1417:5  React Hook useMemo has an unnecessary dependency: 'previewFlagRevision'
```

Someone deliberately suppressed a rule, documented why, and the suppression has not applied since.

## Three sites, found by sweeping rather than by the warning list

I wrote a scan over every `eslint-disable-next-line` under `website/src` asking one question — is the following line itself a comment? It finds three, matching an independent sweep in the First Principles review of this PR:

| Site | Rule | Was it suppressing something real? |
|---|---|---|
| `App.tsx:1414` | `react-hooks/exhaustive-deps` | **Yes** — the deps waiver on `advertisedNavItems` |
| `NotificationFeed.tsx:211` | `no-console` | **Yes** — the inline approve/reject failure diagnostic |
| `ChatPage.tsx:1741` | `react-hooks/exhaustive-deps` | **No** — the rule no longer fires there |

The first two were live suppressions that had stopped working. The third changes no warning count; it is re-aimed anyway so the directive points at the code it names rather than at prose, and so the trap does not sit there for the next person to copy.

Each keeps its rationale, moved above a directive that now sits alone on the line directly above its target. The scan reports zero remaining after this change.

## Also

`i18nT` is imported and never referenced in `CommandBarOverlay.test.tsx`. Removed.

## Verification

- `npx eslint src/`: **678** on this branch, **680** at its base
- Mis-aimed-directive scan: **0** remaining under `website/src`
- `npm run typecheck` clean; `CommandBarOverlay.test.tsx` 22/22
- No behaviour change: the deps arrays and the `console.error` call are untouched; only comment placement moves

## Status

Not blocking anything now that `main` sits under its ceiling. Worth it for the two dead suppressions; happy to close if a maintainer would rather not spend review on a non-blocking cleanup.

<!-- no-visual-delta -->

**Why no screenshot:** every hunk is comment placement plus one deleted unused import in a test file — no component, layout, style, or copy changes, and nothing rendered differs before or after.
