### PR TITLE
fix(instances): reclaim leaked forwarder by recorded identity (#5235)

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -285,7 +285,8 @@ to gain).
 
 ```
 id, name, ssh_host, remote_port (default 5476), local_port (0 = unallocated),
-ttl (default "20h"), remote_bin, was_connected
+ttl (default "20h"), remote_bin, was_connected, forwarder_pid (0 = none),
+forwarder_start ("" = unknown), forwarder_sig ("" = unsigned)
 ```
 
 plus a top-level `last_active_id`. `id` is a slug (`^[a-z0-9][a-z0-9-]{0,62}$`)
@@ -309,8 +310,49 @@ Two persisted hints drive lazy reconnect:
   not just one, and the active pane is frontend state. `get_last_active()` is the
   only reader and has no production caller.
 
+A third hint pair, `forwarder_pid` + `forwarder_start`, exists for crash
+recovery rather than reconnect intent: `connect()` records the spawned
+forwarder child's pid and its opaque `platform_compat.process_start_time`
+identity next to `local_port` (one write), and a successful self-heal rebuild
+moves both to the replacement child. A gateway hard-kill (SIGKILL/crash) never
+runs teardown, so the forwarder survives, reparented to init, still holding its
+port and its session to the remote. The next `connect()` reclaims exactly that
+child, best-effort (a failed reclaim never fails the connect). The registry is
+agent-writable state, so a recorded claim is honored only when it
+authenticates: the record must carry `forwarder_sig`, the gateway's own HMAC
+over (instance id, pid, start time, port) under a key derived from the SEL
+trust root (`sel_hmac_key_path()`, domain-separated exactly like the
+`session_pid_sig` sidecar protocol) — a root an agent can neither read nor
+replace, so a record written, edited, or re-pointed by anything but the
+gateway fails verification outright and nothing is ever signalled for it.
+Behind the MAC, defense in depth from kernel-owned facts: the candidate must
+be a genuine ORPHAN — not a pid this manager currently supervises, and
+reparented to init (`get_ppid == 1`), which no live gateway's forwarder is
+(subreaper hosts read as non-orphaned and merely miss the reclaim). Then, iff
+the recorded
+`local_port` probes occupied AND both identity halves are recorded AND the
+pid's live start time equals the recorded one AND its **full argv exactly
+equals** the forward command line the manager would construct for the recorded
+port (`platform_compat.process_argv_matches_exact`), it is signalled — SIGTERM
+escalating to SIGKILL on a bounded grace, with the start-time identity
+**re-verified before the SIGKILL** (the grace window is exactly where a pid can
+exit and be recycled); pid-scoped for ssh, whose child shares the dead
+gateway's process group; group-scoped for SSM, whose child owns its group, with
+completion judged by the whole group being gone and the port actually
+releasing. Anything short of full identity — either hint missing, start time
+differing or unreadable, argv unreadable (always the case on Windows, so the
+guard fails closed there), or any argv element differing — means the identity
+cannot be confirmed: the process is left alone (logged, and SEL-audited when
+anything was signalled) and allocation simply skips its port; the freed port
+returns to the pool at the next allocation rather than being re-taken by the
+same connect. Reclamation is keyed on the manager's OWN recorded identity,
+never a process-table scan — matching the table by argv pattern is what once
+SIGTERMed forwards operators had opened themselves (#1972).
+
 `disconnect()` resets `local_port` to the unallocated sentinel together with
-`was_connected` in one write, so a freed port is never left reserved.
+`was_connected` and the forwarder identity pair in one write, so a freed port
+is never left reserved and a stale identity never reaches a later reclaim's
+checks.
 
 ---
 

--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -106,6 +106,12 @@ _DEFAULT_CONNECTION_METHOD = "ssh"
 # allocator (Stage 3) assigns a real port at connect time.
 _UNALLOCATED_PORT = 0
 
+# ``forwarder_pid == 0`` is the sentinel for "no forwarder child recorded".
+# Connect records the spawned tunnel child's pid so a forwarder orphaned by a
+# gateway hard-kill can later be reclaimed by identity (its own pid) instead of
+# a process-table match; disconnect resets it together with ``local_port``.
+_NO_FORWARDER_PID = 0
+
 
 class InstancesError(Exception):
     """Base error for registry operations."""
@@ -187,6 +193,22 @@ class Instance:
     # (showing an error / click-to-reconnect state) instead of dropping it.
     # Startup uses it to decide which instances to auto-reconnect.
     was_connected: bool = False
+    # Pid of the tunnel forwarder child this manager spawned for the recorded
+    # ``local_port`` (0 = none recorded), paired with the opaque start-time
+    # identity ``platform_compat.process_start_time`` reported for it ("" =
+    # unknown). Persisted so a forwarder orphaned by a gateway hard-kill can be
+    # reclaimed by its OWN identity — pid + start time + exact argv — never by
+    # matching the process table, which cannot distinguish our child from an
+    # operator's own forward (#1972). Either half missing means the identity
+    # cannot be confirmed and no reclaim happens (fail closed).
+    forwarder_pid: int = _NO_FORWARDER_PID
+    forwarder_start: str = ""
+    # HMAC over (id, forwarder_pid, forwarder_start, local_port) under a
+    # gateway-held key ("" = unsigned). The registry file is agent-writable, so
+    # the identity above gates but cannot authorize by itself; the signature is
+    # what makes it the GATEWAY's own claim — a record an agent wrote or
+    # redirected fails verification and is never reclaimed (fail closed).
+    forwarder_sig: str = ""
 
     def validate(self) -> None:
         """Raise :class:`InvalidInstanceError` if any field is malformed."""
@@ -235,6 +257,21 @@ class Instance:
                     f"invalid {label} {port!r}: must be an int in "
                     f"[{lo}, 65535]" + (" (0 = unallocated)" if allow_zero else "")
                 )
+        if not isinstance(self.forwarder_pid, int) or self.forwarder_pid < 0:
+            raise InvalidInstanceError(
+                f"invalid forwarder_pid {self.forwarder_pid!r}: must be an int "
+                f">= 0 (0 = no forwarder recorded)"
+            )
+        if not isinstance(self.forwarder_start, str):
+            raise InvalidInstanceError(
+                f"invalid forwarder_start {self.forwarder_start!r}: must be a "
+                f"string ('' = unknown)"
+            )
+        if not isinstance(self.forwarder_sig, str):
+            raise InvalidInstanceError(
+                f"invalid forwarder_sig {self.forwarder_sig!r}: must be a "
+                f"string ('' = unsigned)"
+            )
 
     def to_dict(self) -> dict:
         """Serialize to the JSON shape stored in ``instances.json``."""
@@ -252,6 +289,9 @@ class Instance:
             "aws_region": self.aws_region,
             "ssm_run_as": self.ssm_run_as,
             "was_connected": self.was_connected,
+            "forwarder_pid": self.forwarder_pid,
+            "forwarder_start": self.forwarder_start,
+            "forwarder_sig": self.forwarder_sig,
         }
 
     @classmethod
@@ -285,6 +325,12 @@ class Instance:
             # empty string would fail validation — both mean "use the default".
             ssm_run_as=str(data.get("ssm_run_as", "") or _DEFAULT_SSM_RUN_AS),
             was_connected=bool(data.get("was_connected", False)),
+            # max(): a hand-edited negative pid normalizes to the sentinel
+            # rather than poisoning every later update() with a validate error
+            # — matching this loader's documented key tolerance.
+            forwarder_pid=max(_NO_FORWARDER_PID, _as_int(data.get("forwarder_pid"), 0)),
+            forwarder_start=str(data.get("forwarder_start", "") or ""),
+            forwarder_sig=str(data.get("forwarder_sig", "") or ""),
         )
 
 
@@ -462,7 +508,9 @@ class InstancesRegistry:
         Accepts any of: ``name``, ``ssh_host``, ``remote_port``, ``local_port``,
         ``ttl``, ``remote_bin``, ``connection_method``, ``ssm_target``,
         ``ssm_run_as``,
-        ``aws_profile``, ``aws_region``, ``was_connected``. The ``id`` is
+        ``aws_profile``, ``aws_region``, ``was_connected``, ``forwarder_pid``,
+        ``forwarder_start``, ``forwarder_sig``.
+        The ``id`` is
         immutable. ``mark_last_active=True`` additionally records the instance
         as the auto-revive target in the SAME read-modify-write, so callers that
         need both (a connect persisting its hints) get one atomic file rewrite
@@ -482,6 +530,9 @@ class InstancesRegistry:
             "aws_profile",
             "aws_region",
             "was_connected",
+            "forwarder_pid",
+            "forwarder_start",
+            "forwarder_sig",
         }
         unknown = set(changes) - allowed
         if unknown:
@@ -515,16 +566,6 @@ class InstancesRegistry:
             self._write(doc)
             logger.info("Removed instance %s", instance_id)
             return True
-
-    def set_was_connected(self, instance_id: str, value: bool) -> None:
-        """Set the ``was_connected`` hint (no-op if the instance is gone)."""
-        with self._lock:
-            doc = self._read()
-            inst = _find(doc, instance_id)
-            if inst is None:
-                return
-            inst.was_connected = bool(value)
-            self._write(doc)
 
     def set_last_active(self, instance_id: str) -> None:
         """Mark *instance_id* as the one to auto-revive on next startup.

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -46,6 +46,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import enum
+import hashlib
+import hmac
 import json
 import logging
 import re
@@ -93,7 +95,12 @@ from kiro_crew.instances.constants import (
 from kiro_crew.instances.constants import SEARCH_REPLY_MAX_BYTES as _SEARCH_REPLY_MAX_BYTES
 from kiro_crew.instances.diagnostics import diagnose_instance, diagnose_instance_ssm
 from kiro_crew.instances.port_allocator import PortAllocator, _is_port_free
-from kiro_crew.instances.registry import _UNALLOCATED_PORT, Instance, InstancesRegistry
+from kiro_crew.instances.registry import (
+    _NO_FORWARDER_PID,
+    _UNALLOCATED_PORT,
+    Instance,
+    InstancesRegistry,
+)
 from kiro_crew.instances.ssm_token_mint import (
     mint_remote_token_ssm,
     run_remote_kirocrew_ssm,
@@ -115,6 +122,8 @@ from kiro_crew.instances.validation import (
     validate_ssm_target,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import _HMAC_KEY_MIN_BYTES as _SEL_HMAC_KEY_MIN_BYTES
+from kiro_crew.sel import sel, sel_hmac_key_path
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +140,62 @@ _MAX_STDERR_CHARS = 2000
 # can't spin a tight respawn loop. Applied in the scheduling seam (_on_tunnel_exit)
 # so direct _recover() callers (tests) aren't slowed.
 _RECOVER_BACKOFF_BASE_SECS = 1.0
+
+# Grace given to a reclaimed (hard-kill-orphaned) forwarder after SIGTERM
+# before escalating to SIGKILL, and after SIGKILL before giving up waiting.
+# `ssh -N` exits on TERM essentially immediately; the escalation mirrors
+# _SshTunnel._terminate's shape with tighter bounds because this runs inside
+# connect() under the manager lock. Nothing in the connect depends on the wait
+# completing — the recorded port stays excluded from allocation either way —
+# so a slow exit costs only these bounded seconds, never correctness.
+_RECLAIM_TERM_GRACE_SECS = 2.0
+_RECLAIM_KILL_GRACE_SECS = 1.0
+# Liveness poll cadence while waiting out the grace windows above.
+_RECLAIM_POLL_INTERVAL_SECS = 0.05
+
+# Domain tag for the forwarder-identity MAC subkey. Mirrors the
+# ``session_pid_sig`` precedent: the signing key is a one-way derivation of
+# the SEL trust root and this domain, so this protocol, the SEL audit chain,
+# and the session-pid sidecars never share a signing key and a MAC produced by
+# any of them is valueless to the others.
+_RECLAIM_SIG_DOMAIN = b"kirocrew-forwarder-identity-v1"
+
+
+def _reclaim_identity_key() -> bytes | None:
+    """Derive the forwarder-identity signing subkey, or ``None`` when absent.
+
+    Anchored on the SEL trust root (``sel_hmac_key_path()``), which only the
+    gateway creates and which sits on the sensitive-path deny list — an agent
+    can neither read nor replace it, which is the entire point: a signature
+    under this key is a claim only the GATEWAY can have made. Never creates
+    the key (a first-touch race would mint a root the SEL then distrusts);
+    when it cannot be read the reclaim protocol degrades to "never reclaim"
+    (fail closed) rather than trusting unsigned registry state.
+    """
+    try:
+        raw = sel_hmac_key_path().read_bytes()
+    except OSError:
+        return None
+    if len(raw) < _SEL_HMAC_KEY_MIN_BYTES:
+        return None
+    return hmac.new(raw, _RECLAIM_SIG_DOMAIN, hashlib.sha256).digest()
+
+
+def _forwarder_identity_sig(
+    key: bytes, instance_id: str, pid: int, start: str, port: int
+) -> str:
+    """MAC over one instance's recorded forwarder identity.
+
+    Binds the identity to the INSTANCE as well as to the process attributes,
+    so a valid record cannot be replayed under another instance id, and any
+    edit to pid, start time, or port invalidates it. NUL joints keep field
+    boundaries unambiguous (no recorded field can contain a NUL: the id and
+    port are charset/range-validated and the start value is a single
+    ``/proc``/``ps``/FILETIME token).
+    """
+    msg = "\0".join((instance_id, str(pid), start, str(port))).encode("utf-8")
+    return hmac.new(key, msg, hashlib.sha256).hexdigest()
+
 
 # ssh prints these benign advisory lines to stderr on connect (post-quantum KEX
 # warning); they are NOT failures. Strip them from captured stderr so the real
@@ -723,6 +788,123 @@ class _SshTunnel:
         return proc.pid if proc is not None and proc.returncode is None else None
 
 
+def _verify_and_reclaim_forwarder(
+    pid: int,
+    expected_start: str,
+    expected_argv: list[str],
+    port: int,
+    tree: bool,
+    audit_resources: str,
+) -> str:
+    """Verify a recorded forwarder's identity, then SIGTERM/SIGKILL-reclaim it.
+
+    Blocking by design — process-attribute reads, signals, liveness polls —
+    so callers run it in a worker thread, never on the event loop. Doing the
+    verification and the first signal in ONE thread keeps the check-to-signal
+    window at in-process microseconds, the same residual the repo's other
+    pid-reuse guards accept.
+
+    Identity is pid + start time + exact argv, checked in that order, and the
+    start-time comparison is RE-RUN before the destructive SIGKILL: the grace
+    window is exactly the interval in which the pid can exit and be recycled,
+    and ``pid_exists`` polling cannot observe an exit that is immediately
+    followed by reuse. Mirrors the stale-app-backend reaper's guard
+    (leak-not-mis-kill): any unconfirmed identity withholds the signal.
+
+    ``tree=True`` for the SSM transport, whose child was spawned into its own
+    process group (``start_new_session``, so pgid == pid) — the group signal
+    reaps the ``session-manager-plugin`` grandchild still holding the
+    forwarded port, and completion is judged by :func:`pgroup_exists` plus the
+    port actually releasing, so a wrapper that exits first cannot fake
+    success while the plugin keeps the port. If the group leader is already
+    reaped by SIGKILL time, the group cannot be re-addressed through the
+    existing pid-keyed helpers; the TERM broadcast has already reached every
+    member, and a member that ignores it keeps the port — reported truthfully
+    as not reclaimed (the port stays excluded from allocation). The ssh child
+    is spawned WITHOUT a new group: after a gateway hard-kill it sits in the
+    DEAD gateway's process group, where a group signal could hit unrelated
+    survivors — so it gets a pid-scoped signal only, which suffices because
+    ``ssh -N`` holds the forward itself and spawns no descendants of its own.
+
+    Returns one of: ``"reclaimed"`` (identity confirmed, process/group gone,
+    port released), ``"identity_mismatch"`` (nothing was ever signalled),
+    ``"recycled_during_grace"`` (SIGKILL withheld: the pid stopped matching
+    its recorded identity during the TERM grace), ``"not_gone"`` (signals
+    delivered but the process, group, or port is still held at the end).
+    Every path that delivered at least one signal emits a SEL audit event.
+    """
+
+    def _identity_holds() -> bool:
+        now = platform_compat.process_start_time(pid)
+        if now is None or now != expected_start:
+            return False
+        # Both halves, both times: the start token alone is 1s-granular on
+        # macOS (``ps -o lstart=``), so a same-second pid reuse could keep it
+        # matching while the process is someone else's — the argv half breaks
+        # that tie. A mid-death target whose argv is already unreadable reads
+        # as not-held and merely withholds the escalation (TERM was already
+        # delivered to the verified process).
+        return platform_compat.process_argv_matches_exact(pid, list(expected_argv))
+
+    def _alive() -> bool:
+        return platform_compat.pgroup_exists(pid) if tree else platform_compat.pid_exists(pid)
+
+    def _gone() -> bool:
+        return not _alive() and _is_port_free(port)
+
+    def _deliver(sig: int) -> None:
+        if tree and _SshTunnel._signal_group(pid, sig):
+            return
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError, ValueError):
+            platform_compat.kill_pid(pid, sig)
+
+    def _wait_gone(grace_secs: float) -> bool:
+        deadline = time.monotonic() + grace_secs
+        while time.monotonic() < deadline:
+            if _gone():
+                return True
+            time.sleep(_RECLAIM_POLL_INTERVAL_SECS)
+        return _gone()
+
+    def _audit(outcome: str) -> None:
+        try:
+            sel().log_api_access(
+                caller="gateway",
+                operation="forwarder_orphan_reclaim",
+                outcome=outcome,
+                resources=audit_resources,
+            )
+        except Exception as exc:  # noqa: BLE001 — audit must never break reclaim
+            logger.debug("SEL audit failed for forwarder_orphan_reclaim: %s", exc)
+
+    if not _identity_holds():
+        return "identity_mismatch"
+    _deliver(platform_compat.SIGTERM)
+    if _wait_gone(_RECLAIM_TERM_GRACE_SECS):
+        _audit("sigterm")
+        return "reclaimed"
+    # Re-confirm identity before the destructive escalation, and withhold the
+    # SIGKILL on ANYTHING short of a positive match — including a pid that no
+    # longer exists while its group/port linger. A recycled pid would make
+    # ``getpgid`` resolve (and the group kill target) the REPLACEMENT process,
+    # and ``pid_exists`` polling cannot distinguish "still our child" from
+    # "exited and recycled inside a poll gap", so absence of the pid is not a
+    # safe fall-through: no verified identity, no SIGKILL
+    # (leak-not-mis-kill). The TERM broadcast above already reached every
+    # group member while the identity was verified; a member that ignores it
+    # keeps the port, which stays excluded from allocation and is reported
+    # truthfully below.
+    if not _identity_holds():
+        _audit("sigkill_withheld_identity_unconfirmed")
+        return "recycled_during_grace"
+    _deliver(platform_compat.SIGKILL)
+    if _wait_gone(_RECLAIM_KILL_GRACE_SECS):
+        _audit("sigkill")
+        return "reclaimed"
+    _audit("not_gone")
+    return "not_gone"
+
+
 @dataclass
 class _TransportParams:
     """Validated, transport-specific connection parameters for one instance.
@@ -890,6 +1072,162 @@ class SshTunnelManager:
                 reserved.add(inst.local_port)
         return reserved
 
+    async def _reclaim_orphan_forwarder(self, inst: Instance, params: _TransportParams) -> None:
+        """Reclaim *inst*'s own forwarder child leaked by a gateway hard-kill.
+
+        A SIGKILLed gateway never runs teardown, so its forwarder child
+        survives, reparented to init with nothing left to reap it: one idle
+        process, one loopback port, and one live session to the remote per
+        hard-kill → reconnect cycle. The restarted manager finds the recorded
+        ``local_port`` occupied and (correctly) allocates around it; this hook
+        is what turns that permanent leak into a reclaim.
+
+        Reclamation is keyed on OUR OWN recorded identity, never a
+        process-table match — matching the table by argv pattern is what once
+        SIGTERMed forwards operators had opened themselves (#1972), and no
+        pattern can distinguish our child from a stranger's. The registry
+        itself is agent-writable, so a recorded claim is honored only when it
+        AUTHENTICATES: the record must carry the gateway's own MAC over
+        (instance id, pid, start time, port), computed at spawn under a key
+        derived from the SEL trust root — which an agent can neither read nor
+        replace — so a record written or re-pointed by anything but this
+        gateway fails verification outright. Behind the MAC, defense in depth
+        from kernel-owned facts: the candidate must be a genuine ORPHAN — not
+        a pid this manager currently supervises, and reparented to init
+        (``get_ppid == 1``), which no live gateway's forwarder is. Then the
+        recorded pid is trusted only behind a STRICT identity check, both
+        halves recorded at spawn: the pid's start time must equal the recorded
+        ``forwarder_start``, AND its full argv must exactly equal the forward
+        command line this manager would construct for the recorded port (host
+        and all). Anything less — either hint missing, process gone,
+        attributes unreadable, or any element differing — means the identity
+        cannot be confirmed: the process is left alone and connect falls
+        through to normal allocation. The start-time half is what defeats pid
+        recycling (argv can collide in principle; a recycled pid's start time
+        cannot), and it is re-verified before the SIGKILL escalation inside
+        the worker. Best-effort: a failed reclaim never fails the connect, it
+        only leaves the leak for the next attempt.
+
+        A rebuilt-vs-recorded argv can also drift apart without any foul play
+        (an edited compression/host setting, or an ``aws`` entrypoint the
+        kernel rewrites through a shebang) — that misses the reclaim, never
+        mis-kills, and is logged below so the miss is visible instead of
+        silent.
+
+        Runs under the manager lock (its caller ``connect`` holds it); every
+        blocking step — the port probe and the verify-and-signal worker — is
+        pushed off the event loop via ``asyncio.to_thread``.
+        """
+        pid = inst.forwarder_pid
+        port = inst.local_port
+        start = inst.forwarder_start
+        sig = inst.forwarder_sig
+        if pid <= 1 or port <= 0 or not start or not sig:
+            return  # identity not (fully) recorded — nothing we may touch
+        # The registry is agent-writable state, so its identity claims are
+        # UNTRUSTED until authenticated: the record must carry the MAC this
+        # gateway (and only this gateway — the key derives from the SEL trust
+        # root, which sits on the sensitive-path deny list) computed when it
+        # spawned the child. A record an agent wrote, edited, or re-pointed at
+        # someone else's process fails verification and is refused before any
+        # process attribute is even read. Key unreadable -> refuse (never
+        # trust unsigned state).
+        key = await asyncio.to_thread(_reclaim_identity_key)
+        if key is None:
+            return
+        # Both the reconstruction and the comparison are fed agent-writable
+        # text: a record can carry arbitrary strings (even lone surrogates
+        # that refuse UTF-8 encoding), and compare_digest on str raises
+        # TypeError for non-ASCII. Any malformed field IS a verification
+        # failure, never a crash on the connect path.
+        try:
+            expected_sig = _forwarder_identity_sig(key, inst.id, pid, start, port)
+            sig_ok = hmac.compare_digest(sig.encode("utf-8"), expected_sig.encode("utf-8"))
+        except (TypeError, ValueError, UnicodeError):
+            sig_ok = False
+        if not sig_ok:
+            logger.warning(
+                "Recorded forwarder identity for %s failed signature "
+                "verification; refusing reclaim (registry edited outside the "
+                "gateway?)",
+                inst.id,
+            )
+            return
+        # Defense in depth behind the MAC, from gateway-/kernel-owned facts: a
+        # pid this manager is CURRENTLY supervising is never a leak candidate,
+        # and a genuine hard-kill orphan has been reparented to init — a
+        # forwarder whose parent is still alive belongs to a running gateway
+        # (this one or another), so it is refused no matter what the registry
+        # says. Subreaper hosts read as non-orphaned and merely miss the
+        # reclaim (fail closed, leak-not-mis-kill).
+        live_pids = {t.pid for t in self._tunnels.values() if t.pid}
+        if pid in live_pids:
+            return
+        if await asyncio.to_thread(platform_compat.get_ppid, pid) != 1:
+            return
+        if await asyncio.to_thread(_is_port_free, port):
+            return  # nothing holds the recorded port — nothing leaked to reclaim
+        if params.method == "ssm":
+            expected = _build_ssm_tunnel_argv(
+                params.ssm_target,
+                port,
+                inst.remote_port,
+                profile=params.aws_profile,
+                region=params.aws_region,
+            )
+        else:
+            expected = _build_ssh_tunnel_argv(
+                params.ssh_host, port, inst.remote_port, compression=self._ssh_compression
+            )
+        outcome = await asyncio.to_thread(
+            _verify_and_reclaim_forwarder,
+            pid,
+            start,
+            expected,
+            port,
+            params.method == "ssm",
+            f"instance={inst.id} pid={pid} port={port} transport={params.method}",
+        )
+        if outcome == "reclaimed":
+            logger.info(
+                "Reclaimed leaked %s forwarder pid %d for %s (released port %d)",
+                params.method,
+                pid,
+                inst.id,
+                port,
+            )
+        elif outcome == "identity_mismatch":
+            logger.info(
+                "Recorded %s forwarder pid %d for %s no longer matches its "
+                "recorded identity (recycled pid, or the rebuilt command line "
+                "drifted); leaving it alone (#1972) — port %d stays excluded "
+                "from allocation",
+                params.method,
+                pid,
+                inst.id,
+                port,
+            )
+        elif outcome == "recycled_during_grace":
+            logger.warning(
+                "Withheld SIGKILL for %s forwarder pid %d of %s: the pid "
+                "stopped matching its recorded identity during the term grace "
+                "(recycled); port %d stays excluded from allocation",
+                params.method,
+                pid,
+                inst.id,
+                port,
+            )
+        else:  # "not_gone"
+            logger.warning(
+                "Leaked %s forwarder pid %d for %s (or a group member holding "
+                "port %d) did not exit within the reclaim grace; leaving it "
+                "for the next connect (the port stays excluded from allocation)",
+                params.method,
+                pid,
+                inst.id,
+                port,
+            )
+
     def _connect_timeout_for(self, method: str) -> float:
         """Readiness timeout for *method*, honoring an explicit caller override.
 
@@ -1012,6 +1350,13 @@ class SshTunnelManager:
                 if not cloud_ssm.session_manager_plugin_installed():
                     return self._error_status(inst, cloud_ssm.session_manager_plugin_install_hint())
 
+            # Reclaim our own forwarder if a prior gateway hard-kill leaked it
+            # still holding this instance's recorded port. Keyed on the recorded
+            # pid behind a strict exact-argv identity check — see the method for
+            # why nothing else is ever signalled. Best-effort: allocation below
+            # skips the recorded port whether or not the reclaim succeeded.
+            await self._reclaim_orphan_forwarder(inst, params)
+
             # Allocate a free loopback port for the forward. It deliberately does
             # NOT have to equal ``inst.remote_port``. The embedded dashboard runs
             # in an iframe at http://127.0.0.1:<local_port>, and the remote
@@ -1043,15 +1388,16 @@ class SshTunnelManager:
             # That skip is why no orphan-reaping step is needed for connect to
             # make PROGRESS: nothing has to be killed to get a working tunnel.
             #
-            # The cost that buys, stated rather than implied: an ``ssh -N -L``
-            # child orphaned by a gateway hard-kill is no longer signalled, so it
-            # keeps its loopback port and its session to the remote until the OS
-            # reaps it. That is accepted here deliberately. The reaper this
-            # replaced matched the process table by argv and could SIGTERM a
-            # forward the operator had opened themselves (#1972), and no argv
-            # pattern distinguishes our child from a stranger's. Reclaiming it
-            # safely means tracking our own pid, which is #5235, not a rider on
-            # this change.
+            # The cost that skip alone would carry: an ``ssh -N -L`` child
+            # orphaned by a gateway hard-kill keeps its loopback port and its
+            # session to the remote until the OS reaps it. That leak is now
+            # reclaimed by ``_reclaim_orphan_forwarder`` above — by the child's
+            # RECORDED pid behind a strict exact-argv identity check, never by
+            # scanning the process table. The reaper that scan-based approach
+            # replaced matched argv patterns and could SIGTERM a forward the
+            # operator had opened themselves (#1972); an unrecorded or
+            # unverified process is therefore left alone, and allocation simply
+            # skips its port.
             #
             # There is deliberately no "take my own previous port back" branch.
             # It reads as free stability, but the case it fires in cannot benefit:
@@ -1125,18 +1471,40 @@ class SshTunnelManager:
             self._store_token(instance_id, token, inst.ttl)
             self._schedule_token_refresh(instance_id)
 
-            # Persist hints: port assignment, was_connected, last-active — ONE
-            # read-modify-rewrite of instances.json (fsync), so the pair is
+            # Persist hints: port assignment, forwarder identity (pid + start
+            # time), was_connected, last-active — ONE
+            # read-modify-rewrite of instances.json (fsync), so the set is
             # durable together and the manager lock is held for a single fsync
-            # round-trip. _persist_hint runs it off the loop and does not
+            # round-trip. The identity pair is what a later connect uses to
+            # reclaim this child if a gateway hard-kill orphans it; a start
+            # time that cannot be read persists as "" and simply disables the
+            # reclaim for this child (fail closed).
+            # _persist_hint runs it off the loop and does not
             # return — even under cancellation — until the write completes, so
             # the lock cannot release while the worker write is still in
             # flight (a late hint write would race a subsequent disconnect).
+            forwarder_pid = tunnel.pid or _NO_FORWARDER_PID
+            forwarder_start = ""
+            forwarder_sig = ""
+            if forwarder_pid > 0:
+                started = await asyncio.to_thread(
+                    platform_compat.process_start_time, forwarder_pid
+                )
+                forwarder_start = started or ""
+            if forwarder_pid > 0 and forwarder_start:
+                key = await asyncio.to_thread(_reclaim_identity_key)
+                if key is not None:
+                    forwarder_sig = _forwarder_identity_sig(
+                        key, instance_id, forwarder_pid, forwarder_start, local_port
+                    )
             await self._persist_hint(
                 self._registry.update,
                 instance_id,
                 mark_last_active=True,
                 local_port=local_port,
+                forwarder_pid=forwarder_pid,
+                forwarder_start=forwarder_start,
+                forwarder_sig=forwarder_sig,
                 was_connected=True,
             )
             # A successful (re)connect clears any stale give-up counter so the next
@@ -1199,14 +1567,23 @@ class SshTunnelManager:
         await self._cancel_token_refresh_and_wait(instance_id)
         # Clear the lazy-reconnect hint AND the recorded local port together
         # (one atomic write). local_port must return to the unallocated
-        # sentinel so the now-free port is not treated as reserved forever.
-        # _persist_hint runs the read-modify-rewrite off the loop and does
+        # sentinel so the now-free port is not treated as reserved forever,
+        # and the forwarder pid goes with it: the child was just stopped, so a
+        # retained pid would eventually be recycled by the OS and point a later
+        # reclaim at a stranger (the exact-argv guard would refuse it, but a
+        # cleared hint never even asks). _persist_hint runs the
+        # read-modify-rewrite off the loop and does
         # not return — even if this handler is cancelled (e.g. aiohttp
         # aborting at shutdown) — until the write completes: the in-memory
         # teardown above is already done, so abandoning the persisted reset
         # would leave was_connected=True plus a stale local_port, reviving
         # an instance the user disconnected and pinning the freed port.
-        hints: dict[str, object] = {"local_port": _UNALLOCATED_PORT}
+        hints: dict[str, object] = {
+            "local_port": _UNALLOCATED_PORT,
+            "forwarder_pid": _NO_FORWARDER_PID,
+            "forwarder_start": "",
+            "forwarder_sig": "",
+        }
         if not keep_intent:
             hints["was_connected"] = False
         await self._persist_hint(self._registry.update, instance_id, **hints)
@@ -1413,7 +1790,14 @@ class SshTunnelManager:
         return await tunnel.start()
 
     async def _mark_recovered(self, instance_id: str) -> None:
-        """Reset the attempt counter and persist the hint, under lock, iff tracked.
+        """Reset the attempt counter and persist the hints, under lock, iff tracked.
+
+        A rebuild replaced the tunnel child, so the recorded forwarder
+        identity (``forwarder_pid`` + ``forwarder_start``) must move with
+        ``was_connected`` — a stale identity would point a later hard-kill
+        reclaim at a process that no longer exists (harmless, the identity
+        check refuses it) while the ACTUAL replacement child leaked
+        unrecorded. All hints go in one write.
 
         The persist stays INSIDE the manager lock so write order equals
         lock-acquisition order: a concurrent :meth:`disconnect`'s
@@ -1426,10 +1810,36 @@ class SshTunnelManager:
         its write could land after the lock released and break the ordering.
         """
         async with self._lock:
-            if instance_id not in self._tunnels:
+            tunnel = self._tunnels.get(instance_id)
+            if tunnel is None:
                 return
             self._recover_attempts[instance_id] = 0
-            await self._persist_hint(self._registry.set_was_connected, instance_id, True)
+            forwarder_pid = tunnel.pid or _NO_FORWARDER_PID
+            forwarder_start = ""
+            forwarder_sig = ""
+            if forwarder_pid > 0:
+                started = await asyncio.to_thread(
+                    platform_compat.process_start_time, forwarder_pid
+                )
+                forwarder_start = started or ""
+            if forwarder_pid > 0 and forwarder_start:
+                key = await asyncio.to_thread(_reclaim_identity_key)
+                if key is not None:
+                    forwarder_sig = _forwarder_identity_sig(
+                        key,
+                        instance_id,
+                        forwarder_pid,
+                        forwarder_start,
+                        tunnel.status.local_port,
+                    )
+            await self._persist_hint(
+                self._registry.update,
+                instance_id,
+                was_connected=True,
+                forwarder_pid=forwarder_pid,
+                forwarder_start=forwarder_start,
+                forwarder_sig=forwarder_sig,
+            )
 
     async def _recover(self, instance_id: str) -> None:
         """2-tier self-heal for an unhealthy tunnel (either transport).

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -27,7 +27,7 @@ import time
 import zlib
 from ctypes import wintypes  # type aliases only; imports cleanly on every platform
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping, NamedTuple, Optional
+from typing import Any, Callable, Iterator, Mapping, NamedTuple, Optional, Sequence
 
 from kiro_crew.executors import subprocess_executor
 
@@ -1829,6 +1829,61 @@ def _win_process_image_name(pid: int) -> str | None:
             kernel32.CloseHandle(snap)
     except Exception:
         return None
+
+
+def process_argv_matches_exact(pid: int, expected_argv: Sequence[str]) -> bool:
+    """Return True iff *pid*'s FULL command line is exactly *expected_argv*.
+
+    The strict identity check behind reclaiming a child this process's own
+    lineage spawned and then lost (a recorded pid surviving a supervisor
+    hard-kill): a recorded pid may have been recycled onto an unrelated
+    process, and :func:`process_matches`-style substring needles cannot tell
+    the two apart — partial argv matching against the process table is exactly
+    what once killed forwards operators had started themselves. So the whole
+    argv must match, element for element, and every failure answers False.
+
+    For a DESTRUCTIVE decision this check must be paired with a
+    :func:`process_start_time` pin recorded when the child was spawned: argv
+    equality alone cannot rule out a recycled pid running an identical
+    command line, and on macOS the comparison basis below makes equality
+    necessary but not sufficient for vector equality. The pair fails toward
+    "do not signal" on either mismatch.
+
+    Linux: ``/proc/<pid>/cmdline`` NUL-split and compared element-wise (an
+    empty cmdline — a zombie — never matches). macOS: ``ps -ww -o command=``
+    reports the argv space-joined, so the comparison is against
+    ``" ".join(expected_argv)``; exact only when no expected element contains
+    a space, which holds for the argv shapes this guards (option tokens and
+    validated host/target strings). Windows: always False — the raw
+    ``Win32_Process.CommandLine`` string (see :func:`process_command_line`)
+    carries shell quoting rather than an argv vector, so element-exact
+    equality is not verifiable there; the guard fails closed and callers must
+    not signal.
+    """
+    if type(pid) is not int or pid <= 1 or not expected_argv:
+        return False
+    try:
+        if sys.platform == "linux":
+            raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+            if not raw:
+                return False  # zombie / kernel thread: no argv to confirm
+            parts = raw.split(b"\0")
+            if parts and parts[-1] == b"":
+                parts.pop()  # trailing NUL terminator
+            return parts == [a.encode() for a in expected_argv]
+        if sys.platform == "darwin":
+            ps_bin = trusted_system_bin("ps")
+            if ps_bin is None:
+                return False
+            out = subprocess.check_output(
+                [ps_bin, "-ww", "-o", "command=", "-p", str(pid)],
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+            )
+            return out.decode(errors="replace").strip() == " ".join(expected_argv)
+    except Exception:
+        return False
+    return False
 
 
 def listening_pid_tool() -> str:

--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -74,9 +74,6 @@ class _RecordingRegistry:
     def set_last_active(self, instance_id: str) -> None:
         self.write_threads.append(threading.current_thread())
 
-    def set_was_connected(self, instance_id: str, value: bool) -> None:
-        self.write_threads.append(threading.current_thread())
-
 
 # ---------------------------------------------------------------------------
 # Behavior: the walk / write happens on a worker thread, not the loop thread
@@ -179,11 +176,13 @@ async def test_mark_recovered_registry_write_off_the_loop_thread() -> None:
     loop_thread = threading.current_thread()
     registry = _RecordingRegistry()
     mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
-    mgr._tunnels["some-instance"] = SimpleNamespace()  # type: ignore[assignment]
+    # The double carries a pid: _mark_recovered persists the rebuilt child's
+    # forwarder_pid alongside was_connected in its single hint write.
+    mgr._tunnels["some-instance"] = SimpleNamespace(pid=4321)  # type: ignore[assignment]
 
     await mgr._mark_recovered("some-instance")
 
-    assert registry.write_threads, "set_was_connected never happened"
+    assert registry.write_threads, "the recovery hint write never happened"
     assert all(t is not loop_thread for t in registry.write_threads)
 
 
@@ -210,10 +209,10 @@ class _BlockingRegistry(_RecordingRegistry):
         self.release = threading.Event()
         self.completed = False
 
-    def set_was_connected(self, instance_id: str, value: bool) -> None:
+    def update(self, instance_id: str, **changes: object) -> Any:
         self.release.wait(timeout=10)
         self.completed = True
-        super().set_was_connected(instance_id, value)
+        return super().update(instance_id, **changes)
 
 
 @pytest.mark.asyncio
@@ -224,7 +223,7 @@ async def test_cancelled_persist_waits_for_the_worker_write() -> None:
     late write race a subsequent locked write (e.g. a disconnect's reset)."""
     registry = _BlockingRegistry()
     mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
-    mgr._tunnels["inst"] = SimpleNamespace()  # type: ignore[assignment]
+    mgr._tunnels["inst"] = SimpleNamespace(pid=4321)  # type: ignore[assignment]
 
     task = asyncio.create_task(mgr._mark_recovered("inst"))
     await asyncio.sleep(0.05)  # the worker write is submitted and blocked
@@ -351,7 +350,6 @@ def test_no_direct_registry_write_in_async_frames() -> None:
     write_methods = {
         "update",
         "set_last_active",
-        "set_was_connected",
         "remove",
         "get",
         "list",
@@ -386,7 +384,6 @@ def test_no_direct_registry_call_in_instances_handler_async_frames() -> None:
         "update",
         "remove",
         "set_last_active",
-        "set_was_connected",
     }
     offenders: list[str] = []
     for owner, call in _calls_in_async_frames(_module_tree(handlers_instances_mod)):

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -1052,6 +1053,10 @@ class _FakeTunnel:
         self.stopped = False
         self.start_result = True
         self._S = TunnelState
+        # Mirrors _SshTunnel.pid (None when no live child). connect() persists
+        # `tunnel.pid or 0` as the forwarder_pid hint; tests that assert a
+        # recorded pid set this to a concrete value via a factory wrapper.
+        self.pid = None
         # Recorded so transport-selection tests can assert which transport the
         # manager chose for this instance.
         self.transport = transport
@@ -2230,7 +2235,7 @@ class TestHandlers:
         _enable(tmp_path, monkeypatch)
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
-        reg.set_was_connected("cd-1", True)
+        reg.update("cd-1", was_connected=True)
 
         class _Manager:
             def __init__(self):
@@ -2311,7 +2316,7 @@ class TestHandlers:
         _enable(tmp_path, monkeypatch)
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
-        reg.set_was_connected("cd-1", True)
+        reg.update("cd-1", was_connected=True)
 
         class _Manager:
             def __init__(self):
@@ -2352,7 +2357,7 @@ class TestHandlers:
         _enable(tmp_path, monkeypatch)
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
-        reg.set_was_connected("cd-1", True)
+        reg.update("cd-1", was_connected=True)
 
         class _NoTunnelManager:
             async def disconnect(self, instance_id, *, keep_intent=False):
@@ -2444,7 +2449,7 @@ class TestHandlers:
         _enable(tmp_path, monkeypatch)
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
-        reg.set_was_connected("cd-1", True)
+        reg.update("cd-1", was_connected=True)
 
         class _DisconnectMidEdit:
             def __init__(self):
@@ -2458,7 +2463,7 @@ class TestHandlers:
                 reg.update(instance_id, **hints)
                 if self.calls == 1:
                     # The user presses Disconnect while the save is in flight.
-                    reg.set_was_connected(instance_id, False)
+                    reg.update(instance_id, was_connected=False)
                 return True
 
             def status(self, instance_id):
@@ -2496,7 +2501,7 @@ class TestHandlers:
         _enable(tmp_path, monkeypatch)
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
-        reg.set_was_connected("cd-1", True)
+        reg.update("cd-1", was_connected=True)
 
         events: list[str] = []
 
@@ -2551,7 +2556,7 @@ class TestHandlers:
         _enable(tmp_path, monkeypatch)
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
-        reg.set_was_connected("cd-1", True)
+        reg.update("cd-1", was_connected=True)
 
         class _WedgedManager:
             async def reconfigure(self, instance_id, apply):
@@ -3047,6 +3052,8 @@ class _ResilTunnel:
         self.transport = transport
         self.status = TunnelStatus(instance_id=iid, local_port=lp, remote_port=rp)
         self.start_result = True
+        # Mirrors _SshTunnel.pid; _mark_recovered persists it after a rebuild.
+        self.pid = None
 
     async def start(self):
         self.status.state = self._S.CONNECTED if self.start_result else self._S.ERROR
@@ -4731,3 +4738,682 @@ class TestSsmExitErrorClassification:
         t = _SshTunnel("dev", "dev-1", 7777, 7777)
         t._stderr_buf = "Permission denied (publickey)."
         assert "ssh auth failed" in t._exit_error(255)
+
+
+# ── #5235: hard-kill-orphaned forwarder reclaim (pid + exact-argv guard) ────
+
+
+class TestForwarderPidHints:
+    """The registry pid hint lifecycle: recorded on connect, moved by recovery,
+    cleared by disconnect. Fake tunnels; no real processes or ports."""
+
+    @pytest.fixture(autouse=True)
+    def _free_ports(self, monkeypatch):
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+
+        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": True)
+
+    def _mgr(self, tmp_path, *, factory=_FakeTunnel):
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        reg = InstancesRegistry(path=tmp_path / "instances.json")
+
+        async def ok_mint(
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
+        ):
+            return "SECRET_TOK"
+
+        return reg, SshTunnelManager(
+            reg, base_port=54200, mint_token=ok_mint, tunnel_factory=factory
+        )
+
+    def test_registry_field_default_roundtrip_and_validation(self, tmp_path):
+        from kiro_crew.instances.registry import Instance, InvalidInstanceError
+
+        # Older registry files have no keys -> sentinel defaults.
+        old = Instance.from_dict({"id": "a", "name": "A"})
+        assert old.forwarder_pid == 0
+        assert old.forwarder_start == ""
+        # A hand-edited negative pid normalizes to the sentinel instead of
+        # poisoning every later update() with a validation error.
+        assert Instance.from_dict({"id": "a", "name": "A", "forwarder_pid": -7}).forwarder_pid == 0
+        inst = Instance(
+            id="a", name="A", ssh_host="host-a", forwarder_pid=4321, forwarder_start="12345"
+        )
+        d = inst.to_dict()
+        assert d["forwarder_pid"] == 4321
+        assert d["forwarder_start"] == "12345"
+        loaded = Instance.from_dict(d)
+        assert loaded.forwarder_pid == 4321
+        assert loaded.forwarder_start == "12345"
+        # A pid can never be negative; the sentinel 0 is the floor.
+        bad = Instance(id="a", name="A", ssh_host="host-a", forwarder_pid=-1)
+        with pytest.raises(InvalidInstanceError):
+            bad.validate()
+        bad_start = Instance(id="a", name="A", ssh_host="host-a", forwarder_start=123)  # type: ignore[arg-type]
+        with pytest.raises(InvalidInstanceError):
+            bad_start.validate()
+
+    @pytest.mark.asyncio
+    async def test_connect_persists_forwarder_identity(self, tmp_path, monkeypatch):
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        # A REAL pid (our own), so the recorded start-time identity is the
+        # genuine platform value rather than "".
+        my_pid = os.getpid()
+        key = b"k" * 32
+        monkeypatch.setattr(stm, "_reclaim_identity_key", lambda: key)
+
+        def factory(*a, **k):
+            t = _FakeTunnel(*a, **k)
+            t.pid = my_pid
+            return t
+
+        reg, mgr = self._mgr(tmp_path, factory=factory)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        assert (await mgr.connect("cd-1")).state == TunnelState.CONNECTED
+        inst = reg.get("cd-1")
+        assert inst.forwarder_pid == my_pid
+        assert inst.forwarder_start == (pc.process_start_time(my_pid) or "")
+        assert inst.forwarder_start != ""  # readable for a live process we own
+        assert inst.local_port > 0
+        # The identity is signed with the gateway's key, bound to this
+        # instance, pid, start, and port.
+        assert inst.forwarder_sig == stm._forwarder_identity_sig(
+            key, "cd-1", my_pid, inst.forwarder_start, inst.local_port
+        )
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_forwarder_identity_with_local_port(self, tmp_path):
+        def factory(*a, **k):
+            t = _FakeTunnel(*a, **k)
+            t.pid = os.getpid()
+            return t
+
+        reg, mgr = self._mgr(tmp_path, factory=factory)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        await mgr.connect("cd-1")
+        assert reg.get("cd-1").forwarder_pid == os.getpid()
+        await mgr.disconnect("cd-1")
+        inst = reg.get("cd-1")
+        # One atomic reset: a freed port is not reserved forever, and a stale
+        # identity never even reaches a later reclaim's checks.
+        assert inst.local_port == 0
+        assert inst.forwarder_pid == 0
+        assert inst.forwarder_start == ""
+        assert inst.forwarder_sig == ""
+
+    @pytest.mark.asyncio
+    async def test_mark_recovered_refreshes_forwarder_identity(self, tmp_path):
+        """A rebuild replaces the child; the recorded identity must move with
+        it, or the replacement leaks unrecorded at the next hard-kill."""
+        from kiro_crew import platform_compat as pc
+
+        def factory(*a, **k):
+            t = _FakeTunnel(*a, **k)
+            t.pid = 54321  # dead pid: start-time identity records as ""
+            return t
+
+        reg, mgr = self._mgr(tmp_path, factory=factory)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        await mgr.connect("cd-1")
+        assert reg.get("cd-1").forwarder_pid == 54321
+        assert reg.get("cd-1").forwarder_start == ""
+        mgr._tunnels["cd-1"].pid = os.getpid()  # the rebuilt child's pid
+        await mgr._mark_recovered("cd-1")
+        inst = reg.get("cd-1")
+        assert inst.forwarder_pid == os.getpid()
+        assert inst.forwarder_start == (pc.process_start_time(os.getpid()) or "")
+        assert inst.was_connected is True
+
+
+class TestOrphanForwarderReclaim:
+    """End-to-end reclaim behavior against REAL processes holding REAL ports.
+
+    The reclaim path (``_reclaim_orphan_forwarder``) is keyed on the recorded
+    pid behind a strict exact-argv identity check. These tests spawn a real
+    child bound to a real loopback port and drive a real ``connect()``:
+
+    * the leaked-forwarder case proves the child is terminated and its port
+      released (identity confirmed via the real /proc//ps argv read);
+    * the #1972 regression cases prove a process this manager did not spawn is
+      NEVER signalled — whether its pid is recorded (pid recycled), unrecorded,
+      or its port is not even occupied.
+
+    ``_is_port_free`` stays REAL here (unlike the fake-port manager tests):
+    occupancy of the holder's port is the trigger under test.
+    """
+
+    def _mgr(self, tmp_path, *, base_port):
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        reg = InstancesRegistry(path=tmp_path / "instances.json")
+
+        async def ok_mint(
+            host, *, remote_bin="", ttl="20h", remote_port=None, embed_parent_port=None, timeout_secs=None
+        ):
+            return "SECRET_TOK"
+
+        return reg, SshTunnelManager(
+            reg, base_port=base_port, mint_token=ok_mint, tunnel_factory=_FakeTunnel
+        )
+
+    def _spawn_port_holder(self):
+        """Spawn a real child LISTENing on a free loopback port.
+
+        Returns ``(proc, port, argv)``. Readiness is signalled over stdout so
+        the bind (and /proc argv population) cannot be raced. A daemon reaper
+        thread ``wait()``s the child so that, once signalled, it disappears
+        immediately instead of lingering as a zombie — mirroring production,
+        where the leaked forwarder's parent is dead and init reaps it.
+
+        The child's parent is the TEST process, i.e. a LIVE parent: the
+        reclaim's orphan gate refuses it as-is (which the live-parent test
+        pins with the real ``get_ppid``). Tests that exercise the gates
+        BEHIND the orphan gate monkeypatch ``get_ppid`` to 1 for their own
+        scope — a real double-fork orphan would leave an unsupervised process
+        behind on a test crash and is exactly the residue the suite forbids.
+        """
+        code = (
+            "import socket, sys, time\n"
+            "s = socket.socket()\n"
+            "s.bind(('127.0.0.1', 0))\n"
+            "s.listen(1)\n"
+            "sys.stdout.write('%d\\n' % s.getsockname()[1])\n"
+            "sys.stdout.flush()\n"
+            "time.sleep(120)\n"
+        )
+        argv = [sys.executable, "-c", code]
+        proc = subprocess.Popen(
+            argv,
+            start_new_session=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            line = proc.stdout.readline()
+            port = int(line.strip())
+        except Exception:
+            proc.kill()
+            raise
+        threading.Thread(target=proc.wait, daemon=True).start()
+        return proc, port, argv
+
+    @staticmethod
+    def _fake_orphan(monkeypatch):
+        """Make the orphan gate see every pid as init-reparented (test scope)."""
+        from kiro_crew import platform_compat as pc
+
+        monkeypatch.setattr(pc, "get_ppid", lambda pid: 1)
+
+    _TEST_IDENTITY_KEY = b"k" * 32
+
+    @classmethod
+    def _pin_identity_key(cls, monkeypatch):
+        """Pin the reclaim signing key and return a sig factory.
+
+        The real key derives from the SEL trust root, which a test home does
+        not initialize; pinning a fixed key keeps the MAC math (and its
+        compare_digest gate) fully real while making signatures computable by
+        the test exactly the way the pre-kill gateway would have.
+        """
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+
+        monkeypatch.setattr(stm, "_reclaim_identity_key", lambda: cls._TEST_IDENTITY_KEY)
+
+        def sign(instance_id, pid, start, port):
+            return stm._forwarder_identity_sig(
+                cls._TEST_IDENTITY_KEY, instance_id, pid, start, port
+            )
+
+        return sign
+
+    @staticmethod
+    def _cleanup(proc):
+        if proc.poll() is None:
+            proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="positive reclaim needs the python stand-in's kernel argv to equal "
+        "the spawn argv; macOS framework python re-execs (rewriting argv[0]) and "
+        "Windows fails closed by design — production targets (ssh/aws binaries) "
+        "do not re-exec",
+    )
+    @pytest.mark.asyncio
+    async def test_hard_kill_leaked_forwarder_is_reclaimed_by_pid(self, tmp_path, monkeypatch):
+        """hard-kill -> restart -> reconnect: the recorded child is terminated
+        and its port released; connect proceeds on a fresh port."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.port_allocator import _is_port_free
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        proc, port, argv = self._spawn_port_holder()
+        try:
+            # The identity check compares the recorded pid's REAL argv against
+            # the command line the manager would construct. The manager builds
+            # ssh argv; the leaked stand-in is a python child — point the
+            # builder at the stand-in's exact argv so the real /proc read and
+            # the element-wise comparison are exercised end to end. The orphan
+            # gate is faked open (the stand-in's parent is this test).
+            monkeypatch.setattr(
+                stm,
+                "_build_ssh_tunnel_argv",
+                lambda host, lp, rp, compression=True: list(argv),
+            )
+            self._fake_orphan(monkeypatch)
+            sign = self._pin_identity_key(monkeypatch)
+            start = pc.process_start_time(proc.pid)
+            assert start, "test needs a readable start-time identity"
+            reg, mgr = self._mgr(tmp_path, base_port=54300)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            # What the pre-kill gateway persisted: port + signed child identity.
+            reg.update(
+                "cd-1",
+                local_port=port,
+                forwarder_pid=proc.pid,
+                forwarder_start=start,
+                forwarder_sig=sign("cd-1", proc.pid, start, port),
+                was_connected=True,
+            )
+
+            st = await mgr.connect("cd-1")
+
+            assert st.state == TunnelState.CONNECTED
+            # (a) the old forwarder process is no longer alive…
+            assert proc.wait(timeout=10) is not None
+            # …and its port is released.
+            deadline = time.monotonic() + 5.0
+            while not _is_port_free(port) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert _is_port_free(port), "reclaimed forwarder's port was not released"
+            # The connect allocated around the (still-reserved) recorded port.
+            inst = reg.get("cd-1")
+            assert inst.local_port != port
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="positive reclaim needs the python stand-in's kernel argv to equal "
+        "the spawn argv; macOS framework python re-execs and Windows fails closed",
+    )
+    @pytest.mark.asyncio
+    async def test_sigterm_ignoring_forwarder_is_sigkill_escalated(self, tmp_path, monkeypatch):
+        """A verified leaked forwarder that ignores SIGTERM is SIGKILLed after
+        the grace (identity re-confirmed before the destructive escalation)."""
+        import signal as signal_mod
+
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        code = (
+            "import signal, socket, sys, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "s = socket.socket()\n"
+            "s.bind(('127.0.0.1', 0))\n"
+            "s.listen(1)\n"
+            "sys.stdout.write('%d\\n' % s.getsockname()[1])\n"
+            "sys.stdout.flush()\n"
+            "time.sleep(120)\n"
+        )
+        argv = [sys.executable, "-c", code]
+        proc = subprocess.Popen(
+            argv, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
+        try:
+            port = int(proc.stdout.readline().strip())
+            threading.Thread(target=proc.wait, daemon=True).start()
+            monkeypatch.setattr(
+                stm,
+                "_build_ssh_tunnel_argv",
+                lambda host, lp, rp, compression=True: list(argv),
+            )
+            self._fake_orphan(monkeypatch)
+            sign = self._pin_identity_key(monkeypatch)
+            # Keep the TERM grace short so the escalation happens quickly.
+            monkeypatch.setattr(stm, "_RECLAIM_TERM_GRACE_SECS", 0.3)
+            start = pc.process_start_time(proc.pid)
+            assert start
+            reg, mgr = self._mgr(tmp_path, base_port=54700)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            reg.update(
+                "cd-1",
+                local_port=port,
+                forwarder_pid=proc.pid,
+                forwarder_start=start,
+                forwarder_sig=sign("cd-1", proc.pid, start, port),
+                was_connected=True,
+            )
+
+            st = await mgr.connect("cd-1")
+
+            assert st.state == TunnelState.CONNECTED
+            rc = proc.wait(timeout=10)
+            assert rc is not None
+            # SIGTERM was ignored by the child, so death proves the SIGKILL
+            # escalation ran (exit by signal reports negative on POSIX).
+            assert rc == -signal_mod.SIGKILL
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.asyncio
+    async def test_unsigned_or_forged_record_is_never_signalled(self, tmp_path, monkeypatch):
+        """Forged-registry regression (agent-writable instances.json): a record
+        with fully matching process attributes but WITHOUT the gateway's MAC —
+        missing or wrong — authorizes nothing, even with the orphan gate open
+        and the argv matching. Only the gateway can mint the signature (its
+        key derives from the deny-listed SEL trust root)."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        proc, port, argv = self._spawn_port_holder()
+        try:
+            monkeypatch.setattr(
+                stm,
+                "_build_ssh_tunnel_argv",
+                lambda host, lp, rp, compression=True: list(argv),
+            )
+            self._fake_orphan(monkeypatch)
+            self._pin_identity_key(monkeypatch)
+            start = pc.process_start_time(proc.pid) or "x"
+            # "" = unsigned; hex garbage = wrong MAC; non-ASCII and a lone
+            # surrogate = the malformed-text shapes that must read as
+            # verification failure, never crash the connect path.
+            for forged_sig in ("", "deadbeef" * 8, "签名不对", "\udc80bad"):
+                reg, mgr = self._mgr(tmp_path, base_port=55000)
+                reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+                reg.update(
+                    "cd-1",
+                    local_port=port,
+                    forwarder_pid=proc.pid,
+                    forwarder_start=start,
+                    forwarder_sig=forged_sig,
+                    was_connected=True,
+                )
+                st = await mgr.connect("cd-1")
+                assert st.state == TunnelState.CONNECTED
+                assert proc.poll() is None, f"a record with sig={forged_sig!r} was honored"
+                reg.remove("cd-1")
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.asyncio
+    async def test_live_parent_forwarder_is_never_signalled(self, tmp_path, monkeypatch):
+        """Forged-registry regression: the registry is agent-writable, so a
+        record can truthfully describe a LIVE sibling gateway's forwarder
+        (real pid, real start time, matching argv). The orphan gate must
+        refuse it: a process whose parent is alive belongs to a running
+        gateway and is never a hard-kill leak."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        # Direct child of the test process == a live parent (this process).
+        proc, port, argv = self._spawn_port_holder()
+        try:
+            monkeypatch.setattr(
+                stm,
+                "_build_ssh_tunnel_argv",
+                lambda host, lp, rp, compression=True: list(argv),
+            )
+            sign = self._pin_identity_key(monkeypatch)
+            start = pc.process_start_time(proc.pid) or "x"
+            reg, mgr = self._mgr(tmp_path, base_port=54900)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            reg.update(
+                "cd-1",
+                local_port=port,
+                forwarder_pid=proc.pid,
+                forwarder_start=start,
+                forwarder_sig=sign("cd-1", proc.pid, start, port),
+                was_connected=True,
+            )
+
+            st = await mgr.connect("cd-1")
+
+            assert st.state == TunnelState.CONNECTED
+            assert proc.poll() is None, "a live-parented forwarder was signalled"
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="ppid probe of a posix-spawned stand-in"
+    )
+    @pytest.mark.asyncio
+    async def test_recorded_start_mismatch_is_never_signalled(self, tmp_path, monkeypatch):
+        """Pid-recycling regression: the recorded pid now belongs to a process
+        whose argv happens to match, but its start-time identity does not.
+        Nothing may be signalled — the start-time pin is what defeats a
+        recycled pid running an identical command line."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        proc, port, argv = self._spawn_port_holder()
+        try:
+            monkeypatch.setattr(
+                stm,
+                "_build_ssh_tunnel_argv",
+                lambda host, lp, rp, compression=True: list(argv),
+            )
+            self._fake_orphan(monkeypatch)
+            sign = self._pin_identity_key(monkeypatch)
+            reg, mgr = self._mgr(tmp_path, base_port=54800)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            reg.update(
+                "cd-1",
+                local_port=port,
+                forwarder_pid=proc.pid,
+                forwarder_start="not-the-recorded-identity",
+                forwarder_sig=sign("cd-1", proc.pid, "not-the-recorded-identity", port),
+                was_connected=True,
+            )
+
+            st = await mgr.connect("cd-1")
+
+            assert st.state == TunnelState.CONNECTED
+            assert proc.poll() is None, "a start-time-mismatched pid was signalled"
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.asyncio
+    async def test_recorded_pid_with_foreign_argv_is_never_signalled(self, tmp_path, monkeypatch):
+        """#1972 regression: the recorded pid was recycled onto a process this
+        manager did not spawn (its argv is not the forward command line). It
+        must be left alone even with a matching start time and an open orphan
+        gate."""
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        proc, port, _argv = self._spawn_port_holder()
+        try:
+            self._fake_orphan(monkeypatch)
+            sign = self._pin_identity_key(monkeypatch)
+            start = pc.process_start_time(proc.pid) or "x"
+            reg, mgr = self._mgr(tmp_path, base_port=54400)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            # Even with a CORRECT start-time identity the argv gate must still
+            # refuse: the real argv builder expects `ssh …`, not python.
+            reg.update(
+                "cd-1",
+                local_port=port,
+                forwarder_pid=proc.pid,
+                forwarder_start=start,
+                forwarder_sig=sign("cd-1", proc.pid, start, port),
+                was_connected=True,
+            )
+
+            st = await mgr.connect("cd-1")  # real argv builder: expects ssh …
+
+            assert st.state == TunnelState.CONNECTED
+            assert proc.poll() is None, "a foreign process holding the port was signalled"
+            inst = reg.get("cd-1")
+            assert inst.local_port != port  # allocated around the occupied port
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.asyncio
+    async def test_unrecorded_port_holder_is_never_signalled(self, tmp_path):
+        """No recorded identity -> no candidate: the reclaim never scans the
+        process table for whoever holds the port (that scan is what #1972
+        removed)."""
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        proc, port, _argv = self._spawn_port_holder()
+        try:
+            reg, mgr = self._mgr(tmp_path, base_port=54500)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            reg.update("cd-1", local_port=port, was_connected=True)  # identity stays unset
+
+            st = await mgr.connect("cd-1")
+
+            assert st.state == TunnelState.CONNECTED
+            assert proc.poll() is None, "an unrecorded port holder was signalled"
+        finally:
+            self._cleanup(proc)
+
+    @pytest.mark.asyncio
+    async def test_free_port_short_circuits_before_the_identity_check(
+        self, tmp_path, monkeypatch
+    ):
+        """A free recorded port means nothing leaked: the recorded pid is not
+        signalled even when its identity WOULD match (e.g. the pid was
+        recycled onto an innocent process while nothing holds the port)."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        code = "import sys, time; sys.stdout.write('R'); sys.stdout.flush(); time.sleep(120)"
+        argv = [sys.executable, "-c", code]
+        proc = subprocess.Popen(
+            argv, start_new_session=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
+        try:
+            assert proc.stdout.read(1) == b"R"
+            # Even a would-be-exact identity must not matter: the port gates.
+            monkeypatch.setattr(
+                stm,
+                "_build_ssh_tunnel_argv",
+                lambda host, lp, rp, compression=True: list(argv),
+            )
+            self._fake_orphan(monkeypatch)
+            sign = self._pin_identity_key(monkeypatch)
+            # A port nothing listens on: bind(0) to reserve one, then close it.
+            s = socket.socket()
+            s.bind(("127.0.0.1", 0))
+            free_port = s.getsockname()[1]
+            s.close()
+
+            start = pc.process_start_time(proc.pid) or "x"
+            reg, mgr = self._mgr(tmp_path, base_port=54600)
+            reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+            reg.update(
+                "cd-1",
+                local_port=free_port,
+                forwarder_pid=proc.pid,
+                forwarder_start=start,
+                forwarder_sig=sign("cd-1", proc.pid, start, free_port),
+                was_connected=True,
+            )
+
+            st = await mgr.connect("cd-1")
+
+            assert st.state == TunnelState.CONNECTED
+            assert proc.poll() is None, "reclaim signalled a pid while its port was free"
+        finally:
+            self._cleanup(proc)
+
+    def test_sigkill_withheld_when_identity_changes_during_grace(self, monkeypatch):
+        """Open-box guard test: if the pid stops matching its recorded
+        start-time identity during the TERM grace (exit + recycle inside a
+        poll gap, which pid_exists cannot observe), the destructive SIGKILL is
+        withheld — leak-not-mis-kill."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+
+        delivered: list[int] = []
+        starts = iter(["identity-A", "identity-B"])  # pre-TERM, then re-check
+
+        monkeypatch.setattr(pc, "process_start_time", lambda pid: next(starts))
+        monkeypatch.setattr(pc, "process_argv_matches_exact", lambda pid, argv: True)
+        monkeypatch.setattr(pc, "pid_exists", lambda pid: True)
+        monkeypatch.setattr(pc, "kill_pid", lambda pid, sig: delivered.append(sig) or True)
+        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": False)
+        monkeypatch.setattr(stm, "_RECLAIM_TERM_GRACE_SECS", 0.05)
+
+        outcome = stm._verify_and_reclaim_forwarder(
+            4242, "identity-A", ["ssh", "-N"], 50505, False, "instance=t pid=4242"
+        )
+
+        assert outcome == "recycled_during_grace"
+        assert delivered == [pc.SIGTERM], "SIGKILL must be withheld on identity change"
+
+    def test_sigkill_withheld_when_pid_vanishes_but_port_lingers(self, monkeypatch):
+        """Open-box guard test: a pid that no longer exists while the port is
+        still held (SSM wrapper gone, plugin lingering — or a recycle inside a
+        poll gap) is NOT a safe SIGKILL fall-through: getpgid on a recycled
+        pid would resolve the REPLACEMENT process. No verified identity, no
+        SIGKILL."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+
+        delivered: list[int] = []
+        starts = iter(["identity-A", None])  # pre-TERM ok; re-check: pid gone
+
+        monkeypatch.setattr(pc, "process_start_time", lambda pid: next(starts))
+        monkeypatch.setattr(pc, "process_argv_matches_exact", lambda pid, argv: True)
+        monkeypatch.setattr(pc, "pid_exists", lambda pid: False)
+        monkeypatch.setattr(pc, "pgroup_exists", lambda pgid: True)  # plugin lingers
+        monkeypatch.setattr(pc, "kill_pid", lambda pid, sig: delivered.append(sig) or True)
+        monkeypatch.setattr(
+            stm._SshTunnel,
+            "_signal_group",
+            staticmethod(lambda pid, sig: delivered.append(sig) or True),
+        )
+        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": False)
+        monkeypatch.setattr(stm, "_RECLAIM_TERM_GRACE_SECS", 0.05)
+
+        outcome = stm._verify_and_reclaim_forwarder(
+            4242, "identity-A", ["aws", "ssm"], 50506, True, "instance=t pid=4242"
+        )
+
+        assert outcome == "recycled_during_grace"
+        assert delivered == [pc.SIGTERM], "SIGKILL must be withheld when the pid is gone"
+
+    def test_sigkill_withheld_when_argv_stops_matching_during_grace(self, monkeypatch):
+        """Open-box guard test: on macOS the start token is 1s-granular, so a
+        same-second pid reuse can keep it matching — the argv half of the
+        re-check is what breaks the tie. argv mismatch at escalation time
+        withholds the SIGKILL."""
+        import kiro_crew.instances.ssh_tunnel_manager as stm
+        from kiro_crew import platform_compat as pc
+
+        delivered: list[int] = []
+        argv_answers = iter([True, False])  # pre-TERM ok; re-check: different argv
+
+        monkeypatch.setattr(pc, "process_start_time", lambda pid: "identity-A")
+        monkeypatch.setattr(
+            pc, "process_argv_matches_exact", lambda pid, argv: next(argv_answers)
+        )
+        monkeypatch.setattr(pc, "pid_exists", lambda pid: True)
+        monkeypatch.setattr(pc, "kill_pid", lambda pid, sig: delivered.append(sig) or True)
+        monkeypatch.setattr(stm, "_is_port_free", lambda port, host="127.0.0.1": False)
+        monkeypatch.setattr(stm, "_RECLAIM_TERM_GRACE_SECS", 0.05)
+
+        outcome = stm._verify_and_reclaim_forwarder(
+            4242, "identity-A", ["ssh", "-N"], 50507, False, "instance=t pid=4242"
+        )
+
+        assert outcome == "recycled_during_grace"
+        assert delivered == [pc.SIGTERM], "SIGKILL must be withheld on argv change"

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -998,6 +998,93 @@ class TestProcessIdentityPosix:
             assert result is False
 
 
+class TestProcessArgvMatchesExact:
+    """The strict identity check behind reclaiming a recorded-but-orphaned
+    child: the WHOLE argv must match, element for element, and every failure
+    answers False — an unconfirmable identity must never be signalled."""
+
+    def _spawn(self, token: str):
+        argv = [
+            sys.executable,
+            "-c",
+            f"import sys, time; sys.stdout.write('R'); sys.stdout.flush(); "
+            f"time.sleep(30)  # {token}",
+        ]
+        child = subprocess.Popen(
+            argv,
+            start_new_session=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        ready = child.stdout.read(1)
+        assert ready == b"R", f"child did not signal readiness: {ready!r}"
+        return child, argv
+
+    @staticmethod
+    def _reap(child):
+        child.kill()
+        try:
+            child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+    def test_exact_argv_matches_and_near_misses_do_not(self):
+        if pc.IS_POSIX:
+            # A plain binary that does NOT re-exec, so its kernel-visible argv
+            # is exactly the spawn argv on Linux AND macOS (a macOS framework
+            # python re-execs Python.app and rewrites argv[0], which is a
+            # property of the interpreter stand-in, not of the production
+            # targets — ssh and the aws v2 binary do not re-exec).
+            sleep_bin = shutil.which("sleep") or "/bin/sleep"
+            argv = [sleep_bin, "300"]
+            child = subprocess.Popen(
+                argv, start_new_session=True, stderr=subprocess.DEVNULL
+            )
+        else:
+            child, argv = self._spawn("kirocrew-argvexact-probe")
+        try:
+            if pc.IS_POSIX:
+                # Exact match: retry briefly for slow /proc population on
+                # loaded runners (same shape as the process_matches test).
+                deadline = time.monotonic() + 10.0
+                result = pc.process_argv_matches_exact(child.pid, argv)
+                while not result and time.monotonic() < deadline:
+                    time.sleep(0.05)
+                    result = pc.process_argv_matches_exact(child.pid, argv)
+                assert result is True
+                # Anything less than the whole argv is a different process:
+                # a subset (prefix), a superset, and a one-element difference
+                # must all answer False — substring semantics are exactly what
+                # this function exists to NOT have.
+                assert pc.process_argv_matches_exact(child.pid, argv[:-1]) is False
+                assert pc.process_argv_matches_exact(child.pid, argv + ["-x"]) is False
+                changed = list(argv)
+                changed[-1] = changed[-1] + " "
+                assert pc.process_argv_matches_exact(child.pid, changed) is False
+            else:
+                # Windows: element-exact argv equality is not verifiable (the
+                # raw command line carries shell quoting, not a vector) — the
+                # guard fails closed even for the true argv.
+                assert pc.process_argv_matches_exact(child.pid, argv) is False
+        finally:
+            self._reap(child)
+
+    def test_unconfirmable_identities_answer_false(self):
+        # A pid that cannot exist, reserved pids, and an empty expectation all
+        # fail closed rather than raising.
+        assert pc.process_argv_matches_exact(2_000_000_000, ("x",)) is False
+        assert pc.process_argv_matches_exact(0, ("x",)) is False
+        assert pc.process_argv_matches_exact(1, ("x",)) is False
+        assert pc.process_argv_matches_exact(-5, ("x",)) is False
+        assert pc.process_argv_matches_exact(os.getpid(), ()) is False
+
+    def test_own_process_with_wrong_argv_is_false(self):
+        result = pc.process_argv_matches_exact(
+            os.getpid(), ("zzz-not-this-interpreter", "--nope")
+        )
+        assert result is False
+
+
 class TestProcessStartTime:
     """The identity source every PID-reuse guard compares before signalling.
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -984,6 +984,14 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # through the sandbox helper because sandbox imports platform_compat.
         "platform_compat.py::process_owner_uid",
         "platform_compat.py::process_matches",
+        # Same class as process_matches: a read-only process-attribute query
+        # (macOS ``ps -ww -o command= -p <pid>``; Linux reads /proc without
+        # spawning) whose only interpolated value is an int-guarded pid — the
+        # expected argv is compared IN PYTHON, never passed to the child. It is
+        # the strict identity check consulted before reclaiming a recorded
+        # forwarder pid, and cannot route through the sandbox helper because
+        # sandbox imports platform_compat.
+        "platform_compat.py::process_argv_matches_exact",
         # The single icacls chokepoint shared by restrict_to_owner (file shape)
         # and restrict_dir_to_owner (directory shape, inheritable grants). Both
         # public helpers delegate here, so this one entry covers the owner-only


### PR DESCRIPTION
## Problem / Motivation

When the gateway is hard-killed (SIGKILL / crash), its `ssh -N -L` forwarder child survives: `start_new_session` is deliberately scoped to the SSM path only, so the ssh child reparents to init with nothing left to reap it. The restarted manager does not track it, and the connect path simply allocates around the occupied recorded port. Each hard-kill → reconnect cycle therefore leaks one idle ssh process, one loopback port, and one live SSH connection to the remote (#5235).

## Why it matters

Operators who iterate on the gateway (crashes, watchdog kills, `kill -9` during development) accumulate idle ssh processes and live remote sessions with no bound and no cleanup path short of manual `kill`. The port space under `tunnel_base_port` also shrinks by one port per cycle, since every leaked port stays reserved forever.

## What changed (motivation → approach → change)

Symptom → root cause: the old process-table reaper (`_reap_orphan_forwarder`) was removed by #5189 because partial argv matching killed forwards operators had opened themselves (#1972) — no argv *pattern* can distinguish our child from a stranger's. The only safe key is an identity **we recorded ourselves at spawn**.

Change — the record, the trust model, and the kill path:
- **Recorded identity.** `connect()` persists the forwarder child's identity — `forwarder_pid` + `forwarder_start` (the opaque `platform_compat.process_start_time` value) — into the registry hints next to `local_port`, in the same single atomic write. `disconnect()` clears all of them in its one reset write; a self-heal rebuild (`_mark_recovered`, now via `registry.update`) moves the identity to the replacement child. `InstancesRegistry.set_was_connected` thereby lost its last production caller and is deleted.
- **Authenticated, not merely recorded.** `instances.json` is agent-writable (it is not on `security.py`'s sensitive-path lists), so a recorded claim must not by itself authorize a kill: an agent could re-point a truthful-looking record at a live sibling tunnel or an operator's own `ssh -f` forward. The record therefore also carries **`forwarder_sig`** — the gateway's HMAC over `(instance id, pid, start time, port)` under a subkey derived from the SEL trust root (`sel_hmac_key_path()`, domain-separated exactly like the `session_pid_sig` sidecar protocol; the root is deny-listed, so only the gateway can mint a signature). The reclaim verifies the MAC with `hmac.compare_digest` **before reading any process attribute**; unsigned, edited, or re-pointed records are refused outright, and an unreadable key refuses everything (fail closed).
- **Orphan gating (defense in depth behind the MAC).** The candidate must be a genuine hard-kill orphan from kernel-owned facts: not a pid this manager currently supervises, and reparented to init (`platform_compat.get_ppid(pid) == 1`) — no live gateway's forwarder qualifies. Subreaper hosts read as non-orphaned and merely miss the reclaim.
- **Strict identity check.** `_reclaim_orphan_forwarder` then verifies — off the event loop, in one worker thread — that the pid's live start time equals the recorded one AND its full argv exactly equals the forward command line the manager would construct for the recorded port (new `platform_compat.process_argv_matches_exact`: `/proc/<pid>/cmdline` element-wise on Linux, `ps -ww` on macOS, fail-closed `False` on Windows).
- **Kill path.** Only then it signals: SIGTERM → bounded grace → SIGKILL, and the escalation requires a POSITIVE identity re-match — an absent, unreadable, or changed identity withholds the SIGKILL (the grace window is exactly where a pid can exit and be recycled; same guard as the stale-app-backend reaper). Delivery is pid-scoped for ssh (its child shares the dead gateway's process group, where a group signal could hit unrelated survivors) and group-scoped for SSM (child owns its group; completion judged by `pgroup_exists` + the port actually releasing, so the `aws` wrapper exiting first cannot fake success while `session-manager-plugin` keeps the port). Every delivered signal emits a SEL audit event (`forwarder_orphan_reclaim`).
- Anything short of full authenticated identity leaves the process alone (visibly logged) and connect falls through to normal allocation. Reclamation never scans the process table.

Note on the two SEL-root subkey derivations: `session_pid_sig._derive_subkey` (fallback to the live singleton's bytes — long-lived publishers must survive a relocated key file) and `_reclaim_identity_key` here (strictly file-anchored, fail-closed — a destructive consumer must never sign/verify against anything an operator cannot independently inspect). The divergence is deliberate and documented on both.

Pre-push dual model-pinned review (GPT 5.6 + Opus 5) plus three server-side GPT rounds drove the trust model above: round 1 flagged the missing identity re-check before SIGKILL and SSM wrapper-only completion (fixed); rounds 2–3 flagged the agent-writable registry authorizing kills and a fail-open absent-pid escalation branch (both fixed as described).

Documented trade-offs (deliberate, not oversights):
- **Identity is persisted in the existing post-mint write.** A hard-kill *during* the token mint window leaks that child unrecorded — the pre-existing behavior, bounded to one child per such crash. Persisting pre-mint would add a second fsync per connect plus a new clear-on-mint-failure path; the narrow-surface trade was taken per the issue's spec.
- **Expected argv is rebuilt, not recorded**, so config drift between spawn and reclaim (e.g. toggling `instances.ssh_compression`) or an `aws` v1 shebang entrypoint misses the reclaim (never mis-kills) — logged rather than silent. Recording an observed-argv fingerprint at spawn would close these miss classes; filed as a follow-up.
- **macOS argv comparison is against `ps -ww` flattened output** (necessary, not sufficient for vector equality). A mis-kill through that ambiguity would additionally require the recycled pid to match the recorded start time — `lstart` collides only within the same second — so the pair still fails toward "do not signal"; the pairing contract is documented on the helper.

## Tests

All fail-before verified (10/11 failed on pre-fix source; the passing one pins an invariant that must hold before and after).

- `TestOrphanForwarderReclaim` (real processes on real loopback ports): hard-kill → reconnect reclaims the recorded child and releases its port; a SIGTERM-ignoring child is SIGKILL-escalated (exit code proves `-9`); an **unsigned or forged-signature** record is never honored even with matching attributes (forged-registry regression); a **live-parented** forwarder is never signalled even with a fully matching signed record (real `get_ppid`); a recorded pid whose **start time** mismatches is never signalled (pid-recycle regression); a recorded pid with **foreign argv** is never signalled (#1972 regression); an **unrecorded** port holder is never signalled (no table scan); a **free** recorded port short-circuits before any identity check; open-box: SIGKILL is withheld when the identity changes during the TERM grace, and when the pid vanishes while the port lingers.
- `TestForwarderPidHints`: connect persists pid+start; disconnect clears them with `local_port`; `_mark_recovered` moves the identity to the rebuilt child; registry roundtrip/validation/negative-pid normalization.
- `TestProcessArgvMatchesExact` (test_platform_compat.py): exact match true for a live child's real argv; subset/superset/one-element-diff false; unconfirmable identities (dead pid, reserved pids, empty argv) false.
- Loop-offload contract tests updated for the `_mark_recovered` write path.

Local gates: isort / flake8 / mypy / black / brand / harness-parity / docs-lint green; full backend pytest 62741 passed (54 failures reproduced identically on a clean checkout — known host-environment bus/sandbox EPERM class on this dev host, files untouched by this diff).

## Manual verification

N/A — the reclaim, escalation, and never-signal paths are exercised end-to-end by the real-process tests above; the feature has no UI surface.

## Related Issues

Closes #5235

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
