### PR TITLE
fix(ci): regenerate the settings registry to match live extraction

### DIFF
--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -15,6 +15,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "configKey": "dashboard.use_builtin_browser"
   },
   {
+    "id": "channels.app-client-id-teams",
+    "label": "App (Client) ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.app_client_id",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.app_id"
+  },
+  {
     "id": "channels.enable-imessage-channel-imessage",
     "label": "Enable iMessage channel (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.enable",
@@ -254,6 +267,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.hard-context-threshold-teams",
+    "label": "Hard context threshold % (Teams)",
+    "labelKey": "pages.settings.channels.hard_threshold_label",
+    "labelSuffix": "Teams",
+    "description": "Compact automatically at this percentage, even without a reply, so the context window never overflows.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.hard_threshold_pct"
+  },
+  {
     "id": "channels.messages-database-path-imessage",
     "label": "Messages database path (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.db_path",
@@ -344,6 +371,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.soft-context-threshold-teams",
+    "label": "Soft context threshold % (Teams)",
+    "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.soft_threshold_pct"
+  },
+  {
     "id": "channels.soft-context-threshold-telegram",
     "label": "Soft context threshold % (Telegram)",
     "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
@@ -366,6 +406,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "params": {
       "channel": "wecom"
     }
+  },
+  {
+    "id": "channels.tenant-id-teams",
+    "label": "Tenant ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.tenant_id",
+    "labelSuffix": "Teams",
+    "description": "Optional — only for single-tenant bots.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.tenant_id"
   },
   {
     "id": "chat.auto-compact-threshold",


### PR DESCRIPTION
`settingsRegistry.test.ts` carries an anti-stale guard — *"checked-in registry matches live extraction (run `npm run gen:settings` if this fails)"* — and it is **red on `main` itself**, so every branch cut from main inherits it. Verified by checking out bare `origin/main` and running that test there:

```
AssertionError: expected [ …(129) ] to deeply equal [ Array(127) ]
```

## Cause

#5200 (Teams channel parity) added the Teams panel's settings controls without re-running the generator. The extractor sees them; the committed artifact does not. Confirmed: that commit touches `TeamsPanel.tsx` and does not touch `settingsRegistry.gen.ts`.

The added entries are the Teams settings — `channels.app-client-id-teams`, and its siblings.

## Fix

Ran the project's own `npm run gen:settings`. The artifact is exactly what the extractor produces, not a hand edit — which is the point of an anti-stale guard, and the reason this is a generated-file-only diff with no source and no behaviour change.

## Verification

- `settingsRegistry.test.ts` **5/5** after the regen (1 failed / 4 passed before)
- Diff is one generated file, +54 lines
- Generator reports `Generated 131 entries (6 dynamic labels skipped)`

## Scope

Deliberately separate from #5372, which fixes a *different* main breakage (the eslint warning ceiling at 683 vs a pinned 680). Both are "main's frontend gates are red for everyone", but they are unrelated mechanisms in unrelated files, and each is independently reviewable and mergeable. Happy to fold them together if a maintainer prefers one PR.


<!-- no-visual-delta -->

**Why no screenshot:** the diff is a single generated artifact (`settingsRegistry.gen.ts`), reproduced verbatim by `npm run gen:settings` — no component, layout, style, or copy changes, so there is no rendered surface to photograph.

To be precise rather than to claim nothing changes: there **is** a behavioural effect. The registry backs the command palette's settings search, so after this the palette indexes the Teams controls that #5200 already shipped. That restores search coverage of an existing, already-visible UI rather than adding or altering one — the Teams settings page looks exactly the same before and after. A screenshot of it would show nothing this PR did.
