### PR TITLE
fix(dashboard): re-opening a file no longer discards its unsaved edits

### DIFF
--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -176,6 +176,10 @@ interface Props {
   filePath: string
   content: string
   onContentChange: (c: string) => void
+  /** Disk-originated content (file watch, Refresh). Document tabs restamp
+   *  their saved baseline here so a re-open still treats the tab as clean;
+   *  omitted by other hosts, which fall back to onContentChange. */
+  onDiskContent?: (c: string) => void
   onSave: (filePath: string, content: string) => Promise<void>
   onClose: () => void
   liveWatch?: boolean
@@ -819,7 +823,7 @@ export interface MarkdownPanelHandle {
   requestNavigate: (nav: (stillClean: () => boolean) => void) => void
 }
 
-export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPanel({ filePath, content, onContentChange, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, initialDiffMode, onDiffModeChange, embedded, savedBaseline, revealLine, onRevealConsumed, browserRail, railOpen, onRailToggle }: Props, ref) {
+export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPanel({ filePath, content, onContentChange, onDiskContent, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, initialDiffMode, onDiffModeChange, embedded, savedBaseline, revealLine, onRevealConsumed, browserRail, railOpen, onRailToggle }: Props, ref) {
   const ime = useImeGuard()
   const qc = useQueryClient()
   // Code files (non-rich, non-markdown) have no meaningful preview — their
@@ -1133,7 +1137,10 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
 
   useFileWatch(
     liveWatch && !editing && !dirty ? filePath : null,
-    useCallback((c: string) => { onContentChange(c) }, [onContentChange]),
+    // A watch-fired change IS the disk truth, so route it through
+    // onDiskContent when the host can restamp its saved baseline; falling
+    // back to onContentChange keeps non-tab hosts unchanged.
+    useCallback((c: string) => { (onDiskContent ?? onContentChange)(c) }, [onDiskContent, onContentChange]),
   )
 
 
@@ -1173,10 +1180,16 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
       if (onRefresh) { await onRefresh(filePath) }
       else {
         const res = await fetch(fileReadUrl(filePath))
-        if (res.ok) onContentChange(await res.text())
+        if (!res.ok) return
+        const text = await res.text()
+        // The read is async, and the dirty check above ran at click time:
+        // anything typed while it was in flight made the buffer dirty, and
+        // these disk bytes must not clobber that work.
+        if (dirtyRef.current) return
+        ;(onDiskContent ?? onContentChange)(text)
       }
     } finally { setRefreshing(false) }
-  }, [filePath, onContentChange, onRefresh, refreshing, dirty])
+  }, [filePath, onContentChange, onDiskContent, onRefresh, refreshing, dirty])
 
   // Discard pending edits (matches the artifact detail page's Cancel button).
   // Re-reads the file from disk into the buffer, clearing dirty. Confirms first
@@ -1194,12 +1207,16 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
       if (onRefresh) { await onRefresh(filePath) }
       else {
         const res = await fetch(fileReadUrl(filePath))
-        if (res.ok) onContentChange(await res.text())
+        // Cancel means "match the disk", so the re-read moves the saved
+        // baseline too (onDiskContent), the same as Refresh — otherwise the
+        // stale baseline could later read a deliberate edit back to it as
+        // clean and let a close discard that work.
+        if (res.ok) (onDiskContent ?? onContentChange)(await res.text())
       }
       setDirty(false)
       if (canPreview) setEditing(false)
     } finally { setRefreshing(false) }
-  }, [dirty, filePath, onContentChange, onRefresh, canPreview, confirm])
+  }, [dirty, filePath, onContentChange, onDiskContent, onRefresh, canPreview, confirm])
 
   const resolveSelectionCoords = useCallback((fallbackText?: string) => {
     const sel = window.getSelection()

--- a/website/src/hooks/usePanelTabs.ts
+++ b/website/src/hooks/usePanelTabs.ts
@@ -42,6 +42,15 @@ export interface PanelTab {
   // ── document fields ──
   path?: string
   content?: string
+  /** The on-disk bytes this buffer was last known to match — the dirty
+   *  baseline. `openFile` compares the live buffer against it to tell "the
+   *  user edited this tab" from "the file changed on disk", and only the
+   *  former survives a re-open of the same path; a successful save and every
+   *  disk-originated refresh (cold-tab hydration, file watch, panel Refresh,
+   *  error placeholder) restamp it. TRANSIENT — stripped in `serializeBucket`
+   *  alongside the body it mirrors, so persistence stays metadata-only and a
+   *  restored tab is dirty-by-default until hydration re-establishes both. */
+  savedContent?: string
   original?: string
   modified?: string
   /** Last selected working-tree diff view for file tabs. Persisted with the
@@ -356,7 +365,10 @@ export function openPanelView(slotKey: string | null, kind: ViewKind): void {
  *  can be MBs and blow the localStorage quota. Terminal + view tabs and all
  *  tab METADATA (path / slug / sessionId / cwd / order / focus) are kept, so
  *  document tabs restore as lightweight references and re-fetch their content
- *  on demand; artifact tabs self-hydrate by slug via ArtifactPanel's query. */
+ *  on demand; artifact tabs self-hydrate by slug via ArtifactPanel's query.
+ *  The saved baseline is stripped with the body: it is a second copy of the
+ *  same bytes, and a restored tab without one is treated as dirty until its
+ *  content is re-fetched, which restamps it. */
 /** Lean single-bucket projection for persistence. Diff and app tabs are
  *  transient — a restored diff can only re-fetch the CURRENT working-tree diff,
  *  never the original turn snapshot, so it renders a misleading/unreliable diff;
@@ -368,7 +380,7 @@ export function openPanelView(slotKey: string | null, kind: ViewKind): void {
 function serializeBucket(b: Bucket): string {
   const tabs = b.tabs
     .filter(t => t.kind !== 'diff' && t.kind !== 'app')
-    .map(t => { const copy = { ...t }; delete copy.content; delete copy.revealLine; return copy })
+    .map(t => { const copy = { ...t }; delete copy.content; delete copy.savedContent; delete copy.revealLine; return copy })
   // If the focused tab was a dropped diff/app tab, refocus a surviving tab.
   const activeId = tabs.some(t => t.id === b.activeId)
     ? b.activeId
@@ -517,11 +529,31 @@ export function usePanelTabs(slotKey: string | null = null) {
     // keys the incoming object HAS. Omitting it would leave a previous chip's
     // line on the tab, so a later plain click on the same file would re-jump to
     // a line the user did not ask for.
-    upsert({
-      id: `file:${path}`, kind: 'file', title: basename(path), path, content, slot,
-      revealLine: opts?.line != null ? { line: opts.line, endLine: opts.endLine, nonce: nextRevealNonce() } : undefined,
-      ...(opts?.diffMode != null ? { diffMode: opts.diffMode } : {}),
-    }, opts?.replaceId)
+    const reveal = opts?.line != null ? { line: opts.line, endLine: opts.endLine, nonce: nextRevealNonce() } : undefined
+    update(b => {
+      const prev = b.tabs.find(t => t.id === `file:${path}`)
+      if (prev && prev.content !== prev.savedContent) {
+        // The tab holds edits that were never saved (its buffer differs from
+        // its saved baseline; a baseline-less tab with a buffer — legacy or
+        // restored-but-not-yet-hydrated — counts the same way). Re-opening
+        // must FOCUS it, not revert it: the disk bytes in `content` here are
+        // not what the user was looking at, and silently replacing the buffer
+        // destroyed their work with no prompt and no undo. Everything EXCEPT
+        // the buffer and its baseline is refreshed (focus, reveal target,
+        // slot, diff-mode preference).
+        return upsertInBucket(b, {
+          id: `file:${path}`, kind: 'file', title: basename(path), path, slot,
+          revealLine: reveal,
+          ...(opts?.diffMode != null ? { diffMode: opts.diffMode } : {}),
+        }, opts?.replaceId)
+      }
+      return upsertInBucket(b, {
+        id: `file:${path}`, kind: 'file', title: basename(path), path, content, slot,
+        savedContent: content,
+        revealLine: reveal,
+        ...(opts?.diffMode != null ? { diffMode: opts.diffMode } : {}),
+      }, opts?.replaceId)
+    })
   }, [upsert])
 
   const openDiff = useCallback((path: string, modified: string, original = '') => {

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2979,12 +2979,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       body: JSON.stringify({ path: filePath, content }),
     })
     if (!res.ok) throw new Error(`Save failed: ${res.status}`)
+    // The saved bytes become the tab's dirty baseline, so a later re-open of
+    // the same path refreshes the buffer instead of (needlessly) preserving it
+    // as if it still held unsaved work. Best-effort: a tab that is not open
+    // right now is simply not found by id.
+    tabsCtl.patchTab(`file:${filePath}`, { savedContent: content })
     // Reconcile the inline-preview draft for the SAVING slot (drafts are
-    // slot+path keyed). Clear it ONLY if it still equals what we just saved —
+    // slot+path keyed). Clear it ONLY if it still equals what we just saved -
     // if the user typed more while the write was in flight, the draft now holds
     // newer content and must be preserved, not dropped.
     if (getInlineDraft(requestSlot, filePath) === content) clearInlineDraft(requestSlot, filePath)
-  }, [])
+  }, [tabsCtl])
 
   const takeScreenshot = useCallback(async () => {
     // Capture the slot at click-time. If the user switches away before the
@@ -4920,8 +4925,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     coldFileResults.forEach((r, i) => {
       const t = coldFileTabs[i]
       if (!t || t.content !== undefined) return
-      if (r.data) tabsCtl.patchTab(t.id, { content: r.data.text })
-      else if (r.isError) tabsCtl.patchTab(t.id, { content: i18nT('pages.chatPage.error_reading_file') })
+      if (r.data) tabsCtl.patchTab(t.id, { content: r.data.text, savedContent: r.data.text })
+      else if (r.isError) {
+        // The placeholder is not user work: stamp it as its own baseline so
+        // the tab counts clean and the next chip/tree click retries the read
+        // instead of "protecting" the error text as unsaved edits.
+        const errText = i18nT('pages.chatPage.error_reading_file')
+        tabsCtl.patchTab(t.id, { content: errText, savedContent: errText })
+      }
     })
   }, [coldFileResults, coldFileTabs, tabsCtl])
   // Session mode of the active slot. In the unified chat view the page-level

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -756,6 +756,7 @@ export default function SidePanel({
                 slot={slot}
                 onClose={() => handleCloseTab(t.id)}
                 onContentChange={(c) => patchTab(t.id, { content: c })}
+                onDiskContent={(c) => patchTab(t.id, { content: c, savedContent: c })}
                 onDiffModeChange={(diffMode) => patchTab(t.id, { diffMode })}
                 onRevealConsumed={() => patchTab(t.id, { revealLine: undefined })}
                 onPathChange={(p) => patchTab(t.id, { path: p, title: p.replace(/\/+$/, '').split('/').pop() || p })}
@@ -840,10 +841,13 @@ function McpAppTabBody({ tab, slot }: { tab: PanelTab; slot: string }) {
  * Rail visibility is a single app-wide preference; the rail only renders at
  * all when the chat has a project dir whose tree the backend serves.
  */
-function FileTabBody({ tab, projectDir, onContentChange, onDiffModeChange, onFileSave, onFileOpen, onClose, onSubmitComments, onRevealConsumed }: {
+function FileTabBody({ tab, projectDir, onContentChange, onDiskContent, onDiffModeChange, onFileSave, onFileOpen, onClose, onSubmitComments, onRevealConsumed }: {
   tab: PanelTab
   projectDir?: string
   onContentChange: (c: string) => void
+  /** Disk-originated content (file watch / Refresh): the panel routes it here
+   *  so the tab's saved baseline moves with the buffer it just replaced. */
+  onDiskContent: (c: string) => void
   onDiffModeChange: (diffMode: boolean) => void
   onFileSave: (fp: string, c: string) => Promise<void>
   onFileOpen?: (p: string, opts?: { diffMode?: boolean; replaceId?: string; canReplace?: () => boolean }) => void
@@ -864,6 +868,8 @@ function FileTabBody({ tab, projectDir, onContentChange, onDiffModeChange, onFil
       filePath={tab.path || ''}
       content={tab.content || ''}
       onContentChange={onContentChange}
+      onDiskContent={onDiskContent}
+      savedBaseline={tab.savedContent}
       initialDiffMode={tab.diffMode}
       onDiffModeChange={onDiffModeChange}
       onSave={onFileSave}
@@ -896,12 +902,15 @@ function FileTabBody({ tab, projectDir, onContentChange, onDiffModeChange, onFil
   )
 }
 
-function TabBody({ tab, active, slot, projectDir, onClose, onContentChange, onDiffModeChange, onRevealConsumed, onPathChange, onFileSave, onFileOpen, onSubmitComments, onTerminalSendToChat, diffLineNumbers, setDiffLineNumbers, diffSideBySide, setDiffSideBySide }: {
+function TabBody({ tab, active, slot, projectDir, onClose, onContentChange, onDiskContent, onDiffModeChange, onRevealConsumed, onPathChange, onFileSave, onFileOpen, onSubmitComments, onTerminalSendToChat, diffLineNumbers, setDiffLineNumbers, diffSideBySide, setDiffSideBySide }: {
   tab: PanelTab; active: boolean; slot: string
   /** The chat's project directory — the file-browser rail's tree root. */
   projectDir?: string
   onClose: () => void
   onContentChange: (c: string) => void
+  /** Disk-originated content (file watch / Refresh): restamps the tab's saved
+   *  baseline alongside the buffer, so a re-open still treats the tab clean. */
+  onDiskContent: (c: string) => void
   onDiffModeChange: (diffMode: boolean) => void
   /** Drop the tab's one-shot line-reveal target once the panel has acted on it. */
   onRevealConsumed: () => void
@@ -924,6 +933,7 @@ function TabBody({ tab, active, slot, projectDir, onClose, onContentChange, onDi
         tab={tab}
         projectDir={projectDir}
         onContentChange={onContentChange}
+        onDiskContent={onDiskContent}
         onDiffModeChange={onDiffModeChange}
         onFileSave={onFileSave}
         onFileOpen={onFileOpen}

--- a/website/src/test/usePanelTabs.test.ts
+++ b/website/src/test/usePanelTabs.test.ts
@@ -74,6 +74,79 @@ describe('usePanelTabs', () => {
     expect(result.current.activeTab?.content).toBe('body-2')
   })
 
+  it('re-opening a file with unsaved edits focuses it and keeps the edited buffer', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openFile('/notes.md', 'on-disk', 'slot-a'))
+    // The user types into the editor (MarkdownPanel patches content per edit).
+    act(() => result.current.patchTab('file:/notes.md', { content: 'user edits' }))
+    // Something re-opens the same path — another chip, the Files tab row.
+    act(() => result.current.openFile('/notes.md', 'on-disk'))
+    expect(result.current.tabs).toHaveLength(1)
+    expect(result.current.activeId).toBe('file:/notes.md')
+    // The buffer survives; the on-disk bytes do not revert it silently.
+    expect(result.current.activeTab?.content).toBe('user edits')
+    expect(result.current.activeTab?.savedContent).toBe('on-disk')
+  })
+
+  it('re-opening a clean file refreshes it from disk', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openFile('/notes.md', 'version-1'))
+    act(() => result.current.openFile('/notes.md', 'version-2'))
+    expect(result.current.activeTab?.content).toBe('version-2')
+    expect(result.current.activeTab?.savedContent).toBe('version-2')
+  })
+
+  it('a completed save re-arms the baseline so later opens refresh again', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openFile('/notes.md', 'v1'))
+    act(() => result.current.patchTab('file:/notes.md', { content: 'typed' }))
+    // The save handler stamps the written bytes as the new baseline.
+    act(() => result.current.patchTab('file:/notes.md', { savedContent: 'typed' }))
+    // Buffer matches baseline now: an external change may flow in.
+    act(() => result.current.openFile('/notes.md', 'external-edit'))
+    expect(result.current.activeTab?.content).toBe('external-edit')
+  })
+
+  it('a buffered tab with no baseline yet is treated as dirty, not reverted', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openFile('/notes.md', 'v1'))
+    // Simulate a legacy/restored tab whose baseline was never established.
+    act(() => result.current.patchTab('file:/notes.md', { savedContent: undefined }))
+    act(() => result.current.openFile('/notes.md', 'v2'))
+    expect(result.current.activeTab?.content).toBe('v1')
+  })
+
+  it('a disk-originated refresh restamps the baseline so later opens refresh', () => {
+    const { result } = renderHook(() => usePanelTabs())
+    act(() => result.current.openFile('/notes.md', 'v1'))
+    // What SidePanel's onDiskContent wiring does when the file watch or the
+    // panel's Refresh lands new disk bytes in the buffer.
+    act(() => result.current.patchTab('file:/notes.md', { content: 'disk-new', savedContent: 'disk-new' }))
+    act(() => result.current.openFile('/notes.md', 'disk-newer'))
+    expect(result.current.activeTab?.content).toBe('disk-newer')
+  })
+
+  it('persists metadata only: the saved baseline never reaches localStorage', () => {
+    // savedContent mirrors a file body ("can be MBs"), so persisting it would
+    // defeat the same quota protection that strips content itself.
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() => usePanelTabs())
+      act(() => result.current.openFile('/big.md', 'body'))
+      act(() => result.current.patchTab('file:/big.md', { content: 'edited' }))
+      act(() => { vi.advanceTimersByTime(500) })
+      const raw = localStorage.getItem('mc-panel-tabs:__no_slot__')
+      expect(raw).toBeTruthy()
+      const bucket = JSON.parse(raw!)
+      const tab = bucket.tabs.find((t: { id: string }) => t.id === 'file:/big.md')
+      expect(tab.content).toBeUndefined()
+      expect(tab.savedContent).toBeUndefined()
+      expect(tab.path).toBe('/big.md')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('openFile with replaceId swaps the new tab into the replaced tab\'s strip position', () => {
     const { result } = renderHook(() => usePanelTabs())
     act(() => result.current.openView('files'))


### PR DESCRIPTION
﻿<!-- no-visual-delta -->
**Why no screenshot:** the strip renders identically before and after — the change is what survives a re-open (the buffer), not anything visible in a static frame. The one observable difference is a negative (an edit no longer disappears), which a screenshot cannot show; the vitest cases pin it.

## Problem / Motivation

Re-opening a file that is already open as a document tab **silently discards its unsaved edits**. A document tab's `content` field *is* the live editor buffer — `MarkdownPanel` writes edits back through `onContentChange` → `patchTab({ content })` — but every file-open affordance (file chips, tool lines, the Files tab, the file picker) routes through `handleFileOpen` → `openFile`, which re-reads the file from disk and hands it to `upsert`. `upsertInBucket` merges onto an existing tab with a spread, so the disk bytes replaced the buffer. The edits were gone with no prompt and no undo; the close guard never fired because from the panel's perspective the buffer simply changed (fixes #1441).

## Why it matters

This is silent, unrecoverable data loss on a mainstream gesture: clicking any second affordance for a file you are editing reverts your work. Editors conventionally keep the live buffer when a document is re-opened (the hook's own docstring already promises "opening a document that's already open focuses its tab instead of duplicating it" — the implementation just also replaced its content).

## What changed (motivation → approach → change)

Telling "the user edited this tab" apart from "the file changed on disk" needs a baseline, so each file tab now carries one:

- `PanelTab.savedContent` records the on-disk bytes the buffer last matched.
- `openFile` compares the existing tab's buffer against that baseline. Dirty → upsert a patch that omits `content`/`savedContent`, so the spread refreshes everything around the buffer (focus, reveal target, slot, diff-mode preference) and keeps the text. Clean → take the fresh disk bytes and restamp the baseline, exactly as before.
- Every path that moves DISK truth into the buffer restamps the baseline in the same write: successful saves (`handleFileSave`), cold-tab hydration (success **and** its error placeholder — an unreadable-file message is not unsaved work, so the next click retries the read instead of "protecting" it), and the two disk-originated panel paths (file watch and Refresh), which MarkdownPanel now routes through a new optional `onDiskContent` callback that the side panel wires to a content+baseline patch. The panel also receives `savedBaseline={tab.savedContent}` so its dirty guard computes from the same truth.
- `serializeBucket` strips `savedContent` along with `content`: the baseline mirrors a file body ("can be MBs"), so persisting it would re-create exactly the localStorage-quota problem the strip exists to prevent. A restored tab without a baseline is dirty-by-default until hydration re-establishes both.

Alternatives considered: preserving the buffer unconditionally on every re-open needs no new state but makes re-open useless as an external-change refresh for clean tabs; keying off `content !== diskBytes` alone cannot distinguish an edited buffer from a stale one and would freeze stale buffers in place. The baseline gives both cases their right answer, and the panel already enforces the same contract elsewhere — its own Refresh control is disabled while dirty ("save or discard changes first").

## Tests

Six cases in `website/src/test/usePanelTabs.test.ts`:

- Re-opening a path whose tab holds edits focuses the tab and keeps the buffer (baseline untouched).
- Re-opening a clean tab still refreshes content + baseline from disk.
- After a save stamps the baseline, a later open refreshes again.
- A buffered tab without a baseline is treated as dirty, not reverted.
- A disk-originated refresh (`content` + `savedContent` patched together) re-arms refresh-on-reopen.
- Persistence stays metadata-only: the localStorage payload carries neither `content` nor `savedContent`, while `path` survives.

The pre-existing dedupe test ("same path merges fresh content") still passes unchanged — it describes the clean path, which keeps its behaviour.

## Manual verification

Windows 11 / Node 22:

```
cd website
npx vitest run src/test/usePanelTabs.test.ts src/test/MarkdownPanel.test.tsx
   → 69 passed
npm run typecheck                                → clean
npx eslint <five changed files>                  → 0 errors; warning count at the repo's pinned ceiling
```

The full frontend suite (`npm run check`) exceeds this machine's local time budget; CI runs it authoritatively on this PR.

## Screenshots / video

N/A — see the `no-visual-delta` marker above.

## Related Issues

Fixes #1441

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented behaviour changes; the baseline contract is documented on the type and in place
- [x] No secrets, credentials, or internal references in the diff
