### PR TITLE
fix(auto-improvement): stub live DNS out of the pr_recipe origin-url tests (#5364)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
@@ -49,7 +49,7 @@ from pathlib import Path
 
 import pytest
 
-from ..backend import store
+from ..backend import clone_setup, store
 
 #: Git reads these before falling back to config files or the system account, so they make the
 #: identity explicit and hermetic on every host.
@@ -112,3 +112,38 @@ def _isolated_app_data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(store, "data_dir", lambda: data)
     monkeypatch.setenv("AUTO_IMPROVEMENT_SCRATCH", str(tmp_path / "app-scratch"))
     return data
+
+
+@pytest.fixture
+def _public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve every hostname to a fixed public address, and pin ``gh`` to https.
+
+    ``resolve_origin_url`` re-runs ``validate_target_url``, whose ``_host_is_blocked``
+    SSRF check does a LIVE ``socket.getaddrinfo`` resolve and fails CLOSED on any
+    resolver error. On a transient runner DNS hiccup ``github.com`` reads as blocked
+    and a legitimate remote resolves to ``""`` — flaking the legitimate-remote
+    assertions and letting the refusal assertions pass for the WRONG reason (the
+    resolver-error path instead of the allowlist/identity path they exist to pin).
+    Tests that request this fixture are about URL/identity validation, not address
+    screening, so resolution is stubbed — the same shape as the ``public_dns``
+    fixture in ``test/test_meetings_providers.py``. The address decision itself
+    keeps its own live coverage elsewhere; the production fail-closed behaviour is
+    deliberately untouched (it is correct for a real DNS failure — the defect was a
+    unit test exercising the real resolver).
+
+    ``_gh_prefers_ssh`` is pinned on the same seam: ``validate_target_url`` shells
+    out to ``gh config get git_protocol`` / ``git config`` (timeout=15 each) to pick
+    a clone transport, which is a host-configuration dependency a unit test must not
+    read. Pinned to https so the rebuilt clone url has one deterministic shape.
+
+    Deliberately NAMED, never autouse: the patch swaps the shared ``socket``
+    module's ``getaddrinfo`` for the whole process while a test runs
+    (``clone_setup.socket`` IS that module; monkeypatch restores it at teardown).
+    Tests that do other network I/O must not inherit it silently.
+    """
+    monkeypatch.setattr(
+        clone_setup.socket,
+        "getaddrinfo",
+        lambda *_a, **_kw: [(2, 1, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(clone_setup, "_gh_prefers_ssh", lambda: False)

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
@@ -862,6 +862,7 @@ class TestTrustedPublisherStillWorksAfterNeutralizing:
         assert recipe._resolve_fetch_url() is None, "a neutralized clone must not yield a target"
 
 
+@pytest.mark.usefixtures("_public_dns")
 class TestOriginUrlMigratesOldConfigs:
     """Neutralizing BOTH clone urls means the trusted publishers can no longer read the
     remote out of git — they take it from config's ``origin_url``. A config written before
@@ -870,6 +871,11 @@ class TestOriginUrlMigratesOldConfigs:
     Found by inspecting the live dogfood configs on this host: both had ``clone`` set and
     no ``origin_url``. Without a migration they would silently degrade to queue-only after
     an upgrade, so the resolver falls back to the retained ``target_url``.
+
+    Every case runs through ``resolve_origin_url`` -> ``validate_target_url``, whose
+    SSRF screen resolves the host live and fails closed on resolver errors — so DNS is
+    pinned (the shared ``_public_dns`` fixture) and the refusal cases below fail for
+    the allowlist/identity reason they assert, never for a resolver hiccup.
     """
 
     def test_a_config_without_origin_url_still_resolves_a_target(self) -> None:


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

`TestOriginUrlMigratesOldConfigs` in
`src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py` exercises
`resolve_origin_url` → `validate_target_url` → `_host_is_blocked`, whose SSRF
screen does a **live `socket.getaddrinfo` resolve** and fails closed on any
resolver error. On a transient runner DNS hiccup:

- the legitimate-remote assertions (`:881` `assert got`, `:896`
  `assert resolve_origin_url(cfg) == "https://github.com/o/r.git"`) **flake** —
  `github.com` reads as blocked and a valid remote resolves to `""`;
- the refusal assertions expecting `""` **pass for the wrong reason** — the
  resolver-error path fires instead of the allowlist/identity path they exist
  to pin, masking a real regression in those guards.

`:896` has the exact assertion shape already reported flaking in #5229. This is
the same defect class in a sibling file that the #5229 fix (#5365, still open)
deliberately leaves alone — the two PRs have zero file overlap.

On the same seam, `validate_target_url` also calls `_gh_prefers_ssh()`, which
runs `gh config get git_protocol` / `git config` subprocesses (timeout=15 each)
from these unit tests — a latency/robustness host-configuration dependency
(advisory A5 on #5364).

## Why it matters

A flaky CI shard burns a rerun for every contributor it hits, and a
security-guard test that silently passes on the wrong branch is worse than no
test: an edit that broke the allowlist/identity refusal could land green during
a resolver blip.

## What changed (motivation → approach → change)

Symptom: DNS-dependent unit tests. Root cause: the tests reach the real
resolver through the production SSRF screen, which is *correct* to fail closed
in production — the defect is test hermeticity, not production behaviour.

Change (test-only, 2 files):

- **`auto_improvement/tests/conftest.py`** — add a **named, non-autouse**
  `_public_dns` fixture that stubs `clone_setup.socket.getaddrinfo` to return a
  fixed public address (same shape as the `public_dns` precedent in
  `test/test_meetings_providers.py` and the in-flight #5365 fixture), and pins
  `_gh_prefers_ssh` to https, removing the subprocess host dependency (A5).
  Deliberately NOT autouse: the patch swaps the shared `socket` module's
  `getaddrinfo` process-wide while active, so it stays opt-in for tests that do
  no other network I/O.
- **`test_pr_recipe.py`** — `@pytest.mark.usefixtures("_public_dns")` on
  `TestOriginUrlMigratesOldConfigs`, the one class that reaches the resolver.

Scoping notes, verified against the code rather than the issue prose:

- All four flagged assertions (`:881/:896/:912/:922`) live in this **single**
  class; `TestAuthenticatedRemote` already stubs `_gh_prefers_ssh`, and the
  neutralized-clone tests never reach a resolver — so one class requests the
  fixture.
- With DNS stubbed to a public address, the refusal assertions still bite for
  the RIGHT reason: `:912` refuses on the owner/repo identity mismatch, `:922`
  on the host allowlist — neither depends on the address decision.
- No coverage is lost: `_host_is_blocked`'s address-decision coverage is not
  owned by this class (direct coverage is added beside the sibling fixture in
  #5365), and the production fail-closed behaviour is untouched.
- `test_dogfood_learnings.py` is deliberately NOT touched — it is owned by
  in-flight #5365; the sibling's class-level fixture shadows this conftest
  fixture by pytest scoping rules, so the two changes compose cleanly in
  either merge order.

## Tests

This PR is itself a test fix. The four existing assertions now run against a
deterministic resolver; verified empirically with a simulated total DNS outage
(a pytest plugin replacing `socket.getaddrinfo` with a raising stub,
session-wide):

- **unfixed** code under the outage: `test_a_config_without_origin_url_still_resolves_a_target`
  and `test_origin_url_wins_when_present` FAIL (the flake, reproduced
  deterministically), while the refusal tests pass masked — exactly the
  reported defect;
- **fixed** code under the same outage: all 5 tests in the class PASS.

Full `auto_improvement` test directory: 965 passed, 46 skipped.

## Manual verification

N/A — unit coverage sufficient: the change is confined to test fixtures, and
the DNS-outage probe above exercises precisely the failure mode being fixed.

## Related Issues

Closes #5364

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend test-only change; no frontend paths touched.
