### PR TITLE
fix: regenerate stale command-palette settings registry (#5363)

### DIFF
--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -15,6 +15,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "configKey": "dashboard.use_builtin_browser"
   },
   {
+    "id": "channels.app-client-id-teams",
+    "label": "App (Client) ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.app_client_id",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.app_id"
+  },
+  {
     "id": "channels.enable-imessage-channel-imessage",
     "label": "Enable iMessage channel (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.enable",
@@ -254,6 +267,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.hard-context-threshold-teams",
+    "label": "Hard context threshold % (Teams)",
+    "labelKey": "pages.settings.channels.hard_threshold_label",
+    "labelSuffix": "Teams",
+    "description": "Compact automatically at this percentage, even without a reply, so the context window never overflows.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.hard_threshold_pct"
+  },
+  {
     "id": "channels.messages-database-path-imessage",
     "label": "Messages database path (iMessage)",
     "labelKey": "pages.settings.iMessagePanel.db_path",
@@ -344,6 +371,19 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     }
   },
   {
+    "id": "channels.soft-context-threshold-teams",
+    "label": "Soft context threshold % (Teams)",
+    "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
+    "labelSuffix": "Teams",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.soft_threshold_pct"
+  },
+  {
     "id": "channels.soft-context-threshold-telegram",
     "label": "Soft context threshold % (Telegram)",
     "labelKey": "pages.settings.botChannelPanel.soft_context_threshold",
@@ -366,6 +406,20 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "params": {
       "channel": "wecom"
     }
+  },
+  {
+    "id": "channels.tenant-id-teams",
+    "label": "Tenant ID (Teams)",
+    "labelKey": "pages.settings.teamsPanel.tenant_id",
+    "labelSuffix": "Teams",
+    "description": "Optional — only for single-tenant bots.",
+    "tab": "channels",
+    "type": "input",
+    "occurrence": 1,
+    "params": {
+      "channel": "teams"
+    },
+    "configKey": "teams.tenant_id"
   },
   {
     "id": "chat.auto-compact-threshold",


### PR DESCRIPTION
## Problem / Motivation

`Frontend Tests` fails on `main` itself: the checked-in
`website/src/components/commandPalette/settingsRegistry.gen.ts` is stale. The
anti-stale guard (`settingsRegistry.test.ts` — "checked-in registry matches
live extraction") compares the committed file against a live extraction and
fails because the Teams channel settings panel landed without re-running the
generator. Since CI tests each branch merged with `main`, every open PR
inherits the failure regardless of what it touches, and the red lands on the
wrong author.

## Why it matters

A repo-wide red `Frontend Tests` check blocks every PR's readiness rollup and
trains contributors to ignore the guard that exists to catch exactly this
class of drift. The longer it stays red, the more real failures hide behind
"main is already broken".

## What changed (motivation → approach → change)

Symptom: guard test fails on `main` (live extraction finds more settings than
the committed file has). Root cause: `src/pages/settings/TeamsPanel.tsx`
added `SettingsInput` controls with new `configKey`s, but
`npm run gen:settings` was never re-run, so the committed generated file never
caught up. Fix: run the repo's own generator and commit exactly its output —
no hand edits, no other changes.

The delta is the four Teams channel settings entries now present in
`TeamsPanel.tsx` (127 → 131 entries):

- `teams.app_id` (`channels.app-client-id-teams`)
- `teams.tenant_id` (`channels.tenant-id-teams`)
- `teams.soft_threshold_pct` (`channels.soft-context-threshold-teams`)
- `teams.hard_threshold_pct` (`channels.hard-context-threshold-teams`)

Each was verified against the live `configKey` call sites in
`TeamsPanel.tsx`; the diff is additions-only (no existing entry, id, or
`occurrence` changed), and the generator is idempotent on this base (a second
run produces no diff).

Noted follow-up (out of scope here, from the issue discussion): the guard
runs in the frontend-tests job, so a stale regeneration is caught on the PR
*after* the one that caused it. Whether the guard (or the generator itself)
should run in a way that fails the authoring PR is a CI-workflow design
question left for a human.

## Tests

No new tests — this PR restores the invariant an existing test enforces:

- `settingsRegistry.test.ts` (anti-stale guard): 5/5 pass with this change,
  1 failed / 4 passed without it.
- All 17 test files importing the generated registry (settings keywords, tab
  labels, `SettingRef` resolution, settings search, command bar overlay,
  Teams panel suites, i18n extraction): 274/274 pass.
- `npx tsc -b`: clean.

## Manual verification

Re-ran `npm run gen:settings` a second time after rebasing onto current
`main`: output byte-identical (tree stays clean), confirming the committed
file is exactly the generator's output and the generator is deterministic.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** mechanical regeneration of an auto-generated data file;
no component, layout, or styling change. The only effect is that the four
already-shipped Teams settings become discoverable in the command palette /
settings search, identically to every other channel's existing entries.

## Related Issues

Closes #5363

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, generated file only
- [x] No secrets, credentials, or internal references in the diff
