### PR TITLE
refactor(messaging): give the pre-turn sequence one owner

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -453,7 +453,6 @@ src/kiro_crew/transcribe.py
 src/kiro_crew/validation.py
 src/kiro_crew/vector_memory.py
 src/kiro_crew/voice_reply.py
-src/kiro_crew/webex/transport_dispatch.py
 src/kiro_crew/webhooks.py
 src/kiro_crew/weixin/client.py
 src/kiro_crew/weixin/gateway.py

--- a/src/kiro_crew/imessage/transport_dispatch.py
+++ b/src/kiro_crew/imessage/transport_dispatch.py
@@ -25,7 +25,6 @@ Dependency direction is ``imessage -> messaging`` (allowed).
 from __future__ import annotations
 
 import logging
-import time
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.imessage.client import redact_handle
@@ -41,6 +40,7 @@ from kiro_crew.messaging.dispatch import (
 )
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
+from kiro_crew.messaging.pre_turn import resolve_pre_turn
 from kiro_crew.safety_override import safety_override
 
 if TYPE_CHECKING:
@@ -137,22 +137,19 @@ class IMessageDispatcher:
             await self._notify(handle, HELP_TEXT)
             return
 
-        # -- Mid-turn concurrency: check the CURRENT-generation key for an
-        # in-flight turn BEFORE any idle/daily rotation (rotating first could
-        # mint a new key and miss the running turn, letting a second concurrent
-        # turn bypass steer). Fold the message into the running turn via steer.
-        session_key = self._session_key(handle)
-        if self.sessions.is_busy(session_key):
-            await self._handle_busy(inbound, session_key)
-            return
-
-        self._conv.maybe_rotate(
-            handle,
-            time.time(),
+        # Busy check, then rotation, then a re-derived key -- the ordering and the
+        # reasons it matters live in messaging.pre_turn.
+        session_key = await resolve_pre_turn(
+            conv=self._conv,
+            sessions=self.sessions,
+            key=handle,
+            session_key_for=self._session_key,
             idle_minutes=self.cfg.messaging.idle_reset_minutes,
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
+            on_busy=lambda sk: self._handle_busy(inbound, sk),
         )
-        session_key = self._session_key(handle)
+        if session_key is None:
+            return  # folded into the running turn
         conversation_id = f"imessage:{handle}"
         agent = self._resolve_agent()
 

--- a/src/kiro_crew/messaging/pre_turn.py
+++ b/src/kiro_crew/messaging/pre_turn.py
@@ -1,0 +1,86 @@
+"""The ordered pre-turn sequence every DM channel runs before ``drive_turn``.
+
+A channel dispatcher's ``handle_message`` ends the same way everywhere: resolve
+the session key, refuse to start a second concurrent turn, rotate the
+conversation on an idle/daily boundary, then drive the turn. Three ordering
+constraints make that sequence load-bearing rather than incidental, and all
+three are invisible at the call site:
+
+1. **The busy check runs BEFORE rotation.** Rotating first advances the
+   generation, which mints a NEW session key -- so the in-flight turn on the old
+   key is missed, ``is_busy`` reads False, and a second concurrent turn starts
+   instead of the message being folded in via steer.
+2. **The session key is re-derived AFTER rotation.** Rotation changed the
+   generation, so the pre-rotation key addresses the conversation rotation just
+   retired.
+3. **Rotation must happen at all.** ``maybe_rotate`` is also what records
+   activity (``last_active``), so a dispatcher that never calls it leaves that
+   timestamp frozen and BOTH ``messaging.idle_reset_minutes`` and
+   ``daily_reset_hour`` are silently inert -- configured, documented, and dead.
+
+Every one of those is a "remember to do it" contract, and each has been got
+wrong at least once: the shared state object (``ConversationState``) has existed
+all along, but nothing forced a dispatcher to drive it in the right order. This
+module turns the sequence into a single call so the ordering cannot be
+re-litigated per channel.
+
+What stays OUT, deliberately:
+
+* **The command grammar.** Which token a channel spells ``/new`` with, and how a
+  group mention is stripped before matching, remains in that channel's own
+  ``commands.py`` -- the same boundary
+  :mod:`kiro_crew.messaging.commands` already draws. This helper is called
+  AFTER the command intercept has declined to handle the message.
+* **The busy REPLY.** What a user sees when their message folds into a running
+  turn is channel-shaped (a steer receipt, a "resend please" nudge), so the
+  caller passes it as ``on_busy``.
+
+Dependency direction is ``<channel> -> messaging`` (never the reverse).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+from kiro_crew.messaging.conversation import ConversationState
+
+K = TypeVar("K")
+
+__all__ = ["resolve_pre_turn"]
+
+
+async def resolve_pre_turn(
+    *,
+    conv: ConversationState,
+    sessions: Any,
+    key: K,
+    session_key_for: Callable[[K], str],
+    idle_minutes: int = 0,
+    daily_reset_hour: int = -1,
+    on_busy: Callable[[str], Awaitable[None]],
+    now: float | None = None,
+) -> str | None:
+    """Run the busy check, then rotation, and return the key to drive the turn on.
+
+    Returns ``None`` when the inbound message was handed to *on_busy* -- the
+    caller must return without driving a turn. Otherwise returns the
+    post-rotation session key.
+
+    ``session_key_for`` is called TWICE on purpose (once before the busy check,
+    once after rotation); it must be a pure function of *key* plus the
+    conversation generation, which is what makes the second call observe the
+    rotation.
+    """
+    session_key = session_key_for(key)
+    if sessions.is_busy(session_key):
+        await on_busy(session_key)
+        return None
+    conv.maybe_rotate(
+        key,
+        time.time() if now is None else now,
+        idle_minutes=idle_minutes,
+        daily_reset_hour=daily_reset_hour,
+    )
+    return session_key_for(key)

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -26,7 +26,6 @@ Dependency direction is ``webex -> messaging`` (allowed).
 from __future__ import annotations
 
 import logging
-import time
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.messaging.dispatch import (
@@ -37,6 +36,7 @@ from kiro_crew.messaging.dispatch import (
 )
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE
 from kiro_crew.messaging.link import build_dm_session_key, seed_generation
+from kiro_crew.messaging.pre_turn import resolve_pre_turn
 from kiro_crew.safety_override import safety_override
 from kiro_crew.webex.commands import HELP_TEXT, ConversationState, parse_command
 from kiro_crew.webex.renderer import WebexRenderer
@@ -99,7 +99,9 @@ class WebexDispatcher:
         email = inbound.person_email
         room_id = inbound.room_id
         text = inbound.text
-        logger.info("Webex inbound from %s: %d chars", email[:3] + "***" if email else "?", len(text or ""))
+        logger.info(
+            "Webex inbound from %s: %d chars", email[:3] + "***" if email else "?", len(text or "")
+        )
 
         # ── Command intercept (no LLM session needed) ──
         cmd = parse_command(text)
@@ -115,22 +117,19 @@ class WebexDispatcher:
             await self.client.send_message(room_id, HELP_TEXT)
             return
 
-        # ── Mid-turn concurrency: check the CURRENT-generation key for an
-        # in-flight turn BEFORE any idle/daily rotation (rotating first could
-        # mint a new key and miss the running turn, letting a second concurrent
-        # turn bypass steer). Fold the message into the running turn via steer.
-        session_key = self._session_key(email)
-        if self.sessions.is_busy(session_key):
-            await self._handle_busy(inbound, session_key)
-            return
-
-        self._conv.maybe_rotate(
-            email,
-            time.time(),
+        # Busy check, then rotation, then a re-derived key -- the ordering and the
+        # reasons it matters live in messaging.pre_turn.
+        session_key = await resolve_pre_turn(
+            conv=self._conv,
+            sessions=self.sessions,
+            key=email,
+            session_key_for=self._session_key,
             idle_minutes=self.cfg.messaging.idle_reset_minutes,
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
+            on_busy=lambda sk: self._handle_busy(inbound, sk),
         )
-        session_key = self._session_key(email)
+        if session_key is None:
+            return  # folded into the running turn
         conversation_id = f"webex:{email}"
         agent = self._resolve_agent()
 

--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -1,0 +1,245 @@
+"""The shared pre-turn sequence, and the ratchet that keeps channels on it.
+
+Three findings on the Feishu channel review traced to one cause: the shared
+state object (``ConversationState``) existed, but every dispatcher had to
+REMEMBER to drive it in the right order, and nothing enforced that. These tests
+pin the order itself, plus a source-level ratchet so a channel added later
+cannot quietly hand-roll the sequence again and re-open the same hole.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from kiro_crew.messaging.conversation import ConversationState
+from kiro_crew.messaging.pre_turn import resolve_pre_turn
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class FakeSessions:
+    """``is_busy`` answers from a set of busy keys, and records what was asked."""
+
+    def __init__(self, busy: set[str] | None = None) -> None:
+        self.busy = busy or set()
+        self.asked: list[str] = []
+
+    def is_busy(self, key: str) -> bool:
+        self.asked.append(key)
+        return key in self.busy
+
+
+def _key_for(conv: ConversationState) -> "callable":
+    """A session-key function shaped like the real ones: identity + generation."""
+
+    def session_key_for(key: str) -> str:
+        return f"webex:{key}:g{conv.current_gen(key)}"
+
+    return session_key_for
+
+
+# --------------------------------------------------------------------------- #
+# Behaviour
+# --------------------------------------------------------------------------- #
+
+
+class TestResolvePreTurn:
+    @pytest.mark.asyncio
+    async def test_idle_message_returns_a_key_and_does_not_fold(self) -> None:
+        conv: ConversationState = ConversationState()
+        sessions = FakeSessions()
+        folded: list[str] = []
+
+        key = await resolve_pre_turn(
+            conv=conv,
+            sessions=sessions,
+            key="a@b.c",
+            session_key_for=_key_for(conv),
+            on_busy=lambda sk: _record(folded, sk),
+        )
+
+        assert key == "webex:a@b.c:g0"
+        assert folded == []
+
+    @pytest.mark.asyncio
+    async def test_busy_folds_and_returns_none(self) -> None:
+        """None is the caller's signal to return WITHOUT driving a turn."""
+        conv: ConversationState = ConversationState()
+        sessions = FakeSessions(busy={"webex:a@b.c:g0"})
+        folded: list[str] = []
+
+        key = await resolve_pre_turn(
+            conv=conv,
+            sessions=sessions,
+            key="a@b.c",
+            session_key_for=_key_for(conv),
+            on_busy=lambda sk: _record(folded, sk),
+        )
+
+        assert key is None
+        assert folded == ["webex:a@b.c:g0"], "the busy handler must get the live key"
+
+    @pytest.mark.asyncio
+    async def test_busy_is_checked_before_rotation(self) -> None:
+        """The load-bearing ordering constraint.
+
+        Rotating first advances the generation, which mints a NEW session key --
+        so the in-flight turn on the old key is missed, ``is_busy`` reads False,
+        and a second concurrent turn starts instead of the message folding in via
+        steer. Pinned by making the message idle-eligible AND busy: the busy
+        branch must win and the generation must not move.
+        """
+        conv: ConversationState = ConversationState()
+        conv.maybe_rotate("a@b.c", 1_000.0)  # seed last_active far in the past
+        # (POSITIVE on purpose: should_rotate_generation treats <= 0 as the
+        # first message in the bucket and never rotates, which would make
+        # this test pass without the guard it exists to pin.)
+        gen_before = conv.current_gen("a@b.c")
+        sessions = FakeSessions(busy={f"webex:a@b.c:g{gen_before}"})
+        folded: list[str] = []
+
+        key = await resolve_pre_turn(
+            conv=conv,
+            sessions=sessions,
+            key="a@b.c",
+            session_key_for=_key_for(conv),
+            idle_minutes=30,
+            on_busy=lambda sk: _record(folded, sk),
+            now=10_000.0,
+        )
+
+        assert key is None
+        assert conv.current_gen("a@b.c") == gen_before, "rotation ran despite a live turn"
+
+    @pytest.mark.asyncio
+    async def test_key_is_re_derived_after_rotation(self) -> None:
+        """Rotation advances the generation, so the pre-rotation key addresses
+        the conversation rotation just retired."""
+        conv: ConversationState = ConversationState()
+        conv.maybe_rotate("a@b.c", 1_000.0)
+        before = _key_for(conv)("a@b.c")
+
+        key = await resolve_pre_turn(
+            conv=conv,
+            sessions=FakeSessions(),
+            key="a@b.c",
+            session_key_for=_key_for(conv),
+            idle_minutes=30,
+            on_busy=_unreachable,
+            now=10_000.0,
+        )
+
+        assert key is not None and key != before, f"key did not follow rotation ({key})"
+
+    @pytest.mark.asyncio
+    async def test_activity_is_recorded_even_when_nothing_rotates(self) -> None:
+        """``maybe_rotate`` is also what stamps ``last_active``. A dispatcher that
+        skips it leaves that frozen, and BOTH idle_reset_minutes and
+        daily_reset_hour go silently inert -- configured, documented and dead.
+        """
+        conv: ConversationState = ConversationState()
+
+        await resolve_pre_turn(
+            conv=conv,
+            sessions=FakeSessions(),
+            key="a@b.c",
+            session_key_for=_key_for(conv),
+            idle_minutes=30,
+            on_busy=_unreachable,
+            now=1_234.0,
+        )
+
+        assert conv._get("a@b.c").last_active == 1_234.0
+
+    @pytest.mark.asyncio
+    async def test_rotation_is_off_by_default(self) -> None:
+        """Defaults must be inert: a caller that passes no policy gets no rotation,
+        so adopting the helper cannot silently start resetting conversations."""
+        conv: ConversationState = ConversationState()
+        conv.maybe_rotate("a@b.c", 1_000.0)
+        gen_before = conv.current_gen("a@b.c")
+
+        await resolve_pre_turn(
+            conv=conv,
+            sessions=FakeSessions(),
+            key="a@b.c",
+            session_key_for=_key_for(conv),
+            on_busy=_unreachable,
+            now=10_000_000.0,
+        )
+
+        assert conv.current_gen("a@b.c") == gen_before
+
+
+async def _record(sink: list[str], session_key: str) -> None:
+    sink.append(session_key)
+
+
+async def _unreachable(session_key: str) -> None:  # pragma: no cover - guard
+    raise AssertionError(f"on_busy must not run for an idle key ({session_key})")
+
+
+# --------------------------------------------------------------------------- #
+# Ratchet
+# --------------------------------------------------------------------------- #
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+
+#: Channels whose dispatcher drives the shared pre-turn sequence. The others are
+#: deliberately absent: their dispatchers carry extra pre-turn work between the
+#: busy check and rotation (album buffering, forum routing, service-URL binding,
+#: mid-turn override parsing, attachment handling, media ingestion), and in
+#: several cases the busy path is no longer a plain ``on_busy(session_key)``.
+#: Listing them here would assert a migration that has not happened.
+_PRE_TURN_CHANNELS = ("webex", "imessage")
+
+
+class TestPreTurnRatchet:
+    @pytest.mark.parametrize("channel", _PRE_TURN_CHANNELS)
+    def test_dispatcher_uses_the_shared_helper(self, channel: str) -> None:
+        src = (_SRC / channel / "transport_dispatch.py").read_text(encoding="utf-8")
+        assert "resolve_pre_turn(" in src, f"{channel} does not call resolve_pre_turn"
+
+    @pytest.mark.parametrize("channel", _PRE_TURN_CHANNELS)
+    def test_dispatcher_does_not_hand_roll_the_sequence(self, channel: str) -> None:
+        """The point of the helper is that the ordering has ONE owner.
+
+        A dispatcher that also calls ``maybe_rotate`` itself has a second,
+        unreviewed copy of the sequence -- which is exactly how the ordering
+        drifted per channel before.
+        """
+        src = (_SRC / channel / "transport_dispatch.py").read_text(encoding="utf-8")
+        assert "maybe_rotate(" not in src, f"{channel} still rotates outside the helper"
+
+    @pytest.mark.parametrize("channel", _PRE_TURN_CHANNELS)
+    def test_compact_command_releases_the_notice_latch(self, channel: str) -> None:
+        """A user who complies with the soft context notice must be nudged again
+        next cycle. Missing this turns the notice from a per-growth-cycle nudge
+        into a once-ever one -- silent, and only visible as "it stopped warning
+        me". Cheap to assert, and it was got wrong once.
+        """
+        src = (_SRC / channel / "transport_dispatch.py").read_text(encoding="utf-8")
+        assert "clear_awaiting(" in src, f"{channel} never releases the awaiting latch"
+
+    def test_every_rostered_channel_is_accounted_for(self) -> None:
+        """Ratchet on the ratchet: a channel added to the roster must be either
+        migrated to the helper or named in the exempt list, so "not yet migrated"
+        stays an explicit decision instead of a silent omission.
+        """
+        from kiro_crew.channels import builtin_channel_descriptors
+
+        # weixin and wecom are exempt for the same reason as the big four:
+        # their handle_message runs extra pre-turn steps with their own busy
+        # checks (wecom additionally clears attachments there and ingests
+        # media before rotating), so folding them into the helper is a
+        # behaviour change that needs its own review, not a rider here.
+        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom"}
+        rostered = {d.channel_type for d in builtin_channel_descriptors()}
+        unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
+        assert not unaccounted, (
+            "channels neither using messaging.pre_turn nor listed exempt: " f"{sorted(unaccounted)}"
+        )


### PR DESCRIPTION
## Problem / Motivation

The Feishu channel review ([#4282](https://github.com/kirodotdev/KiroCrew/pull/4282))
produced eight findings; **three of them were the same bug in three costumes**, and
they will keep recurring:

- the awaiting-compact latch was never released on a manual `/compact`, so the soft
  context notice degraded from a per-growth-cycle nudge into a once-ever one;
- `maybe_rotate` was never called, so `messaging.idle_reset_minutes` and
  `daily_reset_hour` were silently inert for that channel;
- the session key was not re-derived after rotation.

None of those were missing shared code. `ConversationState` has always been shared.
What was missing is that **every dispatcher has to remember to drive it in the right
order, and nothing enforces that.** The pre-turn sequence carries three constraints
that are invisible at the call site, documented only in a comment each channel
copy-pasted (and Feishu, mirroring the same shape, dropped).

## Why it matters

The failure mode is silence, which is why review keeps being the thing that catches
it rather than a user report:

- Rotating **before** the busy check advances the generation, minting a new session
  key. The in-flight turn on the old key is missed, `is_busy` reads False, and a
  **second concurrent turn starts** instead of the message folding in via steer.
- `maybe_rotate` is also what stamps `last_active`. A dispatcher that skips it
  leaves that frozen, so both rotation settings are **configured, documented, and
  dead** — the operator sets them and nothing happens.
- Using the pre-rotation key addresses the conversation rotation just retired.

Nine channels ship this sequence. Every new channel is another chance to get one of
the three wrong, and each miss is invisible until someone reads the diff.

## What changed (motivation → approach → change)

**Goal:** stop paying for this one finding at a time.

**Approach considered and rejected — extract the command parsing.** That was the
obvious read of "share the dispatcher logic", and it is wrong here:
`messaging/commands.py` already documents the boundary —

> NOT here -- the command GRAMMAR. Which token a channel spells a command with, and
> how many words precede an argument, stays in that channel's own `commands.py`

so how a channel spells `/new`, and how it strips a group mention before matching,
stays local. This helper is called **after** the command intercept has declined the
message.

**What was built:** `messaging/pre_turn.py::resolve_pre_turn` owns the ordered
sequence — busy check, then rotation, then a re-derived key — and returns `None`
when the message was folded into a running turn. `webex` and `imessage` call it; the
reasoning moves from copy-pasted comments into one docstring, and the ordering can no
longer drift for them. The busy *reply* stays channel-shaped and is passed in as
`on_busy`.

**Scope, and one honest correction.** Every other channel is **exempt and named as
such in the ratchet**: their dispatchers run extra work *between* the busy check and
rotation — album buffering, forum routing, service-URL binding, mid-turn override
parsing, attachment handling, media ingestion — and in several the busy path is no
longer a plain `on_busy(session_key)`.

`wecom` was migrated in the first draft of this PR and has been **dropped back out**:
`main` has since rewritten its `handle_message` to parse a mid-turn override, clear
attachments on the busy path, and ingest media before rotating. Forcing the helper
onto that shape would have been an unreviewed behaviour change, which is the thing
this PR's own scope rule exists to prevent. Feishu adopts this in a follow-up once
#4282 lands.

**One baseline line:** reformatting `webex/transport_dispatch.py` made it
black-clean, and the gate requires graduated files to be pruned from
`.github/black-baseline.txt` so the baseline keeps shrinking.

## Tests

16 new, in `test/test_messaging_pre_turn.py`.

Unit tests, one per constraint:

- `test_busy_is_checked_before_rotation` — idle-eligible **and** busy: the busy
  branch wins and the generation does not move.
- `test_key_is_re_derived_after_rotation` — the returned key follows the rotation.
- `test_activity_is_recorded_even_when_nothing_rotates` — `last_active` is stamped
  even on the no-rotation path, which is what keeps both settings live.
- `test_rotation_is_off_by_default` — defaults are inert, so adopting the helper
  cannot silently start resetting conversations.
- plus the fold/no-fold return contract.

A **source-level ratchet** for every non-exempt channel: it calls the helper, does
**not** also call `maybe_rotate` itself (a second unreviewed copy of the sequence is
how the ordering drifted), and releases the awaiting-compact latch. And a ratchet on
the ratchet — `test_every_rostered_channel_is_accounted_for` requires a newly
rostered channel to be either migrated or explicitly exempted, so "not yet migrated"
stays a decision instead of a silent omission. This mirrors the mechanism `main`
just used for `SEED_DISABLED_SECTIONS`.

**Mutation-verified, one test per constraint:**

| mutation | test that fails |
|---|---|
| rotate before the busy check | `test_busy_is_checked_before_rotation` |
| return the pre-rotation key | `test_key_is_re_derived_after_rotation` |
| drop `maybe_rotate` | `test_activity_is_recorded_even_when_nothing_rotates` (+ the re-derive test) |

Two honest notes on the tests themselves:

- `should_rotate_generation` treats `last_active <= 0` as "first message in the
  bucket, nothing to roll over". The first draft seeded `0.0` and therefore passed
  **vacuously** — including the busy-before-rotation test, which would not have
  detected the mutation it exists to catch. Seeds are positive now, with the reason
  in a comment.
- The ratchet reads source files, and the first draft used `Path.read_text()` with no
  `encoding=`. That hard-failed eight tests on the Windows shard (`cp1252` cannot
  decode the box-drawing and CJK characters in those modules). Now
  `read_text(encoding="utf-8")`.

## Manual verification

N/A — this is a behaviour-preserving extraction on a backend path with no UI
surface, and the existing webex/imessage/wecom dispatcher tests pass unchanged,
which is the actual evidence that behaviour did not move.

## Related Issues

Follow-up to #4282 (Feishu channel), which is where the three findings surfaced.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the reasoning now lives in the
      `messaging/pre_turn.py` module docstring, which is where a channel author
      looking for it will be
- [x] No secrets, credentials, or internal references in the diff
