### PR TITLE
fix(settings): regenerate the settings registry main is failing on

### DIFF
--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -15,6 +15,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "configKey": "dashboard.use_builtin_browser"
   },
   {
+    "id": "channels.app-client-id-teams",
+    "label": "App (Client) ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.app_client_id",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.app_id"
+  },
+  {
     "id": "channels.enable-imessage-channel-imessage",
     "label": "Enable iMessage channel (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.enable",
@@ -254,6 +267,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.hard-context-threshold-teams",
+    "label": "Hard context threshold % (Teams)",
+    "labelKey": "pages.settings.channels.hard_threshold_label",
+    "labelSuffix": "Teams",
+    "description": "Compact automatically at this percentage, even without a reply, so the context window never overflows.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.hard_threshold_pct"
+  },
+  {
     "id": "channels.messages-database-path-imessage",
     "label": "Messages database path (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.db_path",
@@ -344,6 +371,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.soft-context-threshold-teams",
+    "label": "Soft context threshold % (Teams)",
+    "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.soft_threshold_pct"
+  },
+  {
     "id": "channels.soft-context-threshold-telegram",
     "label": "Soft context threshold % (Telegram)",
     "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
@@ -366,6 +406,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "params": {
       "channel": "wecom"
     }
+  },
+  {
+    "id": "channels.tenant-id-teams",
+    "label": "Tenant ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.tenant_id",
+    "labelSuffix": "Teams",
+    "description": "Optional — only for single-tenant bots.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.tenant_id"
   },
   {
     "id": "chat.auto-compact-threshold",


### PR DESCRIPTION
fix(settings): regenerate the settings registry main is failing on

`Frontend Tests` is red on `main` itself: the anti-stale guard in
`settingsRegistry.test.ts` extracts 131 settings entries live and compares them
against 127 checked into `settingsRegistry.gen.ts`. Measured on a clean
`origin/main` worktree, not inferred — swapping only main's copy of the generated
file into an otherwise-identical tree reproduces the failure, and regenerating it
clears it.

The drift arrived with #4743 (18:46 UTC), which added six settings entries and a
`description` field to the extractor without re-running `gen:settings`. The guard
is doing exactly its job: it exists so the command palette cannot silently stop
finding settings that exist in the UI, which is what a stale registry causes.

Because a pull request's checks are not re-run when `main` moves, the failure is
invisible in the PR list until an author pushes: every PR whose `Frontend Tests`
completed before that commit still shows green, and every run after it is red.
`Frontend Coverage Merge` and `Coverage Gate` fail downstream of the same shard.

Regenerated with `npm run gen:settings` — 131 entries, 6 dynamic labels skipped.
The file is generated, so this carries no hand edits.

Verified: the guard passes, and all 17 test files that consume `SETTINGS_REGISTRY`
pass (230 tests) — the registry is shared by the command palette, settings search,
and the setting-reference resolvers, so a regeneration that satisfied only its own
guard would not be enough. `tsc -b` clean, `npx eslint src/ --max-warnings 680`
passes, and `I18N_BASE_REF=origin/main npm run i18n:check` reports 18 checks PASS.
